### PR TITLE
[BSR] Remise aux normes de la gestion des erreurs pour le endpoint /api/challenges/:id.

### DIFF
--- a/api/lib/application/challenges/challenge-controller.js
+++ b/api/lib/application/challenges/challenge-controller.js
@@ -1,25 +1,29 @@
-const Boom = require('boom');
-
+const { NotFoundError: DomainNotFoundError } = require('../../domain/errors');
+const controllerReplies = require('../../infrastructure/controller-replies');
+const { NotFoundError: InfrastructureNotFoundError } = require('../../infrastructure/errors');
+const logger = require('../../infrastructure/logger');
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 
-const logger = require('../../infrastructure/logger');
-
 module.exports = {
 
-  get(request) {
+  async get(request, h) {
+    try {
+      const challengeId = request.params.id;
 
-    return challengeRepository
-      .get(request.params.id)
-      .then((challenge) => challengeSerializer.serialize(challenge))
-      .catch((err) => {
-        logger.error(err);
-        if (err.error && 'MODEL_ID_NOT_FOUND' === err.error.type) {
-          throw Boom.notFound(err);
-        }
-        throw Boom.badImplementation(err);
-      });
+      const challenge = await challengeRepository.get(challengeId);
 
+      return challengeSerializer.serialize(challenge);
+    } catch (err) {
+
+      if (err instanceof DomainNotFoundError) {
+        const error = new InfrastructureNotFoundError(err.message);
+        return controllerReplies(h).error(error);
+      }
+
+      logger.error(err);
+      return controllerReplies(h).error(err);
+    }
   },
 
 };

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -3,6 +3,7 @@ const Hapi = require('hapi');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 const ChallengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Controller | challenge-controller', function() {
 
@@ -36,13 +37,7 @@ describe('Unit | Controller | challenge-controller', function() {
 
     it('should reply with error status code 404 if challenge not found', async () => {
       // given
-      const error = {
-        'error': {
-          'type': 'MODEL_ID_NOT_FOUND',
-          'message': 'Could not find row by id unknown_id'
-        }
-      };
-      ChallengeRepoStub.rejects(error);
+      ChallengeRepoStub.rejects(new NotFoundError());
 
       // when
       const response = await server.inject({ method: 'GET', url: '/api/challenges/unknown_id' });


### PR DESCRIPTION
## 🚀 Objectif

La plupart de nos erreurs 500 remontées par [Sentry](https://sentry.io/organizations/pix/issues/) porte sur un accès à un Challenge inexistant ([cf. issue](https://sentry.io/organizations/pix/issues/899836406/?project=1398749&query=is%3Aunresolved&statsPeriod=14d&utc=false)). Plutôt que renvoyer une 4XX, ça sort une 5XX.

## ⛑ Implémentation
Ce qui a été fait : 
- sortir une 404 si le challenge est `NOT_FOUND` dans Airtable
- remettre la gestion des erreurs aux normes (i.e. se débarrasser de Boom) 
- passer en `async/await`