### PR TITLE
[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).

### DIFF
--- a/api/db/seeds/data/assessments.js
+++ b/api/db/seeds/data/assessments.js
@@ -5,4 +5,6 @@ module.exports = [
   { id:5, courseId: 'rec5gEPqhxYjz15eI', createdAt: '2018-02-15 15:07:02', updatedAt: '2018-02-15 15:07:02', userId: 1, type:'PLACEMENT', state: 'completed' },
   { id:6, courseId: '1', createdAt: '2018-02-15 15:14:46', updatedAt: '2018-02-15 15:14:46', userId: 1, type:'CERTIFICATION', state: 'completed' },
   { id:7, courseId: '2', createdAt: '2018-04-27 10:10:52', updatedAt: '2018-04-27 10:10:52', userId: 1, type:'CERTIFICATION', state: 'completed' },
+  { id:8, courseId: 'rec43mpMIR5dUzdjh', createdAt: '2018-01-15 15:00:34', updatedAt: '2018-01-15 15:00:34', userId: 1, type:'PLACEMENT', state: 'started' },
+  { id:9, courseId: '3', createdAt: '2018-01-15 15:14:46', updatedAt: '2018-01-15 15:14:46', userId: 1, type:'CERTIFICATION', state: 'started' },
 ];

--- a/api/db/seeds/data/certification-courses.js
+++ b/api/db/seeds/data/certification-courses.js
@@ -24,5 +24,18 @@ module.exports = [
     sessionId: 2,
     externalId: 'L\'élève',
     isPublished: true
+  },
+  {
+    id: 3,
+    userId: 1,
+    completedAt: '2018-01-15T15:15:52.504Z',
+    createdAt: '2018-01-15 15:14:46',
+    firstName: 'Pix',
+    lastName: 'Aile',
+    birthdate: '01/04/1994',
+    birthplace: 'Bruxelles',
+    sessionId: 1,
+    externalId: 'L\'élève',
+    isPublished: false
   }
 ];

