### PR TITLE
[BSR] Fix a randomly failing test

### DIFF
--- a/api/tests/unit/cat/assessment_test.js
+++ b/api/tests/unit/cat/assessment_test.js
@@ -294,8 +294,8 @@ describe('Unit | Model | Assessment', function() {
     it('should return the union of failed and validated skills', function() {
       // given
       let tube1, tube2;
-      const [s1, s2] = tube1 = domainBuilder.buildCatTube({ maxLevel: 3 });
-      const [t1, t2, t3] = tube2 = domainBuilder.buildCatTube({ maxLevel: 3 });
+      const [s1, s2] = tube1 = domainBuilder.buildCatTube({ maxLevel: 2, name: 'web' });
+      const [t1, t2, t3] = tube2 = domainBuilder.buildCatTube({ maxLevel: 3, name: 'rechUrl' });
       const ch1 = domainBuilder.buildCatChallenge({ skills: [s1] });
       const ch2 = domainBuilder.buildCatChallenge({ skills: [s2] });
       const ch3 = domainBuilder.buildCatChallenge({ skills: [t1] });


### PR DESCRIPTION
🌍 Context
-----------

The test `Unit | Model | Assessment #assessedSkills should return the union of failed and validated skills` was failing randomly.

Cause: it was randomly building two different tubes with identical level 2 skills, which is never supposed to happen.

🗜️Fix
------

This fix gives a fixed name to the two tubes, so the level 2 skills are always different.