### PR TITLE
[BUGFIX] Rétablir la redirection de /connexion vers /compte pour les utilisateurs déjà authentifiés (PF-456)

### DIFF
--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import BaseRoute from 'mon-pix/routes/base-route';
-import RSVP from 'rsvp';
 
 export default BaseRoute.extend(UnauthenticatedRouteMixin, {
 
@@ -9,7 +8,6 @@ export default BaseRoute.extend(UnauthenticatedRouteMixin, {
 
   routeIfNotAuthenticated: 'connexion',
   routeIfAlreadyAuthenticated: 'compte',
-  routeForLoggedUserLinkedToOrganization: 'board',
 
   beforeModel({ queryParams }) {
     if (queryParams && queryParams.token && queryParams['user-id']) {
@@ -19,7 +17,7 @@ export default BaseRoute.extend(UnauthenticatedRouteMixin, {
           this.transitionTo('compte');
         });
     } else {
-      return RSVP.resolve();
+      return this._super(...arguments);
     }
   },
 


### PR DESCRIPTION
Dans a02f04ef nous avons introduit cette régression en travaillant sur le login SAML.

Il manquait un appel à `super(...)` dans la surcharge d'un `beforeModel`.

On en profite pour ajouter un test qui vérifie le fonctionnement de cette redirection.