### PR TITLE
[#62] [FEATURE] Ajout d'une URL pour lancer un test de campagne avec l'algo Smart Random (PF-57).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -27,6 +27,10 @@ module.exports = {
     const assessment = assessmentSerializer.deserialize(request.payload);
     assessment.state = 'started';
 
+    if(assessment.type === 'SMART_PLACEMENT') {
+      assessment.courseId = 'recNPB7dTNt5krlMA';
+    }
+
     if (request.headers.hasOwnProperty('authorization')) {
       const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
       const userId = tokenService.extractUserId(token);

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -113,6 +113,18 @@ module.exports = {
             competenceRepository
           });
         }
+
+        if (assessmentService.isSmartPlacementAssessment(assessment)) {
+          return useCases.getNextChallengeForSmartPlacement({
+            assessment,
+            courseRepository,
+            answerRepository,
+            challengeRepository,
+            skillRepository,
+            competenceRepository
+          });
+        }
+
       })
       .then((challenge) => {
         reply(challengeSerializer.serialize(challenge));

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -270,6 +270,10 @@ function isPlacementAssessment(assessment) {
   return assessment.type === 'PLACEMENT';
 }
 
+function isSmartPlacementAssessment(assessment) {
+  return assessment.type === 'SMART_PLACEMENT';
+}
+
 module.exports = {
   fetchAssessment,
   findByFilters,
@@ -277,6 +281,7 @@ module.exports = {
   isPlacementAssessment,
   isDemoAssessment,
   isCertificationAssessment,
+  isSmartPlacementAssessment,
   getScoreAndLevel,
   getSkills,
   getCompetenceMarks,

--- a/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
@@ -1,0 +1,43 @@
+const { AssessmentEndedError } = require('../errors');
+
+const assessmentAdapter = require('../../infrastructure/adapters/assessment-adapter');
+const _ = require('lodash');
+
+module.exports = function({
+  assessment,
+  courseRepository,
+  answerRepository,
+  challengeRepository,
+  skillRepository,
+  competenceRepository
+} = {}) {
+
+  const courseId = assessment.courseId;
+  let answers, challenges, competence, course;
+
+  return courseRepository.get(courseId)
+    .then(fetchedCourse => (course = fetchedCourse))
+    .then(() => answerRepository.findByAssessment(assessment.id))
+    .then(fetchedAnswers => (answers = fetchedAnswers))
+    .then(() => competenceRepository.get(course.competences[0]))
+    .then((fetchedCompetence) => (competence = fetchedCompetence))
+    .then(() => challengeRepository.findByCompetence(competence))
+    .then(fetchedChallenges => (challenges = fetchedChallenges))
+    .then(() => skillRepository.findByCompetence(competence))
+    .then(skills => getNextChallengeInAdaptiveCourse(answers, challenges, skills))
+    .then((nextChallenge) => {
+      if (nextChallenge) {
+        return nextChallenge;
+      }
+
+      throw new AssessmentEndedError();
+    })
+    .then(challengeRepository.get);
+
+};
+
+function getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills) {
+  const assessment = assessmentAdapter.getSmartAssessment(answersPix, challengesPix, skills);
+  return _.get(assessment, 'nextChallenge.id', null);
+}
+

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -4,6 +4,7 @@ const getNextChallengeForPreview = require('./get-next-challenge-for-preview');
 const getNextChallengeForCertification = require('./get-next-challenge-for-certification');
 const getNextChallengeForDemo = require('./get-next-challenge-for-demo');
 const getNextChallengeForPlacement = require('./get-next-challenge-for-placement');
+const getNextChallengeForSmartPlacement = require('./get-next-challenge-for-smart-placement');
 const findCompletedUserCertifications = require('./find-completed-user-certifications');
 
 module.exports = {
@@ -13,5 +14,6 @@ module.exports = {
   getNextChallengeForPreview,
   getNextChallengeForCertification,
   getNextChallengeForDemo,
-  getNextChallengeForPlacement
+  getNextChallengeForPlacement,
+  getNextChallengeForSmartPlacement
 };

--- a/api/lib/infrastructure/adapters/assessment-adapter.js
+++ b/api/lib/infrastructure/adapters/assessment-adapter.js
@@ -3,6 +3,11 @@ const CatChallenge = require('../../cat/challenge');
 const CatCourse = require('../../cat/course');
 const CatAnswer = require('../../cat/answer');
 const CatAssessment = require('../../cat/assessment');
+const SmartSkill = require('../../smart_random/skill');
+const SmartChallenge = require('../../smart_random/challenge');
+const SmartCourse = require('../../smart_random/course');
+const SmartAnswer = require('../../smart_random/answer');
+const SmartAssessment = require('../../smart_random/assessment');
 
 // TODO: Déclencher une erreur quand pas de skill ?
 
@@ -28,6 +33,29 @@ function getAdaptedAssessment(answersPix, challengesPix, skills) {
   return new CatAssessment(course, answers);
 }
 
+function getSmartAssessment(answersPix, challengesPix, skills) {
+  const challenges = [];
+
+  challengesPix.forEach(challengePix => {
+    if(challengePix.skills) {
+      const challengeSmartSkills = challengePix.skills.map(skill => new SmartSkill(skill.name));
+      const challenge = new SmartChallenge(challengePix.id, challengePix.status, challengeSmartSkills, challengePix.timer);
+      challenges.push(challenge);
+    }
+  });
+
+  const catSkills = skills.map(skill => new SmartSkill(skill.name));
+  const course = new SmartCourse(challenges, catSkills);
+
+  const answers = answersPix.map(answer => {
+    const challengeOfTheAnswer = challenges.find((challenge) => challenge.id === answer.challengeId);
+    return new SmartAnswer(challengeOfTheAnswer, answer.result.status);
+  });
+
+  return new SmartAssessment(course, answers);
+}
+
 module.exports = {
-  getAdaptedAssessment
+  getAdaptedAssessment,
+  getSmartAssessment
 };

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -86,13 +86,18 @@ class AssessmentSerializer extends JSONAPISerializer {
   }
 
   deserialize(json) {
+    let courseId;
+    if (json.data.attributes.type === 'SMART_PLACEMENT') {
+      courseId = null;
+    } else {
+      courseId = json.data.relationships.course.data.id;
+    }
     return new Assessment({
       id: json.data.id,
-      type : json.data.attributes.type,
-      courseId: json.data.relationships.course.data.id
+      type: json.data.attributes.type,
+      courseId
     });
   }
-
 }
 
 module.exports = new AssessmentSerializer();

--- a/api/lib/smart_random/answer.js
+++ b/api/lib/smart_random/answer.js
@@ -1,0 +1,32 @@
+const AnswerStatus = require('../domain/models/AnswerStatus');
+const BASE_DIFFICULTY = 2;
+class Answer {
+  constructor(challenge, result) {
+    this.challenge = this._getValidChallenge(challenge);
+    this.result = result;
+  }
+  _getValidChallenge(challenge) {
+    return challenge || {
+      id: null,
+      status: 'archive',
+      skills: [],
+      timer: null,
+    };
+  }
+
+  get binaryOutcome() {
+    return AnswerStatus.isOK(this.result) ? 1 : 0;
+  }
+
+  get maxDifficulty() {
+    const difficulties = this.challenge.skills.map(skill => skill.difficulty);
+    if (difficulties.length > 0) {
+      return Math.max(...difficulties);
+    } else {
+      // XXX : to avoid problem when challenge has no skill/ when we cannot get challenge
+      return BASE_DIFFICULTY;
+    }
+  }
+}
+
+module.exports = Answer;

--- a/api/lib/smart_random/assessment.js
+++ b/api/lib/smart_random/assessment.js
@@ -2,7 +2,7 @@ const AnswerStatus = require('../domain/models/AnswerStatus');
 
 const MAX_REACHABLE_LEVEL = 5;
 const NB_PIX_BY_LEVEL = 8;
-const MAX_NUMBER_OF_CHALLENGES = 20;
+const MAX_NUMBER_OF_CHALLENGES = 5;
 const LEVEL_FOR_FIRST_CHALLENGE = 2;
 
 class Assessment {

--- a/api/lib/smart_random/assessment.js
+++ b/api/lib/smart_random/assessment.js
@@ -1,0 +1,193 @@
+const AnswerStatus = require('../domain/models/AnswerStatus');
+
+const MAX_REACHABLE_LEVEL = 5;
+const NB_PIX_BY_LEVEL = 8;
+const MAX_NUMBER_OF_CHALLENGES = 20;
+const LEVEL_FOR_FIRST_CHALLENGE = 2;
+
+class Assessment {
+  constructor(course, answers) {
+    this.course = course;
+    this.answers = answers;
+  }
+
+  _randomly()  { return 0.5 - Math.random(); }
+
+  _probaOfCorrectAnswer(level, difficulty) {
+    return 1 / (1 + Math.exp(-(level - difficulty)));
+  }
+
+  _computeLikelihood(level, answers) {
+    const extraAnswers = answers.map(answer => {
+      return { binaryOutcome: answer.binaryOutcome, maxDifficulty: answer.maxDifficulty };
+    });
+
+    const answerThatAnyoneCanSolve = { maxDifficulty: 0, binaryOutcome: 1 };
+    const answerThatNobodyCanSolve = { maxDifficulty: 7, binaryOutcome: 0 };
+    extraAnswers.push(answerThatAnyoneCanSolve, answerThatNobodyCanSolve);
+
+    const diffBetweenResultAndProbaToResolve = extraAnswers.map(answer =>
+      answer.binaryOutcome - this._probaOfCorrectAnswer(level, answer.maxDifficulty));
+
+    return -Math.abs(diffBetweenResultAndProbaToResolve.reduce((a, b) => a + b));
+  }
+
+  _isChallengeNotAnsweredYet(challenge, answeredChallenges) {
+    return !answeredChallenges.includes(challenge);
+  }
+
+  _isAnAvailableChallenge(challenge) {
+    const answeredChallenges = this.answers.map(answer => answer.challenge);
+    return challenge.isActive && this._isChallengeNotAnsweredYet(challenge, answeredChallenges);
+  }
+
+  _isPreviousChallengeTimed() {
+    const answeredChallenges = this.answers.map(answer => answer.challenge);
+    const lastAnswer = this.answers[answeredChallenges.length - 1];
+    return lastAnswer && lastAnswer.challenge.timer !== undefined;
+  }
+
+  _extractNotTimedChallenge(availableChallenges) {
+    return availableChallenges.filter(challenge => challenge.timer === undefined);
+  }
+
+  _skillNotKnownYet(skill) {
+    return !this.validatedSkills.includes(skill) && !this.failedSkills.includes(skill);
+  }
+
+  _getNewSkillsInfoIfChallengeSolved(challenge) {
+    return challenge.skills.reduce((extraValidatedSkills,skill) => {
+      skill.getEasierWithin(this.course.tubes).forEach(skill => {
+        if(this._skillNotKnownYet(skill)) {
+          extraValidatedSkills.push(skill);
+        }
+      });
+      return extraValidatedSkills;
+    }, []);
+  }
+
+  _getNewSkillsInfoIfChallengeUnsolved(challenge) {
+    return challenge.hardestSkill.getHarderWithin(this.course.tubes)
+      .reduce((extraFailedSkills, skill) => {
+        if(this._skillNotKnownYet(skill)) {
+          extraFailedSkills.push(skill);
+        }
+        return extraFailedSkills;
+      }, []);
+  }
+
+  _computeReward(challenge, predictedLevel) {
+    const proba = this._probaOfCorrectAnswer(predictedLevel, challenge.hardestSkill.difficulty);
+    const nbExtraSkillsIfSolved = this._getNewSkillsInfoIfChallengeSolved(challenge).length;
+    const nbFailedSkillsIfUnsolved = this._getNewSkillsInfoIfChallengeUnsolved(challenge).length;
+    return proba * nbExtraSkillsIfSolved + (1 - proba) * nbFailedSkillsIfUnsolved;
+  }
+
+  get validatedSkills() {
+    return this.answers
+      .filter(answer => AnswerStatus.isOK(answer.result))
+      .reduce((skills, answer) => {
+        answer.challenge.skills.forEach(skill => {
+          skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
+            if(!skills.includes(validatedSkill))
+              skills.push(validatedSkill);
+          });
+        });
+        return skills;
+      }, []);
+  }
+
+  get failedSkills() {
+    return this.answers
+      .filter(answer => AnswerStatus.isFailed(answer.result))
+      .reduce((failedSkills, answer) => {
+        // FIXME refactor !
+        // XXX we take the current failed skill and all the harder skills in
+        // its tube and mark them all as failed
+        answer.challenge.skills.forEach(skill => {
+          skill.getHarderWithin(this.course.tubes).forEach(failedSkill => {
+            if(!failedSkills.includes(failedSkill))
+              failedSkills.push(failedSkill);
+          });
+        });
+        return failedSkills;
+      }, []);
+  }
+
+  _getPredictedLevel() {
+    if (this.answers.length === 0) {
+      return LEVEL_FOR_FIRST_CHALLENGE;
+    }
+    let maxLikelihood = -Infinity;
+    let level = 0.5;
+    let predictedLevel = 0.5;
+    // XXX : Question : why 8  when max level is 5 ?
+    while (level < 8) {
+      const likelihood = this._computeLikelihood(level, this.answers);
+      if (likelihood > maxLikelihood) {
+        maxLikelihood = likelihood;
+        predictedLevel = level;
+      }
+      level += 0.5;
+    }
+    return predictedLevel;
+  }
+
+  get filteredChallenges() {
+    let availableChallenges = this.course.challenges.filter(challenge => this._isAnAvailableChallenge(challenge));
+    availableChallenges = this._isPreviousChallengeTimed() ? this._extractNotTimedChallenge(availableChallenges) : availableChallenges;
+    return availableChallenges;
+  }
+
+  get _firstChallenge() {
+    const filteredFirstChallenges = this.filteredChallenges.filter(
+      challenge => (challenge.hardestSkill.difficulty === LEVEL_FOR_FIRST_CHALLENGE) && (challenge.timer === undefined)
+    );
+    filteredFirstChallenges.sort(this._randomly);
+    return filteredFirstChallenges[0];
+  }
+
+  get nextChallenge() {
+    if (this.answers.length === 0) {
+      return this._firstChallenge;
+    }
+    if (this.answers.length >= MAX_NUMBER_OF_CHALLENGES) {
+      return null;
+    }
+
+    const byDescendingRewards = (a, b) => { return b.reward - a.reward; };
+    const predictedLevel = this._getPredictedLevel();
+    const challengesAndRewards = this.filteredChallenges.map(challenge => {
+      return { challenge: challenge, reward: this._computeReward(challenge, predictedLevel) };
+    });
+    const challengeWithMaxReward = challengesAndRewards.sort(byDescendingRewards)[0];
+    const maxReward = challengeWithMaxReward.reward;
+
+    if (maxReward === 0) {
+      return null;
+    }
+
+    const bestChallenges = challengesAndRewards
+      .filter(challengeAndReward => challengeAndReward.reward === maxReward)
+      .map(challengeAndReward => challengeAndReward.challenge);
+    return bestChallenges.sort(this._randomly)[0];
+  }
+
+  get pixScore() {
+    const pixScoreOfSkills = this.course.computePixScoreOfSkills();
+    return this.validatedSkills
+      .map(skill => pixScoreOfSkills[skill.name] || 0)
+      .reduce((a, b) => a + b, 0);
+  }
+
+  get displayedPixScore() {
+    return Math.floor(this.pixScore);
+  }
+
+  get obtainedLevel() {
+    const estimatedLevel = Math.floor(this.pixScore / NB_PIX_BY_LEVEL);
+    return (estimatedLevel >= MAX_REACHABLE_LEVEL) ? MAX_REACHABLE_LEVEL : estimatedLevel;
+  }
+}
+
+module.exports = Assessment;

--- a/api/lib/smart_random/assessment.js
+++ b/api/lib/smart_random/assessment.js
@@ -1,9 +1,11 @@
 const AnswerStatus = require('../domain/models/AnswerStatus');
+const _ = require('lodash');
 
 const MAX_REACHABLE_LEVEL = 5;
 const NB_PIX_BY_LEVEL = 8;
 const MAX_NUMBER_OF_CHALLENGES = 5;
 const LEVEL_FOR_FIRST_CHALLENGE = 2;
+const LEVEL_MAX_TO_BE_AN_EASY_TUBE = 3;
 
 class Assessment {
   constructor(course, answers) {
@@ -11,7 +13,9 @@ class Assessment {
     this.answers = answers;
   }
 
-  _randomly()  { return 0.5 - Math.random(); }
+  _randomly() {
+    return 0.5 - Math.random();
+  }
 
   _probaOfCorrectAnswer(level, difficulty) {
     return 1 / (1 + Math.exp(-(level - difficulty)));
@@ -36,6 +40,10 @@ class Assessment {
     return !answeredChallenges.includes(challenge);
   }
 
+  _isChallengeNotTooHard(challenge) {
+    return challenge.hardestSkill.difficulty - this._getPredictedLevel() <= 2;
+  }
+
   _isAnAvailableChallenge(challenge) {
     const answeredChallenges = this.answers.map(answer => answer.challenge);
     return challenge.isActive && this._isChallengeNotAnsweredYet(challenge, answeredChallenges);
@@ -56,9 +64,9 @@ class Assessment {
   }
 
   _getNewSkillsInfoIfChallengeSolved(challenge) {
-    return challenge.skills.reduce((extraValidatedSkills,skill) => {
+    return challenge.skills.reduce((extraValidatedSkills, skill) => {
       skill.getEasierWithin(this.course.tubes).forEach(skill => {
-        if(this._skillNotKnownYet(skill)) {
+        if (this._skillNotKnownYet(skill)) {
           extraValidatedSkills.push(skill);
         }
       });
@@ -69,7 +77,7 @@ class Assessment {
   _getNewSkillsInfoIfChallengeUnsolved(challenge) {
     return challenge.hardestSkill.getHarderWithin(this.course.tubes)
       .reduce((extraFailedSkills, skill) => {
-        if(this._skillNotKnownYet(skill)) {
+        if (this._skillNotKnownYet(skill)) {
           extraFailedSkills.push(skill);
         }
         return extraFailedSkills;
@@ -89,7 +97,7 @@ class Assessment {
       .reduce((skills, answer) => {
         answer.challenge.skills.forEach(skill => {
           skill.getEasierWithin(this.course.tubes).forEach(validatedSkill => {
-            if(!skills.includes(validatedSkill))
+            if (!skills.includes(validatedSkill))
               skills.push(validatedSkill);
           });
         });
@@ -106,7 +114,7 @@ class Assessment {
         // its tube and mark them all as failed
         answer.challenge.skills.forEach(skill => {
           skill.getHarderWithin(this.course.tubes).forEach(failedSkill => {
-            if(!failedSkills.includes(failedSkill))
+            if (!failedSkills.includes(failedSkill))
               failedSkills.push(failedSkill);
           });
         });
@@ -133,10 +141,61 @@ class Assessment {
     return predictedLevel;
   }
 
+  _skillsToTargetInPriority() {
+    const courseTubes = this.course.tubes;
+    let skillsToTargetInPriority = [];
+
+    for (const tube in courseTubes) {
+      const listOfSkillsForThisTube = courseTubes[tube];
+
+      const mostDifficultSkill = listOfSkillsForThisTube.sort((a, b) => a.difficulty < b.difficulty)[0];
+
+      if (mostDifficultSkill.difficulty <= LEVEL_MAX_TO_BE_AN_EASY_TUBE) {
+
+        const nbSkillsNotEvaluated = listOfSkillsForThisTube.filter((skill) => {
+          return this._skillNotKnownYet(skill);
+        }).length;
+
+        if (nbSkillsNotEvaluated !== 0) {
+          skillsToTargetInPriority = skillsToTargetInPriority.concat(courseTubes[tube]);
+        }
+      }
+    }
+
+    return skillsToTargetInPriority;
+  }
+
   get filteredChallenges() {
     let availableChallenges = this.course.challenges.filter(challenge => this._isAnAvailableChallenge(challenge));
-    availableChallenges = this._isPreviousChallengeTimed() ? this._extractNotTimedChallenge(availableChallenges) : availableChallenges;
+
+    if (this._isPreviousChallengeTimed()) {
+      availableChallenges = this._extractNotTimedChallenge(availableChallenges);
+    }
+
+    availableChallenges = availableChallenges.filter(challenge => this._isChallengeNotTooHard(challenge));
+
+    const listOfSkillsToTargetInPriority = this._skillsToTargetInPriority();
+    if (listOfSkillsToTargetInPriority.length > 0) {
+      availableChallenges = this._filterChallengesBySkills(availableChallenges, listOfSkillsToTargetInPriority);
+    }
+
     return availableChallenges;
+  }
+
+  _filterChallengesBySkills(listOfChallenges, listOfRequiredSkills) {
+    return listOfChallenges.filter((challenge) => {
+
+      let challengeContainsTargetedSkill = false;
+
+      listOfRequiredSkills.map((skill) => skill.name).forEach((skillName) => {
+        const challengeHasSkill = challenge.skills.map((skill) => skill.name).includes(skillName);
+        if (challengeHasSkill) {
+          challengeContainsTargetedSkill = true;
+        }
+      });
+
+      return challengeContainsTargetedSkill;
+    });
   }
 
   get _firstChallenge() {
@@ -148,19 +207,29 @@ class Assessment {
   }
 
   get nextChallenge() {
+
     if (this.answers.length === 0) {
       return this._firstChallenge;
     }
+
     if (this.answers.length >= MAX_NUMBER_OF_CHALLENGES) {
       return null;
     }
 
-    const byDescendingRewards = (a, b) => { return b.reward - a.reward; };
+    const availableChallenges = this.filteredChallenges;
+    if (availableChallenges.length === 0) {
+      return null;
+    }
+
     const predictedLevel = this._getPredictedLevel();
-    const challengesAndRewards = this.filteredChallenges.map(challenge => {
-      return { challenge: challenge, reward: this._computeReward(challenge, predictedLevel) };
+    const challengesAndRewards = availableChallenges.map(challenge => {
+      return {
+        challenge: challenge,
+        reward: this._computeReward(challenge, predictedLevel)
+      };
     });
-    const challengeWithMaxReward = challengesAndRewards.sort(byDescendingRewards)[0];
+
+    const challengeWithMaxReward = _.maxBy(challengesAndRewards, 'reward');
     const maxReward = challengeWithMaxReward.reward;
 
     if (maxReward === 0) {

--- a/api/lib/smart_random/challenge.js
+++ b/api/lib/smart_random/challenge.js
@@ -1,0 +1,20 @@
+class Challenge {
+
+  constructor(id, status, skills, timer) {
+    this.id = id;
+    this.status = status;
+    this.skills = skills;
+    this.timer = timer;
+  }
+
+  get isActive() {
+    const unactiveChallengeStatus = ['validé', 'validé sans test', 'pré-validé'];
+    return unactiveChallengeStatus.includes(this.status);
+  }
+
+  get hardestSkill() {
+    return this.skills.reduce((s1, s2) => (s1.difficulty > s2.difficulty) ? s1 : s2);
+  }
+}
+
+module.exports = Challenge;

--- a/api/lib/smart_random/course.js
+++ b/api/lib/smart_random/course.js
@@ -1,0 +1,43 @@
+const _ = require('lodash');
+
+class Course {
+  constructor(challenges, competenceSkills) {
+    this.challenges = challenges;
+    this.competenceSkills = competenceSkills;
+  }
+
+  get tubes() {
+    const tubes = {};
+
+    this.challenges.forEach(challenge => {
+      challenge.skills.forEach(skill => {
+        const tubeName = skill.tubeName;
+
+        if(!tubes[tubeName]) tubes[tubeName] = [];
+
+        if(!_.find(tubes[tubeName], skill)) tubes[tubeName].push(skill);
+      });
+    });
+    Object.keys(tubes).forEach(tubeName =>  {
+      tubes[tubeName] = _.sortBy(tubes[tubeName], ['difficulty']);
+    });
+    return tubes;
+  }
+
+  computePixScoreOfSkills() {
+    const pixScoreOfSkills = {};
+    const maxDifficulty = 8;
+    const numberOfSkillsByDifficulty = [];
+
+    for (let levelDifficulty = 0; levelDifficulty < maxDifficulty; levelDifficulty++) {
+      numberOfSkillsByDifficulty[levelDifficulty] = _.filter(this.competenceSkills, skill => skill.difficulty === levelDifficulty).length;
+    }
+    this.competenceSkills.forEach(skill => {
+      pixScoreOfSkills[skill.name] = Math.min(4, 8 / numberOfSkillsByDifficulty[skill.difficulty]);
+    });
+    return pixScoreOfSkills;
+  }
+}
+
+module.exports = Course;
+

--- a/api/lib/smart_random/skill.js
+++ b/api/lib/smart_random/skill.js
@@ -1,0 +1,17 @@
+class Skill {
+  constructor(name) {
+    this.name = name;
+    this.tubeName = name.slice(0, -1);
+    this.difficulty = parseInt(name.slice(-1));
+  }
+
+  getEasierWithin(tubes) {
+    return tubes[this.tubeName].filter(skill => skill.difficulty <= this.difficulty);
+  }
+
+  getHarderWithin(tubes) {
+    return tubes[this.tubeName].filter(skill => skill.difficulty >= this.difficulty);
+  }
+}
+
+module.exports = Skill;

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -70,6 +70,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       sandbox.stub(usecases, 'getNextChallengeForCertification').resolves();
       sandbox.stub(usecases, 'getNextChallengeForDemo').resolves();
+      sandbox.stub(usecases, 'getNextChallengeForSmartPlacement').resolves();
       sandbox.stub(certificationChallengeRepository, 'getNonAnsweredChallengeByCourseId').resolves();
     });
 
@@ -234,6 +235,27 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         return promise.then(() => {
           expect(replyStub).to.have.been.calledOnce
             .and.to.have.been.calledWith(Boom.notFound());
+        });
+      });
+    });
+
+    describe('when the assessment is a smart placement assessment', () => {
+      beforeEach(() => {
+        assessmentRepository.get.resolves(new Assessment({
+          id: 1,
+          courseId: 'courseId',
+          userId: 5,
+          type: 'SMART_PLACEMENT'
+        }));
+      });
+
+      it('should call the usecase getNextChallengeForSmartPlacement', () => {
+        // when
+        const promise = assessmentController.getNextChallenge({ params: { id: 1 } }, replyStub);
+
+        // then
+        return promise.then(() => {
+          expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledOnce;
         });
       });
     });

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -29,6 +29,39 @@ describe('Unit | Controller | assessment-controller-save', () => {
       sandbox.restore();
     });
 
+    context('when the assessment saved is a smart placement', () => {
+
+      const request = {
+        headers: {
+          authorization: 'Bearer my-token'
+        },
+        payload: {
+          data: {
+            id: 42,
+            attributes: {
+              'type' : 'SMART_PLACEMENT'
+            }
+          }
+        }
+      };
+
+      beforeEach(() => {
+        sandbox.stub(assessmentRepository, 'save').resolves();
+      });
+
+      it('should save an assessment with the type SMART_PLACEMENT and the courseId of 1.1', function() {
+        // given
+        const expected = new Assessment({ id: 42, courseId: 'recNPB7dTNt5krlMA', type: 'SMART_PLACEMENT', state: 'started', userId: null });
+
+        // when
+        controller.save(request, replyStub);
+
+        // then
+        sinon.assert.calledOnce(assessmentRepository.save);
+        return expect(assessmentRepository.save).to.have.been.calledWith(expected);
+      });
+    });
+
     context('when the assessment saved is a certification test', () => {
 
       const request = {

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -1131,7 +1131,7 @@ describe('Unit | Domain | Services | assessment', () => {
       expect(isPlacementAssessment).to.be.true;
     });
 
-    it('should return true when the assessment is not defined', () => {
+    it('should return false when the assessment is not defined', () => {
       // given
       const assessment = new Assessment({ type: '' });
 
@@ -1140,6 +1140,42 @@ describe('Unit | Domain | Services | assessment', () => {
 
       // then
       expect(isPlacementTest).to.be.false;
+    });
+
+  });
+
+  describe('#isSmartPlacementAssessment', () => {
+    it('should return true when the assessment is a SMART_PLACEMENT', () => {
+      // given
+      const assessment = new Assessment({ type: 'SMART_PLACEMENT' });
+
+      // when
+      const isSmartPlacementAssessment = service.isSmartPlacementAssessment(assessment);
+
+      // then
+      expect(isSmartPlacementAssessment).to.be.true;
+    });
+
+    it('should return false when the assessment is not a SMART_PLACEMENT', () => {
+      // given
+      const assessment = new Assessment({ type: 'PLACEMENT' });
+
+      // when
+      const isSmartPlacementAssessment = service.isSmartPlacementAssessment(assessment);
+
+      // then
+      expect(isSmartPlacementAssessment).to.be.false;
+    });
+
+    it('should return false when the assessment has no type', () => {
+      // given
+      const assessment = new Assessment({});
+
+      // when
+      const isSmartPlacementAssessment = service.isSmartPlacementAssessment(assessment);
+
+      // then
+      expect(isSmartPlacementAssessment).to.be.false;
     });
 
   });

--- a/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
@@ -6,6 +6,11 @@ const CatCourse = require('../../../../lib/cat/course');
 const CatSkill = require('../../../../lib/cat/skill');
 const CatChallenge = require('../../../../lib/cat/challenge');
 const CatAnswer = require('../../../../lib/cat/answer');
+const SmartSkill = require('../../../../lib/smart_random/skill');
+const SmartChallenge = require('../../../../lib/smart_random/challenge');
+const SmartCourse = require('../../../../lib/smart_random/course');
+const SmartAnswer = require('../../../../lib/smart_random/answer');
+const SmartAssessment = require('../../../../lib/smart_random/assessment');
 const Answer = require('../../../../lib/domain/models/Answer');
 
 describe('Unit | Adapter | Assessment', () => {
@@ -126,6 +131,125 @@ describe('Unit | Adapter | Assessment', () => {
         // then
         const { answers } = adaptedAssessment;
         expect(answers).to.deep.equal([new CatAnswer(new CatChallenge(256, 'validé', [], 26), '#ABAND#')]);
+      });
+    });
+  });
+  describe('#getSmartAssessment', () => {
+
+    it('should return an Assessment from the Smart repository', () => {
+      // given
+      const skills = [];
+      const challenges = [];
+      const answers = [];
+
+      // when
+      const adaptedAssessment = assessmentAdapter.getSmartAssessment(answers, challenges, skills);
+
+      // then
+      expect(adaptedAssessment).to.be.an.instanceOf(SmartAssessment);
+    });
+
+    it('should add a course with a list of skills', () => {
+      // given
+      const web3Skill = { name: 'web3' };
+      const skills = [web3Skill];
+      const challenges = [];
+      const answers = [];
+
+      // when
+      const adaptedAssessment = assessmentAdapter.getSmartAssessment(answers, challenges, skills);
+
+      // then
+      expect(adaptedAssessment).to.have.property('course').and.to.be.an.instanceOf(SmartCourse);
+
+      const { course } = adaptedAssessment;
+      expect(course).to.have.property('competenceSkills').and.to.be.an.instanceOf(Array);
+
+      const expectedSetOfSkills = [new SmartSkill('web3')];
+      expect(course.competenceSkills).to.deep.equal(expectedSetOfSkills);
+    });
+
+    describe('the assessment\'s course ', () => {
+
+      it('should have an array of challenges', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [],
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getSmartAssessment(answers, challenges, skills);
+
+        // then
+        const { course } = adaptedAssessment;
+        expect(course).to.have.property('challenges');
+        expect(course.challenges[0]).to.deep.equal(new SmartChallenge(256, 'validé', [], 26));
+      });
+
+      it('should not select challenges without skills', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getSmartAssessment(answers, challenges, skills);
+
+        // then
+        const { course } = adaptedAssessment;
+        expect(course).to.have.property('challenges');
+        expect(course.challenges).to.have.lengthOf(0);
+      });
+
+      it('should have challenges with skills', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [{ name: 'url6' }],
+          timer: 26
+        }];
+        const answers = [];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getSmartAssessment(answers, challenges, skills);
+
+        // then
+        const challenge  = adaptedAssessment.course.challenges[0];
+        expect(challenge.skills).to.deep.equal([new SmartSkill('url6')]);
+      });
+    });
+
+    describe('the assessment\'s answers', () => {
+
+      it('should have an array of challenges', () => {
+        // given
+        const skills = [];
+        const challenges = [{
+          id: 256,
+          status: 'validé',
+          skills: [],
+          timer: 26
+        }];
+
+        const answersGiven = [new Answer({ id: 42, challengeId: 256, result: '#ABAND#' })];
+
+        // when
+        const adaptedAssessment = assessmentAdapter.getSmartAssessment(answersGiven, challenges, skills);
+
+        // then
+        const { answers } = adaptedAssessment;
+        expect(answers).to.deep.equal([new SmartAnswer(new SmartChallenge(256, 'validé', [], 26), '#ABAND#')]);
       });
     });
   });

--- a/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
@@ -14,25 +14,25 @@ describe('Unit | Repository | assessmentRepository', () => {
       userId: JOHN,
       courseId: 'courseId1',
       state: 'completed',
-      type: null
+      type: 'PLACEMENT'
     }, {
       id: 2,
       userId: LAYLA,
       courseId: 'courseId1',
       state: 'completed',
-      type: null
+      type: 'PLACEMENT'
     }, {
       id: 3,
       userId: JOHN,
       courseId: 'courseId1',
       state: 'completed',
-      type: null
+      type: 'PLACEMENT'
     }, {
       id: 4,
       userId: JOHN,
       courseId: 'courseId2',
       state: 'completed',
-      type: null
+      type: 'PLACEMENT'
     }, {
       id: 5,
       userId: JOHN,
@@ -44,7 +44,7 @@ describe('Unit | Repository | assessmentRepository', () => {
       userId: LAYLA,
       courseId: 'nullAssessmentPreview',
       state: 'completed',
-      type: null
+      type: 'DEMO'
     }];
 
     before(() => {
@@ -201,22 +201,26 @@ describe('Unit | Repository | assessmentRepository', () => {
       id: COMPLETED_ASSESSMENT_A_ID,
       userId: JOHN,
       courseId: 'courseId',
-      state: 'completed'
+      state: 'completed',
+      type: 'PLACEMENT'
     }, {
       id: COMPLETED_ASSESSMENT_B_ID,
       userId: JOHN,
       courseId: 'courseId',
-      state: 'completed'
+      state: 'completed',
+      type: 'PLACEMENT'
     }, {
       id: UNCOMPLETE_ASSESSMENT_ID,
       userId: JOHN,
       courseId: 'courseId',
-      state: 'started'
+      state: 'started',
+      type: 'PLACEMENT'
     }, {
       id: 4,
       userId: LAYLA,
       courseId: 'courseId',
-      state: 'completed'
+      state: 'completed',
+      type: 'PLACEMENT'
     }, {
       id: 5,
       userId: JOHN,
@@ -227,7 +231,8 @@ describe('Unit | Repository | assessmentRepository', () => {
       id: 6,
       userId: LAYLA,
       courseId: 'nullAssessmentPreview',
-      state: 'completed'
+      state: 'completed',
+      type: 'DEMO'
     }];
 
     before(() => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -7,6 +7,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
 
   let modelObject;
   let jsonAssessment;
+  let jsonAssessmentSmartPlacement;
 
   beforeEach(() => {
     const associatedCourse = {
@@ -54,6 +55,21 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         }
       }]
     };
+
+    jsonAssessmentSmartPlacement = {
+      data: {
+        type: 'assessment',
+        id: 'assessment_id',
+        attributes: {
+          'estimated-level': undefined,
+          'pix-score': undefined,
+          'success-rate': 24,
+          'type': 'SMART_PLACEMENT',
+          'certification-number': null
+        }
+      }
+    };
+
   });
 
   describe('#serialize()', function() {
@@ -80,17 +96,30 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
       expect(assessment.courseId).to.equal(jsonAssessment.data.relationships.course.data.id);
     });
 
+    context('when the assessment is a SMART_PLACEMENT assessment', () => {
+      it('should convert JSON API data into an Assessment object with courseId null', () => {
+        // when
+        const assessment = serializer.deserialize(jsonAssessmentSmartPlacement);
+
+        // then
+        expect(assessment).to.be.instanceOf(Assessment);
+        expect(assessment.id).to.equal(jsonAssessment.data.id);
+        expect(assessment.type).to.equal('SMART_PLACEMENT');
+        expect(assessment.courseId).to.equal(null);
+      });
+    });
+
     describe('field "type"', () => {
 
       it('should set "type" attribute value when it is present', () => {
         // given
-        jsonAssessment.data.attributes.type = 'URITROTTOIR';
+        jsonAssessment.data.attributes.type = 'PLACEMENT';
 
         // when
         const assessment = serializer.deserialize(jsonAssessment);
 
         // then
-        expect(assessment.type).to.equal('URITROTTOIR'); //
+        expect(assessment.type).to.equal('PLACEMENT');
       });
     });
   });

--- a/api/tests/unit/smart_random/answer_test.js
+++ b/api/tests/unit/smart_random/answer_test.js
@@ -1,0 +1,80 @@
+const expect = require('chai').expect;
+const Answer = require('../../../lib/smart_random/answer');
+const Skill = require('../../../lib/smart_random/skill');
+const Challenge = require('../../../lib/smart_random/challenge');
+
+describe('Unit | Model | Answer', function() {
+
+  describe('#maxDifficulty', function() {
+    it('should exist', function() {
+      // given
+      const url1 = new Skill('url1');
+      const challenge = new Challenge('recXXX', 'validé', [url1]);
+      const answer = new Answer(challenge, 'ko');
+
+      // then
+      expect(answer.maxDifficulty).to.exist;
+    });
+
+    it('should return the maximal skill difficulty of a challenge', function() {
+      // given
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const challenge = new Challenge('recXXX', 'validé', [url1, web5]);
+      const answer = new Answer(challenge, 'ok');
+
+      // when
+      const maxDifficulty = answer.maxDifficulty;
+
+      // then
+      expect(maxDifficulty).to.equal(5);
+    });
+
+    it('should return 2 if the challenge is undefined', function() {
+      // given
+      const answer = new Answer(undefined, 'ok');
+
+      // when
+      const maxDifficulty = answer.maxDifficulty;
+
+      // then
+      expect(maxDifficulty).to.equal(2);
+    });
+  });
+
+  describe('#binaryOutcome', function() {
+    it('should exist', function() {
+      // given
+      const challenge = new Challenge('recXXX', 'validé', []);
+      const answer = new Answer(challenge, 'ko');
+
+      // then
+      expect(answer.binaryOutcome).to.exist;
+    });
+
+    it('should return 1 if answer is correct', function() {
+      // given
+      const challenge = new Challenge('recXXX', 'validé', []);
+      const answer = new Answer(challenge, 'ok');
+
+      // when
+      const maxDifficulty = answer.binaryOutcome;
+
+      // then
+      expect(maxDifficulty).to.equal(1);
+    });
+
+    it('should return 0 if answer is not correct', function() {
+      // given
+      const challenge = new Challenge('recXXX', 'validé', []);
+      const answer = new Answer(challenge, 'partial');
+
+      // when
+      const maxDifficulty = answer.binaryOutcome;
+
+      // then
+      expect(maxDifficulty).to.equal(0);
+    });
+  });
+
+});

--- a/api/tests/unit/smart_random/assessment_test.js
+++ b/api/tests/unit/smart_random/assessment_test.js
@@ -1,0 +1,821 @@
+const { expect, sinon } = require('../../test-helper');
+const Course = require('../../../lib/smart_random/course');
+const Assessment = require('../../../lib/smart_random/assessment');
+const Answer = require('../../../lib/smart_random/answer');
+const Challenge = require('../../../lib/smart_random/challenge');
+const Skill = require('../../../lib/smart_random/skill');
+
+const AnswerStatus = require('../../../lib/domain/models/AnswerStatus');
+
+describe('Unit | Model | Assessment', function() {
+
+  describe('#_probaOfCorrectAnswer()', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._probaOfCorrectAnswer).to.exist;
+    });
+
+    it('should return 1/2 if difficulty equals level', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // when
+      const proba = assessment._probaOfCorrectAnswer(3, 3);
+
+      // then
+      expect(proba).to.equal(0.5);
+    });
+
+    it('should return something lesser than 1/2 if difficulty is higher than level', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // when
+      const proba = assessment._probaOfCorrectAnswer(3, 4);
+
+      // then
+      expect(proba).to.be.below(0.5);
+    });
+  });
+
+  describe('#_computeLikelihood()', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._computeLikelihood).to.exist;
+    });
+
+    it('should return likelihood values for different levels', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const ch1 = new Challenge('a', 'validé', [web4]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [url1]);
+      const challenges = [ch1, ch2, ch3];
+      const answer1 = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const answers = [answer1, answer2];
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, answers);
+
+      // when
+      const likelihoodValues = [3.5, 4.5, 5.5].map(level => assessment._computeLikelihood(level, assessment.answers));
+
+      // then
+      expect(likelihoodValues).to.deep.equal([-0.4400338073954983, -0.06487123739065036, -0.6183891934859586]);
+    });
+
+    it('should return negative values every time', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const ch1 = new Challenge('a', 'validé', [web4]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [url1]);
+      const challenges = [ch1, ch2, ch3];
+      const answer1 = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const answers = [answer1, answer2];
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, answers);
+
+      // when
+      const likelihoodValues = [1.2, 3.4, 5.6].map(level => assessment._computeLikelihood(level, assessment.answers));
+
+      // then
+      likelihoodValues.forEach(likelihoodValue => expect(likelihoodValue).to.be.below(0));
+    });
+  });
+
+  describe('#_getPredictedLevel', function() {
+
+    it('should return 2 if user did not provide any answers so far', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._getPredictedLevel()).to.be.equal(2);
+    });
+
+    it('should return 4.5 if user answered correctly a question of maxDifficulty 4 but failed at 5', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const ch1 = new Challenge('a', 'validé', [web4]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [url1]);
+      const challenges = [ch1, ch2, ch3];
+      const answer1 = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const answers = [answer1, answer2];
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, answers);
+
+      // when
+      const predictedLevel = assessment._getPredictedLevel();
+
+      // then
+      expect(predictedLevel).to.equal(4.5);
+    });
+  });
+
+  describe('#validatedSkills', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.validatedSkills).to.exist;
+    });
+
+    it('should return [web1, web3] if the user answered correctly a question that requires web3', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web3 = new Skill('web3');
+      const url3 = new Skill('url3');
+      const url4 = new Skill('url4');
+      const url5 = new Skill('url5');
+      const url6 = new Skill('url6');
+      const ch1 = new Challenge('a', 'validé', [web3]);
+      const ch2 = new Challenge('b', 'validé', [web1, web3, url3, url4, url5, url6]);
+      const course = new Course([ch1, ch2]);
+      const answer = new Answer(ch1, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect([...assessment.validatedSkills]).to.be.deep.equal([web1, web3]);
+    });
+
+    it('should not have the same skill validated twice', function() {
+      // given
+      const web3forChallengeOne = new Skill('web3');
+      const web3forChallengeTwo = new Skill('web3');
+      const url3 = new Skill('url3');
+      const ch1 = new Challenge('a', 'validé', [web3forChallengeOne]);
+      const ch2 = new Challenge('b', 'validé', [url3, web3forChallengeTwo]);
+      const course = new Course([ch1, ch2]);
+      const answer = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer, answer2]);
+
+      // then
+      expect(assessment.validatedSkills).to.be.deep.equal([web3forChallengeOne, url3]);
+    });
+
+    it('should not try to add skill from undefined challenge', function() {
+      // given
+      const web3forChallengeOne = new Skill('web3');
+      const ch1 = new Challenge('a', 'validé', [web3forChallengeOne]);
+      const course = new Course([ch1]);
+      const answer = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(undefined, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer, answer2]);
+
+      // then
+      expect([...assessment.validatedSkills]).to.be.deep.equal([web3forChallengeOne]);
+    });
+  });
+
+  describe('#failedSkills', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.failedSkills).to.exist;
+    });
+
+    it('should return [web1, web2, web3, url5, url6, url8] if the user fails a question that requires web1 and url5', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const url3 = new Skill('url3');
+      const url4 = new Skill('url4');
+      const url5 = new Skill('url5');
+      const url6 = new Skill('url6');
+      const url8 = new Skill('url8');
+      const ch1 = new Challenge('a', 'validé', [web1, url5]);
+      const ch2 = new Challenge('b', 'validé', [web2, web3, url3, url4, url6, url8]);
+      const course = new Course([ch1, ch2]);
+      const answer = new Answer(ch1, AnswerStatus.KO);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect([...assessment.failedSkills]).to.be.deep.equal([web1, web2, web3, url5, url6, url8]);
+    });
+
+    it('should not try to add skill from undefined challenge', function() {
+      // given
+      const web3forChallengeOne = new Skill('web3');
+      const ch1 = new Challenge('a', 'validé', [web3forChallengeOne]);
+      const course = new Course([ch1]);
+      const answer = new Answer(ch1, AnswerStatus.KO);
+      const answer2 = new Answer(undefined, AnswerStatus.KO);
+      const assessment = new Assessment(course, [answer, answer2]);
+
+      // then
+      expect([...assessment.failedSkills]).to.be.deep.equal([web3forChallengeOne]);
+    });
+
+    it('should return [web3, web4] when challenge requiring web3, web4 was skipped', () => {
+      // given
+      const web3 = new Skill('web3');
+      const web4 = new Skill('web4');
+      const ch1 = new Challenge('a', 'validé', [web3, web4]);
+      const course = new Course([ch1]);
+
+      // when
+      const answer = new Answer(ch1, AnswerStatus.SKIPPED);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect([...assessment.failedSkills]).to.be.deep.equal([web3,web4]);
+    });
+
+  });
+
+  describe('#filteredChallenges', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.filteredChallenges).to.exist;
+    });
+
+    it('should return challenges that have not been already answered', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const url3 = new Skill('url3');
+      const ch1 = new Challenge('a', 'validé', [web1]);
+      const ch2 = new Challenge('b', 'validé', [web2]);
+      const ch3 = new Challenge('c', 'validé', [url3]);
+      const answerCh2 = new Answer(ch2, AnswerStatus.OK);
+      const answerCh3 = new Answer(ch3, AnswerStatus.OK);
+      const challenges = [ch1, ch2, ch3];
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, [answerCh2, answerCh3]);
+
+      // then
+      expect(assessment.filteredChallenges).to.deep.equal([ch1]);
+    });
+
+    it('should return an empty array when all challenges have been answered', function() {
+      // given
+      const web1 = new Skill('web1');
+      const ch1 = new Challenge('a', 'validé', [web1]);
+      const answerCh1 = new Answer(ch1, AnswerStatus.OK);
+      const course = new Course([ch1]);
+      const assessment = new Assessment(course, [answerCh1]);
+
+      // then
+      expect(assessment.filteredChallenges).to.deep.equal([]);
+    });
+
+    it('should not return any timed challenge if previous challenge was timed', function() {
+      // given
+      const ch1 = new Challenge('a', 'validé', [], undefined);
+      const ch2 = new Challenge('b', 'validé', [], 30);
+      const ch3 = new Challenge('c', 'validé', [], undefined);
+      const ch4 = new Challenge('d', 'validé', [], 30);
+      const answerCh1 = new Answer(ch1, AnswerStatus.OK);
+      const answerCh2 = new Answer(ch2, AnswerStatus.OK);
+      const challenges = [ch1, ch2, ch3, ch4];
+      const course = new Course(challenges);
+
+      // when
+      const assessment = new Assessment(course, [answerCh1, answerCh2]);
+
+      // then
+      expect(assessment.filteredChallenges).to.deep.equal([ch3]);
+    });
+
+    it('should return only challenges that are validated, prevalidated, or validated without test', function() {
+      // given
+      const drop1 = new Challenge('a', 'poubelle', []);
+      const keep1 = new Challenge('b', 'validé', []);
+      const keep2 = new Challenge('c', 'pré-validé', []);
+      const drop2 = new Challenge('d', 'archive', []);
+      const drop3 = new Challenge('e', 'proposé', []);
+      const keep3 = new Challenge('f', 'validé sans test', []);
+      const course = new Course([keep1, keep2, keep3, drop1, drop2, drop3]);
+
+      // when
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.filteredChallenges).to.deep.equal([keep1, keep2, keep3]);
+    });
+  });
+
+  describe('#_computeReward()', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._computeReward).to.exist;
+    });
+
+    it('should be 2 if challenge requires web2 within web1-2-3 and no answer has been given yet', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const ch1 = new Challenge('recXXX', 'validé', [web2]);
+      const ch2 = new Challenge('recYYY', 'validé', [web1, web3]);
+      const course = new Course([ch1, ch2]);
+
+      // when
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._computeReward(ch1,2)).to.equal(2);
+    });
+
+    it('should be 2.73 if challenge requires url3 within url2-3-4-5 and no answer has been given yet', function() {
+      // given
+      const url2 = new Skill('url2');
+      const url3 = new Skill('url3');
+      const url4 = new Skill('url4');
+      const url5 = new Skill('url5');
+      const ch1 = new Challenge('recXXX', 'validé', [url3]);
+      const ch2 = new Challenge('recYYY', 'validé', [url2, url4, url5]);
+      const course = new Course([ch1, ch2]);
+
+      // when
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment._computeReward(ch1,2)).to.equal(2.7310585786300052);
+    });
+  });
+
+  describe('#_firstChallenge', function() {
+
+    let url2, url3, url5, challenge1, challenge2, challenge3, challenge4, challenge5, course, assessment;
+
+    beforeEach(() => {
+      url2 = new Skill('url2');
+      url3 = new Skill('url3');
+      url5 = new Skill('url5');
+      challenge1 = new Challenge('b', 'validé', [url2], 30);
+      challenge2 = new Challenge('c', 'validé', [url2], undefined);
+      challenge3 = new Challenge('f', 'validé sans test', [url3], 60);
+      challenge4 = new Challenge('g', 'validé sans test', [url5], undefined);
+      challenge5 = new Challenge('h', 'validé sans test', [url2], undefined);
+      course = new Course([challenge1, challenge2, challenge3, challenge4, challenge5]);
+      assessment = new Assessment(course, []);
+    });
+
+    it('should exist', function() {
+      expect(assessment._firstChallenge).to.exist;
+    });
+
+    it('should return a challenge of level two for a first challenge', function() {
+      // then
+      expect(assessment._firstChallenge.hardestSkill.difficulty).to.equal(2);
+
+    });
+
+    it('should return a challenge which is not timed as a first challenge', function() {
+      // then
+      expect(assessment._firstChallenge.timer).to.equal(undefined);
+    });
+  });
+
+  describe('#nextChallenge', function() {
+    it('should exist', function() {
+      // given
+      const web2 = new Skill('web2');
+      const challenge = new Challenge('recXXX', 'validé', [web2]);
+      const course = new Course([challenge]);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.nextChallenge).to.exist;
+    });
+
+    it('should return a challenge that requires web2 if web1-2-3 is the tube and no answer has been given so far', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const ch1 = new Challenge('a', 'validé', [web1]);
+      const ch2 = new Challenge('b', 'validé', [web2]);
+      const ch3 = new Challenge('c', 'validé', [web3]);
+      const challenges = [ch1, ch2, ch3];
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.nextChallenge).to.equal(ch2);
+    });
+
+    it('should return a challenge of level 5 if user got levels 2-4 ok but level 6 ko', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const url3 = new Skill('url3');
+      const url4 = new Skill('url4');
+      const rechInfo5 = new Skill('rechInfo5');
+      const url6 = new Skill('url6');
+      const rechInfo7 = new Skill('rechInfo7');
+      const ch1 = new Challenge('recEasy', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch3 = new Challenge('rec3', 'validé', [url3]);
+      const ch4 = new Challenge('rec4', 'validé', [url4]);
+      const ch5 = new Challenge('rec5', 'validé', [rechInfo5]);
+      const ch6 = new Challenge('rec6', 'validé', [url6]);
+      const ch7 = new Challenge('rec7', 'validé', [rechInfo7]);
+      const course = new Course([ch1, ch2, ch3, ch4, ch5, ch6, ch7]);
+      const answer1 = new Answer(ch2, AnswerStatus.OK);
+      const answer2 = new Answer(ch4, AnswerStatus.OK);
+      const answer3 = new Answer(ch6, AnswerStatus.KO);
+      const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+      // then
+      expect(assessment.nextChallenge).to.equal(ch5);
+    });
+    context('when one challenge (level3) has been archived', () => {
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const ch1 = new Challenge('recEasy', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch3 = new Challenge('rec3', 'archive', [web3]);
+      const ch3Bis= new Challenge('rec3bis', 'validé', [web3]);
+      const ch4 = new Challenge('rec4', 'validé', [web4]);
+      const ch5 = new Challenge('rec5', 'validé', [web5]);
+
+      it('should return a challenge of level 3 if user got levels 1, 2 ,3 and 4 at KO', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4, ch5]);
+        const answer1 = new Answer(ch1, AnswerStatus.OK);
+        const answer2 = new Answer(ch2, AnswerStatus.OK);
+        const answer3 = new Answer(undefined, AnswerStatus.OK);
+        const answer4 = new Answer(ch4, AnswerStatus.KO);
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch3Bis);
+      });
+
+      it('should return a challenge of level 5 if user got levels 1, 2, 3, 4 with OK', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4, ch5]);
+        const answer1 = new Answer(ch1, AnswerStatus.OK);
+        const answer2 = new Answer(ch2, AnswerStatus.OK);
+        const answer3 = new Answer(undefined, AnswerStatus.OK);
+        const answer4 = new Answer(ch4, AnswerStatus.OK);
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch5);
+      });
+      it('should return a challenge of level 4 if user got levels 1, 2 and  3 archived', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis, ch4]);
+        const answer1 = new Answer(ch1, AnswerStatus.OK);
+        const answer2 = new Answer(ch2, AnswerStatus.OK);
+        const answer3 = new Answer(undefined, AnswerStatus.OK);
+        const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch4);
+      });
+
+      it('should return a challenge of level 3 if user got levels 1, 2 and 3 archived', function() {
+        // given
+        const course = new Course([ch1, ch2, ch3, ch3Bis]);
+        const answer1 = new Answer(ch1, AnswerStatus.OK);
+        const answer2 = new Answer(ch2, AnswerStatus.OK);
+        const answer3 = new Answer(undefined, AnswerStatus.OK);
+        const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+        // then
+        expect(assessment.nextChallenge).to.equal(ch3Bis);
+      });
+    });
+
+    it('should return null if remaining challenges do not provide extra validated or failed skills', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const ch1 = new Challenge('rec1', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch3 = new Challenge('rec3', 'validé', [web2]);
+      const course = new Course([ch1, ch2, ch3]);
+      const answer = new Answer(ch2, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect(assessment.nextChallenge).to.equal(null);
+    });
+
+    it('should return null if 20 challenges have been answered so far', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const challenges = [];
+      const answers = [];
+      for (let i = 0; i < 20; i++) {
+        challenges.push(new Challenge('rec' + i, 'validé', [web1]));
+        answers.push(new Answer(challenges[i], AnswerStatus.OK));
+      }
+      challenges.push(new Challenge('rec20', 'validé', [web2]));
+      const course = new Course(challenges);
+      const assessment = new Assessment(course, answers);
+
+      // then
+      expect(assessment.nextChallenge).to.equal(null);
+    });
+
+    it('should call _firstChallenge function if the assessment has no answer', function() {
+      // given
+      const firstChallenge = new Challenge();
+      const challenges = [];
+      const course = new Course(challenges);
+      const answers = [];
+      const assessment = new Assessment(course, answers);
+      const firstChallengeStub = sinon.stub(assessment, '_firstChallenge').get(() => firstChallenge);
+
+      // then
+      expect(assessment.nextChallenge).to.be.equal(firstChallenge);
+      firstChallengeStub.restore();
+    });
+
+    it('should return an easier challenge if user skipped previous challenge', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const ch1 = new Challenge('rec1', 'validé', [web1]);
+      const ch2a = new Challenge('rec2a', 'validé', [web2]);
+      const ch2b = new Challenge('rec2b', 'validé', [web2]);
+      const ch3 = new Challenge('rec3', 'validé', [web3]);
+      const course = new Course([ch1, ch2a, ch2b, ch3]);
+      const answer = new Answer(ch2a, AnswerStatus.SKIPPED);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect(assessment.nextChallenge.hardestSkill.difficulty).to.be.equal(1);
+    });
+
+    it('should return any challenge at random if several challenges have equal reward at the middle of the test', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web3 = new Skill('web3');
+      const url3 = new Skill('url3');
+      const ch1 = new Challenge('rec1', 'validé', [web1]);
+      const ch2a = new Challenge('rec2a', 'validé', [web2]);
+      const ch3a = new Challenge('rec3a', 'validé', [web3]);
+      const ch3b = new Challenge('rec3b', 'validé', [web3]);
+      const ch3c = new Challenge('rec3c', 'validé', [url3]);
+      const course = new Course([ch1, ch2a, ch3a, ch3b, ch3c]);
+      const answer = new Answer(ch2a, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer]);
+
+      // then
+      expect(assessment.nextChallenge.hardestSkill.difficulty).to.be.equal(3);
+    });
+
+    it('should not return a question of level 6 after first answer is correct', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web4 = new Skill('web4');
+      const web6 = new Skill('web6');
+      const ch1 = new Challenge('rec1', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch4 = new Challenge('rec4', 'validé', [web4]);
+      const ch6 = new Challenge('rec6', 'validé', [web6]);
+      const challenges = [ch1, ch2, ch4, ch6];
+      const course = new Course(challenges);
+      const answer = new Answer(ch2, AnswerStatus.OK);
+      const answers = [answer];
+      const assessment = new Assessment(course, answers);
+
+      // then
+      expect(assessment.nextChallenge.skills[0].difficulty).not.to.be.equal(6);
+    });
+
+    it('should return a challenge of difficulty 7 if challenge of difficulty 6 is correctly answered', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web2 = new Skill('web2');
+      const web4 = new Skill('web4');
+      const web6 = new Skill('web6');
+      const web7 = new Skill('web7');
+      const ch1 = new Challenge('rec1', 'validé', [web1]);
+      const ch2 = new Challenge('rec2', 'validé', [web2]);
+      const ch4 = new Challenge('rec4', 'validé', [web4]);
+      const ch6 = new Challenge('rec6', 'validé', [web6]);
+      const ch7 = new Challenge('rec7', 'validé', [web7]);
+      const challenges = [ch1, ch2, ch4, ch6, ch7];
+      const course = new Course(challenges);
+      const answer2 = new Answer(ch2, AnswerStatus.OK);
+      const answer6 = new Answer(ch6, AnswerStatus.OK);
+      const answers = [answer2, answer6];
+      const assessment = new Assessment(course, answers);
+
+      // then
+      expect(assessment.nextChallenge.skills).to.be.deep.equal([web7]);
+    });
+  });
+
+  describe('#pixScore', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+
+      // then
+      expect(assessment.pixScore).to.exist;
+    });
+
+    it('should be 0 if no skill has been validated', function() {
+      // given
+      const skillNames = ['web1', 'chi1', 'web2', 'web3', 'chi3', 'fou3', 'mis3'];
+      const skills = [];
+      const competenceSkills = skillNames.map(skillName => skills[skillName] = new Skill(skillName));
+      const ch1 = new Challenge('a', 'validé', [skills['web1'], skills['web2']]);
+      const ch2 = new Challenge('b', 'validé', [skills['web3']]);
+      const course = new Course([ch1, ch2], competenceSkills);
+      const answer1 = new Answer(ch1, AnswerStatus.KO);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const assessment = new Assessment(course, [answer1, answer2]);
+
+      // then
+      expect(assessment.pixScore).to.be.equal(0);
+    });
+
+    it('should be 8 if validated skills are web1 among 2 (4 pix), web2 (4 pix) but not web3 among 4 (2 pix)', () => {
+      // given
+      const skillNames = ['web1', 'chi1', 'web2', 'web3', 'chi3', 'fou3', 'mis3'];
+      const skills = [];
+      const competenceSkills = skillNames.map(skillName => skills[skillName] = new Skill(skillName));
+      const ch1 = new Challenge('a', 'validé', [skills['web1'], skills['web2']]);
+      const ch2 = new Challenge('b', 'validé', [skills['web3']]);
+      const course = new Course([ch1, ch2], competenceSkills);
+      const answer1 = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const assessment = new Assessment(course, [answer1, answer2]);
+
+      // then
+      expect(assessment.pixScore).to.be.equal(8);
+    });
+
+    it('should be 6 if validated skills are web1 (4 pix) and fou3 among 4 (2 pix) (web2 was failed)', () => {
+      // given
+      const skillNames = ['web1', 'chi1', 'web2', 'web3', 'chi3', 'fou3', 'mis3'];
+      const skills = {};
+      const competenceSkills = skillNames.map(skillName => skills[skillName] = new Skill(skillName));
+      const ch1 = new Challenge('a', 'validé', [skills['web1']]);
+      const ch2 = new Challenge('b', 'validé', [skills['web2']]);
+      const ch3 = new Challenge('c', 'validé', [skills['fou3']]);
+      const course = new Course([ch1, ch2, ch3], competenceSkills);
+      const answer1 = new Answer(ch1, AnswerStatus.OK);
+      const answer2 = new Answer(ch2, AnswerStatus.KO);
+      const answer3 = new Answer(ch3, AnswerStatus.OK);
+      const assessment = new Assessment(course, [answer1, answer2, answer3]);
+
+      // then
+      expect(assessment.pixScore).to.be.equal(6);
+    });
+
+    context('when one challenge was archived', () => {
+      it('should return maximum score even if one answer has undefined challenge and skill do not exist anymore', () => {
+
+        // given
+        const skillNames = ['web1', 'web3', 'ch1', 'ch2', 'ch3', 'truc2'];
+        const skills = {};
+        const competenceSkills = skillNames.map(skillName => skills[skillName] = new Skill(skillName));
+        const web1Challenge = new Challenge('a', 'validé', [skills['web1']]);
+        const web3Challege = new Challenge('c', 'validé', [skills['web3']]);
+        const ch1Challenge = new Challenge('a', 'validé', [skills['ch1']]);
+        const ch2Challenge = new Challenge('b', 'archived', [skills['ch2']]);
+        const ch3Challege = new Challenge('c', 'validé', [skills['ch3']]);
+        const truc2Challege = new Challenge('c', 'validé', [skills['truc2']]);
+        const course = new Course([web1Challenge, web3Challege, ch1Challenge, ch2Challenge, ch3Challege, truc2Challege], competenceSkills);
+        const answer1 = new Answer(web1Challenge, AnswerStatus.OK);
+        const answer2 = new Answer(undefined, AnswerStatus.OK);
+        const answer3 = new Answer(web3Challege, AnswerStatus.OK);
+        const answer4 = new Answer(ch1Challenge, AnswerStatus.OK);
+        const answer5 = new Answer(ch2Challenge, AnswerStatus.OK);
+        const answer6 = new Answer(ch3Challege, AnswerStatus.OK);
+        const answer7 = new Answer(truc2Challege, AnswerStatus.OK);
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4, answer5, answer6, answer7]);
+
+        // then
+        expect(assessment.pixScore).to.be.equal(24);
+      });
+
+      it('should return maximum score even if one answer has undefined challenge and but skill exist', () => {
+
+        // given
+        const skillNames = ['web1', 'web2', 'web3', 'ch1', 'ch2', 'ch3'];
+        const skills = {};
+        const competenceSkills = skillNames.map(skillName => skills[skillName] = new Skill(skillName));
+        const web1Challenge = new Challenge('a', 'validé', [skills['web1']]);
+        const web2Challenge = new Challenge('a', 'validé', [skills['web2']]);
+        const web3Challege = new Challenge('c', 'validé', [skills['web3']]);
+        const ch1Challenge = new Challenge('a', 'validé', [skills['ch1']]);
+        const ch2Challenge = new Challenge('b', 'archived', [skills['ch2']]);
+        const ch3Challege = new Challenge('c', 'validé', [skills['ch3']]);
+        const course = new Course([web1Challenge, web2Challenge, web3Challege, ch1Challenge, ch2Challenge, ch3Challege], competenceSkills);
+        const answer1 = new Answer(web1Challenge, AnswerStatus.OK);
+        const answer2 = new Answer(undefined, AnswerStatus.OK);
+        const answer3 = new Answer(web3Challege, AnswerStatus.OK);
+        const answer4 = new Answer(ch1Challenge, AnswerStatus.OK);
+        const answer5 = new Answer(ch2Challenge, AnswerStatus.OK);
+        const answer6 = new Answer(ch3Challege, AnswerStatus.OK);
+        const assessment = new Assessment(course, [answer1, answer2, answer3, answer4, answer5, answer6]);
+
+        // then
+        expect(assessment.pixScore).to.be.equal(24);
+      });
+    });
+  });
+
+  describe('#displayedPixScore', function() {
+
+    it('should be 7 if pixScore is 7.98', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+      sinon.stub(assessment, 'pixScore').get(() => 7.98);
+
+      // then
+      expect(assessment.displayedPixScore).to.equal(7);
+    });
+
+    it('should be 8 if pixScore is 8.02', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+      sinon.stub(assessment, 'pixScore').get(() => 8.02);
+
+      // then
+      expect(assessment.displayedPixScore).to.equal(8);
+    });
+  });
+
+  describe('#obtainedLevel', function() {
+
+    it('should be 0 if pixScore is 7.98', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+      sinon.stub(assessment, 'pixScore').get(() => 7.98);
+
+      // then
+      expect(assessment.obtainedLevel).to.equal(0);
+    });
+
+    it('should be 1 if pixScore is 8.02', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+      sinon.stub(assessment, 'pixScore').get(() => 8.02);
+
+      // then
+      expect(assessment.obtainedLevel).to.equal(1);
+    });
+
+    it('should be 5 even if pixScore is 48 (level 6 must not be reachable for the moment)', function() {
+      // given
+      const course = new Course([], []);
+      const assessment = new Assessment(course, []);
+      sinon.stub(assessment, 'pixScore').get(() => 48);
+
+      // then
+      expect(assessment.obtainedLevel).to.equal(5);
+    });
+
+  });
+
+});

