### PR TITLE
[#136] [BUGFIX] Correction de la page "Oups" qui s'affiche en boucle à l'expiration de la session (PF-297).

### DIFF
--- a/live/app/routes/application.js
+++ b/live/app/routes/application.js
@@ -1,11 +1,27 @@
 import { inject as service } from '@ember/service';
+import _ from 'lodash';
 
 import BaseRoute from 'pix-live/routes/base-route';
 
 export default BaseRoute.extend({
+  session: service(),
   splash: service(),
 
   activate() {
     this.get('splash').hide();
+  },
+
+  hasForbiddenError(errorEvent) {
+    const statusCode = _.get(errorEvent, 'errors[0].code');
+    return statusCode === 401;
+  },
+
+  actions: {
+    error: function(error) {
+      if (this.hasForbiddenError(error)) {
+        return this.get('session').invalidate()
+          .then(() => this.transitionTo('login'));
+      }
+    }
   }
 });

--- a/live/app/routes/application.js
+++ b/live/app/routes/application.js
@@ -11,14 +11,14 @@ export default BaseRoute.extend({
     this.get('splash').hide();
   },
 
-  hasForbiddenError(errorEvent) {
+  hasUnauthorizedError(errorEvent) {
     const statusCode = _.get(errorEvent, 'errors[0].code');
     return statusCode === 401;
   },
 
   actions: {
     error: function(error) {
-      if (this.hasForbiddenError(error)) {
+      if (this.hasUnauthorizedError(error)) {
         return this.get('session').invalidate()
           .then(() => this.transitionTo('login'));
       }

--- a/live/tests/unit/routes/application-test.js
+++ b/live/tests/unit/routes/application-test.js
@@ -12,7 +12,7 @@ const SplashServiceStub = EmberObject.extend({
 
 describe('Unit | Route | application splash', function() {
   setupTest('route:application', {
-    needs: ['service:splash', 'service:current-routed-modal']
+    needs: ['service:current-routed-modal', 'service:session', 'service:splash']
   });
 
   it('initializes correctly', function() {
@@ -21,9 +21,55 @@ describe('Unit | Route | application splash', function() {
   });
 
   it('hides the splash when the route is activated', function() {
+    // Given
     const splashStub = SplashServiceStub.create();
     const route = this.subject({ splash: splashStub });
+
+    // When
     route.activate();
+
+    // Then
     expect(splashStub.hideCount).to.equal(1);
+  });
+
+  describe('#hasForbiddenError', function() {
+    let route;
+
+    beforeEach(function() {
+      route = this.subject();
+    });
+
+    it('finds a forbidden code in the first error object', function() {
+      // Given
+      const forbiddenError = { errors: [{ code: 401 }] };
+
+      // When
+      const result = route.hasForbiddenError(forbiddenError);
+
+      // Then
+      expect(result).to.be.true;
+    });
+
+    it('returns false if there is no "errors" key', function() {
+      // Given
+      const forbiddenError = {};
+
+      // When
+      const result = route.hasForbiddenError(forbiddenError);
+
+      // Then
+      expect(result).to.be.false;
+    });
+
+    it('returns false if the "errors" key points to an empty array', function() {
+      // Given
+      const forbiddenError = { errors: [] };
+
+      // When
+      const result = route.hasForbiddenError(forbiddenError);
+
+      // Then
+      expect(result).to.be.false;
+    });
   });
 });

--- a/live/tests/unit/routes/application-test.js
+++ b/live/tests/unit/routes/application-test.js
@@ -32,19 +32,19 @@ describe('Unit | Route | application splash', function() {
     expect(splashStub.hideCount).to.equal(1);
   });
 
-  describe('#hasForbiddenError', function() {
+  describe('#hasUnauthorizedError', function() {
     let route;
 
     beforeEach(function() {
       route = this.subject();
     });
 
-    it('finds a forbidden code in the first error object', function() {
+    it('finds an unauthorized code in the first error object', function() {
       // Given
-      const forbiddenError = { errors: [{ code: 401 }] };
+      const errorEvent = { errors: [{ code: 401 }] };
 
       // When
-      const result = route.hasForbiddenError(forbiddenError);
+      const result = route.hasUnauthorizedError(errorEvent);
 
       // Then
       expect(result).to.be.true;
@@ -52,10 +52,10 @@ describe('Unit | Route | application splash', function() {
 
     it('returns false if there is no "errors" key', function() {
       // Given
-      const forbiddenError = {};
+      const errorEvent = {};
 
       // When
-      const result = route.hasForbiddenError(forbiddenError);
+      const result = route.hasUnauthorizedError(errorEvent);
 
       // Then
       expect(result).to.be.false;
@@ -63,10 +63,10 @@ describe('Unit | Route | application splash', function() {
 
     it('returns false if the "errors" key points to an empty array', function() {
       // Given
-      const forbiddenError = { errors: [] };
+      const errorEvent = { errors: [] };
 
       // When
-      const result = route.hasForbiddenError(forbiddenError);
+      const result = route.hasUnauthorizedError(errorEvent);
 
       // Then
       expect(result).to.be.false;


### PR DESCRIPTION
Quand on avait une session expirée, le serveur renvoyait une erreur 401 à l'appel de `/users/me`. Cette erreur était traitée automatiquement par ember en redirigeant vers la page "Oups" (`error.hbs`) et il était impossible de se connecter.

Correction : 
- interception explicite de l'erreur 401 dans la route de base,
- invalidation de la session,
- redirection vers `/login`