### PR TITLE
[#208] [FEATURE] Ajout du endpoint d'administration "GET /api/users" permettant de lister, filtrer et paginer des utilisateurs (PA-46).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,4 +1,5 @@
-const UserController = require('./user-controller');
+const securityController = require('../../interfaces/controllers/security-controller');
+const userController = require('./user-controller');
 const Joi = require('joi');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../settings');
@@ -12,15 +13,29 @@ exports.register = function(server, options, next) {
       path: '/api/users',
       config: {
         auth: false,
-        handler: UserController.save,
+        handler: userController.save,
         tags: ['api']
       }
-    },
-    {
+    }, {
+      method: 'GET',
+      path: '/api/users',
+      config: {
+        pre: [{
+          method: securityController.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster'
+        }],
+        handler: userController.find,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de récupérer & chercher une liste d’utilisateurs (avec pagination)'
+        ],
+        tags: ['api', 'user']
+      }
+    }, {
       method: 'GET',
       path: '/api/users/{id}',
       config: {
-        handler: UserController.getUser,
+        handler: userController.getUser,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Récupération de l‘utilisateur par id\n' +
@@ -33,7 +48,7 @@ exports.register = function(server, options, next) {
       method: 'GET',
       path: '/api/users/me',
       config: {
-        handler: UserController.getAuthenticatedUserProfile,
+        handler: userController.getAuthenticatedUserProfile,
         tags: ['api']
       }
     },
@@ -45,7 +60,7 @@ exports.register = function(server, options, next) {
           method: userVerification.verifyById,
           assign: 'user'
         }],
-        handler: UserController.getProfileToCertify
+        handler: userController.getProfileToCertify
         , tags: ['api']
       }
     },
