### PR TITLE
[TECH] Simplifier le process de MEP en utilisant l'api GitHub

### DIFF
--- a/api/scripts/get-pull-requests-to-release-in-prod.js
+++ b/api/scripts/get-pull-requests-to-release-in-prod.js
@@ -1,0 +1,96 @@
+#! /usr/bin/env node
+const request = require('request-promise-native');
+const moment = require('moment');
+const _ = require('lodash');
+
+function buildRequestObject() {
+  return {
+    baseUrl: 'https://api.github.com/repos/1024pix/pix',
+    url: '/pulls?state=closed&sort=updated&direction=desc',
+    headers: {
+      'User-Agent': 'jbuget'
+    },
+    json: true
+  };
+}
+
+function getTheLastCommitOnMaster() {
+  return {
+    baseUrl: 'https://api.github.com/repos/1024pix/pix',
+    url: '/commits/master',
+    headers: {
+      'User-Agent': 'jbuget'
+    },
+    json: true
+  };
+}
+
+function getTheCommitDate(RawDataCommit) {
+  return RawDataCommit.commit.committer.date;
+}
+
+function displayPullRequest(pr) {
+  return `- [#${pr.number}](${pr.html_url}) ${pr.title}\n`;
+}
+
+function orderPr(listPR) {
+  const typeOrder = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
+  return _.sortBy(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
+    const typeIndex = _.indexOf(typeOrder, typeOfPR);
+    return typeIndex < 0 ? Number.MAX_VALUE : typeIndex;
+  });
+}
+
+function filterPullRequest(pullrequests, dateOfLastMEP) {
+  return pullrequests.filter(PR => {
+    if (PR.merged_at && PR.merged_at > dateOfLastMEP) {
+      return PR;
+    }
+  });
+}
+
+function getHeadOfChangelog(tagVersion) {
+  const date = ' (' + moment().format('DD/MM/YYYY') + ')';
+  return '## v' + tagVersion + date + ' \n\n';
+}
+
+function main() {
+  const tagVersion = process.argv[2];
+  let addToChangeLog = '';
+
+  request(getTheLastCommitOnMaster())
+    .then((lastCommit) => {
+      return getTheCommitDate(lastCommit);
+    })
+    .then((dateOfLastMEP) => {
+      request(buildRequestObject())
+        .then((pullRequests) => {
+
+          addToChangeLog += getHeadOfChangelog(tagVersion);
+          const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+
+          const orderedPR = orderPr(pullRequestsSinceLastMEP);
+          orderedPR.forEach(pr => addToChangeLog += displayPullRequest(pr));
+
+          console.log('Pull Requests which will be add to the CHANGELOG.md : \n');
+          console.log(addToChangeLog);
+
+        })
+        .catch(console.log);
+    });
+}
+
+/*=================== tests =============================*/
+
+if (process.env.NODE_ENV !== 'test') {
+  main();
+} else {
+  module.exports = {
+    displayPullRequest,
+    filterPullRequest,
+    orderPr,
+    getHeadOfChangelog,
+    getTheCommitDate,
+  };
+}

