### PR TITLE
[#14] [FEATURE] Ajout de nouveaux endpoints d'authentification OAuth 2 (US-1205)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -6,6 +6,7 @@ const authenticationSerializer = require('../../infrastructure/serializers/jsona
 const userRepository = require('../../infrastructure/repositories/user-repository');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const checkUserCredentialsAndGenerateAccessToken = require('../usecases/checkUserCredentialsAndGenerateAccessToken');
+const JSONAPIError = require('jsonapi-serializer').Error;
 
 function _buildError() {
   return {
@@ -65,7 +66,7 @@ module.exports = {
       .catch(() => {
         const errorStatusCode = 403;
         const jsonApiError = new JSONAPIError({
-          code: `${errorStatusCode}`,
+          code: errorStatusCode.toString(),
           title: 'Forbidden',
           detail: 'Bad credentials'
         });

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -5,11 +5,12 @@ const Authentication = require('../../domain/models/Authentication');
 const authenticationSerializer = require('../../infrastructure/serializers/jsonapi/authentication-serializer');
 const userRepository = require('../../infrastructure/repositories/user-repository');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
+const checkUserCredentialsAndGenerateAccessToken = require('../usecases/checkUserCredentialsAndGenerateAccessToken');
 
 function _buildError() {
   return {
     data: {
-      '': [ 'L\'adresse e-mail et/ou le mot de passe saisi(s) sont incorrects.' ]
+      '': ['L\'adresse e-mail et/ou le mot de passe saisi(s) sont incorrects.']
     }
   };
 }
@@ -41,5 +42,35 @@ module.exports = {
         const message = validationErrorSerializer.serialize(_buildError());
         reply(message).code(400);
       });
-  }
+  },
+
+  /**
+   * @see https://tools.ietf.org/html/rfc6749#section-4.3
+   */
+  authenticateUser(request, reply) {
+    const { username, password } = request.payload;
+
+    return checkUserCredentialsAndGenerateAccessToken.execute(username, password)
+      .then(accessToken => {
+        return reply({
+          token_type: 'bearer',
+          expires_in: 3600,
+          access_token: accessToken
+        })
+          .code(200)
+          .header('Content-Type', 'application/json;charset=UTF-8')
+          .header('Cache-Control', 'no-store')
+          .header('Pragma', 'no-cache');
+      })
+      .catch(() => {
+        const errorStatusCode = 403;
+        const jsonApiError = new JSONAPIError({
+          code: `${errorStatusCode}`,
+          title: 'Forbidden',
+          detail: 'Bad credentials'
+        });
+        return reply(jsonApiError).code(errorStatusCode);
+      });
+  },
+
 };

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -17,7 +17,7 @@ exports.register = (server, options, next) => {
 
     {
       method: 'POST',
-      path: '/token',
+      path: '/api/token',
       config: {
         auth: false,
         payload: {
@@ -50,7 +50,7 @@ exports.register = (server, options, next) => {
      */
     {
       method: 'POST',
-      path: '/revoke',
+      path: '/api/revoke',
       config: {
         auth: false,
         payload: {

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -44,6 +44,38 @@ exports.register = (server, options, next) => {
       }
     },
 
+    /**
+     * This endpoint does nothing and exists only because it is required by
+     * Ember Simpl Auth addon, for OAuth 2 "Password Grant" strategy.
+     */
+    {
+      method: 'POST',
+      path: '/revoke',
+      config: {
+        auth: false,
+        payload: {
+          allow: 'application/x-www-form-urlencoded'
+        },
+        validate: {
+          payload: Joi.object().required().keys({
+            token: Joi.string().required(),
+            token_type_hint: 'access_token'
+          }),
+          failAction: (request, reply) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              code: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: 'The server could not understand the request due to invalid syntax.',
+            });
+            return reply(jsonApiError).code(errorHttpStatusCode);
+          }
+        },
+        handler: (request, reply) => reply(),
+        tags: ['api']
+      }
+    },
+
   ]);
 
   return next();

--- a/api/lib/application/usecases/checkUserCredentialsAndGenerateAccessToken.js
+++ b/api/lib/application/usecases/checkUserCredentialsAndGenerateAccessToken.js
@@ -1,0 +1,19 @@
+const userRepository = require('../../infrastructure/repositories/user-repository');
+const encryptionService = require('../../domain/services/encryption-service');
+const tokenService = require('../../domain/services/token-service');
+const { MissingOrInvalidCredentialsError } = require('../../domain/errors');
+
+module.exports = {
+
+  execute(username, password) {
+    let user;
+    return userRepository.findByEmail(username)
+      .then(foundUser => (user = foundUser))
+      .then(() => encryptionService.check(password, user.password))
+      .then(() => tokenService.createTokenFromUser(user))
+      .catch(() => {
+        throw new MissingOrInvalidCredentialsError();
+      });
+  }
+
+};

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -151,6 +151,12 @@ class ObjectValidationError extends Error {
 
 }
 
+class MissingOrInvalidCredentialsError extends Error {
+  constructor() {
+    super('Missing or invalid credentials');
+  }
+}
+
 module.exports = {
   NotFoundError,
   PasswordNotMatching,
@@ -167,5 +173,6 @@ module.exports = {
   AssessmentEndedError,
   AlreadyRatedAssessmentError,
   WrongDateFormatError,
-  ObjectValidationError
+  ObjectValidationError,
+  MissingOrInvalidCredentialsError
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2042,7 +2042,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -1,6 +1,22 @@
-const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
+const querystring = require('querystring');
+const { expect, sinon } = require('../../../test-helper');
 const authenticationController = require('../../../../lib/application/authentication/authentication-controller');
+
+function _expectBadRequestResponse(promise) {
+  return promise.then(response => {
+    const jsonApiError = {
+      errors:
+        [{
+          code: '400',
+          title: 'Bad request',
+          detail: 'The server could not understand the request due to invalid syntax.',
+        }]
+    };
+    expect(response.statusCode).to.equal(400);
+    expect(JSON.parse(response.payload)).to.deep.equal(jsonApiError);
+  });
+}
 
 describe('Integration | Application | Route | AuthenticationRouter', () => {
 
@@ -36,6 +52,122 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       // then
       return promise.then(response => {
         expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+
+  describe('POST /token', () => {
+
+    let options;
+    let server;
+    let useCaseResult;
+
+    beforeEach(() => {
+      // configure a request (valid by default)
+      options = {
+        method: 'POST',
+        url: '/token',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        },
+        payload: querystring.stringify({
+          grant_type: 'password',
+          username: 'user@email.com',
+          password: 'user_password'
+        })
+      };
+
+      // stub dependencies
+      sinon.stub(authenticationController, 'authenticateUser').callsFake((request, reply) => reply(useCaseResult));
+
+      // instance new Hapi.js server with minimal config to test route
+      server = new Hapi.Server();
+      server.connection({ port: null });
+      server.register({ register: require('../../../../lib/application/authentication') });
+    });
+
+    afterEach(() => {
+      authenticationController.authenticateUser.restore();
+    });
+
+    it('should return a response with HTTP status code 200 when route handler (a.k.a. controller) is successful', () => {
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return promise.then(response => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    it('should return a "Bad request error" (400) formatted as JSON API when grant type is not "password"', () => {
+      // given
+      options.payload = querystring.stringify({
+        grant_type: 'authorization_code',
+        username: 'valid@email.com',
+        password: 'valid_password'
+      });
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return _expectBadRequestResponse(promise);
+    });
+
+    it('should return a "Bad request error" (400) formatted as JSON API when username is missing', () => {
+      // given
+      options.payload = querystring.stringify({
+        grant_type: 'password',
+        password: 'valid_password'
+      });
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return _expectBadRequestResponse(promise);
+    });
+
+    it('should return a "Bad request error" (400) formatted as JSON API when password is missing', () => {
+      // given
+      options.payload = querystring.stringify({
+        grant_type: 'password',
+        username: 'valid@email.com',
+      });
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return _expectBadRequestResponse(promise);
+    });
+
+    it('should return a "Bad request error" (400) formatted as JSON API when username is not an email', () => {
+      // given
+      options.payload = querystring.stringify({
+        grant_type: 'authorization_code',
+        username: 'a_login_not_an_email',
+        password: 'valid_password'
+      });
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return _expectBadRequestResponse(promise);
+    });
+
+    it('should return a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', () => {
+      // given
+      options.headers['content-type'] = 'text/html';
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return promise.then(response => {
+        expect(response.statusCode).to.equal(415);
       });
     });
   });

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -56,7 +56,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     });
   });
 
-  describe('POST /token', () => {
+  describe('POST /api/token', () => {
 
     let options;
     let server;
@@ -66,7 +66,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       // configure a request (valid by default)
       options = {
         method: 'POST',
-        url: '/token',
+        url: '/api/token',
         headers: {
           'content-type': 'application/x-www-form-urlencoded'
         },
@@ -182,7 +182,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       // configure a request (valid by default)
       options = {
         method: 'POST',
-        url: '/revoke',
+        url: '/api/revoke',
         headers: {
           'content-type': 'application/x-www-form-urlencoded'
         },

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -176,7 +176,6 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
 
     let options;
     let server;
-    let useCaseResult;
 
     beforeEach(() => {
       // configure a request (valid by default)

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,0 +1,71 @@
+const { sinon, expect } = require('../../../test-helper');
+
+const authenticationController = require('../../../../lib/application/authentication/authentication-controller');
+const checkUserCredentialsAndGenerateAccessToken = require('../../../../lib/application/usecases/checkUserCredentialsAndGenerateAccessToken');
+
+describe('Unit | Application | Controller | Authentication', () => {
+
+  describe('#authenticateUser', () => {
+
+    let request;
+    let stubHeader;
+    let stubCode;
+    let reply;
+
+    beforeEach(() => {
+      request = {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        },
+        payload: {
+          grant_type: 'password',
+          username: 'user@email.com',
+          password: 'user_password'
+        }
+      };
+      sinon.stub(checkUserCredentialsAndGenerateAccessToken, 'execute').resolves('jwt.access.token');
+      stubHeader = sinon.stub();
+      stubHeader.returns({ header: stubHeader });
+      stubCode = sinon.stub().returns({ header: stubHeader });
+      reply = sinon.stub().returns({ code: stubCode });
+    });
+
+    afterEach(() => {
+      checkUserCredentialsAndGenerateAccessToken.execute.restore();
+    });
+
+    it('should check user credentials', () => {
+      // when
+      const promise = authenticationController.authenticateUser(request, reply);
+
+      // then
+      return promise.then(() => {
+        expect(checkUserCredentialsAndGenerateAccessToken.execute).to.have.been.calledWith('user@email.com', 'user_password');
+      });
+    });
+
+    /**
+     * @see https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+     */
+    it('should returns an OAuth 2 token response (even if we do not really implement OAuth 2 authorization protocol)', () => {
+      // when
+      const promise = authenticationController.authenticateUser(request, reply);
+
+      // then
+      return promise.then(() => {
+        const expectedResponseResult = {
+          token_type: 'bearer',
+          expires_in: 3600,
+          access_token: 'jwt.access.token'
+        };
+        expect(reply).to.have.been.calledWithExactly(expectedResponseResult);
+        expect(stubCode).to.have.been.calledWith(200);
+        expect(stubHeader).to.have.been.calledThrice;
+        expect(stubHeader).to.have.been.calledWith('Content-Type', 'application/json;charset=UTF-8');
+        expect(stubHeader).to.have.been.calledWith('Cache-Control', 'no-store');
+        expect(stubHeader).to.have.been.calledWith('Pragma', 'no-cache');
+      });
+    });
+  });
+
+});

--- a/api/tests/unit/application/usecases/checkUserCredentialsAndGenerateAccessToken_test.js
+++ b/api/tests/unit/application/usecases/checkUserCredentialsAndGenerateAccessToken_test.js
@@ -1,0 +1,83 @@
+const { expect, sinon } = require('../../../test-helper');
+const useCase = require('../../../../lib/application/usecases/checkUserCredentialsAndGenerateAccessToken');
+const User = require('../../../../lib/domain/models/User');
+const { MissingOrInvalidCredentialsError, PasswordNotMatching } = require('../../../../lib/domain/errors');
+const encryptionService = require('../../../../lib/domain/services/encryption-service');
+const tokenService = require('../../../../lib/domain/services/token-service');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+function _expectTreatmentToFailWithMissingOrInvalidCredentialsError(promise) {
+  return promise
+    .then(() => {
+      expect.fail('Expected an error to be thrown');
+    }).catch(err => {
+      expect(err).to.be.an.instanceof(MissingOrInvalidCredentialsError);
+      expect(err.message).to.equal('Missing or invalid credentials');
+    });
+}
+
+describe('Unit | Application | Use Case | CheckUserCredentialsAndGenerateAccessToken', () => {
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'findByEmail');
+    sinon.stub(encryptionService, 'check');
+    sinon.stub(tokenService, 'createTokenFromUser');
+  });
+
+  afterEach(() => {
+    userRepository.findByEmail.restore();
+    encryptionService.check.restore();
+    tokenService.createTokenFromUser.restore();
+  });
+
+  it('should resolves a valid JWT access token when authentication succeeded', () => {
+    // given
+    const userEmail = 'user@example.net';
+    let accessToken = 'jwt.access.token';
+    const user = new User({ email: userEmail, password: 'user_password' });
+    userRepository.findByEmail.resolves(user);
+    encryptionService.check.resolves();
+    tokenService.createTokenFromUser.returns(accessToken);
+
+    // when
+    const promise = useCase.execute(userEmail, 'user_password');
+
+    // then
+    return promise.then(accessToken => {
+      expect(userRepository.findByEmail).to.have.been.calledWithExactly(userEmail);
+      expect(tokenService.createTokenFromUser).to.have.been.calledWithExactly(user);
+      expect(accessToken).to.equal(accessToken);
+    });
+  });
+
+  it('should rejects an error when given username (email) does not match an existing one', () => {
+    // given
+    const error = new Error('Simulates BookshelfUser.NotFoundError');
+    userRepository.findByEmail.rejects(error);
+
+    // when
+    const promise = useCase.execute('unknown_user_email@example.net', 'some_password');
+
+    // then
+    return _expectTreatmentToFailWithMissingOrInvalidCredentialsError(promise);
+  });
+
+  it('should rejects an error when given password does not match the found user’s one', () => {
+    // given
+    const userEmail = 'user@example.net';
+    const user = new User({ email: userEmail, password: 'user_password' });
+    userRepository.findByEmail.resolves(user);
+    encryptionService.check.rejects(new PasswordNotMatching());
+
+    // when
+    const promise = useCase.execute(userEmail, 'wrong_password');
+
+    // then
+    return _expectTreatmentToFailWithMissingOrInvalidCredentialsError(promise);
+  });
+
+});
+
+
+
+

--- a/api/tests/unit/application/usecases/checkUserCredentialsAndGenerateAccessToken_test.js
+++ b/api/tests/unit/application/usecases/checkUserCredentialsAndGenerateAccessToken_test.js
@@ -33,7 +33,7 @@ describe('Unit | Application | Use Case | CheckUserCredentialsAndGenerateAccessT
   it('should resolves a valid JWT access token when authentication succeeded', () => {
     // given
     const userEmail = 'user@example.net';
-    let accessToken = 'jwt.access.token';
+    const accessToken = 'jwt.access.token';
     const user = new User({ email: userEmail, password: 'user_password' });
     userRepository.findByEmail.resolves(user);
     encryptionService.check.resolves();
@@ -77,7 +77,4 @@ describe('Unit | Application | Use Case | CheckUserCredentialsAndGenerateAccessT
   });
 
 });
-
-
-
 


### PR DESCRIPTION
Ajout des endpoints `POST /api/token` et `POST /api/revoke` en suivant les spécifications OAuth 2 pour la stratégie [Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3) (moins la partie rafraîchissement de l'access token, pas très utile dans la mesure où les access_token qu'on génère durent 7 jours [remarque : ce qui est trop d'après la-dite doc!]).

OAuth 2 déconseille cette stratégie sauf dans le cas où le client fait parfaitement confiance au back, ce qui est notre cas dans la mesure où nous avons la main sur l'un et l'autre.

Remarque ⚠️!  dans la mesure où les credentials sont passés en clair, **il est absolument nécessaire que la communication se fasse par HTTPS !**

-----------

## POST /api/token

[RFC 6749](https://tools.ietf.org/html/rfc6749)

Cet endpoint est utilisé pour s'authentifier et récupérer un jeton d'accès sécurisé à l'API.

Exemple de requête : 

```
POST /token HTTP/1.1
Host: server.example.com
Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
Content-Type: application/x-www-form-urlencoded

grant_type=password&username=johndoe&password=A3ddj3w
```

Exemple de réponse : 

```
HTTP/1.1 200 OK
Content-Type: application/json;charset=UTF-8
Cache-Control: no-store
Pragma: no-cache

{
    "access_token":"2YotnFZFEjr1zCsicMWpAA",
    "token_type":"example",
    "expires_in":3600,
    "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
    "example_parameter":"example_value"
}
```

-----------

## POST /api/revoke

[RFC 7009](https://tools.ietf.org/html/rfc7009)

Cet endpoint est utilisé par Ember Simpl Auth lors de la déconnexion d'un utilisateur.

Exemple de requête : 

```
POST /revoke HTTP/1.1
Host: server.example.com
Content-Type: application/x-www-form-urlencoded
Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW

token=45ghiukldjahdnhzdauz&token_type_hint=refresh_token
```

Exemple de réponse : 

```
HTTP/1.1 200 OK
Content-Type: application/json;charset=UTF-8
Cache-Control: no-store
Pragma: no-cache
```
