### PR TITLE
[TECH] Déployer une seule application "front" pour les "review apps"

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack
+https://github.com/Scalingo/nginx-buildpack

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,5 @@
+/api
+/orga
+/certif
+/mon-pix
+/node_modules

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -7,25 +7,14 @@ location = /maintenance_page.html {
     root /app/;
 }
 
-# exactly match the / URI
-location = / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
-  root /app/dist/;
-}
-
-# all the other URIs
 location / {
   if ($maintenance_mode = enabled) {
         return 503;
   }
 
   root /app/dist/;
-  # try_files try to load the file of the URI, and if it fails, it serve the / URI
-  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
-  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /;
+
+  try_files $uri /index.html =404;
 }
 
 location /api/ {

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -20,10 +20,11 @@ location / {
 location /api/ {
   <%
   # We compute the API host from the front app name, examples:
-  #   pix-certif-integration       -> pix-certif-integration.scalingo.io
-  #   pix-certif-integration-pr123 -> pix-certif-integration-pr123.scalingo.io
-  #   pix-certif-production        -> pix-certif-production.scalingo.io
+  #   pix-orga-integration       -> pix-api-integration.scalingo.io
+  #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
+  #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/-certif-/, "-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
   proxy_redirect default;
 }
+

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -7,25 +7,14 @@ location = /maintenance_page.html {
     root /app/;
 }
 
-# exactly match the / URI
-location = / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
-  root /app/dist/;
-}
-
-# all the other URIs
 location / {
   if ($maintenance_mode = enabled) {
         return 503;
   }
 
   root /app/dist/;
-  # try_files try to load the file of the URI, and if it fails, it serve the / URI
-  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
-  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /;
+
+  try_files $uri /index.html =404;
 }
 
 location /api/ {

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -3,7 +3,7 @@ set $maintenance_mode <%= ENV['MAINTENANCE'] %>;
 # in case of 503, serve this URI
 error_page 503 /maintenance_page.html;
 location = /maintenance_page.html {
-    # maintenance page is at the root of mon-pix project
+    # maintenance page is at the root of the project
     root /app/;
 }
 
@@ -20,11 +20,11 @@ location / {
 location /api/ {
   <%
   # We compute the API host from the front app name, examples:
-  #   pix-app-integration       -> pix-api-integration.scalingo.io
-  #   pix-app-integration-pr123 -> pix-api-integration-pr123.scalingo.io
-  #   pix-app-production        -> pix-api-production.scalingo.io
+  #   pix-orga-integration       -> pix-api-integration.scalingo.io
+  #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
+  #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/-app-/, "-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
   proxy_redirect default;
 }
 

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,0 +1,13 @@
+# exactly match the / URI
+location = / {
+  root /app/dist/;
+}
+
+# all the other URIs
+location / {
+  root /app/dist/;
+  # try_files try to load the file of the URI, and if it fails, it serve the / URI
+  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
+  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
+  try_files $uri /;
+}

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,13 +1,15 @@
+<% %w(app orga certif).each do |app| %>
 # exactly match the / URI
-location = / {
+location = /<%= app %>/ {
   root /app/dist/;
 }
 
 # all the other URIs
-location / {
+location /<%= app %>/ {
   root /app/dist/;
   # try_files try to load the file of the URI, and if it fails, it serve the / URI
   # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
   # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /;
+  try_files $uri /<%= app %>/;
 }
+<% end %>

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,15 +1,5 @@
-<% %w(app orga certif).each do |app| %>
-# exactly match the / URI
-location = /<%= app %>/ {
+location ~ ^/(?<app>[^/]+)/.*$ {
   root /app/dist/;
-}
 
-# all the other URIs
-location /<%= app %>/ {
-  root /app/dist/;
-  # try_files try to load the file of the URI, and if it fails, it serve the / URI
-  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
-  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /<%= app %>/;
+  try_files $uri /$app/index.html =404;
 }
-<% end %>

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -24,7 +24,7 @@ location /api/ {
   #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
   #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/-orga-/, "-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
   proxy_redirect default;
 }
 

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -7,25 +7,14 @@ location = /maintenance_page.html {
     root /app/;
 }
 
-# exactly match the / URI
-location = / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
-  root /app/dist/;
-}
-
-# all the other URIs
 location / {
   if ($maintenance_mode = enabled) {
         return 503;
   }
 
   root /app/dist/;
-  # try_files try to load the file of the URI, and if it fails, it serve the / URI
-  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
-  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /;
+
+  try_files $uri /index.html =404;
 }
 
 location /api/ {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "git+https://github.com/1024pix/pix.git"
   },
   "scripts": {
-    "build": "run-p build:mon-pix build:orga build:certif",
+    "build": "run-p --print-label build:mon-pix build:orga build:certif",
     "build:mon-pix": "(cd mon-pix && npm run build) && mkdir -p dist && cp -R mon-pix/dist dist/app",
     "build:orga": "(cd orga && npm run build) && mkdir -p dist && cp -R orga/dist dist/orga",
     "build:certif": "(cd certif && npm run build) && mkdir -p dist && cp -R certif/dist dist/certif",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "url": "git+https://github.com/1024pix/pix.git"
   },
   "scripts": {
+    "build": "run-p build:mon-pix build:orga build:certif",
+    "build:mon-pix": "(cd mon-pix && npm run build) && mkdir -p dist && cp -R mon-pix/dist dist/app",
+    "build:orga": "(cd orga && npm run build) && mkdir -p dist && cp -R orga/dist dist/orga",
+    "build:certif": "(cd certif && npm run build) && mkdir -p dist && cp -R certif/dist dist/certif",
     "ci:signal-jira": "node ./scripts/jira/comment-with-review-app-url.js",
     "clean": "node_modules/.bin/run-p clean:api clean:mon-pix clean:orga clean:certif clean:coverage && npm run clean:root",
     "clean:api": "cd api && npm run clean",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "release:prepare": "./scripts/release/prepare.sh",
     "release:perform": "./scripts/release/perform.sh",
     "release:publish": "./scripts/release/publish.sh",
+    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "run-p start:api start:mon-pix start:orga start:certif",
     "start:api": "cd api && npm run start:watch",
     "start:mon-pix": "cd mon-pix && npx ember serve --proxy",

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -36,9 +36,9 @@ extractIssueCodeFromBranchName(process.env.CIRCLE_BRANCH)
   })
   .then(([commentContents, { prNumber }]) => {
 
-    const raAppURL = `https://pix-app-integration-pr${prNumber}.scalingo.io`;
-    const raOrgaURL = `https://pix-orga-integration-pr${prNumber}.scalingo.io`;
-    const raCertifURL = `https://pix-certif-integration-pr${prNumber}.scalingo.io`;
+    const raAppURL = `https://app-pr${prNumber}.review.pix.fr`;
+    const raOrgaURL = `https://orga-pr${prNumber}.review.pix.fr`;
+    const raCertifURL = `https://certif-pr${prNumber}.review.pix.fr`;
     const raAPIURL = `https://pix-api-integration-pr${prNumber}.scalingo.io`;
 
     const scalingoCommentRegex = new RegExp(raAppURL, 'i');

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -19,9 +19,9 @@
 }
 
 PR_NUMBER=`echo $CI_PULL_REQUEST | grep -Po '(?<=pix/pull/)(\d+)'`
-RA_APP_URL="https://pix-app-integration-pr$PR_NUMBER.scalingo.io"
-RA_ORGA_URL="https://pix-orga-integration-pr$PR_NUMBER.scalingo.io"
-RA_CERTIF_URL="https://pix-certif-integration-pr$PR_NUMBER.scalingo.io"
+RA_APP_URL="https://app-pr$PR_NUMBER.review.pix.fr"
+RA_ORGA_URL="https://orga-pr$PR_NUMBER.review.pix.fr"
+RA_CERTIF_URL="https://certif-pr$PR_NUMBER.review.pix.fr"
 RA_API_URL="https://pix-api-integration-pr$PR_NUMBER.scalingo.io"
 
 MESSAGE_PREFIX="I'm deploying this PR to these urls:"


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
Ne pas faire tourner 4, (5 avec Pix Admin) _review apps_ à chaque PR.

# :woman_technologist: :man_technologist: Technique :
On crée une seule _review app_ pour toutes les applis _front_, qui ne servent que des fichiers statiques. Ça nous laissera donc 2 applications pour chaque PR : une pour l'API, qui ne change pas, et une pour toutes les applications _front_. Dans cette application Scalingo nommée `pix-front-integration-prXXX`, les fichiers de `mon-pix` (_alias_ `app`), `orga` et `certif` sont construits et servis dans des sous-répertoires nommés comme l'application en question, ex. https://pix-front-integration-pr370.scalingo.io/orga/index.html .

Bien entendu, nos applications _front_ ne sont pas préparées à exister dans un sous-répertoire et ne fonctionnent donc pas directement ainsi. C'est pourquoi on a introduit par ailleurs https://github.com/1024pix/pix-review-router qui est déployé sur `*.review.pix.fr`, de sorte que les applications sont accessibles sur https://app-pr370.review.pix.fr, https://orga-pr370.review.pix.fr et https://certif-pr370.review.pix.fr.

# :nerd_face: Bon à savoir :
Les changements se passent essentiellement dans les fichiers à la racine et n'impactent donc pas le fonctionnement des applications quand elles sont déployées en production, chacune depuis son sous-répertoire.

Il y a juste une petite simplification de la configuration Nginx qui est faite dans `{mon-pix,orga,certif}/nginx.conf.erb` : en travaillant sur la configuration Nginx utilisée pour servir les 3 applications _front_ depuis la racine, on a découvert une façon plus simple mais fonctionnellement équivalente de servir les fichiers de chaque application.

Noter également qu'il restera possible de créer des _review apps_ "comme avant" suivant le schéma de production, en déclenchant leur création pour une PR donnée dans l'interface Scalingo. Cela pourra permettre de valider certains changements qui pourraient impacter la logique bas-niveau de déploiement, comme par exemple le changement de configuration Nginx décrit dans le paragraphe précédent 😉 