### PR TITLE
[#130] [BUGFIX] Correction du bug des questions en doubles dans le smart-random (PF-287)

### DIFF
--- a/api/lib/domain/strategies/SmartRandom.js
+++ b/api/lib/domain/strategies/SmartRandom.js
@@ -65,8 +65,15 @@ function _isChallengeNotTooHard(challenge, predictedLevel) {
   return challenge.hardestSkill.difficulty - predictedLevel <= 2;
 }
 
-function _isAnAvailableChallenge(challenge, assessedSkills) {
-  return challenge.isPublished() && challenge.testsAtLeastOneNewSkill(assessedSkills);
+function _isNotAnsweredYet(challenge, answers) {
+  const findAnswersForThisChallenge = answers.find(answer => answer.challengeId == challenge.id);
+  return !findAnswersForThisChallenge;
+}
+
+function _isAnAvailableChallenge(challenge, assessedSkills, answers) {
+  return challenge.isPublished()
+    && challenge.testsAtLeastOneNewSkill(assessedSkills)
+    && _isNotAnsweredYet(challenge, answers);
 }
 
 function _isPreviousChallengeTimed(answers) {
@@ -247,7 +254,7 @@ class SmartRandom {
   static _filteredChallenges(challenges, answers, tubes, validatedSkills, failedSkills, predictedLevel) {
 
     const assessedSkills = _.union(validatedSkills, failedSkills);
-    let availableChallenges = challenges.filter(challenge => _isAnAvailableChallenge(challenge, assessedSkills));
+    let availableChallenges = challenges.filter(challenge => _isAnAvailableChallenge(challenge, assessedSkills, answers));
 
     if (_isPreviousChallengeTimed(answers)) {
       availableChallenges = _extractNotTimedChallenge(availableChallenges);

--- a/api/tests/unit/domain/strategies/SmartRandom_test.js
+++ b/api/tests/unit/domain/strategies/SmartRandom_test.js
@@ -489,12 +489,12 @@ describe('Unit | Domain | Models | SmartRandom', () => {
       expect(result).to.deep.equal([challengeAssessingSkill3]);
     });
 
-    context('when a challenge than validated skill not in target profil has been answered', () => {
-      it('should not ask the question that already answered', function() {
+    context('when the selected challenges cover more skills than the defined target profile', () => {
+      it('should ignore the already answered challenges, even if they have non evaluated skills', function() {
         // given
         const [skill1, skill2] = factory.buildSkillCollection();
 
-        const targetProfile = new TargetProfile({ skills: [skill1] });
+        const targetProfile = factory.buildTargetProfile({ skills: [skill1] });
 
         const challengeAssessingSkill1 = factory.buildChallenge({ skills: [skill1, skill2] });
 

--- a/api/tests/unit/domain/strategies/SmartRandom_test.js
+++ b/api/tests/unit/domain/strategies/SmartRandom_test.js
@@ -489,33 +489,35 @@ describe('Unit | Domain | Models | SmartRandom', () => {
       expect(result).to.deep.equal([challengeAssessingSkill3]);
     });
 
-    it('should not ask a question that already answered', function() {
-      // given
-      const [skill1, skill2] = factory.buildSkillCollection();
+    context('when a challenge than validated skill not in target profil has been answered', () => {
+      it('should not ask the question that already answered', function() {
+        // given
+        const [skill1, skill2] = factory.buildSkillCollection();
 
-      const targetProfile = new TargetProfile({ skills: [skill1] });
+        const targetProfile = new TargetProfile({ skills: [skill1] });
 
-      const challengeAssessingSkill1 = factory.buildChallenge({ skills: [skill1, skill2] });
+        const challengeAssessingSkill1 = factory.buildChallenge({ skills: [skill1, skill2] });
 
-      const answerCh1 = factory.buildAnswer({ challengeId: challengeAssessingSkill1.id, result: AnswerStatus.OK });
-      const answers = [answerCh1];
-      const challenges = [
-        challengeAssessingSkill1,
-      ];
+        const answerCh1 = factory.buildAnswer({ challengeId: challengeAssessingSkill1.id, result: AnswerStatus.OK });
+        const answers = [answerCh1];
+        const challenges = [
+          challengeAssessingSkill1,
+        ];
 
-      // when
-      const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
-      const result = SmartRandom._filteredChallenges(
-        smartRandom.challenges,
-        smartRandom.answers,
-        smartRandom.tubes,
-        smartRandom.validatedSkills,
-        smartRandom.failedSkills,
-        smartRandom.getPredictedLevel(),
-      );
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const result = SmartRandom._filteredChallenges(
+          smartRandom.challenges,
+          smartRandom.answers,
+          smartRandom.tubes,
+          smartRandom.validatedSkills,
+          smartRandom.failedSkills,
+          smartRandom.getPredictedLevel(),
+        );
 
-      // then
-      expect(result).to.deep.equal([]);
+        // then
+        expect(result).to.deep.equal([]);
+      });
     });
 
   });

--- a/api/tests/unit/domain/strategies/SmartRandom_test.js
+++ b/api/tests/unit/domain/strategies/SmartRandom_test.js
@@ -488,5 +488,35 @@ describe('Unit | Domain | Models | SmartRandom', () => {
       // then
       expect(result).to.deep.equal([challengeAssessingSkill3]);
     });
+
+    it('should not ask a question that already answered', function() {
+      // given
+      const [skill1, skill2] = factory.buildSkillCollection();
+
+      const targetProfile = new TargetProfile({ skills: [skill1] });
+
+      const challengeAssessingSkill1 = factory.buildChallenge({ skills: [skill1, skill2] });
+
+      const answerCh1 = factory.buildAnswer({ challengeId: challengeAssessingSkill1.id, result: AnswerStatus.OK });
+      const answers = [answerCh1];
+      const challenges = [
+        challengeAssessingSkill1,
+      ];
+
+      // when
+      const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+      const result = SmartRandom._filteredChallenges(
+        smartRandom.challenges,
+        smartRandom.answers,
+        smartRandom.tubes,
+        smartRandom.validatedSkills,
+        smartRandom.failedSkills,
+        smartRandom.getPredictedLevel(),
+      );
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+
   });
 });


### PR DESCRIPTION
**Correction** : 
- Lorsque l'on filtre les `Challenges` valides, on vérifie maintenant que le `Challenge` n'a pas été posé

**Explication du bug**(via un exemple) : 
- Le `targetProfil` contient les `skills` `@outilsTexte1` et `@outilsTexte2`
- La question qui valide `@outilsTexte2` est un QROCM-dep qui valide `@outilsTexte2` et `@outilsTexte4`
- Lorsque la question est loupé, on invalide les `skills` de niveaux supérieurs qui sont dans le `targetProfil`, donc seulement `@outilsTexte2`
- L'acquis `@outilsTexte4` reste non-visité pour l'algorithme
- La question (toujours présente dans la liste des challenges possibles) revient plus tard car `@outilsTexte4` est un skill qui peut apporter de l'information (car non visité).

**Discussions qu'il y eu sur ce bug** :
- Cette correction est très protectrice sur le code, et n'était pas la solution préféré
- Il faut avoir une discussion sur ce qu'il advient des `skills` visités mais non présents dans le `targetProfil`, pour éviter que ce cas arrive sans casser ce qui a été fait et ce qui va être fait.