--- a/api/scripts/get-pull-requests-to-release-in-prod.js
+++ b/api/scripts/get-pull-requests-to-release-in-prod.js
@@ -43,11 +43,7 @@ function orderPr(listPR) {
 }
 
 function filterPullRequest(pullrequests, dateOfLastMEP) {
-  return pullrequests.filter(PR => {
-    if (PR.merged_at && PR.merged_at > dateOfLastMEP) {
-      return PR;
-    }
-  });
+  return pullrequests.filter(PR => PR.merged_at > dateOfLastMEP);
 }
 
 function getHeadOfChangelog(tagVersion) {
@@ -57,28 +53,27 @@ function getHeadOfChangelog(tagVersion) {
 
 function main() {
   const tagVersion = process.argv[2];
+  let dateOfLastMEP;
   let addToChangeLog = '';
 
   request(getTheLastCommitOnMaster())
     .then((lastCommit) => {
-      return getTheCommitDate(lastCommit);
+      dateOfLastMEP = getTheCommitDate(lastCommit);
+      return request(buildRequestObject())
     })
-    .then((dateOfLastMEP) => {
-      request(buildRequestObject())
-        .then((pullRequests) => {
+    .then((pullRequests) => {
 
-          addToChangeLog += getHeadOfChangelog(tagVersion);
-          const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+      addToChangeLog += getHeadOfChangelog(tagVersion);
+      const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
 
-          const orderedPR = orderPr(pullRequestsSinceLastMEP);
-          orderedPR.forEach(pr => addToChangeLog += displayPullRequest(pr));
+      const orderedPR = orderPr(pullRequestsSinceLastMEP);
+      orderedPR.forEach(pr => addToChangeLog += displayPullRequest(pr));
 
-          console.log('Pull Requests which will be add to the CHANGELOG.md : \n');
-          console.log(addToChangeLog);
+      console.log('Pull Requests which will be add to the CHANGELOG.md : \n');
+      console.log(addToChangeLog);
 
-        })
-        .catch(console.log);
-    });
+    })
+    .catch(console.log);
 }
 
 /*=================== tests =============================*/

--- a/api/tests/unit/scripts/get-pull-requests-to-release-in-prod_test.js
+++ b/api/tests/unit/scripts/get-pull-requests-to-release-in-prod_test.js
@@ -1,0 +1,137 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { displayPullRequest, filterPullRequest, getHeadOfChangelog, orderPr, getTheCommitDate } = require('../../../scripts/get-pull-requests-to-release-in-prod');
+
+describe('Unit | Script | GET Pull Request to release in Prod', () => {
+
+  describe('displayPullRequest', () => {
+    const expectedLine = '- [#111](http://git/111) [BUGFIX] Résolution du problème de surestimation du niveau (US-389).\n';
+
+    it('should return a line with correct format from correct PR name', () => {
+      // given
+      const pullRequest = {
+        title: '[BUGFIX] Résolution du problème de surestimation du niveau (US-389).',
+        number: 111,
+        html_url: 'http://git/111'
+      };
+      // when
+      const result = displayPullRequest(pullRequest);
+      // then
+      expect(result).to.equal(expectedLine);
+    });
+  });
+
+  describe('filterPullRequest', () => {
+    it('should return only merged PR since last MEP', () => {
+      // given
+      const date = '2019-01-18T15:29:51Z';
+      const pullRequests = [{
+        'id': 1,
+        'number': 315,
+        'state': 'closed',
+        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+        'created_at': '2019-01-11T15:47:26Z',
+        'updated_at': '2019-01-23T13:37:47Z',
+        'closed_at': '2019-01-23T13:37:37Z',
+        'merged_at': '2019-01-23T13:37:37Z',
+        'assignee': null,
+        'milestone': null,
+      }, {
+        'id': 2,
+        'number': 316,
+        'state': 'closed',
+        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+        'created_at': '2018-01-11T15:47:26Z',
+        'updated_at': '2018-01-23T13:37:47Z',
+        'closed_at': '2018-01-23T13:37:37Z',
+        'merged_at': '2018-01-23T13:37:37Z',
+        'assignee': null,
+        'milestone': null,
+      }, {
+        'id': 3,
+        'number': 317,
+        'state': 'closed',
+        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+        'created_at': '2019-01-11T15:47:26Z',
+        'updated_at': '2019-01-23T13:37:47Z',
+        'closed_at': '2019-01-23T13:37:37Z',
+        'merged_at': null,
+        'assignee': null,
+        'milestone': null,
+      }];
+
+      // when
+      const result = filterPullRequest(pullRequests, date);
+      // then
+      expect(result.length).to.equal(1);
+      expect(result[0].id).to.equal(1);
+    });
+  });
+
+  describe('getHeadOfChangelog', () => {
+    it('should return the head of changelog in correct value', () => {
+      // given
+      sinon.useFakeTimers();
+      const headChangelog = '## v2.0.0 (01/01/1970) \n\n';
+      const versionNumber = '2.0.0';
+      // when
+      const result = getHeadOfChangelog(versionNumber);
+      // then
+      expect(result).to.equal(headChangelog);
+    });
+  });
+
+  describe('orderPr', () => {
+    it('should order PR by type', () => {
+      // given
+      const pullRequests = [
+        { title: '[BUGFIX] TEST' },
+        { title: '[QUICK WIN] TEST' },
+        { title: 'TEST' },
+        { title: '[FEATURE] TEST' },
+        { title: '[TECH] TEST' },
+      ];
+      // when
+      const result = orderPr(pullRequests);
+      // then
+      expect(result[0].title).to.equal('[FEATURE] TEST');
+      expect(result[1].title).to.equal('[QUICK WIN] TEST');
+      expect(result[2].title).to.equal('[BUGFIX] TEST');
+      expect(result[3].title).to.equal('[TECH] TEST');
+      expect(result[4].title).to.equal('TEST');
+    });
+  });
+
+  describe('getTheCommitDate', () => {
+
+    it('should return the date of the commit', () => {
+      // given
+      const RawDataCommit = {
+        'sha': 'ada4',
+        'node_id': 'MDY6Q29',
+        'commit': {
+          'author': {
+            'name': 'petitPix',
+            'email': 'petit.pix@gexample.net',
+            'date': '2019-01-18T15:29:51Z'
+          },
+          'committer': {
+            'name': 'petitPix',
+            'email': 'petit.pix@gexample.net',
+            'date': '2019-01-18T15:29:51Z'
+          }
+        }
+      };
+
+      const expectedDate = '2019-01-18T15:29:51Z';
+
+      // when
+      const result = getTheCommitDate(RawDataCommit);
+
+      // then
+      expect(result).to.equal(expectedDate);
+    });
+  });
+
+});

--- a/scripts/release/prepare.sh
+++ b/scripts/release/prepare.sh
@@ -44,6 +44,10 @@ function create_a_release_commit {
     git commit --message "[RELEASE] A ${NEW_VERSION_TYPE} is being released from ${OLD_PACKAGE_VERSION} to ${NEW_PACKAGE_VERSION}."
 }
 
+function complete_change_log {
+  node api/scripts/get-pull-requests-to-release-in-prod.js $1
+}
+
 echo -e "Preparing a new release for ${RED}production${RESET_COLOR}.\n"
 
 ensure_no_uncommited_changes_are_present
@@ -53,6 +57,7 @@ fetch_and_rebase
 update_version
 reinstall_dependencies
 create_a_release_commit
+complete_change_log NEW_PACKAGE_VERSION
 
 echo -e "From now edit the ${CYAN}CHANGELOG.md${RESET_COLOR} file and then execute ${CYAN}release:perform${RESET_COLOR} NPM task.\n"
 echo -e "Release preparation ${GREEN}succeeded${RESET_COLOR}."


### PR DESCRIPTION
### 🚀 Besoin: 
Ne plus se baser sur les milestones dans GitHub pour savoir quels PR à livrer en production.
Ne plus faire la manipulation dans GitHub pour ajouter les PR à une milestone.

### 🌖 Objectif: 
Utiliser les dates données par l'API de GitHub pour sélectionner les PR à mettre en production.

### ⚙️ Modifications:

- Appeler l'API GitHub pour connaitre la date de la dernière MEP.
- Appeler l'API GitHub pour récupérer les PR `closed`
- Filtrer les PR qui sont `merge` dans dev depuis la dernière MEP
- Afficher les PR dans la console pour pouvoir les ajouter au `CHANGELOG.md`

Il n'est plus nécessaire d'appeler le script 
`> node api/scripts/get-changelog.js <numéro de la milestone dans l'url github>`
L'affichage des PR à ajouter dans le `CHANGELOG.md` se fait directement après le script 
`> npm run release:prepare <type de version>`

### ✨ A Ajouter:
Pour éviter de dépasser le temps que je me suis fixer, je n'ai pas fait en sorte que le script ajoute directement les différentes PR dans le `CHANGELOG.md`.

Fait en pair-prog avec @octo-thlo lors d'un point tech.