### PR TITLE
[#186] Tous les liens vers l'espace perso utilisent app.pix.fr (PF-346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Présentation
 ------------
 
-[PIX](https://pix.beta.gouv.fr) s’adresse à tous les citoyens francophones (élèves, étudiants, professionnels, décrocheurs, demandeurs d’emploi, séniors, citoyens) qui souhaitent mesurer, développer et valoriser leurs compétences numériques.
+[PIX](https://pix.fr) s’adresse à tous les citoyens francophones (élèves, étudiants, professionnels, décrocheurs, demandeurs d’emploi, séniors, citoyens) qui souhaitent mesurer, développer et valoriser leurs compétences numériques.
 
 Le service se présente sous la forme d’une plateforme en ligne d’évaluation et de certification des compétences numériques.
 

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -9,7 +9,7 @@ function sendAccountCreationEmail(email) {
   return mailJet.sendEmail({
     to: email,
     template: ACCOUNT_CREATION_EMAIL_TEMPLATE_ID,
-    from: 'ne-pas-repondre@pix.beta.gouv.fr',
+    from: 'ne-pas-repondre@pix.fr',
     fromName: 'PIX - Ne pas répondre',
     subject: 'Création de votre compte PIX'
   });
@@ -39,7 +39,7 @@ function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
   return mailJet.sendEmail({
     to: email,
     template: RESET_PASSWORD_DEMAND_EMAIL_TEMPLATE_ID,
-    from: 'ne-pas-repondre@pix.beta.gouv.fr',
+    from: 'ne-pas-repondre@pix.fr',
     fromName: 'PIX - Ne pas répondre',
     subject: 'Demande de réinitialisation de mot de passe PIX',
     variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }

--- a/api/lib/infrastructure/mailjet.js
+++ b/api/lib/infrastructure/mailjet.js
@@ -5,7 +5,7 @@ const nodeMailjet = require('node-mailjet');
 function _formatPayload(options) {
 
   const configuration = _.defaults(options, {
-    from: 'communaute@pix.beta.gouv.fr',
+    from: 'communaute@pix.fr',
     fromName: 'Communauté PIX',
     to: null,
     subject: 'Bienvenue dans la communauté PIX',

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -19,7 +19,7 @@ module.exports = (function() {
     },
 
     app: {
-      domain: 'pix.beta.gouv.fr'
+      domain: 'app.pix.fr'
     },
 
     logging: {

--- a/api/scripts/recompute-assessment-results.js
+++ b/api/scripts/recompute-assessment-results.js
@@ -7,7 +7,7 @@ function compute(listOfAssessmentsToRecompute, request) {
   return batch(null, listOfAssessmentsToRecompute, (assessmentId) => {
     return request({
       method: 'POST',
-      uri: 'https://pix.fr/api/assessment-results?recompute=true',
+      uri: 'https://api.pix.fr/api/assessment-results?recompute=true',
       body: {
         'data': {
           'relationships': {

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -110,7 +110,7 @@ describe('Acceptance | API | Courses', () => {
               'k_challenge_id',
             ],
             'Ordre affichage': 2,
-            'Preview': 'http://development.pix.beta.gouv.fr/courses/rec_course_id/preview',
+            'Preview': 'http://development.pix.fr/courses/rec_course_id/preview',
             'Nb d\'épreuves': 10,
             'Acquis': '#ordonnancement,#source,#rechercheInfo,#moteur,#wikipedia,#syntaxe,#sponsor,#rechercheInfo,#cult1.1,#rechercheInfo'
           },

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -107,7 +107,7 @@ describe('Acceptance | Controller | users-controller', () => {
       it('should send account creation email to user', () => {
         // given
         const expectedMail = {
-          from: 'ne-pas-repondre@pix.beta.gouv.fr',
+          from: 'ne-pas-repondre@pix.fr',
           fromName: 'PIX - Ne pas répondre',
           subject: 'Création de votre compte PIX',
           template: '143620',

--- a/api/tests/unit/application/qmail/qmail-controller_test.js
+++ b/api/tests/unit/application/qmail/qmail-controller_test.js
@@ -21,15 +21,15 @@ describe('Unit | Controller | qmailController', () => {
       mail: {
         to: {
           value: [],
-          html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr</a></span>`,
-          text: `${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr`
+          html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.fr</a></span>`,
+          text: `${challengeId}-${assessmentId}-0609@pix.fr`
         }
       },
       headers: {
         to: {
           value: [],
-          html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr</a></span>`,
-          text: `${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr`
+          html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.fr</a></span>`,
+          text: `${challengeId}-${assessmentId}-0609@pix.fr`
         }
       }
     };

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -30,7 +30,7 @@ describe('Unit | Service | MailService', () => {
         sinon.assert.calledWith(sendEmailStub, {
           to: email,
           template: '143620',
-          from: 'ne-pas-repondre@pix.beta.gouv.fr',
+          from: 'ne-pas-repondre@pix.fr',
           fromName: 'PIX - Ne pas répondre',
           subject: 'Création de votre compte PIX'
         });
@@ -181,7 +181,7 @@ describe('Unit | Service | MailService', () => {
         // given
         const email = 'text@example.net';
         const fakeTemporaryKey = 'token';
-        const passwordResetDemandBaseUrl = 'http://dev.pix.beta.gouv.fr';
+        const passwordResetDemandBaseUrl = 'http://dev.pix.fr';
 
         // when
         const promise = mailService.sendResetPasswordDemandEmail(email, passwordResetDemandBaseUrl, fakeTemporaryKey);
@@ -191,7 +191,7 @@ describe('Unit | Service | MailService', () => {
           sinon.assert.calledWith(sendEmailStub, {
             to: email,
             template: '232827',
-            from: 'ne-pas-repondre@pix.beta.gouv.fr',
+            from: 'ne-pas-repondre@pix.fr',
             fromName: 'PIX - Ne pas répondre',
             subject: 'Demande de réinitialisation de mot de passe PIX',
             variables: {

--- a/api/tests/unit/domain/services/qmail-validation-service_test.js
+++ b/api/tests/unit/domain/services/qmail-validation-service_test.js
@@ -19,8 +19,8 @@ describe('Unit | Service | QMail Validation', function() {
           to:
             {
               value: [],
-              html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr</a></span>`,
-              text: `${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr`
+              html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.fr</a></span>`,
+              text: `${challengeId}-${assessmentId}-0609@pix.fr`
             },
           from:
             {
@@ -43,8 +43,8 @@ describe('Unit | Service | QMail Validation', function() {
           to:
             {
               value: [],
-              html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr</a></span>`,
-              text: `${challengeId}-${assessmentId}-0609@pix.beta.gouv.fr`
+              html: `<span class="mp_address_group"><a href="mailto:${challengeId}-${assessmentId}-0609@pix.fr" class="mp_address_email">${challengeId}-${assessmentId}-0609@pix.fr</a></span>`,
+              text: `${challengeId}-${assessmentId}-0609@pix.fr`
             },
           subject: 'Invitation - Ouverture du bar commun ',
           date: '2017-10-10T15:17:36.000Z',

--- a/api/tests/unit/infrastructure/mailjet_test.js
+++ b/api/tests/unit/infrastructure/mailjet_test.js
@@ -90,7 +90,7 @@ describe('Unit | Class | Mailjet', function() {
       // then
       return result.then(() => {
         sinon.assert.calledWith(requestStub, {
-          'FromEmail': 'communaute@pix.beta.gouv.fr',
+          'FromEmail': 'communaute@pix.fr',
           'FromName': 'Communauté PIX',
           'Subject': 'Bienvenue dans la communauté PIX',
           'MJ-TemplateID': '129291',
@@ -114,7 +114,7 @@ describe('Unit | Class | Mailjet', function() {
       // then
       return result.then(() => {
         sinon.assert.calledWith(requestStub, {
-          'FromEmail': 'communaute@pix.beta.gouv.fr',
+          'FromEmail': 'communaute@pix.fr',
           'FromName': 'Communauté PIX',
           'Subject': 'Bienvenue dans la communauté PIX',
           'MJ-TemplateID': '129291',

--- a/api/tests/unit/scripts/recompute-assessment-results_test.js
+++ b/api/tests/unit/scripts/recompute-assessment-results_test.js
@@ -19,7 +19,7 @@ describe('Unit | Scripts | recompute-assessment-results', () => {
 
         expect(request.firstCall.args).to.deep.equal([{
           method: 'POST',
-          uri: 'https://pix.fr/api/assessment-results?recompute=true',
+          uri: 'https://api.pix.fr/api/assessment-results?recompute=true',
           body: {
             'data': {
               'relationships': {
@@ -37,7 +37,7 @@ describe('Unit | Scripts | recompute-assessment-results', () => {
 
         expect(request.secondCall.args).to.deep.equal([{
           method: 'POST',
-          uri: 'https://pix.fr/api/assessment-results?recompute=true',
+          uri: 'https://api.pix.fr/api/assessment-results?recompute=true',
           body: {
             'data': {
               'relationships': {

--- a/mon-pix/tests/unit/services/mail-generator-test.js
+++ b/mon-pix/tests/unit/services/mail-generator-test.js
@@ -37,7 +37,7 @@ describe('Unit | Service | mail generator', function() {
 
     it('when the environment is production', function() {
       // Given
-      const host = 'pix.beta.gouv.fr';
+      const host = 'pix.fr';
       const env = 'production';
 
       // When
@@ -52,7 +52,7 @@ describe('Unit | Service | mail generator', function() {
         // Given
         const env = 'integration';
         const branchName = 'ma-branche';
-        const host = `${branchName}.pix.beta.gouv.fr`;
+        const host = `${branchName}.pix.fr`;
 
         // When
         const email = service.generateEmail('recigAYl5bl96WGXj', '267845', host, env);
@@ -67,7 +67,7 @@ describe('Unit | Service | mail generator', function() {
         // Given
         const env = 'staging';
         const branchName = 'ma-branche';
-        const host = `${branchName}.pix.beta.gouv.fr`;
+        const host = `${branchName}.pix.fr`;
 
         // When
         const email = service.generateEmail('recigAYl5bl96WGXj', '267845', host, env);

--- a/orga/app/templates/components/login-form.hbs
+++ b/orga/app/templates/components/login-form.hbs
@@ -40,7 +40,7 @@
     </form>
 
     <div class="login-form__forgotten-password one-line-text">
-      Vous avez oublié votre mot de passe ? Rendez-vous sur <a href="https://pix.fr/mot-de-passe-oublie" target="_blank">pix.fr</a> pour
+      Vous avez oublié votre mot de passe ? Rendez-vous sur <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank">pix.fr</a> pour
       le réinitialiser.
     </div>
 

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
 
     APP: {
       API_HOST: inferApiURLFromScalingoAppName(process.env.APP),
-      CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL || 'https://pix.fr/campagnes/',
+      CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL || 'https://app.pix.fr/campagnes/',
     },
 
     googleFonts: [
@@ -60,7 +60,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.APP.CAMPAIGNS_ROOT_URL= 'https://pix.fr/campagnes/';
+    ENV.APP.CAMPAIGNS_ROOT_URL= 'https://app.pix.fr/campagnes/';
     // here you can enable a production-specific feature
     //ENV.APP.API_HOST = 'https://pix.fr/api';
   }


### PR DESCRIPTION
NOTE : Il va falloir qu'on se prenne du temps pour réfléchir à notre gestion des urls, et plus particulièrement la manière dont on "référencie" l'url d'une app dans une autre (ex l'url de l'api dans mon orga).
A mettre dans la partie 'Environment' de scalingo ?!
