### PR TITLE
[#266] [BUGFIX] Affichage de l'en-tête avec le titre (s'il existe) sur les pages de résultats intermédiaires (PF-445).

### DIFF
--- a/mon-pix/app/routes/assessments/checkpoint.js
+++ b/mon-pix/app/routes/assessments/checkpoint.js
@@ -6,8 +6,11 @@ export default Route.extend({
   afterModel(assessment) {
 
     return RSVP.hash({
-      assessment,
+      campaigns: this.get('store').query('campaign', { filter: { code: assessment.codeCampaign } }),
       skillReview: assessment.belongsTo('skillReview').reload()
+    }).then((hash) => {
+      assessment.campaign = hash.campaigns.get('firstObject');
+      return assessment;
     });
   },
 

--- a/mon-pix/app/routes/assessments/checkpoint.js
+++ b/mon-pix/app/routes/assessments/checkpoint.js
@@ -9,7 +9,7 @@ export default Route.extend({
       campaigns: this.get('store').query('campaign', { filter: { code: assessment.codeCampaign } }),
       skillReview: assessment.belongsTo('skillReview').reload()
     }).then((hash) => {
-      assessment.campaign = hash.campaigns.get('firstObject');
+      assessment.set('campaign', hash.campaigns.get('firstObject'));
       return assessment;
     });
   },

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -1,7 +1,8 @@
 <div class="assessment-challenge">
 
+  <!-- Currently, there is checkpoints only during campaign participations -->
   <div class="assessment-challenge__course-banner">
-      {{course-banner course=model.course withHomeLink=true}}
+      {{campaign-banner title=model.campaign.title}}
   </div>
 
   <div class="assessment-challenge__content">

--- a/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
@@ -10,19 +10,29 @@ describe('Unit | Route | Assessments | Checkpoint', function() {
   describe('#afterModel', function() {
 
     let route;
+    let assessment;
+
+    let reloadStub;
+    let storeStub;
+    let getCampaignStub;
 
     beforeEach(function() {
       // instance route object
       route = this.subject();
-    });
 
-    it('should call findRecordStub to force the skillReview reload (that has certainly changed since last time)', function() {
-      // given
-      const reloadStub = sinon.stub();
-      const assessment = {
+      reloadStub = sinon.stub();
+      getCampaignStub = sinon.stub();
+      storeStub = {
+        query: sinon.stub().returns({ get: getCampaignStub }),
+      };
+      assessment = {
+        codeCampaign: 'AZERTY',
         belongsTo: sinon.stub().returns({ reload: reloadStub })
       };
+      route.set('store', storeStub);
+    });
 
+    it('should force the skillReview reload (that has certainly changed since last time)', function() {
       // when
       const promise = route.afterModel(assessment);
 
@@ -30,6 +40,17 @@ describe('Unit | Route | Assessments | Checkpoint', function() {
       return promise.then(() => {
         sinon.assert.calledWith(assessment.belongsTo, 'skillReview');
         sinon.assert.calledOnce(reloadStub);
+      });
+    });
+
+    it('should retrieve campaign with campaign code in assessment', function() {
+      // when
+      const promise = route.afterModel(assessment);
+
+      // then
+      return promise.then(() => {
+        sinon.assert.calledWith(storeStub.query, 'campaign', { filter: { code: assessment.codeCampaign } });
+        sinon.assert.calledOnce(getCampaignStub);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
@@ -27,6 +27,7 @@ describe('Unit | Route | Assessments | Checkpoint', function() {
       };
       assessment = {
         codeCampaign: 'AZERTY',
+        set: sinon.stub(),
         belongsTo: sinon.stub().returns({ reload: reloadStub })
       };
       route.set('store', storeStub);


### PR DESCRIPTION
# 🤷‍♀️Besoin : 
Un utilisateur de Pix doit pouvoir passer une campagne en ayant une certaine en-tête, puis arriver sur une page de résultats intermédiaires, avec la même en-tête.

# 👩‍💻Technique : 
Remplacement de la course-banner par la campaign-banner et récupération de la campaign pour avoir son titre dans le checkpoint et le donner à la campaign-banner.