### PR TITLE
[#231] [FEATURE] Ajout d'un titre lors de la création d'une campagne (PO-73)

### DIFF
--- a/api/db/migrations/20181015115708_add_title_to_campaign.js
+++ b/api/db/migrations/20181015115708_add_title_to_campaign.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'campaigns';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string('title');
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('title');
+  });
+};

--- a/api/db/seeds/data/3rd-to-create/campaigns.js
+++ b/api/db/seeds/data/3rd-to-create/campaigns.js
@@ -12,6 +12,7 @@ module.exports = [
     id: 2,
     name: 'Campagne 2',
     code: 'AZERTY456',
+    title: 'Parcours recherche avancée',
     organizationId: 1,
     creatorId: 2,
     targetProfileId: 1,

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -5,6 +5,7 @@ class Campaign {
     // attributes
     name,
     code,
+    title,
     idPixLabel,
     createdAt,
     // includes
@@ -17,6 +18,7 @@ class Campaign {
     // attributes
     this.name = name;
     this.code = code;
+    this.title = title;
     this.idPixLabel = idPixLabel;
     this.createdAt = createdAt;
     // includes

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
 
   serialize(campaigns, tokenForCampaignResults) {
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'createdAt', 'tokenForCampaignResults', 'idPixLabel'],
+      attributes: ['name', 'code', 'title', 'createdAt', 'tokenForCampaignResults', 'idPixLabel'],
       transform: (record) => {
         const campaign = Object.assign({}, record);
         campaign.tokenForCampaignResults = tokenForCampaignResults;

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -84,6 +84,7 @@ describe('Integration | Repository | Campaign', () => {
       const campaignToSave = new Campaign({
         name: 'Evaluation niveau 1 recherche internet',
         code: 'BCTERD153',
+        title: 'Parcours recherche internet',
         creatorId: 6,
         organizationId: 44,
       });
@@ -97,6 +98,7 @@ describe('Integration | Repository | Campaign', () => {
         expect(savedCampaign.id).to.exist;
         expect(savedCampaign.name).to.equal(campaignToSave.name);
         expect(savedCampaign.code).to.equal(campaignToSave.code);
+        expect(savedCampaign.title).to.equal(campaignToSave.title);
         expect(savedCampaign.creatorId).to.equal(campaignToSave.creatorId);
         expect(savedCampaign.organizationId).to.equal(campaignToSave.organizationId);
       });

--- a/api/tests/tooling/database-builder/factory/build-campaign.js
+++ b/api/tests/tooling/database-builder/factory/build-campaign.js
@@ -7,8 +7,9 @@ const databaseBuffer = require('../database-buffer');
 module.exports = function buildCampaign({
   id = faker.random.number(),
   name = faker.company.companyName(),
-  idPixLabel = faker.random.word(),
   code = faker.random.alphaNumeric(9),
+  title = faker.random.word(),
+  idPixLabel = faker.random.word(),
   createdAt = faker.date.recent(),
   organizationId = buildOrganization().id,
   creatorId = buildUser().id,
@@ -19,6 +20,7 @@ module.exports = function buildCampaign({
     id,
     name,
     code,
+    title,
     createdAt,
     idPixLabel,
     organizationId,

--- a/api/tests/tooling/factory/build-campaign.js
+++ b/api/tests/tooling/factory/build-campaign.js
@@ -6,11 +6,12 @@ module.exports = function buildCampaign(
     id = 1,
     name = faker.company.companyName(),
     code = 'AZERTY123',
-    idPixLabel = faker.company.companyName(),
+    title = faker.random.word(),
+    idPixLabel = faker.random.word(),
     createdAt = faker.date.recent(),
     creatorId = faker.random.number(2),
     organizationId = faker.random.number(2),
     targetProfileId = faker.random.number(2),
   } = {}) {
-  return new Campaign({ id, name, code, idPixLabel, createdAt, creatorId, organizationId, targetProfileId });
+  return new Campaign({ id, name, code, title, idPixLabel, createdAt, creatorId, organizationId, targetProfileId });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -11,8 +11,9 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
       const tokenToAccessToCampaign = 'token';
       const campaign = new Campaign({
         id: 5,
-        name: 'My zuper organization',
+        name: 'My zuper campaign',
         code: 'ATDGER342',
+        title: 'Parcours recherche internet',
         createdAt: '2018-02-06 14:12:44',
         creatorId: 3453,
         organizationId: 10293,
@@ -24,8 +25,9 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           type: 'campaigns',
           id: 5,
           attributes: {
-            name: 'My zuper organization',
+            name: 'My zuper campaign',
             code: 'ATDGER342',
+            title: 'Parcours recherche internet',
             'created-at': '2018-02-06 14:12:44',
             'id-pix-label': 'company id',
             'token-for-campaign-results': tokenToAccessToCampaign,
@@ -52,7 +54,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
         data: {
           type: 'campaign',
           attributes: {
-            name: 'My zuper organization',
+            name: 'My zuper campaign',
             'organization-id': organizationId,
           },
           relationships: {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -5,6 +5,7 @@ import ENV from 'pix-orga/config/environment';
 export default DS.Model.extend({
   name: DS.attr('string'),
   code: DS.attr('string'),
+  title: DS.attr('string'),
   createdAt: DS.attr('date'),
   idPixLabel: DS.attr('string'),
   // TODO remove organizationId and work only with the relationship

--- a/orga/app/templates/components/campaign-creation-form.hbs
+++ b/orga/app/templates/components/campaign-creation-form.hbs
@@ -75,6 +75,17 @@
     {{/if}}
   </div>
 
+  <div class="campaign-creation-form__field">
+    <label for="campaign-title" class="label">Titre du parcours</label>
+    {{input id='campaign-title'
+            name='campaign-title'
+            type='text'
+            maxlength='50'
+            value=campaign.title
+            class="input"
+    }}
+  </div>
+
   <div>
     <button class="campaign-creation-form__validation-button button" type="submit">Créer la campagne</button>
   </div>

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -50,12 +50,14 @@ module('Acceptance | Campaign Creation', function(hooks) {
       await fillIn('#campaign-name', 'Ma Campagne');
       await click('#askLabelIdPix');
       await fillIn('#id-pix-label', 'Mail Pro');
+      await fillIn('#campaign-title', 'Savoir rechercher');
 
       // when
       await click('.campaign-creation-form__validation-button');
 
       // then
       assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
+      assert.equal(server.db.campaigns[0].title, 'Savoir rechercher');
       assert.equal(server.db.campaigns[0].targetProfileId, expectedTargetProfileId);
       assert.equal(currentURL(), '/campagnes/liste');
     });

--- a/orga/tests/integration/components/campaign-creation-form-test.js
+++ b/orga/tests/integration/components/campaign-creation-form-test.js
@@ -63,4 +63,12 @@ module('Integration | Component | campaign-creation-form', function(hooks) {
     assert.dom('#campaign-name').hasAttribute('maxLength', "255");
   });
 
+  test('should not allow a campaign title with more than 50 char', async function(assert) {
+    // then
+    await render(hbs`{{campaign-creation-form}}`);
+
+    // when
+    assert.dom('#campaign-title').hasAttribute('maxLength', "50");
+  });
+
 });


### PR DESCRIPTION
Besoin :
Un utilisateur de Pix Orga doit pouvoir ajouter un titre à sa campagne de manière facultative. Ce champ sera affiché ultérieurement dans le bandeau de reprise d'une campagne, ou dans l'en-tête lorsque l'on répond à une campagne (parcours).

Tech :
Ajout au formulaire d'un champ "titre du parcours" lors de la création d'une campagne.
Ajout en base d'un champ "title" dans campaign.