### PR TITLE
[WIP] Désactiver l'historisation des questions pendant une évaluation

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -95,7 +95,7 @@ export default BaseRoute.extend({
 
       return answer.save()
         .then(
-          () => this.transitionTo('assessments.resume', assessment.get('id')),
+          () => this.replaceWith('assessments.resume', assessment.get('id')),
           () => this.send('error')
         );
     },


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 

La gestion du bouton "back" est assez incohérente : on peut revenir sur une question à laquelle on a répondu, mais la nouvelle réponse n'est pas toujours enregistrée…

# :woman_technologist: :man_technologist: Technique :
On remplace un `transitionTo` par un `replaceWith` pour empêcher le navigateur de revenir sur une question précédente.

# :nerd_face: Bon à savoir :
C'est juste un "POC", il faudra aussi enlever pas mal de code dans l'API.
