### PR TITLE
[FEATURE] Ajouter de la recherche filtrée et paginée des organisations (PA-60)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -20,7 +20,7 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations',
       config: {
-        handler: organisationController.search,
+        handler: organisationController.find,
         tags: ['api', 'organizations'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',

--- a/api/lib/domain/usecases/find-organizations.js
+++ b/api/lib/domain/usecases/find-organizations.js
@@ -1,0 +1,17 @@
+const SearchResultList = require('../models/SearchResultList');
+
+module.exports = function findOrganizations({ filters, pagination, organizationRepository }) {
+
+  return Promise.all([
+    organizationRepository.find(filters, pagination),
+    organizationRepository.count(filters)
+  ]).then(([paginatedResults, totalResults]) => {
+
+    return new SearchResultList({
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      totalResults,
+      paginatedResults
+    });
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -56,6 +56,7 @@ module.exports = injectDependencies({
   findSmartPlacementAssessments: require('./find-smart-placement-assessments'),
   findSnapshots: require('./find-snapshots.js'),
   findUsers: require('./find-users.js'),
+  findOrganizations: require('./find-organizations'),
   getAssessment: require('./get-assessment'),
   getCampaign: require('./get-campaign'),
   getCampaignByCode: require('./get-campaign-by-code'),

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -34,6 +34,19 @@ function _toDomain(bookshelfOrganization) {
   return organization;
 }
 
+function _setSearchFiltersForQueryBuilder(filters, qb) {
+  const { name, type, code } = filters;
+  if (name) {
+    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+  }
+  if (type) {
+    qb.whereRaw('LOWER("type") LIKE ?', `%${type.toLowerCase()}%`);
+  }
+  if (code) {
+    qb.whereRaw('LOWER("code") LIKE ?', `%${code.toLowerCase()}%`);
+  }
+}
+
 module.exports = {
 
   create(organization) {
@@ -101,6 +114,17 @@ module.exports = {
       .where(filters)
       .fetchAll()
       .then((organizations) => organizations.models.map(_toDomain));
+  },
+
+  find(filters, pagination) {
+    const { page, pageSize } = pagination;
+    return BookshelfOrganization.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb))
+      .fetchPage({ page, pageSize })
+      .then((results) => results.map(_toDomain));
+  },
+
+  count(filters) {
+    return BookshelfOrganization.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb)).count();
   },
 
   // TODO return domain object

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -2,7 +2,7 @@ const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
 
-  serialize(organizations) {
+  serialize(organizations, meta) {
     return new Serializer('organizations', {
       attributes: ['name', 'type', 'code', 'logoUrl', 'user', 'members'],
       user: {
@@ -17,6 +17,7 @@ module.exports = {
         if (type === 'members') return 'users';
         return undefined;
       },
+      meta
     }).serialize(organizations);
   },
 

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -35,6 +35,7 @@ function _replyWithAuthorizationError(h) {
 module.exports = {
 
   checkUserIsAuthenticated(request, h) {
+
     const authorizationHeader = request.headers.authorization;
     const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -17,9 +17,9 @@ function _insertOrganization(userId) {
 
 function _insertUser() {
   const userRaw = {
-    'firstName': 'john',
-    'lastName': 'Doe',
-    'email': 'john.Doe@internet.fr',
+    firstName: 'john',
+    lastName: 'Doe',
+    email: 'john.Doe@internet.fr',
     password: 'Pix2017!'
   };
 
@@ -376,7 +376,7 @@ describe('Acceptance | Application | organization-controller', () => {
     let userId;
     const options = {
       method: 'GET',
-      url: '/api/organizations?filter[code]=AAA111',
+      url: '/api/organizations?code=AAA111&type=Sup&name=the',
       headers: {},
     };
 
@@ -413,7 +413,7 @@ describe('Acceptance | Application | organization-controller', () => {
       });
     });
 
-    it('should return the expected organization with no email nor user', () => {
+    it('should return the expected organization', () => {
       // when
       const promise = server.inject(options);
 

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -30,7 +30,7 @@ describe('Integration | Application | Organizations | Routes', () => {
   describe('GET /api/organizations', (_) => {
 
     beforeEach(() => {
-      sinon.stub(organisationController, 'search').returns('ok');
+      sinon.stub(organisationController, 'find').returns('ok');
       return server.register(route);
     });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -363,8 +363,8 @@ describe('Integration | Repository | Organization', function() {
       });
 
       it('should return an empty Array, when organization id is not found', function() {
-        const organizationId = 10083;
-        return organizationRepository.getByUserId(organizationId)
+        const userId = 10083;
+        return organizationRepository.getByUserId(userId)
           .then((organization) => {
             expect(organization).to.deep.equal([]);
           });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -489,7 +489,7 @@ describe('Integration | Repository | Organization', function() {
         return databaseBuilder.commit();
       });
 
-      it('should return only Organizations matching name" if given in filters', async () => {
+      it('should return only Organizations matching "name" if given in filters', async () => {
         // given
         const filters = { name: 'dra' };
         const pagination = { page: 1, pageSize: 10 };
@@ -500,6 +500,7 @@ describe('Integration | Repository | Organization', function() {
         // then
         return promise.then((matchingOrganizations) => {
           expect(matchingOrganizations).to.have.lengthOf(2);
+          expect(_.map(matchingOrganizations, 'name')).to.have.members(['Dragon & co', 'Dragonades & co']);
         });
       });
     });
@@ -524,7 +525,7 @@ describe('Integration | Repository | Organization', function() {
 
         // then
         return promise.then((matchingOrganizations) => {
-          expect(matchingOrganizations).to.have.lengthOf(2);
+          expect(_.map(matchingOrganizations, 'type')).to.have.members(['SUP', 'SCO']);
         });
       });
     });
@@ -548,7 +549,7 @@ describe('Integration | Repository | Organization', function() {
 
         // then
         return promise.then((matchingOrganizations) => {
-          expect(matchingOrganizations).to.have.lengthOf(2);
+          expect(_.map(matchingOrganizations, 'code')).to.have.members(['AZH578', 'AZH002']);
         });
       });
     });
@@ -579,7 +580,33 @@ describe('Integration | Repository | Organization', function() {
 
         // then
         return promise.then((matchingOrganizations) => {
-          expect(matchingOrganizations).to.have.lengthOf(3);
+          expect(_.map(matchingOrganizations, 'name')).to.have.members(['name_ok_1', 'name_ok_2', 'name_ok_3']);
+          expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO', 'SCO']);
+          expect(_.map(matchingOrganizations, 'code')).to.have.members(['c_ok_1', 'c_ok_2', 'c_ok_3']);
+        });
+      });
+    });
+
+    context('when there are filters that should be ignored', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ id: 1 });
+        databaseBuilder.factory.buildOrganization({ id: 2 });
+
+        return databaseBuilder.commit();
+      });
+
+      it('should ignore the filters and retrieve all organizations', () => {
+        // given
+        const filters = { id: 1 };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(_.map(matchingOrganizations, 'id')).to.have.members([1, 2]);
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -10,6 +10,14 @@ const organizationRepository = require('../../../../lib/infrastructure/repositor
 
 describe('Integration | Repository | Organization', function() {
 
+  beforeEach(() => {
+    return databaseBuilder.clean();
+  });
+
+  afterEach(() => {
+    return databaseBuilder.clean();
+  });
+
   describe('#create', () => {
 
     afterEach(() => {
@@ -355,8 +363,8 @@ describe('Integration | Repository | Organization', function() {
       });
 
       it('should return an empty Array, when organization id is not found', function() {
-        const userId = 10083;
-        return organizationRepository.getByUserId(userId)
+        const organizationId = 10083;
+        return organizationRepository.getByUserId(organizationId)
           .then((organization) => {
             expect(organization).to.deep.equal([]);
           });
@@ -421,4 +429,206 @@ describe('Integration | Repository | Organization', function() {
       expect(foundOrganization.user).to.be.undefined;
     });
   });
+
+  describe('#find', () => {
+
+    context('when there are Organizations in the database', () => {
+
+      beforeEach(() => {
+        _.times(3, databaseBuilder.factory.buildOrganization);
+        return databaseBuilder.commit();
+      });
+
+      it('should return an Array of Organizations', async () => {
+        // given
+        const filters = {};
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.exist;
+          expect(matchingOrganizations).to.have.lengthOf(3);
+          expect(matchingOrganizations[0]).to.be.an.instanceOf(Organization);
+        });
+      });
+
+    });
+
+    context('when there are lots of Organizations (> 10) in the database', () => {
+
+      beforeEach(() => {
+        _.times(12, databaseBuilder.factory.buildOrganization);
+        return databaseBuilder.commit();
+      });
+
+      it('should return paginated matching Organizations', async () => {
+        // given
+        const filters = {};
+        const pagination = { page: 1, pageSize: 3 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.have.lengthOf(3);
+        });
+      });
+    });
+
+    context('when there are multiple Organizations matching the same "name" search pattern', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ name: 'Dragon & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Dragonades & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Broca & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Donnie & co' });
+        return databaseBuilder.commit();
+      });
+
+      it('should return only Organizations matching name" if given in filters', async () => {
+        // given
+        const filters = { name: 'dra' };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    context('when there are multiple Organizations matching the same "type" search pattern', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+        databaseBuilder.factory.buildOrganization({ type: 'SUP' });
+        databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        return databaseBuilder.commit();
+      });
+
+      it('should return only Organizations matching "type" if given in filters', async () => {
+        // given
+        const filters = { type: 'S' };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    context('when there are multiple Organizations matching the same "code" search pattern', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ code: 'AZH578' });
+        databaseBuilder.factory.buildOrganization({ code: 'BFR842' });
+        databaseBuilder.factory.buildOrganization({ code: 'AZH002' });
+        return databaseBuilder.commit();
+      });
+
+      it('should return only Organizations matching "code" if given in filters', async () => {
+        // given
+        const filters = { code: 'AZ' };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    context('when there are multiple Organizations matching the fields "first name", "last name" and "email" search pattern', () => {
+
+      beforeEach(() => {
+        // Matching users
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_1', type: 'SCO', code: 'c_ok_1' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_2', type: 'SCO', code: 'c_ok_2' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_3', type: 'SCO', code: 'c_ok_3' });
+
+        // Unmatching users
+        databaseBuilder.factory.buildOrganization({ name: 'name_ko_4', type: 'SCO', code: 'c_ok_4' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_5', type: 'SUP', code: 'c_ok_5' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_6', type: 'SCO', code: 'c_ko_1' });
+
+        return databaseBuilder.commit();
+      });
+
+      it('should return only Organizations matching "name" AND "type" AND "code" if given in filters', async () => {
+        // given
+        const filters = { name: 'name_ok', type: 'SCO', code: 'c_ok' };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = organizationRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingOrganizations) => {
+          expect(matchingOrganizations).to.have.lengthOf(3);
+        });
+      });
+    });
+  });
+
+  describe('#count', () => {
+
+    context('when there are multiple Organizations in database', () => {
+
+      beforeEach(() => {
+        _.times(8, databaseBuilder.factory.buildOrganization);
+        return databaseBuilder.commit();
+      });
+
+      it('should return the total number of Organizations when there is no filter', async () => {
+        // given
+        const filters = {};
+
+        // when
+        const promise = organizationRepository.count(filters);
+
+        // then
+        return promise.then((totalMatchingOrganizations) => {
+          expect(totalMatchingOrganizations).to.equal(8);
+        });
+      });
+    });
+
+    context('when there are multiple Organizations matching the same "name" search pattern', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ name: 'Drago & co' });
+        databaseBuilder.factory.buildOrganization({ name: 'Maxie & co' });
+        return databaseBuilder.commit();
+      });
+
+      it('should return the total number of matching Organizations', async () => {
+        // given
+        const filters = { name: 'dra' };
+
+        // when
+        const promise = organizationRepository.count(filters);
+
+        // then
+        return promise.then((totalMatchingOrganizations) => {
+          expect(totalMatchingOrganizations).to.equal(1);
+        });
+      });
+    });
+  });
+  
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -23,6 +23,14 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     samlId: 'some-saml-id',
   };
 
+  beforeEach(() => {
+    return databaseBuilder.clean();
+  });
+
+  afterEach(() => {
+    return databaseBuilder.clean();
+  });
+
   function _insertUser() {
     return knex('users')
       .insert(userToInsert)
@@ -639,7 +647,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         return promise.then((matchingUsers) => {
-          expect(matchingUsers).to.have.lengthOf(3);
+          expect(_.map(matchingUsers, 'firstName')).to.have.members(['Son Gohan', 'Son Goku', 'Son Goten']);
         });
       });
     });
@@ -669,7 +677,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         return promise.then((matchingUsers) => {
-          expect(matchingUsers).to.have.lengthOf(3);
+          expect(_.map(matchingUsers, 'firstName')).to.have.members(['Anakin', 'Luke', 'Leia']);
         });
       });
     });
@@ -699,7 +707,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         return promise.then((matchingUsers) => {
-          expect(matchingUsers).to.have.lengthOf(3);
+          expect(_.map(matchingUsers, 'email')).to.have.members(['playpus@pix.fr', 'panda@pix.fr', 'otter@pix.fr']);
         });
       });
     });
@@ -734,10 +742,37 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         return promise.then((matchingUsers) => {
-          expect(matchingUsers).to.have.lengthOf(3);
+          expect(_.map(matchingUsers, 'firstName')).to.have.members(['fn_ok_1', 'fn_ok_2', 'fn_ok_3']);
+          expect(_.map(matchingUsers, 'lastName')).to.have.members(['ln_ok_1', 'ln_ok_2', 'ln_ok_3']);
+          expect(_.map(matchingUsers, 'email')).to.have.members(['email_ok_1@mail.com', 'email_ok_2@mail.com', 'email_ok_3@mail.com']);
         });
       });
     });
