### PR TITLE
[BUGFIX] Génération du token des résultats CSV sur la page de détails (PO-187).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -63,8 +63,9 @@ module.exports = {
   getById(request, h) {
     const campaignId = request.params.id;
     const options = queryParamsUtils.extractParameters(request.query);
+    const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
     return usecases.getCampaign({ campaignId, options })
-      .then(campaignSerializer.serialize)
+      .then((campaign) => campaignSerializer.serialize(campaign, tokenForCampaignResults))
       .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfraError(error);

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -32,7 +32,6 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/campaigns/{id}',
       config: {
-        auth: false,
         handler: campaignController.getById,
         notes: [
           '- Récupération d\'une campagne par son id',

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -2,7 +2,6 @@ const { PassThrough } = require('stream');
 
 const { EntityValidationError, NotFoundError } = require('../../domain/errors');
 const organizationService = require('../../domain/services/organization-service');
-const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
 const controllerReplies = require('../../infrastructure/controller-replies');
 const { NotFoundError: InfrastructureNotFoundError } = require('../../infrastructure/errors');
@@ -82,10 +81,9 @@ module.exports = {
 
   getCampaigns(request, h) {
     const organizationId = request.params.id;
-    const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
 
     return usecases.getOrganizationCampaigns({ organizationId })
-      .then((campaigns) => campaignSerializer.serialize(campaigns, tokenForCampaignResults))
+      .then((campaigns) => campaignSerializer.serialize(campaigns))
       .then(controllerReplies(h).ok)
       .catch(controllerReplies(h).error);
   },

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -201,6 +201,9 @@ describe('Acceptance | API | Campaigns', () => {
       const options = {
         method: 'GET',
         url: `/api/campaigns/${campaign.id}`,
+        headers: {
+          authorization: generateValidRequestAuhorizationHeader()
+        },
       };
 
       // when
@@ -211,6 +214,7 @@ describe('Acceptance | API | Campaigns', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data.type).to.equal('campaigns');
         expect(response.result.data.attributes.name).to.equal(campaign.name);
+        expect(response.result.data.attributes['token-for-campaign-results']).to.be.a('string');
       });
     });
 
@@ -218,6 +222,9 @@ describe('Acceptance | API | Campaigns', () => {
       const options = {
         method: 'GET',
         url: '/api/campaigns/666',
+        headers: {
+          authorization: generateValidRequestAuhorizationHeader()
+        },
       };
 
       // when
@@ -228,7 +235,6 @@ describe('Acceptance | API | Campaigns', () => {
         expect(response.statusCode).to.equal(404);
       });
     });
-
   });
 
   describe('PATCH /api/campaigns/{id}', () => {

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -49,7 +49,9 @@
   <div class="campaign-details-row">
     <div class="campaign-details-content campaign-details-content--single">
       <h4 class="label-text campaign-details-content__label">Texte de la page d'accueil</h4>
-      <p class="content-text campaign-details-content__text">{{campaign.customLandingPageText}}</p>
+      <p class="content-text campaign-details-content__text">
+        {{markdown-to-html markdown=campaign.customLandingPageText}}
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
# 🤷‍♀️ 🤷‍♂️ Besoin : 
En tant qu'utilisateur de Pix Orga, je veux pouvoir télécharger les résultats du CSV juste après avoir créé une nouvelle campagne.

# 👩‍💻👨‍💻 Technique :
- Déplacement de la logique de génération du token lors du GET campaigns/:id et non plus lors du GET organizations/:id/campaigns

# 🤓 Bon à savoir :
- Le `campaign#getById` est maintenant accessible uniquement authentifié (nécessaire pour avoir les credentials). Le `campaign#getByCode` est, lui, toujours accessible sans authentification.