### PR TITLE
[BSR] Supprime les messages de log dans la sortie console des tests

### DIFF
--- a/api/tests/unit/scripts/delete-user_test.js
+++ b/api/tests/unit/scripts/delete-user_test.js
@@ -362,6 +362,16 @@ describe('Delete User Script', () => {
 
     describe('#delete_dependent_data_from_fetched_assessment_ids', () => {
 
+      let consoleLog;
+
+      beforeEach(() => {
+        consoleLog = sinon.stub(console, 'log');
+      });
+
+      afterEach(() => {
+        consoleLog.restore();
+      });
+
       it('should delete feedbacks, skills, answers, competence-marks and assessment-results', () => {
         // given
         const ids = [123, 456];
@@ -399,6 +409,9 @@ describe('Delete User Script', () => {
         // then
         return promise.then(() => {
           queryBuilderMock.verify();
+          const expectedLog = 'No assessment found: skipping deletion of feedbacks, skills, answers, competence-marks ' +
+            'and assessment-results';
+          sinon.assert.calledWith(consoleLog, expectedLog);
         });
       });
     });

--- a/api/tests/unit/scripts/recompute-assessment-results_test.js
+++ b/api/tests/unit/scripts/recompute-assessment-results_test.js
@@ -5,6 +5,16 @@ describe('Unit | Scripts | recompute-assessment-results', () => {
 
   describe('#recomputeScore', () => {
 
+    let consoleLog;
+
+    beforeEach(() => {
+      consoleLog = sinon.stub(console, 'log');
+    });
+
+    afterEach(() => {
+      consoleLog.restore();
+    });
+
     it('shoud call request with assessment informations', () => {
       // given
       const listOfAssessmentsToRecompute = [123, 987];


### PR DESCRIPTION
Il y a deux tests sur des scripts qui utilisent directement
console.log(). Ces appels généraient du bruit inutiles sur la sortie
console des tests.

J'ai stubé ces appels pour les tests, ce qui ne génère plus de bruit.

Pour aller plus loin, on pourrait éviter d'appeler console.log() et
utiliser une lib de log (je crois qu'on a bunyan par exemple), qui
devrait se comporter correctement par défaut pendant les tests.