### PR TITLE
[#76] [BUGFIX] Correction des bogues sur la gestion de la fin d'un test (PF-170)

### DIFF
--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -7,17 +7,29 @@ const schemaValidateCompetenceMark = Joi.object().keys({
   score: Joi.number().integer().min(0).max(64).required(),
   area_code: Joi.required(),
   competence_code: Joi.required(),
-  assessmentResultId:  Joi.number().optional()
+  assessmentResultId: Joi.number().optional(),
 });
 
 class CompetenceMark {
-  constructor(model) {
-    Object.assign(this, model);
+  constructor({
+    id,
+    level,
+    score,
+    area_code,
+    competence_code,
+    assessmentResultId,
+  } = {}) {
+    this.id = id;
+    this.level = level;
+    this.score = score;
+    this.area_code = area_code;
+    this.competence_code = competence_code;
+    this.assessmentResultId = assessmentResultId;
   }
 
   validate() {
     const result = Joi.validate(this, schemaValidateCompetenceMark);
-    if(result.error === null) {
+    if (result.error === null) {
       return Promise.resolve();
     } else {
       return Promise.reject(new ObjectValidationError(result.error));

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -3,7 +3,7 @@ const { ObjectValidationError } = require('../errors');
 
 const schemaValidateCompetenceMark = Joi.object().keys({
   id: Joi.number().optional(),
-  level: Joi.number().integer().min(-1).max(5).required(),
+  level: Joi.number().integer().min(-1).max(8).required(),
   score: Joi.number().integer().min(0).max(64).required(),
   area_code: Joi.required(),
   competence_code: Joi.required(),

--- a/api/lib/domain/services/assessment-result-service.js
+++ b/api/lib/domain/services/assessment-result-service.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 
 const AssessmentResult = require('../../domain/models/AssessmentResult');
+const Assessment = require('../../domain/models/Assessment');
 
 const skillService = require('../../domain/services/skills-service');
 const assessmentService = require('../../domain/services/assessment-service');
@@ -22,7 +23,7 @@ function _getAssessmentResultEvaluations(marks, assessmentType) {
   }, 0);
   let level = Math.floor(pixScore / 8);
   let status = 'validated';
-  if (pixScore === 0 && assessmentType === 'CERTIFICATION') {
+  if (pixScore === 0 && assessmentType === Assessment.types.CERTIFICATION) {
     status = 'rejected';
     level = -1;
   }
@@ -86,7 +87,7 @@ function evaluateFromAssessmentId(assessmentId) {
          * par contre le reste de l'algorithme peut avoir des niveaux au dessus, et l'on ne plafonnera pas pour les
          * autres Assessments (par exemple Placements).
          */
-        if (assessment.type === 'CERTIFICATION') {
+        if (assessment.type === Assessment.types.CERTIFICATION) {
           mark.level = Math.min(mark.level, CERTIFICATION_MAX_LEVEL);
         }
         return mark;

--- a/api/lib/domain/services/assessment-result-service.js
+++ b/api/lib/domain/services/assessment-result-service.js
@@ -17,12 +17,6 @@ const CERTIFICATION_MAX_LEVEL = 5;
 // TODO: Should compute pixScore automatically in AssessmentResult + create an Utils to compute level/status everywhere
 function _getAssessmentResultEvaluations(marks, assessmentType) {
 
-  // FIXME Limiter le level à 5 pour les certifications
-  // FIXME clarifier avec le PO a quoi correspond le level d'une certification et d'un assessment-result
-  //
-  // dans le cas d'une certification, l'assessment Result level devrait être à 0 car non utilisé.
-  // dans le cas d'une certification, les competenceMarks devraient avoir un niveau limité à 5.
-
   const pixScore = marks.reduce((totalPixScore, mark) => {
     return totalPixScore + mark.score;
   }, 0);
@@ -87,7 +81,11 @@ function evaluateFromAssessmentId(assessmentId) {
         mark.assessmentResultId = assessmentResultId;
         return mark;
       }).map((mark) => {
-        /// XXX une certification ne peut pas avoir une compétence en base au dessus de niveau 5
+        /*
+         * XXX une certification ne peut pas avoir une compétence en base au dessus de niveau 5;
+         * par contre le reste de l'algorithme peut avoir des niveaux au dessus, et l'on ne plafonnera pas pour les
+         * autres Assessments (par exemple Placements).
+         */
         if (assessment.type === 'CERTIFICATION') {
           mark.level = Math.min(mark.level, CERTIFICATION_MAX_LEVEL);
         }

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -9,7 +9,9 @@ const competenceMarkRepository = require('../../infrastructure/repositories/comp
 const assessmentAdapter = require('../../infrastructure/adapters/assessment-adapter');
 const answerService = require('../services/answer-service');
 const certificationService = require('../services/certification-service');
+
 const CompetenceMark = require('../../domain/models/CompetenceMark');
+const Assessment = require('../../domain/models/Assessment');
 
 const _ = require('../../infrastructure/utils/lodash-utils');
 
@@ -235,7 +237,7 @@ function findByFilters(filters) {
     .then((assessments) => {
       const assessmentsWithAssociatedCourse = assessments.map((assessment) => {
         // TODO REFACTO DE LA MAGIC STRING
-        if (assessment.type === 'CERTIFICATION') {
+        if (assessment.type === Assessment.types.CERTIFICATION) {
           return certificationCourseRepository.get(assessment.courseId)
             .then((certificationCourse) => {
               assessment.course = new Course(certificationCourse);
@@ -261,15 +263,15 @@ function isPreviewAssessment(assessment) {
 }
 
 function isDemoAssessment(assessment) {
-  return assessment.type === 'DEMO';
+  return assessment.type === Assessment.types.DEMO;
 }
 
 function isCertificationAssessment(assessment) {
-  return assessment.type === 'CERTIFICATION';
+  return assessment.type === Assessment.types.CERTIFICATION;
 }
 
 function isPlacementAssessment(assessment) {
-  return assessment.type === 'PLACEMENT';
+  return assessment.type === Assessment.types.PLACEMENT;
 }
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -1,12 +1,13 @@
 const CertificationCourseBookshelf = require('../data/certification-course');
 const CertificationCourse = require('../../domain/models/CertificationCourse');
+const Assessment = require('../../domain/models/Assessment');
 const { NotFoundError } = require('../../domain/errors');
 
 function _toDomain(model) {
   return new CertificationCourse({
     id: model.get('id'),
     userId: model.get('userId'),
-    type: 'CERTIFICATION',
+    type: Assessment.types.CERTIFICATION,
     assessment: model.related('assessment').toJSON(),
     challenges: model.related('challenges').toJSON(),
     createdAt: model.get('createdAt'),

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -1,6 +1,8 @@
 const { expect, knex,  generateValidRequestAuhorizationHeader, insertUserWithRolePixMaster, cleanupUsersAndPixRolesTables } = require('../../../test-helper');
 const server = require('../../../../server');
 
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
 describe('Acceptance | Controller | assessment-results-controller', function() {
 
   after(function(done) {
@@ -67,7 +69,7 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
           .insert({
             id: '1',
             courseId: certificationId,
-            type: 'CERTIFICATION'
+            type: Assessment.types.CERTIFICATION
           });
       })
       .then(() => {

--- a/api/tests/acceptance/application/certification-controller_test.js
+++ b/api/tests/acceptance/application/certification-controller_test.js
@@ -4,6 +4,8 @@ const {
 } = require('../../test-helper');
 const server = require('../../../server');
 
+const Assessment = require('../../../lib/domain/models/Assessment');
+
 describe('Acceptance | API | Certifications', () => {
 
   describe('GET /api/certifications', () => {
@@ -35,7 +37,7 @@ describe('Acceptance | API | Certifications', () => {
 
     const assessment = {
       userId: authenticatedUserID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
 
@@ -152,7 +154,7 @@ describe('Acceptance | API | Certifications', () => {
       id: 1000,
       courseId: JOHN_CERTIFICATION_ID,
       userId: JOHN_USERID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
     const assessmentResult = {
@@ -255,7 +257,7 @@ describe('Acceptance | API | Certifications', () => {
     const john_completedAssessment = {
       courseId: JOHN_CERTIFICATION_ID,
       userId: JOHN_USERID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
     const assessmentResult = {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -2,6 +2,8 @@ const { expect, knex, generateValidRequestAuhorizationHeader, insertUserWithRole
 const server = require('../../../server');
 const _ = require('lodash');
 
+const Assessment = require('../../../lib/domain/models/Assessment');
+
 describe('Acceptance | API | Certification Course', () => {
 
   describe('GET /api/admin/certifications/{id}/details', () => {
@@ -69,7 +71,7 @@ describe('Acceptance | API | Certification Course', () => {
           return knex('assessments').insert({
             courseId: certificationCourseId.toString(),
             state: 'completed',
-            type: 'CERTIFICATION'
+            type: Assessment.types.CERTIFICATION
           });
         })
         .then(insertedModelIds => {

--- a/api/tests/factory/build-competence-mark.js
+++ b/api/tests/factory/build-competence-mark.js
@@ -1,0 +1,21 @@
+const CompetenceMark = require('../../lib/domain/models/CompetenceMark');
+
+module.exports = function({
+  id,
+  level = 2,
+  score = 13,
+  area_code = '1',
+  competence_code = '1.1',
+  assessmentResultId,
+} = {}) {
+
+  return new CompetenceMark({
+    id,
+    level,
+    score,
+    area_code,
+    competence_code,
+    assessmentResultId,
+  });
+};
+

--- a/api/tests/factory/index.js
+++ b/api/tests/factory/index.js
@@ -5,6 +5,7 @@ const buildCatChallenge = require('./build-cat-challenge');
 const buildCatCourse= require('./build-cat-course');
 const buildCatTube = require('./build-cat-tube');
 const buildCertification = require('./build-certification');
+const buildCompetenceMark = require('./build-competence-mark');
 
 module.exports = {
   buildAssessementResult,
@@ -14,4 +15,5 @@ module.exports = {
   buildCatCourse,
   buildCatTube,
   buildCertification,
+  buildCompetenceMark,
 };

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -309,7 +309,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     const assessmentToBeSaved = new Assessment({
       userId: JOHN,
       courseId: 'courseId1',
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state:'completed',
       createdAt: '2017-11-08 11:47:38'
     });

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,7 +1,9 @@
 const { expect, knex } = require('../../../test-helper');
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Integration | Repository | Certification Course', function() {
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -3,7 +3,6 @@ const certificationCourseRepository = require('../../../../lib/infrastructure/re
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
-const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Integration | Repository | Certification Course', function() {
 

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -1,8 +1,10 @@
 const { expect, knex } = require('../../../test-helper');
 const certificationRepository = require('../../../../lib/infrastructure/repositories/certification-repository');
-const Certification = require('../../../../lib/domain/models/Certification');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const factory = require('../../../factory');
+
+const Certification = require('../../../../lib/domain/models/Certification');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Integration | Repository | Certification ', () => {
 
@@ -38,7 +40,7 @@ describe('Integration | Repository | Certification ', () => {
       id: 1000,
       courseId: CERTIFICATION_ID,
       userId: USER_ID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
 
@@ -137,7 +139,7 @@ describe('Integration | Repository | Certification ', () => {
       id: 1000,
       courseId: 123,
       userId: USER_ID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
 
@@ -227,7 +229,7 @@ describe('Integration | Repository | Certification ', () => {
       id: 1000,
       courseId: CERTIFICATION_ID,
       userId: USER_ID,
-      type: 'CERTIFICATION',
+      type: Assessment.types.CERTIFICATION,
       state: 'completed',
     };
 

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -54,12 +54,12 @@ describe('Integration | Repository | CompetenceMark', function() {
     context('when competenceMark is not validated', () => {
       it('should return an error', () => {
         // given
-        const markWithLevelSupAtEight = factory.buildCompetenceMark({
+        const markWithLevelGreaterThanEight = factory.buildCompetenceMark({
           level: 10,
         });
 
         // when
-        const promise = CompetenceMarkRepository.save(markWithLevelSupAtEight);
+        const promise = CompetenceMarkRepository.save(markWithLevelGreaterThanEight);
 
         // then
         return promise.catch((error) => {
@@ -69,12 +69,12 @@ describe('Integration | Repository | CompetenceMark', function() {
 
       it('should not saved the competenceMark', () => {
         // given
-        const markWithLevelSupAtEight = factory.buildCompetenceMark({
+        const markWithLevelGreaterThanEight = factory.buildCompetenceMark({
           level: 10,
         });
 
         // when
-        const promise = CompetenceMarkRepository.save(markWithLevelSupAtEight);
+        const promise = CompetenceMarkRepository.save(markWithLevelGreaterThanEight);
 
         // then
         return promise.catch(() => knex('competence-marks').select())

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -2,6 +2,7 @@ const { expect, knex } = require('../../../test-helper');
 
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
 const CompetenceMarkRepository = require('../../../../lib/infrastructure/repositories/competence-mark-repository');
+const factory = require('../../../factory');
 
 describe('Integration | Repository | CompetenceMark', function() {
 
@@ -12,11 +13,11 @@ describe('Integration | Repository | CompetenceMark', function() {
 
     it('should persist the mark in db', () => {
       // given
-      const mark = new CompetenceMark({
+      const mark = factory.buildCompetenceMark({
         score: 13,
         level: 1,
         area_code: '4',
-        competence_code: '4.2'
+        competence_code: '4.2',
       });
 
       // when
@@ -31,11 +32,11 @@ describe('Integration | Repository | CompetenceMark', function() {
 
     it('should return the saved mark', () => {
       // given
-      const mark = new CompetenceMark({
+      const mark = factory.buildCompetenceMark({
         score: 13,
         level: 1,
         area_code: '4',
-        competence_code: '4.2'
+        competence_code: '4.2',
       });
 
       // when
@@ -53,33 +54,27 @@ describe('Integration | Repository | CompetenceMark', function() {
     context('when competenceMark is not validated', () => {
       it('should return an error', () => {
         // given
-        const markWithLevelSupAtFive = new CompetenceMark({
-          score: 13,
+        const markWithLevelSupAtEight = factory.buildCompetenceMark({
           level: 10,
-          area_code: '4',
-          competence_code: '4.2'
         });
 
         // when
-        const promise = CompetenceMarkRepository.save(markWithLevelSupAtFive);
+        const promise = CompetenceMarkRepository.save(markWithLevelSupAtEight);
 
         // then
         return promise.catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 5]');
+          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 8]');
         });
       });
 
       it('should not saved the competenceMark', () => {
         // given
-        const markWithLevelSupAtFive = new CompetenceMark({
-          score: 13,
+        const markWithLevelSupAtEight = factory.buildCompetenceMark({
           level: 10,
-          area_code: '4',
-          competence_code: '4.2'
         });
 
         // when
-        const promise = CompetenceMarkRepository.save(markWithLevelSupAtFive);
+        const promise = CompetenceMarkRepository.save(markWithLevelSupAtEight);
 
         // then
         return promise.catch(() => knex('competence-marks').select())

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -199,7 +199,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       const certificationAssessment = new Assessment({
         id: 'assessmentId',
-        type: 'CERTIFICATION'
+        type: Assessment.types.CERTIFICATION
       });
 
       beforeEach(() => {

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -93,7 +93,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
       it('should save an assessment with the type CERTIFICATION', function() {
         // given
-        const expected = new Assessment({ id: 42, courseId: '1', type: 'CERTIFICATION', state: 'started', userId: null });
+        const expected = new Assessment({ id: 42, courseId: '1', type: Assessment.types.CERTIFICATION, state: 'started', userId: null });
 
         // when
         controller.save(request, replyStub);

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -4,7 +4,9 @@ const certificationService = require('../../../../lib/domain/services/certificat
 const certificationCourseService = require('../../../../lib/domain/services/certification-course-service');
 const certificationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-serializer');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 const logger = require('../../../../lib/infrastructure/logger');
 const Boom = require('boom');
@@ -134,7 +136,7 @@ describe('Unit | Controller | certification-course-controller', () => {
 
     const JsonAPISavedCertification = {
       data: {
-        type: 'certification',
+        type: Assessment.types.CERTIFICATION,
         attributes: {
           id: '1',
           firstName: 'Phil',

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -8,6 +8,8 @@ const Boom = require('boom');
 const logger = require('../../../../lib/infrastructure/logger');
 const factory = require('../../../factory');
 
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
 describe('Unit | Controller | certifications-controller', () => {
 
   let replyStub;
@@ -194,7 +196,7 @@ describe('Unit | Controller | certifications-controller', () => {
       },
       payload: {
         data: {
-          type: 'certification',
+          type: Assessment.types.CERTIFICATION,
           id: certificationId,
           attributes: {
             'is-published': true,

--- a/api/tests/unit/domain/models/CompetenceMark_test.js
+++ b/api/tests/unit/domain/models/CompetenceMark_test.js
@@ -1,16 +1,19 @@
 const { expect } = require('../../../test-helper');
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
+const factory = require('../../../factory');
+
 describe('Unit | Domain | Models | Competence Mark', () => {
 
   describe('constructor', () => {
+
     it('should build a Competence Mark from raw JSON', () => {
       // given
       const rawData = {
         level: 2,
         score: 13,
         area_code: '1',
-        competence_code: '1.1'
+        competence_code: '1.1',
       };
 
       // when
@@ -22,74 +25,13 @@ describe('Unit | Domain | Models | Competence Mark', () => {
       expect(competenceMark.area_code).to.equal('1');
       expect(competenceMark.competence_code).to.equal('1.1');
     });
-
-    it('should return an error if level is > 5', () => {
-      // given
-      const rawData = {
-        level: 7,
-        score: 13,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-
-      // when
-      try {
-        new CompetenceMark(rawData);
-      } catch (error) {
-        // then
-        expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 5]');
-      }
-    });
-
-    it('should return an error if level is < -1', () => {
-      // given
-      const rawData = {
-        level: -2,
-        score: 13,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-
-      // when
-      try {
-        new CompetenceMark(rawData);
-      } catch (error) {
-        // then
-        expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be larger than or equal to -1]');
-      }
-    });
-
-    it('should return an error if score > 64', () => {
-      // given
-      const rawData = {
-        level: 5,
-        score: 65,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-
-      // when
-      try {
-        new CompetenceMark(rawData);
-      } catch (error) {
-        // then
-        expect(error.message).to.be.equal('ValidationError: child "score" fails because ["score" must be less than or equal to 64]');
-      }
-    });
-
   });
 
   describe('validate', () => {
 
     it('should return a resolved promise when the object is valide', () => {
       // given
-      const rawData = {
-        level: 2,
-        score: 13,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-      const competenceMark = new CompetenceMark(rawData);
+      const competenceMark = factory.buildCompetenceMark();
 
       // when
       const promise = competenceMark.validate();
@@ -98,43 +40,28 @@ describe('Unit | Domain | Models | Competence Mark', () => {
       return expect(promise).not.to.be.rejected;
     });
 
-    it('should return an error if level is > 5', () => {
+    it('should return an error if level is > 8', () => {
       // given
-      const rawData = {
-        level: 7,
-        score: 13,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-      const competenceMark = new CompetenceMark(rawData);
+      const competenceMark = factory.buildCompetenceMark({ level: 10 });
 
       // when
       const promise = competenceMark.validate();
 
       // then
-
       return promise
         .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 5]');
+          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 8]');
         });
     });
 
     it('should return an error if level is < -1', () => {
       // given
-      const rawData = {
-        level: -2,
-        score: 13,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-
-      const competenceMark = new CompetenceMark(rawData);
+      const competenceMark = factory.buildCompetenceMark({ level: -2 });
 
       // when
       const promise = competenceMark.validate();
 
       // then
-
       return promise
         .catch((error) => {
           expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be larger than or equal to -1]');
@@ -143,20 +70,12 @@ describe('Unit | Domain | Models | Competence Mark', () => {
 
     it('should return an error if score > 64', () => {
       // given
-      const rawData = {
-        level: 5,
-        score: 65,
-        area_code: '1',
-        competence_code: '1.1'
-      };
-
-      const competenceMark = new CompetenceMark(rawData);
+      const competenceMark = factory.buildCompetenceMark({ score: 65 });
 
       // when
       const promise = competenceMark.validate();
 
       // then
-
       return promise
         .catch((error) => {
           expect(error.message).to.be.equal('ValidationError: child "score" fails because ["score" must be less than or equal to 64]');

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -416,7 +416,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           id: assessmentId,
           courseId: assessmentCourseId,
           userId: 5,
-          type: 'CERTIFICATION',
+          type: Assessment.types.CERTIFICATION,
           state: 'started',
         });
 
@@ -504,7 +504,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           courseId: assessmentCourseId,
           userId: 5,
           state: 'completed',
-          type: 'CERTIFICATION',
+          type: Assessment.types.CERTIFICATION,
         });
 
         // when

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -33,7 +33,7 @@ function _buildCompetence(competence_code, area_code) {
     courseId: 'recvNIWtjJRyBCd0P',
     reference: `${area_code}.${competence_code} bla bla bla`,
     skills: undefined,
-    area: new Area({ id: 'recdmN2Exvq2oAPap', code: `${area_code}`, title: 'Information et données' })
+    area: new Area({ id: 'recdmN2Exvq2oAPap', code: `${area_code}`, title: 'Information et données' }),
   };
 
   Object.assign(competence, defaultCompetenceInfos);
@@ -59,6 +59,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
     let competence12;
     let competence21;
     let competence22;
+    let competence31;
     let listOfAllCompetences = [];
 
     let assessment;
@@ -73,45 +74,54 @@ describe('Unit | Domain | Services | assessment-results', () => {
         courseId: assessmentCourseId,
         userId: 5,
         state: 'started',
-        type: 'PLACEMENT'
+        type: 'PLACEMENT',
       });
 
       evaluatedSkills = {
         assessmentId: assessmentId,
         validatedSkills: _generateValidatedSkills(),
-        failedSkills: _generateFailedSkills()
+        failedSkills: _generateFailedSkills(),
       };
 
-      competenceMarksForCertification = [{
-        competence_code: '1.1',
-        area_code: '1',
-        level: 0,
-        score: 7
-      }, {
-        competence_code: '2.1',
-        area_code: '2',
-        level: 2,
-        score: 19
-      }, {
-        competence_code: '2.2',
-        area_code: '2',
-        level: -1,
-        score: 0
-      }];
+      competenceMarksForCertification = [
+        {
+          competence_code: '1.1',
+          area_code: '1',
+          level: 0,
+          score: 7,
+        }, {
+          competence_code: '2.1',
+          area_code: '2',
+          level: 2,
+          score: 19,
+        }, {
+          competence_code: '2.2',
+          area_code: '2',
+          level: -1,
+          score: 0,
+        },
+        {
+          competence_code: '3.1',
+          area_code: '3',
+          level: 6,
+          score: 52,
+        },
+      ];
 
       competenceMarksForPlacement = [{
         competence_code: '1.1',
         area_code: '1',
         level: 3,
-        score: 18
+        score: 18,
       }];
 
       competence11 = _buildCompetence('1', '1');
       competence12 = _buildCompetence('1', '2');
       competence21 = _buildCompetence('2', '1');
       competence22 = _buildCompetence('2', '2');
+      competence31 = _buildCompetence('3', '1');
 
-      listOfAllCompetences = [competence11, competence12, competence21, competence22];
+      listOfAllCompetences = [competence11, competence12, competence21, competence22, competence31];
 
       course = new AirtableCourse();
       course.id = assessmentCourseId;
@@ -160,7 +170,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           courseId: assessmentCourseId,
           userId: 5,
           state: 'completed',
-          type: 'PLACEMENT'
+          type: 'PLACEMENT',
         });
 
         assessmentRepository.get.resolves(alreadyEvaluatedAssessment);
@@ -214,7 +224,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
         emitter: 'PIX-ALGO',
         commentForJury: 'Computed',
         status: 'validated',
-        assessmentId: assessmentId
+        assessmentId: assessmentId,
       });
 
       // when
@@ -261,7 +271,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           score: 18,
           area_code: '1',
           competence_code: '1.1',
-          assessmentResultId: assessmentResultId
+          assessmentResultId: assessmentResultId,
         };
 
         // then
@@ -306,7 +316,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
         courseId: 'nullCourseId',
         userId: 5,
         status: 'started',
-        type: 'PREVIEW'
+        type: 'PREVIEW',
       });
 
       beforeEach(() => {
@@ -336,7 +346,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           courseId: 'nullCourseId',
           userId: 5,
           state: 'started',
-          type: 'DEMO'
+          type: 'DEMO',
         });
         assessmentRepository.get.resolves(demoAssessment);
         assessmentService.getCompetenceMarks.resolves([]);
@@ -368,26 +378,35 @@ describe('Unit | Domain | Services | assessment-results', () => {
       let clock;
 
       const certificationResults = {
-        competencesWithCompetenceMark: [{
-          index: '1.1',
-          id: 'competence_1',
-          name: 'Mener une recherche',
-          obtainedLevel: 0,
-          obtainedScore: 7
-        }, {
-          index: '2.1',
-          id: 'competence_2',
-          name: 'Partager',
-          obtainedLevel: 2,
-          obtainedScore: 19
-        }, {
-          index: '2.2',
-          id: 'competence_3',
-          name: 'Adapter',
-          obtainedLevel: -1,
-          obtainedScore: 0
-        }],
-        totalScore: 26
+        competencesWithCompetenceMark: [
+          {
+            index: '1.1',
+            id: 'competence_1',
+            name: 'Mener une recherche',
+            obtainedLevel: 0,
+            obtainedScore: 7,
+          }, {
+            index: '2.1',
+            id: 'competence_2',
+            name: 'Partager',
+            obtainedLevel: 2,
+            obtainedScore: 19,
+          }, {
+            index: '2.2',
+            id: 'competence_3',
+            name: 'Adapter',
+            obtainedLevel: -1,
+            obtainedScore: 0,
+          },
+          {
+            index: '3.1',
+            id: 'competence_4',
+            name: 'Va savoir',
+            obtainedLevel: 6,
+            obtainedScore: 52,
+          },
+        ],
+        totalScore: 78,
       };
 
       let assessment;
@@ -398,7 +417,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           courseId: assessmentCourseId,
           userId: 5,
           type: 'CERTIFICATION',
-          state: 'started'
+          state: 'started',
         });
 
         assessmentRepository.get.resolves(assessment);
@@ -416,46 +435,58 @@ describe('Unit | Domain | Services | assessment-results', () => {
 
         // then
         return promise.then(() => {
-          expect(competenceMarkRepository.save).to.have.been.calledThrice;
+          expect(competenceMarkRepository.save.callCount).to.equal(4);
 
-          const firstSavedCompetenceMark = competenceMarkRepository.save.firstCall.args;
+          const firstSavedCompetenceMark = competenceMarkRepository.save.getCall(0).args;
           expect(firstSavedCompetenceMark[0]).to.deep.equal({
             level: 0,
             score: 7,
             area_code: '1',
             competence_code: '1.1',
-            assessmentResultId: assessmentResultId
+            assessmentResultId: assessmentResultId,
           });
 
-          const secondSavedCompetenceMark = competenceMarkRepository.save.secondCall.args;
+          const secondSavedCompetenceMark = competenceMarkRepository.save.getCall(1).args;
           expect(secondSavedCompetenceMark[0]).to.deep.equal({
             level: 2,
             score: 19,
             area_code: '2',
             competence_code: '2.1',
-            assessmentResultId: assessmentResultId
+            assessmentResultId: assessmentResultId,
           });
 
-          const thirdSavedCompetenceMark = competenceMarkRepository.save.thirdCall.args;
+          const thirdSavedCompetenceMark = competenceMarkRepository.save.getCall(2).args;
           expect(thirdSavedCompetenceMark[0]).to.deep.equal({
             level: -1,
             score: 0,
             area_code: '2',
             competence_code: '2.2',
-            assessmentResultId: assessmentResultId
+            assessmentResultId: assessmentResultId,
+          });
+
+          const forthSavedCompetenceMark = competenceMarkRepository.save.getCall(3).args;
+          expect(forthSavedCompetenceMark[0]).to.deep.equal({
+            area_code: '3',
+            assessmentResultId: assessmentResultId,
+            competence_code: '3.1',
+            level: 5,
+            score: 52,
           });
         });
       });
 
       it('should create a new assessment result', () => {
         // given
+        const sumOfCompetenceMarksScores = competenceMarksForCertification.reduce((sum, competenceMark) => {
+          return sum + competenceMark.score;
+        }, 0);
         const assessmentResult = new AssessmentResult({
-          level: 3,
-          pixScore: 26,
+          level: Math.floor(sumOfCompetenceMarksScores / 8),
+          pixScore: sumOfCompetenceMarksScores,
           emitter: 'PIX-ALGO',
           commentForJury: 'Computed',
           status: 'validated',
-          assessmentId: assessmentId
+          assessmentId: assessmentId,
         });
 
         // when
@@ -473,7 +504,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
           courseId: assessmentCourseId,
           userId: 5,
           state: 'completed',
-          type: 'CERTIFICATION'
+          type: 'CERTIFICATION',
         });
 
         // when
@@ -499,6 +530,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
       });
 
       context('when updating the certification course status is failing', () => {
+
         it('should return the raised error', () => {
           // given
           const error = new Error();
@@ -513,6 +545,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
       });
     });
   });
+
   describe('#save', () => {
 
     const assessmentResult = new AssessmentResult({
@@ -523,27 +556,27 @@ describe('Unit | Domain | Services | assessment-results', () => {
       emitter: 'Jury',
       commentForJury: 'Parce que',
       commentForCandidate: 'Voilà',
-      commentForOrganization: 'Truc'
+      commentForOrganization: 'Truc',
     });
     const competenceMarks = [
       new CompetenceMark({
         level: 2,
         score: 18,
         area_code: 2,
-        competence_code: 2.1
+        competence_code: 2.1,
       }),
       new CompetenceMark({
         level: 3,
         score: 27,
         area_code: 3,
-        competence_code: 3.2
-      })
+        competence_code: 3.2,
+      }),
     ];
 
     const sandbox = sinon.sandbox.create();
 
     beforeEach(() => {
-      sandbox.stub(assessmentResultRepository,'save').resolves({ id: 1 });
+      sandbox.stub(assessmentResultRepository, 'save').resolves({ id: 1 });
       sandbox.stub(competenceMarkRepository, 'save').resolves();
     });
 
@@ -574,14 +607,14 @@ describe('Unit | Domain | Services | assessment-results', () => {
           level: 2,
           score: 18,
           area_code: 2,
-          competence_code: 2.1
+          competence_code: 2.1,
         }));
         sinon.assert.calledWith(competenceMarkRepository.save, new CompetenceMark({
           assessmentResultId: 1,
           level: 3,
           score: 27,
           area_code: 3,
-          competence_code: 3.2
+          competence_code: 3.2,
         }));
       });
     });
@@ -593,14 +626,14 @@ describe('Unit | Domain | Services | assessment-results', () => {
           level: 20,
           score: 18,
           area_code: 2,
-          competence_code: 2.1
+          competence_code: 2.1,
         }),
         new CompetenceMark({
           level: 3,
           score: 27,
           area_code: 3,
-          competence_code: 3.2
-        })
+          competence_code: 3.2,
+        }),
       ];
 
       it('should not saved assessmentResult and competenceMarks', () => {
@@ -625,7 +658,6 @@ describe('Unit | Domain | Services | assessment-results', () => {
       });
     });
   });
-
 });
 
 function _generateValidatedSkills() {

--- a/api/tests/unit/domain/services/assessment-service_test.js
+++ b/api/tests/unit/domain/services/assessment-service_test.js
@@ -197,7 +197,7 @@ describe('Unit | Domain | Services | assessment', () => {
 
       context('when the assessement is a certification', () => {
         beforeEach(() => {
-          const assessmentFromCertif = new Assessment({ id: ASSESSMENT_ID, type: 'CERTIFICATION' });
+          const assessmentFromCertif = new Assessment({ id: ASSESSMENT_ID, type: Assessment.types.CERTIFICATION });
           assessmentRepository.get.resolves(assessmentFromCertif);
         });
         it('should return an assessment with an estimated level of 0 and a pix-score of 0', () => {
@@ -496,7 +496,7 @@ describe('Unit | Domain | Services | assessment', () => {
 
         it('should not try to get course details', () => {
           // given
-          const assessmentFromCertif = new Assessment({ id: ASSESSMENT_ID, type: 'CERTIFICATION' });
+          const assessmentFromCertif = new Assessment({ id: ASSESSMENT_ID, type: Assessment.types.CERTIFICATION });
 
           // when
           const promise = service.getSkills(assessmentFromCertif);
@@ -803,7 +803,7 @@ describe('Unit | Domain | Services | assessment', () => {
   describe('#getCompetenceMarks', () => {
 
     context('when assessment is a Certification', () => {
-      const assessment = new Assessment({ id: 1, type: 'CERTIFICATION' });
+      const assessment = new Assessment({ id: 1, type: Assessment.types.CERTIFICATION });
 
       const sandbox = sinon.sandbox.create();
 
@@ -986,7 +986,7 @@ describe('Unit | Domain | Services | assessment', () => {
       it('should get the course associated to each assessment ', function() {
         // given
         const filters = { courseId: 'courseId' };
-        const retrievedAssessments = [new Assessment({ id: 1, type: 'CERTIFICATION', courseId: 'courseId' })];
+        const retrievedAssessments = [new Assessment({ id: 1, type: Assessment.types.CERTIFICATION, courseId: 'courseId' })];
         assessmentRepository.findByFilters.resolves(retrievedAssessments);
 
         // when
@@ -1002,7 +1002,7 @@ describe('Unit | Domain | Services | assessment', () => {
       it('should return one assessment with corresponding course', function() {
         // given
         const filters = { courseId: 'courseId' };
-        const retrievedAssessments = [new Assessment({ id: 1, type: 'CERTIFICATION', courseId: 'courseId' })];
+        const retrievedAssessments = [new Assessment({ id: 1, type: Assessment.types.CERTIFICATION, courseId: 'courseId' })];
         assessmentRepository.findByFilters.resolves(retrievedAssessments);
         certificationCourseRepository.get.resolves({ id: 'courseId', status: 'started' });
         // when
@@ -1023,7 +1023,7 @@ describe('Unit | Domain | Services | assessment', () => {
         // given
         const filters = { userId: 1 };
         const retrievedAssessments = [
-          new Assessment({ id: 1, type: 'CERTIFICATION', courseId: '2' }),
+          new Assessment({ id: 1, type: Assessment.types.CERTIFICATION, courseId: '2' }),
           new Assessment({ id: 2, type: 'DEMO', courseId: 'recCourseId' })
         ];
         assessmentRepository.findByFilters.resolves(retrievedAssessments);
@@ -1042,7 +1042,7 @@ describe('Unit | Domain | Services | assessment', () => {
         // given
         const filters = { userId: 1 };
         const retrievedAssessments = [
-          new Assessment({ id: 1, type: 'CERTIFICATION', courseId: '2' }),
+          new Assessment({ id: 1, type: Assessment.types.CERTIFICATION, courseId: '2' }),
           new Assessment({ id: 2, type: 'DEMO', courseId: 'recCourseId' })
         ];
         assessmentRepository.findByFilters.resolves(retrievedAssessments);
@@ -1070,7 +1070,7 @@ describe('Unit | Domain | Services | assessment', () => {
     context('if assessment type is \'CERTIFICATION\'', () => {
       it('should return true', () => {
         // given
-        const assessment = new Assessment({ type: 'CERTIFICATION' });
+        const assessment = new Assessment({ type: Assessment.types.CERTIFICATION });
 
         // when
         const result = service.isCertificationAssessment(assessment);

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -34,7 +34,7 @@ function _buildAssessmentResult(pixScore, level) {
     id: 'assessment_result_id',
     pixScore,
     level,
-    emitter: 'PIX-ALGO'
+    emitter: 'PIX-ALGO',
   });
 }
 
@@ -110,7 +110,7 @@ const competencesFromAirtable = [
   new Competence({ id: 'competence_1', index: '1.1', name: 'Mener une recherche' }),
   new Competence({ id: 'competence_2', index: '2.2', name: 'Partager' }),
   new Competence({ id: 'competence_3', index: '3.3', name: 'Adapter' }),
-  new Competence({ id: 'competence_4', index: '4.4', name: 'Résoudre' })
+  new Competence({ id: 'competence_4', index: '4.4', name: 'Résoudre' }),
 ];
 
 function _buildCorrectAnswersForAllChallenges() {
@@ -126,7 +126,7 @@ function _buildCorrectAnswersForAllChallenges() {
     _buildAnswer('challenge_I_for_competence_3', 'ok'),
     _buildAnswer('challenge_J_for_competence_4', 'ok'),
     _buildAnswer('challenge_K_for_competence_4', 'ok'),
-    _buildAnswer('challenge_L_for_competence_4', 'ok')
+    _buildAnswer('challenge_L_for_competence_4', 'ok'),
   ];
 }
 
@@ -143,7 +143,7 @@ function _buildWrongAnswersForAllChallenges() {
     _buildAnswer('challenge_I_for_competence_3', 'ko'),
     _buildAnswer('challenge_J_for_competence_4', 'ko'),
     _buildAnswer('challenge_K_for_competence_4', 'ko'),
-    _buildAnswer('challenge_L_for_competence_4', 'ko')
+    _buildAnswer('challenge_L_for_competence_4', 'ko'),
   ];
 }
 
@@ -160,7 +160,7 @@ function _buildAnswersToHaveOnlyTheLastCompetenceFailed() {
     _buildAnswer('challenge_I_for_competence_3', 'ok'),
     _buildAnswer('challenge_J_for_competence_4', 'ko'),
     _buildAnswer('challenge_K_for_competence_4', 'ko'),
-    _buildAnswer('challenge_L_for_competence_4', 'ko')
+    _buildAnswer('challenge_L_for_competence_4', 'ko'),
   ];
 }
 
@@ -177,7 +177,7 @@ function _buildAnswersToHaveAThirdOfTheCompetencesFailedAndReproductibilityRateL
     _buildAnswer('challenge_I_for_competence_3', 'ko'),
     _buildAnswer('challenge_J_for_competence_4', 'ok'),
     _buildAnswer('challenge_K_for_competence_4', 'ko'),
-    _buildAnswer('challenge_L_for_competence_4', 'ok')
+    _buildAnswer('challenge_L_for_competence_4', 'ok'),
   ];
 }
 
@@ -189,7 +189,13 @@ describe('Unit | Service | Certification Service', function() {
 
     let sandbox;
 
-    const certificationAssessement = new Assessment({ id: 'assessment_id', userId: 'user_id', courseId: 'course_id', createdAt: '2018-01-01', state: 'completed' });
+    const certificationAssessement = new Assessment({
+      id: 'assessment_id',
+      userId: 'user_id',
+      courseId: 'course_id',
+      createdAt: '2018-01-01',
+      state: 'completed',
+    });
     const certificationCourse = { id: 'course1', status: 'completed', completedAt: '2018-01-01' };
 
     const userProfile = competences;
@@ -280,7 +286,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -288,7 +294,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -296,7 +302,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -304,7 +310,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: 0
+          obtainedScore: 0,
         }];
 
         // when
@@ -344,7 +350,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 1,
             positionedLevel: 1,
             positionedScore: 10,
-            obtainedScore: pixForCompetence1
+            obtainedScore: pixForCompetence1,
           }, {
             index: '2.2',
             id: 'competence_2',
@@ -352,7 +358,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 2,
             positionedLevel: 2,
             positionedScore: 20,
-            obtainedScore: pixForCompetence2
+            obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
             id: 'competence_3',
@@ -360,7 +366,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 3,
             positionedLevel: 3,
             positionedScore: 30,
-            obtainedScore: pixForCompetence3
+            obtainedScore: pixForCompetence3,
           }, {
             index: '4.4',
             id: 'competence_4',
@@ -368,8 +374,8 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 4,
             positionedLevel: 4,
             positionedScore: 40,
-            obtainedScore: pixForCompetence4
-          }
+            obtainedScore: pixForCompetence4,
+          },
         ];
 
         // when
@@ -406,7 +412,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 1,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: pixForCompetence1
+          obtainedScore: pixForCompetence1,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -414,7 +420,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: pixForCompetence2
+          obtainedScore: pixForCompetence2,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -422,7 +428,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 3,
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: pixForCompetence3
+          obtainedScore: pixForCompetence3,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -431,7 +437,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: 0
+          obtainedScore: 0,
         }];
 
         // when
@@ -474,7 +480,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 0,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: pixForCompetence1 - malusForFalseAnswer
+          obtainedScore: pixForCompetence1 - malusForFalseAnswer,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -482,7 +488,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: pixForCompetence2
+          obtainedScore: pixForCompetence2,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -491,7 +497,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -499,7 +505,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 3,
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: pixForCompetence4 - malusForFalseAnswer
+          obtainedScore: pixForCompetence4 - malusForFalseAnswer,
         }];
 
         // when
@@ -521,7 +527,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 0,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: pixForCompetence1 - malusForFalseAnswer
+          obtainedScore: pixForCompetence1 - malusForFalseAnswer,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -529,7 +535,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: pixForCompetence2
+          obtainedScore: pixForCompetence2,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -538,7 +544,7 @@ describe('Unit | Service | Certification Service', function() {
           positionedScore: 30,
           obtainedLevel: UNCERTIFIED_LEVEL,
 
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -546,7 +552,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 3,
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: pixForCompetence4 - malusForFalseAnswer
+          obtainedScore: pixForCompetence4 - malusForFalseAnswer,
         }];
 
         const expectedChallenges = [
@@ -633,7 +639,7 @@ describe('Unit | Service | Certification Service', function() {
             skill: '@skillChallengeL_4',
             result: 'ok',
             value: 'something',
-          }
+          },
 
         ];
         const expectedResult = {
@@ -644,7 +650,7 @@ describe('Unit | Service | Certification Service', function() {
           totalScore: 54,
           userId: 'user_id',
           completedAt: '2018-01-01',
-          createdAt: '2018-01-01'
+          createdAt: '2018-01-01',
         };
 
         // when
@@ -668,13 +674,13 @@ describe('Unit | Service | Certification Service', function() {
             const answers = [
               _buildAnswer('challenge_A_for_competence_1', 'ok'),
               _buildAnswer('challenge_B_for_competence_1', 'ok'),
-              _buildAnswer('challenge_C_for_competence_1', 'ko')
+              _buildAnswer('challenge_C_for_competence_1', 'ko'),
             ];
 
             const challenges = [
               _buildCertificationChallenge('challenge_A_for_competence_1', 'competence_1', '@skillChallengeA_1'),
               _buildCertificationChallenge('challenge_B_for_competence_1', 'competence_1', '@skillChallengeB_1'),
-              _buildCertificationChallenge('challenge_C_for_competence_1', 'competence_1', '@skillChallengeC_1')
+              _buildCertificationChallenge('challenge_C_for_competence_1', 'competence_1', '@skillChallengeC_1'),
             ];
 
             const challengesForCompetence = [
@@ -683,7 +689,7 @@ describe('Unit | Service | Certification Service', function() {
               _buildChallenge('challenge_C_for_competence_1', 'competence_1', 'QCM')];
 
             const userProfile = [
-              _buildCompetence('Mener une recherche', '1.1', 'competence_1', positionedScore, positionedLevel, challengesForCompetence)
+              _buildCompetence('Mener une recherche', '1.1', 'competence_1', positionedScore, positionedLevel, challengesForCompetence),
             ];
 
             answersRepository.findByAssessment.resolves(answers);
@@ -717,7 +723,7 @@ describe('Unit | Service | Certification Service', function() {
       userId: 'user_id',
       createdAt: '2018-01-01',
       courseId: 'course_id',
-      status: 'completed'
+      status: 'completed',
     });
 
     const userProfile = competences;
@@ -807,7 +813,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -816,7 +822,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -825,7 +831,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -834,7 +840,7 @@ describe('Unit | Service | Certification Service', function() {
 
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: 0
+          obtainedScore: 0,
         }];
 
         // when
@@ -875,7 +881,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 1,
             positionedLevel: 1,
             positionedScore: 10,
-            obtainedScore: pixForCompetence1
+            obtainedScore: pixForCompetence1,
           }, {
             index: '2.2',
             id: 'competence_2',
@@ -883,7 +889,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 2,
             positionedLevel: 2,
             positionedScore: 20,
-            obtainedScore: pixForCompetence2
+            obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
             id: 'competence_3',
@@ -891,7 +897,7 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 3,
             positionedLevel: 3,
             positionedScore: 30,
-            obtainedScore: pixForCompetence3
+            obtainedScore: pixForCompetence3,
           }, {
             index: '4.4',
             id: 'competence_4',
@@ -899,8 +905,8 @@ describe('Unit | Service | Certification Service', function() {
             obtainedLevel: 4,
             positionedLevel: 4,
             positionedScore: 40,
-            obtainedScore: pixForCompetence4
-          }
+            obtainedScore: pixForCompetence4,
+          },
         ];
 
         // when
@@ -937,7 +943,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 1,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: pixForCompetence1
+          obtainedScore: pixForCompetence1,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -945,7 +951,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: pixForCompetence2
+          obtainedScore: pixForCompetence2,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -953,7 +959,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 3,
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: pixForCompetence3
+          obtainedScore: pixForCompetence3,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -961,7 +967,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: 0
+          obtainedScore: 0,
         }];
 
         // when
@@ -1005,7 +1011,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 0,
           positionedLevel: 1,
           positionedScore: 10,
-          obtainedScore: pixForCompetence1 - malusForFalseAnswer
+          obtainedScore: pixForCompetence1 - malusForFalseAnswer,
         }, {
           index: '2.2',
           id: 'competence_2',
@@ -1013,7 +1019,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 2,
           positionedScore: 20,
-          obtainedScore: pixForCompetence2
+          obtainedScore: pixForCompetence2,
         }, {
           index: '3.3',
           id: 'competence_3',
@@ -1021,7 +1027,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 3,
           positionedScore: 30,
-          obtainedScore: 0
+          obtainedScore: 0,
         }, {
           index: '4.4',
           id: 'competence_4',
@@ -1029,7 +1035,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 3,
           positionedLevel: 4,
           positionedScore: 40,
-          obtainedScore: pixForCompetence4 - malusForFalseAnswer
+          obtainedScore: pixForCompetence4 - malusForFalseAnswer,
         }];
 
         // when
@@ -1054,7 +1060,7 @@ describe('Unit | Service | Certification Service', function() {
 
         const competences = [
           _buildCompetence('Compétence à valider', '5.5', 'competence_5', 50, 5, listChallengeComp5WithOneQROCMDEPChallengeAndAnother),
-          _buildCompetence('Compétence réussie moyennement', '6.6', 'competence_6', 36, 3, listChallengeComp6WithThreeChallenge)
+          _buildCompetence('Compétence réussie moyennement', '6.6', 'competence_6', 36, 3, listChallengeComp6WithThreeChallenge),
         ];
         const challenges = [
           _buildCertificationChallenge('challenge_A_for_competence_5', 'competence_5', '@skillChallengeA_5'),
@@ -1085,7 +1091,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 5,
           positionedLevel: 5,
           positionedScore: 50,
-          obtainedScore: 50
+          obtainedScore: 50,
         }, {
           index: '6.6',
           id: 'competence_6',
@@ -1093,7 +1099,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: UNCERTIFIED_LEVEL,
           positionedLevel: 3,
           positionedScore: 36,
-          obtainedScore: 0
+          obtainedScore: 0,
         }];
 
         // when
@@ -1122,7 +1128,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 4,
           positionedLevel: 5,
           positionedScore: 50,
-          obtainedScore: 42
+          obtainedScore: 42,
         }, {
           index: '6.6',
           id: 'competence_6',
@@ -1130,7 +1136,7 @@ describe('Unit | Service | Certification Service', function() {
           obtainedLevel: 2,
           positionedLevel: 3,
           positionedScore: 36,
-          obtainedScore: 28
+          obtainedScore: 28,
         }];
 
         // when
@@ -1172,7 +1178,7 @@ describe('Unit | Service | Certification Service', function() {
       { id: 'competence2', estimatedLevel: 2 },
       { id: 'competence3', estimatedLevel: 0 },
       { id: 'competence4', estimatedLevel: 4 },
-      { id: 'competence5', estimatedLevel: 5 }
+      { id: 'competence5', estimatedLevel: 5 },
     ];
     const fiveCompetencesWithLevelHigherThan0 = [
       { id: 'competence1', estimatedLevel: 1 },
@@ -1180,13 +1186,13 @@ describe('Unit | Service | Certification Service', function() {
       { id: 'competence3', estimatedLevel: 3 },
       { id: 'competence4', estimatedLevel: 4 },
       { id: 'competence5', estimatedLevel: 5 },
-      { id: 'competence6', estimatedLevel: 6 }
+      { id: 'competence6', estimatedLevel: 6 },
     ];
 
     [{ label: 'User Has No AirtableCompetence', competences: noCompetences },
       { label: 'User Has Only 1 AirtableCompetence at Level 0', competences: oneCompetenceWithLevel0 },
       { label: 'User Has Only 1 AirtableCompetence at Level 5', competences: oneCompetenceWithLevel5 },
-      { label: 'User Has 5 Competences with 1 at Level 0', competences: fiveCompetencesAndOneWithLevel0 }
+      { label: 'User Has 5 Competences with 1 at Level 0', competences: fiveCompetencesAndOneWithLevel0 },
     ].forEach(function(testCase) {
       it(`should not create a new certification if ${testCase.label}`, function() {
         // given
@@ -1220,7 +1226,7 @@ describe('Unit | Service | Certification Service', function() {
         sinon.assert.calledOnce(certificationCourseRepository.save);
         expect(certificationCourseRepository.save).to.have.been.calledWith({
           userId: userId,
-          sessionId
+          sessionId,
         });
         expect(newCertification.id).to.equal('certificationCourseWithChallenges');
       });
@@ -1251,12 +1257,12 @@ describe('Unit | Service | Certification Service', function() {
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
-      const assessmentResult = _buildAssessmentResult(20,3);
+      const assessmentResult = _buildAssessmentResult(20, 3);
       sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(new Assessment({
         status: 'completed',
         assessmentResults: [
-          _buildAssessmentResult(20, 3)
-        ]
+          _buildAssessmentResult(20, 3),
+        ],
       }));
       sandbox.stub(certificationCourseRepository, 'get').resolves({
         createdAt: '2017-12-23 15:23:12',
@@ -1266,12 +1272,12 @@ describe('Unit | Service | Certification Service', function() {
         birthplace: 'Savane',
         birthdate: '28/01/1992',
         sessionId: 'MoufMufassa',
-        externalId: 'TimonsFriend'
+        externalId: 'TimonsFriend',
       });
 
       assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1')];
       sandbox.stub(assessmentResultRepository, 'get').resolves(
-        assessmentResult
+        assessmentResult,
       );
 
     });
@@ -1293,10 +1299,12 @@ describe('Unit | Service | Certification Service', function() {
         expect(certification.createdAt).to.deep.equal('2017-12-23 15:23:12');
         expect(certification.completedAt).to.deep.equal('2017-12-23T16:23:12.232Z');
         expect(certification.competencesWithMark).to.deep.equal([{
-          level: 3,
-          competence_code: '2.1',
           area_code: '2',
-          score: 27
+          assessmentResultId: undefined,
+          competence_code: '2.1',
+          id: undefined,
+          level: 3,
+          score: 27,
         }]);
         expect(certification.sessionId).to.deep.equal('MoufMufassa');
       });

--- a/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
@@ -38,7 +38,7 @@ describe('Unit | Repository | assessmentRepository', () => {
       userId: JOHN,
       courseId: 'courseId3',
       state: 'completed',
-      type: 'CERTIFICATION'
+      type: Assessment.types.CERTIFICATION
     }, {
       id: 6,
       userId: LAYLA,
@@ -226,7 +226,7 @@ describe('Unit | Repository | assessmentRepository', () => {
       userId: JOHN,
       courseId: 'courseId',
       state: 'completed',
-      type: 'CERTIFICATION'
+      type: Assessment.types.CERTIFICATION
     }, {
       id: 6,
       userId: LAYLA,
@@ -344,7 +344,7 @@ describe('Unit | Repository | assessmentRepository', () => {
 
     context('when assessment is valid', () => {
       beforeEach(() => {
-        assessment = new Assessment({ id: '1', type: 'CERTIFICATION', userId: 2 });
+        assessment = new Assessment({ id: '1', type: Assessment.types.CERTIFICATION, userId: 2 });
         const assessmentBookshelf = new BookshelfAssessment(assessment);
         sinon.stub(BookshelfAssessment.prototype, 'save').resolves(assessmentBookshelf);
       });
@@ -373,7 +373,7 @@ describe('Unit | Repository | assessmentRepository', () => {
 
     context('when assessment is not valid', () => {
       beforeEach(() => {
-        assessment = new Assessment({ id: '1', type: 'CERTIFICATION', userId: undefined });
+        assessment = new Assessment({ id: '1', type: Assessment.types.CERTIFICATION, userId: undefined });
         const assessmentBookshelf = new BookshelfAssessment(assessment);
         sinon.stub(BookshelfAssessment.prototype, 'save').resolves(assessmentBookshelf);
       });

--- a/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
@@ -1,7 +1,9 @@
 const { expect, sinon } = require('../../../test-helper');
 const CertificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const CertificationCourseBookshelf = require('../../../../lib/infrastructure/data/certification-course');
+
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Unit | Repository | Certification Course', function() {
 
@@ -28,7 +30,7 @@ describe('Unit | Repository | Certification Course', function() {
         userId: 1,
         completedAt: null,
         createdAt: null,
-        type: 'CERTIFICATION',
+        type: Assessment.types.CERTIFICATION,
         firstName: 'Antoine',
         lastName: 'Griezmann',
         birthplace: 'Macon',

--- a/live/app/components/competence-level-progress-bar.js
+++ b/live/app/components/competence-level-progress-bar.js
@@ -16,14 +16,19 @@ export default Component.extend({
   name: null,
   status: null,
 
+  limitedLevel: computed('level', function() {
+    const level = this.get('level');
+    return Math.min(level, this.get('_LIMIT_LEVEL'));
+  }),
+
   hasLevel: computed('level', function() {
     const level = this.get('level');
     return isPresent(this.get('level')) && level !== -1;
   }),
 
-  widthOfProgressBar: computed('level', function() {
+  widthOfProgressBar: computed('limitedLevel', function() {
 
-    const level = this.get('level');
+    const level = this.get('limitedLevel');
     const maxLevel = this.get('_MAX_LEVEL');
     let progressBarWidth;
 

--- a/live/app/components/competence-level-progress-bar.js
+++ b/live/app/components/competence-level-progress-bar.js
@@ -7,7 +7,7 @@ export default Component.extend({
 
   classNames: ['competence-level-progress-bar'],
 
-  _LIMIT_LEVEL: 5,
+  _MAX_REACHABLE_LEVEL: 5,
   _MAX_LEVEL: 8,
 
   level: null,
@@ -18,7 +18,7 @@ export default Component.extend({
 
   limitedLevel: computed('level', function() {
     const level = this.get('level');
-    return Math.min(level, this.get('_LIMIT_LEVEL'));
+    return Math.min(level, this.get('_MAX_REACHABLE_LEVEL'));
   }),
 
   hasLevel: computed('level', function() {

--- a/live/app/templates/components/competence-level-progress-bar.hbs
+++ b/live/app/templates/components/competence-level-progress-bar.hbs
@@ -2,7 +2,7 @@
   <div class="competence-level-progress-bar__background">
     <div class="competence-level-progress-bar__background-level-limit">
       <div class="competence-level-progress-bar__background-level-limit-indicator">
-        {{_LIMIT_LEVEL}}
+        {{_MAX_REACHABLE_LEVEL}}
       </div>
     </div>
     <div class="competence-level-progress-bar__background-available-soon-text">Disponible Prochainement</div>

--- a/live/app/templates/components/competence-level-progress-bar.hbs
+++ b/live/app/templates/components/competence-level-progress-bar.hbs
@@ -21,7 +21,7 @@
 
   <div class="competence-level-progress-bar__level" style={{widthOfProgressBar}}>
     <div class="competence-level-progress-bar__level-indicator">
-      {{level}}
+      {{limitedLevel}}
     </div>
   </div>
 {{/if}}

--- a/live/tests/unit/components/competence-level-progress-bar-test.js
+++ b/live/tests/unit/components/competence-level-progress-bar-test.js
@@ -8,13 +8,41 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
 
   describe('#Computed Properties behaviors: ', function() {
 
+    describe('#limitedLevel', function() {
+
+      [
+        { level: 8, expectedValue: 5 },
+        { level: 7, expectedValue: 5 },
+        { level: 6, expectedValue: 5 },
+        { level: 5, expectedValue: 5 },
+        { level: 4, expectedValue: 4 },
+        { level: 3, expectedValue: 3 },
+        { level: 2, expectedValue: 2 },
+        { level: 1, expectedValue: 1 },
+        { level: 0, expectedValue: 0 },
+        { level: -1, expectedValue: -1 },
+      ].forEach(({ level, expectedValue }) => {
+
+        it(`should return ${expectedValue} when the level of the competence is ${level}`, function() {
+          // given
+          const component = this.subject();
+
+          // when
+          component.set('level', level);
+
+          // then
+          expect(component.get('limitedLevel')).to.equal(expectedValue);
+        });
+      });
+    });
+
     describe('#hasLevel', function() {
 
       [
         { level: 1, expectedValue: true },
         { level: 0, expectedValue: true },
         { level: -1, expectedValue: false },
-        { level: undefined, expectedValue: false }
+        { level: undefined, expectedValue: false },
       ].forEach(({ level, expectedValue }) => {
 
         it(`should return ${expectedValue} when the level of the competence is ${level}`, function() {
@@ -27,9 +55,7 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
           // then
           expect(component.get('hasLevel')).to.equal(expectedValue);
         });
-
       });
-
     });
 
     describe('#widthOfProgressBar', function() {
@@ -40,6 +66,9 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
         { level: 3, expectedValue: 'width : 37.5%' },
         { level: 4, expectedValue: 'width : 50%' },
         { level: 5, expectedValue: 'width : 62.5%' },
+        { level: 6, expectedValue: 'width : 62.5%' },
+        { level: 7, expectedValue: 'width : 62.5%' },
+        { level: 8, expectedValue: 'width : 62.5%' },
       ].forEach(({ level, expectedValue }) => {
 
         it(`should return ${expectedValue} when the level is ${level}`, function() {
@@ -52,7 +81,6 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
           // then
           expect(component.get('widthOfProgressBar').string).to.equal(expectedValue);
         });
-
       });
     });
 
@@ -109,7 +137,6 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
         // then
         expect(component.get('canUserStartCourse')).to.be.false;
       });
-
     });
 
     describe('#canUserResumeAssessment', function() {
@@ -190,7 +217,7 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
       it('should return false if status is not "evaluated"', function() {
         // given
         const status = 'replayed';
-        const courseId ='courseId';
+        const courseId = 'courseId';
         const component = this.subject();
 
         // when
@@ -200,7 +227,6 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
         // then
         expect(component.get('canUserReplayAssessment')).to.equal(false);
       });
-
     });
   });
 });


### PR DESCRIPTION
Correction de bogues liés à la gestion du calcul des scores de fin d'assessment. 

1 - Affichage d'un niveau 6 sur la page profil d'un utilisateur pour un test de positionnement.
2 - Manque de la propriété "completedAt" sur l'objet certificationCourse d'une certification 

Les deux bogues ont été réglé dans l'idée de mettre la Rustine™ le plus "loin" possible pour "libérer" le code / l'algorithme des limites "artificielles" de niveaux. 