### PR TITLE
[#121] [BUGFIX] Respecter la variable DATABASE_CONNECTION_POOL_MAX_SIZE pour le pool PG en staging (PF-284)

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -32,8 +32,8 @@ module.exports = {
     client: 'postgresql',
     connection: process.env.DATABASE_URL,
     pool: {
-      min: 10,
-      max: 100
+      min: 1,
+      max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4),
     },
     migrations: {
       tableName: 'knex_migrations',
@@ -49,7 +49,7 @@ module.exports = {
     connection: process.env.DATABASE_URL,
     pool: {
       min: 1,
-      max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, '10') || 4),
+      max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4),
     },
     migrations: {
       tableName: 'knex_migrations',


### PR DESCRIPTION
Le PG de l'application de staging n'autorise que 30 connexions simultanées or la configuration de `knex` autorisait un _pool_ de 100 connexions. On a eu une erreur 500 en staging avec dans le log l'erreur suivante : 

```
[web-1] error: remaining connection slots are reserved for non-replication superuser connections
[web-1] at Connection.parseE (/app/api/node_modules/pg/lib/connection.js:545:11)
[web-1] at Connection.parseMessage (/app/api/node_modules/pg/lib/connection.js:370:19)
[web-1] at TLSSocket.<anonymous> (/app/api/node_modules/pg/lib/connection.js:113:22)
[web-1] at emitOne (events.js:116:13)
[web-1] at TLSSocket.emit (events.js:211:7)
[web-1] at addChunk (_stream_readable.js:263:12)
[web-1] at readableAddChunk (_stream_readable.js:250:11)
[web-1] at TLSSocket.Readable.push (_stream_readable.js:208:10)
[web-1] at TLSWrap.onread (net.js:597:20)
[web-1] 180704/144856.527, [response,api] http://pix-api-staging-web-1:21477: post /api/assessment-results {} 500 (322ms)
```

Cette PR applique en staging la configuration de production, à savoir utiliser la variable d'environnement `DATABASE_CONNECTION_POOL_MAX_SIZE` avec une valeur par défaut à 4.