### PR TITLE
[BUGFIX] Le niveau affiché à la fin d'un parcours par compétence devrait être plafonné (PF-492).

### DIFF
--- a/api/lib/domain/models/Profile.js
+++ b/api/lib/domain/models/Profile.js
@@ -114,5 +114,6 @@ class Profile {
 }
 
 Profile.competenceStatus = competenceStatus;
+Profile.MAX_REACHABLE_LEVEL = MAX_REACHABLE_LEVEL;
 
 module.exports = Profile;

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -1,3 +1,4 @@
+const { MAX_REACHABLE_LEVEL } = require('../../../lib/domain/models/Profile');
 const scoringService = require('../services/scoring/scoring-service');
 const { NotFoundError } = require('../errors');
 
@@ -29,7 +30,7 @@ module.exports = async function getAssessment(
    * dans le front plutôt qu'engager un calcul lourd à chaque affichage d'épreuve ou chaque récupération d'assessment.
    */
   const assessmentScore = await scoringService.calculateAssessmentScore(dependencies, assessment);
-  assessment.estimatedLevel = assessmentScore.level;
+  assessment.estimatedLevel = Math.min(assessmentScore.level, MAX_REACHABLE_LEVEL);
   assessment.pixScore = assessmentScore.nbPix;
 
   return assessment;

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -205,7 +205,7 @@ describe('Acceptance | API | assessment-controller-get', () => {
           'type': 'assessment',
           'id': inserted_assessment_id,
           'attributes': {
-            'estimated-level': null,
+            'estimated-level': 0,
             'pix-score': 0,
             'state': null,
             'type': 'PLACEMENT',

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -12,7 +12,6 @@ describe('Unit | UseCase | get-assessment', () => {
 
   beforeEach(() => {
     assessment = domainBuilder.buildAssessment();
-    assessmentScore = domainBuilder.buildAssessmentScore();
 
     sinon.stub(assessmentRepository, 'get');
     sinon.stub(scoringService, 'calculateAssessmentScore');
@@ -20,6 +19,7 @@ describe('Unit | UseCase | get-assessment', () => {
 
   it('should resolve the Assessment domain object matching the given assessment ID', async () => {
     // given
+    assessmentScore = domainBuilder.buildAssessmentScore();
     assessmentRepository.get.resolves(assessment);
     scoringService.calculateAssessmentScore.resolves(assessmentScore);
 
@@ -29,8 +29,33 @@ describe('Unit | UseCase | get-assessment', () => {
     // then
     expect(result).to.be.an.instanceOf(Assessment);
     expect(result.id).to.equal(assessment.id);
-    expect(result.estimatedLevel).to.equal(assessmentScore.level);
     expect(result.pixScore).to.equal(assessmentScore.nbPix);
+  });
+
+  it('should resolve the Assessment domain object with estimated level', async () => {
+    // given
+    assessmentScore = domainBuilder.buildAssessmentScore({ level: 2 });
+    assessmentRepository.get.resolves(assessment);
+    scoringService.calculateAssessmentScore.resolves(assessmentScore);
+
+    // when
+    const result = await getAssessment({ assessmentRepository, assessmentId: assessment.id  });
+
+    // then
+    expect(result.estimatedLevel).to.equal(2);
+  });
+
+  it('should resolve the Assessment domain object with ceiling level', async () => {
+    // given
+    assessmentScore = domainBuilder.buildAssessmentScore({ level: 6 });
+    assessmentRepository.get.resolves(assessment);
+    scoringService.calculateAssessmentScore.resolves(assessmentScore);
+
+    // when
+    const result = await getAssessment({ assessmentRepository, assessmentId: assessment.id  });
+
+    // then
+    expect(result.estimatedLevel).to.equal(5);
   });
 
   it('should reject a domain NotFoundError when there is no assessment for given ID', () => {


### PR DESCRIPTION
# 🤷‍♀️ 🤷‍♂️ Besoin : 
En tant qu'utilisateur de Pix, lorsque je me positionne sur une compétence et que je la réussi parfaitement, je devrait voir mon niveau plafonné lors de l'affichage de mes résultats (page de fin de positionnement).

# 👩‍💻👨‍💻 Technique : 
Côté back, on ajoutait déjà des propriétés à `assessment` pour pouvoir afficher cette page de résultats. La valeur de `estimatedLevel` n'était pas plafonnée. Pour résoudre ce bug, il a fallu plafonner le niveau envoyé au front pour affichage.
Ce plafonnage est fait côté back puisque le plafonnage du profil est également fait côté back (affichage du profil et partage du profil). 