### PR TITLE
[FEATURE] Lors des certifications, il faut que l'on propose toujours 3 épreuves (PF-254).

### DIFF
--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -71,17 +71,16 @@ function _addCourseIdAndPixToCompetence(competences, courses, assessments) {
   return competences;
 }
 
-function _sortThreeMostDifficultSkillsInDesc(skills) {
+function _sortByDifficultyDesc(skills) {
   return _(skills)
     .sortBy('difficulty')
     .reverse()
-    .take(3)
     .value();
 }
 
-function _limitSkillsToTheThreeHighestOrderedByDifficultyDesc(competences) {
+function _orderSkillsOfCompetenceByDifficulty(competences) {
   competences.forEach((competence) => {
-    competence.skills = _sortThreeMostDifficultSkillsInDesc(competence.skills);
+    competence.skills = _sortByDifficultyDesc(competence.skills);
   });
   return competences;
 }
@@ -145,24 +144,30 @@ module.exports = {
           }
         });
 
-        userCompetences = _limitSkillsToTheThreeHighestOrderedByDifficultyDesc(userCompetences);
+        // here :
+        userCompetences = _orderSkillsOfCompetenceByDifficulty(userCompetences);
         const challengeIdsAlreadyAnswered = answers.map((answer) => answer.get('challengeId'));
         const challengesAlreadyAnswered = challengeIdsAlreadyAnswered.map((challengeId) => _getChallengeById(challenges, challengeId));
 
         userCompetences = _addCourseIdAndPixToCompetence(userCompetences, coursesFromAdaptativeCourses, userLastAssessments);
 
         userCompetences.forEach((userCompetence) => {
+          const testedSkills = [];
           userCompetence.skills.forEach((skill) => {
-            const challengesToValidateCurrentSkill = _findChallengeBySkill(challenges, skill);
-            const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
+            if(userCompetence.challenges.length < 3) {
+              const challengesToValidateCurrentSkill = _findChallengeBySkill(challenges, skill);
+              const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
 
-            const challenge = (_.isEmpty(challengesLeftToAnswer)) ? _.first(challengesToValidateCurrentSkill) : _.first(challengesLeftToAnswer);
+              const challenge = (_.isEmpty(challengesLeftToAnswer)) ? _.first(challengesToValidateCurrentSkill) : _.first(challengesLeftToAnswer);
 
-            //TODO : Mettre le skill en entier (Skill{id, name})
-            challenge.testedSkill = skill.name;
+              //TODO : Mettre le skill en entier (Skill{id, name})
+              challenge.testedSkill = skill.name;
+              testedSkills.push(skill);
 
-            userCompetence.addChallenge(challenge);
+              userCompetence.addChallenge(challenge);
+            }
           });
+          userCompetence.skills = testedSkills;
         });
 
         return userCompetences;


### PR DESCRIPTION
**BESOIN** : 
- Actuellement, lors des certifications, nous prenons les 3 acquis de niveau le plus élevés pour une compétence, et nous prenons les épreuves qui valident ces 3 acquis. *Problème* : certaines épreuves validant plusieurs acquis, nous pouvions avoir seulement 2 épreuves pour une compétence, ce qui déséquilibrait le nombre d'épreuves entre les différentes certifications
- *Objectif* : Toujours en cherchant à valider les acquis les plus élevés, on cherche à avoir toujours 3 épreuves, même si une des épreuves valide plusieurs acquis

**TECHNIQUE** : 
- Ce ticket est le strict minimum pour répondre à la problématique fonctionnelle, suite au besoin de mettre en prod à une date précise. Il reprend la manière de faire du code, ainsi que des tests.
- Au lieu de filtrer sur les 3 acquis, l'algo continue de trier les acquis, et filtre sur le nombre d'épreuves par Compétence. Les "skills" de la compétence étant précédemment les skills filtrés (donc que 3), on les met à jour avec les "testedSkills" pour ne pas changer le fonctionnement et ne casser aucun test actuel
- Ajout de tests pour vérifier que l'on prend 3 épreuves là où avant on en aurait pris que 2.

**ATTENTION** : 
- Au vu de la période (Noël) et du besoin de passer le ticket en prod à date précise, tout ce qui est refacto sera fait dans une PR à part.

