### PR TITLE
[#264] [FEATURE] Mise-à-jour de la bannière de reprise pour le cas où l'utilisateur n'a pas partagé ses résultats (PF-405).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -41,6 +41,7 @@ class AssessmentSerializer extends JSONAPISerializer {
     data.attributes['estimated-level'] = model.estimatedLevel;
     data.attributes['pix-score'] = model.pixScore;
     data.attributes['type'] = model.type;
+    data.attributes['state'] = model.state;
     if (model.type === 'CERTIFICATION') {
       data.attributes['certification-number'] = model.courseId;
     } else {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -200,6 +200,7 @@ describe('Acceptance | API | assessment-controller-get', () => {
           'attributes': {
             'estimated-level': 0,
             'pix-score': 0,
+            'state': null,
             'success-rate': null,
             'type': null,
             'certification-number': null,
@@ -350,6 +351,7 @@ describe('Acceptance | API | assessment-controller-get', () => {
           'attributes': {
             'estimated-level': 1,
             'pix-score': 8,
+            'state': null,
             'success-rate': 50,
             'type': null,
             'certification-number': null,
@@ -450,6 +452,7 @@ describe('Acceptance | API | assessment-controller-get', () => {
         'attributes': {
           'estimated-level': undefined,
           'pix-score': undefined,
+          'state': 'completed',
           'success-rate': undefined,
           'type': 'SMART_PLACEMENT',
           'certification-number': null,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -33,6 +33,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
         attributes: {
           'estimated-level': undefined,
           'pix-score': undefined,
+          'state': undefined,
           'success-rate': undefined,
           'type': 'charade',
           'certification-number': null,
@@ -134,6 +135,21 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
 
       // then
       expect(json).to.deep.equal(jsonAssessment);
+    });
+
+    describe('field "state"', () => {
+
+      it('should set "state" attribute value when it is present', () => {
+        // given
+        const state = 'started';
+        modelObject.state = state;
+
+        // when
+        const json = serializer.serialize(modelObject);
+
+        // then
+        expect(json.data.attributes.state).to.equal(state);
+      });
     });
 
   });

--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -8,7 +8,7 @@ export default Component.extend({
   classNames: ['resume-campaign-banner'],
   campaignParticipations: [],
 
-  campaignToResume: computed('campaignParticipations', function() {
+  campaignToResumeOrShare: computed('campaignParticipations', function() {
     const campaignParticipations = this.get('campaignParticipations').toArray();
 
     const campaignParticipationsNotShared = _filter(campaignParticipations,
@@ -19,7 +19,11 @@ export default Component.extend({
     const lastCampaignParticipationStarted = campaignParticipationOrdered[0];
 
     if(lastCampaignParticipationStarted) {
-      return lastCampaignParticipationStarted.campaign;
+      return {
+        title: lastCampaignParticipationStarted.campaign.get('title'),
+        code: lastCampaignParticipationStarted.campaign.get('code'),
+        assessment: lastCampaignParticipationStarted.assessment
+      };
     }
 
     return null;

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -21,6 +21,9 @@ export default Model.extend({
   isDemo: equal('type', 'DEMO'),
   isPreview: equal('type', 'PREVIEW'),
   isPlacement: equal('type', 'PLACEMENT'),
+  state: attr('string'),
+  isStarted: equal('state', 'started'),
+  isCompleted: equal('state', 'completed'),
   codeCampaign: attr('string'),
   participantExternalId: attr('string'),
 

--- a/mon-pix/app/templates/components/resume-campaign-banner.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner.hbs
@@ -1,10 +1,19 @@
-{{#if campaignToResume}}
+{{#if campaignToResumeOrShare}}
   <div class="resume-campaign-banner__container">
-    {{#if campaignToResume.title}}
-      <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{campaignToResume.title}}"</span>
+    {{#if campaignToResumeOrShare.assessment.isCompleted}}
+      {{#if campaignToResumeOrShare.title}}
+        <span class="resume-campaign-banner__title">Parcours "{{campaignToResumeOrShare.title}}" terminé ! Envoyez vos résultats.</span>
+      {{else}}
+        <span class="resume-campaign-banner__title">Parcours terminé ! Envoyez vos résultats.</span>
+      {{/if}}
+      {{link-to 'Continuer' 'campaigns.start-or-resume' campaignToResumeOrShare.code class="resume-campaign-banner__button pix-button"}}
     {{else}}
-      <span class="resume-campaign-banner__title">Vous n'avez pas terminé votre parcours</span>
+      {{#if campaignToResumeOrShare.title}}
+        <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{campaignToResumeOrShare.title}}"</span>
+      {{else}}
+        <span class="resume-campaign-banner__title">Vous n'avez pas terminé votre parcours</span>
+      {{/if}}
+      {{link-to 'Reprendre' 'campaigns.start-or-resume' campaignToResumeOrShare.code class="resume-campaign-banner__button pix-button"}}
     {{/if}}
-    {{link-to 'Reprendre' 'campaigns.start-or-resume' campaignToResume.code class="resume-campaign-banner__button pix-button"}}
   </div>
 {{/if}}

--- a/mon-pix/tests/unit/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/unit/components/resume-campaign-banner-test.js
@@ -9,7 +9,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
 
   let component;
 
-  const campaignWanted = EmberObject.create({
+  const campaignNotFinished = EmberObject.create({
     isShared: false,
     createdAt: '2018-01-01',
     campaign: EmberObject.create({
@@ -23,43 +23,95 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       code: 'AZERTY1',
     })
   });
-  const campaignFinish = EmberObject.create({
+  const campaignFinished = EmberObject.create({
     isShared: true,
+    createdAt: '2018-12-12',
     campaign: EmberObject.create({
       code: 'AZERTY2',
-    })
+    }),
+    assessment: EmberObject.create({
+      isCompleted: true,
+    }),
+  });
+  const campaignFinishedButNotShared = EmberObject.create({
+    isShared: false,
+    createdAt: '2017-12-12',
+    campaign: EmberObject.create({
+      code: 'AZERTY3',
+    }),
+    assessment: EmberObject.create({
+      isCompleted: true,
+    }),
   });
 
   beforeEach(function() {
     component = this.subject();
   });
 
-  describe('#campaignToResume', function() {
+  describe('#campaignToResumeOrShare', function() {
 
-    it('should return the most recent not shared campaign', function() {
+    it('should return the most recent campaign among campaigns not finished and not shared', function() {
       // given
-      const listCampaignParticipations = [campaignFinish, oldCampaignNotFinished, campaignWanted];
+      const listCampaignParticipations = [oldCampaignNotFinished, campaignNotFinished];
+      component.set('campaignParticipations', listCampaignParticipations);
+
+      const expectedResult = {
+        title: campaignNotFinished.campaign.title,
+        code: campaignNotFinished.campaign.code,
+        assessment: campaignNotFinished.assessment
+      };
+
+      // when
+      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+
+      // then
+      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+    });
+
+    it('should return the most recent campaign among campaigns not shared', function() {
+      // given
+      const listCampaignParticipations = [oldCampaignNotFinished, campaignFinishedButNotShared];
+      component.set('campaignParticipations', listCampaignParticipations);
+      const expectedResult = {
+        title: campaignFinishedButNotShared.campaign.title,
+        code: campaignFinishedButNotShared.campaign.code,
+        assessment: campaignFinishedButNotShared.assessment
+      };
+
+      // when
+      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+
+      // then
+      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+    });
+
+    it('should return the only campaign not finished or not shared', function() {
+      // given
+      const listCampaignParticipations = [campaignFinished, campaignFinishedButNotShared];
+      component.set('campaignParticipations', listCampaignParticipations);
+      const expectedResult = {
+        title: campaignFinishedButNotShared.campaign.title,
+        code: campaignFinishedButNotShared.campaign.code,
+        assessment: campaignFinishedButNotShared.assessment
+      };
+
+      // when
+      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+
+      // then
+      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+    });
+
+    it('should return null when all campaign are finished', function() {
+      // given
+      const listCampaignParticipations = [campaignFinished];
       component.set('campaignParticipations', listCampaignParticipations);
 
       // when
-      const campaignToResume = component.get('campaignToResume');
+      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
 
       // then
-      expect(campaignToResume).to.equal(campaignWanted.campaign);
+      expect(campaignToResumeOrShare).to.equal(null);
     });
-
-    it('should return undefined when all campaign are finished', function() {
-      // given
-      const listCampaignParticipations = [campaignFinish];
-      component.set('campaignParticipations', listCampaignParticipations);
-
-      // when
-      const campaignToResume = component.get('campaignToResume');
-
-      // then
-      expect(campaignToResume).to.equal(null);
-    });
-
   });
-
 });


### PR DESCRIPTION
# 🚀 Besoin : 
Un utilisateur de Pix doit pouvoir voir une bannière en haut de son profil lorsqu'il n'a pas encore partagé ses résultats mais qu'il a terminé son parcours. Cette bannière doit lui proposer de partager des résultats sur le parcours en question (avec le titre, si celui-ci a été spécifié lors de la création de la campagne).

Technique : Remontée côté front du 'state' ('started' ou 'completed') d'un 'assessment'. Affichage conditionnel du message.

# 🦄 Preview :
![ezgif com-optimize](https://user-images.githubusercontent.com/35838565/48268551-8de82100-e435-11e8-917b-8c14039343ba.gif)