### PR TITLE
Set scalingo formation for review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -8,5 +8,15 @@
   },
   "scripts": {
     "first-deploy": "npm run scalingo-post-ra-creation"
+  },
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    },
+    "background": {
+      "amount": 0,
+      "size": "S"
+    }
   }
 }


### PR DESCRIPTION
Without a specification in scalingo.json, Scalingo defaults to M-sized containers for review apps, which cost twice as much as the S-sized containers which are sufficient.