### PR TITLE
[#247] Ajout de polyfill à ember-cli-babel pour un meilleur support ES6 (PF-433)

### DIFF
--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
+    'ember-cli-babel': {
+      includePolyfill: true
+    }
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Il y a un actuellement un bug sous IE11 qui empêche, une fois sur l'écran de résultat après un positionnement, de voir les réponses individuellement.
Après différentes recherches, le fait d'ajouter un polyfill à ember-cli-babel permet d'avoir un full support des transformations, et fait fonctionner le schmilblick => https://github.com/babel/ember-cli-babel#Polyfill