### PR TITLE
[TECH] Mise à jour des URL pour Matomo (Piwik).

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function(environment) {
         name: 'Piwik',
         environments: ['production'],
         config: {
-          piwikUrl: 'https://pix.matomo.cloud',
+          piwikUrl: 'https://stats.pix.fr/',
           siteId: 4
         }
       }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function(environment) {
         name: 'Piwik',
         environments: ['production'],
         config: {
-          piwikUrl: 'https://pix.matomo.cloud',
+          piwikUrl: 'https://stats.pix.fr/',
           siteId: 5
         }
       }


### PR DESCRIPTION
pix.matomo.cloud →stats.pix.fr

Comme la vie est bien faite, les IDs ne changent pas 😄