### PR TITLE
[TECH] Mise à jour du script de préparation de release pour monter aussi la version de PixAdmin.

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "2.25.0",
+  "version": "2.26.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,16 +1,20 @@
 {
   "name": "pix-admin",
-  "version": "2.25.0",
-  "private": true,
+  "version": "2.26.1",
+  "private": false,
   "description": "Interface d'administration pour les Pix Masters.",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:1024pix/pix.git"
-  },
   "license": "AGPL-3.0",
-  "author": "Team Pix",
+  "author": "GIP Pix",
   "engines": {
     "node": "8.11.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
   },
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",

--- a/api/package.json
+++ b/api/package.json
@@ -1,13 +1,22 @@
 {
   "name": "pix-api",
   "version": "2.26.1",
+  "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones",
-  "main": "server.js",
-  "author": "SGMAP",
   "license": "AGPL-3.0",
+  "author": "GIP Pix",
   "engines": {
     "node": "8.11.4"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "main": "server.js",
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
     "airtable": "^0.5.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,16 +1,20 @@
 {
   "name": "pix-certif",
   "version": "2.26.1",
-  "private": true,
+  "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:1024pix/pix-certif.git"
-  },
   "license": "AGPL-3.0",
-  "author": "Team PIX",
+  "author": "GIP Pix",
   "engines": {
     "node": "8.11.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
   },
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,14 +1,19 @@
 {
   "name": "mon-pix",
   "version": "2.26.1",
+  "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones.",
   "license": "AGPL-3.0",
-  "author": "Team Pix",
+  "author": "GIP Pix",
   "engines": {
     "node": "8.11.4"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
   "directories": {
-    "doc": "doc",
+    "doc": "docs",
     "test": "tests"
   },
   "scripts": {
@@ -100,6 +105,5 @@
     "js-yaml": "^3.12.0",
     "loader.js": "^4.7.0",
     "showdown": "^1.8.6"
-  },
-  "private": false
+  }
 }

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,16 +1,20 @@
 {
   "name": "pix-orga",
   "version": "2.26.1",
-  "private": true,
+  "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:1024pix/pix-orga.git"
-  },
   "license": "AGPL-3.0",
-  "author": "Team PIX",
+  "author": "GIP Pix",
   "engines": {
     "node": "8.11.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
   },
   "scripts": {
     "build": "ember build --environment $BUILD_ENVIRONMENT",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
   "name": "pix",
   "version": "2.26.1",
+  "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques des citoyens francophones.",
-  "author": "Team PIX",
   "license": "AGPL-3.0",
+  "author": "GIP Pix",
+  "engines": {
+    "node": "8.11.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/pix.git"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
   "homepage": "https://github.com/1024pix/pix#readme",
   "bugs": {
     "url": "https://github.com/1024pix/pix/issues"
@@ -17,9 +29,6 @@
     "husky": "^0.14.3",
     "lcov-result-merger": "^1.2.0"
   },
-  "engines": {
-    "node": "8.11.4"
-  },
   "cacheDirectories": [
     "node_modules/",
     "admin/node_modules/",
@@ -28,10 +37,6 @@
     "mon-pix/node_modules/",
     "orga/node_modules/"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/1024pix/pix.git"
-  },
   "scripts": {
     "build": "run-p --print-label build:mon-pix build:orga build:certif build:admin",
     "build:admin": "(cd admin && npm run build) && mkdir -p dist && cp -R admin/dist dist/admin",

--- a/scripts/release/prepare.sh
+++ b/scripts/release/prepare.sh
@@ -30,6 +30,7 @@ function update_version {
     cd $ROOT_PATH/mon-pix/ && npm version $NEW_VERSION_TYPE --git-tag-version=false >> /dev/null
     cd $ROOT_PATH/orga/ && npm version $NEW_VERSION_TYPE --git-tag-version=false >> /dev/null
     cd $ROOT_PATH/certif/ && npm version $NEW_VERSION_TYPE --git-tag-version=false >> /dev/null
+    cd $ROOT_PATH/admin/ && npm version $NEW_VERSION_TYPE --git-tag-version=false >> /dev/null
     cd $ROOT_PATH && npm version $NEW_VERSION_TYPE --git-tag-version=false >> /dev/null
 }
 
@@ -40,7 +41,7 @@ function reinstall_dependencies {
 # Update when adding a new app
 function create_a_release_commit {
     NEW_PACKAGE_VERSION=$(get_package_version)
-    git add package*.json api/package*json mon-pix/package*.json orga/package*.json certif/package*.json --update
+    git add package*.json api/package*json mon-pix/package*.json orga/package*.json certif/package*.json admin/package*.json --update
     git commit --message "[RELEASE] A ${NEW_VERSION_TYPE} is being released from ${OLD_PACKAGE_VERSION} to ${NEW_PACKAGE_VERSION}."
 }
 


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
Suite à l'ajout de Pix Admin dans le mono repo, nous avons oublier de modifier le script de préparation de la release afin qu'il monte aussi la version de Pix Admin dans son package.json
