### PR TITLE
Le CSV des snapshots doit refléter les profils utilisateurs (PF-358).

### DIFF
--- a/api/db/seeds/data/3rd-to-create/assessment-results.js
+++ b/api/db/seeds/data/3rd-to-create/assessment-results.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 module.exports = [
   { id:1, createdAt: moment().subtract(7, 'day').add(1, 'hour').toString(), emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 1, level: 5, pixScore: 44 },
   { id:2, createdAt: '2018-02-15 15:00:34', emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 2, level: 2, pixScore: 23 },
-  { id:3, createdAt: '2018-02-15 15:03:18', emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 3, level: 5, pixScore: 47 },
+  { id:3, createdAt: '2018-02-15 15:03:18', emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 3, level: 8, pixScore: 47 },
   { id:4, createdAt: '2018-02-15 15:04:26', emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 4, level: 4, pixScore: 34 },
   { id:5, createdAt: moment().subtract(1, 'day').toString(), emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 5, level: 5, pixScore: 48 },
   { id:6, createdAt: '2018-02-15 15:14:46', emitter: 'PIX-ALGO', commentForJury: 'Computed', status: 'validated', assessmentId: 6, level: 0, pixScore: 157 },
@@ -31,4 +31,3 @@ module.exports = [
     pixScore: 0
   }
 ];
-

--- a/api/lib/domain/models/Profile.js
+++ b/api/lib/domain/models/Profile.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const moment = require('moment');
 const { MINIMUM_DELAY_IN_DAYS_BETWEEN_TWO_PLACEMENTS } = require('./Assessment');
