### PR TITLE
[#] [BUGFIX] Bug d'affichage du bouton demo IE (PF-179).

### DIFF
--- a/live/app/styles/components/_course-item.scss
+++ b/live/app/styles/components/_course-item.scss
@@ -26,6 +26,7 @@
 
   width: 100%;
   margin-bottom: auto;
+  height: 25%;
 
   font-family: $font-raleway;
   font-size: 22px;


### PR DESCRIPTION
J'ai bloqué la hauteur du titre pour que le reste en dessous s'affiche bien.
Conséquence : 
- Bug sous IE résolu
- Ré-alignement du texte de présentation des démo (qui était décalé pour communication et collaboration)