--- a/api/tests/unit/smart_random/challenge_test.js
+++ b/api/tests/unit/smart_random/challenge_test.js
@@ -1,0 +1,47 @@
+const expect = require('chai').expect;
+const Challenge = require('../../../lib/smart_random/challenge');
+const Skill = require('../../../lib/smart_random/skill');
+
+describe('Unit | Model | Challenge', function() {
+
+  describe('#hardestSkill', function() {
+    it('should exist', function() {
+      // given
+      const url1 = new Skill('url1');
+      const challenge = new Challenge('recXXX', 'validé', [url1]);
+
+      // then
+      expect(challenge.hardestSkill).to.exist;
+    });
+
+    it('should be web5 if challenge requires url1 and web5', function() {
+      // given
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const challenge = new Challenge('recXXX', 'validé', [url1, web5]);
+
+      // then
+      expect(challenge.hardestSkill).to.equal(web5);
+    });
+  });
+
+  describe('#isActive', function() {
+
+    it('should return true if the status is an active status', function() {
+      // given
+      const challenge = new Challenge('recXXX', 'validé', []);
+
+      // then
+      expect(challenge.isActive).to.equal(true);
+    });
+
+    it('should return false if the status is not an active status', function() {
+      // given
+      const challenge = new Challenge('recXXX', 'test', []);
+
+      // then
+      expect(challenge.isActive).to.equal(false);
+    });
+
+  });
+});

