### PR TITLE
[FEATURE] Mise à jour de la gestion de la première question posée à l'utilisateur (PF-436).

### DIFF
--- a/api/lib/cat/assessment.js
+++ b/api/lib/cat/assessment.js
@@ -5,7 +5,7 @@ const logger = require('../infrastructure/logger');
 const MAX_REACHABLE_LEVEL = 5;
 const NB_PIX_BY_LEVEL = 8;
 const MAX_NUMBER_OF_CHALLENGES = 20;
-const LEVEL_FOR_FIRST_CHALLENGE = 2;
+const DEFAULT_LEVEL_FOR_FIRST_CHALLENGE = 2;
 const LEVEL_MAX_TO_BE_AN_EASY_TUBE = 3;
 
 class Assessment {
@@ -125,7 +125,7 @@ class Assessment {
 
   _getPredictedLevel() {
     if (this.answers.length === 0) {
-      return LEVEL_FOR_FIRST_CHALLENGE;
+      return DEFAULT_LEVEL_FOR_FIRST_CHALLENGE;
     }
     let maxLikelihood = -Infinity;
     let level = 0.5;
@@ -204,7 +204,7 @@ class Assessment {
 
   get _firstChallenge() {
     const filteredFirstChallenges = this.filteredChallenges.filter(
-      (challenge) => (challenge.hardestSkill.difficulty === LEVEL_FOR_FIRST_CHALLENGE) && (challenge.timer === undefined)
+      (challenge) => (challenge.hardestSkill.difficulty === DEFAULT_LEVEL_FOR_FIRST_CHALLENGE) && (challenge.timer === undefined)
     );
     filteredFirstChallenges.sort(this._randomly);
     return filteredFirstChallenges[0];

--- a/api/lib/domain/strategies/SmartRandom.js
+++ b/api/lib/domain/strategies/SmartRandom.js
@@ -137,9 +137,26 @@ function _computeReward(challenge, predictedLevel, course, validatedSkills, fail
   return proba * nbExtraSkillsIfSolved + (1 - proba) * nbFailedSkillsIfUnsolved;
 }
 
+function _findLevelForFirstChallenge(filteredChallenges) {
+  const allDifficulties = filteredChallenges
+    .filter((challenge) => challenge.timer === undefined)
+    .map((challenge) => challenge.hardestSkill.difficulty);
+  const difficulties = _.uniq(allDifficulties).sort((a, b) => a > b);
+
+  if (difficulties.includes(LEVEL_FOR_FIRST_CHALLENGE)) { // reorder [1, 2, 3] in [2, 1, 3]
+    _.pull(difficulties, LEVEL_FOR_FIRST_CHALLENGE);
+    difficulties.unshift(LEVEL_FOR_FIRST_CHALLENGE);
+  }
+  return difficulties[0];
+}
+
 function _firstChallenge(challenges, answers, tubes, validatedSkills, failedSkills, predictedLevel) {
-  const filteredFirstChallenges = SmartRandom._filteredChallenges(challenges, answers, tubes, validatedSkills, failedSkills, predictedLevel).filter(
-    (challenge) => (challenge.hardestSkill.difficulty === LEVEL_FOR_FIRST_CHALLENGE) && (challenge.timer === undefined)
+  const filteredChallenges = SmartRandom._filteredChallenges(challenges, answers, tubes, validatedSkills, failedSkills, predictedLevel);
+
+  const levelForFirstChallenge = _findLevelForFirstChallenge(filteredChallenges);
+
+  const filteredFirstChallenges = filteredChallenges.filter((challenge) =>
+    (challenge.hardestSkill.difficulty === levelForFirstChallenge) && (challenge.timer === undefined)
   );
   filteredFirstChallenges.sort(_randomly);
   return filteredFirstChallenges[0];

--- a/api/tests/unit/domain/strategies/SmartRandom_test.js
+++ b/api/tests/unit/domain/strategies/SmartRandom_test.js
@@ -304,21 +304,85 @@ describe('Unit | Domain | Models | SmartRandom', () => {
       expect(nextChallenge).to.be.equal(null);
     });
 
-    it('should call _firstChallenge function if the assessment has no answer', function() {
-      // given
-      const url2 = domainBuilder.buildSkill({ name: '@url2' });
-      const targetProfile = new TargetProfile({ skills: [url2] });
+    context('when assessment has no answer', function() {
 
-      const firstChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [url2] });
-      const challenges = [firstChallenge];
-      const answers = [];
+      it('should start with a not timed question', function() {
+        // given
+        const web1 = domainBuilder.buildSkill({ name: '@web1' });
+        const url2 = domainBuilder.buildSkill({ name: '@url2' });
+        const targetProfile = new TargetProfile({ skills: [url2, web1] });
 
-      // when
-      const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
-      const nextChallenge = smartRandom.getNextChallenge();
+        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [web1] });
+        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [url2], timer: 30 });
+        const challenges = [otherChallenge, firstChallenge];
+        const answers = [];
 
-      // then
-      expect(nextChallenge).to.be.equal(firstChallenge);
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const nextChallenge = smartRandom.getNextChallenge();
+
+        // then
+        expect(nextChallenge).to.be.equal(firstChallenge);
+      });
+
+      it('should start with a level 2 question', function() {
+        // given
+        const web1 = domainBuilder.buildSkill({ name: '@web1' });
+        const cnil2 = domainBuilder.buildSkill({ name: '@cnil2' });
+        const url3 = domainBuilder.buildSkill({ name: '@url3' });
+        const targetProfile = new TargetProfile({ skills: [web1, url3, cnil2] });
+
+        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [cnil2] });
+        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [web1] });
+        const otherChallenge2 = domainBuilder.buildChallenge({ id: 'rec3', skills: [url3] });
+        const challenges = [otherChallenge, otherChallenge2, firstChallenge];
+        const answers = [];
+
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const nextChallenge = smartRandom.getNextChallenge();
+
+        // then
+        expect(nextChallenge).to.be.equal(firstChallenge);
+      });
+
+      it('should start with a level 1 question', function() {
+        // given
+        const web1 = domainBuilder.buildSkill({ name: '@web1' });
+        const url3 = domainBuilder.buildSkill({ name: '@url3' });
+        const targetProfile = new TargetProfile({ skills: [web1, url3] });
+
+        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web1] });
+        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url3] });
+        const challenges = [otherChallenge, firstChallenge];
+        const answers = [];
+
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const nextChallenge = smartRandom.getNextChallenge();
+
+        // then
+        expect(nextChallenge).to.be.equal(firstChallenge);
+      });
+
+      it('should start with a level 4 question', function() {
+        // given
+        const web4 = domainBuilder.buildSkill({ name: '@web4' });
+        const url5 = domainBuilder.buildSkill({ name: '@url5' });
+        const targetProfile = new TargetProfile({ skills: [web4, url5] });
+
+        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web4] });
+        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url5] });
+        const challenges = [otherChallenge, firstChallenge];
+        const answers = [];
+
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const nextChallenge = smartRandom.getNextChallenge();
+
+        // then
+        expect(nextChallenge).to.be.equal(firstChallenge);
+      });
     });
 
     it('should return an easier challenge if user skipped previous challenge', function() {

--- a/api/tests/unit/domain/strategies/SmartRandom_test.js
+++ b/api/tests/unit/domain/strategies/SmartRandom_test.js
@@ -306,15 +306,15 @@ describe('Unit | Domain | Models | SmartRandom', () => {
 
     context('when assessment has no answer', function() {
 
-      it('should start with a not timed question', function() {
+      it('should start with a not timed challenge', function() {
         // given
         const web1 = domainBuilder.buildSkill({ name: '@web1' });
         const url2 = domainBuilder.buildSkill({ name: '@url2' });
         const targetProfile = new TargetProfile({ skills: [url2, web1] });
 
-        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [web1] });
-        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [url2], timer: 30 });
-        const challenges = [otherChallenge, firstChallenge];
+        const notTimedChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [web1] });
+        const timedChallenge = domainBuilder.buildChallenge({ id: 'rec', skills: [url2], timer: 30 });
+        const challenges = [timedChallenge, notTimedChallenge];
         const answers = [];
 
         // when
@@ -322,20 +322,20 @@ describe('Unit | Domain | Models | SmartRandom', () => {
         const nextChallenge = smartRandom.getNextChallenge();
 
         // then
-        expect(nextChallenge).to.be.equal(firstChallenge);
+        expect(nextChallenge).to.be.equal(notTimedChallenge);
       });
 
-      it('should start with a level 2 question', function() {
+      it('should start with a not timed level 2 challenge', function() {
         // given
         const web1 = domainBuilder.buildSkill({ name: '@web1' });
         const cnil2 = domainBuilder.buildSkill({ name: '@cnil2' });
         const url3 = domainBuilder.buildSkill({ name: '@url3' });
         const targetProfile = new TargetProfile({ skills: [web1, url3, cnil2] });
 
-        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [cnil2] });
-        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [web1] });
-        const otherChallenge2 = domainBuilder.buildChallenge({ id: 'rec3', skills: [url3] });
-        const challenges = [otherChallenge, otherChallenge2, firstChallenge];
+        const level2Challenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [cnil2] });
+        const level1Challenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [web1] });
+        const level3Challenge = domainBuilder.buildChallenge({ id: 'rec3', skills: [url3] });
+        const challenges = [level3Challenge, level1Challenge, level2Challenge];
         const answers = [];
 
         // when
