### PR TITLE
[#244] [FEATURE] Ajout d'un message pour prévenir l'utilisateur que le résultats de ses campagnes ne sont pas inclus dans son profil (PF-400)

### DIFF
--- a/mon-pix/app/components/results-warning.js
+++ b/mon-pix/app/components/results-warning.js
@@ -7,7 +7,7 @@ export default Component.extend({
   campaignParticipations: [],
 
   hasCampaignParticipations: computed('campaignParticipations', function() {
-    return this.get('campaignParticipations').toArray().length;
+    return this.get('campaignParticipations').length > 0;
   }),
 
 });

--- a/mon-pix/app/components/results-warning.js
+++ b/mon-pix/app/components/results-warning.js
@@ -1,0 +1,13 @@
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
+
+  classNames: ['results-warning'],
+  campaignParticipations: [],
+
+  hasCampaignParticipations: computed('campaignParticipations', function() {
+    return this.get('campaignParticipations').toArray().length;
+  }),
+
+});

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -61,7 +61,7 @@
 @import 'components/reset-password-form';
 @import 'components/resume-campaign-banner';
 @import 'components/result-item';
-@import 'components/result-item';
+@import 'components/results-warning';
 @import 'components/rounded-panel';
 @import 'components/score-pastille';
 @import 'components/scoring-panel';

--- a/mon-pix/app/styles/components/_results-warning.scss
+++ b/mon-pix/app/styles/components/_results-warning.scss
@@ -1,0 +1,18 @@
+.results-warning {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1190px;
+
+  &__warning-message {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 50px;
+    margin-top: 10px;
+
+    @include device-is('tablet') {
+      padding-left: 100px;
+    }
+  }
+}

--- a/mon-pix/app/styles/components/_results-warning.scss
+++ b/mon-pix/app/styles/components/_results-warning.scss
@@ -6,7 +6,6 @@
 
   &__warning-message {
     display: flex;
-    flex-direction: row;
     align-items: center;
     margin-bottom: 50px;
     margin-top: 10px;

--- a/mon-pix/app/templates/components/results-warning.hbs
+++ b/mon-pix/app/templates/components/results-warning.hbs
@@ -1,0 +1,6 @@
+{{#if hasCampaignParticipations}}
+  <div class="results-warning__warning-message">
+    <img src="/images/icons/icon-warning.svg" alt="attention">
+    Les résultats de vos parcours ne sont pas encore visibles dans votre profil mais le seront prochainement.
+  </div>
+{{/if}}

--- a/mon-pix/app/templates/compte.hbs
+++ b/mon-pix/app/templates/compte.hbs
@@ -8,4 +8,6 @@
     totalPixScore=model.totalPixScore
     searchForOrganization=(route-action 'searchForOrganization')
     shareProfileSnapshot=(route-action 'shareProfileSnapshot')}}
+
+  {{results-warning campaignParticipations=model.campaignParticipations}}
 </div>

--- a/mon-pix/public/images/icons/icon-warning.svg
+++ b/mon-pix/public/images/icons/icon-warning.svg
@@ -1,0 +1,16 @@
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <mask id="mask" fill="white">
+                  <path d="M18.73,6 L11.27,6 L6,11.27 L6,18.73 L11.27,24 L18.73,24 L24,18.73 L24,11.27 L18.73,6 L18.73,6 Z M15,20.3 C14.28,20.3 13.7,19.72 13.7,19 C13.7,18.28 14.28,17.7 15,17.7 C15.72,17.7 16.3,18.28 16.3,19 C16.3,19.72 15.72,20.3 15,20.3 L15,20.3 Z M16,16 L14,16 L14,10 L16,10 L16,16 L16,16 Z" id="path"></path>
+                </mask>
+                <g mask="url(#mask)" fill="#666666" fill-rule="evenodd">
+                    <g transform="translate(2.000000, 2.000000)">
+                        <rect x="0" y="0" width="26" height="26"></rect>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/mon-pix/tests/integration/components/results-warning-test.js
+++ b/mon-pix/tests/integration/components/results-warning-test.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+describe('Integration | Component | results-warning', function() {
+
+  setupComponentTest('results-warning', {
+    integration: true
+  });
+
+  describe('Warning message display', function() {
+    const campaignToResume = EmberObject.create({
+      isShared: false,
+      createdAt: '2018-01-01',
+      campaign: EmberObject.create({
+        code: 'AZERTY',
+        title: 'Parcours Pix'
+      })
+    });
+    const completedAndNotSharedCampaign = EmberObject.create({
+      isShared: false,
+      campaign: EmberObject.create({
+        code: 'AZERTY',
+      })
+    });
+    const completedAndSharedCampaign = EmberObject.create({
+      isShared: true,
+      campaign: EmberObject.create({
+        code: 'AZERTY',
+      })
+    });
+
+    it('should display the warning message when user has began a campaign', function() {
+      // given
+      this.set('campaignParticipations', [campaignToResume]);
+      // when
+      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      // then
+      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
+    });
+
+    it('should display the warning message when user has completed a campaign but not shared his results yet', function() {
+      // given
+      this.set('campaignParticipations', [completedAndNotSharedCampaign]);
+      // when
+      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      // then
+      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
+    });
+
+    it('should display the warning message when user has completed a campaign and shared his results', function() {
+      // given
+      this.set('campaignParticipations', [completedAndSharedCampaign]);
+      // when
+      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      // then
+      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
+    });
+
+    it('should not display the warning message when user has not began any campaign', function() {
+      // given
+      this.set('campaignParticipations', []);
+      // when
+      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      // then
+      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(0);
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/results-warning-test.js
+++ b/mon-pix/tests/integration/components/results-warning-test.js
@@ -11,48 +11,11 @@ describe('Integration | Component | results-warning', function() {
   });
 
   describe('Warning message display', function() {
-    const campaignToResume = EmberObject.create({
-      isShared: false,
-      createdAt: '2018-01-01',
-      campaign: EmberObject.create({
-        code: 'AZERTY',
-        title: 'Parcours Pix'
-      })
-    });
-    const completedAndNotSharedCampaign = EmberObject.create({
-      isShared: false,
-      campaign: EmberObject.create({
-        code: 'AZERTY',
-      })
-    });
-    const completedAndSharedCampaign = EmberObject.create({
-      isShared: true,
-      campaign: EmberObject.create({
-        code: 'AZERTY',
-      })
-    });
+    const campaignParticipationToResume = EmberObject.create({});
 
     it('should display the warning message when user has began a campaign', function() {
       // given
-      this.set('campaignParticipations', [campaignToResume]);
-      // when
-      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
-      // then
-      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
-    });
-
-    it('should display the warning message when user has completed a campaign but not shared his results yet', function() {
-      // given
-      this.set('campaignParticipations', [completedAndNotSharedCampaign]);
-      // when
-      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
-      // then
-      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
-    });
-
-    it('should display the warning message when user has completed a campaign and shared his results', function() {
-      // given
-      this.set('campaignParticipations', [completedAndSharedCampaign]);
+      this.set('campaignParticipations', [campaignParticipationToResume]);
       // when
       this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
       // then


### PR DESCRIPTION
Besoin : L'utilisateur doit pouvoir être averti que les résultats de ses campagnes ne sont pas inclus dans son profil, si il a commencé et/ou terminé et/ou partagé au moins une campagne.

Tech : Ajout d'un composant basé sur si oui ou non on a une campaignParticipation.