### PR TITLE
[TECH] Ajout d'un système de lock afin de limiter les requêtes à Airtable (PF-416).

### DIFF
--- a/api/lib/infrastructure/caches/cache.js
+++ b/api/lib/infrastructure/caches/cache.js
@@ -12,8 +12,8 @@ class Cache {
     }
   }
 
-  get(key) {
-    return this._cache.get(key);
+  get(key, generator) {
+    return this._cache.get(key, generator);
   }
 
   set(key, object) {

--- a/api/lib/infrastructure/caches/in-memory-cache.js
+++ b/api/lib/infrastructure/caches/in-memory-cache.js
@@ -6,37 +6,25 @@ class InMemoryCache {
     this._cache = new NodeCache();
   }
 
-  get(key) {
-    return new Promise((resolve, reject) => {
-      this._cache.get(key, (error, value) => {
-        if (error) return reject(error);
-        return resolve(value);
-      });
-    });
+  async get(key, generator) {
+    const value = this._cache.get(key);
+    if (value) return value;
+    return this.set(key, await generator());
   }
 
-  set(key, object) {
-    return new Promise((resolve, reject) => {
-      this._cache.set(key, object, (error) => {
-        if (error) return reject(error);
-        return resolve(object);
-      });
-    });
+  async set(key, value) {
+    this._cache.set(key, value);
+    return value;
   }
 
-  del(key) {
-    return new Promise((resolve, reject) => {
-      this._cache.del(key, (error, numberOfDeletedKeys) => {
-        if (error) return reject(error);
-        return resolve(numberOfDeletedKeys);
-      });
-    });
+  async del(key) {
+    return this._cache.del(key);
   }
 
-  flushAll() {
+  async flushAll() {
     this._cache.flushAll();
-    return Promise.resolve();
   }
+
 }
 
 module.exports = InMemoryCache;

--- a/api/lib/infrastructure/caches/preloader.js
+++ b/api/lib/infrastructure/caches/preloader.js
@@ -3,7 +3,7 @@ const cache = require('./cache');
 
 function _cacheIndividually(records, tablename) {
   return Promise.all(records.map((record) => {
-    const cacheKey = `${tablename}_${record.id}`;
+    const cacheKey = airtable.generateCacheKey(tablename, record.id);
     return cache.set(cacheKey, record._rawJson);
   }));
 }

--- a/api/lib/infrastructure/caches/redis-cache.js
+++ b/api/lib/infrastructure/caches/redis-cache.js
@@ -1,45 +1,73 @@
-const redis = require('redis');
+const { using } = require('bluebird');
+const logger = require('../logger');
+const settings = require('../../settings');
+const RedisClient = require('./redis-client');
+const Redlock = require('redlock');
+
+const REDIS_LOCK_PREFIX = 'locks:';
 
 class RedisCache {
 
   constructor(redis_url) {
-    this._client = redis.createClient(redis_url);
+    this._client = RedisCache.createClient(redis_url);
   }
 
-  get(key) {
-    return new Promise((resolve, reject) => {
-      this._client.get(key, (error, value) => {
-        if (error) return reject(error);
-        return resolve(JSON.parse(value));
-      });
-    });
+  static createClient(redis_url) {
+    return new RedisClient(redis_url);
   }
 
-  set(key, object) {
-    return new Promise((resolve, reject) => {
-      this._client.set(key, JSON.stringify(object), (error) => {
-        if (error) return reject(error);
-        return resolve(object);
-      });
-    });
+  async get(key, generator) {
+    const value = await this._client.get(key);
+
+    if (value) return JSON.parse(value);
+
+    return this._manageValueNotFoundInCache(key, generator);
+  }
+
+  async _manageValueNotFoundInCache(key, generator) {
+    const keyToLock = REDIS_LOCK_PREFIX + key;
+    const retrieveAndSetValue = async () => {
+      logger.info({ key }, 'Executing generator for Redis key');
+      const value = await generator();
+      return this.set(key, value);
+    };
+    const unlockErrorHandler = (err) => logger.error({ key }, 'Error while trying to unlock Redis key', err);
+
+    try {
+      const locker = this._client.lockDisposer(keyToLock, settings.redisCacheKeyLockTTL, unlockErrorHandler);
+      const value = await using(locker, retrieveAndSetValue);
+      return value;
+    } catch(err) {
+      if (err instanceof Redlock.LockError) {
+        logger.trace({ keyToLock }, 'Could not lock Redis key, waiting');
+        await new Promise((resolve) => setTimeout(resolve, settings.redisCacheLockedWaitBeforeRetry));
+        return this.get(key, generator);
+      }
+      logger.error({ err }, 'Error while trying to update value in Redis cache');
+      throw err;
+    }
+  }
+
+  async set(key, object) {
+    const objectAsString = JSON.stringify(object);
+
+    logger.info({ key, length: objectAsString.length }, 'Setting Redis key');
+
+    await this._client.set(key, objectAsString);
+
+    return object;
   }
 
   del(key) {
-    return new Promise((resolve, reject) => {
-      this._client.del(key, (error, numberOfDeletedKeys) => {
-        if (error) return reject(error);
-        return resolve(numberOfDeletedKeys);
-      });
-    });
+    logger.info({ key }, 'Removing Redis key');
+
+    return this._client.del(key);
   }
 
   flushAll() {
-    return new Promise((resolve, reject) => {
-      this._client.flushall((error) => {
-        if (error) return reject(error);
-        return resolve();
-      });
-    });
+    logger.info('Flusing Redis database');
+
+    return this._client.flushall();
   }
 }
 

--- a/api/lib/infrastructure/caches/redis-client.js
+++ b/api/lib/infrastructure/caches/redis-client.js
@@ -1,0 +1,23 @@
+const redis = require('redis');
+const Redlock = require('redlock');
+const { promisify } = require('util');
+
+module.exports = class RedisClient {
+
+  constructor(redis_url) {
+    this._client = redis.createClient(redis_url);
+    this._clientWithLock = new Redlock(
+      [this._client],
+      // As said in the doc, setting retryCount to 0 and treating a failure as the resource being "locked"
+      // is a good practice
+      { retryCount: 0 }
+    );
+
+    this.get = promisify(this._client.get).bind(this._client);
+    this.set = promisify(this._client.set).bind(this._client);
+    this.del = promisify(this._client.del).bind(this._client);
+    this.flushall = promisify(this._client.flushall).bind(this._client);
+    this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);
+  }
+
+};

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -15,7 +15,7 @@ module.exports = (function() {
 
     airtable: {
       apiKey: process.env.AIRTABLE_API_KEY,
-      base: process.env.AIRTABLE_BASE
+      base: process.env.AIRTABLE_BASE,
     },
 
     app: {
@@ -51,7 +51,9 @@ module.exports = (function() {
 
     passwordValidationPattern: '^(?=.*\\p{L})(?=.*\\d).{8,}$',
 
-    redisUrl: process.env.REDIS_URL
+    redisUrl: process.env.REDIS_URL,
+    redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,
+    redisCacheLockedWaitBeforeRetry: parseInt(process.env.REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY, 10) || 1000,
 
   };
 
@@ -62,7 +64,7 @@ module.exports = (function() {
 
     config.airtable = {
       apiKey: 'test-api-key',
-      base: 'test-base'
+      base: 'test-base',
     };
 
     config.mailjet = {
@@ -83,6 +85,8 @@ module.exports = (function() {
     };
 
     config.redisUrl = null;
+    config.redisCacheKeyLockTTL = 0;
+    config.redisCacheLockedWaitBeforeRetry = 0;
   }
 
   return config;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -975,9 +975,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "bookshelf": {
       "version": "0.12.1",
@@ -985,7 +985,7 @@
       "integrity": "sha512-Fmo0zuoER8PWLP9E3tukacN+AEsp0SEHWj+w0T+RKWgV6COoPqsW9hEdJHrkAGJUJjTK5mh/8O/Q+MLekpCuWA==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.3",
         "chalk": "2.3.2",
         "create-error": "0.3.1",
         "inflection": "1.12.0",
@@ -1026,7 +1026,7 @@
       "resolved": "https://registry.npmjs.org/bookshelf-page/-/bookshelf-page-0.3.2.tgz",
       "integrity": "sha1-i+TMFWQb0zijq/gtXYcyAnEhtTE=",
       "requires": {
-        "bluebird": "3.5.1"
+        "bluebird": "3.5.3"
       }
     },
     "bookshelf-validate": {
@@ -4667,7 +4667,7 @@
       "integrity": "sha1-eZFBBuF9OouMdhawbXW+kHnUsVM=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.3",
         "chalk": "2.3.0",
         "commander": "2.14.1",
         "debug": "3.1.0",
@@ -5347,7 +5347,7 @@
       "resolved": "https://registry.npmjs.org/node-mailjet/-/node-mailjet-3.2.1.tgz",
       "integrity": "sha512-n8fO6NFdrttg2Ct6s266Jw7gFazqkC7e0FESHbvRfvTqam0nAF2yVkKKu1eRTXrVsBjTYmdCZ++ykyVYEO/Sxg==",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.3",
         "json-bigint": "0.2.3",
         "qs": "6.5.1",
         "superagent": "3.8.2",
@@ -7847,7 +7847,7 @@
       "resolved": "https://registry.npmjs.org/redlock/-/redlock-3.1.2.tgz",
       "integrity": "sha512-CKXhOvLd4In5QOfbcF0GIcSsa+pL9JPZd+eKeMk/Sydxh93NUNtwQMTIKFqwPu3PjEgDStwYFJTurVzNA33pZw==",
       "requires": {
-        "bluebird": "3.5.1"
+        "bluebird": "3.5.3"
       }
     },
     "regenerator-runtime": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7842,6 +7842,14 @@
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
+    "redlock": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redlock/-/redlock-3.1.2.tgz",
+      "integrity": "sha512-CKXhOvLd4In5QOfbcF0GIcSsa+pL9JPZd+eKeMk/Sydxh93NUNtwQMTIKFqwPu3PjEgDStwYFJTurVzNA33pZw==",
+      "requires": {
+        "bluebird": "3.5.1"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -48,6 +48,7 @@
     "prom-client": "^10.2.3",
     "randomstring": "^1.1.5",
     "redis": "^2.8.0",
+    "redlock": "^3.1.2",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "sqlite3": "^3.1.13",

--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
     "airtable": "^0.5.2",
     "bcrypt": "^1.0.3",
     "blipp": "^2.3.0",
+    "bluebird": "^3.5.3",
     "bookshelf": "^0.12.1",
     "bookshelf-page": "^0.3.2",
     "bookshelf-validate": "^2.0.3",

--- a/api/tests/unit/infrastructure/caches/cache_test.js
+++ b/api/tests/unit/infrastructure/caches/cache_test.js
@@ -87,4 +87,5 @@ describe('Unit | Infrastructure | Cache', () => {
         });
     });
   });
+
 });

--- a/api/tests/unit/infrastructure/caches/redis-cache_test.js
+++ b/api/tests/unit/infrastructure/caches/redis-cache_test.js
@@ -1,80 +1,141 @@
 const { expect, sinon } = require('../../../test-helper');
-const redis = require('redis');
+const settings = require('../../../../lib/settings');
+const Redlock = require('redlock');
 const RedisCache = require('../../../../lib/infrastructure/caches/redis-cache');
 
 describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
+  let sandbox;
   let stubbedClient;
   let redisCache;
 
   const REDIS_URL = 'redis_url';
   const CACHE_KEY = 'cache_key';
-  const NO_ERROR = null;
   const REDIS_CLIENT_ERROR = new Error('A Redis client error');
 
   beforeEach(() => {
-    stubbedClient = {};
-    sinon.stub(redis, 'createClient').returns(stubbedClient);
+    sandbox = sinon.sandbox.create();
+    stubbedClient = {
+      lockDisposer: sinon.stub().resolves(() => {})
+    };
+    sandbox.stub(RedisCache, 'createClient')
+      .withArgs(REDIS_URL)
+      .returns(stubbedClient);
     redisCache = new RedisCache(REDIS_URL);
   });
 
   afterEach(() => {
-    redis.createClient.restore();
-  });
-
-  describe('#constructor', () => {
-
-    it('should create redis client with redis url', () => {
-      // when
-      new RedisCache(REDIS_URL);
-
-      // then
-      expect(redis.createClient).to.have.been.calledWith(REDIS_URL);
-    });
+    sandbox.restore();
   });
 
   describe('#get', () => {
-
     beforeEach(() => {
       stubbedClient.get = sinon.stub();
+      redisCache.set = sinon.stub();
     });
 
-    it('should resolve with the previously cached value when it exists', () => {
-      // given
-      const cachedObject = { foo: 'bar' };
-      const redisCachedValue = JSON.stringify(cachedObject);
-      stubbedClient.get.yields(NO_ERROR, redisCachedValue);
+    context('when the value is already in cache', () => {
 
-      // when
-      const promise = redisCache.get(CACHE_KEY);
+      it('should resolve with the existing value', () => {
+        // given
+        const cachedData = { foo: 'bar' };
+        const redisCachedData = JSON.stringify(cachedData);
+        stubbedClient.get.withArgs(CACHE_KEY).resolves(redisCachedData);
 
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then((result) => {
-          expect(result).to.deep.equal(cachedObject);
-          expect(stubbedClient.get).to.have.been.calledWith(CACHE_KEY);
-        });
+        // when
+        const promise = redisCache.get(CACHE_KEY);
+
+        // then
+        return expect(promise).to.have.been.fulfilled
+          .then((result) => {
+            expect(result).to.deep.equal(cachedData);
+          });
+      });
+
     });
 
-    it('should resolve with null when no object was previously cached for given key', () => {
-      // given
-      const noRedisCachedValue = 'null';
-      stubbedClient.get.yields(NO_ERROR, noRedisCachedValue);
+    context('when the value is not in cache', () => {
 
-      // when
-      const promise = redisCache.get(CACHE_KEY);
+      beforeEach(() => {
+        const cachedObject = { foo: 'bar' };
+        const redisCachedValue = JSON.stringify(cachedObject);
+        stubbedClient.get.withArgs(CACHE_KEY).onCall(0).resolves(null);
+        stubbedClient.get.withArgs(CACHE_KEY).onCall(1).resolves(redisCachedValue);
+        redisCache.set.resolves();
+      });
 
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then((result) => {
-          expect(result).to.deep.equal(null);
+      it('should try to lock the cache key', () => {
+        // given
+        const expectedLockedKey = 'locks:' + CACHE_KEY;
+        const handler = sinon.stub().resolves();
+
+        // when
+        const promise = redisCache.get(CACHE_KEY, handler);
+
+        // then
+        return promise.then(() => {
+          return expect(stubbedClient.lockDisposer).to.have.been.calledWith(expectedLockedKey, settings.redisCacheKeyLockTTL);
         });
+      });
+
+      context('and the cache key is not already locked', () => {
+
+        it('should add into the cache the value returned by the handler', () => {
+          // given
+          const dataFromHandler = { name: 'data from airtable' };
+          const handler = () => Promise.resolve(dataFromHandler);
+
+          // when
+          const promise = redisCache.get(CACHE_KEY, handler);
+
+          // then
+          return promise.then(() => {
+            return expect(redisCache.set).to.have.been.calledWith(CACHE_KEY, dataFromHandler);
+          });
+        });
+
+        it('should return the value', () => {
+          // given
+          const dataFromHandler = { name: 'data from airtable' };
+          const handler = () => Promise.resolve(dataFromHandler);
+          redisCache.set.resolves(dataFromHandler);
+
+          // when
+          const promise = redisCache.get(CACHE_KEY, handler);
+
+          // then
+          return promise.then((value) => {
+            return expect(value).to.equal(dataFromHandler);
+          });
+        });
+
+      });
+
+      context('and the cache key is already locked', () => {
+
+        it('should wait and retry to get the value from the cache', () => {
+          // given
+          stubbedClient.lockDisposer.rejects(new Redlock.LockError());
+          const handler = () => {
+          };
+
+          // when
+          const promise = redisCache.get(CACHE_KEY, handler);
+
+          // then
+          return promise.then(() => {
+            expect(stubbedClient.get).to.have.been.calledTwice;
+          });
+        });
+
+      });
+
     });
 
     it('should reject when the Redis cache client throws an error', () => {
       // given
 
-      stubbedClient.get.yields(REDIS_CLIENT_ERROR);
+      stubbedClient.get.rejects(REDIS_CLIENT_ERROR);
 
       // when
       const promise = redisCache.get(CACHE_KEY);
@@ -86,7 +147,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
     it('should reject when the previously cached value can not be parsed as JSON', () => {
       // given
       const redisCachedValue = 'Unprocessable JSON object';
-      stubbedClient.get.yields(NO_ERROR, redisCachedValue);
+      stubbedClient.get.resolves(redisCachedValue);
 
       // when
       const promise = redisCache.get(CACHE_KEY);
@@ -106,7 +167,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
     it('should resolve with the object to cache', () => {
       // given
-      stubbedClient.set.yields(NO_ERROR);
+      stubbedClient.set.resolves();
 
       // when
       const promise = redisCache.set(CACHE_KEY, objectToCache);
@@ -121,7 +182,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
     it('should reject when the Redis cache client throws an error', () => {
       // given
-      stubbedClient.set.yields(REDIS_CLIENT_ERROR);
+      stubbedClient.set.rejects(REDIS_CLIENT_ERROR);
 
       // when
       const promise = redisCache.set(CACHE_KEY, objectToCache);
@@ -140,7 +201,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
     it('should resolve', () => {
       // given
       const numberOfDeletedKeys = 1;
-      stubbedClient.del.yields(NO_ERROR, numberOfDeletedKeys);
+      stubbedClient.del.resolves(numberOfDeletedKeys);
 
       // when
       const promise = redisCache.del(CACHE_KEY);
@@ -151,7 +212,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
     it('should reject when the Redis cache client throws an error', () => {
       // given
-      stubbedClient.del.yields(REDIS_CLIENT_ERROR);
+      stubbedClient.del.rejects(REDIS_CLIENT_ERROR);
 
       // when
       const promise = redisCache.del(CACHE_KEY);
@@ -169,7 +230,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
     it('should resolve', () => {
       // given
-      stubbedClient.flushall.yields(NO_ERROR);
+      stubbedClient.flushall.resolves();
 
       // when
       const promise = redisCache.flushAll();
@@ -180,7 +241,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
     it('should reject when the Redis cache client throws an error', () => {
       // given
-      stubbedClient.flushall.yields(REDIS_CLIENT_ERROR);
+      stubbedClient.flushall.rejects(REDIS_CLIENT_ERROR);
 
       // when
       const promise = redisCache.flushAll();
@@ -189,4 +250,5 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
       return expect(promise).to.have.been.rejectedWith(REDIS_CLIENT_ERROR);
     });
   });
+
 });


### PR DESCRIPTION
Aujourd'hui, quand plusieurs requêtes utilisateur ont besoin de la même ressource Airtable, et que celle-ci n'est pas en cache, alors chaque requête va tenter de récupérer la valeur dans Airtable, ce qui provoque une surcharge du service et de grosse lenteurs (voir de l'indisponibilité) de Pix.

Solution: gérer les demandes de resources Airtable similaires via un système de lock.
Quand plusieurs requêtes ont beosin de la même resources Airtable "en même temps" et que celle-ci n'est pas en cache, la première requête va récupérer un lock dans Redis (clé de type "locks:**) avant de faire la requête Airtable. Les requêtes suivantes vont elles aussi essayé de prendre le même lock, mais celui-ci étant déjà pris, vont se faire jeter. Elles vont alors attendre quelques secondes, puis réessayer, jusqu'à ce que la donnée soit disponible dans le cache.

Variables d'environnements à rajouter (optionnellement) à votre .env et dans Scalingo : 
REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY=1000
REDIS_CACHE_KEY_LOCK_TTL=60000

Redis explication : https://redis.io/topics/distlock
Librairie nodejs : https://github.com/mike-marcacci/node-redlock