### PR TITLE
[#219] [TECH] Creation d'une participation à une campagne plutôt qu'un assessment (PF-407)

### DIFF
--- a/api/db/migrations/20180921125008_add-column-user-id-in-campaign-participation.js
+++ b/api/db/migrations/20180921125008_add-column-user-id-in-campaign-participation.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'campaign-participations';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer('userId').unsigned().references('users.id').index();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('userId');
+  });
+};

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -22,6 +22,12 @@ module.exports = {
       .then(controllerReplies(reply).created)
       .catch((error) => {
         logger.error(error);
+
+        if (error instanceof NotFoundError) {
+          const infraError = new infraErrors.NotFoundError(error.message);
+          return controllerReplies(reply).error(infraError);
+        }
+
         return controllerReplies(reply).error(error);
       });
   },
@@ -61,18 +67,16 @@ module.exports = {
         })
         .catch((error) => {
           logger.error(error);
-          return controllerReplies(reply).error(mapToInfrastructureErrors(error));
+          return controllerReplies(reply).error(_mapToInfrastructureErrors(error));
         });
     }
     else {
       return controllerReplies(reply).error(new infraErrors.BadRequestError('campaignParticipationId manquant'));
     }
   }
-}
-;
+};
 
-function mapToInfrastructureErrors(error) {
-
+function _mapToInfrastructureErrors(error) {
   if (error instanceof NotFoundError) {
     return new infraErrors.NotFoundError('Participation non trouvée');
   }

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -14,6 +14,18 @@ const serializer = require('../../infrastructure/serializers/jsonapi/campaign-pa
 
 module.exports = {
 
+  save(request, reply) {
+    const userId = request.auth.credentials.userId;
+    return serializer.deserialize(request.payload)
+      .then((campaignParticipation) => usecases.startCampaignParticipation({ campaignParticipation, userId }))
+      .then(serializer.serialize)
+      .then(controllerReplies(reply).created)
+      .catch((error) => {
+        logger.error(error);
+        return controllerReplies(reply).error(error);
+      });
+  },
+
   getCampaignParticipationByAssessment(request, reply) {
     const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
     const userId = tokenService.extractUserId(token);
@@ -27,7 +39,7 @@ module.exports = {
       smartPlacementAssessmentRepository
     })
       .then((campaignParticipation) => {
-        return serializer.serialize(campaignParticipation);
+        return serializer.serialize([campaignParticipation]);
       })
       .then(controllerReplies(reply).ok);
   },

--- a/api/lib/application/campaignParticipations/index.js
+++ b/api/lib/application/campaignParticipations/index.js
@@ -27,6 +27,18 @@ exports.register = function(server, options, next) {
         tags: ['api', 'campaign-participation']
       }
     },
+    {
+      method: 'POST',
+      path: '/api/campaign-participations',
+      config: {
+        handler: campaignParticipationController.save,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Création d‘une nouvelle participation à une campagne'
+        ],
+        tags: ['api', 'campaign-participation']
+      }
+    }
   ]);
 
   return next();

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -11,7 +11,8 @@ class CampaignParticipation {
     // includes
     campaign,
     // references
-    assessmentId
+    assessmentId,
+    userId,
   } = {}) {
     this.id = id;
     this.campaign = campaign;
@@ -19,6 +20,7 @@ class CampaignParticipation {
     this.participantExternalId = participantExternalId;
     this.isShared = isShared;
     this.sharedAt = sharedAt;
+    this.userId = userId;
   }
 
   isAboutCampaignCode(code) {

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -12,10 +12,12 @@ class CampaignParticipation {
     campaign,
     // references
     assessmentId,
+    campaignId,
     userId,
   } = {}) {
     this.id = id;
     this.campaign = campaign;
+    this.campaignId = campaignId;
     this.assessmentId = assessmentId;
     this.participantExternalId = participantExternalId;
     this.isShared = isShared;

--- a/api/lib/domain/usecases/create-assessment-for-campaign.js
+++ b/api/lib/domain/usecases/create-assessment-for-campaign.js
@@ -15,6 +15,7 @@ function _getCampaignFromCode(codeCampaign, campaignRepository) {
 
 module.exports = function createAssessmentForCampaign(
   {
+    userId,
     assessment,
     codeCampaign,
     participantExternalId,
@@ -36,8 +37,9 @@ module.exports = function createAssessmentForCampaign(
     .then((assessmentCreatedInDb) => {
       assessmentCreated = assessmentCreatedInDb;
       const campaignParticipation = new CampaignParticipation({
+        userId,
         assessmentId: assessmentCreated.id,
-        campaign: campaign,
+        campaignId: campaign.id,
         participantExternalId
       });
       return campaignParticipationRepository.save(campaignParticipation);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -65,6 +65,7 @@ module.exports = injectDependencies({
   removeAllCacheEntries: require('./remove-all-cache-entries'),
   removeCacheEntry: require('./remove-cache-entry'),
   shareCampaignResult: require('./share-campaign-result'),
+  startCampaignParticipation: require('./start-campaign-participation'),
   updateCertification: require('./update-certification'),
   updateUserPassword: require('./update-user-password'),
 });

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -1,0 +1,21 @@
+const Assessment = require('../models/Assessment');
+
+module.exports = function startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository }) {
+  return _createSmartPlacementAssessment(userId, assessmentRepository)
+    .then((assessment) => _saveCampaignParticipation(campaignParticipation, assessment, userId, campaignParticipationRepository));
+};
+
+function _createSmartPlacementAssessment(userId, assessmentRepository) {
+  const assessment = new Assessment();
+  assessment.state = Assessment.states.STARTED;
+  assessment.type = Assessment.types.SMARTPLACEMENT;
+  assessment.courseId = 'Smart Placement Tests CourseId Not Used';
+  assessment.userId = userId;
+  return assessmentRepository.save(assessment);
+}
+
+function _saveCampaignParticipation(campaignParticipation, assessment, userId, campaignParticipationRepository) {
+  campaignParticipation.userId = userId;
+  campaignParticipation.assessmentId = assessment.id;
+  return campaignParticipationRepository.save(campaignParticipation);
+}

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -1,9 +1,22 @@
 const Assessment = require('../models/Assessment');
 
-module.exports = function startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository }) {
-  return _createSmartPlacementAssessment(userId, assessmentRepository)
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = function startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository }) {
+  return _checkCampaignExists(campaignParticipation.campaignId, campaignRepository)
+    .then(() => _createSmartPlacementAssessment(userId, assessmentRepository))
     .then((assessment) => _saveCampaignParticipation(campaignParticipation, assessment, userId, campaignParticipationRepository));
 };
+
+function _checkCampaignExists(campaignId, campaignRepository) {
+  return campaignRepository.get(campaignId)
+    .then((campaign) => {
+      if(campaign === null) {
+        return Promise.reject(new NotFoundError('La campagne demandée n\'existe pas'));
+      }
+      return Promise.resolve();
+    });
+}
 
 function _createSmartPlacementAssessment(userId, assessmentRepository) {
   const assessment = new Assessment();

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -9,9 +9,11 @@ function _toDomain(bookshelfCampaignParticipation) {
     id: bookshelfCampaignParticipation.get('id'),
     assessmentId: bookshelfCampaignParticipation.get('assessmentId'),
     campaign: new Campaign(bookshelfCampaignParticipation.related('campaign').toJSON()),
+    campaignId: bookshelfCampaignParticipation.get('campaignId'),
     isShared: Boolean(bookshelfCampaignParticipation.get('isShared')),
     sharedAt: new Date(bookshelfCampaignParticipation.get('sharedAt')),
     participantExternalId: bookshelfCampaignParticipation.get('participantExternalId'),
+    userId: bookshelfCampaignParticipation.get('userId'),
   });
 }
 
@@ -59,8 +61,9 @@ module.exports = {
 function _adaptModelToDb(campaignParticipation) {
   return {
     assessmentId: campaignParticipation.assessmentId,
-    campaignId: campaignParticipation.campaign.id,
+    campaignId: campaignParticipation.campaignId,
     participantExternalId: campaignParticipation.participantExternalId,
+    userId: campaignParticipation.userId,
   };
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -1,10 +1,22 @@
-const { Serializer } = require('jsonapi-serializer');
+const _ = require('lodash');
+const { Serializer, Deserializer } = require('jsonapi-serializer');
+
+const CampaignParticipation = require('../../../domain/models/CampaignParticipation');
 
 module.exports = {
 
   serialize(campaignParticipation) {
     return new Serializer('campaign-participation', {
-      attributes: ['campaignId', 'assessmentId', 'isShared', 'sharedAt'],
+      attributes: ['campaignId', 'assessmentId', 'isShared', 'sharedAt', 'userId'],
     }).serialize([campaignParticipation]);
   },
+
+  deserialize(json) {
+    return new Deserializer({ keyForAttribute: 'camelCase' })
+      .deserialize(json)
+      .then((campaignParticipation) => {
+        campaignParticipation.campaignId = _.get(json.data, ['relationships', 'campaign', 'data', 'id']);
+        return new CampaignParticipation(campaignParticipation);
+      });
+  }
 };

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -7,8 +7,22 @@ module.exports = {
 
   serialize(campaignParticipation) {
     return new Serializer('campaign-participation', {
-      attributes: ['campaignId', 'assessmentId', 'isShared', 'sharedAt', 'userId'],
-    }).serialize([campaignParticipation]);
+      attributes: ['isShared', 'sharedAt', 'campaign', 'assessment'],
+      campaign: {
+        ref: 'id',
+        includes: false,
+      },
+      assessment: {
+        ref: 'id',
+        includes: false,
+      },
+      transform: (campaignParticipation) => {
+        const updatedCampaignParticipation = Object.assign({}, campaignParticipation);
+        updatedCampaignParticipation.assessment = { id: updatedCampaignParticipation.assessmentId };
+        updatedCampaignParticipation.campaign = { id: updatedCampaignParticipation.campaignId };
+        return updatedCampaignParticipation;
+      },
+    }).serialize(campaignParticipation);
   },
 
   deserialize(json) {

--- a/api/tests/acceptance/application/answer-controller_test.js
+++ b/api/tests/acceptance/application/answer-controller_test.js
@@ -9,12 +9,12 @@ describe('Acceptance | Controller | answer-controller-save', () => {
 
     let insertedAssessmentId;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       insertedAssessmentId = databaseBuilder.factory.buildAssessment({
         type: Assessment.types.PLACEMENT,
       }).id;
 
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
     afterEach(() => {

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -128,13 +128,13 @@ describe('Acceptance | API | Campaigns', () => {
     };
     let insertedCampaign;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       insertedCampaign = databaseBuilder.factory.buildCampaign({ name: 'Ou est Brandone 1.0', code: 'AZERTY123' });
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
+    afterEach(async () => {
+      await databaseBuilder.clean();
     });
 
     it('should return the campaign found for the given code', () => {

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -16,11 +16,11 @@ describe('Acceptance | API | Campaign Participations', () => {
 
   describe('GET /api/campaign-participations?filter[assessmentId]={id}', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         assessmentId: assessment.id,
       });
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
     afterEach(async () => {
@@ -100,7 +100,7 @@ describe('Acceptance | API | Campaign Participations', () => {
 
   describe('PATCH /api/campaign-participations/{id}', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         isShared: false,
         sharedAt: null,
@@ -117,7 +117,7 @@ describe('Acceptance | API | Campaign Participations', () => {
           }
         },
       };
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
 
     });
 
@@ -163,13 +163,13 @@ describe('Acceptance | API | Campaign Participations', () => {
       }
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       campaignInDb = databaseBuilder.factory.buildCampaign({ id: campaignId });
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
+    afterEach(async () => {
+      await databaseBuilder.clean();
     });
 
     it('should return 201 and the campaign participation when it has been successfully created', () => {

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -140,38 +140,39 @@ describe('Acceptance | API | Campaign Participations', () => {
   describe('POST /api/campaign-participations', () => {
 
     let campaignInDb;
-
-    beforeEach(() => {
-      campaignInDb = databaseBuilder.factory.buildCampaign({});
-      databaseBuilder.commit();
-    });
-
-    afterEach(() => {
-    });
-
-    it('should return 201 and the campaign when it has been successfully created', () => {
-      const options = {
-        method: 'POST',
-        url: '/api/campaign-participations',
-        headers: { authorization: generateValidRequestAuhorizationHeader() },
-        payload: {
-          data: {
-            type: 'campaign-participations',
-            attributes: {
-              'participant-external-id': 'iuqezfh13736',
-            },
-            relationships: {
-              'campaign': {
-                data: {
-                  id: campaignInDb.id,
-                  type: 'campaigns',
-                }
+    const campaignId = 132435;
+    const options = {
+      method: 'POST',
+      url: '/api/campaign-participations',
+      headers: { authorization: generateValidRequestAuhorizationHeader() },
+      payload: {
+        data: {
+          type: 'campaign-participations',
+          attributes: {
+            'participant-external-id': 'iuqezfh13736',
+          },
+          relationships: {
+            'campaign': {
+              data: {
+                id: campaignId,
+                type: 'campaigns',
               }
             }
           }
         }
-      };
+      }
+    };
 
+    beforeEach(() => {
+      campaignInDb = databaseBuilder.factory.buildCampaign({ id: campaignId });
+      return databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      return databaseBuilder.clean();
+    });
+
+    it('should return 201 and the campaign participation when it has been successfully created', () => {
       const expectedResult = {
         data: {
           type: 'campaign-participations',
@@ -197,6 +198,19 @@ describe('Acceptance | API | Campaign Participations', () => {
         _deleteIrrelevantIds(result);
 
         expect(result).to.deep.equal(expectedResult);
+      });
+    });
+
+    it('should return 404 error if the campaign related to the participation does not exist', () => {
+      // given
+      options.payload.data.relationships.campaign.data.id = null;
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return promise.then((response) => {
+        expect(response.statusCode).to.equal(404);
       });
     });
   });

--- a/api/tests/acceptance/application/skill-review-controller_test.js
+++ b/api/tests/acceptance/application/skill-review-controller_test.js
@@ -35,7 +35,7 @@ describe('Acceptance | API | SkillReviews', () => {
 
     let assessmentId;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       nock.cleanAll();
 
       nock('https://api.airtable.com')
@@ -54,12 +54,12 @@ describe('Acceptance | API | SkillReviews', () => {
       databaseBuilder.factory.buildTargetProfile(insertedTargetProfile);
       databaseBuilder.factory.buildCampaign(insertedCampaign);
       databaseBuilder.factory.buildCampaignParticipation(insertedCampaignParticipation);
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       nock.cleanAll();
-      return databaseBuilder.clean();
+      await databaseBuilder.clean();
     });
 
     context('without authorization token', () => {

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -11,7 +11,7 @@ describe('Acceptance | Controller | target-profile-controller', () => {
       let linkedOrganization;
 
       const connectedUserId = 1;
-      beforeEach(() => {
+      beforeEach(async () => {
         connectedUser = databaseBuilder.factory.buildUser({ id: connectedUserId });
         linkedOrganization = databaseBuilder.factory.buildOrganization();
         databaseBuilder.factory.buildOrganizationAccess({
@@ -19,11 +19,11 @@ describe('Acceptance | Controller | target-profile-controller', () => {
           organizationId: linkedOrganization.id
         });
 
-        return databaseBuilder.commit();
+        await databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
+      afterEach(async () => {
+        await databaseBuilder.clean();
       });
 
       it('should return 200', () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, knex, databaseBuilder } = require('../../../test-helper');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
-const Campaign = require('../../../../lib/domain/models/Campaign');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | Campaign Participation', () => {
@@ -46,7 +45,8 @@ describe('Integration | Repository | Campaign Participation', () => {
       const campaignId = 23;
       const campaignParticipationToSave = new CampaignParticipation({
         assessmentId: 12,
-        campaign: new Campaign({ id: campaignId }),
+        campaignId,
+        userId: 1,
       });
 
       // when
@@ -57,6 +57,8 @@ describe('Integration | Repository | Campaign Participation', () => {
         expect(savedCampaignParticipations).to.be.instanceof(CampaignParticipation);
         expect(savedCampaignParticipations.id).to.exist;
         expect(savedCampaignParticipations.assessmentId).to.equal(campaignParticipationToSave.assessmentId);
+        expect(savedCampaignParticipations.campaignId).to.equal(campaignId);
+        expect(savedCampaignParticipations.userId).to.equal(campaignParticipationToSave.userId);
       });
     });
 
@@ -65,7 +67,7 @@ describe('Integration | Repository | Campaign Participation', () => {
       const campaignId = 23;
       const campaignParticipationToSave = new CampaignParticipation({
         assessmentId: 12,
-        campaign: new Campaign({ id: campaignId }),
+        campaignId,
         participantExternalId: '034516273645RET'
       });
 
@@ -80,8 +82,9 @@ describe('Integration | Repository | Campaign Participation', () => {
           .then(([campaignParticipationInDb]) => {
             expect(campaignParticipationInDb.id).to.equal(campaignParticipationSaved.id);
             expect(campaignParticipationInDb.assessmentId).to.equal(campaignParticipationToSave.assessmentId);
-            expect(campaignParticipationInDb.campaignId).to.equal(campaignParticipationToSave.campaign.id);
+            expect(campaignParticipationInDb.campaignId).to.equal(campaignParticipationToSave.campaignId);
             expect(campaignParticipationInDb.participantExternalId).to.equal(campaignParticipationToSave.participantExternalId);
+            expect(campaignParticipationInDb.userId).to.equal(campaignParticipationToSave.userId);
           });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -141,10 +141,9 @@ describe('Integration | Repository | Campaign Participation', () => {
 
     let campaignParticipation;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
-
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
     afterEach(async () => {
@@ -185,7 +184,7 @@ describe('Integration | Repository | Campaign Participation', () => {
     let clock;
     const frozenTime = new Date('1987-09-01:00:00.000+01:00');
 
-    beforeEach(() => {
+    beforeEach(async () => {
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         isShared: false,
         sharedAt: null,
@@ -193,7 +192,7 @@ describe('Integration | Repository | Campaign Participation', () => {
 
       clock = sinon.useFakeTimers(frozenTime);
 
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
     afterEach(async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -85,7 +85,7 @@ describe('Integration | Repository | Certification Challenge', function() {
     let challenge2;
     let challenge3;
 
-    beforeEach(() => {
+    beforeEach(async () => {
 
       challenge1 = factory.buildCertificationChallenge({
         id: 1,
@@ -137,11 +137,11 @@ describe('Integration | Repository | Certification Challenge', function() {
         courseId: otherCourseId,
       });
 
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
+    afterEach(async () => {
+      await databaseBuilder.clean();
     });
 
     it('should find all challenges related to a given courseId', () => {

--- a/api/tests/integration/infrastructure/repositories/smart-placement-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-assessment-repository_test.js
@@ -29,7 +29,7 @@ describe('Integration | Repository | SmartPlacementAssessmentRepository', () => 
     let secondSkill;
     let thirdSkill;
 
-    beforeEach(() => {
+    beforeEach(async () => {
 
       assessmentId = 987654321;
       notSmartPlacementAssessmentId = 32323;
@@ -172,12 +172,12 @@ describe('Integration | Repository | SmartPlacementAssessmentRepository', () => 
         skillId: thirdSkill.id,
       });
 
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       airtableBuilder.cleanAll();
-      return databaseBuilder.clean();
+      await databaseBuilder.clean();
     });
 
     it('should get the smart placement assessment', () => {
@@ -220,14 +220,14 @@ describe('Integration | Repository | SmartPlacementAssessmentRepository', () => 
     let userWithNoAssessment;
     let assessment;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       user = databaseBuilder.factory.buildUser();
       assessment = databaseBuilder.factory.buildAssessment({
         userId: user.id,
         type: Assessment.types.SMARTPLACEMENT
       });
       userWithNoAssessment = databaseBuilder.factory.buildUser();
-      return databaseBuilder.commit();
+      await databaseBuilder.commit();
     });
 
     afterEach(async () => {

--- a/api/tests/integration/infrastructure/usecases/find-user-assessment-by-filter_test.js
+++ b/api/tests/integration/infrastructure/usecases/find-user-assessment-by-filter_test.js
@@ -12,7 +12,7 @@ describe('Integration | Infrastructure | Usecases | find-user-assessment-by-filt
       let certificationWanted;
       let assessmentWanted;
       let user;
-      beforeEach(() => {
+      beforeEach(async () => {
         user = databaseBuilder.factory.buildUser();
         certificationWanted = databaseBuilder.factory.buildCertificationCourse();
         assessmentWanted = databaseBuilder.factory.buildAssessment({
@@ -28,11 +28,11 @@ describe('Integration | Infrastructure | Usecases | find-user-assessment-by-filt
         databaseBuilder.factory.buildAssessment({
           type: 'CERTIFICATION'
         });
-        return databaseBuilder.commit();
+        await databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
+      afterEach(async () => {
+        await databaseBuilder.clean();
       });
 
       it('should return only the certification asked', () => {

--- a/api/tests/tooling/database-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/database-builder/factory/build-campaign-participation.js
@@ -1,6 +1,7 @@
 const faker = require('faker');
 const buildAssessment = require('./build-assessment');
 const buildCampaign = require('./build-campaign');
+const buildUser = require('./build-user');
 const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildCampaignParticipation({
@@ -9,10 +10,11 @@ module.exports = function buildCampaignParticipation({
   campaignId = buildCampaign().id,
   isShared = faker.random.boolean(),
   sharedAt = faker.date.past(),
+  userId = buildUser().id,
 } = {}) {
 
   const values = {
-    id, assessmentId, campaignId, isShared, sharedAt
+    id, assessmentId, campaignId, userId, isShared, sharedAt
   };
 
   databaseBuffer.pushInsertable({

--- a/api/tests/tooling/factory/build-campaign-participation.js
+++ b/api/tests/tooling/factory/build-campaign-participation.js
@@ -11,7 +11,7 @@ module.exports = function buildCampaignParticipation(
     isShared = faker.random.boolean(),
     sharedAt = faker.date.recent(),
     participantExternalId = 'Mon mail pro',
-    campaignId = null,
+    campaignId = faker.random.number(2),
     userId = faker.random.number(2),
   } = {}) {
   return new CampaignParticipation({ id, assessmentId, campaign, isShared, sharedAt, participantExternalId, campaignId, userId });

--- a/api/tests/tooling/factory/build-campaign-participation.js
+++ b/api/tests/tooling/factory/build-campaign-participation.js
@@ -11,6 +11,8 @@ module.exports = function buildCampaignParticipation(
     isShared = faker.random.boolean(),
     sharedAt = faker.date.recent(),
     participantExternalId = 'Mon mail pro',
+    campaignId = null,
+    userId = faker.random.number(2),
   } = {}) {
-  return new CampaignParticipation({ id, assessmentId, campaign, isShared, sharedAt, participantExternalId });
+  return new CampaignParticipation({ id, assessmentId, campaign, isShared, sharedAt, participantExternalId, campaignId, userId });
 };

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -1,4 +1,7 @@
 const { expect, sinon, factory } = require('../../../test-helper');
+
+const faker = require('faker');
+
 const createAssessmentForCampaign = require('../../../../lib/domain/usecases/create-assessment-for-campaign');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 const { CampaignCodeError } = require('../../../../lib/domain/errors');
@@ -44,11 +47,13 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
   });
 
   context('when campaignCode exist', () => {
+    let userId;
     let campaign;
     let assessment;
     let campaignParticipation;
 
     beforeEach(() => {
+      userId = faker.random.number()
       // given
       campaign = factory.buildCampaign({
         id: 'campaignId',
@@ -56,11 +61,13 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
       assessment = factory.buildAssessment({
         id: 'assessmentId',
         type: 'SMART_PLACEMENT',
+        userId: userId
       });
 
       campaignParticipation = new CampaignParticipation({
         assessmentId: assessment.id,
-        campaign: campaign,
+        campaignId: campaign.id,
+        userId: userId,
       });
 
       campaignRepository.getByCode.resolves(campaign);
@@ -71,6 +78,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     it('should save the assessment', () => {
       // when
       const promise = createAssessmentForCampaign({
+        userId,
         assessment,
         codeCampaign: availableCampaignCode,
         campaignRepository,
@@ -88,6 +96,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     it('should save a campaign-participation without participantExternalId', () => {
       // when
       const promise = createAssessmentForCampaign({
+        userId,
         assessment,
         codeCampaign: availableCampaignCode,
         campaignRepository,
@@ -105,6 +114,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     it('should save a campaign-participation with participantExternalId', () => {
       // when
       const promise = createAssessmentForCampaign({
+        userId,
         assessment,
         codeCampaign: availableCampaignCode,
         participantExternalId: 'matricule123',
@@ -125,6 +135,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     it('should return the newly created assessment', () => {
       // when
       const promise = createAssessmentForCampaign({
+        userId,
         assessment,
         codeCampaign: availableCampaignCode,
         campaignRepository,
@@ -137,6 +148,5 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
         expect(assessmentCreated).to.deep.equal(assessment);
       });
     });
-
   });
 });

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     let campaignParticipation;
 
     beforeEach(() => {
-      userId = faker.random.number()
+      userId = faker.random.number();
       // given
       campaign = factory.buildCampaign({
         id: 'campaignId',

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -61,13 +61,13 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
       assessment = factory.buildAssessment({
         id: 'assessmentId',
         type: 'SMART_PLACEMENT',
-        userId: userId
+        userId
       });
 
       campaignParticipation = new CampaignParticipation({
         assessmentId: assessment.id,
         campaignId: campaign.id,
-        userId: userId,
+        userId,
       });
 
       campaignRepository.getByCode.resolves(campaign);

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -1,0 +1,78 @@
+const { expect, sinon, factory } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
+describe('Unit | UseCase | start-campaign-participation', () => {
+
+  let sandbox;
+  const userId = 19837482;
+  const campaignParticipation = factory.buildCampaignParticipation({});
+  const campaignParticipationRepository = { save: () => undefined };
+  const assessmentRepository = { save: () => undefined };
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(campaignParticipationRepository, 'save');
+    sandbox.stub(assessmentRepository, 'save');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should create a smart placement assessment', () => {
+    // given
+    assessmentRepository.save.resolves({});
+
+    // when
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+
+    // then
+    return promise.then(() => {
+      expect(assessmentRepository.save).to.have.been.called;
+
+      const assessmentToSave = assessmentRepository.save.firstCall.args[0];
+      expect(assessmentToSave.type).to.equal(Assessment.types.SMARTPLACEMENT);
+      expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
+      expect(assessmentToSave.userId).to.equal(userId);
+      expect(assessmentToSave.courseId).to.equal('Smart Placement Tests CourseId Not Used');
+    });
+  });
+
+  it('should save the campaign participation with userId and assessmentId', () => {
+    // given
+    const assessmentId = 987654321;
+    assessmentRepository.save.resolves({ id: assessmentId });
+    campaignParticipationRepository.save.resolves({});
+
+    // when
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+
+    // then
+    return promise.then(() => {
+      expect(campaignParticipationRepository.save).to.have.been.called;
+
+      const campaignParticipationToSave = campaignParticipationRepository.save.firstCall.args[0];
+      expect(campaignParticipationToSave.userId).to.equal(userId);
+      expect(campaignParticipationToSave.assessmentId).to.equal(assessmentId);
+      expect(campaignParticipationToSave).to.deep.equal(campaignParticipation);
+    });
+  });
+
+  it('should return the saved campaign participation', () => {
+    // given
+    const assessmentId = 987654321;
+    const createdCampaignParticipation = factory.buildCampaignParticipation();
+    assessmentRepository.save.resolves({ id: assessmentId });
+    campaignParticipationRepository.save.resolves(createdCampaignParticipation);
+
+    // when
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+
+    // then
+    return promise.then((campaignParticipation) => {
+      expect(campaignParticipation).to.deep.equal(createdCampaignParticipation);
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -1,23 +1,40 @@
 const { expect, sinon, factory } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases');
+
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const usecases = require('../../../../lib/domain/usecases');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | start-campaign-participation', () => {
 
   let sandbox;
   const userId = 19837482;
   const campaignParticipation = factory.buildCampaignParticipation({});
+  const campaignRepository = { get: () => undefined };
   const campaignParticipationRepository = { save: () => undefined };
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(campaignRepository, 'get');
     sandbox.stub(campaignParticipationRepository, 'save');
     sandbox.stub(assessmentRepository, 'save');
+
+    campaignRepository.get.resolves(factory.buildCampaign());
   });
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it('should throw an error if the campaign does not exists', () => {
+    // given
+    campaignRepository.get.resolves(null);
+
+    // when
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+
+    // then
+    return expect(promise).to.be.rejectedWith(NotFoundError);
   });
 
   it('should create a smart placement assessment', () => {
@@ -25,7 +42,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     assessmentRepository.save.resolves({});
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
     return promise.then(() => {
@@ -46,7 +63,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.save.resolves({});
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
     return promise.then(() => {
@@ -67,7 +84,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.save.resolves(createdCampaignParticipation);
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository });
+    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
     return promise.then((campaignParticipation) => {

--- a/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
@@ -5,8 +5,8 @@ const targetProfileAdapter = require('../../../../lib/infrastructure/adapters/ta
 
 describe('Unit | Infrastructure | Adapter | targetSkillAdapter', () => {
 
-  afterEach(() => {
-    return databaseBuilder.clean();
+  afterEach(async () => {
+    await databaseBuilder.clean();
   });
 
   it('should adapt TargetSkill object to domain', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -1,8 +1,54 @@
-const { expect } = require('../../../../test-helper');
+const { expect, factory } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const CampaignParticipation  = require('../../../../../lib/domain/models/CampaignParticipation');
 
 describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', function() {
+
+  describe('#serialize', function() {
+
+    it('should convert a CampaignParticipation model object into JSON API data', function() {
+      // given
+      const campaignParticipation = factory.buildCampaignParticipation({
+        id: 5,
+        isShared: true,
+        sharedAt: '2018-02-06 14:12:44',
+        campaignId: 12345,
+        assessmentId: 67890,
+      });
+
+      const expectedSerializedCampaignParticipation = {
+        data: {
+          type: 'campaign-participations',
+          id: 5,
+          attributes: {
+            'is-shared': true,
+            'shared-at': '2018-02-06 14:12:44',
+          },
+          relationships: {
+            assessment: {
+              data: {
+                id: '67890',
+                type: 'assessments'
+              }
+            },
+            campaign: {
+              data: {
+                id: '12345',
+                type: 'campaigns'
+              }
+            }
+          }
+        }
+      };
+
+      // when
+      const json = serializer.serialize(campaignParticipation);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedCampaignParticipation);
+    });
+
+  });
 
   describe('#deserialize', function() {
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -1,0 +1,42 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
+const CampaignParticipation  = require('../../../../../lib/domain/models/CampaignParticipation');
+
+describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', function() {
+
+  describe('#deserialize', function() {
+
+    it('should convert JSON API campaign participation data into a CampaignParticipation model', function() {
+      // given
+      const campaignId = '28346762';
+      const jsonAnswer = {
+        data: {
+          type: 'campaign-participations',
+          attributes: {
+            participantExternalId: 'azerty@qwerty.net',
+          },
+          relationships: {
+            'campaign': {
+              data: {
+                id: campaignId,
+              }
+            }
+          }
+        }
+      };
+
+      // when
+      const promise = serializer.deserialize(jsonAnswer);
+
+      // then
+      return expect(promise).to.be.fulfilled
+        .then((campaignParticipation) => {
+          expect(campaignParticipation).to.be.instanceOf(CampaignParticipation);
+          expect(campaignParticipation.participantExternalId).to.equal(jsonAnswer.data.attributes.participantExternalId);
+          expect(campaignParticipation.campaignId).to.equal(campaignId);
+        });
+    });
+
+  });
+
+});

--- a/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
@@ -10,7 +10,7 @@ export default Controller.extend({
       const participantExternalId = this.get('model.participantExternalId');
       if (participantExternalId) {
         this.set('model.loading', true);
-        return this.get('start')(this.get('model.campaignCode'), participantExternalId);
+        return this.get('start')(this.get('model.campaign'), this.get('model.campaignCode'), participantExternalId);
       } else {
         return this.set('model.errorMessage', `Merci de renseigner votre ${this.get('model.idPixLabel')}.`);
       }

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -1,5 +1,10 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  isShared: DS.attr('boolean')
+const { Model, attr, belongsTo } = DS;
+
+export default Model.extend({
+  isShared: attr('boolean'),
+  participantExternalId: attr('string'),
+  assessment: belongsTo('assessment'),
+  campaign: belongsTo('campaign'),
 });

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -16,6 +16,7 @@ import patchAnswer from './routes/patch-answer';
 import postAnswers from './routes/post-answers';
 import postAssessments from './routes/post-assessments';
 import postAuthentications from './routes/post-authentications';
+import postCampaignParticipation from './routes/post-campaign-participation';
 import postCertificationCourse from './routes/post-certification-course';
 import postFeedbacks from './routes/post-feedbacks';
 
@@ -92,5 +93,5 @@ export default function() {
 
   this.get('/skill-reviews/:id');
   this.get('/campaigns', getCampaigns);
-  this.post('/campaign-participations');
+  this.post('/campaign-participations', postCampaignParticipation);
 }

--- a/mon-pix/mirage/routes/post-campaign-participation.js
+++ b/mon-pix/mirage/routes/post-campaign-participation.js
@@ -1,0 +1,11 @@
+export default function(schema) {
+  const newAssessment = {
+    'user-id': 'user_id',
+    'user-name': 'Jane Doe',
+    'user-email': 'jane@acme.com',
+  };
+  newAssessment.type = 'SMART_PLACEMENT';
+
+  const assessment = schema.assessments.create(newAssessment);
+  return schema.campaignParticipations.create({ assessment });
+}

--- a/mon-pix/mirage/serializers/campaign-participation.js
+++ b/mon-pix/mirage/serializers/campaign-participation.js
@@ -1,0 +1,7 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+const relationshipsToInclude = ['assessment'];
+
+export default JSONAPISerializer.extend({
+  include: relationshipsToInclude
+});

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
@@ -8,6 +8,7 @@ describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', functi
     needs: ['service:current-routed-modal']
   });
 
+  const campaign = { id: 1243 };
   const campaignCode = 'CODECAMPAIGN';
   const participantExternalId = 'matricule123';
   let controller;
@@ -15,6 +16,7 @@ describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', functi
   beforeEach(function() {
     controller = this.subject();
     controller.set('model', {
+      campaign,
       campaignCode,
       participantExternalId,
       idPixLabel: 'Identifiant professionnel',
@@ -36,7 +38,7 @@ describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', functi
       controller.actions.submit.call(controller);
 
       // then
-      sinon.assert.calledWith(startStub, campaignCode, participantExternalId);
+      sinon.assert.calledWith(startStub, campaign, campaignCode, participantExternalId);
     });
 
     it('should display error when participant external id is empty', () => {

--- a/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
@@ -13,26 +13,29 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
 
   let route;
   let storeStub;
-  let createAssessementStub;
+  let createCampaignParticipationStub;
   let queryChallengeStub;
   let queryStub;
   let savedAssessment;
+  let createdCampaignParticipation;
+  let campaign;
+  const campaignCode = 'CODECAMPAIGN';
 
   beforeEach(function() {
-    createAssessementStub = sinon.stub();
+    createCampaignParticipationStub = sinon.stub();
     queryChallengeStub = sinon.stub();
     queryStub = sinon.stub();
     storeStub = Service.extend({
-      queryRecord: queryChallengeStub, query: queryStub, createRecord: createAssessementStub });
+      queryRecord: queryChallengeStub, query: queryStub, createRecord: createCampaignParticipationStub });
     this.register('service:store', storeStub);
     this.inject.service('store', { as: 'store' });
     savedAssessment = EmberObject.create({ id: 1234, codeCampaign: 'CODECAMPAIGN', reload: sinon.stub() });
+    createdCampaignParticipation = EmberObject.create({ id: 456, assessment: savedAssessment });
+    campaign = EmberObject.create({ code: campaignCode });
     route = this.subject();
   });
 
   describe('#model', function() {
-
-    const campaignCode = 'CODECAMPAIGN';
 
     beforeEach(function() {
     });
@@ -43,7 +46,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
         campaign_code: campaignCode
       };
 
-      const campaigns = A([EmberObject.create({ code: campaignCode })]);
+      const campaigns = A([campaign]);
       queryStub.resolves(campaigns);
 
       // when
@@ -60,7 +63,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       const params = {
         campaign_code: campaignCode
       };
-      const campaigns = A([EmberObject.create({ code: campaignCode })]);
+      const campaigns = A([campaign]);
       queryStub.resolves(campaigns);
       route.transitionTo = sinon.stub();
 
@@ -78,7 +81,8 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       const params = {
         campaign_code: campaignCode
       };
-      const campaigns = A([EmberObject.create({ code: campaignCode, idPixLabel: 'email' })]);
+      campaign.idPixLabel = 'email';
+      const campaigns = A([campaign]);
       queryStub.resolves(campaigns);
       route.transitionTo = sinon.stub();
 
@@ -156,7 +160,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       queryChallengeStub.resolves();
 
       // when
-      const promise = route.start(campaignCode, participantExternalId);
+      const promise = route.start(campaign, campaignCode, participantExternalId);
 
       // then
       return promise.then(() => {
@@ -164,19 +168,19 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       });
     });
 
-    it('should create new assessment if nothing found', function() {
+    it('should create new campaignParticipation if nothing found', function() {
       // given
       const assessments = A([]);
       queryStub.resolves(assessments);
-      createAssessementStub.returns({ save: () => savedAssessment });
+      createCampaignParticipationStub.returns({ save: () => Promise.resolve(createdCampaignParticipation) });
       queryChallengeStub.resolves();
 
       // when
-      const promise = route.start(campaignCode, participantExternalId);
+      const promise = route.start(campaign, campaignCode, participantExternalId);
 
       // then
       return promise.then(() => {
-        sinon.assert.calledWith(createAssessementStub, 'assessment', { type: 'SMART_PLACEMENT', codeCampaign: campaignCode, participantExternalId });
+        sinon.assert.calledWith(createCampaignParticipationStub, 'campaign-participation', { campaign, participantExternalId });
       });
     });
 
@@ -187,7 +191,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       queryChallengeStub.resolves();
 
       // when
-      const promise = route.start(campaignCode, participantExternalId);
+      const promise = route.start(campaign, campaignCode, participantExternalId);
 
       // then
       return promise.then(() => {
@@ -202,7 +206,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       queryChallengeStub.resolves({ id: 23 });
 
       // when
-      const promise = route.start(campaignCode, participantExternalId);
+      const promise = route.start(campaign, campaignCode, participantExternalId);
 
       // then
       return promise.then(() => {


### PR DESCRIPTION
Aujourd'hui, lorsqu'on commence son parcours de campagne, on appelle un endpoint qui va créer un assessment de type SMART_PLACEMENT, ainsi qu'un campaignParticipation (mais indirectement).

Cette PR va introduire un endpoint qui correspond au démarrage de parcours (post campaign-participation), avec la création de l'assessment de manière transparente.