### PR TITLE
[TECH] Correction des seeds pour PG (codes orga trop longs)

### DIFF
--- a/api/db/seeds/data/organization-with-related/dragon-and-co-builder.js
+++ b/api/db/seeds/data/organization-with-related/dragon-and-co-builder.js
@@ -78,7 +78,7 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     type: 'PRO',
     name: 'Dragon subsidiary',
     userId: proUserSub.id,
-    code: 'DRAGOSUB'
+    code: 'DRASUB'
   });
 
   databaseBuilder.factory.buildOrganizationAccess({
@@ -102,7 +102,7 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     type: 'PRO',
     name: 'Dragon subsidiary 2',
     userId: proUserSub2.id,
-    code: 'DRAGOSUB'
+    code: 'DRASU2'
   });
 
   databaseBuilder.factory.buildOrganizationAccess({


### PR DESCRIPTION
Certains codes d'organisation dans les données de _seed_ étaient trop longs pour le champ `organization.code`. On ne s'en est pas rendu compte plus tôt à cause de SQLite qui ne contrôle pas les longueurs de champs.