--- a/api/lib/domain/usecases/find-certification-assessments.js
+++ b/api/lib/domain/usecases/find-certification-assessments.js
@@ -1,7 +1,7 @@
 module.exports = function findCertificationAssessments({ userId, filters, assessmentRepository }) {
 
-  if (filters.courseId) {
-    return assessmentRepository.getCertificationAssessmentByUserIdAndCourseId(userId, filters.courseId)
+  if (filters.courseId && filters.resumable === 'true') {
+    return assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId(userId, filters.courseId)
       .then((assessment) => {
         if(!assessment) {
           return [];

--- a/api/lib/domain/usecases/find-placement-assessments.js
+++ b/api/lib/domain/usecases/find-placement-assessments.js
@@ -1,7 +1,8 @@
 module.exports = function findPlacementAssessments({ userId, filters, assessmentRepository }) {
 
-  if (filters.courseId && filters.state === 'started') {
-    return assessmentRepository.getStartedPlacementAssessmentByUserIdAndCourseId(userId, filters.courseId)
+  if (filters.courseId && filters.resumable === 'true') {
+    return assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, filters.courseId)
+      .then((assessment) => assessment && assessment.state === 'started'? assessment : null)
       .then((assessment) => {
         if(!assessment) {
           return [];

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -19,11 +19,12 @@ function _checkCampaignExists(campaignId, campaignRepository) {
 }
 
 function _createSmartPlacementAssessment(userId, assessmentRepository) {
-  const assessment = new Assessment();
-  assessment.state = Assessment.states.STARTED;
-  assessment.type = Assessment.types.SMARTPLACEMENT;
-  assessment.courseId = 'Smart Placement Tests CourseId Not Used';
-  assessment.userId = userId;
+  const assessment = new Assessment({
+    userId,
+    state: Assessment.states.STARTED,
+    type: Assessment.types.SMARTPLACEMENT,
+    courseId: 'Smart Placement Tests CourseId Not Used'
+  });
   return assessmentRepository.save(assessment);
 }
 

--- a/api/lib/domain/usecases/start-placement-assessment.js
+++ b/api/lib/domain/usecases/start-placement-assessment.js
@@ -2,7 +2,7 @@ const { AssessmentStartError } = require('../../domain/errors');
 
 module.exports = async function startAssessmentForPlacement({ assessment, assessmentRepository }) {
 
-  const lastPlacement = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(assessment.userId, assessment.courseId);
+  const lastPlacement = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(assessment.userId, assessment.courseId);
 
   if(lastPlacement && !lastPlacement.canStartNewAttemptOnCourse()) {
     throw new AssessmentStartError('Impossible de démarrer un nouveau positionnement');

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -77,7 +77,7 @@ module.exports = {
       .then(fp.map(_toDomain));
   },
 
-  getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId) {
+  findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId) {
     return BookshelfAssessment
       .where({ userId, courseId, type: 'PLACEMENT' })
       .orderBy('createdAt', 'desc')
@@ -106,17 +106,10 @@ module.exports = {
       .then(_toDomain);
   },
 
-  getCertificationAssessmentByUserIdAndCourseId(userId, courseId) {
+  findOneCertificationAssessmentByUserIdAndCourseId(userId, courseId) {
     return BookshelfAssessment
       .where({ userId, courseId, type: 'CERTIFICATION' })
       .fetch({ withRelated: ['assessmentResults', 'answers'] })
-      .then(_toDomain);
-  },
-
-  getStartedPlacementAssessmentByUserIdAndCourseId(userId, courseId) {
-    return BookshelfAssessment
-      .where({ userId, courseId, type: 'PLACEMENT', state: 'started' })
-      .fetch({ require: false })
       .then(_toDomain);
   },
 

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -480,7 +480,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
-  describe('#getCertificationAssessmentByUserIdAndCourseId', () => {
+  describe('#findOneCertificationAssessmentByUserIdAndCourseId', () => {
 
     let assessmentsInDb;
     let answersInDb;
@@ -542,7 +542,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       const courseId = 'courseId1';
 
       // when
-      const promise = assessmentRepository.getCertificationAssessmentByUserIdAndCourseId(userId, courseId);
+      const promise = assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return promise.then((assessment) => {
@@ -557,84 +557,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       const courseId = 'inexistantId';
 
       // when
-      const promise = assessmentRepository.getStartedPlacementAssessmentByUserIdAndCourseId(userId, courseId);
-
-      // then
-      return promise.then((assessment) => {
-        expect(assessment).to.equal(null);
-      });
-    });
-  });
-
-  describe('#getStartedPlacementAssessmentByUserIdAndCourseId', () => {
-
-    let assessmentsInDb;
-
-    beforeEach(() => {
-      assessmentsInDb = [
-        databaseBuilder.factory.buildAssessment({
-          id: 1,
-          courseId: 'courseId1',
-          userId: 1,
-          type: 'PLACEMENT'
-        }),
-        databaseBuilder.factory.buildAssessment({
-          id: 2,
-          courseId: 'courseId1',
-          userId: 2,
-          type: 'PLACEMENT',
-        }),
-        databaseBuilder.factory.buildAssessment({
-          id: 3,
-          courseId: 'courseId1',
-          userId: 2,
-          type: 'CERTIFICATION',
-          state: 'started',
-        }),
-        databaseBuilder.factory.buildAssessment({
-          id: 4,
-          courseId: 'courseId2',
-          userId: 2,
-          type: 'PLACEMENT',
-          state: 'started',
-        }),
-        databaseBuilder.factory.buildAssessment({
-          id: 5,
-          courseId: 'courseId1',
-          userId: 2,
-          type: 'PLACEMENT',
-          state: 'started',
-        }),
-      ];
-      return knex('assessments').insert(assessmentsInDb);
-    });
-
-    afterEach(() => {
-      return knex('assessments').delete()
-        .then(() => databaseBuilder.clean());
-    });
-
-    it('should return assessment when it matches with userId and courseId', function() {
-      // given
-      const userId = 2;
-      const courseId = 'courseId1';
-
-      // when
-      const promise = assessmentRepository.getStartedPlacementAssessmentByUserIdAndCourseId(userId, courseId);
-
-      // then
-      return promise.then((assessment) => {
-        expect(assessment.id).to.equal(5);
-      });
-    });
-
-    it('should return null when it does not match with userId and courseId', function() {
-      // given
-      const userId = 234;
-      const courseId = 'inexistantId';
-
-      // when
-      const promise = assessmentRepository.getStartedPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const promise = assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return promise.then((assessment) => {
@@ -710,7 +633,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
-  describe('#getLastPlacementAssessmentByUserIdAndCourseId', () => {
+  describe('#findOneLastPlacementAssessmentByUserIdAndCourseId', () => {
 
     const userId = 42;
     const courseId = 'rec23kfr5hfD54f';
@@ -721,7 +644,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
     it('should return null if nothing found', async () => {
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment).to.be.null;
@@ -747,7 +670,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
 
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment.id).to.deep.equal(userOlderAssessment.id);
@@ -772,13 +695,13 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
 
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment.id).to.deep.equal(userOlderAssessment.id);
     });
 
-    it('should return a placement', async () => {
+    it('should return an assessment of type placement', async () => {
       // given
       const userOlderAssessment = databaseBuilder.factory.buildAssessment({
         type: Assessment.types.PLACEMENT,
@@ -797,7 +720,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
 
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment.id).to.deep.equal(userOlderAssessment.id);
@@ -829,7 +752,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
 
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment.id).to.deep.equal(lastAssessment.id);
@@ -850,7 +773,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
 
       // when
-      const foundAssessment = await assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
+      const foundAssessment = await assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId(userId, courseId);
 
       // then
       return expect(foundAssessment.assessmentResults).to.have.length.of(2);

--- a/api/tests/unit/domain/usecases/find-certification-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-assessments_test.js
@@ -58,11 +58,11 @@ describe('Unit | UseCase | find-certification-assessments', () => {
   it('should resolve an assessment of type CERTIFICATION even if state is started', () => {
     // given
     const userId = 1234;
-    const course = domainBuilder.buildCertificationCourse();
-    const filters = { type: 'CERTIFICATION', courseId: course.id, resumable: 'true' };
+    const courseId = 5678;
+    const filters = { type: 'CERTIFICATION', courseId, resumable: 'true' };
     const  assessment = domainBuilder.buildAssessment({
       type: 'CERTIFICATION',
-      courseId: course.id,
+      courseId,
       state: 'started',
       userId,
     });
@@ -80,11 +80,11 @@ describe('Unit | UseCase | find-certification-assessments', () => {
   it('should resolve an assessment of type CERTIFICATION even if state is completed', () => {
     // given
     const userId = 1234;
-    const course = domainBuilder.buildCertificationCourse();
-    const filters = { type: 'CERTIFICATION', courseId: course.id, resumable: 'true' };
+    const courseId = 5678;
+    const filters = { type: 'CERTIFICATION', courseId, resumable: 'true' };
     const  assessment = domainBuilder.buildAssessment({
       type: 'CERTIFICATION',
-      courseId: course.id,
+      courseId,
       state: 'completed',
       userId,
     });

--- a/api/tests/unit/domain/usecases/find-certification-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-assessments_test.js
@@ -3,32 +3,17 @@ const findCertificationAssessments = require('../../../../lib/domain/usecases/fi
 
 describe('Unit | UseCase | find-certification-assessments', () => {
 
-  const assessmentRepository = {
-    getCertificationAssessmentByUserIdAndCourseId: () => {
-    },
-  };
+  const assessmentRepository = {};
 
-  it('should resolve an empty array', () => {
-    // given
-    const userId = 1234;
-    const courseId = 2;
-    const filters = { type: 'CERTIFICATION', courseId };
-    sinon.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(null);
-
-    // when
-    const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
-
-    // then
-    return promise.then((result) => {
-      expect(result).to.deep.equal([]);
-    });
+  beforeEach(() => {
+    assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId = sinon.stub();
   });
 
-  it('should resolve an empty array since there is no courseId', () => {
+  it('should resolve an empty array when courseId is null', () => {
     // given
     const userId = 1234;
     const courseId = null;
-    const filters = { type: 'CERTIFICATION', courseId };
+    const filters = { type: 'CERTIFICATION', courseId, resumable: 'true' };
 
     // when
     const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
@@ -39,16 +24,71 @@ describe('Unit | UseCase | find-certification-assessments', () => {
     });
   });
 
-  it('should resolve an assessment of type CERTIFICATION', () => {
+  it('should resolve an empty array when resumable is false', () => {
+    // given
+    const userId = 1234;
+    const courseId = null;
+    const filters = { type: 'CERTIFICATION', courseId, resumable: 'false' };
+
+    // when
+    const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
+
+    // then
+    return promise.then((result) => {
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  it('should resolve an empty array when the repository returns null', () => {
+    // given
+    const userId = 1234;
+    const courseId = 2;
+    const filters = { type: 'CERTIFICATION', courseId, resumable: 'true' };
+    assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId.resolves(null);
+
+    // when
+    const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
+
+    // then
+    return promise.then((result) => {
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  it('should resolve an assessment of type CERTIFICATION even if state is started', () => {
     // given
     const userId = 1234;
     const course = domainBuilder.buildCertificationCourse();
-    const filters = { type: 'CERTIFICATION', courseId: course.id };
+    const filters = { type: 'CERTIFICATION', courseId: course.id, resumable: 'true' };
     const  assessment = domainBuilder.buildAssessment({
-      ...filters,
+      type: 'CERTIFICATION',
+      courseId: course.id,
+      state: 'started',
       userId,
     });
-    sinon.stub(assessmentRepository, 'getCertificationAssessmentByUserIdAndCourseId').resolves(assessment);
+    assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId.resolves(assessment);
+
+    // when
+    const promise = findCertificationAssessments({ userId, filters, assessmentRepository });
+
+    // then
+    return promise.then((result) => {
+      expect(result).to.deep.equal([assessment]);
+    });
+  });
+
+  it('should resolve an assessment of type CERTIFICATION even if state is completed', () => {
+    // given
+    const userId = 1234;
+    const course = domainBuilder.buildCertificationCourse();
+    const filters = { type: 'CERTIFICATION', courseId: course.id, resumable: 'true' };
+    const  assessment = domainBuilder.buildAssessment({
+      type: 'CERTIFICATION',
+      courseId: course.id,
+      state: 'completed',
+      userId,
+    });
+    assessmentRepository.findOneCertificationAssessmentByUserIdAndCourseId.resolves(assessment);
 
     // when
     const promise = findCertificationAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/find-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-placement-assessments_test.js
@@ -66,11 +66,11 @@ describe('Unit | UseCase | find-placement-assessments', () => {
   it('should resolve an assessment of type PLACEMENT', () => {
     // given
     const userId = 1234;
-    const course = domainBuilder.buildCertificationCourse();
-    const filters = { type: 'PLACEMENT', courseId: course.id, resumable: 'true' };
+    const courseId = 5678;
+    const filters = { type: 'PLACEMENT', courseId, resumable: 'true' };
     const assessment = domainBuilder.buildAssessment({
       type: 'PLACEMENT',
-      courseId: course.id,
+      courseId,
       state: 'started',
       userId,
     });

--- a/api/tests/unit/domain/usecases/find-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-placement-assessments_test.js
@@ -3,17 +3,18 @@ const findPlacementAssessments = require('../../../../lib/domain/usecases/find-p
 
 describe('Unit | UseCase | find-placement-assessments', () => {
 
-  const assessmentRepository = {
-    getStartedPlacementAssessmentByUserIdAndCourseId: () => {
-    },
-  };
+  const assessmentRepository = {};
 
-  it('should resolve an empty array', () => {
+  beforeEach(() => {
+    assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId = sinon.stub();
+  });
+
+  it('should resolve an empty array when courseId is null', () => {
     // given
     const userId = 1234;
     const courseId = 2;
-    const filters = { type: 'PLACEMENT', courseId, state: 'started' };
-    sinon.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(null);
+    const filters = { type: 'PLACEMENT', courseId, resumable: 'true' };
+    assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId.resolves(null);
 
     // when
     const promise = findPlacementAssessments({ userId, filters, assessmentRepository });
@@ -24,11 +25,34 @@ describe('Unit | UseCase | find-placement-assessments', () => {
     });
   });
 
-  it('should resolve an empty array since state is completed', () => {
+  it('should resolve an empty array when state is completed', () => {
     // given
     const userId = 1234;
     const courseId = 2;
-    const filters = { type: 'PLACEMENT', courseId, state: 'completed' };
+    const filters = { type: 'PLACEMENT', courseId, resumable: 'true' };
+    const assessment = domainBuilder.buildAssessment({
+      type: 'PLACEMENT',
+      state: 'completed',
+      courseId,
+      userId,
+    });
+    assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId.resolves(assessment);
+
+    // when
+    const promise = findPlacementAssessments({ userId, filters, assessmentRepository });
+
+    // then
+    return promise.then((result) => {
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  it('should resolve an empty array when the repository returns null', () => {
+    // given
+    const userId = 1234;
+    const courseId = 2;
+    const filters = { type: 'PLACEMENT', courseId, resumable: 'true' };
+    assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId.resolves(null);
 
     // when
     const promise = findPlacementAssessments({ userId, filters, assessmentRepository });
@@ -43,12 +67,14 @@ describe('Unit | UseCase | find-placement-assessments', () => {
     // given
     const userId = 1234;
     const course = domainBuilder.buildCertificationCourse();
-    const filters = { type: 'PLACEMENT', courseId: course.id, state: 'started' };
-    const  assessment = domainBuilder.buildAssessment({
-      ...filters,
+    const filters = { type: 'PLACEMENT', courseId: course.id, resumable: 'true' };
+    const assessment = domainBuilder.buildAssessment({
+      type: 'PLACEMENT',
+      courseId: course.id,
+      state: 'started',
       userId,
     });
-    sinon.stub(assessmentRepository, 'getStartedPlacementAssessmentByUserIdAndCourseId').resolves(assessment);
+    assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId.resolves(assessment);
 
     // when
     const promise = findPlacementAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/start-placement-assessment_test.js
+++ b/api/tests/unit/domain/usecases/start-placement-assessment_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
 
   const assessmentRepository = {
     save: () => undefined,
-    getLastPlacementAssessmentByUserIdAndCourseId: () => undefined,
+    findOneLastPlacementAssessmentByUserIdAndCourseId: () => undefined,
   };
 
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
     clock = sinon.useFakeTimers(testCurrentDate.getTime());
 
     sinon.stub(assessmentRepository, 'save');
-    sinon.stub(assessmentRepository, 'getLastPlacementAssessmentByUserIdAndCourseId');
+    sinon.stub(assessmentRepository, 'findOneLastPlacementAssessmentByUserIdAndCourseId');
   });
 
   afterEach(() => {
@@ -77,7 +77,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
         state: Assessment.states.STARTED,
       });
 
-      assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId
+      assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId
         .withArgs(userId, courseId)
         .resolves(alreadyStartedPlacementAssessment);
 
@@ -114,7 +114,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
           assessmentResults: [assessmentResult],
         });
 
-        assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId
+        assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId
           .withArgs(userId, courseId)
           .resolves(completedAssessment);
 
@@ -150,7 +150,7 @@ describe('Unit | UseCase | start-placement-assessment', () => {
           assessmentResults: [assessmentResult],
         });
 
-        assessmentRepository.getLastPlacementAssessmentByUserIdAndCourseId
+        assessmentRepository.findOneLastPlacementAssessmentByUserIdAndCourseId
           .withArgs(userId, courseId)
           .resolves(completedAssessment);
       });

--- a/mon-pix/app/routes/courses/create-assessment.js
+++ b/mon-pix/app/routes/courses/create-assessment.js
@@ -6,9 +6,9 @@ export default BaseRoute.extend({
   afterModel(course) {
     const store = this.get('store');
 
-    return store.query('assessment', { filter: { type: course.get('type'), courseId: course.id, state: 'started' } })
+    return store.query('assessment', { filter: { type: course.get('type'), courseId: course.id, resumable: true } })
       .then((assessments) => {
-        if (this._thereIsNoStartedAssessment(assessments)) {
+        if (this._thereIsNoResumableAssessment(assessments)) {
           return store.createRecord('assessment', { course, type: course.get('type') }).save();
         } else {
           return assessments.get('firstObject');
@@ -18,7 +18,7 @@ export default BaseRoute.extend({
       });
   },
 
-  _thereIsNoStartedAssessment(assessments) {
+  _thereIsNoResumableAssessment(assessments) {
     return isEmpty(assessments);
   }
 });

--- a/mon-pix/mirage/routes/find-assessments.js
+++ b/mon-pix/mirage/routes/find-assessments.js
@@ -16,15 +16,14 @@ export default function(schema, request) {
 
   const type = request.queryParams['filter[type]'];
   const courseId = request.queryParams['filter[courseId]'];
+  const resumable = request.queryParams['filter[resumable]'];
 
-  if (type === 'CERTIFICATION' && courseId) {
+  if (type === 'CERTIFICATION' && courseId && resumable === 'true') {
     return schema.assessments.where({ courseId, type });
   }
 
-  const state = request.queryParams['filter[state]'];
-
-  if (type === 'PLACEMENT' && courseId && state === 'started') {
-    return schema.assessments.where({ courseId, type, state });
+  if (type === 'PLACEMENT' && courseId && resumable === 'true') {
+    return schema.assessments.where({ courseId, type, state: 'started' });
   }
 
   return schema.assessments.all();

--- a/mon-pix/tests/unit/routes/courses/create-assessment-test.js
+++ b/mon-pix/tests/unit/routes/courses/create-assessment-test.js
@@ -49,7 +49,7 @@ describe('Unit | Route | Courses | Create Assessment', function() {
 
       // then
       return promise.then(() => {
-        sinon.assert.calledWith(queryStub, 'assessment', { filter: { type: course.get('type'), courseId: course.id, state: 'started' } });
+        sinon.assert.calledWith(queryStub, 'assessment', { filter: { type: course.get('type'), courseId: course.id, resumable: true } });
       });
     });
 


### PR DESCRIPTION
# 🤷‍♀️ 🤷‍♂️ Besoin : 
En tant qu'utilisateur de Pix, lorsque je retente un compétence, je veux créer une nouvelle évaluation, et non en reprendre une ancienne non terminée.

# 👩‍💻👨‍💻 Technique : 
Lorsqu'on cherche les assessments resumable :
1) chercher les assessments pour le user et le course donnés
2) les trier par date de création
3) prendre le plus récent
4) regarder si le plus récent est commencé ou terminé

Si commencé : c'est une reprise ; si terminé : on crée une nouvelle évaluation.