### PR TITLE
[TECH] Fix random stack trace message in API tests

### DIFF
--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -298,17 +298,17 @@ describe('Unit | Controller | assessment-controller-save', () => {
         sinon.stub(assessmentSerializer, 'serialize').returns(serializedAssessment);
       });
 
-      it('should de-serialize the payload', () => {
+      it('should de-serialize the payload', async() => {
         // when
-        controller.save(request, hFake);
+        await controller.save(request, hFake);
 
         // then
         sinon.assert.calledWith(assessmentSerializer.deserialize, request.payload);
       });
 
-      it('should call a service that extract the id of user', () => {
+      it('should call a service that extract the id of user', async () => {
         //When
-        controller.save(request, hFake);
+        await controller.save(request, hFake);
 
         //Then
         expect(tokenService.extractUserId).to.have.been.calledWith('my-token');


### PR DESCRIPTION
🌍 Context
-----------

Running the API tests sometimes display a stack trace showing a `UnhandledPromiseRejectionWarning` error, without failing the tests:

```
(node:33509) UnhandledPromiseRejectionWarning: CustomError: No Rows Updated
    at Child.<anonymous> (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bookshelf/lib/model.js:1128:19)
    at Child.tryCatcher (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/promise.js:694:18)
    at _drainQueueStep (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/async.js:138:12)
    at _drainQueue (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/async.js:147:5)
    at Immediate.Async.drainQueues (/Users/sebastien.roccaserra/Developer/Pix/pix/api/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:810:20)
    at tryOnImmediate (timers.js:768:5)
    at processImmediate [as _immediateCallback] (timers.js:745:5)
(node:33509) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:33509) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
🔨 Fix
------
This was due to missing `await` declarations, this PR adds them.