### PR TITLE
[#259] [BUGFIX] Filtrer les acquis par status (PF-147).

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -4,12 +4,16 @@ const { Skill: { fromAirTableObject } } = require('./objects');
 const _ = require('lodash');
 
 const AIRTABLE_TABLE_NAME = 'Acquis';
+const VALIDATED_STATUS = ['actif'];
 
 function _doQuery(filter) {
   return airtable.findRecords(AIRTABLE_TABLE_NAME)
     .then((rawSkills) => {
-      return _.filter(rawSkills, filter)
-        .map(fromAirTableObject);
+      return _(rawSkills)
+        .filter(filter)
+        .filter((rawSkill) => _.includes(rawSkill.fields['Status'], VALIDATED_STATUS))
+        .map(fromAirTableObject)
+        .value();
     });
 }
 

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -4,14 +4,14 @@ const { Skill: { fromAirTableObject } } = require('./objects');
 const _ = require('lodash');
 
 const AIRTABLE_TABLE_NAME = 'Acquis';
-const VALIDATED_STATUS = ['actif'];
+const ACTIVATED_STATUS = ['actif'];
 
 function _doQuery(filter) {
   return airtable.findRecords(AIRTABLE_TABLE_NAME)
     .then((rawSkills) => {
       return _(rawSkills)
         .filter(filter)
-        .filter((rawSkill) => _.includes(rawSkill.fields['Status'], VALIDATED_STATUS))
+        .filter((rawSkill) => _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS))
         .map(fromAirTableObject)
         .value();
     });

--- a/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
@@ -7,6 +7,7 @@ module.exports = function skillRawAirTableFixture() {
       'Nom': '@accesDonnées1',
       'Indice': 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ?',
       'Statut de l\'indice': 'Validé',
+      'Status': 'actif',
       'Epreuves': [
         'recF2iWmZKIuOsKO1',
         'recYu7YmDXXt5Owo8',

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -104,7 +104,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       });
     });
 
-    it('should resolve an array of Skills with only actiaved Skillfrom airTable', () => {
+    it('should resolve an array of Skills with only activated Skillfrom airTable', () => {
       // given
       const
         rawSkill1 = skillRawAirTableFixture(),

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -130,7 +130,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       const acquix1 = new AirtableRecord('Acquis', 'recAcquix1', { fields: { 'Nom': '@acquix1', 'Status': 'actif', 'Compétence': [ 'recCompetence' ] } });
       const acquix2 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix2', 'Status': 'actif', 'Compétence': [ 'recCompetence' ] } });
       const acquix3 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix3', 'Status': 'en construction', 'Compétence': [ 'recCompetence' ] } });
-      const acquix4 = new AirtableRecord('Acquis', 'recAcquix3', { fields: { 'Nom': '@acquix3', 'Status': 'actif', 'Compétence': [ 'recOtherCompetence' ] } });
+      const acquix4 = new AirtableRecord('Acquis', 'recAcquix4', { fields: { 'Nom': '@acquix4', 'Status': 'actif', 'Compétence': [ 'recOtherCompetence' ] } });
       sandbox.stub(airtable, 'findRecords')
         .withArgs('Acquis')
         .resolves([acquix1, acquix2, acquix3, acquix4]);

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -51,10 +51,14 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       const rawSkill3 = skillRawAirTableFixture();
       rawSkill3.id = 'FAKE_REC_ID_RAW_SKILL_3' ;
 
-      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3]);
+      const rawSkill4 = skillRawAirTableFixture();
+      rawSkill4.id = 'FAKE_REC_ID_RAW_SKILL_4' ;
+      rawSkill4.fields['Status'] = 'périmé';
+
+      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3, rawSkill4]);
 
       // when
-      const promise = skillDatasource.findByRecordIds([rawSkill1.id, rawSkill2.id]);
+      const promise = skillDatasource.findByRecordIds([rawSkill1.id, rawSkill2.id, rawSkill4.id]);
 
       // then
       return promise.then((foundSkills) => {
@@ -99,17 +103,37 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
         expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);
       });
     });
+
+    it('should resolve an array of Skills with only actiaved Skillfrom airTable', () => {
+      // given
+      const
+        rawSkill1 = skillRawAirTableFixture(),
+        rawSkill2 = skillRawAirTableFixture(),
+        rawSkill3 = skillRawAirTableFixture();
+      rawSkill3.fields['Status'] = 'périmé';
+      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3]);
+
+      // when
+      const promise = skillDatasource.list();
+
+      // then
+      return promise.then((foundSkills) => {
+        expect(foundSkills[0]).to.be.an.instanceOf(Skill);
+        expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);
+      });
+    });
   });
 
   describe('#findByCompetenceId', function() {
 
     beforeEach(() => {
-      const acquix1 = new AirtableRecord('Acquis', 'recAcquix1', { fields: { 'Nom': '@acquix1', 'Compétence': [ 'recCompetence' ] } });
-      const acquix2 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix2', 'Compétence': [ 'recCompetence' ] } });
-      const acquix3 = new AirtableRecord('Acquis', 'recAcquix3', { fields: { 'Nom': '@acquix3', 'Compétence': [ 'recOtherCompetence' ] } });
+      const acquix1 = new AirtableRecord('Acquis', 'recAcquix1', { fields: { 'Nom': '@acquix1', 'Status': 'actif', 'Compétence': [ 'recCompetence' ] } });
+      const acquix2 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix2', 'Status': 'actif', 'Compétence': [ 'recCompetence' ] } });
+      const acquix3 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix3', 'Status': 'en construction', 'Compétence': [ 'recCompetence' ] } });
+      const acquix4 = new AirtableRecord('Acquis', 'recAcquix3', { fields: { 'Nom': '@acquix3', 'Status': 'actif', 'Compétence': [ 'recOtherCompetence' ] } });
       sandbox.stub(airtable, 'findRecords')
         .withArgs('Acquis')
-        .resolves([acquix1, acquix2, acquix3]);
+        .resolves([acquix1, acquix2, acquix3, acquix4]);
     });
 
     it('should retrieve all skills from Airtable for one competence', function() {


### PR DESCRIPTION
*Besoin* : 
- Il y a des acquis non utilisé dans Airtable (acquis en cours de développement, sans question etc...) qui étaient remontés dans la liste des acquis. Ces acquis sans question posaient problème notamment lors du calcul du nombre de Pix gagné, qui dépend des acquis présents.

*Tech* : 
- Une colonne "Status" a été ajouté dans AirTable pour préciser le status de l'acquis. Suite à une discussion avec Benoit, c'est via ce status que nous souhaiterions filtrer les acquis, dans tous les cas  : "’à partir du moment où un acquis est marqué comme non valide, il ne devrait pas exister pour l’appli".
- Ajout d'un filtre sur le status dans le _doQuery par lequel passe list(), findBy*()