### PR TITLE
[TECH] Refacto des transition de reprise des assessments 

### DIFF
--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -15,7 +15,6 @@ export default Model.extend({
   pixScore: attr('number'),
   result: belongsTo('assessment-result'),
   type: attr('string'),
-  hasCheckpoints: equal('type', 'SMART_PLACEMENT'),
   isSmartPlacement: equal('type', 'SMART_PLACEMENT'),
   isCertification: equal('type', 'CERTIFICATION'),
   isDemo: equal('type', 'DEMO'),

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -18,10 +18,10 @@ export default BaseRoute.extend({
       .then((nextChallenge) => {
 
         if (assessment.isPlacement || assessment.isDemo || assessment.isCertification || assessment.isPreview) {
-          return this._resumeAssessmentPlacement(assessment, nextChallenge);
+          return this._resumeAssessmentWithoutCheckpoint(assessment, nextChallenge);
         }
         if (assessment.isSmartPlacement) {
-          return this._resumeAssesmentSmartPlacement(assessment, nextChallenge);
+          return this._resumeAssessmentWithCheckpoint(assessment, nextChallenge);
         }
 
         throw new Error('This transition should not be happening');
@@ -35,7 +35,7 @@ export default BaseRoute.extend({
     }
   },
 
-  _resumeAssessmentPlacement(assessment, nextChallenge) {
+  _resumeAssessmentWithoutCheckpoint(assessment, nextChallenge) {
     const {
       nextChallengeId,
       assessmentIsFinished,
@@ -48,7 +48,7 @@ export default BaseRoute.extend({
     return this._routeToNextChallenge(assessment, nextChallengeId);
   },
 
-  _resumeAssesmentSmartPlacement(assessment, nextChallenge) {
+  _resumeAssessmentWithCheckpoint(assessment, nextChallenge) {
     const {
       nextChallengeId,
       assessmentIsFinished,

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -38,11 +38,11 @@ export default BaseRoute.extend({
   _resumeAssessmentWithoutCheckpoint(assessment, nextChallenge) {
     const {
       nextChallengeId,
-      assessmentIsFinished,
+      assessmentHasNoMoreQuestions,
       assessmentIsCompleted
     } = this._parseState(assessment, nextChallenge);
 
-    if (assessmentIsFinished || assessmentIsCompleted) {
+    if (assessmentHasNoMoreQuestions || assessmentIsCompleted) {
       return this._rateAssessment(assessment);
     }
     return this._routeToNextChallenge(assessment, nextChallengeId);
@@ -51,7 +51,7 @@ export default BaseRoute.extend({
   _resumeAssessmentWithCheckpoint(assessment, nextChallenge) {
     const {
       nextChallengeId,
-      assessmentIsFinished,
+      assessmentHasNoMoreQuestions,
       assessmentIsCompleted,
       userHasSeenCheckpoint,
       userHasReachedCheckpoint
@@ -60,10 +60,10 @@ export default BaseRoute.extend({
     if (assessmentIsCompleted) {
       return this._rateAssessment(assessment);
     }
-    if (assessmentIsFinished && userHasSeenCheckpoint) {
+    if (assessmentHasNoMoreQuestions && userHasSeenCheckpoint) {
       return this._rateAssessment(assessment);
     }
-    if (assessmentIsFinished && !userHasSeenCheckpoint) {
+    if (assessmentHasNoMoreQuestions && !userHasSeenCheckpoint) {
       return this._routeToFinalCheckpoint(assessment);
     }
     if (userHasReachedCheckpoint && !userHasSeenCheckpoint) {
@@ -76,14 +76,14 @@ export default BaseRoute.extend({
   },
 
   _parseState(assessment, nextChallenge) {
-    const assessmentIsFinished = !nextChallenge;
+    const assessmentHasNoMoreQuestions = !nextChallenge;
     const userHasSeenCheckpoint = this.get('hasSeenCheckpoint');
     const userHasReachedCheckpoint = assessment.get('answers.length') > 0 && assessment.get('answers.length') % ENV.APP.NUMBER_OF_CHALLENGE_BETWEEN_TWO_CHECKPOINTS_IN_SMART_PLACEMENT === 0;
-    const nextChallengeId = !assessmentIsFinished && nextChallenge.get('id');
+    const nextChallengeId = !assessmentHasNoMoreQuestions && nextChallenge.get('id');
     const assessmentIsCompleted = assessment.get('isCompleted');
 
     return {
-      assessmentIsFinished,
+      assessmentHasNoMoreQuestions,
       userHasSeenCheckpoint,
       userHasReachedCheckpoint,
       nextChallengeId,

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -6,11 +6,6 @@ export default BaseRoute.extend({
   hasSeenCheckpoint: false,
   campaignCode: null,
 
-  _hasReachedCheckpoint(assessment) {
-    return assessment.get('answers.length') > 0 &&
-      assessment.get('answers.length') % ENV.APP.NUMBER_OF_CHALLENGE_BETWEEN_TWO_CHECKPOINTS_IN_SMART_PLACEMENT === 0;
-  },
-
   beforeModel({ queryParams }) {
     this.set('hasSeenCheckpoint', queryParams.hasSeenCheckpoint);
     this.set('campaignCode', queryParams.campaignCode);
@@ -21,24 +16,15 @@ export default BaseRoute.extend({
     return this.get('store')
       .queryRecord('challenge', { assessmentId: assessment.get('id') })
       .then((nextChallenge) => {
-        if (nextChallenge) {
-          const nbCurrentAnswers = assessment.get('nbCurrentAnswers');
 
-          if (assessment.get('hasCheckpoints') && this._hasReachedCheckpoint(assessment) && !this.get('hasSeenCheckpoint')) {
-            assessment.set('nbCurrentAnswers', 0);
-            return this.replaceWith('assessments.checkpoint', assessment.get('id'));
-          }
-
-          assessment.set('nbCurrentAnswers', nbCurrentAnswers + 1);
-
-          this.replaceWith('assessments.challenge', assessment.get('id'), nextChallenge.get('id'));
-        } else {
-          if (assessment.get('hasCheckpoints') && !this.get('hasSeenCheckpoint') && !assessment.get('isCompleted')) {
-            return this.replaceWith('assessments.checkpoint', assessment.get('id'), { queryParams: { finalCheckpoint: true } });
-          }
-
-          this.replaceWith('assessments.rating', assessment.get('id'));
+        if (assessment.isPlacement || assessment.isDemo || assessment.isCertification || assessment.isPreview) {
+          return this._resumeAssessmentPlacement(assessment, nextChallenge);
         }
+        if (assessment.isSmartPlacement) {
+          return this._resumeAssesmentSmartPlacement(assessment, nextChallenge);
+        }
+
+        throw new Error('This transition should not be happening');
       });
   },
 
@@ -47,5 +33,81 @@ export default BaseRoute.extend({
       // allows the loading template to be shown or not
       return originRoute._router.currentRouteName !== 'assessments.challenge';
     }
-  }
+  },
+
+  _resumeAssessmentPlacement(assessment, nextChallenge) {
+    const {
+      nextChallengeId,
+      assessmentIsFinished,
+      assessmentIsCompleted
+    } = this._parseState(assessment, nextChallenge);
+
+    if (assessmentIsFinished || assessmentIsCompleted) {
+      return this._rateAssessment(assessment);
+    }
+    return this._routeToNextChallenge(assessment, nextChallengeId);
+  },
+
+  _resumeAssesmentSmartPlacement(assessment, nextChallenge) {
+    const {
+      nextChallengeId,
+      assessmentIsFinished,
+      assessmentIsCompleted,
+      userHasSeenCheckpoint,
+      userHasReachedCheckpoint
+    } = this._parseState(assessment, nextChallenge);
+
+    if (assessmentIsCompleted) {
+      return this._rateAssessment(assessment);
+    }
+    if (assessmentIsFinished && userHasSeenCheckpoint) {
+      return this._rateAssessment(assessment);
+    }
+    if (assessmentIsFinished && !userHasSeenCheckpoint) {
+      return this._routeToFinalCheckpoint(assessment);
+    }
+    if (userHasReachedCheckpoint && !userHasSeenCheckpoint) {
+      return this._routeToCheckpoint(assessment);
+    }
+    if (userHasReachedCheckpoint && userHasSeenCheckpoint) {
+      return this._routeToNextChallenge(assessment, nextChallengeId);
+    }
+    return this._routeToNextChallenge(assessment, nextChallengeId);
+  },
+
+  _parseState(assessment, nextChallenge) {
+    const assessmentIsFinished = !nextChallenge;
+    const userHasSeenCheckpoint = this.get('hasSeenCheckpoint');
+    const userHasReachedCheckpoint = assessment.get('answers.length') > 0 && assessment.get('answers.length') % ENV.APP.NUMBER_OF_CHALLENGE_BETWEEN_TWO_CHECKPOINTS_IN_SMART_PLACEMENT === 0;
+    const nextChallengeId = !assessmentIsFinished && nextChallenge.get('id');
+    const assessmentIsCompleted = assessment.get('isCompleted');
+
+    return {
+      assessmentIsFinished,
+      userHasSeenCheckpoint,
+      userHasReachedCheckpoint,
+      nextChallengeId,
+      nextChallenge,
+      assessmentIsCompleted
+    };
+  },
+
+  _routeToNextChallenge(assessment, nextChallengeId) {
+    assessment.incrementProperty('nbCurrentAnswers');
+    return this.replaceWith('assessments.challenge', assessment.get('id'), nextChallengeId);
+  },
+
+  _rateAssessment(assessment) {
+    return this.replaceWith('assessments.rating', assessment.get('id'));
+  },
+
+  _routeToCheckpoint(assessment) {
+    assessment.set('nbCurrentAnswers', 0);
+    return this.replaceWith('assessments.checkpoint', assessment.get('id'));
+  },
+
+  _routeToFinalCheckpoint(assessment) {
+    return this.replaceWith('assessments.checkpoint', assessment.get('id'), { queryParams: { finalCheckpoint: true } });
+  },
+
 });

--- a/mon-pix/tests/acceptance/resume-campaigns-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-test.js
@@ -153,8 +153,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
     });
   });
 
-  describe.only('Resume 2 campaigns', function() {
-    debugger;
+  describe('Resume 2 campaigns', function() {
     beforeEach(async function() {
       server.create('assessment', {
         id: 1,
@@ -185,13 +184,6 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
       });
 
       await authenticateAsSimpleUser();
-      await visit('/campagnes/AZERTY1');
-      await click('.challenge-actions__action-skip');
-      await completeCampaignByCode('AZERTY1');
-
-      await visit('/campagnes/AZERTY2');
-      await click('.challenge-actions__action-skip');
-      await completeCampaignByCode('AZERTY2');
     });
 
     context('When user has finished but not shared 2 campaigns', function() {

--- a/mon-pix/tests/acceptance/resume-campaigns-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-test.js
@@ -153,8 +153,8 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
     });
   });
 
-  describe('Resume 2 campaigns', function() {
-
+  describe.only('Resume 2 campaigns', function() {
+    debugger;
     beforeEach(async function() {
       server.create('assessment', {
         id: 1,

--- a/mon-pix/tests/acceptance/resume-campaigns-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-test.js
@@ -155,6 +155,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
   describe('Resume 2 campaigns', function() {
     beforeEach(async function() {
+
       server.create('assessment', {
         id: 1,
         type: 'SMART_PLACEMENT',
@@ -184,6 +185,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
       });
 
       await authenticateAsSimpleUser();
+
     });
 
     context('When user has finished but not shared 2 campaigns', function() {
@@ -212,17 +214,11 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
     context('When user has finished both campaigns but shared only 1 campaign', function() {
 
       beforeEach(async function() {
-        server.create('campaignParticipation', {
-          id: 1,
-          isShared: true,
-          campaignId: 1,
-          assessmentId: 1,
-        });
+        await visit('/campagnes/AZERTY1');
+        await click('.skill-review__share__button');
       });
 
       it('should show thanks message for the first campaign', async function() {
-        // when
-        await visit('/campagnes/AZERTY1');
 
         // then
         return andThen(() => {

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -4,8 +4,6 @@ import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 import _ from 'lodash';
 
-const SMART_PLACEMENT_TYPE = 'SMART_PLACEMENT';
-
 describe('Unit | Model | Assessment', function() {
 
   setupModelTest('assessment', {
@@ -15,37 +13,6 @@ describe('Unit | Model | Assessment', function() {
   it('exists', function() {
     const model = this.subject();
     expect(model).to.be.ok;
-  });
-
-  describe('Computed property #hasCheckpoints', function() {
-
-    it('should be true when challenge is a SMART_PLACEMENT', function() {
-      run(() => {
-        // given
-        const store = this.store();
-        const assessment = store.createRecord('assessment', { type: SMART_PLACEMENT_TYPE });
-
-        // when
-        const hasCheckpoints = assessment.get('hasCheckpoints');
-
-        // then
-        expect(hasCheckpoints).to.be.true;
-      });
-    });
-
-    it('should be true when challenge is NOT a SMART_PLACEMENT', function() {
-      run(() => {
-        // given
-        const assessment = this.subject();
-        assessment.set('type', 'DEMO');
-
-        // when
-        const hasCheckpoints = assessment.get('hasCheckpoints');
-
-        // then
-        expect(hasCheckpoints).to.be.false;
-      });
-    });
   });
 
   describe('@answersSinceLastCheckpoints', function() {

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -43,7 +43,7 @@ describe('Unit | Route | Assessments | Resume', function() {
     let assessment;
 
     beforeEach(function() {
-      assessment = EmberObject.create({ id: 123 });
+      assessment = EmberObject.create({ id: 123, isDemo: true });
     });
 
     it('should get the next challenge of the assessment', function() {
@@ -72,7 +72,8 @@ describe('Unit | Route | Assessments | Resume', function() {
       context('when assessment is a SMART_PLACEMENT', function() {
 
         beforeEach(function() {
-          assessment.type = 'SMART_PLACEMENT';
+          assessment.isSmartPlacement = true;
+          assessment.isDemo = false;
           assessment.hasCheckpoints = true;
         });
 
@@ -135,6 +136,9 @@ describe('Unit | Route | Assessments | Resume', function() {
       });
 
       context('when assessment is a DEMO, PLACEMENT, CERTIFICATION or PREVIEW', function() {
+        beforeEach(() => {
+          assessment.isPlacement = true;
+        });
         it('should redirect to the challenge view', function() {
           // when
           const promise = route.afterModel(assessment);
@@ -157,7 +161,8 @@ describe('Unit | Route | Assessments | Resume', function() {
       context('when assessment is a SMART_PLACEMENT', function() {
 
         beforeEach(function() {
-          assessment.type = 'SMART_PLACEMENT';
+          assessment.isSmartPlacement = true;
+          assessment.isDemo = false;
           assessment.hasCheckpoints = true;
         });
 
@@ -226,6 +231,9 @@ describe('Unit | Route | Assessments | Resume', function() {
       });
 
       context('when assessment is a DEMO, PLACEMENT, CERTIFICATION or PREVIEW', function() {
+        beforeEach(() => {
+          assessment.isPlacement = true;
+        });
         it('should redirect to assessment rating page', function() {
           // when
           const promise = route.afterModel(assessment);


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
Dans cette PR, je me suis attaqué à deux problèmes, sur un fichier centrale de l'application front, celui qui gère la reprise d'assessment :
- Permettre à 5 développeurs de travailler en parallèle sur les 5 types d'assessment
- Réduire le coût d'entrée du code avec des techniques simples 
Ce fichier me semblait idéal pour ça parce qu'il mélange beaucoup de choses: on a plein de transitions possibles, certaines que pour certains types d'assessments. 

# :woman_technologist: :man_technologist: Technique :

### Réduire le coût d'entrée

**Concrètement**, si Benoit débarque et demande, _Au fait, il se passe quoi dans le cas des positionnements si l'utilisateur éteint le navigateur par erreur après avoir envoyé la dernière question, et qu'il reprend la certification ?_  Si vous n'avez pas touché aux assessments depuis un moment, vous ouvrez `resume.js` et vous tombez sur ça vous répondez quoi ? 
````
afterModel(assessment) {
  return this.get('store')
    .queryRecord('challenge', { assessmentId: assessment.get('id') })
    .then((nextChallenge) => {
       if (nextChallenge) {
         const nbCurrentAnswers = assessment.get('nbCurrentAnswers');
         if (assessment.get('hasCheckpoints') && this._hasReachedCheckpoint(assessment) && !this.get('hasSeenCheckpoint')) {
           assessment.set('nbCurrentAnswers', 0);
           return this.replaceWith('assessments.checkpoint', assessment.get('id'));
          }
          assessment.set('nbCurrentAnswers', nbCurrentAnswers + 1);
          this.replaceWith('assessments.challenge', assessment.get('id'), nextChallenge.get('id'));
        } else {
          if (assessment.get('hasCheckpoints') && !this.get('hasSeenCheckpoint') && !assessment.get('isCompleted')) {
            return this.replaceWith('assessments.checkpoint', assessment.get('id'), { queryParams: { finalCheckpoint: true } });
         }
         this.replaceWith('assessments.rating', assessment.get('id'));
       }
}
````
La réponse est que l'application fait une transition vers la route interne `rating` qui a pour effet d'envoyer une requête pour terminer l'assessment. Cela suppose de savoir que : 
- Il y a une différence entre un assessment "terminé" = l'algo n'a plus de question a poser, et un assessment completed, = on a enregistré les résultat. Donc la on passerait dans le `else` puisqu'il n'y aurait pas de `nextChallenge` 
- Que seules les campagnes ont la notion de checkpoint, et que donc, on tombe dans le cas par défaut de transition vers `assessments.rating` 
- Que cette route `rating` correspond bien à une action de terminaison d'assessment.

Pour augmenter la lisibilité sur du code qui doit switcher de façon complexe, ce qui est proposé dans cette PR est de : 
- Créer une fonction `parseState` qui prend les paramètres d'entrées et les traduits sous la forme d'un nommage clair qui mime exactement le nommage métier, là où parfois des membres d'un objets le retranscrivent mal. Pareil pour des actions (`nextChallenge` traduit en `hasFinishedAssessment`) 
- Proposer le cas le plus probable en haut des conditions avec des early `return`, et plus on descend, plus on tombe sur des cas spécifique. Ca permet à la lecture de très vite se rendre compte qu'on comprend 80% des branchements, de ce qui se passe. Et ca permet d'avoir des conditions simples. C'est à dire si on commence par écrire : 
````
  if (condition) {
    return A();
   }
````
Dans tout le reste de code, on sait que condition est false, donc pas besoin de le ré-écrire
````
   if (something && !somethingElse) {
     return ...
   }
    if (something && somethingElse) {
     return ...
   }
````
Dans la suite, on sait qu'on est forcément dans le cas `! something` donc pas besoin de le ré-écrire et les conditions s'en trouvent grandement simplifié.


### Permettre de développer indépendamment sur les assessments

Dans le code ci-dessus, on voit que tout est lié. Seul un développeur peut travailler à un instant donné sur cette partie du code. C'est problématique pour scaler. Pour autant, je ne pense pas que ce soit conflictuel avec le fait d'avoir un seul point d'entée sur l'URI `/assessment/{assessmentId}`. 

**Règles de base**
- Avoir des bloc atomiques indivisibles, des fonctions dans lesquels les chaque assessment pourra piocher. Ces fonctions doivent être suffisamment petites pour qu'elles n'aient pas à être diviser.
- Branchement au plus tôt avec un `if` sur le type d'assessment. Ensuite, avoir une fonction par type d'assessment, laquelle est uniquement composée des blocs mentionnés plus haut. 
- Si l'on voit `A(); B(); C();` dans `somethingPlacement` et `somethingSmartPlacement` résister à la tentation de regrouper ça dans un `D()`. Résister fortement. Ce regroupement n'a aucune réalité métier. Si on part du postulat que notre code reflète le métier, faire ce regroupement revient ni plus ni moins à *exprimer une contrainte métier qui n'existe pas* . Tôt ou tard, `Placement` aura besoin de faire `A(); B(); B1(); C();` et là c'est le début de la bolognaise. En revanche, si le principe 1/ est bien respecté, on aura jamais de besoin de faire un `A(); Bmod(); C();` où `Bmod` serait une version customisée de `B`. Si c'est le cas, c'est que `B` n'était pas assez atomique, et on refacto sur le moment. 

**Evolutivité de ce genre de design**

1/ Arrivé d'un nouvel assessment arbitrairement différent  _sur une certaine partie du code_
`somethingPlacement` et `somethingSmartPlacement` existent, et viennent s'ajouter d'autres placement, exemple, `somethingPreview` Supposons que `somethingPreview` ait lors de son inception, des règles similaires à `somethingPlacement`, ainsi que d'autres règles. 
- Créer les règles associées `E` et `F` et les combiner avec les autres pour former par `somethingPlacement` par exemple de la forme `A();E();F();C();` et c'est terminé.

2/ Arrivé d'un nouvel assessment totalement identique _sur une certaine partie du code_
`somethingPlacement` et `somethingSmartPlacement` existent, et viennent s'ajouter d'autres placement, exemple, `somethingDemo` Supposons que `somethingDemo` ait lors de son inception, des règles totalement identique à `somethingPlacement`
Fausse bonne idée numéro 1 : créer un concept non-existant dans le métier et les regrouper sous la forme d'un `somethingSuperCool` qui se met à pop-er dans le code et éclatera en milles morceaux dès que le métier voudra que l'un diverge un peu de l'autre.
Privilégier le fait d'exprimer le deuxième entièrement en fonction de l'autre. C'est la tradition exacte de ce qui se passe côté métier après tout. Ce deuxième concept vient, ressemble totalement au premier à cet endroit _pour l'instant_ donc exprimer ça dans le code. En faisant par exemple : 
````
  if (somethingPlacement) {
    somethingPlacementFn();
   }
  if (somethingPreview) {
    somethingPlacementFn();
   }
````
Ce genre de code peut gêner. On peut être tenter de se dire qu'il manque un concept de base. Ou alors d'avoir peur que si B s'exprimer en fonction de A, et que C en fonction de B, et que D en fonction... ça devient vite le bazar. En réalité ce genre de longues chaînes n'arrive jamais. Le métier se réfèrera souvent à un cas de base. Et quand bien même il voudrait faire ça, tant qu'il est cohérent, nous on est prêt à le "décrocher" et à l'exprimer lui même en fonction des blocs élémentaires à tout instant.

3/ Arrivé d'aucun nouvel assessment, mais...  _sur une certaine partie du code_ d'un besoin d'évolution concernant un sous-ensemble des assessments _(Hello les checkpoints)_
Fausse bonne idée numéro 2 : créer une deuxième partition sur le type de base (`hasCheckPoint` / `!hasCheckPoint`) pour pouvoir brancher simplement. En faisant ça, on fait en réalité exploser la complexité. Pourquoi ? Parce qu'on a introduit de l'inversion de contrôle non pas au niveau d'une méthode mais au niveau de la donnée elle même. Et là encore c'est en dissonance totale avec la représentation métier et donc la notre. Ce que je défend, c'est que c'est beaucoup plus naturel de penser d'abord assessmentType, et ensuite features... que de penser feature, et remonter au type d'assessment (elle est là l'indirection).

Par conséquent je pense que ce genre de code : 
````
  A();
  if (assessmentHasCheckpoint) {
   checkpointAction(); 
  }
  C();
````
Est beaucoup moins compréhensible et scalable que celui-là : 
````
  if (somethingPlacement) {
    A();
    checkpointAction();
    C();
  }
  if (somethingOther) {
    A();
    C();
  }
````

# :nerd_face: Bon à savoir :
Les pattern précédents et d'autres ont été mis en pratique sur mon ancien projet où on a transitionné d'une code base et d'un métier que même le client avait du mal à suivre à un code que le PO pouvait lire et comprendre. Ca avait très bien marché pour nous, et que je vois que chez pix on manipule le même objet Assessment avec au moins 3 types différents critiques, je sens qu'on prend le même chemin.
