### PR TITLE
[BSR] Suppression de l'utilisation de controllerReplies pour les codes 200, 201 et 204.

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -48,8 +48,9 @@ module.exports = {
           answer: newAnswer,
         });
       })
-      .then(answerSerializer.serialize)
-      .then(controllerReplies(h).created)
+      .then((answer) => {
+        return h.response(answerSerializer.serialize(answer)).created();
+      })
       .catch((error) => {
         const mappedError = mapToInfrastructureErrors(error);
         return controllerReplies(h).error(mappedError);

--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -79,10 +79,8 @@ module.exports = {
         // XXX if assessment is a Smart Placement, then return 204 and do not update answer. If not proceed normally.
         return isAssessmentSmartPlacement(existingAnswer.get('assessmentId'))
           .then((assessmentIsSmartPlacement) => {
-
             if (assessmentIsSmartPlacement) {
-              return controllerReplies(h).noContent();
-
+              return null;
             } else {
               return _updateExistingAnswer(existingAnswer, updatedAnswer);
             }

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -45,7 +45,7 @@ module.exports = {
     const { assessmentResult, competenceMarks } = _deserializeResultsAdd(jsonResult);
     assessmentResult.juryId = request.auth.credentials.userId;
     return assessmentResultService.save(assessmentResult, competenceMarks)
-      .then(() => '')
+      .then(() => null)
       .catch((error) => {
         if(error instanceof NotFoundError) {
           throw Boom.notFound(error);
@@ -69,7 +69,7 @@ module.exports = {
       assessmentId: assessmentRating.assessmentId,
       forceRecomputeResult,
     })
-      .then(() => '')
+      .then(() => null)
       .catch((error) => {
         if(error instanceof NotFoundError) {
           throw Boom.notFound(error);

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -56,7 +56,7 @@ module.exports = {
         }
       })
       .then((assessment) => {
-        return h.response(assessmentSerializer.serialize(assessment)).code(201);
+        return h.response(assessmentSerializer.serialize(assessment)).created();
       })
       .catch((err) => {
         if (err instanceof ObjectValidationError) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -166,7 +166,7 @@ module.exports = {
         logContext.err = err;
         logger.trace(logContext, 'catching exception');
         if (err instanceof AssessmentEndedError) {
-          return controllerReplies(h).ok(JSONAPI.emptyDataResponse());
+          return JSONAPI.emptyDataResponse();
         } else {
           logger.error(err);
           return controllerReplies(h).error(err);

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -43,7 +43,7 @@ module.exports = {
         const token = tokenService.createTokenFromUser(user, 'pix');
 
         const authentication = new Authentication({ userId: user.id, token });
-        return h.response(authenticationSerializer.serialize(authentication)).code(201);
+        return h.response(authenticationSerializer.serialize(authentication)).created();
       })
       .catch(() => {
         const message = validationErrorSerializer.serialize(_buildError());

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -16,19 +16,19 @@ module.exports = {
     const cacheKey = request.params.cachekey || '';
     const [ tableName, recordId ] = cacheKey.split('_');
     return usecases.reloadCacheEntry({ preloader, tableName, recordId })
-      .then(() => h.response().code(204))
+      .then(() => null)
       .catch((error) => h.response(_buildJsonApiInternalServerError(error)).code(500));
   },
 
   removeAllCacheEntries(request, h) {
     return usecases.removeAllCacheEntries({ cache })
-      .then(() => h.response().code(204))
+      .then(() => null)
       .catch((error) => h.response(_buildJsonApiInternalServerError(error)).code(500));
   },
 
   preloadCacheEntries(request, h) {
     return usecases.preloadCacheEntries({ preloader, logger })
-      .then(() => h.response().code(204))
+      .then(() => null)
       .catch((error) => h.response(_buildJsonApiInternalServerError(error)).code(500));
   }
 };

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -62,9 +62,7 @@ module.exports = {
         campaignParticipationRepository,
         smartPlacementAssessmentRepository
       })
-        .then(() => {
-          return controllerReplies(h).noContent();
-        })
+        .then(() => null)
         .catch((error) => {
           logger.error(error);
           return controllerReplies(h).error(_mapToInfrastructureErrors(error));

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -18,8 +18,9 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     return serializer.deserialize(request.payload)
       .then((campaignParticipation) => usecases.startCampaignParticipation({ campaignParticipation, userId }))
-      .then(serializer.serialize)
-      .then(controllerReplies(h).created)
+      .then((campaignParticipation) => {
+        return h.response(serializer.serialize(campaignParticipation)).created();
+      })
       .catch((error) => {
         logger.error(error);
 
@@ -32,7 +33,7 @@ module.exports = {
       });
   },
 
-  getCampaignParticipationByAssessment(request, h) {
+  getCampaignParticipationByAssessment(request) {
     const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
     const userId = tokenService.extractUserId(token);
 

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -46,8 +46,7 @@ module.exports = {
     })
       .then((campaignParticipation) => {
         return serializer.serialize([campaignParticipation]);
-      })
-      .then(controllerReplies(h).ok);
+      });
   },
 
   shareCampaignResult(request, h) {

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -30,7 +30,7 @@ module.exports = {
       })
       .then((campaign) => usecases.createCampaign({ campaign }))
       .then((createdCampaign) => {
-        return h.response(campaignSerializer.serialize(createdCampaign)).code(201);
+        return h.response(campaignSerializer.serialize(createdCampaign)).created();
       })
       .catch((error) => {
         if (error instanceof UserNotAuthorizedToCreateCampaignError) {

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -53,7 +53,6 @@ module.exports = {
       .then((campaign) => {
         return campaignSerializer.serialize([campaign]);
       })
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfraError(error);
         return controllerReplies(h).error(mappedError);
@@ -66,7 +65,6 @@ module.exports = {
     const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
     return usecases.getCampaign({ campaignId, options })
       .then((campaign) => campaignSerializer.serialize(campaign, tokenForCampaignResults))
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfraError(error);
         return controllerReplies(h).error(mappedError);
@@ -103,7 +101,6 @@ module.exports = {
 
     return usecases.updateCampaign({ userId, campaignId, title, customLandingPageText })
       .then(campaignSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         if (error instanceof UserNotAuthorizedToUpdateCampaignError) {
           const infraError = new infraErrors.ForbiddenError(error.message);

--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -9,7 +9,7 @@ module.exports = {
     const userId = request.payload.data.attributes['user-id'];
     const certificationCenterId = request.payload.data.attributes['certification-center-id'];
     return usecases.createCertificationCenterMembership({ userId, certificationCenterId })
-      .then(controllerReplies(h).created)
+      .then((membership) => h.response(membership).created())
       .catch((error) => {
         if (error instanceof CertificationCenterMembershipCreationError) {
           const badRequestError = new infraErrors.BadRequestError('Le membre ou le centre de certification n\'existe pas.');

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -28,7 +28,6 @@ module.exports = {
     const certificationCenterId = request.params.id;
     return usecases.getCertificationCenter({ id: certificationCenterId })
       .then(certificationCenterSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         if (error instanceof NotFoundError) {
           const err = new InfrastructureNotFoundError(error.message);
@@ -41,7 +40,6 @@ module.exports = {
   find(request, h) {
     return usecases.findCertificationCenters()
       .then(certificationCenterSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch(controllerReplies(h).error);
   },
 
@@ -51,7 +49,6 @@ module.exports = {
 
     return usecases.findSessionsForCertificationCenter({ userId, certificationCenterId })
       .then((sessions) => sessionSerializer.serialize(sessions))
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         if(error instanceof ForbiddenAccess) {
           const err = new ForbiddenError(error.message);

--- a/api/lib/application/corrections/corrections-controller.js
+++ b/api/lib/application/corrections/corrections-controller.js
@@ -28,7 +28,7 @@ module.exports = {
         });
       })
       .then((correction) => Array.of(correction))
-      .then((corrections) => h.response(correctionSerializer.serialize(corrections)).code(200))
+      .then(correctionSerializer.serialize)
       .catch((error) => {
         // TODO: factoriser la gestion des erreurs
         if (error instanceof infraErrors.InfrastructureError) {

--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -49,12 +49,15 @@ module.exports = {
       });
   },
 
-  save(request, h) {
+  async save(request, h) {
     const userId = request.auth.credentials.userId;
     const accessCode = request.payload.data.attributes['access-code'];
+
     return usecases.retrieveLastOrCreateCertificationCourse({ accessCode, userId })
       .then(({ created, certificationCourse }) => {
-        return h.response(certificationCourseSerializer.serialize(certificationCourse)).code(created ? 201 : 200);
+        const serialized = certificationCourseSerializer.serialize(certificationCourse);
+
+        return created ? h.response(serialized).created() : serialized;
       })
       .catch((err) => {
         if (err instanceof UserNotAuthorizedToCertifyError) {

--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -49,7 +49,7 @@ module.exports = {
       });
   },
 
-  async save(request, h) {
+  save(request, h) {
     const userId = request.auth.credentials.userId;
     const accessCode = request.payload.data.attributes['access-code'];
 

--- a/api/lib/application/feedbacks/feedback-controller.js
+++ b/api/lib/application/feedbacks/feedback-controller.js
@@ -17,7 +17,7 @@ module.exports = {
     return newFeedback
       .save()
       .then((persistedFeedback) => {
-        return h.response(serializer.serialize(persistedFeedback.toJSON())).code(201);
+        return h.response(serializer.serialize(persistedFeedback.toJSON())).created();
       })
       .catch((err) => {
         logger.error(err);

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -13,8 +13,9 @@ module.exports = {
     const organizationId = request.payload.data.relationships.organization.data.id;
 
     return usecases.createMembership({ userId, organizationId })
-      .then(membershipSerializer.serialize)
-      .then(controllerReplies(h).created)
+      .then((membership) => {
+        return h.response(membershipSerializer.serialize(membership)).created();
+      })
       .catch((error) => {
         if (error instanceof MembershipCreationError) {
           const badRequestError = new infraErrors.BadRequestError(error.message);

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -22,7 +22,6 @@ module.exports = {
 
     return usecases.getOrganizationDetails({ organizationId })
       .then(organizationSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfraError(error);
         return controllerReplies(h).error(mappedError);
@@ -34,7 +33,6 @@ module.exports = {
 
     return usecases.createOrganization({ name, type })
       .then(organizationSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         if (error instanceof EntityValidationError) {
           return h.response(JSONAPI.unprocessableEntityError(error.invalidAttributes)).code(422);
@@ -49,7 +47,6 @@ module.exports = {
 
     return usecases.updateOrganizationInformation({ id, name, type, logoUrl })
       .then(organizationSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfraError(error);
         return controllerReplies(h).error(mappedError);
@@ -84,7 +81,6 @@ module.exports = {
 
     return usecases.getOrganizationCampaigns({ organizationId })
       .then((campaigns) => campaignSerializer.serialize(campaigns))
-      .then(controllerReplies(h).ok)
       .catch(controllerReplies(h).error);
   },
 
@@ -93,7 +89,6 @@ module.exports = {
 
     return usecases.getOrganizationMemberships({ organizationId })
       .then(membershipSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch(controllerReplies(h).error);
   },
 
@@ -102,7 +97,6 @@ module.exports = {
 
     return organizationService.findAllTargetProfilesAvailableForOrganization(requestedOrganizationId)
       .then(targetProfileSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch(controllerReplies(h).error);
   },
 

--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -40,7 +40,7 @@ module.exports = {
         _sendPasswordResetDemandUrlEmail(user.email, temporaryKey);
       })
       .then(() => passwordResetSerializer.serialize(passwordResetDemand.attributes))
-      .then((serializedPayload) => h.response(serializedPayload).code(201))
+      .then((serializedPayload) => h.response(serializedPayload).created())
       .catch((err) => {
         if (err instanceof UserNotFoundError) {
           return h.response(errorSerializer.serialize(err.getErrorMessage())).code(404);

--- a/api/lib/application/smartPlacementProgressions/smart-placement-progression-controller.js
+++ b/api/lib/application/smartPlacementProgressions/smart-placement-progression-controller.js
@@ -24,7 +24,6 @@ module.exports = {
       userId,
     })
       .then(smartPlacementProgressionSerializer.serialize)
-      .then((serializedSmartPlacementProgression) => h.response(serializedSmartPlacementProgression).code(200))
       .catch((error) => {
 
         if (error instanceof UserNotAuthorizedToAccessEntity) {

--- a/api/lib/application/snapshots/snapshot-controller.js
+++ b/api/lib/application/snapshots/snapshot-controller.js
@@ -103,7 +103,7 @@ function create(request, h) {
     .then((testsFinished) => snapshot.testsFinished = testsFinished)
     .then(() => snapshotService.create(snapshot, user, serializedProfile))
     .then((snapshotId) => snapshotSerializer.serialize({ id: snapshotId }))
-    .then((snapshotSerialized) => h.response(snapshotSerialized).code(201))
+    .then((snapshotSerialized) => h.response(snapshotSerialized).created())
     .catch((err) => _replyError(err, h));
 }
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -42,7 +42,7 @@ module.exports = {
       reCaptchaToken,
     })
       .then((savedUser) => {
-        return h.response(userSerializer.serialize(savedUser)).code(201);
+        return h.response(userSerializer.serialize(savedUser)).created();
       })
       .catch((error) => {
 
@@ -85,11 +85,8 @@ module.exports = {
       .then((foundUser) => {
         return profileService.getByUserId(foundUser.id);
       })
-      .then((buildedProfile) => {
-        return h.response(profileSerializer.serialize(buildedProfile)).code(201);
-      })
+      .then((buildedProfile) => profileSerializer.serialize(buildedProfile))
       .catch((err) => {
-
         if (err instanceof InvalidTokenError) {
           return _replyErrorWithMessage(h, 'Le token n’est pas valide', 401);
         }

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -125,7 +125,7 @@ module.exports = {
         }
         return Promise.reject(new BadRequestError());
       })
-      .then(() => h.response().code(204))
+      .then(() => null)
       .catch((err) => {
         if (err instanceof PasswordResetDemandNotFoundError) {
           return h.response(validationErrorSerializer.serialize(err.getErrorMessage())).code(404);

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -206,7 +206,6 @@ module.exports = {
 
     return usecases.getUserCampaignParticipations({ authenticatedUserId, requestedUserId })
       .then(campaignParticipationSerializer.serialize)
-      .then(controllerReplies(h).ok)
       .catch((error) => {
         const mappedError = _mapToInfrastructureErrors(error);
         return controllerReplies(h).error(mappedError);

--- a/api/lib/infrastructure/controller-replies.js
+++ b/api/lib/infrastructure/controller-replies.js
@@ -4,21 +4,11 @@ const logger = require('./logger');
 
 function controllerReplies(h) {
   return {
-
-    ok(payload) {
-      return h.response(payload).code(200);
-    },
-
-    created(payload) {
-      return h.response(payload).code(201);
-    },
-
     noContent() {
       return h.response().code(204);
     },
 
     error(error) {
-
       if (error instanceof infraError.InfrastructureError) {
         return h.response(errorSerializer.serialize(error)).code(error.code);
       }

--- a/api/lib/infrastructure/controller-replies.js
+++ b/api/lib/infrastructure/controller-replies.js
@@ -4,10 +4,6 @@ const logger = require('./logger');
 
 function controllerReplies(h) {
   return {
-    noContent() {
-      return h.response().code(204);
-    },
-
     error(error) {
       if (error instanceof infraError.InfrastructureError) {
         return h.response(errorSerializer.serialize(error)).code(error.code);

--- a/api/server.js
+++ b/api/server.js
@@ -16,6 +16,9 @@ const createServer = async () => {
       cors: {
         origin: ['*'],
         additionalHeaders: ['X-Requested-With']
+      },
+      response: {
+        emptyStatusCode: 204
       }
     },
     port: config.port,

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -95,14 +95,14 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
       });
     });
 
-    it('should return an OK status after saving in database', () => {
+    it('should return a 204 after saving in database', () => {
       // when
       const promise = server.inject(options);
 
       // then
       return promise
         .then((response) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response.statusCode).to.equal(204);
         });
     });
 
@@ -162,7 +162,7 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
     });
 
     context('when the correction to be applied has a mistake', () => {
-      it('should return an OK status after saving in database', () => {
+      it('should return a 422 error', () => {
         const wrongScore = 9999999999;
 
         const options = {

--- a/api/tests/acceptance/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-controller_test.js
@@ -55,13 +55,13 @@ describe('Acceptance | Controller | assessment-results', function() {
           .then(() => knex('assessments').delete());
       });
 
-      it('should return a 200 when everything is fine', () => {
+      it('should return a 204 when everything is fine', () => {
         // when
         const request = server.inject(options);
 
         // Then
         return request.then((response) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response.statusCode).to.equal(204);
         });
       });
 

--- a/api/tests/acceptance/application/users/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-profile_test.js
@@ -187,7 +187,7 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
         profileServiceStub = sinon.stub(profileService, 'getByUserId');
       });
 
-      it('should response with 201 HTTP status code, when authorization is valid and user is found', () => {
+      it('should response with 200 HTTP status code, when authorization is valid and user is found', () => {
         // given
         profileServiceStub.resolves(fakeBuildedProfile);
 
@@ -196,7 +196,7 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
 
         // then
         return promise.then((response) => {
-          expect(response.statusCode).to.equal(201);
+          expect(response.statusCode).to.equal(200);
           expect(response.result).to.deep.equal(expectedSerializedProfile);
         });
       });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -102,6 +102,10 @@ const hFake = {
         this.isTakeOver = true;
         return this;
       },
+      created() {
+        this.statusCode = 201;
+        return this;
+      }
     };
   },
   authenticated(data) {

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -308,10 +308,8 @@ describe('Unit | Controller | answer-controller', () => {
 
       it('should return no content', () => {
         // then
-        expect(response.source).to.be.undefined;
-        expect(response.statusCode).to.equal(204);
+        expect(response).to.be.null;
       });
     });
   });
 });
-

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -50,7 +50,7 @@ describe('Unit | Controller | assessment-results', () => {
         assessmentId: '22',
         forceRecomputeResult: false,
       });
-      expect(response).to.equal('');
+      expect(response).to.be.null;
     });
 
     it('should return 404 when the assessment is not found', () => {
@@ -195,7 +195,7 @@ describe('Unit | Controller | assessment-results', () => {
       const response = await assessmentResultController.save(request, hFake);
 
       // then
-      expect(response).to.equal('');
+      expect(response).to.be.null;
       expect(assessmentResultService.save).to.have.been.calledWith(expectedAssessmentResult, [competenceMark1, competenceMark2, competenceMark3]);
     });
   });

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -83,7 +83,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         const response = await assessmentController.getNextChallenge({ params: { id: PREVIEW_ASSESSMENT_ID } }, hFake);
 
         // then
-        expect(response.source).to.deep.equal({ data: null });
+        expect(response).to.deep.equal({ data: null });
       });
     });
 
@@ -122,7 +122,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
           const response = await assessmentController.getNextChallenge({ params: { id: 7531 } }, hFake);
 
           // then
-          expect(response.source).to.deep.equal({ data: null });
+          expect(response).to.deep.equal({ data: null });
         });
       });
     });
@@ -176,7 +176,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         const response = await assessmentController.getNextChallenge({ params: { id: 12 } }, hFake);
 
         // then
-        expect(response.source).to.deep.equal({ data: null });
+        expect(response).to.deep.equal({ data: null });
       });
     });
 
@@ -225,4 +225,3 @@ function _generateFailedSkills() {
 
   return skill;
 }
-

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -19,7 +19,7 @@ describe('Unit | Controller | cache-controller', () => {
       sinon.stub(usecases, 'reloadCacheEntry');
     });
 
-    it('should reply with 204 when the cache key exists', async () => {
+    it('should reply with null when the cache key exists', async () => {
       // given
       const numberOfDeletedKeys = 1;
       usecases.reloadCacheEntry.resolves(numberOfDeletedKeys);
@@ -33,11 +33,10 @@ describe('Unit | Controller | cache-controller', () => {
         tableName: 'Epreuves',
         recordId: 'recABCDEF'
       });
-      expect(response.source).to.deep.equal();
-      expect(response.statusCode).to.equal(204);
+      expect(response).to.be.null;
     });
 
-    it('should reply with 204 when the cache key does not exist', async () => {
+    it('should reply with null when the cache key does not exist', async () => {
       // given
       const numberOfDeletedKeys = 0;
       usecases.reloadCacheEntry.resolves(numberOfDeletedKeys);
@@ -46,7 +45,7 @@ describe('Unit | Controller | cache-controller', () => {
       const response = await cacheController.reloadCacheEntry(request, hFake);
 
       // Then
-      expect(response.statusCode).to.equal(204);
+      expect(response).to.be.null;
     });
 
     it('should allow a table name without a record id', async () => {
@@ -63,7 +62,7 @@ describe('Unit | Controller | cache-controller', () => {
         tableName: 'Epreuves',
         recordId: undefined
       });
-      expect(response.statusCode).to.equal(204);
+      expect(response).to.be.null;
     });
 
     context('when cache reloading fails', () => {
@@ -94,7 +93,7 @@ describe('Unit | Controller | cache-controller', () => {
       sinon.stub(usecases, 'removeAllCacheEntries');
     });
 
-    it('should reply with 204 when there is no error', async () => {
+    it('should reply with null when there is no error', async () => {
       // given
       usecases.removeAllCacheEntries.resolves();
 
@@ -103,7 +102,7 @@ describe('Unit | Controller | cache-controller', () => {
 
       // Then
       expect(usecases.removeAllCacheEntries).to.have.been.calledWith({ cache });
-      expect(response.statusCode).to.equal(204);
+      expect(response).to.be.null;
     });
 
     context('when cache deletion fails', () => {
@@ -134,7 +133,7 @@ describe('Unit | Controller | cache-controller', () => {
       sinon.stub(usecases, 'preloadCacheEntries');
     });
 
-    it('should reply with 204 when there is no error', async () => {
+    it('should reply with null when there is no error', async () => {
       // given
       usecases.preloadCacheEntries.resolves();
 
@@ -143,7 +142,7 @@ describe('Unit | Controller | cache-controller', () => {
 
       // Then
       expect(usecases.preloadCacheEntries).to.have.been.calledWith({ preloader, logger });
-      expect(response.statusCode).to.equal(204);
+      expect(response).to.be.null;
     });
 
     context('when cache preload fails', () => {

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -273,8 +273,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
       // then
       expect(campaignSerializer.serialize).to.have.been.calledWith([createdCampaign]);
-      expect(response.source).to.deep.equal(serializedCampaign);
-      expect(response.statusCode).to.equal(200);
+      expect(response).to.deep.equal(serializedCampaign);
     });
 
     it('should return a 404 error if campaign is not found', async () => {
@@ -340,8 +339,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       const response = await campaignController.getById(request, hFake);
 
       // then
-      expect(response.source).to.deep.equal(expectedCampaign);
-      expect(response.statusCode).to.equal(200);
+      expect(response).to.deep.equal(expectedCampaign);
     });
 
     it('should throw an error when the campaign could not be retrieved', async () => {
@@ -411,8 +409,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       const response = await campaignController.update(request, hFake);
 
       // then
-      expect(response.source).to.deep.equal(updatedCampaign);
-      expect(response.statusCode).to.equal(200);
+      expect(response).to.deep.equal(updatedCampaign);
     });
 
     it('should throw an error when the campaign could not be updated', async () => {

--- a/api/tests/unit/application/corrections/corrections-controller_test.js
+++ b/api/tests/unit/application/corrections/corrections-controller_test.js
@@ -103,8 +103,7 @@ describe('Unit | Controller | corrections-controller', () => {
       const response = await correctionsController.findByAnswerId(request, hFake);
 
       // then
-      expect(response.source).to.deep.equal(expectedResponse);
-      expect(response.statusCode).to.equal(200);
+      expect(response).to.deep.equal(expectedResponse);
       expect(usecases.getCorrectionForAnswerWhenAssessmentEnded).to.have.been.calledWith({
         answerId: '234'
       });

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -11,7 +11,7 @@ const certificationCourseSerializer = require('../../../../lib/infrastructure/se
 const courseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/course-serializer');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 
-describe('Integration | Controller | course-controller', () => {
+describe('Unit | Controller | course-controller', () => {
 
   let server;
 
@@ -202,11 +202,10 @@ describe('Integration | Controller | course-controller', () => {
         certificationCourseSerializer.serialize.resolves({});
 
         // when
-        const response = await courseController.save(request, hFake);
+        await courseController.save(request, hFake);
 
         // then
         sinon.assert.calledWith(certificationCourseSerializer.serialize, existingCertificationCourse);
-        expect(response.statusCode).to.equal(200);
       });
 
     });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -98,7 +98,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
         const response = await organizationController.create(request, hFake);
 
         // then
-        expect(response.source).to.deep.equal(serializedOrganization);
+        expect(response).to.deep.equal(serializedOrganization);
       });
     });
 
@@ -399,8 +399,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       const response = await organizationController.getCampaigns(request, hFake);
 
       // then
-      expect(response.source).to.deep.equal(serializedCampaigns);
-      expect(response.statusCode).to.equal(200);
+      expect(response).to.deep.equal(serializedCampaigns);
     });
 
     it('should return a 500 error when an error occurs', async () => {
@@ -473,8 +472,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
         const response = await organizationController.findTargetProfiles(request, hFake);
 
         // then
-        expect(response.source).to.deep.equal(serializedTargetProfiles);
-        expect(response.statusCode).to.equal(200);
+        expect(response).to.deep.equal(serializedTargetProfiles);
       });
 
     });

--- a/api/tests/unit/application/smartPlacementProgressions/smart-placement-progression-controller_test.js
+++ b/api/tests/unit/application/smartPlacementProgressions/smart-placement-progression-controller_test.js
@@ -57,8 +57,7 @@ describe('Unit | Controller | smart-placement-progression-controller', () => {
             userId,
           });
 
-          expect(response.source).to.deep.equal(serializedSmartPlacementProgression);
-          expect(response.statusCode).to.equal(200);
+          expect(response).to.deep.equal(serializedSmartPlacementProgression);
         });
       });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -240,7 +240,7 @@ describe('Unit | Controller | user-controller', () => {
         const response = await userController.updateUser(request, hFake);
 
         // then
-        expect(response.source).to.be.undefined;
+        expect(response).to.be.null;
       });
 
       describe('When unknown error is handle', () => {

--- a/api/tests/unit/infrastructure/controller-replies_test.js
+++ b/api/tests/unit/infrastructure/controller-replies_test.js
@@ -13,22 +13,6 @@ describe('Unit | Infrastructure | ControllerReplies', () => {
       sinon.stub(logger, 'error');
     });
 
-    context('noContent', () => {
-
-      let response;
-
-      beforeEach(() => {
-        // when
-        response = controllerReplies(hFake).noContent();
-      });
-
-      it('should return reply with payload and 201', () => {
-        // then
-        expect(response.source).to.deep.equal();
-        expect(response.statusCode).to.equal(204);
-      });
-    });
-
     context('error', () => {
 
       let response;

--- a/api/tests/unit/infrastructure/controller-replies_test.js
+++ b/api/tests/unit/infrastructure/controller-replies_test.js
@@ -13,46 +13,6 @@ describe('Unit | Infrastructure | ControllerReplies', () => {
       sinon.stub(logger, 'error');
     });
 
-    context('ok', () => {
-
-      let payload;
-      let response;
-
-      beforeEach(() => {
-        // given
-        payload = { data: 'stuff' };
-
-        // when
-        response = controllerReplies(hFake).ok(payload);
-      });
-
-      it('should return reply with payload and 200', () => {
-        // then
-        expect(response.source).to.deep.equal(payload);
-        expect(response.statusCode).to.equal(200);
-      });
-    });
-
-    context('created', () => {
-
-      let payload;
-      let response;
-
-      beforeEach(() => {
-        // given
-        payload = { data: 'stuff' };
-
-        // when
-        response = controllerReplies(hFake).created(payload);
-      });
-
-      it('should return reply with payload and 201', () => {
-        // then
-        expect(response.source).to.deep.equal(payload);
-        expect(response.statusCode).to.equal(201);
-      });
-    });
-
     context('noContent', () => {
 
       let response;


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
ControllerReplies est relativement lourd d'utilisation et n'apporte pas de valeur tangible, les méthodes de gestion de response par Hapi sont plus efficaces et simples d'utilisations.

# :woman_technologist: :man_technologist: Technique :
Suppression de controllerReplies pour les code 200, 201 et 204 :
-> remplacement pour code 200 : aucun (déjà gérer par défaut dans Hapi)
-> remplacement pour code 201 : h.response(payload).created()
-> remplacement pour code 204 : configuration dans Hapi au niveau server pour que les routes qui ne renvoie rien renvoie 204 par défaut

# :nerd_face: Bon à savoir :
Cette PR est un premier débroussaillage de nos réponses de controllers, le but est d'ensuite refactoriser les retours d'erreur ainsi que les serializers. 
J'ai vérifié que les quelques codes de retour changés n'ont pas d'impact sur le front et que les tests sur les codes de retour supprimés étaient déjà testés en acceptance.