### PR TITLE
[#240] [BUGFIX] Les documents 'embed' fonctionnent maintenant sous Internet Explorer (PF-432)

### DIFF
--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -23,7 +23,7 @@ export default Model.extend({
     return !!embedUrl
       && !!this.get('embedTitle')
       && !!this.get('embedHeight')
-      && embedUrl.toLowerCase().startsWith('https://');
+      && embedUrl.toLowerCase().indexOf('https://') === 0; // fixes bug on IE: startsWith in not supported (PR #242) 
   }),
   hasAttachment: notEmpty('attachments'),
   hasSingleAttachment: equal('attachments.length', 1),


### PR DESCRIPTION
Besoin : En tant qu'utilisateur d'Internet Explorer, je dois pouvoir répondre à des questions avec des applications embarquées.

Technique : Remplacement du `startsWith` non supporté par IE par `indexOf === 0`