### PR TITLE
[#24] [BSR] Jette une exception lorsqu’on charge une certification qui n’est pas complétée 

### DIFF
--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const moment = require('moment');
 const AnswerStatus = require('../models/AnswerStatus');
 const CertificationCourse = require('../../domain/models/CertificationCourse');
-const { UserNotAuthorizedToCertifyError } = require('../../../lib/domain/errors');
+const { UserNotAuthorizedToCertifyError, NotCompletedAssessmentError } = require('../../../lib/domain/errors');
 
 const userService = require('../../../lib/domain/services/user-service');
 const certificationChallengesService = require('../../../lib/domain/services/certification-challenges-service');
@@ -216,12 +216,16 @@ module.exports = {
     let certification = {};
     return assessmentRepository
       .getByCertificationCourseId(certificationCourseId)
-      .then(foundAssessement => {
-        assessment = foundAssessement;
-        return certificationCourseRepository.get(certificationCourseId);
+      .then(foundAssessment => {
+        certification = certificationCourseRepository.get(certificationCourseId);
+        assessment = foundAssessment;
+        return certification;
       })
       .then(foundCertification => {
         certification = foundCertification;
+        if (assessment == null) {
+          throw new NotCompletedAssessmentError();
+        }
         assessmentLastResult = assessment.getLastAssessmentResult();
         return assessmentResultRepository.get(assessmentLastResult.id);
       })

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -37,8 +37,11 @@ module.exports = {
       .where({ id })
       .fetch({ require: true, withRelated: ['assessment', 'challenges'] })
       .then(_toDomain)
-      .catch(() => {
-        return Promise.reject(new NotFoundError());
+      .catch(bookshelfError => {
+        if (bookshelfError instanceof CertificationCourseBookshelf.NotFoundError) {
+          return Promise.reject(new NotFoundError());
+        }
+        return Promise.reject(bookshelfError);
       });
   },
 


### PR DESCRIPTION
Avant:
```
Apr 12 11:23:11 nodeapp-production-0 npm:  Debug: internal, implementation, error
Apr 12 11:23:11 nodeapp-production-0 npm:      TypeError: Cannot read property 'getLastAssessmentResult' of null
Apr 12 11:23:11 nodeapp-production-0 npm:      at Child.assessmentRepository.getByCertificationCourseId.then.then.foundCertification (/home/deploy/app/api/lib/domain/services/certification-service.js:225:42)
Apr 12 11:23:11 nodeapp-production-0 npm:      at bound (domain.js:280:14)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Child.runBound (domain.js:293:12)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Child.tryCatcher (/home/deploy/app/api/node_modules/bluebird/js/release/util.js:16:23)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Promise._settlePromiseFromHandler (/home/deploy/app/api/node_modules/bluebird/js/release/promise.js:512:31)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Promise._settlePromise (/home/deploy/app/api/node_modules/bluebird/js/release/promise.js:569:18)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Promise._settlePromise0 (/home/deploy/app/api/node_modules/bluebird/js/release/promise.js:614:10)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Promise._settlePromises (/home/deploy/app/api/node_modules/bluebird/js/release/promise.js:693:18)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Async._drainQueue (/home/deploy/app/api/node_modules/bluebird/js/release/async.js:133:16)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Async._drainQueues (/home/deploy/app/api/node_modules/bluebird/js/release/async.js:143:10)
Apr 12 11:23:11 nodeapp-production-0 npm:      at Immediate.Async.drainQueues (/home/deploy/app/api/node_modules/bluebird/js/release/async.js:17:14)
Apr 12 11:23:11 nodeapp-production-0 npm:      at runCallback (timers.js:672:20)
Apr 12 11:23:11 nodeapp-production-0 npm:      at tryOnImmediate (timers.js:645:5)
Apr 12 11:23:11 nodeapp-production-0 npm:      at processImmediate [as _immediateCallback] (timers.js:617:5)
Apr 12 11:23:11 nodeapp-production-0 npm:  180412/092311.628, [response,api] http://nodeapp-production-0:3000: get /api/admin/certifications/3588 {} 500 (184ms)
``` 

Normalement après on aura une erreur plus sympa.