### PR TITLE
[TECH] Ajoute une première version de nos standards de code

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contribuer à Pix
+
+#### Table des matières
+
+- [Notre utilisation de Git](#notre-utilisation-de-git)
+- [Guide de style JavaScript](#guide-de-style-javascript)
+
+
+## Notre utilisation de Git
+
+### Branche `dev`
+
+⚠️ On ne merge jamais `dev` dans une autre branche ⚠️
+
+### Nommage
+
+Tests, commits, branches : en anglais
+
+Description des Pull Requests : en français
+
+### Nommage des commits
+
+Exemples :
+
+```
+[po-31] Enlarge text width on details page
+
+[pf-509] Check email domain before submitting address to Mailjet
+
+[BSR] Add markdown templating for custom landing page text display
+
+[BUGFIX] Problème de style sous IE (PF-440).
+```
+
+### Node.js
+
+On ne commit le `package-lock.json` qu'en cas de modification du `package.json`
+
+## Guide de style JavaScript
+
+### Nommage
+
+Les noms de classes prennent une majuscule au début, les noms de modules et de variables prennent une minuscule au début.
+
+Exemples :
+
+```
+const userRepository = ...
+
+class User {
+  ...
+```

--- a/docs/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/docs/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,8 @@
+# :woman_shrugging: :man_shrugging: Besoin : 
+> _Décrivez ici le besoin lié à la Pull Request._
+
+# :woman_technologist: :man_technologist: Technique :
+> _Ajoutez à cet endroit, si nécessaire, des détails quant à la solution technique mise en place._
+
+# :nerd_face: Bon à savoir :
+> _Des infos supplémentaires, trucs et astuces ?_


### PR DESCRIPTION
Proposition d'intégrer nos standards et guidelines dans le répo, pour la retrouver facilement, la partager au monde, et pouvoir avoir des discussions autour de sa mise à jour (par exemple en utilisant les mêmes process de relecture que ceux qu'on utilise déjà pour le code).

Infos sur les guidelines selon Github :

- https://help.github.com/articles/setting-guidelines-for-repository-contributors/