### PR TITLE
[#256] [BUGFIX] Affichage correct sous IE de la phrase légale lors de la création de compte (PF-441).

### DIFF
--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -118,6 +118,8 @@
 }
 
 .signup-form__legal-details-container {
+  display: block;
+  max-width: 100%;
   padding: 10px 80px 50px 80px;
   font-size: 11px;
 }


### PR DESCRIPTION
Besoin : Un utilisateur d'Internet Explorer doit pouvoir s'inscrire à Pix en voyant s'afficher correctement la phrase légale en bas de page.

Technique : Ajout de propriétés CSS permettant un affichage correct sous IE.