@@ -343,18 +343,18 @@ describe('Unit | Domain | Models | SmartRandom', () => {
         const nextChallenge = smartRandom.getNextChallenge();
 
         // then
-        expect(nextChallenge).to.be.equal(firstChallenge);
+        expect(nextChallenge).to.be.equal(level2Challenge);
       });
 
-      it('should start with a level 1 question', function() {
+      it('should start with a not timed level 1 challenge when no level 2 exists', function() {
         // given
         const web1 = domainBuilder.buildSkill({ name: '@web1' });
         const url3 = domainBuilder.buildSkill({ name: '@url3' });
         const targetProfile = new TargetProfile({ skills: [web1, url3] });
 
-        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web1] });
-        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url3] });
-        const challenges = [otherChallenge, firstChallenge];
+        const level1Challenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web1] });
+        const level3Challenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url3] });
+        const challenges = [level3Challenge, level1Challenge];
         const answers = [];
 
         // when
@@ -362,18 +362,18 @@ describe('Unit | Domain | Models | SmartRandom', () => {
         const nextChallenge = smartRandom.getNextChallenge();
 
         // then
-        expect(nextChallenge).to.be.equal(firstChallenge);
+        expect(nextChallenge).to.be.equal(level1Challenge);
       });
 
-      it('should start with a level 4 question', function() {
+      it('should start with a not timed level 4 challenge when no level 2, 1 and 3 exists', function() {
         // given
         const web4 = domainBuilder.buildSkill({ name: '@web4' });
         const url5 = domainBuilder.buildSkill({ name: '@url5' });
         const targetProfile = new TargetProfile({ skills: [web4, url5] });
 
-        const firstChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web4] });
-        const otherChallenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url5] });
-        const challenges = [otherChallenge, firstChallenge];
+        const level4Challenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web4] });
+        const level5Challenge = domainBuilder.buildChallenge({ id: 'rec2', skills: [url5] });
+        const challenges = [level4Challenge, level5Challenge];
         const answers = [];
 
         // when
