### PR TITLE
[#46][BSR] Pointer l'url d'intégration vers integration.pix.fr

### DIFF
--- a/live/scripts/signal_deploy_to_pr.sh
+++ b/live/scripts/signal_deploy_to_pr.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-[ -z $GITHUB_TOKEN ] && {
-	echo 'FATAL: $GITHUB_TOKEN is absent'
+[ -z $GITHUB_USER ] && {
+	echo 'FATAL: $GITHUB_USER is absent'
+	exit 1
+}
+
+[ -z $GITHUB_USER_TOKEN ] && {
+	echo 'FATAL: $GITHUB_USER_TOKEN is absent'
 	exit 1
 }
 [ -z $CIRCLE_BRANCH ] && {
@@ -15,8 +20,8 @@
 
 PR_NUMBER=`echo $CI_PULL_REQUEST | grep -Po '(?<=pix/pull/)(\d+)'`
 
-curl -u mackwic:$GITHUB_TOKEN --verbose \
+curl -u $GITHUB_USER:$GITHUB_USER_TOKEN --verbose \
 	-X POST "https://api.github.com/repos/1024pix/pix/issues/${PR_NUMBER}/comments" \
-	--data "{\"body\":\"I've deployed this PR to http://${CIRCLE_BRANCH}.pix-dev.ovh . Please check it out\"}"
+	--data "{\"body\":\"I've deployed this PR to http://${CIRCLE_BRANCH}.integration.pix.fr . Please check it out\"}"
 
 

--- a/scripts/trello/comment_with_review_app_url.sh
+++ b/scripts/trello/comment_with_review_app_url.sh
@@ -24,7 +24,7 @@ fi
 
 CARD_ID=$(echo $RESPONSE | jq .id | tr -d '"')
 CARD_COMMENTS=$(curl "$API_URL/cards/$CARD_ID/actions?$CREDENTIALS" | jq '.[].data.text')
-REVIEW_APP_URL="http://$CIRCLE_BRANCH.pix-dev.ovh"
+REVIEW_APP_URL="http://$CIRCLE_BRANCH.integration.pix.fr"
 if [[ $CARD_COMMENTS =~ .*$REVIEW_APP_URL.* ]]
 then
     echo "Review app url already found in card comments. No need to add it again"


### PR DESCRIPTION
et utiliser le compte de service pour les notifications Github

J'ai changé le nom de la variable de token pour ne pas casser la build avant de merge. On supprimera la variable en trop quand cette PR sera sur dev.