### PR TITLE
[#17] Corriger le problème de CORS (US-1216).

### DIFF
--- a/api/bin/www
+++ b/api/bin/www
@@ -5,5 +5,5 @@ const logger = require('../lib/infrastructure/logger');
 
 server.start((err) => {
   if (err) throw err;
-  logger.info('Server running at %s:%s', server.info.address, server.info.port)
+  logger.info('Server running at %s:%s', server.info.address, server.info.port);
 });

--- a/api/server.js
+++ b/api/server.js
@@ -13,7 +13,10 @@ const security = require('./lib/infrastructure/security');
 const server = new Hapi.Server({
   connections: {
     routes: {
-      cors: true
+      cors: {
+        origin: ['*'],
+        additionalHeaders:['X-Requested-With']
+      }
     },
     router: {
       isCaseSensitive: false,


### PR DESCRIPTION
Je pense que la Func review ça va être compliqué... Pas grand risque à merger ça de toute façon.

Pour tester:
```bash
curl -X OPTIONS http://1216-fix-cors-headers.pix-dev.ovh/api/ -H 'Access-Control-Request-Method: GET' -H 'Origin: https://pix-api.scalingo.io' -v
```

Et vérifier que la ligne:
> < access-control-allow-headers: Accept,Authorization,Content-Type,If-None-Match,X-Requested-With 

est présente (surtout le X-Requested-With qui était le header manquant).