### PR TITLE
[#41] [FEATURE] Modification de la route GET /organizations pour permettre à un Pix Master de récupérer la liste de toutes les organisations de façon sécurisée (US-1248).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -19,7 +19,14 @@ exports.register = (server, options, next) => {
     {
       method: 'GET',
       path: '/api/organizations',
-      config: { handler: organisationController.search, tags: ['api'] }
+      config: {
+        handler: organisationController.search,
+        tags: ['api'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle peut être utilisée dans 3 cas : \n- un usager qui souhaite partager son profil de compétences avec une organisation (retourne un tableau vide)\n- à la connexion d’un prescripteur (pour détecter qu’il est bien prescripteur (retourne un tableau avec 1 seul élément)\n- un Pix master qui souhaite consulter la liste de toutes les organisations (retourne un tableau avec n éléments)',
+        ]
+      }
     },
     {
       method: 'GET',

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -61,9 +61,10 @@ module.exports = {
   },
 
   search: (request, reply) => {
+    const userId = request.auth.credentials.userId;
     const filters = _extractFilters(request);
 
-    return organizationService.search(filters)
+    return organizationService.search(userId, filters)
       .then(organizations => reply(organizationSerializer.serialize(organizations)))
       .catch(err => {
         logger.error(err);

--- a/api/lib/domain/services/organization-service.js
+++ b/api/lib/domain/services/organization-service.js
@@ -1,5 +1,6 @@
 const { sampleSize, random } = require('lodash');
 const organisationRepository = require('../../infrastructure/repositories/organization-repository');
+const userRepository = require('../../infrastructure/repositories/user-repository');
 
 function _randomLetters(count) {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXZ'.split('');
@@ -48,12 +49,18 @@ module.exports = {
       .then(jsonSnapshots => snapshotsCsvConverter.convertJsonToCsv(organization, competences, jsonSnapshots));
   },
 
-  search(filters = {}) {
-    if(_noCodeGivenIn(filters)) return Promise.resolve([]);
+  search(userId, filters = {}) {
+    return userRepository
+      .hasRolePixMaster(userId)
+      .then(isUserPixMaster => {
+        if (!isUserPixMaster && _noCodeGivenIn(filters)) {
+          return [];
+        }
+        return organisationRepository
+          .findBy(filters)
+          .then((organizations) => organizations.map(_organizationWithoutEmail));
+      });
 
-    return organisationRepository
-      .findBy(filters)
-      .then((organizations) => organizations.map(_organizationWithoutEmail));
   }
 
 };

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -54,6 +54,6 @@ module.exports = {
       .where({ userId })
       .fetchAll()
       .then(organizations => organizations.models);
-  }
+  },
 };
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -71,5 +71,11 @@ module.exports = {
         require: false
       })
       .then(bookshelfUser => bookshelfUser.toDomainEntity());
+  },
+
+  hasRolePixMaster(userId) {
+    return this.get(userId)
+      .then(user => user.hasRolePixMaster);
   }
+
 };

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -29,7 +29,12 @@ describe('Integration | Repository | Organization', function() {
 
     it('should save model in database', () => {
       // given
-      const organization = new BookshelfOrganization({ code: 'AAAA99', name: 'Lycée Rousseau', type: 'SCO', email: 'a@b.fr' });
+      const organization = new BookshelfOrganization({
+        code: 'AAAA99',
+        name: 'Lycée Rousseau',
+        type: 'SCO',
+        email: 'a@b.fr'
+      });
 
       // when
       const promise = organizationRepository.saveFromModel(organization);

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -322,27 +322,39 @@ describe('Unit | Controller | organizationController', () => {
     });
 
     it('should retrieve organizations with one filter', () => {
+      // given
+      const userId = 1234;
+      const request = {
+        auth: { credentials: { userId: 1234 } },
+        query: { 'filter[query]': 'my search' }
+      };
+
       // when
-      const promise = organizationController.search({ query: { 'filter[query]': 'my search' } }, replyStub);
+      const promise = organizationController.search(request, replyStub);
 
       // then
       return promise.then(() => {
-        sinon.assert.calledWith(organizationService.search, { query: 'my search' });
+        sinon.assert.calledWith(organizationService.search, userId, { query: 'my search' });
       });
     });
 
     it('should retrieve organizations with two different filters', () => {
-      // when
-      const promise = organizationController.search({
+      // given
+      const userId = 1234;
+      const request = {
+        auth: { credentials: { userId } },
         query: {
           'filter[query]': 'my search',
           'filter[code]': 'with params'
         }
-      }, replyStub);
+      };
+
+      // when
+      const promise = organizationController.search(request, replyStub);
 
       // then
       return promise.then(() => {
-        sinon.assert.calledWith(organizationService.search, { query: 'my search', code: 'with params' });
+        sinon.assert.calledWith(organizationService.search, userId, { query: 'my search', code: 'with params' });
       });
     });
 
@@ -350,9 +362,13 @@ describe('Unit | Controller | organizationController', () => {
       // given
       const error = new Error('');
       organizationService.search.rejects(error);
+      const request = {
+        auth: { credentials: { userId: 1234 } },
+        query: { 'filter[first]': 'with params' }
+      };
 
       // when
-      const promise = organizationController.search({ query: { 'filter[first]': 'with params' } }, replyStub);
+      const promise = organizationController.search(request, replyStub);
 
       // then
       return promise.then(() => {
@@ -364,9 +380,13 @@ describe('Unit | Controller | organizationController', () => {
       // given
       const error = new Error('');
       organizationService.search.rejects(error);
+      const request = {
+        auth: { credentials: { userId: 1234 } },
+        query: { 'filter[first]': 'with params' }
+      };
 
       // when
-      const promise = organizationController.search({ query: { 'filter[first]': 'with params' } }, replyStub);
+      const promise = organizationController.search(request, replyStub);
 
       // then
       return promise.then(() => {
@@ -376,8 +396,14 @@ describe('Unit | Controller | organizationController', () => {
     });
 
     it('should serialize results', () => {
+      // given
+      const request = {
+        auth: { credentials: { userId: 1234 } },
+        query: { 'filter[first]': 'with params' }
+      };
+
       // when
-      const promise = organizationController.search({ query: { 'filter[first]': 'with params' } }, replyStub);
+      const promise = organizationController.search(request, replyStub);
 
       // then
       return promise.then(() => {

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -118,7 +118,7 @@ describe('Unit | Service | OrganizationService', () => {
     });
   });
 
-  describe('#search(userId, filters)', () => {
+  describe('#search', () => {
 
     let sandbox;
     const userId = 1234;

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -5,6 +5,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const organizationService = require('../../../../lib/domain/services/organization-service');
 const organisationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Unit | Service | OrganizationService', () => {
 
@@ -117,61 +118,107 @@ describe('Unit | Service | OrganizationService', () => {
     });
   });
 
-  describe('#search', () => {
+  describe('#search(userId, filters)', () => {
 
     let sandbox;
+    const userId = 1234;
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
+      sandbox.stub(userRepository, 'hasRolePixMaster');
+      sandbox.stub(organisationRepository, 'findBy');
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    it('should return an empty list of organizations if no code given in filters', () => {
-      // given
-      const filters = { param1: 'param1' };
+    context('when user has role PIX_MASTER', () => {
 
-      // when
-      const promise = organizationService.search(filters);
-
-      // then
-      return promise.then((organization) => {
-        expect(organization).to.be.an('array').that.is.empty;
+      beforeEach(() => {
+        userRepository.hasRolePixMaster.resolves(true);
       });
+
+      it('should return all the existing organizations', () => {
+        // given
+        const filters = {};
+        const organizations = [
+          new Organization({ name: 'organization_1', type: 'PRO', code: 'ORGA1' }),
+          new Organization({ name: 'organization_2', type: 'SCO', code: 'ORGA2' }),
+          new Organization({ name: 'organization_3', type: 'SUP', code: 'ORGA3' }),
+        ];
+        organisationRepository.findBy.withArgs(filters).resolves(organizations);
+
+        // when
+        const promise = organizationService.search(userId, filters);
+
+        // then
+        return promise.then((organizations) => {
+          expect(organizations).to.be.an('array');
+          expect(organizations).to.have.lengthOf(3);
+        });
+      });
+
     });
 
-    it('should return an empty list of organizations if a code is given but is empty', () => {
-      // given
-      const filters = { code: ' ' };
+    context('when user does not have role PIX_MASTER', () => {
 
-      // when
-      const promise = organizationService.search(filters);
+      beforeEach(() => {
+        userRepository.hasRolePixMaster.resolves(false);
+      });
 
-      // then
-      return promise.then((organization) => {
-        expect(organization).to.be.an('array').that.is.empty;
+      it('should return an empty list of organizations if no code given in filters', () => {
+        // given
+        const filters = { param1: 'param1' };
+
+        // when
+        const promise = organizationService.search(userId, filters);
+
+        // then
+        return promise.then((organization) => {
+          expect(organization).to.be.an('array').that.is.empty;
+        });
+      });
+
+      it('should return an empty list of organizations if a code is given but is empty', () => {
+        // given
+        const filters = { code: ' ' };
+
+        // when
+        const promise = organizationService.search(userId, filters);
+
+        // then
+        return promise.then((organization) => {
+          expect(organization).to.be.an('array').that.is.empty;
+        });
+      });
+
+      it('should return the organization found for the given filters, without the email', () => {
+        // given
+        const filters = { code: 'OE34RND', type: 'SCO' };
+        const organizationWithEmail = [new Organization({
+          type: 'SCO',
+          name: 'Lycée des Tuileries',
+          code: 'OE34RND',
+          email: 'tuileries@sco.com'
+        })];
+        const expectedReturnedOrganizationWithoutEmail = [new Organization({
+          type: 'SCO',
+          name: 'Lycée des Tuileries',
+          code: 'OE34RND'
+        })];
+
+        organisationRepository.findBy.withArgs(filters).resolves(organizationWithEmail);
+
+        // when
+        const promise = organizationService.search(userId, filters);
+
+        // then
+        return promise.then((organization) => {
+          expect(organization).to.deep.equal(expectedReturnedOrganizationWithoutEmail);
+        });
       });
     });
-
-    it('should return the organization found for the given filters, without the email', () => {
-      // given
-      const filters = { code: 'OE34RND', type: 'SCO' };
-      const organizationWithEmail = [new Organization({ type: 'SCO', name: 'Lycée des Tuileries', code: 'OE34RND', email: 'tuileries@sco.com' })];
-      const expectedReturnedOrganizationWithoutEmail = [new Organization({ type: 'SCO', name: 'Lycée des Tuileries', code: 'OE34RND' })];
-
-      sandbox.stub(organisationRepository, 'findBy').withArgs(filters).resolves(organizationWithEmail);
-
-      // when
-      const promise = organizationService.search(filters);
-
-      // then
-      return promise.then((organization) => {
-        expect(organization).to.deep.equal(expectedReturnedOrganizationWithoutEmail);
-      });
-    });
-
   });
 
 });

--- a/api/tests/unit/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/user-repository_test.js
@@ -3,19 +3,19 @@ const { expect, sinon } = require('../../../test-helper');
 const BookshelfUser = require('../../../../lib/infrastructure/data/user');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const DomainUser = require('../../../../lib/domain/models/User');
-const { NotFoundError } = require('../../../../lib/domain/errors');
+const { NotFoundError, UserNotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Infrastructure | Repository | UserRepository', () => {
 
+  beforeEach(() => {
+    sinon.stub(BookshelfUser.prototype, 'where');
+  });
+
+  afterEach(() => {
+    BookshelfUser.prototype.where.restore();
+  });
+
   describe('#get', () => {
-
-    beforeEach(() => {
-      sinon.stub(BookshelfUser.prototype, 'where');
-    });
-
-    afterEach(() => {
-      BookshelfUser.prototype.where.restore();
-    });
 
     it('should resolve a domain User matching its ID', () => {
       // given
@@ -51,6 +51,55 @@ describe('Unit | Infrastructure | Repository | UserRepository', () => {
         .catch(err => expect(err).to.be.an.instanceof(NotFoundError));
     });
 
+  });
+
+  describe('#hasRolePixMaster', () => {
+
+    it('should resolve true when user has role PIX_MASTER', () => {
+      // given
+      const userId = 1234;
+      const domainUser = new DomainUser({
+        id: userId,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'jdoe@example.net',
+        pixRoles: [{ name: 'PIX_MASTER' }],
+      });
+      const bookshelfUser = { toDomainEntity: () => domainUser };
+      const fetchStub = sinon.stub().resolves(bookshelfUser);
+      BookshelfUser.prototype.where.returns({ fetch: fetchStub });
+
+      // when
+      const promise = userRepository.hasRolePixMaster(userId);
+
+      // then
+      return promise.then(result => {
+        expect(result).to.be.true;
+      });
+    });
+
+    it('should resolve false when user does not have role PIX_MASTER', () => {
+      // given
+      const userId = 1234;
+      const domainUser = new DomainUser({
+        id: userId,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'jdoe@example.net',
+        pixRoles: [],
+      });
+      const bookshelfUser = { toDomainEntity: () => domainUser };
+      const fetchStub = sinon.stub().resolves(bookshelfUser);
+      BookshelfUser.prototype.where.returns({ fetch: fetchStub });
+
+      // when
+      const promise = userRepository.hasRolePixMaster(userId);
+
+      // then
+      return promise.then(result => {
+        expect(result).to.be.false;
+      });
+    });
   });
 
 });

--- a/api/tests/unit/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/user-repository_test.js
@@ -3,7 +3,7 @@ const { expect, sinon } = require('../../../test-helper');
 const BookshelfUser = require('../../../../lib/infrastructure/data/user');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const DomainUser = require('../../../../lib/domain/models/User');
-const { NotFoundError, UserNotFoundError } = require('../../../../lib/domain/errors');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Infrastructure | Repository | UserRepository', () => {
 


### PR DESCRIPTION
**Besoin fonctionnel**
L'objet de cette PR est de faire évoluer la route `GET /organizations`.

Actuellement, cette route remonte un tableau avec 1 seule organisation pour un utilisateur de type prescripteur (possédant une organization). Si l'utilisateur n'est pas associé à une organisation, on lui retourne un tableau vide.

Dans le cadre de Pix Admin, on a désormais besoin de remonter toutes les organisations afin de les afficher, mais seulement pour un Pix Master.

**Cas métiers**
- si on est ni Pix Master et qu'on n'a pas saisi de code orga (on n'est pas prescripteur) => renvoie tableau vide
- si on est Pix Master => renvoie TOUTES les organisations
- si on est prescripteur => renvoie seulement les informations de l'organisation concernée

**Détails d'implémentation**
Il m'a semblé plus judicieux de mettre la logique qui vérifie si on est un Pix Master dans le service plutôt que le controller. Ce sera plus facile quand on voudra faire la bascule en Use Case de ce bout de code (que je n'ai pas voulu faire dans le cadre de cette PR, pour limiter les impacts de Pix Admin sur Pix.fr).

Par ailleurs, La route étant protégée (il faut absolument être connecté, avec un access_token et un userId dans la requête), j'ai pu facilement récupérer le `userId` qu'on passe désormais en paramètre de la méthode  `organization-service#search`.

J'en ai profité pour créer une nouvelle méthode dans le repository : `user-repository#hasRolePixMaster`. J'avoue que je ne me suis pas pris la tête, et je l'ai faite appeler directement la méthode `user-repository#get` un peu plus haut. Au moins elle est testée et on pourra la refactorer facilement.