### PR TITLE
[TECH] Amélioration du script récupérant le ChangeLog

### DIFF
--- a/api/scripts/get-changelog.js
+++ b/api/scripts/get-changelog.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 const request = require('request-promise-native');
 const moment = require('moment');
+const _ = require('lodash');
 
 function buildRequestObject() {
   return {
@@ -14,13 +15,35 @@ function buildRequestObject() {
 }
 
 function displayPullRequest(pr) {
-  const closeNumber = pr.title.indexOf(']');
-  let title = pr.title.substring(closeNumber + 1);
-  title = (title.charAt(0) === ' ') ? title.substring(1) : title;
-  title = (title.charAt(title.length - 1) === ' ') ? title.substring(0, title.length - 1) : title;
-  title = (title.charAt(title.length - 1) === '.') ? title : title + '.';
+  return `- [#${pr.number}](${pr.html_url}) ${pr.title}\n`;
+}
 
-  return `- [#${pr.number}](${pr.html_url}) ${title}\n`;
+function filterListPrByType(listPR, type) {
+  const filteredPR = _.filter(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
+    return typeOfPR === type;
+  });
+  return filteredPR;
+}
+
+function filterListPrWithoutType(listPR, listType) {
+  const filteredPR = _.filter(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
+    return _.indexOf(listType,typeOfPR) < 0;
+  });
+  return filteredPR;
+
+}
+
+function orderPr(listPR) {
+  const typeOrdered = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
+  const featurePR = filterListPrByType(listPR, typeOrdered[0]);
+  const quickWinPR = filterListPrByType(listPR, typeOrdered[1]);
+  const bugfixPR = filterListPrByType(listPR, typeOrdered[2]);
+  const techPR = filterListPrByType(listPR, typeOrdered[3]);
+  const otherPR = filterListPrWithoutType(listPR, typeOrdered);
+  return _.concat(featurePR, quickWinPR, bugfixPR, techPR, otherPR);
+
 }
 
 function filterPullRequest(pullrequests, milestone) {
@@ -32,7 +55,7 @@ function filterPullRequest(pullrequests, milestone) {
 function getHeadOfChangelog(pullrequest) {
   const version = pullrequest.milestone.title;
   const date = ' (' + moment().format('DD/MM/YYYY') + ')';
-  return '## ' + version + date + ' \n\n';
+  return '## v' + version + date + ' \n\n';
 }
 
 function main() {
@@ -45,10 +68,13 @@ function main() {
       const headOfChangeLog = getHeadOfChangelog(pullRequestsInMilestone[0]);
 
       let changeLogForMilestone = '';
-      pullRequestsInMilestone.forEach(pr => changeLogForMilestone += displayPullRequest(pr));
+      const orderedPR = orderPr(pullRequestsInMilestone);
+      orderedPR.forEach(pr => changeLogForMilestone += displayPullRequest(pr));
 
       console.log(headOfChangeLog + changeLogForMilestone);
-    });
+
+    })
+    .catch(console.log);
 }
 
 /*=================== tests =============================*/
@@ -59,6 +85,7 @@ if (process.env.NODE_ENV !== 'test') {
   module.exports = {
     displayPullRequest,
     filterPullRequest,
+    orderPr,
     getHeadOfChangelog
   };
 }

--- a/api/scripts/get-changelog.js
+++ b/api/scripts/get-changelog.js
@@ -18,31 +18,13 @@ function displayPullRequest(pr) {
   return `- [#${pr.number}](${pr.html_url}) ${pr.title}\n`;
 }
 
-function filterListPrByType(listPR, type) {
-  const filteredPR = _.filter(listPR, (pr) => {
-    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
-    return typeOfPR === type;
-  });
-  return filteredPR;
-}
-
-function filterListPrWithoutType(listPR, listType) {
-  const filteredPR = _.filter(listPR, (pr) => {
-    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
-    return _.indexOf(listType,typeOfPR) < 0;
-  });
-  return filteredPR;
-
-}
-
 function orderPr(listPR) {
-  const typeOrdered = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
-  const featurePR = filterListPrByType(listPR, typeOrdered[0]);
-  const quickWinPR = filterListPrByType(listPR, typeOrdered[1]);
-  const bugfixPR = filterListPrByType(listPR, typeOrdered[2]);
-  const techPR = filterListPrByType(listPR, typeOrdered[3]);
-  const otherPR = filterListPrWithoutType(listPR, typeOrdered);
-  return _.concat(featurePR, quickWinPR, bugfixPR, techPR, otherPR);
+  const typeOrder = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
+  return _.sortBy(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
+    const typeIndex = _.indexOf(typeOrder,typeOfPR);
+    return typeIndex < 0 ? Number.MAX_VALUE : typeIndex;
+  });
 
 }
 