@@ -53,7 +68,7 @@ exports.register = function(server, options, next) {
       method: 'GET',
       path: '/api/users/{id}/organization-accesses',
       config: {
-        handler: UserController.getOrganizationAccesses,
+        handler: userController.getOrganizationAccesses,
         notes : [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Récupération des accès utilisateurs à partir de l\'id\n' +
@@ -71,7 +86,7 @@ exports.register = function(server, options, next) {
           method: userVerification.verifyById,
           assign: 'user'
         }],
-        handler: UserController.updatePassword,
+        handler: userController.updatePassword,
         validate: {
           options: {
             allowUnknown: true

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -161,7 +161,7 @@ module.exports = {
       pageSize: request.query['pageSize'] ? request.query['pageSize'] : 10,
     };
 
-    return usecases.findUsers({ filters, pagination, userRepository })
+    return usecases.findUsers({ filters, pagination })
       .then((searchResultList) => {
         const meta = {
           page: searchResultList.page,

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -148,6 +148,29 @@ module.exports = {
         logger.error(error);
         reply(JSONAPI.internalError('Une erreur est survenue lors de la récupération de l’utilisateur')).code(500);
       });
+  },
+
+  find(request, reply) {
+    const filters = {
+      firstName: request.query['firstName'],
+      lastName: request.query['lastName'],
+      email: request.query['email']
+    };
+    const pagination = {
+      page: request.query['page'] ? request.query['page'] : 1,
+      pageSize: request.query['pageSize'] ? request.query['pageSize'] : 10,
+    };
+
+    return usecases.findUsers({ filters, pagination, userRepository })
+      .then((searchResultList) => {
+        const meta = {
+          page: searchResultList.page,
+          pageSize: searchResultList.pageSize,
+          itemsCount: searchResultList.totalResults,
+          pagesCount: searchResultList.pagesCount,
+        };
+        return reply(userSerializer.serialize(searchResultList.paginatedResults, meta));
+      });
   }
 };
 

--- a/api/lib/domain/models/SearchResultList.js
+++ b/api/lib/domain/models/SearchResultList.js
@@ -1,0 +1,26 @@
+class SearchResultList {
+
+  constructor({
+    // attributes
+    page,
+    pageSize,
+    totalResults,
+    // includes
+    paginatedResults = [],
+    // references
+  } = {}) {
+    // attributes
+    this.page = page;
+    this.pageSize = pageSize;
+    this.totalResults = totalResults;
+    // includes
+    this.paginatedResults = paginatedResults;
+    // references
+  }
+
+  get pagesCount() {
+    return Math.ceil(this.totalResults / this.pageSize);
+  }
+}
+
+module.exports = SearchResultList;

--- a/api/lib/domain/usecases/find-users.js
+++ b/api/lib/domain/usecases/find-users.js
@@ -1,15 +1,17 @@
 const SearchResultList = require('../models/SearchResultList');
 
 module.exports = function findUsers({ filters, pagination, userRepository }) {
+
   return Promise.all([
     userRepository.find(filters, pagination),
     userRepository.count(filters)
-  ]).then((values) => {
+  ]).then(([paginatedResults, totalResults]) => {
+
     return new SearchResultList({
       page: pagination.page,
       pageSize: pagination.pageSize,
-      totalResults: values[1],
-      paginatedResults: values[0]
+      totalResults,
+      paginatedResults
     });
   });
 };

--- a/api/lib/domain/usecases/find-users.js
+++ b/api/lib/domain/usecases/find-users.js
@@ -1,0 +1,15 @@
+const SearchResultList = require('../models/SearchResultList');
+
+module.exports = function findUsers({ filters, pagination, userRepository }) {
+  return Promise.all([
+    userRepository.find(filters, pagination),
+    userRepository.count(filters)
+  ]).then((values) => {
+    return new SearchResultList({
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      totalResults: values[1],
+      paginatedResults: values[0]
+    });
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -44,6 +44,7 @@ module.exports = injectDependencies({
   findAvailableTargetProfiles: require('./find-available-target-profiles'),
   findCampaignParticipationsByAssessmentId: require('./find-campaign-participations-by-assessmentId'),
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
+  findUsers: require('./find-users.js'),
   findUserAssessmentsByFilters: require('./find-user-assessments-by-filters'),
   getCampaignByCode: require('./get-campaign-by-code'),
   getCorrectionForAnswerWhenAssessmentEnded: require('./get-correction-for-answer-when-assessment-ended'),

--- a/api/lib/infrastructure/bookshelf.js
+++ b/api/lib/infrastructure/bookshelf.js
@@ -21,6 +21,7 @@ bookshelf.plugin('bookshelf-validate', {
 });
 
 bookshelf.plugin('registry');
+bookshelf.plugin('pagination');
 
 if (bookshelf.VERSION !== '0.12.1') {
   logger.error('WARNING: nous avons patché la version 0.12.1 de Bookshelf. Risque de bug dans les versions à venir.');

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -38,6 +38,19 @@ function _toDomain(userBookshelf) {
   });
 }
 
+function _setSearchFiltersForQueryBuilder(filters, qb) {
+  const { firstName, lastName, email } = filters;
+  if (firstName) {
+    qb.where('firstName', 'LIKE', `%${firstName}%`);
+  }
+  if (lastName) {
+    qb.where('lastName', 'LIKE', `%${lastName}%`);
+  }
+  if (email) {
+    qb.where('email', 'LIKE', `%${email}%`);
+  }
+}
+
 module.exports = {
 
   // TODO use _toDomain()
@@ -61,7 +74,7 @@ module.exports = {
         ]
       })
       .then((foundUser) => {
-        if(foundUser === null) {
+        if (foundUser === null) {
           return Promise.reject(new UserNotFoundError());
         }
         return _toDomain(foundUser);
@@ -93,6 +106,17 @@ module.exports = {
       });
   },
 
+  find(filters, pagination) {
+    const { page, pageSize } = pagination;
+    return BookshelfUser.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb))
+      .fetchPage({ page, pageSize })
+      .then((results) => results.map(_toDomain));
+  },
+
+  count(filters) {
+    return BookshelfUser.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb)).count();
+  },
+
   getWithOrganizationAccesses(userId) {
     return BookshelfUser
       .where({ id: userId })
@@ -104,7 +128,7 @@ module.exports = {
         ]
       })
       .then((foundUser) => {
-        if(foundUser === null) {
+        if (foundUser === null) {
           return Promise.reject(new UserNotFoundError(`User not found for ID ${userId}`));
         }
         return _toDomain(foundUser);

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -3,7 +3,7 @@ const User = require('../../../domain/models/User');
 
 module.exports = {
 
-  serialize(users) {
+  serialize(users, meta) {
     return new Serializer('user', {
       attributes: ['firstName', 'lastName', 'email', 'cgu', 'organizationAccesses'],
       organizationAccesses: {
@@ -15,10 +15,11 @@ module.exports = {
           }
         }
       },
-      transform: (model) => {
+      transform(model) {
         // FIXME: Used to make it work in both cases
         return (model instanceof User) ? model : model.toJSON();
-      }
+      },
+      meta
     }).serialize(users);
   },
 

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -2,9 +2,12 @@ const _ = require('lodash');
 
 function extractFilters(request) {
   return _.reduce(request.query, (result, queryFilterValue, queryFilterKey) => {
-    const field = queryFilterKey.match(/filter\[([a-zA-Z]*)]/)[1];
-    if (field) {
-      result[field] = queryFilterValue;
+    const filter = queryFilterKey.match(/filter\[([a-zA-Z]*)]/);
+    if (filter) {
+      const field = filter[1];
+      if (field) {
+        result[field] = queryFilterValue;
+      }
     }
     return result;
   }, {});

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -135,20 +135,26 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.51",
         "@babel/parser": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "globals": "11.3.0",
         "invariant": "2.2.4",
         "lodash": "4.17.5"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -1015,6 +1021,14 @@
         }
       }
     },
+    "bookshelf-page": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bookshelf-page/-/bookshelf-page-0.3.2.tgz",
+      "integrity": "sha1-i+TMFWQb0zijq/gtXYcyAnEhtTE=",
+      "requires": {
+        "bluebird": "3.5.1"
+      }
+    },
     "bookshelf-validate": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/bookshelf-validate/-/bookshelf-validate-2.0.3.tgz",
@@ -1449,6 +1463,7 @@
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
         "braces": "2.3.1",
+        "fsevents": "1.2.4",
         "glob-parent": "3.1.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3021,6 +3036,608 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.11.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
+        "nan": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -5673,7 +6290,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -5683,17 +6301,20 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "append-transform": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+          "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
           "dev": true,
           "requires": {
             "default-require-extensions": "2.0.0"
@@ -5701,27 +6322,32 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -5730,12 +6356,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-2.0.0.tgz",
+          "integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
           "dev": true,
           "requires": {
             "make-dir": "1.3.0",
@@ -5746,13 +6374,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5762,7 +6392,8 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5773,7 +6404,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -5781,27 +6413,32 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "4.1.3",
@@ -5810,7 +6447,8 @@
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5818,17 +6456,20 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+          "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
           "dev": true,
           "requires": {
             "strip-bom": "3.0.0"
@@ -5836,7 +6477,8 @@
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -5844,12 +6486,14 @@
         },
         "es6-error": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+          "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
@@ -5863,7 +6507,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "4.1.3",
@@ -5875,7 +6520,8 @@
         },
         "find-cache-dir": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -5885,7 +6531,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
             "locate-path": "3.0.0"
@@ -5893,7 +6540,8 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -5902,22 +6550,26 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5930,12 +6582,14 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -5946,7 +6600,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -5956,22 +6611,26 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+          "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5980,27 +6639,32 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -6008,27 +6672,32 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+          "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.1.tgz",
+          "integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
           "dev": true,
           "requires": {
             "append-transform": "1.0.0"
@@ -6036,7 +6705,8 @@
         },
         "istanbul-lib-report": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.1.tgz",
+          "integrity": "sha512-pXYOWwpDNc5AHIY93WjFTuxzkDOOZ7B8eSa0cBHTmTnKRst5ccc/xBfWu/5wcNJqB6/Qy0lDMhpn+Uy0qyyUjA==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "2.0.1",
@@ -6046,7 +6716,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-2.0.1.tgz",
+          "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
           "dev": true,
           "requires": {
             "debug": "3.1.0",
@@ -6058,14 +6729,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "istanbul-reports": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.0.0.tgz",
+          "integrity": "sha512-d2YRSnAOHHb+6vMc5qjJEyPN4VapkgUMhKlMmr3BzKdMDWdJbyYGEi/7m5AjDjkvRRTjs68ttPRZ7W2jBZ31SQ==",
           "dev": true,
           "requires": {
             "handlebars": "4.0.11"
@@ -6073,12 +6746,14 @@
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
@@ -6086,13 +6761,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -6100,7 +6777,8 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6111,7 +6789,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
             "p-locate": "3.0.0",
@@ -6120,17 +6799,20 @@
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+          "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6139,7 +6821,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "3.0.0"
@@ -6147,7 +6830,8 @@
         },
         "md5-hex": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+          "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -6155,12 +6839,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
@@ -6168,7 +6854,8 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -6176,19 +6863,22 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -6196,12 +6886,14 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6209,19 +6901,22 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.7.1",
@@ -6232,7 +6927,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -6240,12 +6936,14 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -6253,7 +6951,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "0.0.10",
@@ -6262,12 +6961,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -6277,12 +6978,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
             "p-try": "2.0.0"
@@ -6290,7 +6993,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
             "p-limit": "2.0.0"
@@ -6298,12 +7002,14 @@
         },
         "p-try": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "package-hash": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+          "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6314,7 +7020,8 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "1.3.2",
@@ -6323,22 +7030,26 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
             "pify": "3.0.0"
@@ -6346,12 +7057,14 @@
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
             "find-up": "3.0.0"
@@ -6359,12 +7072,14 @@
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
             "load-json-file": "4.0.0",
@@ -6374,7 +7089,8 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
             "find-up": "3.0.0",
@@ -6383,7 +7099,8 @@
         },
         "release-zalgo": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+          "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
           "dev": true,
           "requires": {
             "es6-error": "4.1.1"
@@ -6391,27 +7108,32 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6420,7 +7142,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -6428,17 +7151,20 @@
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
@@ -6446,23 +7172,27 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -6475,7 +7205,8 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
@@ -6484,12 +7215,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "2.1.0",
@@ -6498,12 +7231,14 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6512,7 +7247,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
@@ -6520,17 +7256,20 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -6538,7 +7277,8 @@
         },
         "test-exclude": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
+          "integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -6549,7 +7289,8 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6560,7 +7301,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6574,18 +7316,21 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "uuid": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
             "spdx-correct": "3.0.0",
@@ -6594,7 +7339,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -6602,23 +7348,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -6627,12 +7377,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -6640,7 +7392,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -6650,7 +7403,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -6660,12 +7414,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6675,17 +7431,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
             "cliui": "4.1.0",
@@ -6704,7 +7463,8 @@
           "dependencies": {
             "cliui": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
                 "string-width": "2.1.1",
@@ -6714,7 +7474,8 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
                 "locate-path": "2.0.0"
@@ -6722,7 +7483,8 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
               "dev": true,
               "requires": {
                 "p-locate": "2.0.0",
@@ -6731,7 +7493,8 @@
             },
             "p-limit": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+              "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
               "dev": true,
               "requires": {
                 "p-try": "1.0.0"
@@ -6739,7 +7502,8 @@
             },
             "p-locate": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
               "dev": true,
               "requires": {
                 "p-limit": "1.3.0"
@@ -6747,14 +7511,16 @@
             },
             "p-try": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
               "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
@@ -6762,7 +7528,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }

--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,7 @@
     "bcrypt": "^1.0.3",
     "blipp": "^2.3.0",
     "bookshelf": "^0.12.1",
+    "bookshelf-page": "^0.3.2",
     "bookshelf-validate": "^2.0.3",
     "boom": "^5.2.0",
     "bunyan": "^1.8.12",

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -1,4 +1,4 @@
-const { expect, generateValidRequestAuhorizationHeader } = require('../../../test-helper');
+const { expect, generateValidRequestAuhorizationHeader, databaseBuilder } = require('../../../test-helper');
 const server = require('../../../../server');
 
 describe('Acceptance | users-controller-find-users', () => {
@@ -6,12 +6,25 @@ describe('Acceptance | users-controller-find-users', () => {
   let options;
 
   beforeEach(() => {
+    // Insert 1 user with role PixMaster
+    const userPixMaster = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+
+    // Insert 2 more users
+    databaseBuilder.factory.buildUser({ firstName: 'fn_ok_1', lastName: 'ln_ok_1', email: 'email_ok_1@mail.com' });
+    databaseBuilder.factory.buildUser({ firstName: 'fn_ok_2', lastName: 'ln_ok_2', email: 'email_ok_2@mail.com' });
+
     options = {
       method: 'GET',
       url: '/api/users',
       payload: { },
-      headers: { authorization: generateValidRequestAuhorizationHeader() },
+      headers: { authorization: generateValidRequestAuhorizationHeader(userPixMaster.id) },
     };
+
+    return databaseBuilder.commit();
+  });
+
+  afterEach(() => {
+    return databaseBuilder.clean();
   });
 
   describe('GET /users', () => {
@@ -46,6 +59,23 @@ describe('Acceptance | users-controller-find-users', () => {
       });
     });
 
-  });
+    describe('Success case', () => {
 
+      it('should return a 200 status code response with JSON API serialized SearchResponse', () => {
+        // given
+        const expectedMetaData = { page: 1, pageSize: 10, itemsCount: 3, pagesCount: 1 };
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.meta).to.deep.equal(expectedMetaData);
+          expect(response.result.data).to.have.lengthOf(3);
+          expect(response.result.data[0].type).to.equal('users');
+        });
+      });
+    });
+  });
 });

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -1,0 +1,51 @@
+const { expect, generateValidRequestAuhorizationHeader } = require('../../../test-helper');
+const server = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-find-users', () => {
+
+  let options;
+
+  beforeEach(() => {
+    options = {
+      method: 'GET',
+      url: '/api/users',
+      payload: { },
+      headers: { authorization: generateValidRequestAuhorizationHeader() },
+    };
+  });
+
+  describe('GET /users', () => {
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(401);
+        });
+      });
+
+      it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', () => {
+        // given
+        const nonPixMAsterUserId = 9999;
+        options.headers.authorization = generateValidRequestAuhorizationHeader(nonPixMAsterUserId);
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
+
+  });
+
+});

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -1,7 +1,7 @@
 const { expect, generateValidRequestAuhorizationHeader } = require('../../../test-helper');
 const server = require('../../../../server');
 
