### PR TITLE
[BUGFIX] Vérifier le domaine d'une adresse avant de la soumettre à Mailjet (PF-509)

### DIFF
--- a/api/lib/infrastructure/mail-check.js
+++ b/api/lib/infrastructure/mail-check.js
@@ -1,0 +1,9 @@
+const { promisify } = require('util');
+const resolveMx = promisify(require('dns').resolveMx);
+
+module.exports = {
+  checkMail(address) {
+    const domain = address.replace(/.*@/g, '');
+    return resolveMx(domain).then(() => true);
+  },
+};

--- a/api/lib/infrastructure/mailjet.js
+++ b/api/lib/infrastructure/mailjet.js
@@ -1,6 +1,8 @@
 const _ = require('lodash');
 const mailjetConfig = require('../settings').mailjet;
 const nodeMailjet = require('node-mailjet');
+const logger = require('./logger');
+const mailCheck = require('./mail-check');
 
 function _formatPayload(options) {
 
@@ -23,11 +25,15 @@ function _formatPayload(options) {
 }
 
 function sendEmail(options) {
-  const mailjet = nodeMailjet.connect(mailjetConfig.apiKey, mailjetConfig.apiSecret);
+  return mailCheck.checkMail(options.to).then(()=>{
+    const mailjet = nodeMailjet.connect(mailjetConfig.apiKey, mailjetConfig.apiSecret);
 
-  return mailjet
-    .post('send')
-    .request(_formatPayload(options));
+    return mailjet
+      .post('send')
+      .request(_formatPayload(options));
+  }).catch((err)=>{
+    logger.warn({ err }, `Could not send email to '${options.to}'`);
+  });
 }
 
 function getContactListByName(Name) {


### PR DESCRIPTION
# 🌝 Objectif

Notre fournisseur d'envoi d'email, Mailjet, exige que notre taux d'erreur d'envoi reste en-dessous de 8%. Il nous incombe donc de faire le maximum pour éviter de soumettre des adresses erronées à l'envoi.

# 🚀 Approche

On utilise la fonction [dns.resolveMx](https://nodejs.org/api/dns.html#dns_dns_resolvemx_hostname_callback) pour vérifier que le domaine de l'adresse possède bien un enregistrement MX. Ceci devrait permettre d'intercepter une bonne partie des adresses en erreur.

# 🔬Comment vérifier

Réaliser une inscription avec une adresse dont le domaine n'existe pas.
Constater dans les logs de l'application qu'un message `Could not send email to '…'` a été généré.
On peut aussi vérifier que Mailjet n'a pas été contacté, par exemple en configurant une clé d'API invalide.