--- a/api/tests/unit/smart_random/course_test.js
+++ b/api/tests/unit/smart_random/course_test.js
@@ -1,0 +1,154 @@
+const expect = require('chai').expect;
+const Course = require('../../../lib/smart_random/course');
+const Skill = require('../../../lib/smart_random/skill');
+const Challenge = require('../../../lib/smart_random/challenge');
+
+describe('Unit | Model | Course', function() {
+
+  describe('#tubes', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+
+      // then
+      expect(course.tubes).to.exist;
+    });
+
+    it('should return a dictionary of tubes when all challenges require only one skill', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const ch1 = new Challenge('a', 'validé', [web4]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [url1]);
+      const challenges = [ch1, ch2, ch3];
+      const course = new Course(challenges);
+
+      // when
+      const tubes = course.tubes;
+
+      // then
+      const expectedTubes = { 'web': [web4, web5], 'url': [url1] };
+      expect(tubes).to.deep.equal(expectedTubes);
+    });
+
+    it('should not add the same skill twice in a tube', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const ch1 = new Challenge('a', 'validé', [url1]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [web4]);
+      const ch4 = new Challenge('d', 'validé', [web4]);
+      const challenges = [ch1, ch2, ch3, ch4];
+      const course = new Course(challenges);
+
+      // when
+      const tubes = course.tubes;
+
+      // then
+      const expectedTubes = { 'web': [web4, web5], 'url': [url1] };
+      expect(tubes).to.deep.equal(expectedTubes);
+    });
+
+    it('should return a dictionary of tubes when some challenges require multiple skills', function() {
+      // given
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const url2 = new Skill('url2');
+      const ch1 = new Challenge('a', 'validé', [web4, url1]);
+      const ch2 = new Challenge('b', 'validé', [web5]);
+      const ch3 = new Challenge('c', 'validé', [url2]);
+      const challenges = [ch1, ch2, ch3];
+      const course = new Course(challenges);
+
+      // when
+      const tubes = course.tubes;
+
+      // then
+      const expectedTubes = { 'web': [web4, web5], 'url': [url1, url2] };
+      expect(tubes).to.deep.equal(expectedTubes);
+    });
+
+    it('should return a dictionary of tubes which difficulties are ordered by value', function() {
+      // given
+      const web1 = new Skill('web1');
+      const web4 = new Skill('web4');
+      const web5 = new Skill('web5');
+      const url1 = new Skill('url1');
+      const url2 = new Skill('url2');
+      const ch1 = new Challenge('a', 'validé', [web5, url2]);
+      const ch2 = new Challenge('b', 'validé', [web4, url1, web1]);
+      const challenges = [ch1, ch2];
+      const course = new Course(challenges);
+
+      // when
+      const tubes = course.tubes;
+
+      // then
+      const expectedTubes = { 'web': [web1, web4, web5], 'url': [url1, url2] };
+      expect(tubes).to.deep.equal(expectedTubes);
+    });
+  });
+
+  describe('#computePixScoreOfSkills()', function() {
+    it('should exist', function() {
+      // given
+      const course = new Course([]);
+
+      // then
+      expect(course.computePixScoreOfSkills).to.exist;
+    });
+
+    it('should return a mapping defined for each skill', function() {
+      // given
+      const skillNames = ['web1', 'chi1', 'fou1', 'mis1', 'web3', 'url3', 'web4', 'chi5', 'fou5', 'mis5'];
+      const competenceSkills = skillNames.map(skillName => new Skill(skillName));
+      const course = new Course([], competenceSkills);
+
+      // when
+      const pixScoreOfSkills = course.computePixScoreOfSkills();
+
+      // then
+      expect(pixScoreOfSkills.length).to.equal(competenceSkills.size);
+      competenceSkills.forEach(skill => {
+        expect(pixScoreOfSkills[skill.name]).to.not.equal(undefined);
+      });
+    });
+
+    it('should return a mapping between skills and pix scores', function() {
+      // given
+      const skillNames = ['web1', 'chi1', 'fou1', 'mis1', 'web3', 'url3', 'web4', 'chi5', 'fou5', 'mis5'];
+      const competenceSkills = skillNames.map(skillName => new Skill(skillName));
+
+      const course = new Course([], competenceSkills);
+
+      // when
+      const pixScoreOfSkills = course.computePixScoreOfSkills();
+
+      // then
+      const expectedPixScoresByLevel = { 1: 2, 3: 4, 4: 4, 5: 2.6666666666666665 };
+      competenceSkills.forEach(skill => {
+        expect(pixScoreOfSkills[skill.name]).to.equal(expectedPixScoresByLevel[skill.difficulty]);
+      });
+    });
+
+    it('the pix score of each skill should be 4 at most', function() {
+      // given
+      const skillNames = ['web1', 'chi1', 'fou1', 'mis1', 'web3', 'url3', 'web4', 'chi5', 'fou5', 'mis5'];
+      const competenceSkills = skillNames.map(skillName => new Skill(skillName));
+      const course = new Course([], competenceSkills);
+
+      // when
+      const pixScoreOfSkills = course.computePixScoreOfSkills();
+
+      // then
+      competenceSkills.forEach(skill => {
+        expect(pixScoreOfSkills[skill.name]).to.be.at.most(4);
+      });
+    });
+  });
+});

