### PR TITLE
[#16] [FEATURE] Ajout de toutes les informations dans le CSV d'export (US-1181).

### DIFF
--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -42,42 +42,42 @@ function toCSVRow(rowJSON) {
   const certificationData = rowJSON.data.attributes;
   const res = {};
 
-  const [idColumn,
-    sessionNumberColumn,
-    dateStartColumn,
-    dateEndColumn,
+  const [id,
+    sessionNumber,
+    dateStart,
+    dateEnd,
     status,
-    noteColumn,
+    note,
     firstname,
     lastname,
     birthdate,
     birthplace,
-    commentCandidateColumn,
-    commentOrganizationColumn,
-    commentJuryColumn,
-    ...competencesColumns] = HEADERS;
+    commentCandidate,
+    commentOrganization,
+    commentJury,
+    ...competencess] = HEADERS;
 
-  res[idColumn] = certificationData['certification-id'];
-  res[sessionNumberColumn] = certificationData['session-id'];
+  res[id] = certificationData['certification-id'];
+  res[sessionNumber] = certificationData['session-id'];
 
-  res[dateStartColumn] = moment.utc(certificationData['created-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
+  res[dateStart] = moment.utc(certificationData['created-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
   if (certificationData['completed-at']) {
-    res[dateEndColumn] = moment(certificationData['completed-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
+    res[dateEnd] = moment(certificationData['completed-at']).tz('Europe/Paris').format('DD/MM/YYYY HH:mm:ss');
   } else {
-    res[dateEndColumn] = '';
+    res[dateEnd] = '';
   }
 
   res[status] = certificationData['status'];
-  res[noteColumn] = certificationData['pix-score'];
+  res[note] = certificationData['pix-score'];
   res[firstname] = certificationData['first-name'];
   res[lastname] = certificationData['last-name'];
   res[birthdate] = certificationData['birthdate'];
   res[birthplace] = certificationData['birthplace'];
-  res[commentCandidateColumn] = certificationData['comment-for-candidate'];
-  res[commentOrganizationColumn] = certificationData['comment-for-organization'];
-  res[commentJuryColumn] = certificationData['comment-for-jury'];
+  res[commentCandidate] = certificationData['comment-for-candidate'];
+  res[commentOrganization] = certificationData['comment-for-organization'];
+  res[commentJury] = certificationData['comment-for-jury'];
 
-  competencesColumns.forEach(column => {
+  competencess.forEach(column => {
     res[column] = findCompetence(certificationData['competences-with-mark'], column);
   });
 

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -6,7 +6,6 @@ const request = require('request-promise-native');
 const json2csv = require('json2csv');
 const moment = require('moment-timezone');
 
-// request.debug = true;
 const HEADERS = [
   'Numero certification', 'Numero de session', 'Date de début', 'Date de fin',
   'Status de la session', 'Note Pix',
@@ -32,10 +31,6 @@ function buildRequestObject(baseUrl, authToken, certificationId) {
       return body;
     }
   };
-}
-
-function makeRequest(config) {
-  return request(config);
 }
 
 function findCompetence(profile, competenceName) {
@@ -104,7 +99,7 @@ function main() {
   const ids = process.argv.slice(4);
   const requests = Promise.all(
     ids.map(id => buildRequestObject(baseUrl, authToken, id))
-      .map(requestObject => makeRequest(requestObject))
+      .map(requestObject => request(requestObject))
   );
 
   return requests.then(certificationResults => certificationResults.map(toCSVRow))

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -26,10 +26,7 @@ function buildRequestObject(baseUrl, authToken, certificationId) {
     baseUrl: baseUrl,
     url: `/api/admin/certifications/${certificationId}`,
     json: true,
-    transform: (body) => {
-      body.data.attributes.certificationId = certificationId;
-      return body;
-    }
+    simple: false
   };
 }
 
@@ -39,6 +36,9 @@ function findCompetence(profile, competenceName) {
 }
 
 function toCSVRow(rowJSON) {
+  if(!rowJSON.data) {
+    return {};
+  }
   const certificationData = rowJSON.data.attributes;
   const res = {};
 

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -70,7 +70,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
             'comment-for-jury': 'You get it',
             'first-name': 'Goku',
             'last-name': 'Son',
-            'birthdate': '20/11/1984',
+            'birthdate': '20/11/737',
             'birthplace': 'Vegeta',
             'session-id': 1
           }
@@ -87,7 +87,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       expect(result[HEADERS[5]]).to.equal(7331);
       expect(result[HEADERS[6]]).to.equal('Goku');
       expect(result[HEADERS[7]]).to.equal('Son');
-      expect(result[HEADERS[8]]).to.equal('20/11/1984');
+      expect(result[HEADERS[8]]).to.equal('20/11/737');
       expect(result[HEADERS[9]]).to.equal('Vegeta');
       expect(result[HEADERS[10]]).to.equal('GG');
       expect(result[HEADERS[11]]).to.equal('Too bad');

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -71,7 +71,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
             'first-name': 'Goku',
             'last-name': 'Son',
             'birthdate': '20/11/1984',
-            'birthplace': 'Tokyo',
+            'birthplace': 'Vegeta',
             'session-id': 1
           }
         }
@@ -79,19 +79,19 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       // when
       const result = getResultsCertifications.toCSVRow(object);
       // then
-      expect(result[HEADERS[0]]).to.equals('1337');
-      expect(result[HEADERS[1]]).to.equals(1);
-      expect(result[HEADERS[2]]).to.equals('31/01/2018 10:01:00');
-      expect(result[HEADERS[3]]).to.equals('31/01/2018 10:29:16');
-      expect(result[HEADERS[4]]).to.equals('validated');
-      expect(result[HEADERS[5]]).to.equals(7331);
-      expect(result[HEADERS[6]]).to.equals('Goku');
-      expect(result[HEADERS[7]]).to.equals('Son');
-      expect(result[HEADERS[8]]).to.equals('20/11/1984');
-      expect(result[HEADERS[9]]).to.equals('Tokyo');
-      expect(result[HEADERS[10]]).to.equals('GG');
-      expect(result[HEADERS[11]]).to.equals('Too bad');
-      expect(result[HEADERS[12]]).to.equals('You get it');
+      expect(result[HEADERS[0]]).to.equal('1337');
+      expect(result[HEADERS[1]]).to.equal(1);
+      expect(result[HEADERS[2]]).to.equal('31/01/2018 10:01:00');
+      expect(result[HEADERS[3]]).to.equal('31/01/2018 10:29:16');
+      expect(result[HEADERS[4]]).to.equal('validated');
+      expect(result[HEADERS[5]]).to.equal(7331);
+      expect(result[HEADERS[6]]).to.equal('Goku');
+      expect(result[HEADERS[7]]).to.equal('Son');
+      expect(result[HEADERS[8]]).to.equal('20/11/1984');
+      expect(result[HEADERS[9]]).to.equal('Vegeta');
+      expect(result[HEADERS[10]]).to.equal('GG');
+      expect(result[HEADERS[11]]).to.equal('Too bad');
+      expect(result[HEADERS[12]]).to.equal('You get it');
     });
 
     it('should extract competences', () => {
@@ -102,7 +102,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.toCSVRow(object);
 
       // then
-      expect(result[HEADERS[13]]).to.equals('');
+      expect(result[HEADERS[13]]).to.equal('');
     });
 
     it('should extract competences 1.1', () => {
@@ -124,7 +124,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.toCSVRow(object);
 
       // then
-      expect(result['1.1']).to.equals(9001);
+      expect(result['1.1']).to.equal(9001);
     });
 
     it('should extract all competences', () => {
@@ -150,8 +150,8 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.toCSVRow(object);
 
       // then
-      expect(result['1.1']).to.equals(4);
-      expect(result['1.2']).to.equals(6);
+      expect(result['1.1']).to.equal(4);
+      expect(result['1.2']).to.equal(6);
     });
 
   });
@@ -182,7 +182,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.findCompetence(profile, competenceCode);
 
       // then
-      expect(result).to.be.equals(9);
+      expect(result).to.be.equal(9);
     });
   });
 });

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -31,17 +31,6 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       expect(result.headers).to.have.property('authorization', 'Bearer jwt.tokken');
     });
 
