### PR TITLE
[#34] [BUGFIX] Corriger l'adresse de contact (US - 1220).

### DIFF
--- a/live/app/templates/components/app-footer.hbs
+++ b/live/app/templates/components/app-footer.hbs
@@ -3,7 +3,7 @@
 </section>
 
 <section class="app-footer__section app-footer__section--contact">
-  <a class="app-footer__link-text" href="mailto:contact@pix.beta.gouv.fr">Contactez-nous</a>
+  <a class="app-footer__link-text" href="mailto:contact@pix.fr">Contactez-nous</a>
   |
   <a class="app-footer__link-text" href="/mentions-legales">Mentions légales</a>
   |


### PR DESCRIPTION
Remplacer `contact@pix.beta.gouv.fr` dans le footer par `contact@pix.fr`