--- a/api/tests/unit/smart_random/skill_test.js
+++ b/api/tests/unit/smart_random/skill_test.js
@@ -1,0 +1,67 @@
+const expect = require('chai').expect;
+const Skill = require('../../../lib/smart_random/skill');
+
+describe('Unit | Model | Skill', function() {
+
+  describe('#getEasierWithin()', function() {
+    it('should exist', function() {
+      // given
+      const url1 = new Skill('url1');
+      const tubes = { 'url': [url1] };
+
+      // then
+      expect(url1.getEasierWithin(tubes)).to.exist;
+    });
+
+    it('should return the skill itself if it is alone within its tube', function() {
+      // given
+      const url1 = new Skill('url1');
+      const tubes = { 'url': [url1] };
+
+      // then
+      expect(url1.getEasierWithin(tubes)).to.be.deep.equal([url1]);
+    });
+
+    it('should return url1 and url3 when requesting skills easier than url3 within url1-3-5', function() {
+      // given
+      const url1 = new Skill('url1');
+      const url3 = new Skill('url3');
+      const url5 = new Skill('url5');
+      const tubes = { 'url': [url1, url3, url5] };
+
+      // then
+      expect(url3.getEasierWithin(tubes)).to.be.deep.equal([url1, url3]);
+    });
+  });
+
+  describe('#getHarderWithin()', function() {
+    it('should exist', function() {
+      // given
+      const url1 = new Skill('url1');
+      const tubes = { 'url': [url1] };
+
+      // then
+      expect(url1.getHarderWithin(tubes)).to.exist;
+    });
+
+    it('should return the skill itself if it is alone within its tube', function() {
+      // given
+      const url1 = new Skill('url1');
+      const tubes = { 'url': [url1] };
+
+      // then
+      expect(url1.getHarderWithin(tubes)).to.be.deep.equal([url1]);
+    });
+
+    it('should return url3 and url5 when requesting skills harder than url3 within url1-3-5', function() {
+      // given
+      const url1 = new Skill('url1');
+      const url3 = new Skill('url3');
+      const url5 = new Skill('url5');
+      const tubes = { 'url': [url1, url3, url5] };
+
+      // then
+      expect(url3.getHarderWithin(tubes)).to.be.deep.equal([url3, url5]);
+    });
+  });
+});

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -60,6 +60,9 @@ Router.map(function() {
     this.route('results', { path: '/:certification_number/results' });
   });
   this.route('user-certifications', { path: 'mes-certifications' });