-describe('Acceptance | Controller | users-controller-find-users', () => {
+describe('Acceptance | users-controller-find-users', () => {
 
   let options;
 

--- a/api/tests/tooling/database-builder/factory/build-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-pix-role.js
@@ -1,0 +1,21 @@
+const faker = require('faker');
+const databaseBuffer = require('../database-buffer');
+
+const buildPixRole = function buildPixRole({
+  id = faker.random.number(),
+  name = 'PIX_MASTER',
+} = {}) {
+
+  const values = {
+    id, name,
+  };
+
+  databaseBuffer.pushInsertable({
+    tableName: 'pix_roles',
+    values,
+  });
+
+  return values;
+};
+
+module.exports = buildPixRole;

--- a/api/tests/tooling/database-builder/factory/build-user-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-user-pix-role.js
@@ -1,0 +1,29 @@
+const buildUser = require('./build-user');
+const buildPixRole = require('./build-pix-role');
+
+const faker = require('faker');
+const databaseBuffer = require('../database-buffer');
+
+const buildUserPixRole = function buildUserPixRole({
+  id = faker.random.number(),
+  userId = buildUser().id,
+  pixRoleId = buildPixRole().id
+} = {}) {
+
+  const values = {
+    id, userId, pixRoleId,
+  };
+
+  databaseBuffer.pushInsertable({
+    tableName: 'users_pix_roles',
+    values: {
+      id,
+      'user_id': userId,
+      'pix_role_id': pixRoleId
+    },
+  });
+
+  return values;
+};
+
+module.exports = buildUserPixRole;

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -1,6 +1,8 @@
 const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 const encrypt = require('../../../../lib/domain/services/encryption-service');
+const buildPixRole = require('./build-pix-role');
+const buildUserPixRole = require('./build-user-pix-role');
 
 const buildUser = function buildUser({
   id = faker.random.number(),
@@ -37,6 +39,31 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   const values = {
     id, firstName, lastName, email, password, cgu,
   };
+
+  databaseBuffer.pushInsertable({
+    tableName: 'users',
+    values,
+  });
+
+  return values;
+};
+
+buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
+  id = faker.random.number(),
+  firstName = faker.name.firstName(),
+  lastName = faker.name.lastName(),
+  email = faker.internet.email(),
+  password = encrypt.hashPasswordSync(faker.internet.password()),
+  cgu = true,
+} = {}) {
+
+  const values = {
+    id, firstName, lastName, email, password, cgu,
+  };
+
+  const pixRolePixMaster = buildPixRole({ id: 1, name: 'PIX_MASTER' });
+
+  buildUserPixRole({ userId: id, pixRoleId: pixRolePixMaster.id });
 
   databaseBuffer.pushInsertable({
     tableName: 'users',

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -7,9 +7,11 @@ module.exports = {
   buildCertificationCourse: require('./build-certification-course'),
   buildOrganization: require('./build-organization'),
   buildOrganizationAccess: require('./build-organization-access'),
+  buildPixRole: require('./build-pix-role'),
   buildSmartPlacementKnowledgeElement: require('./build-smart-placement-knowledge-element'),
   buildSession: require('./build-session'),
   buildTargetProfile: require('./build-target-profile'),
   buildTargetProfilesSkills: require('./build-target-profiles-skills'),
   buildUser: require('./build-user'),
+  buildUserPixRole: require('./build-user-pix-role'),
 };

--- a/api/tests/unit/domain/models/SearchResultList_test.js
+++ b/api/tests/unit/domain/models/SearchResultList_test.js
@@ -1,0 +1,46 @@
+const { expect } = require('../../../test-helper');
+const SearchResultList = require('../../../../lib/domain/models/SearchResultList');
+
+describe('Unit | Domain | Models | SearchResultList', () => {
+
+  describe('#pagesCount', function() {
+
+    [{
+      conditions: { totalResults: 0, pageSize: 10 },
+      expectations: { pagesCount: 0 }
+    }, {
+      conditions: { totalResults: 9, pageSize: 10 },
+      expectations: { pagesCount: 1 }
+    }, {
+      conditions: { totalResults: 10, pageSize: 10 },
+      expectations: { pagesCount: 1 }
+    }, {
+      conditions: { totalResults: 11, pageSize: 10 },
+      expectations: { pagesCount: 2 }
+    }, {
+      conditions: { totalResults: 19, pageSize: 10 },
+      expectations: { pagesCount: 2 }
+    }, {
+      conditions: { totalResults: 20, pageSize: 10 },
+      expectations: { pagesCount: 2 }
+    }, {
+      conditions: { totalResults: 21, pageSize: 10 },
+      expectations: { pagesCount: 3 }
+    }].forEach((testCase) => {
+
+      it(`should return a total of pages equal to ${testCase.expectations.pagesCount} for given total results ${testCase.conditions.totalResults} and page size ${testCase.conditions.pageSize}`, () => {
+        // given
+        const searchResultList = new SearchResultList({
+          totalResults: testCase.conditions.totalResults,
+          pageSize: testCase.conditions.pageSize
+        });
+
+        // when
+        const actual = searchResultList.pagesCount;
+
+        // then
+        expect(actual).to.equal(testCase.expectations.pagesCount);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-users_test.js
+++ b/api/tests/unit/domain/usecases/find-users_test.js
@@ -1,0 +1,34 @@
+const { expect } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const SearchResultList = require('../../../../lib/domain/models/SearchResultList');
+const User = require('../../../../lib/domain/models/User');
+
+describe('Unit | UseCase | find-users', () => {
+
+  it('should result a SearchResultList object that take into account User search with filtering and pagination', () => {
+    // given
+    const filters = {};
+    const pagination = { page: 1, pageSize: 10 };
+    const matchingUsers = [
+      new User({ id: 1 }),
+      new User({ id: 2 }),
+      new User({ id: 3 }),
+    ];
+    const userRepository = {
+      find: () => matchingUsers,
+      count: () => matchingUsers.length
+    };
+
+    // when
+    const promise = usecases.findUsers({ filters, pagination, userRepository });
+
+    // then
+    return expect(promise).to.be.fulfilled.then((response) => {
+      expect(response).to.be.an.instanceOf(SearchResultList);
+      expect(response.page).to.equal(1);
+      expect(response.pageSize).to.equal(10);
+      expect(response.totalResults).to.equal(3);
+      expect(response.paginatedResults).to.deep.equal(matchingUsers);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -1,4 +1,4 @@
-const { expect,  } = require('../../../test-helper');
+const { expect, } = require('../../../test-helper');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 
 describe('Unit | Utils | Query Params Utils', function() {
@@ -8,8 +8,8 @@ describe('Unit | Utils | Query Params Utils', function() {
     it('should extract a filter from request Object', function() {
       // given
       const request = {
-        query : {
-          'filter[courseId]' : '26'
+        query: {
+          'filter[courseId]': '26'
         }
       };
 
@@ -18,16 +18,16 @@ describe('Unit | Utils | Query Params Utils', function() {
 
       // then
       expect(result).to.deep.equal({
-        courseId : '26'
+        courseId: '26'
       });
     });
 
     it('should extract multiple filters from request Object', function() {
       // given
       const request = {
-        query : {
-          'filter[courseId]' : '26',
-          'filter[userId]' : '1'
+        query: {
+          'filter[courseId]': '26',
+          'filter[userId]': '1'
         }
       };
 
@@ -36,11 +36,25 @@ describe('Unit | Utils | Query Params Utils', function() {
 
       // then
       expect(result).to.deep.equal({
-        courseId : '26',
-        userId : '1'
+        courseId: '26',
+        userId: '1'
       });
     });
 
-  });
+    it('should return an empty object if the request contains no query param "filter"', function() {
+      // given
+      const request = {
+        query: {
+          'page': 1,
+          'pageSize': 10
+        }
+      };
 
+      // when
+      const result = queryParamsUtils.extractFilters(request);
+
+      // then
+      expect(result).to.deep.equal({});
+    });
+  });
 });


### PR DESCRIPTION
### 📱 Application cible

Pix Admin

### 🎁 Fonctionnalités

![pa-46-list-users](https://user-images.githubusercontent.com/265963/46549338-ef1a5300-c8d1-11e8-93ce-a7f107189b51.gif)

L'objet de cette PR est de définir dans l'API la ressource `GET /api/users`, qui permet de : 

- lister des utilisateurs (id, firstName, lastName, email) ;
- filter des utilisateurs par prénom, nom et/ou email ;
- et de les retourner de façon paginée.

Cette ressource est réservée aux Pix Masters.

La route prend les paramètres (optionnels) suivants : 

| Param     | Type   | Usage      | Default value |
|-----------|--------|------------|---------------|
| firstName | string | search     | null          |
| lastName  | string | search     | null          |
| email     | string | search     | null          |
| page      | number | pagination | 1             |
| pageSize  | number | pagination | 10            |

### 📜 Exemples

- `GET /api/users`
- `GET /api/users?firstName=Bruce&lastName=Wayne&email=batman@gotham.city&page=3&pageSize=25`

### ⚙️ Implémentation

Faits notables :

-  Introduction d'un nouveau concept modèle du domaine `SearchResultList` qui se veut être un conteneur générique pour lister des entités métier avec pagination
- 1 seul UseCase `UseCases.findUsers` faisant appel à 2 nouvelles méthodes de repo `UserRepository#find` et `UserRepository#count` 
- Premières utilisation des méthodes de Bookshelf `Model#fetchPage` et `Model#count`
- Le package-lock file a été mis à jour dans un ultime commit suite au rebase sur dev

### 👓 Code review

Chaque commit est unitaire (i.e. les tests restent vert après chaque commit) et peut être revu indépendamment.