### PR TITLE
[#109] Ajout de traces de log dans la sélection du next challenge (PF-267).

### DIFF
--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -214,10 +214,12 @@ class Assessment {
       zone: 'CatAsessment.nextChallenge',
       type: 'cat',
       answers: this.answers.map(answer => {
+        const challenge = answer.challenge || { id: null };
+        const skills = (challenge.skills || []).map(skill => skill.name);
         return {
-          challengeId: answer.challenge.id,
-          skills: answer.challenge.skills.map(skill => skill.name),
+          challengeId: challenge.id,
           result: answer.result,
+          skills,
         };
       }),
       courseId: this.course.id,

--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -9,9 +9,10 @@ const LEVEL_FOR_FIRST_CHALLENGE = 2;
 const LEVEL_MAX_TO_BE_AN_EASY_TUBE = 3;
 
 class Assessment {
-  constructor(course, answers) {
+  constructor(course, answers, assessmentId) {
     this.course = course;
     this.answers = answers;
+    this.assessmentId = assessmentId;
   }
 
   _randomly() {
@@ -222,6 +223,7 @@ class Assessment {
           skills,
         };
       }),
+      assessmentId: this.assessmentId,
       courseId: this.course.id,
     };
     logger.trace(logContext, 'looking for next challenge in CAT Assessment');

--- a/api/lib/domain/services/assessment-service.js
+++ b/api/lib/domain/services/assessment-service.js
@@ -61,7 +61,7 @@ async function fetchAssessment(assessmentId) {
 
       if (skillsAndChallenges) {
         const [skills, challengesPix] = skillsAndChallenges;
-        const catAssessment = assessmentAdapter.getAdaptedAssessment(answers, challengesPix, skills);
+        const catAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challengesPix, skills);
 
         skillsReport = {
           assessmentId,
@@ -112,7 +112,7 @@ async function getSkills(assessment) {
 
       if (skillsAndChallenges) {
         const [skills, challengesPix] = skillsAndChallenges;
-        const catAssessment = assessmentAdapter.getAdaptedAssessment(answers, challengesPix, skills);
+        const catAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challengesPix, skills);
 
         skillsReport = {
           validatedSkills: catAssessment.validatedSkills,
@@ -149,7 +149,7 @@ function getScoreAndLevel(assessmentId) {
       .then((skillsAndChallenges) => {
         if (skillsAndChallenges) {
           const [skills, challengesPix] = skillsAndChallenges;
-          const catAssessment = assessmentAdapter.getAdaptedAssessment(answers, challengesPix, skills);
+          const catAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challengesPix, skills);
 
           estimatedLevel = catAssessment.obtainedLevel;
           pixScore = catAssessment.displayedPixScore;

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -1,7 +1,21 @@
+
+const logger = require('../../infrastructure/logger');
+
 module.exports = function({ certificationChallengeRepository, challengeRepository, assessment }) {
+
+  const logContext = {
+    zone: 'usecase.getNextChallengeForCertification',
+    type: 'usecase',
+    assessment,
+    assessmentId: assessment.id,
+  };
+  logger.trace(logContext, 'looking for next challenge in CERTIFICATION assessment');
 
   return certificationChallengeRepository.getNonAnsweredChallengeByCourseId(assessment.id, assessment.courseId)
     .then((certificationChallenge) => {
+      logContext.certificationChallenge = certificationChallenge;
+      logger.trace(logContext, 'found next challenge');
+
       return challengeRepository.get(certificationChallenge.challengeId);
     });
 

--- a/api/lib/domain/usecases/get-next-challenge-for-placement.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-placement.js
@@ -38,7 +38,7 @@ module.exports = function({
       logContext.challenges = challenges.map(challenge => challenge.id);
       logContext.skills = skills.map(skill => skill.name);
       logger.trace(logContext, 'fetched all entites. Running cat to look for next challenge');
-      return getNextChallengeInAdaptiveCourse(answers, challenges, skills);
+      return getNextChallengeInAdaptiveCourse(assessment.id, answers, challenges, skills);
     })
     .then((nextChallenge) => {
       if (nextChallenge) {
@@ -54,7 +54,7 @@ module.exports = function({
 
 };
 
-function getNextChallengeInAdaptiveCourse(answersPix, challengesPix, skills) {
-  const assessment = assessmentAdapter.getAdaptedAssessment(answersPix, challengesPix, skills);
+function getNextChallengeInAdaptiveCourse(assessmentId, answersPix, challengesPix, skills) {
+  const assessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answersPix, challengesPix, skills);
   return _.get(assessment, 'nextChallenge.id', null);
 }

--- a/api/lib/infrastructure/adapters/assessment-adapter.js
+++ b/api/lib/infrastructure/adapters/assessment-adapter.js
@@ -6,7 +6,7 @@ const CatAssessment = require('../../cat/assessment');
 
 // TODO: Déclencher une erreur quand pas de skill ?
 
-function getAdaptedAssessment(answersPix, challengesPix, skills) {
+function getAdaptedAssessment(assessmentId, answersPix, challengesPix, skills) {
   const challenges = [];
 
   challengesPix.forEach(challengePix => {
@@ -25,7 +25,7 @@ function getAdaptedAssessment(answersPix, challengesPix, skills) {
     return new CatAnswer(challengeOfTheAnswer, answer.result.status);
   });
 
-  return new CatAssessment(course, answers);
+  return new CatAssessment(course, answers, assessmentId);
 }
 
 module.exports = {

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -1,8 +1,9 @@
 const Airtable = require('airtable');
-const AirtableRecord = Airtable.Record;
 const airtableConfig = require('../settings').airtable;
+const AirtableRecord = Airtable.Record;
 const cache = require('./caches/cache');
 const hash = require('object-hash');
+const logger = require('./logger');
 
 module.exports = {
 
@@ -12,37 +13,65 @@ module.exports = {
 
   getRecord(tableName, recordId) {
     const cacheKey = `${tableName}_${recordId}`;
+    const logContext = {
+      zone: 'airtable.getRecord',
+      type: 'airtable',
+      recordId,
+      tableName,
+    };
+
     return cache.get(cacheKey)
       .then(cachedRawJson => {
         if (cachedRawJson) {
           return new AirtableRecord(tableName, cachedRawJson.id, cachedRawJson);
         }
 
+        logger.trace(logContext, 'cache miss. Calling airtable');
         return this._base()
           .table(tableName)
           .find(recordId)
           .then(record => {
+            logger.trace(logContext, 'found record in Airtable.');
             return cache.set(cacheKey, record._rawJson)
               .then(() => record);
+          })
+          .catch(err => {
+            logContext.err = err;
+            logger.error(logContext, 'Airtable error');
+            return Promise.reject(err);
           });
       });
   },
 
   findRecords(tableName, query) {
     const cacheKey = `${tableName}_${hash(query)}`;
+    const logContext = {
+      zone: 'airtable.getRecord',
+      type: 'airtable',
+      query,
+      tableName,
+    };
+
     return cache.get(cacheKey)
       .then(cachedArrayOfRawJson => {
         if (cachedArrayOfRawJson) {
           return cachedArrayOfRawJson.map(rawJson => new AirtableRecord(tableName, rawJson.id, rawJson));
         }
 
+        logger.trace(logContext, 'cache miss. Calling airtable');
         return this._base()
           .table(tableName)
           .select(query)
           .all()
           .then(records => {
+            logger.trace(logContext, 'found record in Airtable.');
             return cache.set(cacheKey, records.map(record => record._rawJson))
               .then(() => records);
+          })
+          .catch(err => {
+            logContext.err = err;
+            logger.error(logContext, 'Airtable error');
+            return Promise.reject(err);
           });
       });
   }

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -8,8 +8,11 @@ if (settings.logging.enabled) {
   logger.addStream({
     name: 'standard-output',
     stream: process.stdout,
-    level: 'info'
+    level: settings.logging.logLevel,
   });
+
+  logger.debug('DEBUG logs enabled');
+  logger.trace('TRACE logs enabled');
 }
 
 module.exports = logger;

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -24,7 +24,8 @@ module.exports = (function() {
 
     logging: {
       enabled: (process.env.LOG_ENABLED || process.env.NODE_ENV != 'test'),
-      colorEnabled: ('development' === process.env.NODE_ENV)
+      colorEnabled: ('development' === process.env.NODE_ENV),
+      logLevel: (process.env.LOG_LEVEL || 'info'),
     },
 
     mailjet: {

--- a/api/tests/factory/build-cat-assessment.js
+++ b/api/tests/factory/build-cat-assessment.js
@@ -1,10 +1,12 @@
 const buildCatAnswer = require('./build-cat-answer');
 const buildCatCourse = require('./build-cat-course');
 const CatAssessment = require('../../lib/cat/assessment');
+const faker = require('faker');
 
 module.exports = function buildCatAssessment({
   course = buildCatCourse(),
   answers = [buildCatAnswer()],
+  assessmentId = faker.random.uuid(),
 } = {}) {
-  return new CatAssessment(course, answers);
+  return new CatAssessment(course, answers, assessmentId);
 };

--- a/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
@@ -25,6 +25,8 @@ describe('Unit | Adapter | Assessment', () => {
 
   describe('#getAdaptedAssessment', () => {
 
+    const assessmentId = 0;
+
     it('should return an Assessment from the Cat repository', () => {
       // given
       const skills = defaultRawSkillCollection;
@@ -32,7 +34,7 @@ describe('Unit | Adapter | Assessment', () => {
       const answers = [];
 
       // when
-      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challenges, skills);
 
       // then
       expect(adaptedAssessment).to.be.an.instanceOf(CatAssessment);
@@ -46,7 +48,7 @@ describe('Unit | Adapter | Assessment', () => {
       const answers = [];
 
       // when
-      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+      const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challenges, skills);
 
       // then
       expect(adaptedAssessment).to.have.property('course').and.to.be.an.instanceOf(CatCourse);
@@ -68,7 +70,7 @@ describe('Unit | Adapter | Assessment', () => {
         const expectedChallenge = defaultCatChallenge;
 
         // when
-        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challenges, skills);
 
         // then
         const { course } = adaptedAssessment;
@@ -87,7 +89,7 @@ describe('Unit | Adapter | Assessment', () => {
         const answers = [];
 
         // when
-        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challenges, skills);
 
         // then
         const { course } = adaptedAssessment;
@@ -106,7 +108,7 @@ describe('Unit | Adapter | Assessment', () => {
         const answers = [];
 
         // when
-        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answers, challenges, skills);
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answers, challenges, skills);
 
         // then
         const challenge  = adaptedAssessment.course.challenges[0];
@@ -125,7 +127,7 @@ describe('Unit | Adapter | Assessment', () => {
         const answersGiven = [new Answer({ id: 42, challengeId: challenge.id, result: '#ABAND#' })];
 
         // when
-        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(answersGiven, [challenge], skills);
+        const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answersGiven, [challenge], skills);
 
         // then
         const { answers } = adaptedAssessment;


### PR DESCRIPTION
Fait:
- choix du niveau de logging par variable d'environnement (`LOG_LEVEL`) avec défaut à `info` (comme avant)
- toutes les traces sont écrite au niveau `logger.trace()`, [qui est inférieur à debug](https://github.com/trentm/node-bunyan#levels)
- Ajout de quelques traces vues avec Benoit pour aider au débugging