### PR TITLE
[#22] Les métriques de /metrics exposent le path dans les compteurs api_request (US-1202)

### DIFF
--- a/api/lib/infrastructure/plugins/metrics.js
+++ b/api/lib/infrastructure/plugins/metrics.js
@@ -39,7 +39,7 @@ const Metrics = {
       const { statusCode } = request.response;
 
       if (statusCode < 400) {
-        metrics.request.success.inc();
+        metrics.request.success.inc({ 'path': request.route.path });
       }
 
       if (statusCode >= 400 && statusCode < 500) {

--- a/api/lib/infrastructure/plugins/metrics.js
+++ b/api/lib/infrastructure/plugins/metrics.js
@@ -43,11 +43,11 @@ const Metrics = {
       }
 
       if (statusCode >= 400 && statusCode < 500) {
-        metrics.request.client_error.inc();
+        metrics.request.client_error.inc({ 'path': request.route.path });
       }
 
       if (statusCode >= 500) {
-        metrics.request.server_error.inc();
+        metrics.request.server_error.inc({ 'path': request.route.path });
       }
     });
 

--- a/api/tests/unit/infrastructure/plugins/metrics_test.js
+++ b/api/tests/unit/infrastructure/plugins/metrics_test.js
@@ -9,7 +9,7 @@ describe('Unit | Plugins | Metrics', () => {
 
   let serverStub;
 
-  const defaultRoute = {};
+  const defaultRoute = { path: '/api/other/{id}' };
   const defaultInfo = { responded: 2, received: 1 };
 
   class ResponseStub {
@@ -118,11 +118,11 @@ describe('Unit | Plugins | Metrics', () => {
 
     it('should increment on successful response event', () => {
       // when
-      serverStub.emit('response', new ResponseStub({ statusCode: 200 }, defaultInfo, { path: '/api/other/{id}' }));
+      serverStub.emit('response', new ResponseStub({ statusCode: 200 }, defaultInfo, defaultRoute));
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_success', '/api/other/{id}');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_success', defaultRoute.path);
       expect(expectedCountFromSpecificPath).to.equal('1');
     });
 
@@ -164,11 +164,11 @@ describe('Unit | Plugins | Metrics', () => {
 
     it('should increment on error response event', () => {
       // when
-      serverStub.emit('response', new ResponseStub({ statusCode: 500 }, defaultInfo, { path: '/api/other/{id}' }));
+      serverStub.emit('response', new ResponseStub({ statusCode: 500 }, defaultInfo, defaultRoute));
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_server_error', '/api/other/{id}');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_server_error', defaultRoute.path);
       expect(expectedCountFromSpecificPath).to.equal('1');
     });
   });
@@ -188,11 +188,11 @@ describe('Unit | Plugins | Metrics', () => {
 
     it('should increment on response with statusCode 400', () => {
       // when
-      serverStub.emit('response', new ResponseStub({ statusCode: 400 }, defaultInfo, { path: '/api/other/{id}' }));
+      serverStub.emit('response', new ResponseStub({ statusCode: 400 }, defaultInfo, defaultRoute));
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_client_error', '/api/other/{id}');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_client_error', defaultRoute.path);
       expect(expectedCountFromSpecificPath).to.equal('1');
     });
 

--- a/api/tests/unit/infrastructure/plugins/metrics_test.js
+++ b/api/tests/unit/infrastructure/plugins/metrics_test.js
@@ -66,8 +66,8 @@ describe('Unit | Plugins | Metrics', () => {
       .split('\n')
       .find((line) => line.match(new RegExp(`${metric}.*path="${path}"`)));
 
-    if (metricLine === undefined) {
-      throw new Error(`Expected metric ${metric} to be found in:\n${allMetrics}`);
+    if (!metricLine) {
+      return '0';
     }
 
     const matches = /(\d+)\s*$/.exec(metricLine);
@@ -133,8 +133,8 @@ describe('Unit | Plugins | Metrics', () => {
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const result = _extractNumericValueFromSingleMetric(prometheusMetrics, 'api_request_success');
-      expect(result).to.equals('0');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_success', defaultRoute.path);
+      expect(expectedCountFromSpecificPath).to.equal('0');
     });
   });
 
@@ -158,8 +158,8 @@ describe('Unit | Plugins | Metrics', () => {
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const result = _extractNumericValueFromSingleMetric(prometheusMetrics, 'api_request_server_error');
-      expect(result).to.equals('0');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_server_error', defaultRoute.path);
+      expect(expectedCountFromSpecificPath).to.equal('0');
     });
 
     it('should increment on error response event', () => {
@@ -202,8 +202,8 @@ describe('Unit | Plugins | Metrics', () => {
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const result = _extractNumericValueFromSingleMetric(prometheusMetrics, 'api_request_client_error');
-      expect(result).to.equals('0');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_client_error', defaultRoute.path);
+      expect(expectedCountFromSpecificPath).to.equal('0');
     });
   });
 

--- a/api/tests/unit/infrastructure/plugins/metrics_test.js
+++ b/api/tests/unit/infrastructure/plugins/metrics_test.js
@@ -118,12 +118,12 @@ describe('Unit | Plugins | Metrics', () => {
 
     it('should increment on successful response event', () => {
       // when
-      serverStub.emit('response', new ResponseStub({ statusCode: 200 }, defaultInfo, defaultRoute));
+      serverStub.emit('response', new ResponseStub({ statusCode: 200 }, defaultInfo, { path: '/api/other/{id}' }));
 
       // then
       const prometheusMetrics = Metrics.prometheusClient.metrics();
-      const result = _extractNumericValueFromSingleMetric(prometheusMetrics, 'api_request_success');
-      expect(result).to.equals('1');
+      const expectedCountFromSpecificPath = _extractCountFromSpecificPath(prometheusMetrics, 'api_request_success', '/api/other/{id}');
+      expect(expectedCountFromSpecificPath).to.equal('1');
     });
 
     it('should not increment on error response event', () => {


### PR DESCRIPTION
A valider sur : http://1202-path-on-error-metrics.pix-app.ovh/metrics