### PR TITLE
[BUGFIX] Créer une session sans ID de centre de certification depuis Pix Admin.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -29,10 +29,12 @@ module.exports = {
   deserialize(json) {
     const attributes = json.data.attributes;
 
+    const certificationCenterId = _.get(json.data, ['relationships', 'certification-center', 'data', 'id']);
+
     return new Session({
       id: json.data.id,
       certificationCenter: attributes['certification-center'],
-      certificationCenterId: parseInt(_.get(json.data, ['relationships', 'certification-center', 'data', 'id'])),
+      certificationCenterId: certificationCenterId ? parseInt(certificationCenterId) : null,
       address: attributes.address,
       room: attributes.room,
       examiner: attributes.examiner,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -129,6 +129,21 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       expect(session.description).to.equal('');
     });
 
+    context('when there is no certification center ID', () => {
+
+      beforeEach(() => {
+        jsonApiSession.data.relationships = undefined;
+      });
+
+      it('should set null for session.certificationCenterId (without loosing certification center name)', () => {
+        // when
+        const session = serializer.deserialize(jsonApiSession);
+
+        // then
+        expect(session.certificationCenter).to.equal('Université de dressage de loutres');
+        expect(session.certificationCenterId).to.be.null;
+      });
+    });
   });
 
 });


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 

Permettre à un Pix Master de créer une session sans indiquer de `certificationCenterId`.

## :woman_technologist: :man_technologist: Technique :

Bon à savoir : 
- `parseInt(undefined)` → NaN.
- JS considère que NaN === false
- Bookshelf ne peut pas enregister NaN pour un champ de type `Number`