+
+    context('when there are filters that should be ignored', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildUser({ id: 1 });
+        databaseBuilder.factory.buildUser({ id: 2 });
+
+        return databaseBuilder.commit();
+      });
+
+      it('should ignore the filters and retrieve all users', () => {
+        // given
+        const filters = { id: 1 };
+        const pagination = { page: 1, pageSize: 10 };
+
+        // when
+        const promise = userRepository.find(filters, pagination);
+
+        // then
+        return promise.then((matchingUsers) => {
+          expect(_.map(matchingUsers, 'id')).to.have.members([1, 2]);
+        });
+      });
+    });
+
   });
 
   describe('#count', () => {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -1,0 +1,45 @@
+const { expect, sinon } = require('../../../test-helper');
+const Hapi = require('hapi');
+const organizationController = require('../../../../lib/application/organizations/organization-controller');
+
+const sandbox = sinon.createSandbox();
+
+let server;
+
+function startServer() {
+  server = Hapi.server();
+  return server.register(require('../../../../lib/application/organizations'));
+}
+
+describe('Unit | Router | organization-router', () => {
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('GET /api/organizations', () => {
+
+    beforeEach(() => {
+      sandbox.stub(organizationController, 'find').returns('ok');
+      startServer();
+    });
+
+    it('should exist', () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/organizations?name=DRA&code=AZ&type=SCO&page=3&pageSize=25',
+      };
+
+      // when
+      const promise = server.inject(options);
+
+      // then
+      return promise.then((response) => {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+  });
+
+});

--- a/api/tests/unit/domain/usecases/find-organizations_test.js
+++ b/api/tests/unit/domain/usecases/find-organizations_test.js
@@ -1,0 +1,34 @@
+const { expect } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const SearchResultList = require('../../../../lib/domain/models/SearchResultList');
+const Organization = require('../../../../lib/domain/models/Organization');
+
+describe('Unit | UseCase | find-organizations', () => {
+
+  it('should result a SearchResultList object that take into account Organization search with filtering and pagination', () => {
+    // given
+    const filters = {};
+    const pagination = { page: 1, pageSize: 10 };
+    const matchingOrganizations = [
+      new Organization({ id: 1 }),
+      new Organization({ id: 2 }),
+      new Organization({ id: 3 }),
+    ];
+    const organizationRepository = {
+      find: () => matchingOrganizations,
+      count: () => matchingOrganizations.length
+    };
+
+    // when
+    const promise = usecases.findOrganizations({ filters, pagination, organizationRepository });
+
+    // then
+    return expect(promise).to.be.fulfilled.then((response) => {
+      expect(response).to.be.an.instanceOf(SearchResultList);
+      expect(response.page).to.equal(1);
+      expect(response.pageSize).to.equal(10);
+      expect(response.totalResults).to.equal(3);
+      expect(response.paginatedResults).to.deep.equal(matchingOrganizations);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -8,9 +8,9 @@ describe('Unit | Serializer | organization-serializer', () => {
     it('should return a JSON API serialized organization', () => {
       // given
       const organization = domainBuilder.buildOrganization();
-
+      const meta = { some: 'meta' };
       // when
-      const serializedOrganization = serializer.serialize(organization);
+      const serializedOrganization = serializer.serialize(organization, meta);
 
       // then
       expect(serializedOrganization).to.deep.equal({
@@ -27,6 +27,9 @@ describe('Unit | Serializer | organization-serializer', () => {
             user: { data: null },
             members: { data: [] }
           }
+        },
+        meta: {
+          some: 'meta'
         }
       });
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -37,9 +37,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
           pixOrgaTermsOfServiceAccepted: false,
           pixCertifTermsOfServiceAccepted: false
         });
-
+        const meta = { some: 'meta' };
         // when
-        const json = serializer.serialize(modelObject);
+        const json = serializer.serialize(modelObject, meta);
 
         // then
         expect(json).to.be.deep.equal({
@@ -54,6 +54,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             },
             id: '234567',
             type: 'users'
+          },
+          meta: {
+            some: 'meta'
           }
         });
       });


### PR DESCRIPTION
Lien vers le ticket jira : https://1024pix.atlassian.net/secure/RapidBoard.jspa?rapidView=33&projectKey=PIX&modal=detail&selectedIssue=PA-60

🤷‍♀️ 🤷‍♂️ Besoin :
Pouvoir effectuer une recherche dans des inputs en laissant le serveur totalement responsable de gérer la pagination ainsi que le filtrage des résultats

👩‍💻👨‍💻Technique :
On réutilise et s'inspire beaucoup de ce qui a été fait pour les users. L'ancienne recherche basée sur la notion de service et appelée `search` a été renommée en `find` pour homogénéité avec les users, et a été transposé d'un `service` à un `usecases`

**Attention limitation importante :** la librairie [qu'on utilise](http://onechiporenko.github.io/ember-models-table/v.2/docs/classes/Components.ModelsTableServerPaginated.html) pour gérer les tables dans Ember est complexe et vaste, et ne permet pas de resizer les colonne en 1 clic sur ce type de table (celle paginées par le serveur). Le serveur est responsable d'ordonner les résultats également, ce que l'on ne fait pas. Du coup ils sont renvoyés par ordre d'id, ce qui apparaît clairement dans les users mais pas dans les organisations.