+  this.route('campagnes', function() {
+    this.route('create-assessment', { path: '/:course_id' });
+  });
 });
 
 export default Router;

--- a/live/app/router.js
+++ b/live/app/router.js
@@ -60,9 +60,8 @@ Router.map(function() {
     this.route('results', { path: '/:certification_number/results' });
   });
   this.route('user-certifications', { path: 'mes-certifications' });
-  this.route('campagnes', function() {
-    this.route('create-assessment', { path: '/:course_id' });
-  });
+  this.route('campagnes.create-assessment', { path: '/campagnes/codecampagnepix' });
+
 });
 
 export default Router;

--- a/live/app/routes/campagnes/create-assessment.js
+++ b/live/app/routes/campagnes/create-assessment.js
@@ -2,12 +2,12 @@ import BaseRoute from 'pix-live/routes/base-route';
 
 export default BaseRoute.extend({
 
-  redirect(course) {
+  redirect() {
     const store = this.get('store');
 
     let assessment;
 
-    return store.createRecord('assessment', { course, type: 'SMART_PLACEMENT' }).save()
+    return store.createRecord('assessment', { type: 'SMART_PLACEMENT' }).save()
       .then((createdAssessment) => assessment = createdAssessment)
       .then(() => store.queryRecord('challenge', { assessmentId: assessment.get('id') }))
       .then(challenge => this.replaceWith('assessments.challenge', { assessment, challenge }))

--- a/live/app/routes/campagnes/create-assessment.js
+++ b/live/app/routes/campagnes/create-assessment.js
@@ -1,0 +1,18 @@
+import BaseRoute from 'pix-live/routes/base-route';
+
+export default BaseRoute.extend({
+
+  redirect(course) {
+    const store = this.get('store');
+
+    let assessment;
+
+    return store.createRecord('assessment', { course, type: 'SMART_PLACEMENT' }).save()
+      .then((createdAssessment) => assessment = createdAssessment)
+      .then(() => store.queryRecord('challenge', { assessmentId: assessment.get('id') }))
+      .then(challenge => this.replaceWith('assessments.challenge', { assessment, challenge }))
+      .catch(() => {
+        this.replaceWith('logout');
+      });
+  }
+});

--- a/live/app/templates/campagnes/create-assessment-loading.hbs
+++ b/live/app/templates/campagnes/create-assessment-loading.hbs
@@ -1,0 +1,6 @@
+<div class="app-loader">
+  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+  <p class="app-loader__text">
+    Votre campagne est en cours de préparation.
+  </p>
+</div>

--- a/live/app/templates/campagnes/create-assessment.hbs
+++ b/live/app/templates/campagnes/create-assessment.hbs
@@ -1,0 +1,6 @@
+<div class="app-loader">
+  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+  <p class="app-loader__text">
+    Votre campagne est en cours de préparation.
+  </p>
+</div>


### PR DESCRIPTION
Dans cette PR : 

- Duplication du code de CAT dans smart_random (+ modif pour le limiter à 5 questions pour les tests)
- Modifier le back pour pouvoir sauvegarder un SMART_PLACEMENT
- Modification du repository pour ne pas impacter le code courant
- Ajout d'une route simple /campagnes/codecampagnepix qui lance le SMART_PLACEMENT