-    it('should add certificationId to API response when the object is transform after the request', () => {
-      // given
-      const baseUrl = 'http://localhost:3000';
-      const requestObject = getResultsCertifications.buildRequestObject(baseUrl, '', 12);
-
-      // when
-      const result = requestObject.transform({ data: { attributes: {} } });
-
-      // then
-      expect(result.data.attributes).to.have.property('certificationId', 12);
-    });
   });
 
   describe('toCSVRow', () => {

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -16,18 +16,6 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
     '5.1', '5.2'
   ];
 
-  describe('parseArgs', () => {
-    it('should return an array', () => {
-      // given
-      const args = ['/usr/bin/node', '/path/to/script.js', 'http://localhost:3000', '1', '2', '3'];
-      // when
-      const result = getResultsCertifications.parseArgs(args);
-      // then
-      expect(result).to.be.an('array');
-      expect(result).to.deep.equals(['1', '2', '3']);
-    });
-  });
-
   describe('buildRequestObject', () => {
 
     it('should take an id and return a request object', () => {

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -5,12 +5,15 @@ const getResultsCertifications = require('../../../../api/scripts/get-results-ce
 describe('Unit | Scripts | get-results-certifications.js', () => {
 
   const HEADERS = [
-    'Numero certification', 'Date de début', 'Date de fin', 'Note Pix',
+    'Numero certification', 'Numero de session', 'Date de début', 'Date de fin',
+    'Status de la session', 'Note Pix',
+    'Prénom', 'Nom', 'Date de naissance', 'Lieu de naissance',
+    'Commentaire pour le candidat', 'Commentaire pour l\'organisation', 'Commentaire du jury',
     '1.1', '1.2', '1.3',
     '2.1', '2.2', '2.3', '2.4',
     '3.1', '3.2', '3.3', '3.4',
     '4.1', '4.2', '4.3',
-    '5.1', '5.2',
+    '5.1', '5.2'
   ];
 
   describe('parseArgs', () => {
@@ -63,16 +66,25 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       expect(result).to.have.all.keys(HEADERS);
     });
 
-    it('should extract certificationId, date, and pix score', () => {
+    it('should extract all the informations of the certification', () => {
       // given
       const object = {
         data: {
           attributes: {
-            certificationId: '1337',
+            'certification-id': '1337',
             'pix-score': 7331,
             'created-at': '2018-01-31 09:01',
             'completed-at': '2018-01-31T09:29:16.394Z',
-            'competences-with-mark': []
+            'competences-with-mark': [],
+            'status': 'validated',
+            'comment-for-candidate': 'GG',
+            'comment-for-organization': 'Too bad',
+            'comment-for-jury': 'You get it',
+            'first-name': 'Goku',
+            'last-name': 'Son',
+            'birthdate': '20/11/1984',
+            'birthplace': 'Tokyo',
+            'session-id': 1
           }
         }
       };
@@ -80,9 +92,18 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.toCSVRow(object);
       // then
       expect(result[HEADERS[0]]).to.equals('1337');
-      expect(result[HEADERS[1]]).to.equals('31/01/2018 10:01:00');
-      expect(result[HEADERS[2]]).to.equals('31/01/2018 10:29:16');
-      expect(result[HEADERS[3]]).to.equals(7331);
+      expect(result[HEADERS[1]]).to.equals(1);
+      expect(result[HEADERS[2]]).to.equals('31/01/2018 10:01:00');
+      expect(result[HEADERS[3]]).to.equals('31/01/2018 10:29:16');
+      expect(result[HEADERS[4]]).to.equals('validated');
+      expect(result[HEADERS[5]]).to.equals(7331);
+      expect(result[HEADERS[6]]).to.equals('Goku');
+      expect(result[HEADERS[7]]).to.equals('Son');
+      expect(result[HEADERS[8]]).to.equals('20/11/1984');
+      expect(result[HEADERS[9]]).to.equals('Tokyo');
+      expect(result[HEADERS[10]]).to.equals('GG');
+      expect(result[HEADERS[11]]).to.equals('Too bad');
+      expect(result[HEADERS[12]]).to.equals('You get it');
     });
 
     it('should extract competences', () => {
@@ -93,7 +114,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       const result = getResultsCertifications.toCSVRow(object);
 
       // then
-      expect(result[HEADERS[4]]).to.equals('');
+      expect(result[HEADERS[13]]).to.equals('');
     });
 
     it('should extract competences 1.1', () => {


### PR DESCRIPTION
Pour cet US: 
- L'API renvoyait déjà toutes les informations
- Nous avons juste ajouté de nouvelles colonnes au CSV créé par le script
- Nous en avons profité pour créer un fichier csv comme fichier de sortie (avec la date comme nom)
- Le parseArgs et le slice(4) faisait la même chose, on l'a retiré