### PR TITLE
[#210] [TECH] Publication de l'API sur les domaines front pour éviter les requêtes OPTIONS

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-      API_HOST: inferApiURLFromScalingoAppName(process.env.APP),
+      API_HOST: process.env.API_HOST || '',
       HOME_HOST: 'https://pix.fr',
       isChallengeTimerEnable: true,
       MESSAGE_DISPLAY_DURATION: 1500,
@@ -143,22 +143,3 @@ module.exports = function(environment) {
 
   return ENV;
 };
-
-function inferApiURLFromScalingoAppName(appName) {
-
-  const matchesReviewApp = /pix-app-integration-pr(\d+)/.exec(appName);
-  if (matchesReviewApp) {
-    return `https://pix-api-integration-pr${matchesReviewApp[1]}.scalingo.io`;
-  }
-
-  switch (appName) {
-    case 'pix-app-integration':
-      return 'https://api.integration.pix.fr';
-    case 'pix-mon-pix-production':
-    case 'pix-app-production':
-      return 'https://api.pix.fr';
-    default:
-      return 'http://localhost:3000';
-  }
-}
-

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -2,3 +2,14 @@
 set $maintenance_mode <%= ENV['MAINTENANCE'] %>;
 
 include /app/<%= ENV['APPLICATION_NAME'].downcase %>/nginx.conf;
+
+location /api/ {
+  <%
+  # We compute the API host from the front app name, examples:
+  #   pix-orga-integration      -> pix-api-integration.scalingo.io
+  #   pix-app-integration-pr123 -> pix-api-integration-pr123.scalingo.io
+  #   pix-app-production        -> pix-api-production.scalingo.io
+  %>
+  proxy_pass https://<%= ENV['APP'].gsub(/-(app|orga)-/, "-api-") %>.scalingo.io;
+  proxy_redirect default;
+}

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -18,7 +18,7 @@ module.exports = function(environment) {
     },
 
     APP: {
-      API_HOST: inferApiURLFromScalingoAppName(process.env.APP),
+      API_HOST: process.env.API_HOST || '',
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL || 'https://app.pix.fr/campagnes/',
     },
 
@@ -67,20 +67,3 @@ module.exports = function(environment) {
 
   return ENV;
 };
-
-function inferApiURLFromScalingoAppName(appName) {
-
-  const matchesReviewApp = /pix-orga-integration-pr(\d+)/.exec(appName);
-  if (matchesReviewApp) {
-    return `https://pix-api-integration-pr${matchesReviewApp[1]}.scalingo.io`;
-  }
-
-  switch (appName) {
-    case 'pix-orga-integration':
-      return 'https://api.integration.pix.fr';
-    case 'pix-orga-production':
-      return 'https://api.pix.fr';
-    default:
-      return 'http://localhost:3000';
-  }
-}


### PR DESCRIPTION
Avec cette PR, les applications front (https://app.pix.fr, https://orga.pix.fr) accèdent à l'API via https://app.pix.fr/api/ et https://orga.pix.fr/api/ ce qui évite au navigateur d'avoir à faire des requêtes `OPTIONS`.