@@ -381,7 +381,24 @@ describe('Unit | Domain | Models | SmartRandom', () => {
         const nextChallenge = smartRandom.getNextChallenge();
 
         // then
-        expect(nextChallenge).to.be.equal(firstChallenge);
+        expect(nextChallenge).to.be.equal(level4Challenge);
+      });
+
+      it('should start with a timed level 3 challenge when no not timed challenge exists', function() {
+        // given
+        const web3 = domainBuilder.buildSkill({ name: '@web3' });
+        const targetProfile = new TargetProfile({ skills: [web3] });
+
+        const timedChallenge = domainBuilder.buildChallenge({ id: 'rec1', skills: [web3], timer:10 });
+        const challenges = [timedChallenge];
+        const answers = [];
+
+        // when
+        const smartRandom = new SmartRandom({ answers, challenges, targetProfile });
+        const nextChallenge = smartRandom.getNextChallenge();
+
+        // then
+        expect(nextChallenge).to.be.equal(timedChallenge);
       });
     });
 


### PR DESCRIPTION
# 🤷‍♀️ 🤷‍♂️ Besoin : 
En tant qu'utilisateur, je dois pouvoir répondre à une première question, peu importe le niveau des acquis.

# 👩‍💻👨‍💻 Technique : 
Avant : La première question est obligatoirement une question non timée de niveau 2. Si je n'ai pas de niveau 2 non timé, je n'ai pas de question.
Maintenant : La première question est non timée et de niveau 2. Si je n'ai de de question niveau 2 non timé, la première question est non timée et de niveau 1. Si je n'ai de de question niveau 1 non timé, la première question est non timée et de niveau 3. Etc avec les niveaux supérieurs. 