### PR TITLE
[TECH] Génération de logs au format JSON

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -2,21 +2,35 @@ const Pack = require('../package');
 const Metrics = require('./infrastructure/plugins/metrics');
 const settings = require('./settings');
 
-const consoleReporters = [
-  {
-    module: 'good-squeeze',
-    name: 'Squeeze',
-    args: [{
-      response: '*',
-      log: '*'
-    }]
-  }, {
-    module: 'good-console',
-    args: [{
-      color: settings.logging.colorEnabled
-    }]
-  }
-];
+const doesUseJsonLogs = ['production', 'staging'].includes(process.env.NODE_ENV);
+
+const consoleReporters =
+  doesUseJsonLogs ?
+    [
+      {
+        module: 'good-squeeze',
+        name: 'SafeJson',
+        args: []
+      },
+    ]
+    :
+    [
+      {
+        module: 'good-squeeze',
+        name: 'Squeeze',
+        args: [{
+          response: '*',
+          log: '*'
+        }]
+      },
+      {
+        module: 'good-console',
+        args: [{
+          color: settings.logging.colorEnabled
+        }]
+      }
+    ]
+    ;
 
 if (settings.logging.enabled) {
   consoleReporters.push('stdout');


### PR DESCRIPTION
Pour mieux comprendre ce qui nous arrive en production, une idée est de générer des logs à un format plus facile à exploiter et analyser.

Actuellement les logs que nous générons explicitement dans le code sont au format JSON avec `bunyan`. Mais les logs générés par requête par Hapi sont au format texte.

Cette PR passe les logs Hapi au format JSON quand `NODE_ENV` contient `production` ou `staging`.