--- a/api/tests/unit/scripts/get-changelog_test.js
+++ b/api/tests/unit/scripts/get-changelog_test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const { displayPullRequest, filterPullRequest, getHeadOfChangelog } = require('../../../scripts/get-changelog');
+const { displayPullRequest, filterPullRequest, getHeadOfChangelog, orderPr } = require('../../../scripts/get-changelog');
 
 describe('Unit | Script | GET Changelog', () => {
 
@@ -11,19 +11,7 @@ describe('Unit | Script | GET Changelog', () => {
     it('should return a line with correct format from correct PR name', () => {
       // given
       const pullRequest = {
-        title: '[#111] [BUGFIX] Résolution du problème de surestimation du niveau (US-389).',
-        number: 111,
-        html_url: 'http://git/111'
-      };
-      // when
-      const result = displayPullRequest(pullRequest);
-      // then
-      expect(result).to.equal(expectedLine);
-    });
-    it('should return a line with correct format from PR name with error', () => {
-      // given
-      const pullRequest = {
-        title: '[#111][BUGFIX] Résolution du problème de surestimation du niveau (US-389) ',
+        title: '[BUGFIX] Résolution du problème de surestimation du niveau (US-389).',
         number: 111,
         html_url: 'http://git/111'
       };
@@ -40,13 +28,13 @@ describe('Unit | Script | GET Changelog', () => {
       const milestone = 1;
       const pullRequests = [
         {
-          title: '[#111] [BUGFIX] TEST (US-11).',
+          title: '[BUGFIX] TEST (US-11).',
           milestone: {
             number: milestone
           }
         },
         {
-          title: '[#222] [BUGFIX] TRUC (US-22).',
+          title: '[BUGFIX] TRUC (US-22).',
           milestone: {
             number: 2
           }
@@ -54,7 +42,7 @@ describe('Unit | Script | GET Changelog', () => {
       ];
       const pullRequestsInMilestone = [
         {
-          title: '[#111] [BUGFIX] TEST (US-11).',
+          title: '[BUGFIX] TEST (US-11).',
           milestone: {
             number: milestone
           }
@@ -72,10 +60,10 @@ describe('Unit | Script | GET Changelog', () => {
       const clock = sinon.useFakeTimers();
       const headChangelog = '## v1.0.0 (01/01/1970) \n\n';
       const pullRequestsInMilestone = {
-        title: '[#111] [BUGFIX] TEST (US-11).',
+        title: '[BUGFIX] TEST (US-11).',
         milestone: {
           number: 1,
-          title: 'v1.0.0'
+          title: '1.0.0'
         }
       };
       // when
@@ -83,6 +71,27 @@ describe('Unit | Script | GET Changelog', () => {
       // then
       expect(result).to.equal(headChangelog);
       clock.restore();
+    });
+  });
+
+  describe('orderPr', () => {
+    it('should order PR by type', () => {
+      // given
+      const pullRequests = [
+        { title: '[BUGFIX] TEST' },
+        { title: '[QUICK WIN] TEST' },
+        { title: 'TEST' },
+        { title: '[FEATURE] TEST' },
+        { title: '[TECH] TEST' },
+      ];
+      // when
+      const result = orderPr(pullRequests);
+      // then
+      expect(result[0].title).to.equal('[FEATURE] TEST');
+      expect(result[1].title).to.equal('[QUICK WIN] TEST');
+      expect(result[2].title).to.equal('[BUGFIX] TEST');
+      expect(result[3].title).to.equal('[TECH] TEST');
+      expect(result[4].title).to.equal('TEST');
     });
   });
 


### PR DESCRIPTION
*Besoin:*
Simplifier la mise en prod

*Changement sur le script:*

-Le Script prend en compte des Merge au format "[FEATURE] Nom de la Pr (PF-Num).", sans numéro de la PR au début > **Suppression du numéro de PR dans le nom de la PR**
-Le numéro de PR est toujours présent dans le Changelog (car récupéré de la PR et non du titre).
-Tri automatiquement les PR par type.
-Remise en place du "v" de "version" dans le numéro de version.