-
+const MAX_REACHABLE_LEVEL = 5;
 const competenceStatus = {
   NOT_ASSESSED: 'notAssessed',
   ASSESSMENT_NOT_COMPLETED: 'assessmentNotCompleted',
@@ -81,20 +81,15 @@ class Profile {
     return this._computeDaysBeforeNewAttempt(daysSinceLastCompletedAssessment);
   }
 
-  _setLevelAndPixScoreToCompetences(assessments, courses) {
-    assessments.forEach((assessment) => {
-      const courseIdFromAssessment = assessment.courseId;
-      const course = this._getCourseById(courses, courseIdFromAssessment);
-
+  _setLevelAndPixScoreToCompetences(lastAssessments, courses) {
+    lastAssessments.forEach((assessment) => {
       if (assessment.isCompleted()) {
+        const courseIdFromAssessment = assessment.courseId;
+        const course = this._getCourseById(courses, courseIdFromAssessment);
         const competence = this.competences.find((competence) => course.competences.includes(competence.id));
-        competence.level = assessment.getLevel();
+
+        competence.level = Math.min(assessment.getLevel(), MAX_REACHABLE_LEVEL);
         competence.pixScore = assessment.getPixScore();
-        // TODO: Standardiser l'usage de status pour une compétence
-        if (competence.status === competenceStatus.ASSESSMENT_NOT_COMPLETED) {
-          competence.level = -1;
-          delete competence.pixScore;
-        }
       }
     });
   }

--- a/api/tests/unit/domain/models/profile_test.js
+++ b/api/tests/unit/domain/models/profile_test.js
@@ -148,6 +148,55 @@ describe('Unit | Domain | Models | Profile', () => {
       expect(profile.areas).to.be.equal(areas);
     });
 
+    it('should assign max reachable level to level of competence if level of assessment is too high', () => {
+      // given
+      courses[0].competences = ['competenceId1'];
+      const assessment = domainBuilder.buildAssessment({
+        id: 'assessmentId1',
+        courseId: 'courseId8',
+        assessmentResults: [new AssessmentResult({ pixScore: 10, level: 6, createdAt: new Date('2018-01-01 05:00:00') })],
+        state: 'completed',
+      });
+      assessments = [assessment];
+
+      const expectedCompetences = [
+        {
+          id: 'competenceId1',
+          name: '1.1 Mener une recherche d’information',
+          index: '1.1',
+          areaId: 'areaId1',
+          level: 5,
+          pixScore: 10,
+          courseId: 'courseId8',
+          assessmentId: 'assessmentId1',
+          status: 'assessed',
+          isRetryable: true,
+        },
+        {
+          id: 'competenceId2',
+          name: '1.2 Gérer des données',
+          index: '1.2',
+          areaId: 'areaId2',
+          level: -1,
+          courseId: 'courseId9',
+          status: 'notAssessed',
+          isRetryable: false,
+        }];
+
+      // when
+      const profile = new Profile({
+        user,
+        competences,
+        areas,
+        lastAssessments: assessments,
+        assessmentsCompletedWithResults: assessments,
+        courses,
+      });
+
+      // then
+      expect(profile.competences).to.be.deep.equal(expectedCompetences);
+    });
+
     it('should assign assessment id to competence', () => {
       courses[0].competences = ['competenceId1'];
       courses[1].competences = ['competenceId2'];

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -109,7 +109,7 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
         courseId: 'courseID1',
         state: 'completed',
         assessmentResults: [new AssessmentResult({
-          level: 8,
+          level: 5,
           pixScore: 128,
           createdAt: new Date('2018-01-10 05:00:00'),
         })],
@@ -187,7 +187,7 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
             attributes: {
               name: 'competence-name-1',
               index: '1.1',
-              level: 8,
+              level: 5,
               'pix-score': 128,
               'course-id': 'courseID1',
               'assessment-id': 'assessmentID1',

--- a/mon-pix/app/components/competence-level-progress-bar.js
+++ b/mon-pix/app/components/competence-level-progress-bar.js
@@ -11,14 +11,9 @@ export default Component.extend({
 
   _showSecondChanceModal: false,
 
-  limitedLevel: computed('competence.level', function() {
+  widthOfProgressBar: computed('competence.level', function() {
+
     const level = this.get('competence.level');
-    return Math.min(level, this.get('_MAX_REACHABLE_LEVEL'));
-  }),
-
-  widthOfProgressBar: computed('limitedLevel', function() {
-
-    const level = this.get('limitedLevel');
     const maxLevel = this.get('_MAX_LEVEL');
     let progressBarWidth;
 

--- a/mon-pix/app/templates/components/competence-level-progress-bar.hbs
+++ b/mon-pix/app/templates/components/competence-level-progress-bar.hbs
@@ -54,7 +54,7 @@
 
   <div class="competence-level-progress-bar__level" style={{widthOfProgressBar}}>
     <div class="competence-level-progress-bar__level-indicator">
-      {{limitedLevel}}
+      {{competence.level}}
     </div>
   </div>
 {{/if}}

--- a/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
+++ b/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
@@ -16,9 +16,9 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
         { level: 3, expectedValue: 'width : 37.5%' },
         { level: 4, expectedValue: 'width : 50%' },
         { level: 5, expectedValue: 'width : 62.5%' },
-        { level: 6, expectedValue: 'width : 62.5%' },
-        { level: 7, expectedValue: 'width : 62.5%' },
-        { level: 8, expectedValue: 'width : 62.5%' },
+        { level: 6, expectedValue: 'width : 75%' },
+        { level: 7, expectedValue: 'width : 87.5%' },
+        { level: 8, expectedValue: 'width : 100%' },
       ].forEach(({ level, expectedValue }) => {
 
         it(`should return ${expectedValue} when the level is ${level}`, function() {

--- a/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
+++ b/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
@@ -8,35 +8,6 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
 
   describe('#Computed Properties behaviors: ', function() {
 
-    describe('#limitedLevel', function() {
-
-      [
-        { level: 8, expectedValue: 5 },
-        { level: 7, expectedValue: 5 },
-        { level: 6, expectedValue: 5 },
-        { level: 5, expectedValue: 5 },
-        { level: 4, expectedValue: 4 },
-        { level: 3, expectedValue: 3 },
-        { level: 2, expectedValue: 2 },
-        { level: 1, expectedValue: 1 },
-        { level: 0, expectedValue: 0 },
-        { level: -1, expectedValue: -1 },
-      ].forEach(({ level, expectedValue }) => {
-
-        it(`should return ${expectedValue} when the level of the competence is ${level}`, function() {
-          // given
-          const component = this.subject();
-          const competence = { level };
-
-          // when
-          component.set('competence', competence);
-
-          // then
-          expect(component.get('limitedLevel')).to.equal(expectedValue);
-        });
-      });
-    });
-
     describe('#widthOfProgressBar', function() {
       [
         { level: 1, expectedValue: 'width : 12.5%' },


### PR DESCRIPTION
# 🤷‍♀️ 🤷‍♂️ Besoin : 
En tant qu'utilisateur de Pix Board, je dois pouvoir voir les mêmes valeurs de niveau dans le CSV des snapshots que dans chaque profil utilisateur.

La plateforme peut poser des questions de niveaux supérieurs si un utilisateur est suffisamment doué. Le "vrai" niveau est stocké en base, mais le niveau "obtenu" et donc affiché à l'utilisateur, sera le niveau maximum (actuellement 5).

# 👩‍💻👨‍💻 Technique : 
Le niveau dans l'affichage du profil utilisateur est plafonné, ce n'était pas le cas lors de la sauvegarde du profil dans la table snapshots. Solution :
- Le profil envoyé au front ou sauvegardé côté snapshots est le même, à savoir le plafonné.
- Le front ne gère plus le plafonnage

Dans un ticket tech ultérieur, on voulait supprimer la classe Score, et couper les liens à cat dans assessmentService. Les 2 niveaux (obtenus et réels, à renommer) ne seraient accessibles que via des getters de 'profile'.