### PR TITLE
[#172] [BUGFIX] Problème de téléchargement du fichier csv des profils partagées sous Firefox (PF-285)

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -51,10 +51,10 @@ module.exports = {
       competenceRepository, campaignParticipationRepository, organizationRepository,
       smartPlacementAssessmentRepository })
       .then((resultCampaign) => {
-        const fileName = `resultats-${campaignId}-${moment().format('YYYY-MM-DD-hhmm')}.csv`;
+        const fileName = `Resultats-${resultCampaign.campaignName}-${campaignId}-${moment().format('YYYY-MM-DD-hhmm')}.csv`;
         return reply(resultCampaign.csvData)
           .header('Content-Type', 'text/csv;charset=utf-8')
-          .header('Content-Disposition', `attachment; filename=${fileName}`);
+          .header('Content-Disposition', `attachment; filename="${fileName}"`);
       })
       .catch((error) => {
         if(error instanceof UserNotAuthorizedToGetCampaignResultsError) {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -23,7 +23,6 @@ const logger = require('../../infrastructure/logger');
 const JSONAPI = require('../../interfaces/jsonapi');
 const User = require('../../domain/models/User');
 const Organization = require('../../domain/models/Organization');
-const exportCsvFileName = 'Pix - Export donnees partagees.csv';
 const { EntityValidationError } = require('../../domain/errors');
 
 module.exports = {
@@ -102,14 +101,14 @@ module.exports = {
       snapshotsCsvConverter,
     };
     const organizationId = request.params.id;
+    const fileName = `pix-export-donnees-partagees-${organizationId}.csv`;
 
     return organizationService.getOrganizationSharedProfilesAsCsv(dependencies, organizationId)
       .then((snapshotsTextCsv) => {
         return reply(snapshotsTextCsv)
           .header('Content-Type', 'text/csv;charset=utf-8')
-          .header('Content-Disposition', `attachment; filename=${exportCsvFileName}`);
-      }
-      )
+          .header('Content-Disposition', `attachment; filename=${fileName}`);
+      })
       .catch((err) => {
         logger.error(err);
         return reply(validationErrorSerializer.serialize(

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -25,6 +25,8 @@ const User = require('../../domain/models/User');
 const Organization = require('../../domain/models/Organization');
 const { EntityValidationError } = require('../../domain/errors');
 
+const fileName = 'Pix - Export donnees partagees.csv';
+
 module.exports = {
 
   // TODO extract domain logic into use case, like create user
@@ -101,13 +103,12 @@ module.exports = {
       snapshotsCsvConverter,
     };
     const organizationId = request.params.id;
-    const fileName = `pix-export-donnees-partagees-${organizationId}.csv`;
 
     return organizationService.getOrganizationSharedProfilesAsCsv(dependencies, organizationId)
       .then((snapshotsTextCsv) => {
         return reply(snapshotsTextCsv)
           .header('Content-Type', 'text/csv;charset=utf-8')
-          .header('Content-Disposition', `attachment; filename=${fileName}`);
+          .header('Content-Disposition', `attachment; filename="${fileName}"`);
       })
       .catch((err) => {
         logger.error(err);

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -25,7 +25,7 @@ const User = require('../../domain/models/User');
 const Organization = require('../../domain/models/Organization');
 const { EntityValidationError } = require('../../domain/errors');
 
-const fileName = 'Pix - Export donnees partagees.csv';
+const EXPORT_CSV_FILE_NAME = 'Pix - Export donnees partagees.csv';
 
 module.exports = {
 
@@ -108,7 +108,7 @@ module.exports = {
       .then((snapshotsTextCsv) => {
         return reply(snapshotsTextCsv)
           .header('Content-Type', 'text/csv;charset=utf-8')
-          .header('Content-Disposition', `attachment; filename="${fileName}"`);
+          .header('Content-Disposition', `attachment; filename="${EXPORT_CSV_FILE_NAME}"`);
       })
       .catch((err) => {
         logger.error(err);


### PR DESCRIPTION
Problème : 
- Le fichier CSV des profils partagées se téléchargeait mal sous Firefox. N'apparaissait que "Pix" sans extension de fichier

Cause : 
- Firefox ne supporte pas les espaces dans les noms de fichiers pour le téléchargement

Résolution : 
- Ajout de double quote autour du nom
- Même modification pour les fichiers csv des campagnes pour mettre le nom des campagnes