### PR TITLE
[TECH] Ne pas planter l'application quand Redis est temporairement déconnecté

### DIFF
--- a/api/lib/infrastructure/caches/redis-client.js
+++ b/api/lib/infrastructure/caches/redis-client.js
@@ -1,11 +1,22 @@
 const redis = require('redis');
 const Redlock = require('redlock');
+const logger = require('../logger');
 const { promisify } = require('util');
+
+const REDIS_CLIENT_OPTIONS = {
+  // All commands that were unfulfilled while the connection is lost will be
+  // retried after the connection has been reestablished.
+  // Note that this is safe because all of our commands are idempotent.
+  retry_unfulfilled_commands: true
+};
 
 module.exports = class RedisClient {
 
   constructor(redis_url) {
-    this._client = redis.createClient(redis_url);
+    this._client = redis.createClient(redis_url, REDIS_CLIENT_OPTIONS);
+    this._client.on('error', (err) => {
+      logger.warn({ err }, 'Redis connection error');
+    });
     this._clientWithLock = new Redlock(
       [this._client],
       // As said in the doc, setting retryCount to 0 and treating a failure as the resource being "locked"


### PR DESCRIPTION
# 🎯 Motivation
Notre hébergeur semble de temps en temps déconnecter ou redémarrer le serveur Redis. 

Actuellement cela occasionne un crash de l'application car l'événement `error` remonté par le client Redis n'est pas intercepté, et tout événement `error` émis sans abonné provoque la fin du processus Node.js par défaut (https://nodejs.org/api/events.html#events_error_events).

C'est dommage car le client Redis que nous utilisons (https://www.npmjs.com/package/redis) possède une logique de reconnexion automatique (avec délai exponentiel). Il suffit donc de s'abonner à cet événement `error` pour donner une chance à cette reconnexion d'avoir lieu.

De plus, on active l'option `retry_unfulfilled_commands` qui autorise le client Redis à réessayer les commandes éventuellement impactées par une déconnexion. Ceci est permis car toutes les commandes que nous utilisons sont idempotentes.

Ainsi, aucun client de l'API ne devrait être impacté par une indisponibilité temporaire de Redis.

# 🔬Procédure de test
Nous ne sommes malheureusement pas encore outillés pour des tests automatisés de ce qui touche à Redis. Pour vérifier le changement apporté par cette PR, voici ce que j'ai fait :

* Démarrer un serveur Redis local :
```
$ docker run --rm -ti --name pix-redis -p 6379:6379 redis
```

* Démarrer l'API :
```
pix/api$ REDIS_URL=redis://localhost:6379 LOG_ENABLED=true npm start
```

* Lancer des requêtes en boucle qui touchent Redis (ici, utilisation de https://github.com/JoeDog/siege mais tout autre outil équivalent fera l'affaire) :

```
$ siege http://localhost:3000/api/challenges/rec24qEH0DP4uqf4s
…
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.00 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
…
```

* Redémarrer le serveur Redis :
```
$ docker restart pix-redis
```

* Constater que l'application n'a pas planté, et qu'aucun client n'a reçu de code d'erreur. On voit juste que quelques requêtes ont été suspendues le temps que le serveur revienne :
```
…
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.00 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.00 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.00 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.79 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.79 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.79 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.78 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.78 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.77 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.78 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.78 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.77 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.77 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.76 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.76 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.75 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.75 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   1.74 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.02 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.02 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
HTTP/1.1 200   0.01 secs:     523 bytes ==> GET  /api/challenges/rec24qEH0DP4uqf4s
…
```