### PR TITLE
[BUGFIX] Change /api/scripts to avoid side effects in tests

### DIFF
--- a/api/scripts/delete-assessment.js
+++ b/api/scripts/delete-assessment.js
@@ -99,7 +99,7 @@ class ScriptQueryBuilder {
 
 /*=================== tests =============================*/
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 }
 

--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -176,7 +176,7 @@ class ScriptQueryBuilder {
 
 /*=================== tests =============================*/
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 }
 

--- a/api/scripts/export-organisation-snapshot.js
+++ b/api/scripts/export-organisation-snapshot.js
@@ -23,4 +23,6 @@ function main(args) {
     .pipe(fs.createWriteStream(`organization-${organizationId}-${fileName}.csv`));
 }
 
-main(process.argv);
+if (require.main === module) {
+  main(process.argv);
+}

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -48,7 +48,7 @@ function main() {
 
 /*=================== tests =============================*/
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   console.log('Start script : ');
   main();
 }

--- a/api/scripts/get-changelog.js
+++ b/api/scripts/get-changelog.js
@@ -61,7 +61,7 @@ function main() {
 
 /*=================== tests =============================*/
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 } else {
   module.exports = {

--- a/api/scripts/get-results-certifications-old.js
+++ b/api/scripts/get-results-certifications-old.js
@@ -84,7 +84,7 @@ function main() {
 
 /*=================== tests =============================*/
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 } else {
   module.exports = {

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -155,7 +155,7 @@ function main() {
 
 }
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 }
 

--- a/api/scripts/import-certifications-from-csv.js
+++ b/api/scripts/import-certifications-from-csv.js
@@ -139,7 +139,7 @@ function main() {
   }
 }
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 }
 

--- a/api/scripts/recompute-all-score.js
+++ b/api/scripts/recompute-all-score.js
@@ -50,4 +50,6 @@ function main() {
   process.exit();
 }
 
-main();
+if (require.main === module) {
+  main();
+}

--- a/api/scripts/recompute-assessment-results.js
+++ b/api/scripts/recompute-assessment-results.js
@@ -49,7 +49,7 @@ function main() {
 
 }
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   main();
 }
 

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -646,17 +646,17 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
   describe('#findSmartPlacementAssessmentsByUserId', () => {
     let assessmentId;
 
-    const assessmentInDb = databaseBuilder.factory.buildAssessment({
-      courseId: 'course_A',
-      userId: 1,
-      type: 'SMART_PLACEMENT',
-    });
-
-    const campaign = databaseBuilder.factory.buildCampaign({
-      name: 'Campagne',
-    });
-
     beforeEach(() => {
+      const assessmentInDb = databaseBuilder.factory.buildAssessment({
+        courseId: 'course_A',
+        userId: 1,
+        type: 'SMART_PLACEMENT',
+      });
+
+      const campaign = databaseBuilder.factory.buildCampaign({
+        name: 'Campagne',
+      });
+
       return knex('assessments').insert(assessmentInDb)
         .then((assessmentIds) => {
           assessmentId = _.first(assessmentIds);

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -142,9 +142,9 @@ describe('Integration | Repository | Certification Course', function() {
       userId = 1;
       sessionId = 'ABCD12';
       certificationCourses = [
-        databaseBuilder.factory.buildCertificationCourse({ id: 1, userId: 2, sessionId, completedAt: null }),
-        databaseBuilder.factory.buildCertificationCourse({ id: 2, userId, sessionId: 'ABCD21', completedAt: null }),
-        databaseBuilder.factory.buildCertificationCourse({ id: 3, userId, sessionId }),
+        databaseBuilder.factory.buildCertificationCourse({ id: 1, userId: 2, sessionId, completedAt: null, createdAt: '2018-12-21' }),
+        databaseBuilder.factory.buildCertificationCourse({ id: 2, userId, sessionId: 'ABCD21', completedAt: null, createdAt: '2018-12-21' }),
+        databaseBuilder.factory.buildCertificationCourse({ id: 3, userId, sessionId, createdAt: '2018-12-11' }),
         databaseBuilder.factory.buildCertificationCourse({ id: 4, userId, sessionId, completedAt: null, createdAt: '2018-11-11' }),
         databaseBuilder.factory.buildCertificationCourse({ id: 5, userId, sessionId, completedAt: null, createdAt: '2018-12-12' }),
       ];


### PR DESCRIPTION
## 🌍 Context

Many scripts in `/api/scripts` are required by tests (because they are tested), and had side effects if `NODE_ENV` was != `'test'`. This was a problem to run tests on a real Postgres database, which requires `NODE_ENV` to be `production`.

## 🔧 Fix

There exists in Node.js a better protection mecanism to avoid side effects when standalone scripts are required instead of run.

So in `/api/scripts`, I changed all instances of:

```
if (process.env.NODE_ENV !== 'test') {
  main();
}
```

to:

```
if (require.main === module) {
  main();
}
```