### PR TITLE
[#151][FEATURE] Faire passer le code Campagne dans l'url de démarrage d'une campagne (PF-294).

### DIFF
--- a/api/db/migrations/20180730120109_create_campaign_participations_table.js
+++ b/api/db/migrations/20180730120109_create_campaign_participations_table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'campaign-participations';
+
+exports.up = (knex) => {
+  return knex.schema
+    .createTable(TABLE_NAME, (t) => {
+      t.increments().primary();
+      t.integer('campaignId').unsigned().references('campaigns.id').index();
+      t.integer('assessmentId').unsigned().references('assessments.id').index();
+      t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    })
+    .then(() => {
+      console.log(`${TABLE_NAME} table is created!`);
+    });
+};
+
+exports.down = (knex) => {
+  return knex.schema
+    .dropTable(TABLE_NAME)
+    .then(() => {
+      console.log(`${TABLE_NAME} table was dropped!`);
+    });
+};

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -9,6 +9,7 @@ const assessmentService = require('../../domain/services/assessment-service');
 const certificationChallengeRepository = require('../../infrastructure/repositories/certification-challenge-repository');
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
+const campaignRepository = require('../../infrastructure/repositories/campaign-repository');
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const courseRepository = require('../../infrastructure/repositories/course-repository');
 const skillRepository = require('../../infrastructure/repositories/skill-repository');
@@ -17,19 +18,13 @@ const targetProfileRepository = require('../../infrastructure/repositories/targe
 
 const useCases = require('../../domain/usecases');
 
-const { NotFoundError, AssessmentEndedError, ObjectValidationError } = require('../../domain/errors');
+const { NotFoundError, AssessmentEndedError, ObjectValidationError, CampaignCodeError } = require('../../domain/errors');
 
 module.exports = {
 
   save(request, reply) {
 
     const assessment = assessmentSerializer.deserialize(request.payload);
-    assessment.state = 'started';
-
-    // XXX Fake name, waiting for campaign
-    if (assessment.isSmartPlacementAssessment()) {
-      assessment.courseId = 'Smart Placement Tests CourseId Not Used';
-    }
 
     if (request.headers.hasOwnProperty('authorization')) {
       const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
@@ -38,7 +33,21 @@ module.exports = {
       assessment.userId = userId;
     }
 
-    return assessmentRepository.save(assessment)
+    assessment.state = 'started';
+    return Promise.resolve()
+      .then(() => {
+        if (assessment.isSmartPlacementAssessment()) {
+          const codeCampaign = request.payload.data.attributes['code-campaign'];
+          return useCases.createAssessmentForCampaign({
+            assessment,
+            codeCampaign,
+            assessmentRepository,
+            campaignRepository,
+          });
+        } else {
+          return assessmentRepository.save(assessment);
+        }
+      })
       .then((assessment) => {
         reply(assessmentSerializer.serialize(assessment)).code(201);
       })
@@ -46,9 +55,13 @@ module.exports = {
         if (err instanceof ObjectValidationError) {
           return reply(Boom.badData(err));
         }
+        if (err instanceof CampaignCodeError) {
+          return reply(Boom.notFound(CampaignCodeError));
+        }
         logger.error(err);
         reply(Boom.badImplementation(err));
       });
+
   },
 
   get(request, reply) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -10,6 +10,7 @@ const certificationChallengeRepository = require('../../infrastructure/repositor
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 const campaignRepository = require('../../infrastructure/repositories/campaign-repository');
+const campaignParticipationRepository = require('../../infrastructure/repositories/campaign-participation-repository');
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const courseRepository = require('../../infrastructure/repositories/course-repository');
 const skillRepository = require('../../infrastructure/repositories/skill-repository');
@@ -43,6 +44,7 @@ module.exports = {
             codeCampaign,
             assessmentRepository,
             campaignRepository,
+            campaignParticipationRepository,
           });
         } else {
           return assessmentRepository.save(assessment);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -36,6 +36,12 @@ class AssessmentEndedError extends DomainError {
   }
 }
 
+class CampaignCodeError extends DomainError {
+  constructor() {
+    super('Le code campagne n\'existe pas.');
+  }
+}
+
 class CertificationComputeError extends DomainError {
   constructor(message) {
     super(message);
@@ -237,6 +243,7 @@ module.exports = {
   AlreadyRatedAssessmentError,
   AlreadyRegisteredEmailError,
   AssessmentEndedError,
+  CampaignCodeError,
   CertificationComputeError,
   ChallengeAlreadyAnsweredError,
   EntityValidationError,

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -43,6 +43,8 @@ class Assessment {
     // includes
     answers = [],
     assessmentResults = [],
+    campaign,
+    campaignParticipation,
     course,
     targetProfile,
     // references
@@ -57,6 +59,8 @@ class Assessment {
     // includes
     this.answers = answers;
     this.assessmentResults = assessmentResults;
+    this.campaign = campaign;
+    this.campaignParticipation = campaignParticipation;
     this.course = course;
     this.targetProfile = targetProfile;
     // references

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -1,0 +1,10 @@
+class CampaignParticipation {
+
+  constructor({ id, campaignId, assessmentId } = {}) {
+    this.id = id;
+    this.campaignId = campaignId;
+    this.assessmentId = assessmentId;
+  }
+}
+
+module.exports = CampaignParticipation;

--- a/api/lib/domain/usecases/create-assessment-for-campaign.js
+++ b/api/lib/domain/usecases/create-assessment-for-campaign.js
@@ -1,0 +1,21 @@
+const { CampaignCodeError } = require('../errors');
+
+function _checkCampaignCodeRelatedToExistingCampaign(codeCampaign, campaignRepository) {
+  return campaignRepository.getByCode(codeCampaign)
+    .then((campaign) => {
+      if(campaign) {
+        return campaign;
+      } else {
+        return Promise.reject(new CampaignCodeError());
+      }
+    });
+}
+
+module.exports = function createAssessmentForCampaign({ assessment, codeCampaign, assessmentRepository, campaignRepository }) {
+
+  return _checkCampaignCodeRelatedToExistingCampaign(codeCampaign, campaignRepository)
+    .then(() => {
+      assessment.courseId = 'Smart Placement Tests CourseId Not Used';
+      return assessmentRepository.save(assessment);
+    });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -2,6 +2,7 @@ module.exports = {
   authenticateUser: require('./authenticate-user'),
   createCampaign: require('./create-campaign'),
   createAssessmentResultForCompletedCertification: require('./create-assessment-result-for-completed-certification'),
+  createAssessmentForCampaign: require('./create-assessment-for-campaign'),
   createUser: require('./create-user'),
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findUserAssessmentsByFilters: require('./find-user-assessments-by-filters'),

--- a/api/lib/infrastructure/data/assessment.js
+++ b/api/lib/infrastructure/data/assessment.js
@@ -3,6 +3,7 @@ const Bookshelf = require('../bookshelf');
 require('./answer');
 require('./assessment-result');
 require('./knowledge-element');
+require('./campaign-participation');
 
 module.exports = Bookshelf.model('Assessment', {
 
@@ -19,4 +20,8 @@ module.exports = Bookshelf.model('Assessment', {
   knowledgeElements() {
     return this.hasMany('KnowledgeElement', 'assessmentId');
   },
+  campaignParticipations() {
+    return this.hasOne('CampaignParticipation', 'assessmentId');
+  },
+
 });

--- a/api/lib/infrastructure/data/campaign-participation.js
+++ b/api/lib/infrastructure/data/campaign-participation.js
@@ -7,4 +7,11 @@ module.exports = Bookshelf.model('CampaignParticipation', {
 
   tableName: 'campaign-participations',
 
+  assessment() {
+    return this.belongsTo('Assessment', 'assessmentId');
+  },
+
+  campaign() {
+    return this.belongsTo('Campaign', 'campaignId');
+  },
 });

--- a/api/lib/infrastructure/data/campaign-participation.js
+++ b/api/lib/infrastructure/data/campaign-participation.js
@@ -1,0 +1,10 @@
+const Bookshelf = require('../bookshelf');
+
+require('./assessment');
+require('./campaign');
+
+module.exports = Bookshelf.model('CampaignParticipation', {
+
+  tableName: 'campaign-participations',
+
+});

--- a/api/lib/infrastructure/data/campaign.js
+++ b/api/lib/infrastructure/data/campaign.js
@@ -15,6 +15,6 @@ module.exports = Bookshelf.model('Campaign', {
 
   assessments: function() {
     return this.belongsToMany('Assessment', 'campaingId').through('CampaignParticipation');
-  }
+  },
 
 });

--- a/api/lib/infrastructure/data/campaign.js
+++ b/api/lib/infrastructure/data/campaign.js
@@ -2,9 +2,20 @@ const Bookshelf = require('../bookshelf');
 
 require('./user');
 require('./organization');
+require('./campaign-participation');
+require('./assessment');
 
 module.exports = Bookshelf.model('Campaign', {
 
   tableName: 'campaigns',
+
+  campaignParticipations() {
+    return this.hasMany('CampaignParticipation', 'campaignId');
+  },
+
+  assessments: function() {
+    return this.belongsToMany('Assessment', 'campaingId').through('CampaignParticipation');
+  }
+
 
 });

--- a/api/lib/infrastructure/data/campaign.js
+++ b/api/lib/infrastructure/data/campaign.js
@@ -17,5 +17,4 @@ module.exports = Bookshelf.model('Campaign', {
     return this.belongsToMany('Assessment', 'campaingId').through('CampaignParticipation');
   }
 
-
 });

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -30,9 +30,11 @@ function _toDomain(bookshelfAssessment) {
 
     let campaignParticipation = null;
     let campaign = null;
-    if(bookshelfAssessment.related('campaignParticipations')) {
-      campaignParticipation = new CampaignParticipation(bookshelfAssessment.related('campaignParticipations').toJSON());
-      campaign = new Campaign(bookshelfAssessment.related('campaignParticipations').related('campaign').toJSON());
+    const campaignOfAssessment = bookshelfAssessment.related('campaignParticipations');
+
+    if(campaignOfAssessment.attributes.campaignId) {
+      campaignParticipation = new CampaignParticipation(campaignOfAssessment.toJSON());
+      campaign = new Campaign(campaignOfAssessment.related('campaign').toJSON());
     }
 
     return new Assessment(Object.assign(modelObjectInJSON, {
@@ -54,6 +56,8 @@ function _adaptModelToDb(assessment) {
     'answers',
     'assessmentResults',
     'targetProfile',
+    'campaign',
+    'campaignParticipation',
   ]);
 }
 
@@ -151,9 +155,7 @@ module.exports = {
     return BookshelfAssessment
       .where(filters)
       .fetchAll({ withRelated: ['campaignParticipations', 'campaignParticipations.campaign'] })
-      .then((bookshelfAssessmentCollection) => {
-        return bookshelfAssessmentCollection.models
-      })
+      .then((bookshelfAssessmentCollection) => bookshelfAssessmentCollection.models)
       .then(fp.map(_toDomain));
   },
 

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -1,0 +1,16 @@
+const BookshelfCampaignParticipation = require('../data/campaign-participation');
+const CampaignParticipation = require('../../domain/models/CampaignParticipation');
+
+function _toDomain(bookshelfCampaignParticipation) {
+  return new CampaignParticipation(bookshelfCampaignParticipation.toJSON());
+}
+
+module.exports = {
+
+  save(campaignParticipation) {
+    return new BookshelfCampaignParticipation(campaignParticipation)
+      .save()
+      .then(_toDomain);
+  }
+
+};

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -20,6 +20,18 @@ module.exports = {
       });
   },
 
+  getByCode(code) {
+    return BookshelfCampaign
+      .where({ code })
+      .fetch()
+      .then((campaign) => {
+        if (campaign) {
+          return _toDomain(campaign);
+        }
+        return Promise.resolve(null);
+      });
+  },
+
   save(campaignToSave) {
     return new BookshelfCampaign(campaignToSave)
       .save()

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -46,6 +46,9 @@ class AssessmentSerializer extends JSONAPISerializer {
     } else {
       data.attributes['certification-number'] = null;
     }
+    if(model.campaign) {
+      data.attributes['campaign-code'] = model.campaign.code;
+    }
   }
 
   serializeRelationships(model, data) {

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -47,7 +47,7 @@ class AssessmentSerializer extends JSONAPISerializer {
       data.attributes['certification-number'] = null;
     }
     if(model.campaign) {
-      data.attributes['campaign-code'] = model.campaign.code;
+      data.attributes['code-campaign'] = model.campaign.code;
     }
   }
 

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -328,6 +328,8 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
           state: 'completed',
           createdAt: '2017-11-08 12:47:38',
           type: null,
+          campaign: null,
+          campaignParticipation: null,
           assessmentResults: [
             {
               assessmentId: 3,

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,0 +1,34 @@
+const { expect, knex } = require('../../../test-helper');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
+
+describe('Integration | Repository | Campaign Participation', () => {
+
+  describe('#save', () => {
+
+    afterEach(() => {
+      return knex('campaign-participations').delete();
+    });
+
+    it('should save the given campaign participation', () => {
+      // given
+      const campaignParticipationToSave = new CampaignParticipation({
+        assessmentId: 12,
+        campaignId: 24,
+      });
+
+      // when
+      const promise = campaignParticipationRepository.save(campaignParticipationToSave);
+
+      // then
+      return promise.then((savedCampaignParticipations) => {
+        expect(savedCampaignParticipations).to.be.instanceof(CampaignParticipation);
+        expect(savedCampaignParticipations.id).to.exist;
+        expect(savedCampaignParticipations.assessmentId).to.equal(campaignParticipationToSave.assessmentId);
+        expect(savedCampaignParticipations.campaignId).to.equal(campaignParticipationToSave.campaignId);
+      });
+    });
+
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -42,6 +42,46 @@ describe('Integration | Repository | Campaign', () => {
 
   });
 
+  describe('#getByCode', () => {
+
+    let campaignInsered;
+    beforeEach(() => {
+      campaignInsered = {
+        id: 3,
+        name: 'Nom de Campagne',
+        code: 'BADOIT710',
+        creatorId: 1,
+        organizationId: 1
+      };
+      return knex('campaigns').insert(campaignInsered);
+    });
+
+    afterEach(() => {
+      return knex('campaigns').delete();
+    });
+
+    it('should resolve the campaign relies to the code', () => {
+      // when
+      const promise = campaignRepository.getByCode('BADOIT710');
+
+      // then
+      return promise.then((result) => {
+        expect(result).to.deep.equal(campaignInsered);
+      });
+    });
+
+    it('should resolve null if the code do not correspond to any campaign ', () => {
+      // when
+      const promise = campaignRepository.getByCode('BIDULEFAUX');
+
+      // then
+      return promise.then((result) => {
+        expect(result).to.be.null;
+      });
+    });
+
+  });
+
   describe('#save', () => {
 
     afterEach(() => {

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -5,8 +5,11 @@ const controller = require('../../../../lib/application/assessments/assessment-c
 
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const usecases = require('../../../../lib/domain/usecases');
+
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Controller | assessment-controller-save', () => {
@@ -40,31 +43,40 @@ describe('Unit | Controller | assessment-controller-save', () => {
             id: 42,
             attributes: {
               'type': 'SMART_PLACEMENT',
+              'code-campaign': 'CODECAMPAIGN'
             },
           },
         },
       };
 
       beforeEach(() => {
-        sandbox.stub(assessmentRepository, 'save').resolves();
+        sandbox.stub(usecases, 'createAssessmentForCampaign').resolves();
       });
 
       it('should save an assessment with the type SMART_PLACEMENT and with a fake courseId', function() {
         // given
-        const expected = Assessment.fromAttributes({
+        const expectedAssessment = Assessment.fromAttributes({
           id: 42,
-          courseId: 'Smart Placement Tests CourseId Not Used',
+          courseId: null,
           type: 'SMART_PLACEMENT',
           state: 'started',
           userId: null,
         });
 
+        const expectedCallArguments = {
+          assessment: expectedAssessment,
+          codeCampaign: 'CODECAMPAIGN',
+          assessmentRepository,
+          campaignRepository
+        };
         // when
-        controller.save(request, replyStub);
+        const promise = controller.save(request, replyStub);
 
         // then
-        sinon.assert.calledOnce(assessmentRepository.save);
-        return expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        return promise.then(() => {
+          sinon.assert.calledOnce(usecases.createAssessmentForCampaign);
+          sinon.assert.calledWith(usecases.createAssessmentForCampaign, expectedCallArguments);
+        });
       });
     });
 
@@ -108,11 +120,13 @@ describe('Unit | Controller | assessment-controller-save', () => {
         });
 
         // when
-        controller.save(request, replyStub);
+        const promise = controller.save(request, replyStub);
 
         // then
-        sinon.assert.calledOnce(assessmentRepository.save);
-        return expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        return promise.then(() => {
+          sinon.assert.calledOnce(assessmentRepository.save);
+          expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        });
       });
 
       context('where there is no UserId', () => {
@@ -179,10 +193,12 @@ describe('Unit | Controller | assessment-controller-save', () => {
         });
 
         // when
-        controller.save(request, replyStub);
+        const promise = controller.save(request, replyStub);
 
         // then
-        expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        return promise.then(() => {
+          expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        });
       });
     });
 
@@ -260,10 +276,12 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
       it('should persist the deserializedAssessment', () => {
         // when
-        controller.save(request, replyStub);
+        const promise = controller.save(request, replyStub);
 
         // then
-        expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+        return promise.then(() => {
+          expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+        });
       });
 
       it('should serialize the deserializedAssessment after its creation', () => {

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -6,6 +6,7 @@ const controller = require('../../../../lib/application/assessments/assessment-c
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const usecases = require('../../../../lib/domain/usecases');
@@ -67,7 +68,8 @@ describe('Unit | Controller | assessment-controller-save', () => {
           assessment: expectedAssessment,
           codeCampaign: 'CODECAMPAIGN',
           assessmentRepository,
-          campaignRepository
+          campaignRepository,
+          campaignParticipationRepository,
         };
         // when
         const promise = controller.save(request, replyStub);
@@ -243,6 +245,8 @@ describe('Unit | Controller | assessment-controller-save', () => {
         assessmentResults: [],
         course: undefined,
         targetProfile: undefined,
+        campaignParticipation: undefined,
+        campaign: undefined,
       };
       const serializedAssessment = {
         id: 42,

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -1,0 +1,70 @@
+const { expect, sinon, factory } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const { CampaignCodeError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | create-assessment-for-campaign', () => {
+
+  let sandbox;
+  const availableCampaignCode = 'ABCDEF123';
+  const campaignRepository = { getByCode: () => undefined };
+  const assessmentRepository = { save: () => undefined };
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(campaignRepository, 'getByCode');
+    sandbox.stub(assessmentRepository, 'save');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should throw an CampaignCodeError if code Campaign not exist', () => {
+    // given
+    campaignRepository.getByCode.resolves(null);
+
+    // when
+    const promise = usecases.createAssessmentForCampaign({ assessment: {}, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
+
+    // then
+    return expect(promise).to.be.rejectedWith(CampaignCodeError);
+  });
+
+  it('should save the campaign with name, userId, organizationId and generated code', () => {
+    // given
+    const campaign = factory.buildCampaign();
+    campaignRepository.getByCode.resolves(campaign);
+    const assessment = factory.buildAssessment({
+      type: 'SMART_PLACEMENT',
+    });
+
+    // when
+    const promise = usecases.createAssessmentForCampaign({ assessment, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
+
+    // then
+    return promise.then(() => {
+      expect(assessmentRepository.save).to.have.been.called;
+      expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+    });
+  });
+
+  it('should return the newly created assessment', () => {
+    // given
+    const campaign = factory.buildCampaign();
+    const assessment = factory.buildAssessment({
+      type: 'SMART_PLACEMENT',
+    });
+
+    campaignRepository.getByCode.resolves(campaign);
+    assessmentRepository.save.resolves(assessment);
+
+    // when
+    const promise = usecases.createAssessmentForCampaign({ assessment, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
+
+    // then
+    return promise.then((assessmentCreated) => {
+      expect(assessmentCreated).to.deep.equal(assessment);
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -1,5 +1,6 @@
 const { expect, sinon, factory } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
+const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 const { CampaignCodeError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-assessment-for-campaign', () => {
@@ -7,64 +8,114 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
   let sandbox;
   const availableCampaignCode = 'ABCDEF123';
   const campaignRepository = { getByCode: () => undefined };
+  const campaignParticipationRepository = { save: () => undefined };
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(campaignRepository, 'getByCode');
     sandbox.stub(assessmentRepository, 'save');
+    sandbox.stub(campaignParticipationRepository, 'save');
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should throw an CampaignCodeError if code Campaign not exist', () => {
-    // given
-    campaignRepository.getByCode.resolves(null);
+  context('when campaignCode not exist', () => {
+    it('should throw an CampaignCodeError', () => {
+      // given
+      campaignRepository.getByCode.resolves(null);
 
-    // when
-    const promise = usecases.createAssessmentForCampaign({ assessment: {}, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
+      // when
+      const promise = usecases.createAssessmentForCampaign({
+        assessment: {},
+        codeCampaign:availableCampaignCode,
+        campaignRepository,
+        assessmentRepository,
+        campaignParticipationRepository
+      });
 
-    // then
-    return expect(promise).to.be.rejectedWith(CampaignCodeError);
+      // then
+      return expect(promise).to.be.rejectedWith(CampaignCodeError);
+    });
+
   });
 
-  it('should save the campaign with name, userId, organizationId and generated code', () => {
-    // given
-    const campaign = factory.buildCampaign();
-    campaignRepository.getByCode.resolves(campaign);
-    const assessment = factory.buildAssessment({
-      type: 'SMART_PLACEMENT',
+  context('when campaignCode exist', () => {
+    let campaign;
+    let assessment;
+    let campaignParticipation;
+
+    beforeEach(() => {
+      // given
+      campaign = factory.buildCampaign({
+        id: 'campaignId',
+      });
+      assessment = factory.buildAssessment({
+        id: 'assessmentId',
+        type: 'SMART_PLACEMENT',
+      });
+
+      campaignParticipation = new CampaignParticipation({
+        assessmentId: assessment.id,
+        campaignId: campaign.id,
+      });
+
+      campaignRepository.getByCode.resolves(campaign);
+      assessmentRepository.save.resolves(assessment);
+      campaignParticipationRepository.save.resolves({});
     });
 
-    // when
-    const promise = usecases.createAssessmentForCampaign({ assessment, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
+    it('should save the assessment', () => {
+      // when
+      const promise = usecases.createAssessmentForCampaign({
+        assessment,
+        codeCampaign:availableCampaignCode,
+        campaignRepository,
+        assessmentRepository,
+        campaignParticipationRepository
+      });
 
-    // then
-    return promise.then(() => {
-      expect(assessmentRepository.save).to.have.been.called;
-      expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+      // then
+      return promise.then(() => {
+        expect(assessmentRepository.save).to.have.been.called;
+        expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+      });
     });
+
+    it('should save a campaign-participation object', () => {
+      // when
+      const promise = usecases.createAssessmentForCampaign({
+        assessment,
+        codeCampaign:availableCampaignCode,
+        campaignRepository,
+        assessmentRepository,
+        campaignParticipationRepository
+      });
+
+      // then
+      return promise.then(() => {
+        expect(campaignParticipationRepository.save).to.have.been.called;
+        expect(campaignParticipationRepository.save).to.have.been.calledWith(campaignParticipation);
+      });
+    });
+
+    it('should return the newly created assessment', () => {
+      // when
+      const promise = usecases.createAssessmentForCampaign({
+        assessment,
+        codeCampaign:availableCampaignCode,
+        campaignRepository,
+        assessmentRepository,
+        campaignParticipationRepository
+      });
+
+      // then
+      return promise.then((assessmentCreated) => {
+        expect(assessmentCreated).to.deep.equal(assessment);
+      });
+    });
+
   });
-
-  it('should return the newly created assessment', () => {
-    // given
-    const campaign = factory.buildCampaign();
-    const assessment = factory.buildAssessment({
-      type: 'SMART_PLACEMENT',
-    });
-
-    campaignRepository.getByCode.resolves(campaign);
-    assessmentRepository.save.resolves(assessment);
-
-    // when
-    const promise = usecases.createAssessmentForCampaign({ assessment, codeCampaign:availableCampaignCode,  campaignRepository, assessmentRepository });
-
-    // then
-    return promise.then((assessmentCreated) => {
-      expect(assessmentCreated).to.deep.equal(assessment);
-    });
-  });
-
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -1,7 +1,7 @@
 const { expect, factory } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
-const BookshelfAssessment = require('../../../../../lib/infrastructure/data/assessment');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
+const Campaign = require('../../../../../lib/domain/models/Campaign');
 
 describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
 
@@ -17,10 +17,9 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
       name: 'PIX EST FORMIDABLE',
     };
 
-    modelObject = new BookshelfAssessment({
+    modelObject = new Assessment({
       id: 'assessment_id',
       courseId: 'course_id',
-      successRate: 24,
       type: 'charade',
       course: associatedCourse,
     });
@@ -32,7 +31,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         attributes: {
           'estimated-level': undefined,
           'pix-score': undefined,
-          'success-rate': 24,
+          'success-rate': undefined,
           'type': 'charade',
           'certification-number': null,
         },
@@ -43,6 +42,9 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
               id: 'course_id',
             },
           },
+          answers: {
+            data: []
+          }
         },
       },
       included: [{
@@ -101,6 +103,19 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         .and.to.contain.key('skill-review');
 
       expect(json.data.relationships['skill-review']).to.deep.equal(expectedSkillReviewRelationship);
+    });
+
+    it('should add campaign-code when the model has a campaign', function() {
+      // given
+      const codeCampaign = 'CODECAMP';
+      modelObject.campaign = new Campaign({ code: codeCampaign });
+      jsonAssessment.data.attributes['code-campaign'] = codeCampaign;
+
+      // when
+      const json = serializer.serialize(modelObject);
+
+      // then
+      expect(json).to.deep.equal(jsonAssessment);
     });
 
   });

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -17,6 +17,7 @@ export default Model.extend({
   pixScore: attr('number'),
   result: belongsTo('assessment-result'),
   type: attr('string'),
+  codeCampaign: attr('string'),
 
   answersSinceLastCheckpoints: computed('answers.[]', function() {
     const answers = this.get('answers').toArray();

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -65,8 +65,8 @@ Router.map(function() {
   });
 
   this.route('campaigns', { path: '/campagnes' }, function() {
-    this.route('start-or-resume', { path: '/codecampagnepix' });
-    this.route('skill-review', { path: '/codecampagnepix/resultats/:assessment_id' });
+    this.route('start-or-resume', { path: '/:campaign_code' });
+    this.route('skill-review', { path: '/:campaign_code/resultats/:assessment_id' });
   });
 
   // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -4,7 +4,8 @@ import { isEmpty } from '@ember/utils';
 
 export default BaseRoute.extend(AuthenticatedRouteMixin, {
 
-  model() {
+  model(params) {
+    const codeCampaign = params.campaign_code;
     const store = this.get('store');
     return store.query('assessment', { filter: { type: 'SMART_PLACEMENT' } })
       .then((smartPlacementAssessments) => {

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -11,7 +11,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
         if (!isEmpty(smartPlacementAssessments)) {
           return smartPlacementAssessments.get('firstObject');
         }
-        return store.createRecord('assessment', { type: 'SMART_PLACEMENT' }).save();
+        return store.createRecord('assessment', { type: 'SMART_PLACEMENT', codeCampaign }).save();
       });
   },
 

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -10,7 +10,10 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
     return store.query('assessment', { filter: { type: 'SMART_PLACEMENT' } })
       .then((smartPlacementAssessments) => {
         if (!isEmpty(smartPlacementAssessments)) {
-          return smartPlacementAssessments.get('firstObject');
+          const findCampaignAssessment = smartPlacementAssessments.find((assessment) => assessment.codeCampaign === codeCampaign);
+          if(findCampaignAssessment) {
+            return findCampaignAssessment;
+          }
         }
         return store.createRecord('assessment', { type: 'SMART_PLACEMENT', codeCampaign }).save();
       });


### PR DESCRIPTION
**TICKET** : https://1024pix.atlassian.net/browse/PF-294

**RÉALISÉ** : 
- Ajout d'une table Campaign-Participation, qui fait le lien entre un Assessment et une Campaign. Cette table est amené à évolué pour porter d'autres infos sur la participation de l'utilisateur à la campagne
- Création du usecase createAssessmentForCampaign
- Modification knex/bookshelf pour remonter la Campaign d'un Assessment (via Campaign-participation) quand on le cherche par Filtre (pour vérifier si l'utilisateur en a commencé un).
- Modification de start-or-resume