### PR TITLE
[TECH] Mise à jour de sinon.js (API)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -217,13 +217,33 @@
         }
       }
     },
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "3.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "1.3.0",
+        "array-from": "2.1.1",
+        "lodash.get": "4.4.2"
       }
     },
     "abbrev": {
@@ -707,6 +727,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-slice": {
       "version": "1.1.0",
@@ -5356,9 +5382,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "jwa": {
@@ -5570,9 +5596,9 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
       "dev": true
     },
     "longest": {
@@ -5970,16 +5996,24 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "nise": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.1.tgz",
-      "integrity": "sha512-kIH3X5YCj1vvj/32zDa9KNgzvfZd51ItGbiaCbtYhpnsCedLo0tIkb9zl169a41ATzF4z7kwMLz35XXDypma3g==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.3.2",
+        "@sinonjs/formatio": "3.1.0",
+        "just-extend": "4.0.2",
+        "lolex": "2.7.5",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "no-case": {
@@ -8850,12 +8884,6 @@
         }
       }
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -8938,24 +8966,24 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.6.tgz",
-      "integrity": "sha512-bzQag30yErCC4lJPv+C2HcmD1+3ula4JQNePZldKcagi0Exq6XDfcC2yqXVfEwtfTIq1rYGujrUIZbwHPpKjog==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
+        "@sinonjs/commons": "1.3.0",
+        "@sinonjs/formatio": "3.1.0",
+        "@sinonjs/samsam": "3.0.2",
         "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "nise": "1.3.1",
-        "supports-color": "5.3.0",
-        "type-detect": "4.0.8"
+        "lolex": "3.0.0",
+        "nise": "1.4.8",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -8964,9 +8992,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
-      "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
       "dev": true
     },
     "slash": {

--- a/api/package.json
+++ b/api/package.json
@@ -68,8 +68,8 @@
     "nodemon": "^1.17.2",
     "nyc": "^13.0.1",
     "plop": "^2.1.0",
-    "sinon": "^4.4.3",
-    "sinon-chai": "^3.0.0"
+    "sinon": "^7.2.2",
+    "sinon-chai": "^3.3.0"
   },
   "scripts": {
     "clean": "rm -rf node_modules db/*.sqlite3",

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -72,10 +72,6 @@ describe('Acceptance | Controller | password-controller', () => {
         sinon.stub(mailjetService, 'sendResetPasswordDemandEmail').resolves();
       });
 
-      afterEach(() => {
-        mailjetService.sendResetPasswordDemandEmail.restore();
-      });
-
       it('should reply with 201', () => {
         // when
         const promise = server.inject(options);
@@ -102,10 +98,6 @@ describe('Acceptance | Controller | password-controller', () => {
         };
 
         sinon.stub(resetPasswordDemandRepository, 'create').rejects(new Error());
-      });
-
-      afterEach(() => {
-        resetPasswordDemandRepository.create.restore();
       });
 
       it('should reply with 500', () => {
@@ -202,10 +194,6 @@ describe('Acceptance | Controller | password-controller', () => {
 
       beforeEach(() => {
         sinon.stub(resetPasswordService, 'verifyDemand').rejects(new Error());
-      });
-
-      afterEach(() => {
-        resetPasswordService.verifyDemand.restore();
       });
 
       it('should reply with 500 status code', () => {

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -93,23 +93,17 @@ const spConfig = {
 };
 
 describe('Acceptance | Controller | saml-controller', () => {
-  let sandbox;
   let server;
 
   beforeEach(async () => {
     server = await createServer();
-    sandbox = sinon.createSandbox();
-    sandbox.stub(settings.saml, 'spConfig').value(spConfig);
-    sandbox.stub(settings.saml, 'idpConfig').value(idpConfig);
-    sandbox.stub(settings.saml, 'attributeMapping').value({
+    sinon.stub(settings.saml, 'spConfig').value(spConfig);
+    sinon.stub(settings.saml, 'idpConfig').value(idpConfig);
+    sinon.stub(settings.saml, 'attributeMapping').value({
       samlId: 'IDO',
       firstName: 'PRE',
       lastName: 'NOM',
     });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('GET /api/saml/metadata.xml', () => {

--- a/api/tests/acceptance/application/snapshot-controller_test.js
+++ b/api/tests/acceptance/application/snapshot-controller_test.js
@@ -117,11 +117,6 @@ describe('Acceptance | Controller | snapshot-controller', () => {
       sinon.stub(profileService, 'getByUserId').resolves(fakeBuildedProfile);
     });
 
-    afterEach(() => {
-      authorizationToken.verify.restore();
-      profileService.getByUserId.restore();
-    });
-
     context('When creating with a correct payload', () => {
 
       it('should return 201 HTTP status code', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-profile_test.js
@@ -173,7 +173,6 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
     describe('Success cases:', () => {
 
       let profileServiceStub;
-      let userRepositoryStub;
       const user = new User({
         id: 1234,
         'first-name': faker.name.firstName(),
@@ -184,13 +183,8 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
       });
 
       beforeEach(() => {
-        userRepositoryStub = sinon.stub(userRepository, 'findUserById').resolves(user);
+        sinon.stub(userRepository, 'findUserById').resolves(user);
         profileServiceStub = sinon.stub(profileService, 'getByUserId');
-      });
-
-      afterEach(() => {
-        profileServiceStub.restore();
-        userRepositoryStub.restore();
       });
 
       it('should response with 201 HTTP status code, when authorization is valid and user is found', () => {
@@ -212,10 +206,6 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
 
       beforeEach(() => {
         sinon.stub(userRepository, 'findUserById').resolves();
-      });
-
-      afterEach(() => {
-        userRepository.findUserById.restore();
       });
 
       it('should response with 401 HTTP status code, when authorization token is not valid', () => {

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | Controller | users-controller', () => {
       let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(mailJet, 'sendEmail');
 
         nock('https://www.google.com')

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -34,11 +34,8 @@ describe('Acceptance | Controller | users-controller', () => {
         },
       };
 
-      let sandbox;
-
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
-        sandbox.stub(mailJet, 'sendEmail');
+        sinon.stub(mailJet, 'sendEmail');
 
         nock('https://www.google.com')
           .post('/recaptcha/api/siteverify')
@@ -50,7 +47,6 @@ describe('Acceptance | Controller | users-controller', () => {
 
       afterEach(() => {
         nock.cleanAll();
-        sandbox.restore();
         return knex('users').delete();
       });
 

--- a/api/tests/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/integration/application/assessments/assessment-controller_test.js
@@ -8,18 +8,12 @@ describe('Integration | Application | Assessments | assessment-controller', () =
 
   const assessment = domainBuilder.buildAssessment({ id: 1234 });
 
-  const sandbox = sinon.createSandbox();
-
   let httpTestServer;
 
   beforeEach(() => {
-    sandbox.stub(usecases, 'getAssessment');
-    sandbox.stub(assessmentAuthorization, 'verify');
+    sinon.stub(usecases, 'getAssessment');
+    sinon.stub(assessmentAuthorization, 'verify');
     httpTestServer = new HttpTestServer(moduleUnderTest);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#get', () => {

--- a/api/tests/integration/application/assessments/assessment-controller_test.js
+++ b/api/tests/integration/application/assessments/assessment-controller_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Assessments | assessment-controller', () =
 
   const assessment = domainBuilder.buildAssessment({ id: 1234 });
 
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   let httpTestServer;
 

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -27,7 +27,6 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
 
   afterEach(() => {
     server.stop();
-    authenticationController.save.restore();
   });
 
   describe('POST /api/authentications', () => {
@@ -76,10 +75,6 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       server = Hapi.server();
 
       return server.register(require('../../../../lib/application/authentication'));
-    });
-
-    afterEach(() => {
-      authenticationController.authenticateUser.restore();
     });
 
     it('should return a response with HTTP status code 200 when route handler (a.k.a. controller) is successful', async () => {

--- a/api/tests/integration/application/campaignParticipations/index_test.js
+++ b/api/tests/integration/application/campaignParticipations/index_test.js
@@ -5,12 +5,10 @@ const campaignParticipationController = require('../../../../lib/application/cam
 describe('Integration | Application | Route | campaignParticipationRouter', () => {
 
   let server;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(campaignParticipationController, 'shareCampaignResult').callsFake((request, h) => h.response('ok').code(201));
-    sandbox.stub(campaignParticipationController, 'getCampaignParticipationByAssessment').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignParticipationController, 'shareCampaignResult').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignParticipationController, 'getCampaignParticipationByAssessment').callsFake((request, h) => h.response('ok').code(201));
 
     server = Hapi.server();
 
@@ -18,7 +16,6 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
   });
 
   afterEach(() => {
-    sandbox.restore();
     server.stop();
   });
 

--- a/api/tests/integration/application/campaignParticipations/index_test.js
+++ b/api/tests/integration/application/campaignParticipations/index_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(campaignParticipationController, 'shareCampaignResult').callsFake((request, h) => h.response('ok').code(201));
     sandbox.stub(campaignParticipationController, 'getCampaignParticipationByAssessment').callsFake((request, h) => h.response('ok').code(201));
 

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -17,11 +17,6 @@ describe('Integration | Application | Route | campaignRouter', () => {
   });
 
   afterEach(() => {
-    campaignController.save.restore();
-    campaignController.getCsvResults.restore();
-    campaignController.getById.restore();
-    campaignController.update.restore();
-
     server.stop();
   });
 

--- a/api/tests/integration/application/certifications/index_test.js
+++ b/api/tests/integration/application/certifications/index_test.js
@@ -18,11 +18,6 @@ describe('Integration | Application | Route | Certifications', () => {
   });
 
   afterEach(() => {
-    certificationController.findUserCertifications.restore();
-    certificationController.updateCertification.restore();
-    certificationController.getCertification.restore();
-    securityController.checkUserHasRolePixMaster.restore();
-
     server.stop();
   });
 

--- a/api/tests/integration/application/corrections/index_test.js
+++ b/api/tests/integration/application/corrections/index_test.js
@@ -17,7 +17,6 @@ describe('Integration | Application | Route | Corrections ', () => {
 
   afterEach(() => {
     server.stop();
-    correctionsController.findByAnswerId.restore();
   });
 
   describe('GET /api/corrections?answerId=234', () => {

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 const organisationController = require('../../../../lib/application/organizations/organization-controller');
+const route = require('../../../../lib/application/organizations/index');
 
 describe('Integration | Application | Organizations | Routes', () => {
 
@@ -9,19 +10,14 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   beforeEach(() => {
     server = Hapi.server();
-    return server.register(require('../../../../lib/application/organizations/index'));
   });
 
   describe('POST /api/organizations', (_) => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(organisationController, 'create').returns('ok');
-    });
-
-    after(() => {
-      securityController.checkUserHasRolePixMaster.restore();
-      organisationController.create.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {
@@ -33,12 +29,9 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   describe('GET /api/organizations', (_) => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(organisationController, 'search').returns('ok');
-    });
-
-    after(() => {
-      organisationController.search.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {
@@ -50,12 +43,9 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   describe('GET /api/organizations/:id/snapshots', (_) => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(organisationController, 'getSharedProfiles').returns('ok');
-    });
-
-    after(() => {
-      organisationController.getSharedProfiles.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {
@@ -67,12 +57,9 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   describe('GET /api/organizations/:id/campaigns', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(organisationController, 'getCampaigns').returns('ok');
-    });
-
-    after(() => {
-      organisationController.getCampaigns.restore();
+      return server.register(route);
     });
 
     it('should call the organization controller to get the campaigns', () => {

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -16,11 +16,6 @@ describe('Integration | Application | Organizations | organization-controller', 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
-  afterEach(() => {
-    usecases.updateOrganizationInformation.restore();
-    securityController.checkUserHasRolePixMaster.restore();
-  });
-
   describe('#updateOrganizationInformation', () => {
 
     const payload = {

--- a/api/tests/integration/domain/services/scoring/scoring-certification_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-certification_test.js
@@ -30,7 +30,7 @@ describe('Integration | Domain | services | scoring | scoring-certification', ()
 
     const dependencies = { competenceRepository };
 
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
       sandbox.stub(competenceRepository, 'list').resolves(competences);

--- a/api/tests/integration/domain/services/scoring/scoring-certification_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-certification_test.js
@@ -30,15 +30,9 @@ describe('Integration | Domain | services | scoring | scoring-certification', ()
 
     const dependencies = { competenceRepository };
 
-    const sandbox = sinon.createSandbox();
-
     beforeEach(() => {
-      sandbox.stub(competenceRepository, 'list').resolves(competences);
-      sandbox.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves({ competencesWithMark });
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(competenceRepository, 'list').resolves(competences);
+      sinon.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves({ competencesWithMark });
     });
 
     context('when an error occurred', () => {

--- a/api/tests/integration/domain/services/scoring/scoring-placement_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-placement_test.js
@@ -35,7 +35,7 @@ describe('Integration | Domain | services | scoring | scoring-placement', () => 
 
     const dependencies = { answerRepository, challengeRepository, competenceRepository, courseRepository, skillRepository };
 
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
       sandbox.stub(competenceRepository, 'get').resolves(competence);

--- a/api/tests/integration/domain/services/scoring/scoring-placement_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-placement_test.js
@@ -35,18 +35,12 @@ describe('Integration | Domain | services | scoring | scoring-placement', () => 
 
     const dependencies = { answerRepository, challengeRepository, competenceRepository, courseRepository, skillRepository };
 
-    const sandbox = sinon.createSandbox();
-
     beforeEach(() => {
-      sandbox.stub(competenceRepository, 'get').resolves(competence);
-      sandbox.stub(courseRepository, 'get').resolves(course);
-      sandbox.stub(skillRepository, 'findByCompetenceId').resolves([skill_web1, skill_web2]);
-      sandbox.stub(challengeRepository, 'findByCompetenceId').resolves(challenges);
-      sandbox.stub(answerRepository, 'findByAssessment').resolves([answer_web1_ok, answer_web2_ko]);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(competenceRepository, 'get').resolves(competence);
+      sinon.stub(courseRepository, 'get').resolves(course);
+      sinon.stub(skillRepository, 'findByCompetenceId').resolves([skill_web1, skill_web2]);
+      sinon.stub(challengeRepository, 'findByCompetenceId').resolves(challenges);
+      sinon.stub(answerRepository, 'findByAssessment').resolves([answer_web1_ok, answer_web2_ko]);
     });
 
     context('when an error occurred', () => {

--- a/api/tests/integration/domain/services/smart-random/SmartRandom_test.js
+++ b/api/tests/integration/domain/services/smart-random/SmartRandom_test.js
@@ -630,7 +630,6 @@ describe('Integration | Domain | strategies | smart-random | SmartRandom', () =>
 
         // This is where we assert the randomness behavior to have deterministic test
         expect(_.sample).to.have.been.called;
-        _.sample.restore();
       });
     });
 

--- a/api/tests/integration/infrastructure/airtable_test.js
+++ b/api/tests/integration/infrastructure/airtable_test.js
@@ -13,7 +13,7 @@ function assertAirtableRecordToEqualExpected(actualRecord, expectedRecord) {
 
 describe('Integration | Infrastructure | airtable', () => {
 
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   const findStub = sandbox.stub();
   const allStub = sandbox.stub();

--- a/api/tests/integration/infrastructure/airtable_test.js
+++ b/api/tests/integration/infrastructure/airtable_test.js
@@ -13,16 +13,14 @@ function assertAirtableRecordToEqualExpected(actualRecord, expectedRecord) {
 
 describe('Integration | Infrastructure | airtable', () => {
 
-  const sandbox = sinon.createSandbox();
-
-  const findStub = sandbox.stub();
-  const allStub = sandbox.stub();
+  const findStub = sinon.stub();
+  const allStub = sinon.stub();
 
   beforeEach(() => {
-    sandbox.stub(cache, 'get');
-    sandbox.stub(cache, 'set');
-    sandbox.stub(Airtable.prototype, 'init').returns();
-    sandbox.stub(Airtable.prototype, 'base').returns({
+    sinon.stub(cache, 'get');
+    sinon.stub(cache, 'set');
+    sinon.stub(Airtable.prototype, 'init').returns();
+    sinon.stub(Airtable.prototype, 'base').returns({
       table() {
         return {
           find: findStub,
@@ -34,10 +32,6 @@ describe('Integration | Infrastructure | airtable', () => {
         };
       }
     });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#getRecord{SkipCache}', () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -218,7 +218,6 @@ describe('Integration | Repository | Campaign Participation', () => {
   describe('#updateCampaignParticipation', () => {
 
     let campaignParticipation;
-    let clock;
     const frozenTime = new Date('1987-09-01:00:00.000+01:00');
 
     beforeEach(async () => {
@@ -227,13 +226,12 @@ describe('Integration | Repository | Campaign Participation', () => {
         sharedAt: null,
       });
 
-      clock = sinon.useFakeTimers(frozenTime);
+      sinon.useFakeTimers(frozenTime);
 
       await databaseBuilder.commit();
     });
 
     afterEach(async () => {
-      clock.restore();
       await databaseBuilder.clean();
     });
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -25,7 +25,6 @@ describe('Integration | Repository | Target-profile', () => {
     });
 
     afterEach(async () => {
-      skillDatasource.findByRecordIds.restore();
       await databaseBuilder.clean();
     });
 
@@ -71,7 +70,6 @@ describe('Integration | Repository | Target-profile', () => {
     });
 
     afterEach(async () => {
-      skillDatasource.findByRecordIds.restore();
       await databaseBuilder.clean();
     });
 
@@ -144,7 +142,6 @@ describe('Integration | Repository | Target-profile', () => {
     });
 
     afterEach(async () => {
-      skillDatasource.findByRecordIds.restore();
       await databaseBuilder.clean();
     });
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -7,6 +7,10 @@ chai.use(require('chai-as-promised'));
 const sinon = require('sinon');
 chai.use(require('sinon-chai'));
 
+afterEach(function() {
+  sinon.restore();
+});
+
 // Knex
 const knexConfig = require('../db/knexfile');
 const knex = require('knex')(knexConfig['test']);

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -10,11 +10,6 @@ const Hapi = require('hapi');
  *   sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, reply) => reply(true));
  *   httpTestServer = new HttpTestServer(moduleUnderTest);
  * });
- *
- * afterEach(() => {
- *   usecases.updateOrganizationInformation.restore();
- *   securityController.checkUserHasRolePixMaster.restore();
- * });
  */
 class HttpTestServer {
 

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -14,7 +14,7 @@ describe('Unit | Controller | answer-controller', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(answerSerializer, 'serialize');
     sandbox.stub(answerRepository, 'findByChallengeAndAssessment');

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -11,20 +11,14 @@ const smartPlacementAssessmentRepository =
 const { ChallengeAlreadyAnsweredError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Controller | answer-controller', () => {
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(answerSerializer, 'serialize');
-    sandbox.stub(answerRepository, 'findByChallengeAndAssessment');
-    sandbox.stub(smartPlacementAssessmentRepository, 'get');
-    sandbox.stub(usecases, 'correctAnswerThenUpdateAssessment');
-    sandbox.stub(logger, 'error');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(answerSerializer, 'serialize');
+    sinon.stub(answerRepository, 'findByChallengeAndAssessment');
+    sinon.stub(smartPlacementAssessmentRepository, 'get');
+    sinon.stub(usecases, 'correctAnswerThenUpdateAssessment');
+    sinon.stub(logger, 'error');
   });
 
   describe('#save', () => {

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -5,15 +5,13 @@ const AnswerController = require('../../../../lib/application/answers/answer-con
 describe('Unit | Router | answer-router', function() {
 
   let server;
-  let sandbox;
 
   beforeEach(function() {
 
-    sandbox = sinon.createSandbox();
-    sandbox.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
-    sandbox.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
-    sandbox.stub(AnswerController, 'findByChallengeAndAssessment').callsFake((request, h) => h.response().code(200));
-    sandbox.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
+    sinon.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
+    sinon.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
+    sinon.stub(AnswerController, 'findByChallengeAndAssessment').callsFake((request, h) => h.response().code(200));
+    sinon.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
 
     server = Hapi.server();
 
@@ -21,7 +19,6 @@ describe('Unit | Router | answer-router', function() {
   });
 
   afterEach(() => {
-    sandbox.restore();
     server.stop();
   });
 

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -9,7 +9,7 @@ describe('Unit | Router | answer-router', function() {
 
   beforeEach(function() {
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
     sandbox.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
     sandbox.stub(AnswerController, 'findByChallengeAndAssessment').callsFake((request, h) => h.response().code(200));

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -39,7 +39,7 @@ describe('Unit | Controller | assessment-results', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(usecases, 'createAssessmentResultForCompletedAssessment').resolves();
       sandbox.stub(logger, 'error');
     });
@@ -163,7 +163,7 @@ describe('Unit | Controller | assessment-results', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(assessmentResultService, 'save').resolves();
     });

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -16,8 +16,6 @@ describe('Unit | Controller | assessment-results', () => {
 
   describe('#evaluate', () => {
 
-    let sandbox;
-
     const request = {
       payload: {
         data: {
@@ -39,13 +37,8 @@ describe('Unit | Controller | assessment-results', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'createAssessmentResultForCompletedAssessment').resolves();
-      sandbox.stub(logger, 'error');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'createAssessmentResultForCompletedAssessment').resolves();
+      sinon.stub(logger, 'error');
     });
 
     it('should evaluate the assessment', async () => {
@@ -118,8 +111,6 @@ describe('Unit | Controller | assessment-results', () => {
 
   describe('#save', () => {
 
-    let sandbox;
-
     const request = {
       payload: {
         data: {
@@ -163,13 +154,8 @@ describe('Unit | Controller | assessment-results', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(assessmentResultService, 'save').resolves();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(assessmentResultService, 'save').resolves();
     });
 
     it('should return a Assessment Result and an Array of Competence Marks', async () => {

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -31,7 +31,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       assessmentWithoutScore = Assessment.fromAttributes({
         id: 1,

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -19,7 +19,6 @@ const Skill = require('../../../../lib/cat/skill');
 describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
   describe('#getNextChallenge', () => {
-    let sandbox;
     let assessmentWithoutScore;
     let assessmentWithScore;
     let scoredAsssessment;
@@ -31,7 +30,6 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
       assessmentWithoutScore = Assessment.fromAttributes({
         id: 1,
@@ -52,21 +50,17 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         skills: assessmentSkills,
       };
 
-      sandbox.stub(skillService, 'saveAssessmentSkills').resolves();
-      sandbox.stub(assessmentRepository, 'get');
-      sandbox.stub(assessmentRepository, 'save');
-      sandbox.stub(challengeRepository, 'get').resolves({});
-      sandbox.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
+      sinon.stub(skillService, 'saveAssessmentSkills').resolves();
+      sinon.stub(assessmentRepository, 'get');
+      sinon.stub(assessmentRepository, 'save');
+      sinon.stub(challengeRepository, 'get').resolves({});
+      sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
 
-      sandbox.stub(usecases, 'getAssessment').resolves(scoredAsssessment);
-      sandbox.stub(usecases, 'getNextChallengeForCertification').resolves();
-      sandbox.stub(usecases, 'getNextChallengeForDemo').resolves();
-      sandbox.stub(usecases, 'getNextChallengeForSmartPlacement').resolves();
-      sandbox.stub(certificationChallengeRepository, 'getNonAnsweredChallengeByCourseId').resolves();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'getAssessment').resolves(scoredAsssessment);
+      sinon.stub(usecases, 'getNextChallengeForCertification').resolves();
+      sinon.stub(usecases, 'getNextChallengeForDemo').resolves();
+      sinon.stub(usecases, 'getNextChallengeForSmartPlacement').resolves();
+      sinon.stub(certificationChallengeRepository, 'getNonAnsweredChallengeByCourseId').resolves();
     });
 
     // TODO: Que faire si l'assessment n'existe pas pas ?

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -17,7 +17,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -14,16 +14,6 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
   describe('#save', () => {
 
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     context('when the assessment saved is a smart placement', () => {
 
       const request = {
@@ -43,7 +33,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       beforeEach(() => {
-        sandbox.stub(usecases, 'createAssessmentForCampaign').resolves({});
+        sinon.stub(usecases, 'createAssessmentForCampaign').resolves({});
       });
 
       it('should save an assessment with the type SMART_PLACEMENT and with a fake courseId', async function() {
@@ -96,7 +86,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       beforeEach(() => {
-        sandbox.stub(assessmentRepository, 'save').resolves({});
+        sinon.stub(assessmentRepository, 'save').resolves({});
       });
 
       it('should save an assessment with the type CERTIFICATION', async function() {
@@ -158,7 +148,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       beforeEach(() => {
-        sandbox.stub(assessmentRepository, 'save').resolves({});
+        sinon.stub(assessmentRepository, 'save').resolves({});
       });
 
       it('should save an assessment with type PREVIEW', async function() {
@@ -220,8 +210,8 @@ describe('Unit | Controller | assessment-controller-save', () => {
           state: null,
         });
 
-        sandbox.stub(assessmentSerializer, 'deserialize').returns(assessmentToStart);
-        sandbox.stub(usecases, 'startPlacementAssessment').resolves(startedAssessment);
+        sinon.stub(assessmentSerializer, 'deserialize').returns(assessmentToStart);
+        sinon.stub(usecases, 'startPlacementAssessment').resolves(startedAssessment);
 
         // when
         const promise = controller.save(request, hFake);
@@ -240,8 +230,8 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
         const expectedError = { errors: [{ code: '409', detail: 'Error', title: 'Conflict' }] };
 
-        sandbox.stub(assessmentSerializer, 'deserialize').returns(assessmentToStart);
-        sandbox.stub(usecases, 'startPlacementAssessment').throws(new AssessmentStartError('Error'));
+        sinon.stub(assessmentSerializer, 'deserialize').returns(assessmentToStart);
+        sinon.stub(usecases, 'startPlacementAssessment').throws(new AssessmentStartError('Error'));
 
         // when
         const promise = controller.save(request, hFake);
@@ -305,10 +295,10 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       beforeEach(() => {
-        sandbox.stub(assessmentSerializer, 'deserialize').returns(deserializedAssessment);
-        sandbox.stub(tokenService, 'extractUserId').returns('userId');
-        sandbox.stub(assessmentRepository, 'save').resolves(deserializedAssessment);
-        sandbox.stub(assessmentSerializer, 'serialize').returns(serializedAssessment);
+        sinon.stub(assessmentSerializer, 'deserialize').returns(deserializedAssessment);
+        sinon.stub(tokenService, 'extractUserId').returns('userId');
+        sinon.stub(assessmentRepository, 'save').resolves(deserializedAssessment);
+        sinon.stub(assessmentSerializer, 'serialize').returns(serializedAssessment);
       });
 
       it('should de-serialize the payload', () => {
@@ -378,7 +368,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       beforeEach(() => {
-        sandbox.stub(assessmentRepository, 'save');
+        sinon.stub(assessmentRepository, 'save');
       });
 
       it('should throw a badImplementationError', () => {

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -284,7 +284,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
       };
 
       const deserializedAssessment = Assessment.fromAttributes({ id: 42, courseId: 'recCourseId', type: 'PLACEMENT' });
-      const assessment = {
+      const assessment = Assessment.fromAttributes({
         id: 42,
         courseId: 'recCourseId',
         createdAt: undefined,
@@ -296,7 +296,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
         course: undefined,
         targetProfile: undefined,
         campaignParticipation: undefined,
-      };
+      });
       const serializedAssessment = {
         id: 42,
         attributes: {

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -8,8 +8,6 @@ describe('Unit | Controller | assessment-controller', function() {
 
   describe('#findByFilters', () => {
 
-    let sandbox;
-
     const assessments = [{ id: 1 }, { id: 2 }];
     const assessmentsInJSONAPI = [{
       id: 1,
@@ -24,16 +22,11 @@ describe('Unit | Controller | assessment-controller', function() {
     const userId = 24504875;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(useCases, 'findCertificationAssessments');
-      sandbox.stub(useCases, 'findPlacementAssessments');
-      sandbox.stub(useCases, 'findSmartPlacementAssessments');
-      sandbox.stub(assessmentSerializer, 'serializeArray');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(useCases, 'findCertificationAssessments');
+      sinon.stub(useCases, 'findPlacementAssessments');
+      sinon.stub(useCases, 'findSmartPlacementAssessments');
+      sinon.stub(assessmentSerializer, 'serializeArray');
     });
 
     it('should serialize assessment to JSON API', async function() {

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -24,7 +24,7 @@ describe('Unit | Controller | assessment-controller', function() {
     const userId = 24504875;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(useCases, 'findCertificationAssessments');
       sandbox.stub(useCases, 'findPlacementAssessments');

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -21,7 +21,7 @@ describe('Integration | Route | AssessmentRoute', () => {
 
   beforeEach(() => {
     // stub dependencies
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(assessmentController, 'save');
     sandbox.stub(assessmentController, 'getNextChallenge');
     sandbox.stub(assessmentController, 'findByFilters');

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -6,7 +6,6 @@ const securityController = require('../../../../lib/interfaces/controllers/secur
 
 describe('Integration | Route | AssessmentRoute', () => {
 
-  let sandbox;
   let server;
 
   function _expectRouteToExist(routeOptions) {
@@ -21,13 +20,12 @@ describe('Integration | Route | AssessmentRoute', () => {
 
   beforeEach(() => {
     // stub dependencies
-    sandbox = sinon.createSandbox();
-    sandbox.stub(assessmentController, 'save');
-    sandbox.stub(assessmentController, 'getNextChallenge');
-    sandbox.stub(assessmentController, 'findByFilters');
-    sandbox.stub(assessmentController, 'get');
-    sandbox.stub(assessmentAuthorization, 'verify');
-    sandbox.stub(securityController, 'checkUserHasRolePixMaster');
+    sinon.stub(assessmentController, 'save');
+    sinon.stub(assessmentController, 'getNextChallenge');
+    sinon.stub(assessmentController, 'findByFilters');
+    sinon.stub(assessmentController, 'get');
+    sinon.stub(assessmentAuthorization, 'verify');
+    sinon.stub(securityController, 'checkUserHasRolePixMaster');
 
     // instance server
     server = this.server = Hapi.server();
@@ -36,7 +34,6 @@ describe('Integration | Route | AssessmentRoute', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     server.stop();
   });
 

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -8,10 +8,8 @@ describe('Unit | Application | Controller | Authentication', () => {
 
   describe('#authenticateUser', () => {
     let request;
-    let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
       request = {
         headers: {
@@ -24,12 +22,8 @@ describe('Unit | Application | Controller | Authentication', () => {
           scope: 'pix-orga'
         }
       };
-      sandbox.stub(usecases, 'authenticateUser').resolves('jwt.access.token');
-      sandbox.stub(tokenService, 'extractUserId').returns(1);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'authenticateUser').resolves('jwt.access.token');
+      sinon.stub(tokenService, 'extractUserId').returns(1);
     });
 
     it('should check user credentials', async () => {

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -103,10 +103,6 @@ describe('Unit | Controller | cache-controller', () => {
       sinon.stub(usecases, 'removeAllCacheEntries');
     });
 
-    afterEach(() => {
-      usecases.removeAllCacheEntries.restore();
-    });
-
     it('should reply with 204 when there is no error', async () => {
       // given
       usecases.removeAllCacheEntries.resolves();
@@ -145,10 +141,6 @@ describe('Unit | Controller | cache-controller', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'preloadCacheEntries');
-    });
-
-    afterEach(() => {
-      usecases.preloadCacheEntries.restore();
     });
 
     it('should reply with 204 when there is no error', async () => {

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -6,15 +6,6 @@ const logger = require('../../../../lib/infrastructure/logger');
 const cacheController = require('../../../../lib/application/cache/cache-controller');
 
 describe('Unit | Controller | cache-controller', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   describe('#reloadCacheEntry', () => {
 
@@ -25,7 +16,7 @@ describe('Unit | Controller | cache-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox.stub(usecases, 'reloadCacheEntry');
+      sinon.stub(usecases, 'reloadCacheEntry');
     });
 
     it('should reply with 204 when the cache key exists', async () => {

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -9,7 +9,7 @@ describe('Unit | Router | cache-router', () => {
   let server;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(cacheController, 'reloadCacheEntry').callsFake((request, h) => h.response().code(204));
     sandbox.stub(cacheController, 'removeAllCacheEntries').callsFake((request, h) => h.response().code(204));
     sandbox.stub(cacheController, 'preloadCacheEntries').callsFake((request, h) => h.response().code(204));

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -5,15 +5,13 @@ const securityController = require('../../../../lib/interfaces/controllers/secur
 
 describe('Unit | Router | cache-router', () => {
 
-  let sandbox;
   let server;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(cacheController, 'reloadCacheEntry').callsFake((request, h) => h.response().code(204));
-    sandbox.stub(cacheController, 'removeAllCacheEntries').callsFake((request, h) => h.response().code(204));
-    sandbox.stub(cacheController, 'preloadCacheEntries').callsFake((request, h) => h.response().code(204));
-    sandbox.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+    sinon.stub(cacheController, 'reloadCacheEntry').callsFake((request, h) => h.response().code(204));
+    sinon.stub(cacheController, 'removeAllCacheEntries').callsFake((request, h) => h.response().code(204));
+    sinon.stub(cacheController, 'preloadCacheEntries').callsFake((request, h) => h.response().code(204));
+    sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
     server = Hapi.server();
 
@@ -21,7 +19,6 @@ describe('Unit | Router | cache-router', () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
     server.stop();
   });
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -12,24 +12,15 @@ const { UserNotAuthorizedToCreateCampaignError,
 } = require('../../../../lib/domain/errors');
 
 describe('Unit | Application | Controller | Campaign', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   describe('#save', () => {
 
     const deserializedCampaign = domainBuilder.buildCampaign({ id: NaN, code: '' });
 
     beforeEach(() => {
-      sandbox.stub(usecases, 'createCampaign');
-      sandbox.stub(campaignSerializer, 'deserialize').resolves(deserializedCampaign);
-      sandbox.stub(campaignSerializer, 'serialize');
+      sinon.stub(usecases, 'createCampaign');
+      sinon.stub(campaignSerializer, 'deserialize').resolves(deserializedCampaign);
+      sinon.stub(campaignSerializer, 'serialize');
     });
 
     it('should call the use case to create the new campaign', async () => {
@@ -159,17 +150,11 @@ describe('Unit | Application | Controller | Campaign', () => {
   });
 
   describe('#getCsvResult', () => {
-    let sandbox;
     const userId = 1;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'getResultsCampaignInCSVFormat');
-      sandbox.stub(tokenService, 'extractUserIdForCampaignResults').resolves(userId);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'getResultsCampaignInCSVFormat');
+      sinon.stub(tokenService, 'extractUserIdForCampaignResults').resolves(userId);
     });
 
     it('should call the use case to get result campaign in csv', async () => {
@@ -255,8 +240,8 @@ describe('Unit | Application | Controller | Campaign', () => {
       request = {
         query: { 'filter[code]': campaignCode }
       };
-      sandbox.stub(usecases, 'getCampaignByCode');
-      sandbox.stub(campaignSerializer, 'serialize');
+      sinon.stub(usecases, 'getCampaignByCode');
+      sinon.stub(campaignSerializer, 'serialize');
     });
 
     it('should call the use case to retrieve the campaign with the expected code', async () => {
@@ -329,8 +314,8 @@ describe('Unit | Application | Controller | Campaign', () => {
         }
       };
 
-      sandbox.stub(usecases, 'getCampaign');
-      sandbox.stub(campaignSerializer, 'serialize');
+      sinon.stub(usecases, 'getCampaign');
+      sinon.stub(campaignSerializer, 'serialize');
     });
 
     it('should returns the campaign', async () => {
@@ -400,8 +385,8 @@ describe('Unit | Application | Controller | Campaign', () => {
         customLandingPageText: updatedCampaign.customLandingPageText,
       };
 
-      sandbox.stub(usecases, 'updateCampaign');
-      sandbox.stub(campaignSerializer, 'serialize');
+      sinon.stub(usecases, 'updateCampaign');
+      sinon.stub(campaignSerializer, 'serialize');
     });
 
     it('should returns the updated campaign', async () => {

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -16,7 +16,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(queryParamsUtils, 'extractFilters').resolves(resultFilter);
       sandbox.stub(usecases, 'findCampaignParticipationsByAssessmentId');
     });
@@ -170,7 +170,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     const userId = 6;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(usecases, 'startCampaignParticipation');
       sandbox.stub(serializer, 'serialize');
       request = {

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -10,19 +10,13 @@ const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-par
 describe('Unit | Application | Controller | Campaign-Participation', () => {
 
   describe('#getCampaignParticipationByAssessment', () => {
-    let sandbox;
     const resultFilter = {
       assessmentId: 4,
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(queryParamsUtils, 'extractFilters').resolves(resultFilter);
-      sandbox.stub(usecases, 'findCampaignParticipationsByAssessmentId');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(queryParamsUtils, 'extractFilters').resolves(resultFilter);
+      sinon.stub(usecases, 'findCampaignParticipationsByAssessmentId');
     });
 
     it('should call the usecases to get the campaign participations of the given assessmentId', async () => {
@@ -44,18 +38,12 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
   });
 
   describe('#shareCampaignResult', () => {
-    let sandbox;
     const userId = 1;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'shareCampaignResult');
-      sandbox.stub(tokenService, 'extractTokenFromAuthChain').resolves();
-      sandbox.stub(tokenService, 'extractUserId').resolves(userId);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'shareCampaignResult');
+      sinon.stub(tokenService, 'extractTokenFromAuthChain').resolves();
+      sinon.stub(tokenService, 'extractUserId').resolves(userId);
     });
 
     it('should call the use case to share campaign result', async () => {
@@ -163,16 +151,14 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
   });
 
   describe('#save', () => {
-    let sandbox;
     let request;
     const campaignId = 123456;
     const participantExternalId = 'azer@ty.com';
     const userId = 6;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'startCampaignParticipation');
-      sandbox.stub(serializer, 'serialize');
+      sinon.stub(usecases, 'startCampaignParticipation');
+      sinon.stub(serializer, 'serialize');
       request = {
         headers: { authorization: 'token' },
         auth: { credentials: { userId } },
@@ -193,10 +179,6 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
           }
         }
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should call the usecases to start the campaign participation', async () => {

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -15,7 +15,7 @@ describe('Unit | Controller | certification-course-controller', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certificationCourses/certification-course-controller_test.js
@@ -12,16 +12,6 @@ const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Unit | Controller | certification-course-controller', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#computeResult', () => {
 
     const certificationCourseId = 1245;
@@ -37,8 +27,8 @@ describe('Unit | Controller | certification-course-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox.stub(certificationService, 'calculateCertificationResultByCertificationCourseId').resolves(certificationScore);
-      sandbox.stub(logger, 'error');
+      sinon.stub(certificationService, 'calculateCertificationResultByCertificationCourseId').resolves(certificationScore);
+      sinon.stub(logger, 'error');
     });
 
     it('should call certification Service to compute score', async () => {
@@ -98,12 +88,9 @@ describe('Unit | Controller | certification-course-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox.stub(certificationService, 'getCertificationResult').resolves({});
+      sinon.stub(certificationService, 'getCertificationResult').resolves({});
     });
 
-    afterEach(() => {
-      sandbox.restore();
-    });
     it('should call certification-service to get certification result from database', async () => {
       // when
       await certificationCourseController.getResult(request, hFake);
@@ -130,8 +117,8 @@ describe('Unit | Controller | certification-course-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox.stub(certificationSerializer, 'deserialize').resolves();
-      sandbox.stub(certificationSerializer, 'serializeFromCertificationCourse').returns(JsonAPISavedCertification);
+      sinon.stub(certificationSerializer, 'deserialize').resolves();
+      sinon.stub(certificationSerializer, 'serializeFromCertificationCourse').returns(JsonAPISavedCertification);
     });
 
     const options = {
@@ -149,7 +136,7 @@ describe('Unit | Controller | certification-course-controller', () => {
 
     it('should deserialize the request payload', async () => {
       // given
-      sandbox.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
+      sinon.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
 
       // when
       await certificationCourseController.update(options, hFake);
@@ -160,7 +147,7 @@ describe('Unit | Controller | certification-course-controller', () => {
 
     it('should patch certificationCourse data using save method', async () => {
       // given
-      sandbox.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
+      sinon.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
 
       // when
       await certificationCourseController.update(options, hFake);
@@ -172,7 +159,7 @@ describe('Unit | Controller | certification-course-controller', () => {
     context('when certification course was modified', () => {
 
       beforeEach(() => {
-        sandbox.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
+        sinon.stub(certificationCourseService, 'update').resolves(updatedCertificationCourse);
       });
 
       it('should serialize saved certification course', async () => {
@@ -196,7 +183,7 @@ describe('Unit | Controller | certification-course-controller', () => {
     context('When certification course was not modified', () => {
 
       beforeEach(() => {
-        sandbox.stub(certificationCourseService, 'update').rejects(NotFoundError);
+        sinon.stub(certificationCourseService, 'update').rejects(NotFoundError);
       });
 
       it('should reply a 404 if no certification where updated', function() {

--- a/api/tests/unit/application/certificationCourses/index_test.js
+++ b/api/tests/unit/application/certificationCourses/index_test.js
@@ -6,23 +6,17 @@ const certificationCoursesController = require('../../../../lib/application/cert
 describe('Unit | Application | Certifications Course | Route', function() {
 
   let server;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sandbox.stub(certificationCoursesController, 'getResult').returns('ok');
-    sandbox.stub(certificationCoursesController, 'update').returns('ok');
-    sandbox.stub(certificationCoursesController, 'computeResult').returns('ok');
+    sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+    sinon.stub(certificationCoursesController, 'getResult').returns('ok');
+    sinon.stub(certificationCoursesController, 'update').returns('ok');
+    sinon.stub(certificationCoursesController, 'computeResult').returns('ok');
 
     server = Hapi.server();
 
     return server.register(require('../../../../lib/application/certificationCourses'));
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('GET /api/admin/certifications/{id}/details', () => {

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -11,16 +11,6 @@ const certificationSerializer = require('../../../../lib/infrastructure/serializ
 
 describe('Unit | Controller | certifications-controller', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#findUserCertifications', () => {
 
     const retrievedCertifications = [];
@@ -32,9 +22,9 @@ describe('Unit | Controller | certifications-controller', () => {
     const infraError = new Error();
 
     beforeEach(() => {
-      sandbox.stub(usecases, 'findCompletedUserCertifications');
-      sandbox.stub(certificationSerializer, 'serialize').returns(serializedCertifications);
-      sandbox.stub(logger, 'error');
+      sinon.stub(usecases, 'findCompletedUserCertifications');
+      sinon.stub(certificationSerializer, 'serialize').returns(serializedCertifications);
+      sinon.stub(logger, 'error');
     });
 
     it('should return a serialized certifications array when use case return a array of Certifications', async () => {
@@ -75,9 +65,9 @@ describe('Unit | Controller | certifications-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox.stub(usecases, 'getUserCertificationWithResultTree');
-      sandbox.stub(certificationSerializer, 'serialize').returns(serializedCertification);
-      sandbox.stub(logger, 'error');
+      sinon.stub(usecases, 'getUserCertificationWithResultTree');
+      sinon.stub(certificationSerializer, 'serialize').returns(serializedCertification);
+      sinon.stub(logger, 'error');
     });
 
     it('should return a serialized certification when use case returns a certification', async () => {
@@ -185,10 +175,10 @@ describe('Unit | Controller | certifications-controller', () => {
     const usecaseError = new Error('This is a critical error.');
 
     beforeEach(() => {
-      sandbox.stub(usecases, 'updateCertification');
-      sandbox.stub(certificationSerializer, 'serialize');
+      sinon.stub(usecases, 'updateCertification');
+      sinon.stub(certificationSerializer, 'serialize');
 
-      sandbox.stub(logger, 'error');
+      sinon.stub(logger, 'error');
     });
 
     it('should return a serialized certification when update was successful', async () => {

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -14,7 +14,7 @@ describe('Unit | Controller | certifications-controller', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | challenge-controller', function() {
   let ChallengeSerializerStub;
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ChallengeRepoStub = sandbox.stub(ChallengeRepository, 'get');
     ChallengeSerializerStub = sandbox.stub(ChallengeSerializer, 'serialize');
     server = Hapi.server();

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -7,21 +7,15 @@ const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/
 describe('Unit | Controller | challenge-controller', function() {
 
   let server;
-  let sandbox;
   let ChallengeRepoStub;
   let ChallengeSerializerStub;
 
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    ChallengeRepoStub = sandbox.stub(ChallengeRepository, 'get');
-    ChallengeSerializerStub = sandbox.stub(ChallengeSerializer, 'serialize');
+    ChallengeRepoStub = sinon.stub(ChallengeRepository, 'get');
+    ChallengeSerializerStub = sinon.stub(ChallengeSerializer, 'serialize');
     server = Hapi.server();
 
     return server.register(require('../../../../lib/application/challenges'));
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#get', function() {

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -21,8 +21,7 @@ describe('Unit | Controller | challenge-controller', function() {
   });
 
   afterEach(() => {
-    ChallengeRepository.get.restore();
-    ChallengeSerializer.serialize.restore();
+    sandbox.restore();
   });
 
   describe('#get', function() {

--- a/api/tests/unit/application/challenges/index_test.js
+++ b/api/tests/unit/application/challenges/index_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const ChallengeController = require('../../../../lib/application/challenges/challenge-controller');
+const route = require('../../../../lib/application/challenges');
 
 describe('Unit | Router | challenge-router', function() {
 
@@ -8,18 +9,14 @@ describe('Unit | Router | challenge-router', function() {
 
   beforeEach(function() {
     server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/challenges'));
   });
 
   describe('GET /api/challenges/{id}', function() {
 
-    before(function() {
+    beforeEach(function() {
       sinon.stub(ChallengeController, 'get').returns('ok');
-    });
 
-    after(function() {
-      ChallengeController.get.restore();
+      return server.register(route);
     });
 
     it('should exist', async () => {

--- a/api/tests/unit/application/corrections/corrections-controller_test.js
+++ b/api/tests/unit/application/corrections/corrections-controller_test.js
@@ -9,15 +9,9 @@ const { NotFoundError, NotCompletedAssessmentError } = require('../../../../lib/
 const correctionsController = require('../../../../lib/application/corrections/corrections-controller');
 
 describe('Unit | Controller | corrections-controller', () => {
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(usecases, 'getCorrectionForAnswerWhenAssessmentEnded');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(usecases, 'getCorrectionForAnswerWhenAssessmentEnded');
   });
 
   describe('#findByAnswerId', () => {

--- a/api/tests/unit/application/corrections/corrections-controller_test.js
+++ b/api/tests/unit/application/corrections/corrections-controller_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | corrections-controller', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'getCorrectionForAnswerWhenAssessmentEnded');
   });
 

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -19,7 +19,7 @@ describe('Integration | Controller | course-controller', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(courseService, 'getCourse');
     sandbox.stub(courseSerializer, 'serialize');
     sandbox.stub(securityController, 'checkUserHasRolePixMaster');

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -16,26 +16,20 @@ const { UserNotAuthorizedToCertifyError } = require('../../../../lib/domain/erro
 describe('Integration | Controller | course-controller', () => {
 
   let server;
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(courseService, 'getCourse');
-    sandbox.stub(courseSerializer, 'serialize');
-    sandbox.stub(securityController, 'checkUserHasRolePixMaster');
-    sandbox.stub(courseRepository, 'getProgressionCourses');
-    sandbox.stub(courseRepository, 'getAdaptiveCourses');
-    sandbox.stub(courseRepository, 'getCoursesOfTheWeek');
-    sandbox.stub(certificationService, 'startNewCertification');
-    sandbox.stub(certificationCourseSerializer, 'serialize');
-    sandbox.stub(sessionService, 'sessionExists');
+    sinon.stub(courseService, 'getCourse');
+    sinon.stub(courseSerializer, 'serialize');
+    sinon.stub(securityController, 'checkUserHasRolePixMaster');
+    sinon.stub(courseRepository, 'getProgressionCourses');
+    sinon.stub(courseRepository, 'getAdaptiveCourses');
+    sinon.stub(courseRepository, 'getCoursesOfTheWeek');
+    sinon.stub(certificationService, 'startNewCertification');
+    sinon.stub(certificationCourseSerializer, 'serialize');
+    sinon.stub(sessionService, 'sessionExists');
 
     server = this.server = Hapi.server();
     return server.register(require('../../../../lib/application/courses'));
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#list', () => {

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -5,22 +5,16 @@ const courseController = require('../../../../lib/application/courses/course-con
 
 describe('Integration | Router | course-router', () => {
 
-  let sandbox;
   let server;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sandbox.stub(courseController, 'list').returns('ok');
-    sandbox.stub(courseController, 'get').returns('ok');
-    sandbox.stub(courseController, 'save').returns('ok');
+    sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+    sinon.stub(courseController, 'list').returns('ok');
+    sinon.stub(courseController, 'get').returns('ok');
+    sinon.stub(courseController, 'save').returns('ok');
 
     server = this.server = Hapi.server();
     return server.register(require('../../../../lib/application/courses'));
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('GET /api/courses', () => {

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -9,7 +9,7 @@ describe('Integration | Router | course-router', () => {
   let server;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sandbox.stub(courseController, 'list').returns('ok');
     sandbox.stub(courseController, 'get').returns('ok');

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -5,14 +5,15 @@ const Feedback = require('../../../../lib/infrastructure/data/feedback');
 const feedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
 const feedbackRepository = require('../../../../lib/infrastructure/repositories/feedback-repository');
 const feedbackSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/feedback-serializer');
+const route = require('../../../../lib/application/feedbacks');
 
 describe('Unit | Controller | feedback-controller', function() {
 
   let server;
 
-  before(function() {
+  beforeEach(function() {
     server = Hapi.server();
-    return server.register(require('../../../../lib/application/feedbacks'));
+    return server.register(route);
   });
 
   describe('#save', function() {
@@ -45,12 +46,8 @@ describe('Unit | Controller | feedback-controller', function() {
       content: 'Lorem ipsum dolor sit amet consectetur adipiscet.'
     });
 
-    before(function() {
+    beforeEach(function() {
       sinon.stub(Feedback.prototype, 'save').resolves(persistedFeedback);
-    });
-
-    after(function() {
-      Feedback.prototype.save.restore();
     });
 
     it('should return a successful response with HTTP code 201 when feedback was saved', async function() {
@@ -63,7 +60,7 @@ describe('Unit | Controller | feedback-controller', function() {
 
     it('should return an error 400 if feedback content is missing or empty', async function() {
       // given
-      const payload = _.clone(jsonFeedback);
+      const payload = _.cloneDeep(jsonFeedback);
       payload.data.attributes.content = '   ';
 
       // when
@@ -75,7 +72,7 @@ describe('Unit | Controller | feedback-controller', function() {
 
     it('should persist feedback data into the Feedback Repository', async function() {
       // given
-      const payload = _.clone(jsonFeedback);
+      const payload = _.cloneDeep(jsonFeedback);
 
       // when
       await server.inject({ method: 'POST', url: '/api/feedbacks', payload });

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -85,16 +85,9 @@ describe('Unit | Controller | feedback-controller', function() {
 
   describe('#find', () => {
 
-    let sandbox;
-
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(feedbackRepository, 'find');
-      sandbox.stub(feedbackSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(feedbackRepository, 'find');
+      sinon.stub(feedbackSerializer, 'serialize');
     });
 
     it('should fetch all the feedbacks from the DB when no query params are passed', async function() {

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -91,7 +91,7 @@ describe('Unit | Controller | feedback-controller', function() {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(feedbackRepository, 'find');
       sandbox.stub(feedbackSerializer, 'serialize');
     });

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 const feedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
+const route = require('../../../../lib/application/feedbacks');
 
 describe('Unit | Router | feedback-router', () => {
 
@@ -9,17 +10,13 @@ describe('Unit | Router | feedback-router', () => {
 
   beforeEach(() => {
     server = Hapi.server();
-    return server.register(require('../../../../lib/application/feedbacks'));
   });
 
   describe('POST /api/feedbacks', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(feedbackController, 'save').returns('ok');
-    });
-
-    after(() => {
-      feedbackController.save.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {
@@ -41,18 +38,13 @@ describe('Unit | Router | feedback-router', () => {
 
   describe('GET /api/feedbacks', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(securityController, 'checkUserIsAuthenticated').callsFake((request, h) => {
         h.continue({ credentials: { accessToken: 'jwt.access.token' } });
       });
       sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(feedbackController, 'find').returns('ok');
-    });
-
-    after(() => {
-      securityController.checkUserIsAuthenticated.restore();
-      securityController.checkUserHasRolePixMaster.restore();
-      feedbackController.find.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -24,10 +24,6 @@ describe('Unit | Controller | healthcheckController', () => {
       sinon.stub(healthcheckRepository, 'check');
     });
 
-    afterEach(() => {
-      healthcheckRepository.check.restore();
-    });
-
     it('should check if DB connection is successful', async () => {
       // given
       healthcheckRepository.check.resolves();

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -1,23 +1,20 @@
 const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');
+const route = require('../../../../lib/application/healthcheck');
 
 describe('Unit | Router | HealthcheckRouter', function() {
   let server;
 
   beforeEach(function() {
     server = this.server = Hapi.server();
-    return server.register(require('../../../../lib/application/healthcheck'));
   });
 
   describe('GET /api', function() {
 
-    before(function() {
+    beforeEach(function() {
       sinon.stub(healthcheckController, 'get').returns('ok');
-    });
-
-    after(function() {
-      healthcheckController.get.restore();
+      return server.register(route);
     });
 
     it('should exist', async function() {

--- a/api/tests/unit/application/metrics/index_test.js
+++ b/api/tests/unit/application/metrics/index_test.js
@@ -1,25 +1,20 @@
-const PROJECT_ROOT = '../../../..';
-
 const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
-const metricController = require(`${PROJECT_ROOT}/lib/application/metrics/metric-controller`);
+const metricController = require('../../../../lib/application/metrics/metric-controller');
+const route = require('../../../../lib/application/metrics');
 
 describe('Unit | Router | Metrics', () => {
   let server;
 
   beforeEach(() => {
-    server = this.server = Hapi.server();
-    return server.register(require(`${PROJECT_ROOT}/lib/application/metrics`));
+    server = Hapi.server();
   });
 
   describe('GET /metrics', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(metricController, 'get').returns('ok');
-    });
-
-    after(() => {
-      metricController.get.restore();
+      return server.register(route);
     });
 
     it('should exist', async () => {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -25,7 +25,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
   describe('#getOrganizationDetails', () => {
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(usecases, 'getOrganizationDetails');
       sandbox.stub(organizationSerializer, 'serialize');
     });
@@ -55,7 +55,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
   describe('#create', () => {
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(usecases, 'createOrganization');
       sandbox.stub(organizationSerializer, 'serialize');
@@ -193,7 +193,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     const arrayOfOrganizations = [new Organization({ code: 'AAA111' }), new Organization({ code: 'BBB222' })];
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(logger, 'error');
       sandbox.stub(organizationService, 'search').resolves(arrayOfOrganizations);
@@ -276,7 +276,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(logger, 'error');
       sandbox.stub(snapshotRepository, 'getSnapshotsByOrganizationId');
       sandbox.stub(snapshotSerializer, 'serialize');
@@ -492,7 +492,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       campaign = domainBuilder.buildCampaign();
       serializedCampaigns = { data: [{ name: campaign.name, code: campaign.code }] };
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(usecases, 'getOrganizationCampaigns');
       sandbox.stub(campaignSerializer, 'serialize');
     });
@@ -552,7 +552,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     const organizationId = '145';
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       request = {
         auth: { credentials: { userId: connectedUserId } },
         params: { id: organizationId }

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -403,11 +403,6 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       sinon.stub(validationErrorSerializer, 'serialize');
     });
 
-    afterEach(() => {
-      usecases.writeOrganizationSharedProfilesAsCsvToStream.restore();
-      validationErrorSerializer.serialize.restore();
-    });
-
     it('should call the use case service that exports shared profile of an organization as CSV (and reply an HTTP response)', async () => {
       // given
       const request = {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -19,19 +19,13 @@ const targetProfileSerializer = require('../../../../lib/infrastructure/serializ
 
 describe('Unit | Application | Organizations | organization-controller', () => {
 
-  let sandbox;
   let request;
 
   describe('#getOrganizationDetails', () => {
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'getOrganizationDetails');
-      sandbox.stub(organizationSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'getOrganizationDetails');
+      sinon.stub(organizationSerializer, 'serialize');
     });
 
     it('should call the usecase and serialize the response', async () => {
@@ -55,10 +49,9 @@ describe('Unit | Application | Organizations | organization-controller', () => {
   describe('#create', () => {
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(usecases, 'createOrganization');
-      sandbox.stub(organizationSerializer, 'serialize');
+      sinon.stub(usecases, 'createOrganization');
+      sinon.stub(organizationSerializer, 'serialize');
 
       request = {
         payload: {
@@ -70,10 +63,6 @@ describe('Unit | Application | Organizations | organization-controller', () => {
           }
         }
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     context('successful case', () => {
@@ -188,20 +177,14 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
   describe('#search', () => {
 
-    let sandbox;
     const arrayOfSerializedOrganization = [{ code: 'AAA111' }, { code: 'BBB222' }];
     const arrayOfOrganizations = [new Organization({ code: 'AAA111' }), new Organization({ code: 'BBB222' })];
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(logger, 'error');
-      sandbox.stub(organizationService, 'search').resolves(arrayOfOrganizations);
-      sandbox.stub(organizationSerializer, 'serialize').returns(arrayOfSerializedOrganization);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(logger, 'error');
+      sinon.stub(organizationService, 'search').resolves(arrayOfOrganizations);
+      sinon.stub(organizationSerializer, 'serialize').returns(arrayOfSerializedOrganization);
     });
 
     it('should retrieve organizations with one filter', async () => {
@@ -273,19 +256,12 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
   describe('#getSharedProfiles', () => {
 
-    let sandbox;
-
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(logger, 'error');
-      sandbox.stub(snapshotRepository, 'getSnapshotsByOrganizationId');
-      sandbox.stub(snapshotSerializer, 'serialize');
-      sandbox.stub(validationErrorSerializer, 'serialize');
-      sandbox.stub(bookshelfUtils, 'mergeModelWithRelationship');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(logger, 'error');
+      sinon.stub(snapshotRepository, 'getSnapshotsByOrganizationId');
+      sinon.stub(snapshotSerializer, 'serialize');
+      sinon.stub(validationErrorSerializer, 'serialize');
+      sinon.stub(bookshelfUtils, 'mergeModelWithRelationship');
     });
 
     describe('Collaborations', () => {
@@ -468,7 +444,6 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
   describe('#getCampaigns', () => {
 
-    let sandbox;
     let organizationId;
     let request;
     let campaign;
@@ -487,13 +462,8 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       campaign = domainBuilder.buildCampaign();
       serializedCampaigns = { data: [{ name: campaign.name, code: campaign.code }] };
 
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'getOrganizationCampaigns');
-      sandbox.stub(campaignSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'getOrganizationCampaigns');
+      sinon.stub(campaignSerializer, 'serialize');
     });
 
     it('should call the usecase to get the campaigns', async () => {
@@ -547,16 +517,11 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     const organizationId = '145';
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
       request = {
         auth: { credentials: { userId: connectedUserId } },
         params: { id: organizationId }
       };
-      sandbox.stub(organizationService, 'findAllTargetProfilesAvailableForOrganization').resolves();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(organizationService, 'findAllTargetProfilesAvailableForOrganization').resolves();
     });
 
     it('should call usecases with appropriated arguments', async () => {
@@ -576,7 +541,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
         // given
         foundTargetProfiles = [domainBuilder.buildTargetProfile()];
         organizationService.findAllTargetProfilesAvailableForOrganization.resolves(foundTargetProfiles);
-        sandbox.stub(targetProfileSerializer, 'serialize');
+        sinon.stub(targetProfileSerializer, 'serialize');
       });
 
       it('should serialize the array of target profile', async () => {
@@ -605,7 +570,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     context('error cases', () => {
 
       beforeEach(() => {
-        sandbox.stub(logger, 'error');
+        sinon.stub(logger, 'error');
       });
 
       it('should log the error and reply with 500 error', async () => {

--- a/api/tests/unit/application/passwords/index_test.js
+++ b/api/tests/unit/application/passwords/index_test.js
@@ -15,7 +15,6 @@ describe('Unit | Router | Password router', () => {
   });
 
   afterEach(() => {
-    passwordController.createResetDemand.restore();
     server.stop();
   });
 

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -40,7 +40,7 @@ describe('Unit | Controller | PasswordController', () => {
       let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
 
         sandbox.stub(userService, 'isUserExistingByEmail');
         sandbox.stub(mailService, 'sendResetPasswordDemandEmail');
@@ -251,7 +251,7 @@ describe('Unit | Controller | PasswordController', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(resetPasswordService, 'verifyDemand');
       sandbox.stub(tokenService, 'verifyValidity').resolves({});
       sandbox.stub(errorSerializer, 'serialize');

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -37,23 +37,16 @@ describe('Unit | Controller | PasswordController', () => {
         }
       };
 
-      let sandbox;
-
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
 
-        sandbox.stub(userService, 'isUserExistingByEmail');
-        sandbox.stub(mailService, 'sendResetPasswordDemandEmail');
-        sandbox.stub(resetPasswordService, 'generateTemporaryKey');
-        sandbox.stub(resetPasswordService, 'invalidOldResetPasswordDemand');
-        sandbox.stub(resetPasswordRepository, 'create');
-        sandbox.stub(errorSerializer, 'serialize');
-        sandbox.stub(passwordResetSerializer, 'serialize');
-        sandbox.stub(logger, 'error');
-      });
-
-      afterEach(() => {
-        sandbox.restore();
+        sinon.stub(userService, 'isUserExistingByEmail');
+        sinon.stub(mailService, 'sendResetPasswordDemandEmail');
+        sinon.stub(resetPasswordService, 'generateTemporaryKey');
+        sinon.stub(resetPasswordService, 'invalidOldResetPasswordDemand');
+        sinon.stub(resetPasswordRepository, 'create');
+        sinon.stub(errorSerializer, 'serialize');
+        sinon.stub(passwordResetSerializer, 'serialize');
+        sinon.stub(logger, 'error');
       });
 
       describe('User existence test cases', () => {
@@ -235,7 +228,6 @@ describe('Unit | Controller | PasswordController', () => {
   });
 
   describe('#checkResetDemand', () => {
-    let sandbox;
     const request = {
       params: {
         temporaryKey: 'token'
@@ -251,16 +243,11 @@ describe('Unit | Controller | PasswordController', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(resetPasswordService, 'verifyDemand');
-      sandbox.stub(tokenService, 'verifyValidity').resolves({});
-      sandbox.stub(errorSerializer, 'serialize');
-      sandbox.stub(UserRepository, 'findByEmail').resolves(fetchedUser);
-      sandbox.stub(userSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(resetPasswordService, 'verifyDemand');
+      sinon.stub(tokenService, 'verifyValidity').resolves({});
+      sinon.stub(errorSerializer, 'serialize');
+      sinon.stub(UserRepository, 'findByEmail').resolves(fetchedUser);
+      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should verify temporary key validity (format, signature, expiration)', () => {

--- a/api/tests/unit/application/preHandlers/assessment-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-authorization_test.js
@@ -6,7 +6,6 @@ const assessmentRepository = require('../../../../lib/infrastructure/repositorie
 describe('Unit | Pre-handler | Assessment Authorization', () => {
 
   describe('#verify', () => {
-    let sandbox;
     const request = {
       headers: { authorization: 'VALID_TOKEN' },
       params: {
@@ -15,14 +14,9 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(tokenService, 'extractTokenFromAuthChain');
-      sandbox.stub(tokenService, 'extractUserId');
-      sandbox.stub(assessmentRepository, 'getByUserIdAndAssessmentId');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      sinon.stub(tokenService, 'extractUserId');
+      sinon.stub(assessmentRepository, 'getByUserIdAndAssessmentId');
     });
 
     it('should be a function', () => {

--- a/api/tests/unit/application/preHandlers/assessment-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-authorization_test.js
@@ -15,7 +15,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(tokenService, 'extractTokenFromAuthChain');
       sandbox.stub(tokenService, 'extractUserId');
       sandbox.stub(assessmentRepository, 'getByUserIdAndAssessmentId');

--- a/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
@@ -18,7 +18,7 @@ describe('Unit | Pre-handler | Snapshot Authorization', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(tokenService, 'extractTokenFromAuthChain');
       sandbox.stub(tokenService, 'extractUserId');
       sandbox.stub(organizationRepository, 'getByUserId');

--- a/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/snapshot-authorization_test.js
@@ -6,7 +6,6 @@ const organizationRepository = require('../../../../lib/infrastructure/repositor
 describe('Unit | Pre-handler | Snapshot Authorization', () => {
 
   describe('#verify', () => {
-    let sandbox;
     const request = {
       headers: { },
       params: {
@@ -18,14 +17,9 @@ describe('Unit | Pre-handler | Snapshot Authorization', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(tokenService, 'extractTokenFromAuthChain');
-      sandbox.stub(tokenService, 'extractUserId');
-      sandbox.stub(organizationRepository, 'getByUserId');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      sinon.stub(tokenService, 'extractUserId');
+      sinon.stub(organizationRepository, 'getByUserId');
     });
 
     it('should get userId from token in queryString', () => {

--- a/api/tests/unit/application/preHandlers/user-existence-verification_test.js
+++ b/api/tests/unit/application/preHandlers/user-existence-verification_test.js
@@ -15,7 +15,7 @@ describe('Unit | Pre-handler | User Verification', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(userRepository, 'findUserById');
       sandbox.stub(errorSerializer, 'serialize');
     });

--- a/api/tests/unit/application/preHandlers/user-existence-verification_test.js
+++ b/api/tests/unit/application/preHandlers/user-existence-verification_test.js
@@ -7,7 +7,6 @@ const errorSerializer = require('../../../../lib/infrastructure/serializers/json
 describe('Unit | Pre-handler | User Verification', () => {
 
   describe('#verifyById', () => {
-    let sandbox;
     const request = {
       params: {
         id: 7
@@ -15,13 +14,8 @@ describe('Unit | Pre-handler | User Verification', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(userRepository, 'findUserById');
-      sandbox.stub(errorSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(userRepository, 'findUserById');
+      sinon.stub(errorSerializer, 'serialize');
     });
 
     it('should be a function', () => {

--- a/api/tests/unit/application/qmail/qmail-controller_test.js
+++ b/api/tests/unit/application/qmail/qmail-controller_test.js
@@ -34,7 +34,7 @@ describe('Unit | Controller | qmailController', () => {
     const challengeToEvaluate = { type: 'QMAIL', value: '--- TOTO' };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       answer = new Answer({ result: '#PENDING#' });
       sinon.stub(answer, 'save').resolves();

--- a/api/tests/unit/application/qmail/qmail-controller_test.js
+++ b/api/tests/unit/application/qmail/qmail-controller_test.js
@@ -30,22 +30,16 @@ describe('Unit | Controller | qmailController', () => {
       }
     };
 
-    let sandbox;
     const challengeToEvaluate = { type: 'QMAIL', value: '--- TOTO' };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
       answer = new Answer({ result: '#PENDING#' });
       sinon.stub(answer, 'save').resolves();
 
-      sandbox.stub(AnswerRepository, 'findByChallengeAndAssessment').resolves(answer);
-      sandbox.stub(solutionRepository, 'getByChallengeId').resolves(challengeToEvaluate);
-      sandbox.stub(QmailValidationService, 'validateEmail').returns(true);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(AnswerRepository, 'findByChallengeAndAssessment').resolves(answer);
+      sinon.stub(solutionRepository, 'getByChallengeId').resolves(challengeToEvaluate);
+      sinon.stub(QmailValidationService, 'validateEmail').returns(true);
     });
 
     it('should fetch the validation rules', async () => {

--- a/api/tests/unit/application/saml/saml-controller_test.js
+++ b/api/tests/unit/application/saml/saml-controller_test.js
@@ -5,18 +5,12 @@ const saml = require('../../../../lib/infrastructure/saml');
 const tokenService = require('../../../../lib/domain/services/token-service');
 
 describe('Unit | Application | Controller | Saml', () => {
-  let sandbox;
 
   describe('#assert', () => {
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(tokenService, 'createTokenFromUser').returns('dummy-token');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(tokenService, 'createTokenFromUser').returns('dummy-token');
     });
 
     it('should call use case to get or create account for user', async () => {
@@ -27,11 +21,11 @@ describe('Unit | Application | Controller | Saml', () => {
         'urn:oid:2.5.4.42': 'Adèle',
       };
 
-      sandbox.stub(saml, 'parsePostResponse')
+      sinon.stub(saml, 'parsePostResponse')
         .withArgs('fake-request-payload')
         .resolves(userAttributes);
 
-      sandbox.stub(usecases, 'getOrCreateSamlUser').resolves({
+      sinon.stub(usecases, 'getOrCreateSamlUser').resolves({
         id: 12,
       });
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -2,25 +2,21 @@ const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 const sessionController = require('../../../../lib/application/sessions/session-controller');
+const route = require('../../../../lib/application/sessions');
 
 describe('Unit | Application | Sessions | Routes', () => {
   let server;
 
   beforeEach(() => {
     server = this.server = Hapi.server();
-    return server.register(require('../../../../lib/application/sessions'));
   });
 
   describe('GET /api/sessions/{id}', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(sessionController, 'get').returns('ok');
-    });
-
-    after(() => {
-      securityController.checkUserHasRolePixMaster.restore();
-      sessionController.get.restore();
+      return server.register(route);
     });
 
     it('should exist', async () => {
@@ -31,14 +27,10 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('GET /api/sessions', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(sessionController, 'find').returns('ok');
-    });
-
-    after(() => {
-      securityController.checkUserHasRolePixMaster.restore();
-      sessionController.find.restore();
+      return server.register(route);
     });
 
     it('should exist', async () => {
@@ -49,14 +41,10 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('POST /api/session', () => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(sessionController, 'save').returns('ok');
-    });
-
-    after(() => {
-      securityController.checkUserHasRolePixMaster.restore();
-      sessionController.save.restore();
+      return server.register(route);
     });
 
     it('should exist', async () => {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -10,7 +10,6 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 
 describe('Unit | Controller | sessionController', () => {
-  let sandbox;
   let request;
   let expectedSession;
 
@@ -28,11 +27,10 @@ describe('Unit | Controller | sessionController', () => {
         accessCode: 'ABCD12'
       });
 
-      sandbox = sinon.createSandbox();
-      sandbox.stub(sessionService, 'save').resolves();
-      sandbox.stub(logger, 'error');
-      sandbox.stub(sessionSerializer, 'deserialize').resolves(expectedSession);
-      sandbox.stub(sessionSerializer, 'serialize');
+      sinon.stub(sessionService, 'save').resolves();
+      sinon.stub(logger, 'error');
+      sinon.stub(sessionSerializer, 'deserialize').resolves(expectedSession);
+      sinon.stub(sessionSerializer, 'serialize');
 
       request = {
         payload: {
@@ -50,10 +48,6 @@ describe('Unit | Controller | sessionController', () => {
           }
         }
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should save the session', async () => {
@@ -117,18 +111,13 @@ describe('Unit | Controller | sessionController', () => {
   describe('#get', function() {
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(sessionService, 'get');
-      sandbox.stub(sessionSerializer, 'serialize');
+      sinon.stub(sessionService, 'get');
+      sinon.stub(sessionSerializer, 'serialize');
       request = {
         params: {
           id: 'sessionId'
         }
       };
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     context('when session exists', () => {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -28,7 +28,7 @@ describe('Unit | Controller | sessionController', () => {
         accessCode: 'ABCD12'
       });
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(sessionService, 'save').resolves();
       sandbox.stub(logger, 'error');
       sandbox.stub(sessionSerializer, 'deserialize').resolves(expectedSession);
@@ -117,7 +117,7 @@ describe('Unit | Controller | sessionController', () => {
   describe('#get', function() {
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(sessionService, 'get');
       sandbox.stub(sessionSerializer, 'serialize');
       request = {

--- a/api/tests/unit/application/skillReviews/index_test.js
+++ b/api/tests/unit/application/skillReviews/index_test.js
@@ -14,8 +14,6 @@ describe('Unit | Router | skill-review-router', () => {
   });
 
   afterEach(() => {
-    skillReviewController.get.restore();
-
     server.stop();
   });
 

--- a/api/tests/unit/application/skillReviews/skill-review-controller_test.js
+++ b/api/tests/unit/application/skillReviews/skill-review-controller_test.js
@@ -24,11 +24,6 @@ describe('Unit | Controller | skill-review-controller', () => {
       sinon.stub(logger, 'error').returns();
     });
 
-    afterEach(() => {
-      usecases.getSkillReview.restore();
-      logger.error.restore();
-    });
-
     context('if assessment exists', () => {
 
       const skillReview = domainBuilder.buildSkillReview({ validatedSkills: [], failedSkills: [] });

--- a/api/tests/unit/application/snapshots/index_test.js
+++ b/api/tests/unit/application/snapshots/index_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
-
 const snapshotController = require('../../../../lib/application/snapshots/snapshot-controller');
+const route = require('../../../../lib/application/snapshots');
 
 describe('Unit | Router | snapshot-router', () => {
 
@@ -9,17 +9,13 @@ describe('Unit | Router | snapshot-router', () => {
 
   beforeEach(() => {
     server = Hapi.server();
-    return server.register(require('../../../../lib/application/snapshots'));
   });
 
   describe('POST /api/snapshots', (_) => {
 
-    before(() => {
+    beforeEach(() => {
       sinon.stub(snapshotController, 'create').returns('ok');
-    });
-
-    after(() => {
-      snapshotController.create.restore();
+      return server.register(route);
     });
 
     it('should exist', () => {

--- a/api/tests/unit/application/snapshots/snapshot-controller_test.js
+++ b/api/tests/unit/application/snapshots/snapshot-controller_test.js
@@ -55,24 +55,18 @@ describe('Unit | Controller | snapshot-controller', () => {
     };
 
     describe('Behavior', () => {
-      let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
-        sandbox.stub(authorizationToken, 'verify');
-        sandbox.stub(userRepository, 'findUserById');
-        sandbox.stub(snapshotSerializer, 'deserialize');
-        sandbox.stub(profileService, 'getByUserId');
-        sandbox.stub(organizationRepository, 'isOrganizationIdExist');
-        sandbox.stub(snapshotService, 'create');
-        sandbox.stub(profileSerializer, 'serialize');
-        sandbox.stub(profileCompletionService, 'getNumberOfFinishedTests');
-        sandbox.stub(snapshotSerializer, 'serialize');
-        sandbox.stub(logger, 'error');
-      });
-
-      afterEach(() => {
-        sandbox.restore();
+        sinon.stub(authorizationToken, 'verify');
+        sinon.stub(userRepository, 'findUserById');
+        sinon.stub(snapshotSerializer, 'deserialize');
+        sinon.stub(profileService, 'getByUserId');
+        sinon.stub(organizationRepository, 'isOrganizationIdExist');
+        sinon.stub(snapshotService, 'create');
+        sinon.stub(profileSerializer, 'serialize');
+        sinon.stub(profileCompletionService, 'getNumberOfFinishedTests');
+        sinon.stub(snapshotSerializer, 'serialize');
+        sinon.stub(logger, 'error');
       });
 
       describe('Test collaboration', function() {

--- a/api/tests/unit/application/snapshots/snapshot-controller_test.js
+++ b/api/tests/unit/application/snapshots/snapshot-controller_test.js
@@ -58,7 +58,7 @@ describe('Unit | Controller | snapshot-controller', () => {
       let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(authorizationToken, 'verify');
         sandbox.stub(userRepository, 'findUserById');
         sandbox.stub(snapshotSerializer, 'deserialize');

--- a/api/tests/unit/application/usecases/checkUserHasRolePixMaster_test.js
+++ b/api/tests/unit/application/usecases/checkUserHasRolePixMaster_test.js
@@ -13,11 +13,6 @@ describe('Unit | Application | Use Case | CheckUserHasRolePixMaster', () => {
     sinon.stub(userRepository, 'get');
   });
 
-  afterEach(() => {
-    tokenService.extractUserId.restore();
-    userRepository.get.restore();
-  });
-
   it('should resolve true when the user (designed by the access_token via its userId) has role PIX_MASTER', () => {
     // given
     const user = {

--- a/api/tests/unit/application/usecases/checkUserIsAuthenticated_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsAuthenticated_test.js
@@ -11,10 +11,6 @@ describe('Unit | Application | Use Case | CheckUserIsAuthenticated', () => {
     sinon.stub(tokenService, 'verifyValidity');
   });
 
-  afterEach(() => {
-    tokenService.verifyValidity.restore();
-  });
-
   it('should resolve credentials (ie. userId) when JWT access token is valid', () => {
     // given
     const authenticatedUser = { user_id: 1234 };

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -4,8 +4,6 @@ const securityController = require('../../../../lib/interfaces/controllers/secur
 const userController = require('../../../../lib/application/users/user-controller');
 const userVerification = require('../../../../lib/application/preHandlers/user-existence-verification');
 
-const sandbox = sinon.createSandbox();
-
 let server;
 
 function startServer() {
@@ -15,18 +13,14 @@ function startServer() {
 
 describe('Unit | Router | user-router', () => {
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('GET /api/users', () => {
 
     beforeEach(() => {
-      sandbox.stub(securityController, 'checkUserIsAuthenticated').callsFake((request, h) => {
+      sinon.stub(securityController, 'checkUserIsAuthenticated').callsFake((request, h) => {
         h.continue({ credentials: { accessToken: 'jwt.access.token' } });
       });
-      sandbox.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sandbox.stub(userController, 'find').returns('ok');
+      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(userController, 'find').returns('ok');
       startServer();
     });
 
@@ -50,7 +44,7 @@ describe('Unit | Router | user-router', () => {
   describe('POST /api/users', () => {
 
     beforeEach(() => {
-      sandbox.stub(userController, 'save').returns('ok');
+      sinon.stub(userController, 'save').returns('ok');
       startServer();
     });
 
@@ -84,7 +78,7 @@ describe('Unit | Router | user-router', () => {
   describe('GET /api/users/{id}', function() {
 
     beforeEach(() => {
-      sandbox.stub(userController, 'getUser').returns('ok');
+      sinon.stub(userController, 'getUser').returns('ok');
       startServer();
     });
 
@@ -105,7 +99,7 @@ describe('Unit | Router | user-router', () => {
   describe('GET /api/users/me', function() {
 
     beforeEach(() => {
-      sandbox.stub(userController, 'getAuthenticatedUserProfile').returns('ok');
+      sinon.stub(userController, 'getAuthenticatedUserProfile').returns('ok');
       startServer();
     });
 
@@ -125,8 +119,8 @@ describe('Unit | Router | user-router', () => {
 
   describe('GET /api/users/{id}/skills', function() {
     beforeEach(() => {
-      sandbox.stub(userController, 'getProfileToCertify').returns('ok');
-      sandbox.stub(userVerification, 'verifyById').returns('ok');
+      sinon.stub(userController, 'getProfileToCertify').returns('ok');
+      sinon.stub(userVerification, 'verifyById').returns('ok');
       startServer();
     });
 
@@ -147,7 +141,7 @@ describe('Unit | Router | user-router', () => {
 
   describe('GET /api/users/{id}/memberships', function() {
     beforeEach(() => {
-      sandbox.stub(userController, 'getMemberships').returns('ok');
+      sinon.stub(userController, 'getMemberships').returns('ok');
       startServer();
     });
 
@@ -176,8 +170,8 @@ describe('Unit | Router | user-router', () => {
     });
 
     beforeEach(() => {
-      sandbox.stub(userController, 'updateUser').returns('ok');
-      sandbox.stub(userVerification, 'verifyById').returns('ok');
+      sinon.stub(userController, 'updateUser').returns('ok');
+      sinon.stub(userVerification, 'verifyById').returns('ok');
       startServer();
     });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -32,7 +32,7 @@ describe('Unit | Controller | user-controller', () => {
     const savedUser = new User({ email });
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(logger, 'error').returns({});
       sandbox.stub(userSerializer, 'deserialize').returns(deserializedUser);
@@ -229,7 +229,7 @@ describe('Unit | Controller | user-controller', () => {
       });
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(passwordResetService, 'hasUserAPasswordResetDemandInProgress');
         sandbox.stub(passwordResetService, 'invalidOldResetPasswordDemand');
         sandbox.stub(validationErrorSerializer, 'serialize');
@@ -321,7 +321,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.sandbox.create();
+        const sandbox = sinon.createSandbox();
         const usecaseUpdateUserPasswordStub = sandbox.stub(usecases, 'updateUserPassword');
 
         // when
@@ -350,7 +350,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.sandbox.create();
+        const sandbox = sinon.createSandbox();
         const usecaseAcceptPixOrgaTermsOfServiceStub = sandbox.stub(usecases, 'acceptPixOrgaTermsOfService');
 
         // when
@@ -378,7 +378,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.sandbox.create();
+        const sandbox = sinon.createSandbox();
         const usecaseAcceptPixCertifTermsOfServiceStub = sandbox.stub(usecases, 'acceptPixCertifTermsOfService');
 
         // when
@@ -398,7 +398,7 @@ describe('Unit | Controller | user-controller', () => {
     const request = { params: { id: 1 } };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(userService, 'isUserExistingById').resolves(true);
       sandbox.stub(userService, 'getProfileToCertify').resolves([]);
@@ -482,7 +482,7 @@ describe('Unit | Controller | user-controller', () => {
         }
       };
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(usecases, 'getUserWithMemberships').resolves();
       sandbox.stub(userSerializer, 'serialize');
     });
@@ -575,7 +575,7 @@ describe('Unit | Controller | user-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(membershipSerializer, 'serialize');
     });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -26,26 +26,20 @@ const {
 describe('Unit | Controller | user-controller', () => {
 
   describe('#save', () => {
-    let sandbox;
     const email = 'to-be-free@ozone.airplane';
     const deserializedUser = new User({ password: 'password_1234' });
     const savedUser = new User({ email });
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(logger, 'error').returns({});
-      sandbox.stub(userSerializer, 'deserialize').returns(deserializedUser);
-      sandbox.stub(userSerializer, 'serialize');
-      sandbox.stub(userRepository, 'create').resolves(savedUser);
-      sandbox.stub(validationErrorSerializer, 'serialize');
-      sandbox.stub(encryptionService, 'hashPassword');
-      sandbox.stub(mailService, 'sendAccountCreationEmail');
-      sandbox.stub(usecases, 'createUser');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(logger, 'error').returns({});
+      sinon.stub(userSerializer, 'deserialize').returns(deserializedUser);
+      sinon.stub(userSerializer, 'serialize');
+      sinon.stub(userRepository, 'create').resolves(savedUser);
+      sinon.stub(validationErrorSerializer, 'serialize');
+      sinon.stub(encryptionService, 'hashPassword');
+      sinon.stub(mailService, 'sendAccountCreationEmail');
+      sinon.stub(usecases, 'createUser');
     });
 
     describe('when request is valid', () => {
@@ -210,7 +204,6 @@ describe('Unit | Controller | user-controller', () => {
   describe('#updateUser', () => {
 
     context('When payload is good (with a payload and a password attribute)', () => {
-      let sandbox;
       const request = {
         params: {
           id: 7,
@@ -229,17 +222,12 @@ describe('Unit | Controller | user-controller', () => {
       });
 
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
-        sandbox.stub(passwordResetService, 'hasUserAPasswordResetDemandInProgress');
-        sandbox.stub(passwordResetService, 'invalidOldResetPasswordDemand');
-        sandbox.stub(validationErrorSerializer, 'serialize');
-        sandbox.stub(userRepository, 'updatePassword');
-        sandbox.stub(userRepository, 'findUserById').resolves(user);
-        sandbox.stub(encryptionService, 'hashPassword');
-      });
-
-      afterEach(() => {
-        sandbox.restore();
+        sinon.stub(passwordResetService, 'hasUserAPasswordResetDemandInProgress');
+        sinon.stub(passwordResetService, 'invalidOldResetPasswordDemand');
+        sinon.stub(validationErrorSerializer, 'serialize');
+        sinon.stub(userRepository, 'updatePassword');
+        sinon.stub(userRepository, 'findUserById').resolves(user);
+        sinon.stub(encryptionService, 'hashPassword');
       });
 
       it('should reply with no content', async () => {
@@ -321,8 +309,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.createSandbox();
-        const usecaseUpdateUserPasswordStub = sandbox.stub(usecases, 'updateUserPassword');
+        const usecaseUpdateUserPasswordStub = sinon.stub(usecases, 'updateUserPassword');
 
         // when
         await userController.updateUser(request, hFake);
@@ -350,8 +337,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.createSandbox();
-        const usecaseAcceptPixOrgaTermsOfServiceStub = sandbox.stub(usecases, 'acceptPixOrgaTermsOfService');
+        const usecaseAcceptPixOrgaTermsOfServiceStub = sinon.stub(usecases, 'acceptPixOrgaTermsOfService');
 
         // when
         await userController.updateUser(request, hFake);
@@ -378,8 +364,7 @@ describe('Unit | Controller | user-controller', () => {
             },
           },
         };
-        const sandbox = sinon.createSandbox();
-        const usecaseAcceptPixCertifTermsOfServiceStub = sandbox.stub(usecases, 'acceptPixCertifTermsOfService');
+        const usecaseAcceptPixCertifTermsOfServiceStub = sinon.stub(usecases, 'acceptPixCertifTermsOfService');
 
         // when
         const promise = userController.updateUser(request, hFake);
@@ -393,20 +378,14 @@ describe('Unit | Controller | user-controller', () => {
   });
 
   describe('#getProfileToCertify', () => {
-    let sandbox;
 
     const request = { params: { id: 1 } };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(userService, 'isUserExistingById').resolves(true);
-      sandbox.stub(userService, 'getProfileToCertify').resolves([]);
-      sandbox.stub(logger, 'error').returns({});
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(userService, 'isUserExistingById').resolves(true);
+      sinon.stub(userService, 'getProfileToCertify').resolves([]);
+      sinon.stub(logger, 'error').returns({});
     });
 
     it('should be a function', () => {
@@ -458,7 +437,6 @@ describe('Unit | Controller | user-controller', () => {
   });
 
   describe('#getUser', () => {
-    let sandbox;
     let requestedUserId;
     let authenticatedUserId;
     let request;
@@ -476,13 +454,8 @@ describe('Unit | Controller | user-controller', () => {
         }
       };
 
-      sandbox = sinon.createSandbox();
-      sandbox.stub(usecases, 'getUserWithMemberships').resolves();
-      sandbox.stub(userSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(usecases, 'getUserWithMemberships').resolves();
+      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should retrieve user informations from user Id', async () => {
@@ -554,7 +527,6 @@ describe('Unit | Controller | user-controller', () => {
   });
 
   describe('#getMemberships', () => {
-    let sandbox;
     const authenticatedUserId = 1;
     const requestedUserId = '1';
     const request = {
@@ -569,18 +541,13 @@ describe('Unit | Controller | user-controller', () => {
     };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(membershipSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(membershipSerializer, 'serialize');
     });
 
     it('should get accesses of the user passed on params', async () => {
       // given
       const stringifiedAuthenticatedUserId = authenticatedUserId.toString();
-      sandbox.stub(usecases, 'getUserWithMemberships').resolves();
+      sinon.stub(usecases, 'getUserWithMemberships').resolves();
 
       // when
       await userController.getMemberships(request, hFake);
@@ -595,7 +562,7 @@ describe('Unit | Controller | user-controller', () => {
     context('When accesses are found', () => {
 
       beforeEach(() => {
-        sandbox.stub(usecases, 'getUserWithMemberships');
+        sinon.stub(usecases, 'getUserWithMemberships');
       });
 
       it('should serialize found memberships', async () => {
@@ -629,7 +596,7 @@ describe('Unit | Controller | user-controller', () => {
     context('When authenticated user want to retrieve access of another user', () => {
       it('should return a 403 Forbidden access error ', async () => {
         // given
-        sandbox.stub(usecases, 'getUserWithMemberships').rejects(new UserNotAuthorizedToAccessEntity());
+        sinon.stub(usecases, 'getUserWithMemberships').rejects(new UserNotAuthorizedToAccessEntity());
 
         // when
         const response = await userController.getMemberships(request, hFake);
@@ -643,7 +610,7 @@ describe('Unit | Controller | user-controller', () => {
     context('When an unexpected error occurs', () => {
       it('should return a 500 internal error ', async () => {
         // given
-        sandbox.stub(usecases, 'getUserWithMemberships').rejects(new Error());
+        sinon.stub(usecases, 'getUserWithMemberships').rejects(new Error());
 
         // when
         const response = await userController.getMemberships(request, hFake);

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -434,14 +434,8 @@ describe('Unit | Controller | user-controller', () => {
 
     context('when the user exists', () => {
 
-      let clock;
-
       beforeEach(() => {
-        clock = sinon.useFakeTimers();
-      });
-
-      afterEach(() => {
-        clock.restore();
+        sinon.useFakeTimers();
       });
 
       it('should load his current achieved assessments', async () => {
@@ -666,11 +660,6 @@ describe('Unit | Controller | user-controller', () => {
     beforeEach(() => {
       sinon.stub(usecases, 'findUsers');
       sinon.stub(userSerializer, 'serialize');
-    });
-
-    afterEach(() => {
-      usecases.findUsers.restore();
-      userSerializer.serialize.restore();
     });
 
     it('should return a list of JSON API users fetched from the data repository', async () => {

--- a/api/tests/unit/cat/assessment_test.js
+++ b/api/tests/unit/cat/assessment_test.js
@@ -757,7 +757,7 @@ describe('Unit | Model | Assessment', function() {
       const assessment = new CatAssessment(course, answers);
       // XXX getters stubs does not spy so we do it manually in the getter stub
       const firstChallengeSpy = sinon.stub().returns(firstChallenge);
-      const firstChallengeStub = sinon.stub(assessment, '_firstChallenge').get(firstChallengeSpy);
+      sinon.stub(assessment, '_firstChallenge').get(firstChallengeSpy);
 
       // when
       const result = assessment.nextChallenge;
@@ -765,7 +765,6 @@ describe('Unit | Model | Assessment', function() {
       // then
       expect(firstChallengeSpy).to.have.been.called;
       expect(result).to.be.equal(firstChallenge);
-      firstChallengeStub.restore();
     });
 
     it('should return an easier challenge if user skipped previous challenge', function() {

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -460,16 +460,11 @@ describe('Unit | Domain | Models | Assessment', () => {
 
   describe('#getRemainingDaysBeforeNewAttempt', () => {
 
-    let clock;
     let testCurrentDate;
 
     beforeEach(() => {
       testCurrentDate = new Date('2018-01-10 05:00:00');
-      clock = sinon.useFakeTimers(testCurrentDate.getTime());
-    });
-
-    afterEach(() => {
-      clock.restore();
+      sinon.useFakeTimers(testCurrentDate.getTime());
     });
 
     [
@@ -505,16 +500,11 @@ describe('Unit | Domain | Models | Assessment', () => {
 
   describe('canStartNewAttemptOnCourse', () => {
 
-    let clock;
     let testCurrentDate;
 
     beforeEach(() => {
       testCurrentDate = new Date('2018-01-10 05:00:00');
-      clock = sinon.useFakeTimers(testCurrentDate.getTime());
-    });
-
-    afterEach(() => {
-      clock.restore();
+      sinon.useFakeTimers(testCurrentDate.getTime());
     });
 
     it('should throw an error if the assessment if not a placement', () => {

--- a/api/tests/unit/domain/models/Profile_test.js
+++ b/api/tests/unit/domain/models/Profile_test.js
@@ -20,12 +20,11 @@ describe('Unit | Domain | Models | Profile', () => {
     let lastAssessments;
     let competences;
 
-    let clock;
     let testCurrentDate;
 
     beforeEach(() => {
       testCurrentDate = new Date('2018-01-10 05:00:00');
-      clock = sinon.useFakeTimers(testCurrentDate.getTime());
+      sinon.useFakeTimers(testCurrentDate.getTime());
       user = new BookshelfUser({
         'first-name': faker.name.findName(),
         'last-name': faker.name.findName(),
@@ -75,10 +74,6 @@ describe('Unit | Domain | Models | Profile', () => {
           level: -1,
           status: 'notAssessed',
         }];
-    });
-
-    afterEach(() => {
-      clock.restore();
     });
 
     it('should exist', () => {

--- a/api/tests/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCM_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Models | ValidatorQCM', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(solutionServiceQcm, 'match');
   });

--- a/api/tests/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCM_test.js
@@ -7,16 +7,9 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQCM', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(solutionServiceQcm, 'match');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(solutionServiceQcm, 'match');
   });
 
   describe('#assess', () => {

--- a/api/tests/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCU_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Models | ValidatorQCU', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(solutionServiceQcu, 'match');
   });

--- a/api/tests/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCU_test.js
@@ -7,16 +7,9 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQCU', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(solutionServiceQcu, 'match');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(solutionServiceQcu, 'match');
   });
 
   describe('#assess', () => {

--- a/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(solutionServiceQrocmDep, 'match');
   });

--- a/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
@@ -7,16 +7,9 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQROCMDep', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(solutionServiceQrocmDep, 'match');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(solutionServiceQrocmDep, 'match');
   });
 
   describe('#assess', () => {

--- a/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
@@ -7,16 +7,9 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQROCMInd', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(solutionServiceQrocmInd, 'match');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(solutionServiceQrocmInd, 'match');
   });
 
   describe('#assess', () => {

--- a/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Models | ValidatorQROCMInd', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(solutionServiceQrocmInd, 'match');
   });

--- a/api/tests/unit/domain/models/ValidatorQROC_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROC_test.js
@@ -7,16 +7,9 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | ValidatorQROC', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(solutionServiceQroc, 'match');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(solutionServiceQroc, 'match');
   });
 
   describe('#assess', () => {

--- a/api/tests/unit/domain/models/ValidatorQROC_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROC_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Models | ValidatorQROC', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(solutionServiceQroc, 'match');
   });

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -39,15 +39,9 @@ describe('Unit | Domain | Services | assessment-results', () => {
       }),
     ];
 
-    const sandbox = sinon.createSandbox();
-
     beforeEach(() => {
-      sandbox.stub(assessmentResultRepository, 'save').resolves({ id: 1 });
-      sandbox.stub(competenceMarkRepository, 'save').resolves();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(assessmentResultRepository, 'save').resolves({ id: 1 });
+      sinon.stub(competenceMarkRepository, 'save').resolves();
     });
 
     it('should save the assessment results', () => {

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -39,7 +39,7 @@ describe('Unit | Domain | Services | assessment-results', () => {
       }),
     ];
 
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
       sandbox.stub(assessmentResultRepository, 'save').resolves({ id: 1 });

--- a/api/tests/unit/domain/services/campaigns/campaign-code-generator_test.js
+++ b/api/tests/unit/domain/services/campaigns/campaign-code-generator_test.js
@@ -16,11 +16,6 @@ describe('Unit | Domain | Services | campaign code generator', function() {
       sinon.spy(randomString, 'generate');
     });
 
-    afterEach(() => {
-      randomString.generate.restore();
-      campaignRepository.isCodeAvailable.restore();
-    });
-
     it('should create a code with a length of 9 characters', () => {
       // when
       const promise = campaignCodeGenerator.generate(campaignRepository);

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -39,10 +39,6 @@ describe('Unit | Service | Certification Challenge Service', function() {
       sinon.stub(certificationChallengeRepository, 'save').resolves({});
     });
 
-    afterEach(() => {
-      certificationChallengeRepository.save.restore();
-    });
-
     context('when profile return one competence with two challenges', () => {
       it('should call certification Challenge Repository save twice', () => {
         //When

--- a/api/tests/unit/domain/services/certification-course-service_test.js
+++ b/api/tests/unit/domain/services/certification-course-service_test.js
@@ -12,10 +12,6 @@ describe('Unit | Service | Certification Course Service', function() {
     certificationCourseRepositoryUpdateStub = sinon.stub(certificationCourseRepository, 'update');
   });
 
-  afterEach(() => {
-    certificationCourseRepositoryUpdateStub.restore();
-  });
-
   describe('#updatedCertifcationCourse', () => {
 
     const certificationCourse = CertificationCourse.fromAttributes({

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -183,7 +183,6 @@ describe('Unit | Service | Certification Service', function() {
 
   describe('#calculateCertificationResultByCertificationCourseId', () => {
 
-    let sandbox;
     const dateCreationCertif = '2018-01-01';
     const certificationAssessment = Assessment.fromAttributes({
       id: 'assessment_id',
@@ -196,18 +195,13 @@ describe('Unit | Service | Certification Service', function() {
     const certificationCourse = { id: 'course1', status: 'completed', completedAt: dateCreationCertif };
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(certificationAssessment);
-      sandbox.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
-      sandbox.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
-      sandbox.stub(certificationChallengesRepository, 'findByCertificationCourseId').resolves(challenges);
-      sandbox.stub(certificationCourseRepository, 'get').resolves(certificationCourse);
-      sandbox.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-      sandbox.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(assessmentRepository, 'getByCertificationCourseId').resolves(certificationAssessment);
+      sinon.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
+      sinon.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
+      sinon.stub(certificationChallengesRepository, 'findByCertificationCourseId').resolves(challenges);
+      sinon.stub(certificationCourseRepository, 'get').resolves(certificationCourse);
+      sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
+      sinon.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
     });
 
     it('should call Assessment Repository to get Assessment by CertificationCourseId', function() {
@@ -727,7 +721,6 @@ describe('Unit | Service | Certification Service', function() {
 
   describe('#calculateCertificationResultByAssessmentId', () => {
 
-    let sandbox;
     const certificationCourse = { id: 'course1', status: 'completed' };
     const dateCreationCertif = '2018-02-02';
 
@@ -740,19 +733,14 @@ describe('Unit | Service | Certification Service', function() {
     });
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(assessmentRepository, 'get').resolves(certificationAssessment);
-      sandbox.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
-      sandbox.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
-      sandbox.stub(certificationChallengesRepository, 'findByCertificationCourseId').resolves(challenges);
-      sandbox.stub(certificationCourseRepository, 'get').resolves(certificationCourse);
-      sandbox.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-      sandbox.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
+      sinon.stub(assessmentRepository, 'get').resolves(certificationAssessment);
+      sinon.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
+      sinon.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
+      sinon.stub(certificationChallengesRepository, 'findByCertificationCourseId').resolves(challenges);
+      sinon.stub(certificationCourseRepository, 'get').resolves(certificationCourse);
+      sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
+      sinon.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
 
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should call Assessment Repository to get Assessment by CertificationCourseId', function() {
@@ -1190,19 +1178,12 @@ describe('Unit | Service | Certification Service', function() {
 
   describe('#startNewCertification', () => {
 
-    let sandbox;
-
     const certificationCourse = { id: 'newlyCreatedCertificationCourse' };
     const certificationCourseWithNbOfChallenges = { id: 'certificationCourseWithChallenges', nbChallenges: 3 };
     const sessionId = 23;
 
     beforeEach(() => {
       sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     const noCompetences = [];
@@ -1232,8 +1213,8 @@ describe('Unit | Service | Certification Service', function() {
       it(`should not create a new certification if ${testCase.label}`, function() {
         // given
         const userId = 12345;
-        sandbox.stub(userService, 'getProfileToCertify').resolves(testCase.competences);
-        sandbox.stub(certificationCourseRepository, 'save');
+        sinon.stub(userService, 'getProfileToCertify').resolves(testCase.competences);
+        sinon.stub(certificationCourseRepository, 'save');
 
         // when
         const createNewCertificationPromise = certificationService.startNewCertification(userId, sessionId);
@@ -1249,9 +1230,9 @@ describe('Unit | Service | Certification Service', function() {
     it('should create the certification course with status "started", if at least 5 competences with level higher than 0', function() {
       // given
       const userId = 12345;
-      sandbox.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
-      sandbox.stub(userService, 'getProfileToCertify').resolves(fiveCompetencesWithLevelHigherThan0);
-      sandbox.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
+      sinon.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
+      sinon.stub(userService, 'getProfileToCertify').resolves(fiveCompetencesWithLevelHigherThan0);
+      sinon.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
 
       // when
       const promise = certificationService.startNewCertification(userId, sessionId);
@@ -1267,9 +1248,9 @@ describe('Unit | Service | Certification Service', function() {
     it('should create the challenges for the certification course, based on the user profile', function() {
       // given
       const userId = 12345;
-      sandbox.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
-      sandbox.stub(userService, 'getProfileToCertify').resolves(fiveCompetencesWithLevelHigherThan0);
-      sandbox.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
+      sinon.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
+      sinon.stub(userService, 'getProfileToCertify').resolves(fiveCompetencesWithLevelHigherThan0);
+      sinon.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
 
       // when
       const promise = certificationService.startNewCertification(userId);
@@ -1285,20 +1266,18 @@ describe('Unit | Service | Certification Service', function() {
   });
 
   describe('#getCertificationResult', () => {
-    let sandbox;
 
     context('when certification is finished', () => {
 
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
         const assessmentResult = _buildAssessmentResult(20, 3);
-        sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
+        sinon.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
           state: 'completed',
           assessmentResults: [
             _buildAssessmentResult(20, 3),
           ],
         }));
-        sandbox.stub(certificationCourseRepository, 'get').resolves({
+        sinon.stub(certificationCourseRepository, 'get').resolves({
           createdAt: '2017-12-23 15:23:12',
           completedAt: '2017-12-23T16:23:12.232Z',
           firstName: 'Pumba',
@@ -1309,13 +1288,9 @@ describe('Unit | Service | Certification Service', function() {
           externalId: 'TimonsFriend',
         });
         assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1')];
-        sandbox.stub(assessmentResultRepository, 'get').resolves(
+        sinon.stub(assessmentResultRepository, 'get').resolves(
           assessmentResult,
         );
-      });
-
-      afterEach(() => {
-        sandbox.restore();
       });
 
       it('should return certification results with pix score, date and certified competences levels', () => {
@@ -1364,11 +1339,10 @@ describe('Unit | Service | Certification Service', function() {
     context('when certification is not finished', () => {
 
       beforeEach(() => {
-        sandbox = sinon.createSandbox();
-        sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
+        sinon.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
           state: 'started',
         }));
-        sandbox.stub(certificationCourseRepository, 'get').resolves({
+        sinon.stub(certificationCourseRepository, 'get').resolves({
           createdAt: '2017-12-23 15:23:12',
           firstName: 'Pumba',
           lastName: 'De La Savane',
@@ -1377,11 +1351,7 @@ describe('Unit | Service | Certification Service', function() {
           sessionId: 'MoufMufassa',
           externalId: 'TimonsFriend',
         });
-        sandbox.stub(assessmentResultRepository, 'get').resolves(null);
-      });
-
-      afterEach(() => {
-        sandbox.restore();
+        sinon.stub(assessmentResultRepository, 'get').resolves(null);
       });
 
       it('should return certification results with state at started, empty marks and undefined for information not yet valid', () => {

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -1190,7 +1190,6 @@ describe('Unit | Service | Certification Service', function() {
 
   describe('#startNewCertification', () => {
 
-    let clock;
     let sandbox;
 
     const certificationCourse = { id: 'newlyCreatedCertificationCourse' };
@@ -1198,12 +1197,11 @@ describe('Unit | Service | Certification Service', function() {
     const sessionId = 23;
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
+      sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
       sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {
-      clock.restore();
       sandbox.restore();
     });
 

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -196,7 +196,7 @@ describe('Unit | Service | Certification Service', function() {
     const certificationCourse = { id: 'course1', status: 'completed', completedAt: dateCreationCertif };
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(certificationAssessment);
       sandbox.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
       sandbox.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
@@ -740,7 +740,7 @@ describe('Unit | Service | Certification Service', function() {
     });
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(assessmentRepository, 'get').resolves(certificationAssessment);
       sandbox.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves(assessments);
       sandbox.stub(answersRepository, 'findByAssessment').resolves(_buildWrongAnswersForAllChallenges());
@@ -1199,7 +1199,7 @@ describe('Unit | Service | Certification Service', function() {
 
     beforeEach(() => {
       clock = sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {
@@ -1292,7 +1292,7 @@ describe('Unit | Service | Certification Service', function() {
     context('when certification is finished', () => {
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         const assessmentResult = _buildAssessmentResult(20, 3);
         sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
           state: 'completed',
@@ -1366,7 +1366,7 @@ describe('Unit | Service | Certification Service', function() {
     context('when certification is not finished', () => {
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
           state: 'started',
         }));

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -16,7 +16,7 @@ describe('Unit | Service | Course Service', () => {
     const certificationCourse = new Course({ id: 1 });
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -11,22 +11,13 @@ describe('Unit | Service | Course Service', () => {
 
   describe('#getCourse', function() {
 
-    let sandbox;
     const airtableCourse = { id: 'recAirtableId' };
     const certificationCourse = new Course({ id: 1 });
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
 
     context('when the id is a certification course id', () => {
 
       beforeEach(() => {
-        sandbox.stub(certificationCourseRepository, 'get');
+        sinon.stub(certificationCourseRepository, 'get');
       });
 
       it('should call the certification course repository  ', () => {
@@ -84,7 +75,7 @@ describe('Unit | Service | Course Service', () => {
     context('when the id is not a certification course id', () => {
 
       beforeEach(() => {
-        sandbox.stub(courseRepository, 'get');
+        sinon.stub(courseRepository, 'get');
       });
 
       it('should call the course repository', () => {

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -14,10 +14,6 @@ describe('Unit | Service | MailService', () => {
       sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
     });
 
-    afterEach(() => {
-      sendEmailStub.restore();
-    });
-
     it('should use mailJet to send an email', () => {
       // given
       const email = 'text@example.net';
@@ -44,10 +40,6 @@ describe('Unit | Service | MailService', () => {
 
     beforeEach(() => {
       sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
-    });
-
-    afterEach(() => {
-      sendEmailStub.restore();
     });
 
     it('should use mailJet to send an email', () => {
@@ -90,13 +82,6 @@ describe('Unit | Service | MailService', () => {
       lodashSampleSpy = sinon.spy(_, 'sample');
       getContactListByNameStub = sinon.stub(mailJet, 'getContactListByName').resolves(contactListDetails);
       addEmailToContactListStub = sinon.stub(mailJet, 'addEmailToContactList').resolves();
-    });
-
-    afterEach(() => {
-      lodashSampleSpy.restore();
-      getContactListByNameStub.restore();
-      addEmailToContactListStub.restore();
-      errorStub.restore();
     });
 
     it('should randomly pick a contact list', () => {
@@ -165,10 +150,6 @@ describe('Unit | Service | MailService', () => {
 
     beforeEach(() => {
       sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
-    });
-
-    afterEach(() => {
-      sendEmailStub.restore();
     });
 
     it('should be a function', () => {

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -49,17 +49,11 @@ describe('Unit | Service | OrganizationService', () => {
 
   describe('#search', () => {
 
-    let sandbox;
     const userId = 1234;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(userRepository, 'hasRolePixMaster');
-      sandbox.stub(organizationRepository, 'findBy');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(userRepository, 'hasRolePixMaster');
+      sinon.stub(organizationRepository, 'findBy');
     });
 
     context('when user has role PIX_MASTER', () => {
@@ -152,7 +146,6 @@ describe('Unit | Service | OrganizationService', () => {
 
   describe('#findAllTargetProfilesAvailableForOrganization', () => {
 
-    let sandbox;
     let organizationId;
     let targetProfilesOwnedByOrganization;
     let targetProfileSharesWithOrganization;
@@ -168,14 +161,9 @@ describe('Unit | Service | OrganizationService', () => {
       }];
       const organization = domainBuilder.buildOrganization({ id: organizationId, targetProfileShares });
 
-      sandbox = sinon.createSandbox();
-      sandbox.stub(targetProfileRepository, 'findPublicTargetProfiles').resolves(publicTargetProfiles);
-      sandbox.stub(targetProfileRepository, 'findTargetProfilesOwnedByOrganizationId').resolves(targetProfilesOwnedByOrganization);
-      sandbox.stub(organizationRepository, 'get').resolves(organization);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(targetProfileRepository, 'findPublicTargetProfiles').resolves(publicTargetProfiles);
+      sinon.stub(targetProfileRepository, 'findTargetProfilesOwnedByOrganizationId').resolves(targetProfilesOwnedByOrganization);
+      sinon.stub(organizationRepository, 'get').resolves(organization);
     });
 
     it('should return an array of target profiles', () => {

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -53,7 +53,7 @@ describe('Unit | Service | OrganizationService', () => {
     const userId = 1234;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(userRepository, 'hasRolePixMaster');
       sandbox.stub(organizationRepository, 'findBy');
     });
@@ -168,7 +168,7 @@ describe('Unit | Service | OrganizationService', () => {
       }];
       const organization = domainBuilder.buildOrganization({ id: organizationId, targetProfileShares });
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(targetProfileRepository, 'findPublicTargetProfiles').resolves(publicTargetProfiles);
       sandbox.stub(targetProfileRepository, 'findTargetProfilesOwnedByOrganizationId').resolves(targetProfilesOwnedByOrganization);
       sandbox.stub(organizationRepository, 'get').resolves(organization);

--- a/api/tests/unit/domain/services/profile-service_test.js
+++ b/api/tests/unit/domain/services/profile-service_test.js
@@ -91,7 +91,7 @@ describe('Unit | Service | Profil User Service', function() {
 
       beforeEach(() => {
 
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
 
         sandbox.stub(userRepository, 'findUserById').resolves(fakeUserRecord);
         sandbox.stub(competenceRepository, 'list').resolves(fakeCompetenceRecords);

--- a/api/tests/unit/domain/services/profile-service_test.js
+++ b/api/tests/unit/domain/services/profile-service_test.js
@@ -87,23 +87,15 @@ describe('Unit | Service | Profil User Service', function() {
 
     describe('Enhanced user', () => {
 
-      let sandbox;
-
       beforeEach(() => {
 
-        sandbox = sinon.createSandbox();
-
-        sandbox.stub(userRepository, 'findUserById').resolves(fakeUserRecord);
-        sandbox.stub(competenceRepository, 'list').resolves(fakeCompetenceRecords);
-        sandbox.stub(areaRepository, 'list').resolves(fakeAreaRecords);
-        sandbox.stub(courseRepository, 'getAdaptiveCourses').resolves(fakeCoursesRecords);
-        sandbox.stub(assessmentRepository, 'findLastAssessmentsForEachCoursesByUser').resolves(fakeAssessmentRecords);
-        sandbox.stub(assessmentRepository, 'findCompletedAssessmentsByUserId').resolves(fakeAssessmentRecords);
-        sandbox.stub(organizationRepository, 'getByUserId').resolves(fakeOrganizationsRecords);
-      });
-
-      afterEach(() => {
-        sandbox.restore();
+        sinon.stub(userRepository, 'findUserById').resolves(fakeUserRecord);
+        sinon.stub(competenceRepository, 'list').resolves(fakeCompetenceRecords);
+        sinon.stub(areaRepository, 'list').resolves(fakeAreaRecords);
+        sinon.stub(courseRepository, 'getAdaptiveCourses').resolves(fakeCoursesRecords);
+        sinon.stub(assessmentRepository, 'findLastAssessmentsForEachCoursesByUser').resolves(fakeAssessmentRecords);
+        sinon.stub(assessmentRepository, 'findCompletedAssessmentsByUserId').resolves(fakeAssessmentRecords);
+        sinon.stub(organizationRepository, 'getByUserId').resolves(fakeOrganizationsRecords);
       });
 
       it('should return a resolved promise', () => {

--- a/api/tests/unit/domain/services/reset-password-service_test.js
+++ b/api/tests/unit/domain/services/reset-password-service_test.js
@@ -12,10 +12,6 @@ describe('Unit | Service | Password Service', function() {
       sinon.stub(jsonwebtoken, 'sign');
     });
 
-    afterEach(() => {
-      jsonwebtoken.sign.restore();
-    });
-
     it('should call sign function from jwt', () => {
       // given
       const signParams = {
@@ -37,10 +33,6 @@ describe('Unit | Service | Password Service', function() {
 
     beforeEach(() => {
       sinon.stub(resetPasswordRepository, 'markAsBeingUsed');
-    });
-
-    afterEach(() => {
-      resetPasswordRepository.markAsBeingUsed.restore();
     });
 
     it('should call reset password repository', () => {

--- a/api/tests/unit/domain/services/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring-service_test.js
@@ -9,7 +9,7 @@ describe('Unit | Service | scoring-service', () => {
 
   describe('#calculateAssessmentScore', () => {
 
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     beforeEach(() => {
       sandbox.stub(scoringPlacement, 'calculate').resolves();

--- a/api/tests/unit/domain/services/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring-service_test.js
@@ -9,15 +9,9 @@ describe('Unit | Service | scoring-service', () => {
 
   describe('#calculateAssessmentScore', () => {
 
-    const sandbox = sinon.createSandbox();
-
     beforeEach(() => {
-      sandbox.stub(scoringPlacement, 'calculate').resolves();
-      sandbox.stub(scoringCertification, 'calculate').resolves();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(scoringPlacement, 'calculate').resolves();
+      sinon.stub(scoringCertification, 'calculate').resolves();
     });
 
     it('should resolve an AssessmentScore', async () => {

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -9,7 +9,7 @@ describe('Unit | Service | CodeSession', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {
@@ -64,7 +64,7 @@ describe('Unit | Service | CodeSession', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -6,19 +6,9 @@ describe('Unit | Service | CodeSession', () => {
 
   describe('#isSessionCodeAvailable', () => {
 
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it('should return a session code with 4 random capital letters and 2 random numbers', () => {
       // given
-      sandbox.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
+      sinon.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
 
       // when
       const promise = sessionCodeService.getNewSessionCode();
@@ -31,7 +21,7 @@ describe('Unit | Service | CodeSession', () => {
 
     it('should call Repository isSessionCodeAvailable to validate code unicity', () => {
       // given
-      sandbox.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
+      sinon.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
 
       // when
       const promise = sessionCodeService.getNewSessionCode();
@@ -45,7 +35,7 @@ describe('Unit | Service | CodeSession', () => {
 
     it('should call Repository isSessionCodeAvailable twice if first code was not unique', () => {
       // given
-      sandbox.stub(sessionRepository, 'isSessionCodeAvailable')
+      sinon.stub(sessionRepository, 'isSessionCodeAvailable')
         .onCall(0).resolves(false)
         .onCall(1).resolves(true);
 
@@ -61,19 +51,9 @@ describe('Unit | Service | CodeSession', () => {
 
   describe('#getSessionByAccessCode', () => {
 
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it('should return true if session exists with this accessCode', () => {
       // given
-      sandbox.stub(sessionRepository, 'getByAccessCode').resolves({ id: 1 });
+      sinon.stub(sessionRepository, 'getByAccessCode').resolves({ id: 1 });
 
       // when
       const promise = sessionCodeService.getSessionByAccessCode('ABCD12');
@@ -86,7 +66,7 @@ describe('Unit | Service | CodeSession', () => {
 
     it('should return false if accessCode does not link to a session', () => {
       // given
-      sandbox.stub(sessionRepository, 'getByAccessCode').resolves(null);
+      sinon.stub(sessionRepository, 'getByAccessCode').resolves(null);
 
       // when
       const promise = sessionCodeService.getSessionByAccessCode('BBAAAHHHHH');

--- a/api/tests/unit/domain/services/session-service_test.js
+++ b/api/tests/unit/domain/services/session-service_test.js
@@ -12,10 +12,6 @@ describe('Unit | Service | session', () => {
       sinon.stub(sessionCodeService, 'getSessionByAccessCode');
     });
 
-    afterEach(() => {
-      sessionCodeService.getSessionByAccessCode.restore();
-    });
-
     context('when access-code is not given', () => {
       it('should stop the request', () => {
         // given

--- a/api/tests/unit/domain/services/skills-service_test.js
+++ b/api/tests/unit/domain/services/skills-service_test.js
@@ -11,10 +11,6 @@ describe('Unit | Service | Skills Service', () => {
       sinon.stub(skillRepository, 'save').resolves();
     });
 
-    afterEach(() => {
-      skillRepository.save.restore();
-    });
-
     it('should call Skills Repository#save with formatted skills', () => {
 
       const skillsFormatted = [

--- a/api/tests/unit/domain/services/snapshot-service_test.js
+++ b/api/tests/unit/domain/services/snapshot-service_test.js
@@ -95,10 +95,6 @@ describe('Unit | Service | Snapshot service', function() {
       sinon.stub(snapshotRepository, 'save');
     });
 
-    afterEach(() => {
-      snapshotRepository.save.restore();
-    });
-
     it('should correctly call snapshot repository', () => {
       // given
       const snapshotModel = new Snapshot({ id: 3 });

--- a/api/tests/unit/domain/services/solution-service-function-match_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-match_test.js
@@ -59,8 +59,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQcu.match.restore();
-
         expect(result).to.deep.equal({ result: ANSWER_OK, resultDetails: null });
       });
 
@@ -76,8 +74,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQcu.match.restore();
-
         expect(result).to.deep.equal({ result: ANSWER_TIMEDOUT, resultDetails: null });
       });
 
@@ -104,8 +100,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQcm.match.restore();
-
         expect(result).to.deep.equal({ result: ANSWER_OK, resultDetails: null });
       });
 
@@ -121,8 +115,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQcm.match.restore();
-
         expect(result).to.deep.equal({ result: ANSWER_TIMEDOUT, resultDetails: null });
       });
 
@@ -151,8 +143,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQroc.match.restore();
-
         sinon.assert.calledOnce(serviceQrocMatch);
         sinon.assert.calledWithExactly(serviceQrocMatch, 'qrocAnswer', 'qrocSolution', {
           t1: true,
@@ -175,8 +165,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQroc.match.restore();
-
         sinon.assert.calledOnce(serviceQrocMatch);
         sinon.assert.calledWithExactly(serviceQrocMatch, 'qrocAnswer', 'qrocSolution', {
           t1: true,
@@ -211,8 +199,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQrocmInd.match.restore();
-
         sinon.assert.calledOnce(serviceQrocmInd$match);
         sinon.assert.calledWithExactly(serviceQrocmInd$match, 'qrocmIndAnswer', 'qrocmIndSolution', ['t2', 't3']);
         expect(result).to.deep.equal({ result: ANSWER_OK, resultDetails: { shi: true, fu: false, mi: true } });
@@ -232,8 +218,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQrocmInd.match.restore();
-
         sinon.assert.calledOnce(serviceQrocmInd$match);
         sinon.assert.calledWithExactly(serviceQrocmInd$match, 'qrocmIndAnswer', 'qrocmIndSolution', ['t2', 't3']);
 
@@ -264,8 +248,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQrocmDep.match.restore();
-
         sinon.assert.calledOnce(serviceQrocmDep$match);
         sinon.assert.calledWithExactly(serviceQrocmDep$match, 'qrocmDepAnswer', 'qrocmDepSolution', 'anyScoring', {
           t1: true,
@@ -288,8 +270,6 @@ describe('Unit | Service | SolutionService', function() {
         const result = service.validate(answer, solution);
 
         // then
-        serviceQrocmDep.match.restore();
-
         sinon.assert.calledOnce(serviceQrocmDep$match);
         sinon.assert.calledWithExactly(serviceQrocmDep$match, 'qrocmDepAnswer', 'qrocmDepSolution', 'anyScoring', {
           t1: true,

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -90,9 +90,6 @@ describe('Unit | Service | SolutionService', function() {
       service.revalidate(new Answer(ko_answer)).then(function(foundAnswer) {
 
         // then
-        solutionRepository.getByChallengeId.restore();
-        service.validate.restore();
-
         expect(solutionRepository.getByChallengeId.callOnce);
         expect(service.validate.callOnce);
         expect(foundAnswer.id).equals(ko_answer.id);
@@ -117,9 +114,6 @@ describe('Unit | Service | SolutionService', function() {
       service.revalidate(new Answer(ok_answer)).then(function(foundAnswer) {
 
         // then
-        solutionRepository.getByChallengeId.restore();
-        service.validate.restore();
-
         expect(solutionRepository.getByChallengeId.callOnce);
         expect(service.validate.callOnce);
         expect(foundAnswer.id).equals(ok_answer.id);
@@ -144,9 +138,6 @@ describe('Unit | Service | SolutionService', function() {
       service.revalidate(new Answer(unimplemented_answer)).then(function(foundAnswer) {
 
         // then
-        solutionRepository.getByChallengeId.restore();
-        service.validate.restore();
-
         expect(solutionRepository.getByChallengeId.callOnce);
         expect(service.validate.callOnce);
         expect(foundAnswer.id).equals(unimplemented_answer.id);

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -121,7 +121,6 @@ describe('Unit | Service | User Service', () => {
 
   describe('#getProfileToCertify', () => {
 
-    let sandbox;
     const userId = 63731;
 
     const AnswerCollection = Bookshelf.Collection.extend({
@@ -186,17 +185,16 @@ describe('Unit | Service | User Service', () => {
     const assessment3 = Assessment.fromAttributes({ id: 145, status: 'completed', courseId: 'courseId3', assessmentResults: [assessmentResult3] });
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
 
-      sandbox.stub(courseRepository, 'getAdaptiveCourses').resolves([
+      sinon.stub(courseRepository, 'getAdaptiveCourses').resolves([
         { competences: ['competenceRecordIdOne'], id: 'courseId1' },
         { competences: ['competenceRecordIdTwo'], id: 'courseId2' },
       ]);
-      sandbox.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves([
+      sinon.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCoursesByUser').resolves([
         assessment1, assessment2, assessment3
       ]);
 
-      sandbox.stub(challengeRepository, 'list').resolves([
+      sinon.stub(challengeRepository, 'list').resolves([
         challengeForSkillCitation4,
         archivedChallengeForSkillCitation4,
         challengeForSkillCitation4AndMoteur3,
@@ -209,15 +207,11 @@ describe('Unit | Service | User Service', () => {
         challengeRecordWithoutSkills,
         oldChallengeWithAlreadyValidatedSkill
       ]);
-      sandbox.stub(answerRepository, 'findCorrectAnswersByAssessment').resolves(answerCollectionWithEmptyData);
-      sandbox.stub(competenceRepository, 'list').resolves([
+      sinon.stub(answerRepository, 'findCorrectAnswersByAssessment').resolves(answerCollectionWithEmptyData);
+      sinon.stub(competenceRepository, 'list').resolves([
         competenceFlipper,
         competenceDauphin
       ]);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should load achieved assessments', () => {

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -27,10 +27,6 @@ describe('Unit | Service | User Service', () => {
       sinon.stub(userRepository, 'findByEmail');
     });
 
-    afterEach(() => {
-      userRepository.findByEmail.restore();
-    });
-
     it('should call a userRepository#findByEmail', () => {
       // given
       userRepository.findByEmail.resolves();
@@ -79,10 +75,6 @@ describe('Unit | Service | User Service', () => {
 
     beforeEach(() => {
       sinon.stub(userRepository, 'findUserById');
-    });
-
-    afterEach(() => {
-      userRepository.findUserById.restore();
     });
 
     it('should call a userRepository.findUserById', () => {

--- a/api/tests/unit/domain/services/user-service_test.js
+++ b/api/tests/unit/domain/services/user-service_test.js
@@ -194,7 +194,7 @@ describe('Unit | Service | User Service', () => {
     const assessment3 = Assessment.fromAttributes({ id: 145, status: 'completed', courseId: 'courseId3', assessmentResults: [assessmentResult3] });
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(courseRepository, 'getAdaptiveCourses').resolves([
         { competences: ['competenceRecordIdOne'], id: 'courseId1' },

--- a/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
@@ -8,7 +8,7 @@ describe('Unit | UseCase | accept-pix-certif-terms-of-service', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(userRepository, 'get');
     sandbox.stub(userRepository, 'updateUser');
   });

--- a/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
@@ -5,16 +5,9 @@ const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | UseCase | accept-pix-certif-terms-of-service', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(userRepository, 'get');
-    sandbox.stub(userRepository, 'updateUser');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(userRepository, 'get');
+    sinon.stub(userRepository, 'updateUser');
   });
 
   context('when user has already accepted pix-certif terms of service', () => {

--- a/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-certif-terms-of-service_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const acceptPixCertifTermsOfService = require('../../../../lib/domain/usecases/accept-pix-certif-terms-of-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | UseCase | accept-pix-certif-terms-of-service', () => {
 
@@ -44,7 +45,7 @@ describe('Unit | UseCase | accept-pix-certif-terms-of-service', () => {
         pixCertifTermsOfServiceAccepted: false
       });
       userRepository.get.resolves(user);
-      const expectedUser = { ...user, pixCertifTermsOfServiceAccepted: true };
+      const expectedUser = new User({ ...user, pixCertifTermsOfServiceAccepted: true });
 
       // when
       const promise = acceptPixCertifTermsOfService({ userId, userRepository });

--- a/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const acceptPixOrgaTermsOfService = require('../../../../lib/domain/usecases/accept-pix-orga-terms-of-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | UseCase | accept-pix-orga-terms-of-service', () => {
 
@@ -44,7 +45,7 @@ describe('Unit | UseCase | accept-pix-orga-terms-of-service', () => {
         pixOrgaTermsOfServiceAccepted: false
       });
       userRepository.get.resolves(user);
-      const expectedUser = { ...user, pixOrgaTermsOfServiceAccepted: true };
+      const expectedUser = new User({ ...user, pixOrgaTermsOfServiceAccepted: true });
 
       // when
       const promise = acceptPixOrgaTermsOfService({ userId, userRepository });

--- a/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
@@ -8,7 +8,7 @@ describe('Unit | UseCase | accept-pix-orga-terms-of-service', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(userRepository, 'get');
     sandbox.stub(userRepository, 'updateUser');
   });

--- a/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-orga-terms-of-service_test.js
@@ -5,16 +5,9 @@ const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | UseCase | accept-pix-orga-terms-of-service', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(userRepository, 'get');
-    sandbox.stub(userRepository, 'updateUser');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(userRepository, 'get');
+    sinon.stub(userRepository, 'updateUser');
   });
 
   context('when user has already accepted pix-orga terms of service', () => {

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -18,7 +18,7 @@ describe('Unit | Application | Use Case | authenticate-user', () => {
   const userPassword = 'user_password';
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     userRepository = { findByEmailWithRoles: sandbox.stub() };
     tokenService = { createTokenFromUser: sandbox.stub() };
     sandbox.stub(encryptionService, 'check');

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -10,7 +10,6 @@ function _expectTreatmentToFailWithMissingOrInvalidCredentialsError(promise) {
 
 describe('Unit | Application | Use Case | authenticate-user', () => {
 
-  let sandbox;
   let userRepository;
   let tokenService;
 
@@ -18,14 +17,9 @@ describe('Unit | Application | Use Case | authenticate-user', () => {
   const userPassword = 'user_password';
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    userRepository = { findByEmailWithRoles: sandbox.stub() };
-    tokenService = { createTokenFromUser: sandbox.stub() };
-    sandbox.stub(encryptionService, 'check');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    userRepository = { findByEmailWithRoles: sinon.stub() };
+    tokenService = { createTokenFromUser: sinon.stub() };
+    sinon.stub(encryptionService, 'check');
   });
 
   it('should resolves a valid JWT access token when authentication succeeded', () => {

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -9,8 +9,6 @@ const { ChallengeAlreadyAnsweredError, NotFoundError } = require('../../../../li
 
 describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', () => {
 
-  let sandbox;
-
   const answerRepository = {
     hasChallengeAlreadyBeenAnswered: () => undefined,
     save: () => undefined,
@@ -20,18 +18,13 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
   const smartPlacementKnowledgeElementRepository = { save: () => undefined };
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
 
-    sandbox.stub(answerRepository, 'hasChallengeAlreadyBeenAnswered');
-    sandbox.stub(answerRepository, 'save');
-    sandbox.stub(challengeRepository, 'get');
-    sandbox.stub(smartPlacementAssessmentRepository, 'get');
-    sandbox.stub(smartPlacementKnowledgeElementRepository, 'save');
-    sandbox.stub(SmartPlacementKnowledgeElement, 'createKnowledgeElementsForAnswer');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(answerRepository, 'hasChallengeAlreadyBeenAnswered');
+    sinon.stub(answerRepository, 'save');
+    sinon.stub(challengeRepository, 'get');
+    sinon.stub(smartPlacementAssessmentRepository, 'get');
+    sinon.stub(smartPlacementKnowledgeElementRepository, 'save');
+    sinon.stub(SmartPlacementKnowledgeElement, 'createKnowledgeElementsForAnswer');
   });
 
   context('when an answer for that challenge and that assessment already exists', () => {

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -8,21 +8,15 @@ const { CampaignCodeError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-assessment-for-campaign', () => {
 
-  let sandbox;
   const availableCampaignCode = 'ABCDEF123';
   const campaignRepository = { getByCode: () => undefined };
   const campaignParticipationRepository = { save: () => undefined };
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(campaignRepository, 'getByCode');
-    sandbox.stub(assessmentRepository, 'save');
-    sandbox.stub(campaignParticipationRepository, 'save');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(campaignRepository, 'getByCode');
+    sinon.stub(assessmentRepository, 'save');
+    sinon.stub(campaignParticipationRepository, 'save');
   });
 
   context('when campaignCode not exist', () => {

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -15,7 +15,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(campaignRepository, 'getByCode');
     sandbox.stub(assessmentRepository, 'save');
     sandbox.stub(campaignParticipationRepository, 'save');

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -142,7 +142,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       competenceMarks: competenceMarksForPlacement
     };
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     sandbox.stub(scoringService, 'calculateAssessmentScore').resolves(assessmentScore);
     sandbox.stub(assessmentRepository, 'save').resolves();

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -58,7 +58,6 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
   const competenceId = 'competenceId';
 
   let course;
-  let sandbox;
 
   let competence11;
   let competence12;
@@ -142,23 +141,18 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       competenceMarks: competenceMarksForPlacement
     };
 
-    sandbox = sinon.createSandbox();
+    sinon.stub(scoringService, 'calculateAssessmentScore').resolves(assessmentScore);
+    sinon.stub(assessmentRepository, 'save').resolves();
+    sinon.stub(assessmentResultRepository, 'save').resolves({ id: assessmentResultId });
+    sinon.stub(assessmentRepository, 'get').resolves(assessment);
+    sinon.stub(skillsService, 'saveAssessmentSkills').resolves();
+    sinon.stub(courseRepository, 'get').resolves(course);
+    sinon.stub(competenceRepository, 'get').resolves(competence11);
+    sinon.stub(competenceRepository, 'list').resolves(listOfAllCompetences);
+    sinon.stub(competenceMarkRepository, 'save').resolves();
+    sinon.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves();
+    sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
 
-    sandbox.stub(scoringService, 'calculateAssessmentScore').resolves(assessmentScore);
-    sandbox.stub(assessmentRepository, 'save').resolves();
-    sandbox.stub(assessmentResultRepository, 'save').resolves({ id: assessmentResultId });
-    sandbox.stub(assessmentRepository, 'get').resolves(assessment);
-    sandbox.stub(skillsService, 'saveAssessmentSkills').resolves();
-    sandbox.stub(courseRepository, 'get').resolves(course);
-    sandbox.stub(competenceRepository, 'get').resolves(competence11);
-    sandbox.stub(competenceRepository, 'list').resolves(listOfAllCompetences);
-    sandbox.stub(competenceMarkRepository, 'save').resolves();
-    sandbox.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves();
-    sandbox.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should reject with a NotFoundError when the assessment does not exist', () => {

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -505,7 +505,6 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
   context('when the assessment is a CERTIFICATION', () => {
 
-    let clock;
     let assessment;
     let sumOfCompetenceMarksScores;
 
@@ -537,10 +536,8 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       assessmentRepository.get.resolves(assessment);
       scoringService.calculateAssessmentScore.resolves(assessmentScore);
 
-      clock = sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
+      sinon.useFakeTimers(new Date('2018-02-04T01:00:00.000+01:00'));
     });
-
-    afterEach(() => clock.restore());
 
     context('happy path', () => {
 

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -6,7 +6,6 @@ const { EntityValidationError, UserNotAuthorizedToCreateCampaignError } = requir
 
 describe('Unit | UseCase | create-campaign', () => {
 
-  let sandbox;
   const availableCampaignCode = 'ABCDEF123';
   const targetProfileId = 12;
   const campaignToCreate = domainBuilder.buildCampaign({ id: '', code: '', targetProfileId  });
@@ -24,16 +23,11 @@ describe('Unit | UseCase | create-campaign', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(campaignCodeGenerator, 'generate');
-    sandbox.stub(campaignRepository, 'save');
-    sandbox.stub(campaignValidator, 'validate');
-    sandbox.stub(userRepository, 'getWithMemberships');
-    sandbox.stub(organizationService, 'findAllTargetProfilesAvailableForOrganization');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(campaignCodeGenerator, 'generate');
+    sinon.stub(campaignRepository, 'save');
+    sinon.stub(campaignValidator, 'validate');
+    sinon.stub(userRepository, 'getWithMemberships');
+    sinon.stub(organizationService, 'findAllTargetProfilesAvailableForOrganization');
   });
 
   it('should throw an EntityValidationError if campaign is not valid', () => {

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | create-campaign', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(campaignCodeGenerator, 'generate');
     sandbox.stub(campaignRepository, 'save');
     sandbox.stub(campaignValidator, 'validate');

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | create-organization', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(organizationCreationValidator, 'validate');
     sandbox.stub(organizationService, 'generateUniqueOrganizationCode');
   });

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -7,16 +7,9 @@ const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-organization', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(organizationCreationValidator, 'validate');
-    sandbox.stub(organizationService, 'generateUniqueOrganizationCode');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(organizationCreationValidator, 'validate');
+    sinon.stub(organizationService, 'generateUniqueOrganizationCode');
   });
 
   context('Green cases', () => {

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | create-user', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(userRepository, 'isEmailAvailable');
     sandbox.stub(userRepository, 'create');
     sandbox.stub(userValidator, 'validate');

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -22,16 +22,13 @@ describe('Unit | UseCase | create-user', () => {
   const encryptedPassword = '3ncrypt3dP@$$w@rd';
   const savedUser = new User({ id: userId, email: userEmail });
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(userRepository, 'isEmailAvailable');
-    sandbox.stub(userRepository, 'create');
-    sandbox.stub(userValidator, 'validate');
-    sandbox.stub(encryptionService, 'hashPassword');
-    sandbox.stub(mailService, 'sendAccountCreationEmail');
-    sandbox.stub(reCaptchaValidator, 'verify');
+    sinon.stub(userRepository, 'isEmailAvailable');
+    sinon.stub(userRepository, 'create');
+    sinon.stub(userValidator, 'validate');
+    sinon.stub(encryptionService, 'hashPassword');
+    sinon.stub(mailService, 'sendAccountCreationEmail');
+    sinon.stub(reCaptchaValidator, 'verify');
 
     userRepository.isEmailAvailable.resolves();
     userRepository.create.resolves(savedUser);
@@ -39,10 +36,6 @@ describe('Unit | UseCase | create-user', () => {
     encryptionService.hashPassword.resolves(encryptedPassword);
     mailService.sendAccountCreationEmail.resolves();
     reCaptchaValidator.verify.resolves();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   context('step validation of user', () => {

--- a/api/tests/unit/domain/usecases/find-certification-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-assessments_test.js
@@ -8,22 +8,12 @@ describe('Unit | UseCase | find-certification-assessments', () => {
     },
   };
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should resolve an empty array', () => {
     // given
     const userId = 1234;
     const courseId = 2;
     const filters = { type: 'CERTIFICATION', courseId };
-    sandbox.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(null);
+    sinon.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(null);
 
     // when
     const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
@@ -58,7 +48,7 @@ describe('Unit | UseCase | find-certification-assessments', () => {
       ...filters,
       userId,
     });
-    sandbox.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(assessment);
+    sinon.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(assessment);
 
     // when
     const promise = findCertificationAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/find-certification-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-assessments_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | find-certification-assessments', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/domain/usecases/find-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-placement-assessments_test.js
@@ -8,22 +8,12 @@ describe('Unit | UseCase | find-placement-assessments', () => {
     },
   };
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should resolve an empty array', () => {
     // given
     const userId = 1234;
     const courseId = 2;
     const filters = { type: 'PLACEMENT', courseId, state: 'started' };
-    sandbox.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(null);
+    sinon.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(null);
 
     // when
     const promise = findPlacementAssessments({ userId, filters, assessmentRepository });
@@ -58,7 +48,7 @@ describe('Unit | UseCase | find-placement-assessments', () => {
       ...filters,
       userId,
     });
-    sandbox.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(assessment);
+    sinon.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(assessment);
 
     // when
     const promise = findPlacementAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/find-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-placement-assessments_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | find-placement-assessments', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
@@ -8,16 +8,6 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
     },
   };
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should resolve assessments that match userId and belong to the user but has no campaign participation', () => {
     // given
     const userId = 1234;
@@ -26,7 +16,7 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
       ...filters,
       userId,
     });
-    sandbox.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
+    sinon.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
 
     // when
     const promise = findSmartPlacementAssessments({ userId, filters, assessmentRepository });
@@ -48,7 +38,7 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
       userId,
       campaignParticipation
     });
-    sandbox.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
+    sinon.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
 
     // when
     const promise = findSmartPlacementAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -10,18 +10,12 @@ describe('Unit | UseCase | get-assessment', () => {
   let assessment;
   let assessmentScore;
 
-  const sandbox = sinon.createSandbox();
-
   beforeEach(() => {
     assessment = domainBuilder.buildAssessment();
     assessmentScore = domainBuilder.buildAssessmentScore();
 
-    sandbox.stub(assessmentRepository, 'get');
-    sandbox.stub(scoringService, 'calculateAssessmentScore');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(assessmentRepository, 'get');
+    sinon.stub(scoringService, 'calculateAssessmentScore');
   });
 
   it('should resolve the Assessment domain object matching the given assessment ID', async () => {

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | get-assessment', () => {
   let assessment;
   let assessmentScore;
 
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
     assessment = domainBuilder.buildAssessment();

--- a/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
@@ -4,7 +4,6 @@ const { NotFoundError, InternalError } = require('../../../../lib/domain/errors'
 
 describe('Unit | UseCase | get-campaign-by-code', () => {
 
-  let sandbox;
   let requestErr;
   let requestResult;
 
@@ -18,15 +17,10 @@ describe('Unit | UseCase | get-campaign-by-code', () => {
   const testError = 'some error';
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    campaignRepository.getByCode = sandbox.stub();
-    organizationRepository.get = sandbox.stub();
+    campaignRepository.getByCode = sinon.stub();
+    organizationRepository.get = sinon.stub();
     requestErr = null;
     requestResult = null;
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
   
   context('the campaign was retrieved by code', () => {

--- a/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-by-code_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | get-campaign-by-code', () => {
   const testError = 'some error';
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     campaignRepository.getByCode = sandbox.stub();
     organizationRepository.get = sandbox.stub();
     requestErr = null;

--- a/api/tests/unit/domain/usecases/get-correction-for-answer-when-assessment-ended_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer-when-assessment-ended_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | getCorrectionForAnswerWhenAssessmentEnded', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(assessmentRepository, 'get');
     sandbox.stub(answerRepository, 'get');
     sandbox.stub(correctionRepository, 'getByChallengeId');

--- a/api/tests/unit/domain/usecases/get-correction-for-answer-when-assessment-ended_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer-when-assessment-ended_test.js
@@ -10,17 +10,11 @@ describe('Unit | UseCase | getCorrectionForAnswerWhenAssessmentEnded', () => {
   const assessmentRepository = { get: () => undefined };
   const answerRepository = { get: () => undefined };
   const correctionRepository = { getByChallengeId: () => undefined };
-  let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(assessmentRepository, 'get');
-    sandbox.stub(answerRepository, 'get');
-    sandbox.stub(correctionRepository, 'getByChallengeId');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(assessmentRepository, 'get');
+    sinon.stub(answerRepository, 'get');
+    sinon.stub(correctionRepository, 'getByChallengeId');
   });
 
   context('when assessment is not completed', () => {

--- a/api/tests/unit/domain/usecases/get-results-campaign-in-csv-format_test.js
+++ b/api/tests/unit/domain/usecases/get-results-campaign-in-csv-format_test.js
@@ -87,7 +87,7 @@ describe('Unit | Domain | Use Cases | get-results-campaign-in-csv-format', () =
 
     beforeEach(() => {
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(campaignRepository, 'get').resolves(campaign);
       sandbox.stub(competenceRepository, 'list').resolves(competences);
       sandbox.stub(targetProfileRepository, 'get').resolves(targetProfile);

--- a/api/tests/unit/domain/usecases/get-results-campaign-in-csv-format_test.js
+++ b/api/tests/unit/domain/usecases/get-results-campaign-in-csv-format_test.js
@@ -82,24 +82,18 @@ describe('Unit | Domain | Use Cases | get-results-campaign-in-csv-format', () =
     const campaignParticipationRepository = { findByCampaignId: () => undefined };
     const smartPlacementAssessmentRepository = { get: () => undefined };
 
-    let sandbox;
     let findCampaignParticipationStub;
 
     beforeEach(() => {
 
-      sandbox = sinon.createSandbox();
-      sandbox.stub(campaignRepository, 'get').resolves(campaign);
-      sandbox.stub(competenceRepository, 'list').resolves(competences);
-      sandbox.stub(targetProfileRepository, 'get').resolves(targetProfile);
-      sandbox.stub(userRepository, 'getWithMemberships').resolves(user);
-      sandbox.stub(organizationRepository, 'get').resolves(organization);
-      sandbox.stub(userRepository, 'get').resolves(user);
-      sandbox.stub(smartPlacementAssessmentRepository, 'get').resolves(assessment);
-      findCampaignParticipationStub = sandbox.stub(campaignParticipationRepository, 'findByCampaignId');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(campaignRepository, 'get').resolves(campaign);
+      sinon.stub(competenceRepository, 'list').resolves(competences);
+      sinon.stub(targetProfileRepository, 'get').resolves(targetProfile);
+      sinon.stub(userRepository, 'getWithMemberships').resolves(user);
+      sinon.stub(organizationRepository, 'get').resolves(organization);
+      sinon.stub(userRepository, 'get').resolves(user);
+      sinon.stub(smartPlacementAssessmentRepository, 'get').resolves(assessment);
+      findCampaignParticipationStub = sinon.stub(campaignParticipationRepository, 'findByCampaignId');
     });
 
     it('should return the header in CSV styles with all competence, domain and skills', () => {

--- a/api/tests/unit/domain/usecases/get-skill-review_test.js
+++ b/api/tests/unit/domain/usecases/get-skill-review_test.js
@@ -18,15 +18,8 @@ describe('Unit | Domain | Use Cases | get-skill-review', () => {
 
   const smartPlacementAssessmentRepository = { get: () => undefined };
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(smartPlacementAssessmentRepository, 'get').resolves(smartPlacementAssessment);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(smartPlacementAssessmentRepository, 'get').resolves(smartPlacementAssessment);
   });
 
   describe('#getSkillReview', () => {

--- a/api/tests/unit/domain/usecases/get-user-campaign-participations_test.js
+++ b/api/tests/unit/domain/usecases/get-user-campaign-participations_test.js
@@ -27,7 +27,7 @@ describe('Unit | UseCase | get-user-campaign-participations', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(campaignParticipationRepository, 'findByUserId');
     });
 

--- a/api/tests/unit/domain/usecases/get-user-campaign-participations_test.js
+++ b/api/tests/unit/domain/usecases/get-user-campaign-participations_test.js
@@ -24,15 +24,8 @@ describe('Unit | UseCase | get-user-campaign-participations', () => {
 
   context('When authenticated User is authorized to retrieve his campaign participations', () => {
 
-    let sandbox;
-
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(campaignParticipationRepository, 'findByUserId');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(campaignParticipationRepository, 'findByUserId');
     });
 
     it('should call findByUserId to find all campaign-participations', () => {

--- a/api/tests/unit/domain/usecases/get-user-with-memberships_test.js
+++ b/api/tests/unit/domain/usecases/get-user-with-memberships_test.js
@@ -29,7 +29,7 @@ describe('Unit | UseCase | get-user-with-memberships', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(userRepository, 'getWithMemberships');
     });
 

--- a/api/tests/unit/domain/usecases/get-user-with-memberships_test.js
+++ b/api/tests/unit/domain/usecases/get-user-with-memberships_test.js
@@ -26,15 +26,8 @@ describe('Unit | UseCase | get-user-with-memberships', () => {
 
   context('When authenticated User is authorized to retrieve his accesses', () => {
 
-    let sandbox;
-
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(userRepository, 'getWithMemberships');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(userRepository, 'getWithMemberships');
     });
 
     it('should use find all organizations user accesses', () => {

--- a/api/tests/unit/domain/usecases/preload-cache-entries_test.js
+++ b/api/tests/unit/domain/usecases/preload-cache-entries_test.js
@@ -8,7 +8,7 @@ describe('Unit | UseCase | preload-cache-entries', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(preloader, 'loadAllTables').resolves();
     sandbox.stub(logger, 'info').returns();
   });

--- a/api/tests/unit/domain/usecases/preload-cache-entries_test.js
+++ b/api/tests/unit/domain/usecases/preload-cache-entries_test.js
@@ -5,16 +5,9 @@ const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Unit | UseCase | preload-cache-entries', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(preloader, 'loadAllTables').resolves();
-    sandbox.stub(logger, 'info').returns();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(preloader, 'loadAllTables').resolves();
+    sinon.stub(logger, 'info').returns();
   });
 
   it('should load Airtable objects', () => {

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -4,7 +4,6 @@ const usecases = require('../../../../lib/domain/usecases');
 
 describe('Unit | UseCase | share-campaign-result', () => {
 
-  let sandbox;
   let user;
   let userId;
   let assessment;
@@ -29,13 +28,8 @@ describe('Unit | UseCase | share-campaign-result', () => {
     assessmentId = assessment.id;
     campaignParticipation = domainBuilder.buildCampaignParticipation({ assessmentId });
 
-    sandbox = sinon.createSandbox();
-    sandbox.stub(smartPlacementAssessmentRepository, 'checkIfAssessmentBelongToUser');
-    sandbox.stub(campaignParticipationRepository, 'get').resolves();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(smartPlacementAssessmentRepository, 'checkIfAssessmentBelongToUser');
+    sinon.stub(campaignParticipationRepository, 'get').resolves();
   });
 
   context('when the share request comes from the owner of the assessment', () => {
@@ -55,7 +49,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
           isShared: true
         });
 
-        sandbox.stub(campaignParticipationRepository, 'updateCampaignParticipation')
+        sinon.stub(campaignParticipationRepository, 'updateCampaignParticipation')
           .resolves(expectedCampaignParticipation);
       });
 

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -29,7 +29,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
     assessmentId = assessment.id;
     campaignParticipation = domainBuilder.buildCampaignParticipation({ assessmentId });
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(smartPlacementAssessmentRepository, 'checkIfAssessmentBelongToUser');
     sandbox.stub(campaignParticipationRepository, 'get').resolves();
   });

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(campaignRepository, 'get');
     sandbox.stub(campaignParticipationRepository, 'save');
     sandbox.stub(assessmentRepository, 'save');

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -6,7 +6,6 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | start-campaign-participation', () => {
 
-  let sandbox;
   const userId = 19837482;
   const campaignParticipation = domainBuilder.buildCampaignParticipation({});
   const campaignRepository = { get: () => undefined };
@@ -14,16 +13,11 @@ describe('Unit | UseCase | start-campaign-participation', () => {
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(campaignRepository, 'get');
-    sandbox.stub(campaignParticipationRepository, 'save');
-    sandbox.stub(assessmentRepository, 'save');
+    sinon.stub(campaignRepository, 'get');
+    sinon.stub(campaignParticipationRepository, 'save');
+    sinon.stub(assessmentRepository, 'save');
 
     campaignRepository.get.resolves(domainBuilder.buildCampaign());
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should throw an error if the campaign does not exists', () => {

--- a/api/tests/unit/domain/usecases/start-placement-assessment_test.js
+++ b/api/tests/unit/domain/usecases/start-placement-assessment_test.js
@@ -9,7 +9,6 @@ const { AssessmentStartError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | start-placement-assessment', () => {
 
-  let sandbox;
   let clock;
   let testCurrentDate;
 
@@ -22,14 +21,12 @@ describe('Unit | UseCase | start-placement-assessment', () => {
     testCurrentDate = new Date('2018-01-10 05:00:00');
     clock = sinon.useFakeTimers(testCurrentDate.getTime());
 
-    sandbox = sinon.createSandbox();
-    sandbox.stub(assessmentRepository, 'save');
-    sandbox.stub(assessmentRepository, 'getLastPlacementAssessmentByUserIdAndCourseId');
+    sinon.stub(assessmentRepository, 'save');
+    sinon.stub(assessmentRepository, 'getLastPlacementAssessmentByUserIdAndCourseId');
   });
 
   afterEach(() => {
     clock.restore();
-    sandbox.restore();
   });
 
   context('when there is no assessment completed and no assessment started concerning the user and course', () => {

--- a/api/tests/unit/domain/usecases/start-placement-assessment_test.js
+++ b/api/tests/unit/domain/usecases/start-placement-assessment_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
     testCurrentDate = new Date('2018-01-10 05:00:00');
     clock = sinon.useFakeTimers(testCurrentDate.getTime());
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(assessmentRepository, 'save');
     sandbox.stub(assessmentRepository, 'getLastPlacementAssessmentByUserIdAndCourseId');
   });

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | update-user-password', () => {
   const password = '123ASXCG';
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(resetPasswordService, 'hasUserAPasswordResetDemandInProgress');
     sandbox.stub(resetPasswordService, 'invalidOldResetPasswordDemand');
     sandbox.stub(validationErrorSerializer, 'serialize');

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -14,8 +14,6 @@ const { PasswordResetDemandNotFoundError } = require('../../../../lib/domain/err
 
 describe('Unit | UseCase | update-user-password', () => {
 
-  let sandbox;
-
   const userId = 1;
   const user = new BookshelfUser({
     id: userId,
@@ -24,17 +22,12 @@ describe('Unit | UseCase | update-user-password', () => {
   const password = '123ASXCG';
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(resetPasswordService, 'hasUserAPasswordResetDemandInProgress');
-    sandbox.stub(resetPasswordService, 'invalidOldResetPasswordDemand');
-    sandbox.stub(validationErrorSerializer, 'serialize');
-    sandbox.stub(userRepository, 'updatePassword');
-    sandbox.stub(userRepository, 'findUserById').resolves(user);
-    sandbox.stub(encryptionService, 'hashPassword');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(resetPasswordService, 'hasUserAPasswordResetDemandInProgress');
+    sinon.stub(resetPasswordService, 'invalidOldResetPasswordDemand');
+    sinon.stub(validationErrorSerializer, 'serialize');
+    sinon.stub(userRepository, 'updatePassword');
+    sinon.stub(userRepository, 'findUserById').resolves(user);
+    sinon.stub(encryptionService, 'hashPassword');
   });
 
   it('should get user by his id', () => {

--- a/api/tests/unit/infrastructure/caches/redis-cache_test.js
+++ b/api/tests/unit/infrastructure/caches/redis-cache_test.js
@@ -5,7 +5,6 @@ const RedisCache = require('../../../../lib/infrastructure/caches/redis-cache');
 
 describe('Unit | Infrastructure | Cache | redis-cache', () => {
 
-  let sandbox;
   let stubbedClient;
   let redisCache;
 
@@ -14,18 +13,13 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
   const REDIS_CLIENT_ERROR = new Error('A Redis client error');
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     stubbedClient = {
       lockDisposer: sinon.stub().resolves(() => {})
     };
-    sandbox.stub(RedisCache, 'createClient')
+    sinon.stub(RedisCache, 'createClient')
       .withArgs(REDIS_URL)
       .returns(stubbedClient);
     redisCache = new RedisCache(REDIS_URL);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#get', () => {

--- a/api/tests/unit/infrastructure/caches/redis-cache_test.js
+++ b/api/tests/unit/infrastructure/caches/redis-cache_test.js
@@ -14,7 +14,7 @@ describe('Unit | Infrastructure | Cache | redis-cache', () => {
   const REDIS_CLIENT_ERROR = new Error('A Redis client error');
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     stubbedClient = {
       lockDisposer: sinon.stub().resolves(() => {})
     };

--- a/api/tests/unit/infrastructure/controller-replies_test.js
+++ b/api/tests/unit/infrastructure/controller-replies_test.js
@@ -7,16 +7,10 @@ const logger = require('../../../lib/infrastructure/logger');
 describe('Unit | Infrastructure | ControllerReplies', () => {
 
   describe('#controllerReplies', () => {
-    let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(errorSerializer, 'serialize');
-      sandbox.stub(logger, 'error');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(errorSerializer, 'serialize');
+      sinon.stub(logger, 'error');
     });
 
     context('ok', () => {

--- a/api/tests/unit/infrastructure/controller-replies_test.js
+++ b/api/tests/unit/infrastructure/controller-replies_test.js
@@ -10,7 +10,7 @@ describe('Unit | Infrastructure | ControllerReplies', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(errorSerializer, 'serialize');
       sandbox.stub(logger, 'error');
     });

--- a/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
@@ -9,7 +9,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | AreaDatasource', () =>
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
@@ -6,21 +6,11 @@ const airTableDataObjects = require('../../../../../lib/infrastructure/datasourc
 
 describe('Unit | Infrastructure | Datasource | Airtable | AreaDatasource', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#list', () => {
 
     it('should call airtable on Domaines table with the id and return an Area dataObject', () => {
       // given
-      sandbox.stub(airtable, 'findRecords').resolves([areaRawAirTableFixture()]);
+      sinon.stub(airtable, 'findRecords').resolves([areaRawAirTableFixture()]);
 
       // when
       const promise = areaDatasource.list();

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -8,8 +8,6 @@ const _ = require('lodash');
 
 describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', () => {
 
-  let sandbox;
-
   const
     competence1 = { id: 'competence1' },
     competence2 = { id: 'competence2' },
@@ -51,21 +49,13 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       fields: { Acquix: [ web3.id ] }
     });
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#list', () => {
 
     let promise;
 
     beforeEach(() => {
       // when
-      sandbox.stub(airtable, 'findRecords').resolves([
+      sinon.stub(airtable, 'findRecords').resolves([
         challenge_competence1,
         challenge_competence1_notValidated,
       ]);
@@ -92,7 +82,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
     it('should call airtable on Epreuves table with the id and return a datamodel Challenge object', () => {
       // given
-      sandbox.stub(airtable, 'getRecord').resolves(challengeRawAirTableFixture());
+      sinon.stub(airtable, 'getRecord').resolves(challengeRawAirTableFixture());
 
       // when
       const promise = challengeDatasource.get('243');
@@ -111,7 +101,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
       it('should reject with a specific error when resource not found', () => {
         // given
-        sandbox.stub(airtable, 'getRecord').rejects(new AirtableError('NOT_FOUND'));
+        sinon.stub(airtable, 'getRecord').rejects(new AirtableError('NOT_FOUND'));
 
         // when
         const promise = challengeDatasource.get('243');
@@ -122,7 +112,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
       it('should reject with the original error in any other case', () => {
         // given
-        sandbox.stub(airtable, 'getRecord').rejects(new AirtableError('SERVICE_UNAVAILABLE'));
+        sinon.stub(airtable, 'getRecord').rejects(new AirtableError('SERVICE_UNAVAILABLE'));
 
         // when
         const promise = challengeDatasource.get('243');
@@ -136,7 +126,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
   describe('#findBySkillIds', () => {
 
     beforeEach(() => {
-      sandbox.stub(airtable, 'findRecords').resolves([
+      sinon.stub(airtable, 'findRecords').resolves([
         challenge_web1,
         challenge_web1_notValidated,
         challenge_web2,
@@ -168,7 +158,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
     beforeEach(() => {
       // given
-      sandbox.stub(airtable, 'findRecords').resolves([
+      sinon.stub(airtable, 'findRecords').resolves([
         challenge_competence1,
         challenge_competence1_noSkills,
         challenge_competence1_notValidated,

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -52,7 +52,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     });
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
@@ -9,7 +9,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CompetenceDatasource',
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
@@ -6,21 +6,11 @@ const airTableDataModels = require('../../../../../lib/infrastructure/datasource
 
 describe('Unit | Infrastructure | Datasource | Airtable | CompetenceDatasource', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#get', () => {
 
     it('should call airtable on Competences table with the id and return a Competence data object', () => {
       // given
-      sandbox.stub(airtable, 'getRecord')
+      sinon.stub(airtable, 'getRecord')
         .withArgs('Competences', 'recsvLz0W2ShyfD63')
         .resolves(competenceRawAirTableFixture());
 
@@ -40,7 +30,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CompetenceDatasource',
 
     it('should call airtable on Competences table to retrieve all Competences', () => {
       // given
-      sandbox.stub(airtable, 'findRecords')
+      sinon.stub(airtable, 'findRecords')
         .withArgs('Competences')
         .resolves([ competenceRawAirTableFixture() ]);
 

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -11,7 +11,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -8,22 +8,12 @@ const _ = require('lodash');
 
 describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#get', () => {
 
     it('should call airtable on Acquis table with the id and return a datamodel Skill object', () => {
       // given
       const rawSkill = skillRawAirTableFixture();
-      sandbox.stub(airtable, 'getRecord').withArgs('Acquis', rawSkill.id).resolves(rawSkill);
+      sinon.stub(airtable, 'getRecord').withArgs('Acquis', rawSkill.id).resolves(rawSkill);
 
       // when
       const promise = skillDatasource.get(rawSkill.id);
@@ -55,7 +45,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       rawSkill4.id = 'FAKE_REC_ID_RAW_SKILL_4' ;
       rawSkill4.fields['Status'] = 'périmé';
 
-      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3, rawSkill4]);
+      sinon.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3, rawSkill4]);
 
       // when
       const promise = skillDatasource.findByRecordIds([rawSkill1.id, rawSkill2.id, rawSkill4.id]);
@@ -76,7 +66,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
 
     it('should query Airtable skills with empty query', () => {
       // given
-      sandbox.stub(airtable, 'findRecords').resolves([]);
+      sinon.stub(airtable, 'findRecords').resolves([]);
 
       // when
       const promise = skillDatasource.list();
@@ -92,7 +82,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       const
         rawSkill1 = skillRawAirTableFixture(),
         rawSkill2 = skillRawAirTableFixture();
-      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2]);
+      sinon.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2]);
 
       // when
       const promise = skillDatasource.list();
@@ -111,7 +101,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
         rawSkill2 = skillRawAirTableFixture(),
         rawSkill3 = skillRawAirTableFixture();
       rawSkill3.fields['Status'] = 'périmé';
-      sandbox.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3]);
+      sinon.stub(airtable, 'findRecords').resolves([rawSkill1, rawSkill2, rawSkill3]);
 
       // when
       const promise = skillDatasource.list();
@@ -131,7 +121,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       const acquix2 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix2', 'Status': 'actif', 'Compétence': [ 'recCompetence' ] } });
       const acquix3 = new AirtableRecord('Acquis', 'recAcquix2', { fields: { 'Nom': '@acquix3', 'Status': 'en construction', 'Compétence': [ 'recCompetence' ] } });
       const acquix4 = new AirtableRecord('Acquis', 'recAcquix4', { fields: { 'Nom': '@acquix4', 'Status': 'actif', 'Compétence': [ 'recOtherCompetence' ] } });
-      sandbox.stub(airtable, 'findRecords')
+      sinon.stub(airtable, 'findRecords')
         .withArgs('Acquis')
         .resolves([acquix1, acquix2, acquix3, acquix4]);
     });

--- a/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
@@ -9,7 +9,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | TutorialDatasource', (
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
@@ -6,22 +6,12 @@ const tutorialRawAirTableFixture = require('../../../../tooling/fixtures/infrast
 
 describe('Unit | Infrastructure | Datasource | Airtable | TutorialDatasource', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#get', () => {
 
     it('should call airtable on Tutoriels table with the id and return a datamodel Tutorial object', () => {
       // given
       const givenAirtableTutorial = tutorialRawAirTableFixture();
-      sandbox.stub(airtable, 'getRecord').resolves(givenAirtableTutorial);
+      sinon.stub(airtable, 'getRecord').resolves(givenAirtableTutorial);
 
       // when
       const promise = tutorialDatasource.get(givenAirtableTutorial.getId());

--- a/api/tests/unit/infrastructure/mailjet_test.js
+++ b/api/tests/unit/infrastructure/mailjet_test.js
@@ -9,10 +9,6 @@ describe('Unit | Class | Mailjet', function() {
     sinon.stub(nodeMailjet, 'connect');
   });
 
-  afterEach(() => {
-    nodeMailjet.connect.restore();
-  });
-
   describe('#sendEmail', () => {
 
     it('should create an instance of mailJet', () => {

--- a/api/tests/unit/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/area-repository_test.js
@@ -10,7 +10,7 @@ describe('Unit | Repository | area-repository', function() {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(areaDatasource, 'list');
 
     areaDatasource.list.resolves([

--- a/api/tests/unit/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/area-repository_test.js
@@ -7,11 +7,8 @@ const areaRepository = require('../../../../lib/infrastructure/repositories/area
 
 describe('Unit | Repository | area-repository', function() {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(areaDatasource, 'list');
+    sinon.stub(areaDatasource, 'list');
 
     areaDatasource.list.resolves([
       domainBuilder.buildAreaAirtableDataObject({
@@ -27,10 +24,6 @@ describe('Unit | Repository | area-repository', function() {
         name: '2. Domaine 2',
       }),
     ]);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('#list', () => {
@@ -81,7 +74,7 @@ describe('Unit | Repository | area-repository', function() {
       });
 
     beforeEach(() => {
-      sandbox.stub(competenceRepository, 'list');
+      sinon.stub(competenceRepository, 'list');
       competenceRepository.list.resolves([
         competence1,
         competence2,

--- a/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
@@ -84,7 +84,7 @@ describe('Unit | Repository | assessmentRepository', () => {
     it('should throw an error if something went wrong', () => {
       //Given
       const error = new Error('Unable to fetch');
-      const whereStub = sinon.stub(BookshelfAssessment, 'where').returns({
+      sinon.stub(BookshelfAssessment, 'where').returns({
         fetchAll: () => {
           return Promise.reject(error);
         },
@@ -94,7 +94,6 @@ describe('Unit | Repository | assessmentRepository', () => {
       const promise = assessmentRepository.findLastAssessmentsForEachCoursesByUser(JOHN);
 
       // then
-      whereStub.restore();
       return promise
         .catch((err) => {
           expect(err).to.equal(error);
@@ -185,7 +184,7 @@ describe('Unit | Repository | assessmentRepository', () => {
     it('should throw an error if something went wrong', () => {
       //Given
       const error = new Error('Unable to fetch');
-      const whereStub = sinon.stub(BookshelfAssessment, 'where').returns({
+      sinon.stub(BookshelfAssessment, 'where').returns({
         fetchAll: () => {
           return Promise.reject(error);
         },
@@ -195,7 +194,6 @@ describe('Unit | Repository | assessmentRepository', () => {
       const promise = assessmentRepository.findLastAssessmentsForEachCoursesByUser(JOHN);
 
       // then
-      whereStub.restore();
       return promise
         .catch((err) => {
           expect(err).to.equal(error);
@@ -246,10 +244,6 @@ describe('Unit | Repository | assessmentRepository', () => {
   describe('#save', function() {
 
     let assessment;
-
-    afterEach(() => {
-      BookshelfAssessment.prototype.save.restore();
-    });
 
     context('when assessment is valid', () => {
       beforeEach(() => {

--- a/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/assessment-repository_test.js
@@ -220,10 +220,6 @@ describe('Unit | Repository | assessmentRepository', () => {
         });
       });
 
-      after(() => {
-        BookshelfAssessment.query.restore();
-      });
-
       it('should correctly query Assessment', () => {
         // given
         const fakeUserId = 3;
@@ -322,10 +318,6 @@ describe('Unit | Repository | assessmentRepository', () => {
       sinon.stub(BookshelfAssessment, 'where').returns({
         fetch: fetchStub,
       });
-    });
-
-    after(() => {
-      BookshelfAssessment.where.restore();
     });
 
     it('should correctly query Assessment', () => {

--- a/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-challenge-repository_test.js
@@ -38,10 +38,6 @@ describe('Unit | Repository | certification-challenge-repository', () => {
       sinon.stub(CertificationChallengeBookshelf.prototype, 'save').resolves(certificationChallengeBookshelf);
     });
 
-    afterEach(() => {
-      CertificationChallengeBookshelf.prototype.save.restore();
-    });
-
     it('should save certification challenge object', () => {
       // when
       const promise = certificationChallengeRepository.save(challengeObject, certificationCourseObject);

--- a/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/certification-course-repository_test.js
@@ -31,10 +31,6 @@ describe('Unit | Repository | Certification Course', function() {
       sinon.stub(CertificationCourseBookshelf.prototype, 'save').resolves(certificationCourseBookshelf);
     });
 
-    afterEach(() => {
-      CertificationCourseBookshelf.prototype.save.restore();
-    });
-
     it('should save the certification-course', () => {
       // when
       const promise = CertificationCourseRepository.save(certificationCourse);

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -20,7 +20,7 @@ const solutionAdapter = require('../../../../lib/infrastructure/adapters/solutio
 
 describe('Unit | Repository | challenge-repository', () => {
 
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.restore();

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -20,18 +20,12 @@ const solutionAdapter = require('../../../../lib/infrastructure/adapters/solutio
 
 describe('Unit | Repository | challenge-repository', () => {
 
-  const sandbox = sinon.createSandbox();
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#get', () => {
 
     beforeEach(() => {
-      sandbox.stub(challengeDatasource, 'get');
-      sandbox.stub(skillDatasource, 'get').resolves();
-      sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
+      sinon.stub(challengeDatasource, 'get');
+      sinon.stub(skillDatasource, 'get').resolves();
+      sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
     });
 
     const challengeTypeAndValidators = {
@@ -197,8 +191,8 @@ describe('Unit | Repository | challenge-repository', () => {
       skills = [skillWeb1, skillURL2, skillURL3];
       skillIds = [skillWeb1.id, skillURL2.id, skillURL3.id];
 
-      sandbox.stub(skillDatasource, 'get');
-      sandbox.stub(skillDatasource, 'list');
+      sinon.stub(skillDatasource, 'get');
+      sinon.stub(skillDatasource, 'list');
       skillDatasource.list.resolves([
         domainBuilder.buildSkillAirtableDataObject({
           id: skillURL3.id, name: skillURL3.name,
@@ -216,8 +210,8 @@ describe('Unit | Repository | challenge-repository', () => {
     describe('#list', () => {
 
       beforeEach(() => {
-        sandbox.stub(challengeDatasource, 'list');
-        sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
+        sinon.stub(challengeDatasource, 'list');
+        sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
       context('when query happens with no error', () => {
@@ -317,8 +311,8 @@ describe('Unit | Repository | challenge-repository', () => {
       beforeEach(() => {
         competence = domainBuilder.buildCompetence();
 
-        sandbox.stub(challengeDatasource, 'findByCompetenceId');
-        sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
+        sinon.stub(challengeDatasource, 'findByCompetenceId');
+        sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
       context('when query happens with no error', () => {
@@ -391,8 +385,8 @@ describe('Unit | Repository | challenge-repository', () => {
 
       beforeEach(() => {
 
-        sandbox.stub(challengeDatasource, 'findBySkillIds');
-        sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
+        sinon.stub(challengeDatasource, 'findBySkillIds');
+        sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
       context('when query happens with no error', () => {

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -10,8 +10,6 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 
 describe('Unit | Repository | competence-repository', () => {
 
-  const sandbox = sinon.createSandbox();
-
   const rawCompetence1 = new AirtableRecord('Competences', 'recCompetence1', {
     fields: {
       'Titre': 'Mener une recherche d’information',
@@ -37,7 +35,7 @@ describe('Unit | Repository | competence-repository', () => {
   });
 
   beforeEach(() => {
-    sandbox.stub(areaDatasource, 'list')
+    sinon.stub(areaDatasource, 'list')
       .resolves([
         new airTableDataObjects.Area({
           id: 'recArea',
@@ -47,14 +45,10 @@ describe('Unit | Repository | competence-repository', () => {
       ]);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#list', () => {
 
     beforeEach(() => {
-      sandbox.stub(airtable, 'findRecords')
+      sinon.stub(airtable, 'findRecords')
         .withArgs('Competences')
         .resolves([rawCompetence2, rawCompetence1]);
     });
@@ -85,7 +79,7 @@ describe('Unit | Repository | competence-repository', () => {
 
     beforeEach(() => {
       // given
-      sandbox.stub(competenceDatasource, 'get')
+      sinon.stub(competenceDatasource, 'get')
         .withArgs('recCompetence1')
         .resolves(competenceData1);
     });

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -10,7 +10,7 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 
 describe('Unit | Repository | competence-repository', () => {
 
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   const rawCompetence1 = new AirtableRecord('Competences', 'recCompetence1', {
     fields: {

--- a/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
@@ -8,7 +8,7 @@ describe('Unit | Repository | competence-tree-repository', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(areaRepository, 'listWithCompetences');
   });
 

--- a/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
@@ -5,15 +5,8 @@ const CompetenceTree = require('../../../../lib/domain/models/CompetenceTree');
 
 describe('Unit | Repository | competence-tree-repository', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(areaRepository, 'listWithCompetences');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(areaRepository, 'listWithCompetences');
   });
 
   describe('#get', () => {

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -11,17 +11,10 @@ const tutorialAirtableDataObjectFixture = require('../../../tooling/fixtures/inf
 
 describe('Unit | Repository | correction-repository', function() {
 
-  let sandbox;
-
   beforeEach(function() {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(challengeDatasource, 'get');
-    sandbox.stub(skillDatasource, 'get');
-    sandbox.stub(tutorialDataSource, 'get');
-  });
-
-  afterEach(function() {
-    sandbox.restore();
+    sinon.stub(challengeDatasource, 'get');
+    sinon.stub(skillDatasource, 'get');
+    sinon.stub(tutorialDataSource, 'get');
   });
 
   describe('#getByChallengeId', function() {

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -14,7 +14,7 @@ describe('Unit | Repository | correction-repository', function() {
   let sandbox;
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(challengeDatasource, 'get');
     sandbox.stub(skillDatasource, 'get');
     sandbox.stub(tutorialDataSource, 'get');

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -76,16 +76,10 @@ const courses = [
   }),
 ];
 
-const sandbox = sinon.createSandbox();
-
-afterEach(() => {
-  sandbox.restore();
-});
-
 describe('Unit | Repository | course-repository', function() {
 
   beforeEach(() => {
-    sandbox.stub(airtable, 'findRecords')
+    sinon.stub(airtable, 'findRecords')
       .withArgs('Tests')
       .resolves(courses);
   });
@@ -93,7 +87,7 @@ describe('Unit | Repository | course-repository', function() {
   describe('#get', function() {
 
     beforeEach(() => {
-      sandbox.stub(airtable, 'getRecord')
+      sinon.stub(airtable, 'getRecord')
         .withArgs('Tests', 'recTestAdaptative')
         .resolves(adaptativeCourse);
     });

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -76,7 +76,7 @@ const courses = [
   }),
 ];
 
-const sandbox = sinon.sandbox.create();
+const sandbox = sinon.createSandbox();
 
 afterEach(() => {
   sandbox.restore();

--- a/api/tests/unit/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -9,10 +9,6 @@ describe('Unit | Repository | Reset Password Demand Repository', function() {
     sinon.stub(ResetPasswordDemand.prototype, 'save');
   });
 
-  afterEach(() => {
-    ResetPasswordDemand.prototype.save.restore();
-  });
-
   describe('#create', () => {
 
     it('should save a new reset password demand', () => {
@@ -51,10 +47,6 @@ describe('Unit | Repository | Reset Password Demand Repository', function() {
 
     beforeEach(() => {
       sinon.stub(ResetPasswordDemand, 'where');
-    });
-
-    afterEach(() => {
-      ResetPasswordDemand.where.restore();
     });
 
     it('should be a function', () => {
@@ -121,10 +113,6 @@ describe('Unit | Repository | Reset Password Demand Repository', function() {
 
     beforeEach(() => {
       sinon.stub(ResetPasswordDemand, 'where');
-    });
-
-    afterEach(() => {
-      ResetPasswordDemand.where.restore();
     });
 
     it('should be a function', () => {

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -11,10 +11,6 @@ describe('Unit | Repository | skill-repository', function() {
     sinon.stub(skillDatasource, 'findByCompetenceId');
   });
 
-  afterEach(() => {
-    skillDatasource.findByCompetenceId.restore();
-  });
-
   describe('#findByCompetenceId', function() {
 
     const competenceID = 'competence_id';

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -43,24 +43,18 @@ describe('Unit | Repository | skill-repository', function() {
   });
 
   describe('#save', () => {
-    let sandbox;
     let forgeStub;
     let invokeStub;
 
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      invokeStub = sandbox.stub().resolves();
-      forgeStub = sandbox.stub().returns({
+      invokeStub = sinon.stub().resolves();
+      forgeStub = sinon.stub().returns({
         invokeThen: invokeStub
       });
 
-      sandbox.stub(Bookshelf.Collection, 'extend').returns({
+      sinon.stub(Bookshelf.Collection, 'extend').returns({
         forge: forgeStub
       });
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should save assessment skills', () => {

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -52,7 +52,7 @@ describe('Unit | Repository | skill-repository', function() {
     let invokeStub;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       invokeStub = sandbox.stub().resolves();
       forgeStub = sandbox.stub().returns({
         invokeThen: invokeStub

--- a/api/tests/unit/infrastructure/repositories/snapshot-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/snapshot-repository_test.js
@@ -89,10 +89,6 @@ describe('Unit | Repository | SnapshotRepository', function() {
       sinon.spy(Snapshot.prototype, 'save');
     });
 
-    afterEach(() => {
-      Snapshot.prototype.save.restore();
-    });
-
     it('should save a snapshot', () => {
       // when
       const promise = snapshotRepository.save(snapshot);
@@ -109,10 +105,6 @@ describe('Unit | Repository | SnapshotRepository', function() {
 
     beforeEach(() => {
       sinon.stub(Snapshot.prototype, 'where');
-    });
-
-    afterEach(() => {
-      Snapshot.prototype.where.restore();
     });
 
     it('should be a function', () => {

--- a/api/tests/unit/infrastructure/repositories/solution-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/solution-repository_test.js
@@ -6,16 +6,9 @@ const Solution = require('../../../../lib/domain/models/Solution');
 
 describe('Unit | Repository | solution-repository', () => {
 
-  let sandbox;
-
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(challengeDatasource, 'get');
-    sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    sinon.stub(challengeDatasource, 'get');
+    sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
   });
 
   describe('#getByChallengeId', () => {

--- a/api/tests/unit/infrastructure/repositories/solution-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/solution-repository_test.js
@@ -9,7 +9,7 @@ describe('Unit | Repository | solution-repository', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(challengeDatasource, 'get');
     sandbox.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
   });

--- a/api/tests/unit/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/user-repository_test.js
@@ -11,10 +11,6 @@ describe('Unit | Infrastructure | Repository | UserRepository', () => {
     sinon.stub(BookshelfUser.prototype, 'where');
   });
 
-  afterEach(() => {
-    BookshelfUser.prototype.where.restore();
-  });
-
   describe('#get', () => {
 
     it('should resolve a domain User matching its ID', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -106,8 +106,6 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
   describe('#deserialize()', function() {
     beforeEach(() => sinon.stub(sessionCodeService, 'getNewSessionCode').resolves('ABCD12'));
 
-    afterEach(() => sessionCodeService.getNewSessionCode.restore());
-
     it('should convert JSON API data to a Session', function() {
       // when
       const promise = serializer.deserialize(jsonSession);

--- a/api/tests/unit/infrastructure/validators/grecaptcha-validator_test.js
+++ b/api/tests/unit/infrastructure/validators/grecaptcha-validator_test.js
@@ -20,9 +20,8 @@ describe('Unit | Service | google-recaptcha-validator', () => {
 
     it('should call google verify with good url and query parameters', function() {
       // given
-      const requestPostStub = sinon.stub(request, 'post').callsFake((uri, cb) => {
+      sinon.stub(request, 'post').callsFake((uri, cb) => {
         // then
-        requestPostStub.restore();
         expect(uri).to.equal(`https://www.google.com/recaptcha/api/siteverify?secret=${googleReCaptcha.secret}&response=${RECAPTCHA_TOKEN}`);
 
         cb(null, SUCCESSFULL_VERIFICATION_RESPONSE);
@@ -35,12 +34,8 @@ describe('Unit | Service | google-recaptcha-validator', () => {
     describe('Success case', function() {
       let requestPostErrorStub;
 
-      before(() => {
+      beforeEach(() => {
         requestPostErrorStub = sinon.stub(request, 'post');
-      });
-
-      after(() => {
-        requestPostErrorStub.restore();
       });
 
       it('should return a resolved promise when user response token is valid', function() {
@@ -65,11 +60,6 @@ describe('Unit | Service | google-recaptcha-validator', () => {
       beforeEach(() => {
         loggerStub = sinon.stub(logger, 'error').returns({});
         requestPostErrorStub = sinon.stub(request, 'post');
-      });
-
-      afterEach(() => {
-        loggerStub.restore();
-        requestPostErrorStub.restore();
       });
 
       it('should return a rejected promise, when user response token is invalid', function() {

--- a/api/tests/unit/infrastructure/validators/jsonwebtoken-verify_test.js
+++ b/api/tests/unit/infrastructure/validators/jsonwebtoken-verify_test.js
@@ -43,10 +43,6 @@ describe('Unit | Validator | json-web-token-verify', function() {
         });
       });
 
-      afterEach(function() {
-        jsonwebtokenStub.restore();
-      });
-
       it('should reject a promise, when token is valid but has not key word bearer', () => {
         // when
         const promise = authorizationToken.verify('VALID_TOKEN');

--- a/api/tests/unit/interfaces/controllers/security-controller_test.js
+++ b/api/tests/unit/interfaces/controllers/security-controller_test.js
@@ -6,25 +6,11 @@ const checkUserHasRolePixMasterUseCase = require('../../../../lib/application/us
 
 describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('#checkUserIsAuthenticated', () => {
 
     beforeEach(() => {
-      sandbox.stub(tokenService, 'extractTokenFromAuthChain');
-      sandbox.stub(checkUserIsAuthenticatedUseCase, 'execute');
-    });
-
-    afterEach(() => {
-      sandbox.restore();
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      sinon.stub(checkUserIsAuthenticatedUseCase, 'execute');
     });
 
     context('Successful case', () => {
@@ -101,8 +87,8 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
     let hasRolePixMasterStub;
 
     beforeEach(() => {
-      sandbox.stub(tokenService, 'extractTokenFromAuthChain');
-      hasRolePixMasterStub = sandbox.stub(checkUserHasRolePixMasterUseCase, 'execute');
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      hasRolePixMasterStub = sinon.stub(checkUserHasRolePixMasterUseCase, 'execute');
     });
 
     context('Successful case', () => {

--- a/api/tests/unit/scripts/delete-user_test.js
+++ b/api/tests/unit/scripts/delete-user_test.js
@@ -368,10 +368,6 @@ describe('Delete User Script', () => {
         consoleLog = sinon.stub(console, 'log');
       });
 
-      afterEach(() => {
-        consoleLog.restore();
-      });
-
       it('should delete feedbacks, skills, answers, competence-marks and assessment-results', () => {
         // given
         const ids = [123, 456];

--- a/api/tests/unit/scripts/get-changelog_test.js
+++ b/api/tests/unit/scripts/get-changelog_test.js
@@ -57,7 +57,7 @@ describe('Unit | Script | GET Changelog', () => {
   describe('getHeadOfChangelog', () => {
     it('should return the head of changelog in correct value', () => {
       // given
-      const clock = sinon.useFakeTimers();
+      sinon.useFakeTimers();
       const headChangelog = '## v1.0.0 (01/01/1970) \n\n';
       const pullRequestsInMilestone = {
         title: '[BUGFIX] TEST (US-11).',
@@ -70,7 +70,6 @@ describe('Unit | Script | GET Changelog', () => {
       const result = getHeadOfChangelog(pullRequestsInMilestone);
       // then
       expect(result).to.equal(headChangelog);
-      clock.restore();
     });
   });
 

--- a/api/tests/unit/scripts/recompute-assessment-results_test.js
+++ b/api/tests/unit/scripts/recompute-assessment-results_test.js
@@ -5,14 +5,8 @@ describe('Unit | Scripts | recompute-assessment-results', () => {
 
   describe('#recomputeScore', () => {
 
-    let consoleLog;
-
     beforeEach(() => {
-      consoleLog = sinon.stub(console, 'log');
-    });
-
-    afterEach(() => {
-      consoleLog.restore();
+      sinon.stub(console, 'log');
     });
 
     it('shoud call request with assessment informations', () => {


### PR DESCRIPTION
# 🎯Motivation
Pour générer des _spies_, _stubs_ et _mocks_ pour les tests nous utilisons la bibliothèque [Sinon.JS](https://sinonjs.org/).

Actuellement nous utilisons une version 4.4 de Sinon.JS, mais la dernière version disponible est la 7.2.2.

Comme nouveauté intéressante apparue en version 5, il y a la possibilité d'utiliser le module `sinon` comme une _sandbox_ par défaut, ce qui évite d'avoir à créer et détruire à la main les _sandbox_.

Cette PR ne fait la mise à jour que sur la partie `api/`. Il y a du Sinon.JS aussi dans `mon-pix/`, à migrer dans un futur proche de préférence.

# 💅Réalisation
Un parcours des _commits_, par ordre chronologique :
* On commence par mettre à jour les versions de `sinon` et `sinon-chai`, en corrigeant dans la foulée quelques tests qui ne passent plus suite au renforcement des contrôles de type des objets dans Sinon.JS ;
* En suivant les _warnings_ signalés par Sinon.JS, on corrige les appels à `sinon.sandbox.create()` en `sinon.createSandbox()` ;
* On active la réinitialisation de la _sandbox_ par défaut, en ajoutant un `afterEach()` global qui fait `sinon.restore()` comme suggéré dans [la documentation](https://sinonjs.org/releases/v7.2.2/general-setup/) — ce qui oblige à corriger quelques tests qui faisaient des `sinon.stub()` dans un `before()` au lieu de `beforeEach()` ;
* On supprime les appels à `restore()` faits sur des _stubs_ individuels créés avec `sinon.stub()` puisqu'ils sont couverts par le `sinon.store()` global ;
* Enfin, là où c'est possible (c'est-à-dire quasiment partout) on supprime le code qui crée et utilise une _sandbox_ pour utiliser la _sandbox_ par défaut à la place.

# 💳 Credits
@DaRiviere et @jonathanperret 