### PR TITLE
[#181] [FEATURE] Rendre accessible l'espace perso pix via l'url app.pix.fr (PF-345)

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -145,15 +145,17 @@ module.exports = function(environment) {
 
 function inferApiURLFromScalingoAppName(appName) {
 
-  const matchesReviewApp = /pix-mon-pix-integration-pr(\d+)/.exec(appName);
+  const matchesReviewApp = /pix-(mon-pix|app)-integration-pr(\d+)/.exec(appName);
   if (matchesReviewApp) {
-    return `https://pix-api-integration-pr${matchesReviewApp[1]}.scalingo.io`;
+    return `https://pix-api-integration-pr${matchesReviewApp[2]}.scalingo.io`;
   }
 
   switch (appName) {
     case 'pix-mon-pix-integration':
+    case 'pix-app-integration':
       return 'https://api.integration.pix.fr';
     case 'pix-mon-pix-production':
+    case 'pix-app-production':
       return 'https://api.pix.fr';
     default:
       return 'http://localhost:3000';

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -36,28 +36,23 @@ extractIssueCodeFromBranchName(process.env.CIRCLE_BRANCH)
   })
   .then(([commentContents, { prNumber }]) => {
 
-    const raMonPixURL = `https://pix-mon-pix-integration-pr${prNumber}.scalingo.io`;
-    const raOragaURL = `https://pix-orga-integration-pr${prNumber}.scalingo.io`;
+    const raAppURL = `https://pix-app-integration-pr${prNumber}.scalingo.io`;
+    const raOrgaURL = `https://pix-orga-integration-pr${prNumber}.scalingo.io`;
     const raAPIURL = `https://pix-api-integration-pr${prNumber}.scalingo.io`;
 
-    const scalingoCommentRegex = new RegExp(`${raMonPixURL}`, 'i');
+    const scalingoCommentRegex = new RegExp(raAppURL, 'i');
 
     console.log(`Checking comment has not already been posted for PR number: ${prNumber}`);
 
-    const hasAlreadyScalingoComment = commentContents.reduce((hasAlreadyScalingoComment, comment) => {
-
-      const hasScalingoComment = comment.match(scalingoCommentRegex);
-      return hasAlreadyScalingoComment || hasScalingoComment;
-
-    }, false);
+    const hasAlreadyScalingoComment = commentContents.some((comment) => comment.match(scalingoCommentRegex));
 
     if (hasAlreadyScalingoComment) {
       console.log('Review apps urls already found in issue comments. No need to add it again');
     } else {
-      const text = `Je m'apprête à déployer la Review App. Elle sera consultable sur les URL suivantes:\n` +
-                   `- Mon Pix: ${raMonPixURL}\n` +
-                   `- Orga: ${raOragaURL}\n` +
-                   `- API (Postman): ${raAPIURL}`;
+      const text = `Je m'apprête à déployer la Review App. Elle sera consultable sur les URL suivantes :\n` +
+                   `- App : ${raAppURL}\n` +
+                   `- Orga : ${raOrgaURL}\n` +
+                   `- API (Postman) : ${raAPIURL}`;
 
       console.log(`Posting Review apps urls for PR number: ${prNumber} to JIRA issue: ${contextObject.issueCode}`);
       return axios({

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -19,10 +19,10 @@
 }
 
 PR_NUMBER=`echo $CI_PULL_REQUEST | grep -Po '(?<=pix/pull/)(\d+)'`
-RA_MON_PIX_URL="https://pix-mon-pix-integration-pr$PR_NUMBER.scalingo.io"
+RA_APP_URL="https://pix-app-integration-pr$PR_NUMBER.scalingo.io"
 RA_ORGA_URL="https://pix-orga-integration-pr$PR_NUMBER.scalingo.io"
 RA_API_URL="https://pix-api-integration-pr$PR_NUMBER.scalingo.io"
 
 curl -u $GITHUB_USER:$GITHUB_USER_TOKEN --verbose \
 	-X POST "https://api.github.com/repos/1024pix/pix/issues/${PR_NUMBER}/comments" \
-	--data "{\"body\":\"I'm deploying this PR to these urls:\n\n- Mon pix: $RA_MON_PIX_URL\n- Orga: $RA_ORGA_URL\n- API: $RA_API_URL\n\n Please check it out\"}"
+	--data "{\"body\":\"I'm deploying this PR to these urls:\n\n- App: $RA_APP_URL\n- Orga: $RA_ORGA_URL\n- API: $RA_API_URL\n\n Please check it out\"}"


### PR DESCRIPTION
L'espace perso est maintenant accessible via app.pix.fr et www.app.pix.fr
Les RAs sont maintenant accessibles via app.integration.pix.fr
Ce commit met à jour l'environment.js qui spécifie l'API à utiliser en fonction de l'environnement, et 2 scripts afin qu'ils utilisent maintenant la nouvelle url en 'app'.