### PR TITLE
[FEATURE] Affiche le nombre de participants et les profils reçus sur la page de détails d'une campagne. (PO-183)

### DIFF
--- a/api/lib/application/campaignReports/campaign-report-controller.js
+++ b/api/lib/application/campaignReports/campaign-report-controller.js
@@ -1,0 +1,12 @@
+const usecases = require('../../domain/usecases');
+const serializer = require('../../infrastructure/serializers/jsonapi/campaign-report-serializer');
+
+module.exports = {
+  async get(request) {
+    const campaignId = parseInt(request.params.id);
+
+    const report = await usecases.getCampaignReport({ campaignId });
+
+    return serializer.serialize(report);
+  },
+};

--- a/api/lib/application/campaignReports/index.js
+++ b/api/lib/application/campaignReports/index.js
@@ -1,0 +1,20 @@
+const campaignReportController = require('./campaign-report-controller');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/campaigns/{id}/campaign-report',
+      config: {
+        handler: campaignReportController.get,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération du rapport d\'une campagne',
+        ],
+        tags: ['api', 'campaign-report']
+      }
+    },
+  ]);
+};
+
+exports.name = 'campaign-report-api';

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -12,6 +12,7 @@ class Campaign {
     customLandingPageText,
     // includes
     targetProfile,
+    campaignReport,
     // references
     creatorId,
     organizationId,
@@ -28,6 +29,7 @@ class Campaign {
     this.customLandingPageText = customLandingPageText;
     // includes
     this.targetProfile = targetProfile;
+    this.campaignReport = campaignReport;
     // references
     this.creatorId = creatorId;
     this.organizationId = organizationId;

--- a/api/lib/domain/models/CampaignReport.js
+++ b/api/lib/domain/models/CampaignReport.js
@@ -1,0 +1,15 @@
+class CampaignReport {
+  constructor({
+    id,
+    // attributes
+    participationsCount,
+    sharedParticipationsCount,
+  } = {}) {
+    this.id = id;
+    // attributes
+    this.participationsCount = participationsCount;
+    this.sharedParticipationsCount = sharedParticipationsCount;
+  }
+}
+
+module.exports = CampaignReport;

--- a/api/lib/domain/usecases/get-campaign-report.js
+++ b/api/lib/domain/usecases/get-campaign-report.js
@@ -1,0 +1,10 @@
+const CampaignReport = require('../models/CampaignReport');
+
+module.exports = async function getCampaignReport({ campaignId, campaignParticipationRepository }) {
+  const [participationsCount, sharedParticipationsCount] = await Promise.all([
+    campaignParticipationRepository.count({ campaignId }),
+    campaignParticipationRepository.count({ campaignId, isShared: true }),
+  ]);
+
+  return new CampaignReport({ id: campaignId, participationsCount, sharedParticipationsCount });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -72,6 +72,7 @@ module.exports = injectDependencies({
   getAssessment: require('./get-assessment'),
   getCampaign: require('./get-campaign'),
   getCampaignByCode: require('./get-campaign-by-code'),
+  getCampaignReport: require('./get-campaign-report'),
   getCertificationCenter: require('./get-certification-center'),
   getCorrectionForAnswerWhenAssessmentEnded: require('./get-correction-for-answer-when-assessment-ended'),
   getNextChallengeForCertification: require('./get-next-challenge-for-certification'),

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -64,7 +64,11 @@ module.exports = {
       .save({ isShared: true, sharedAt: new Date() }, { patch: true, require: true })
       .then(_toDomain)
       .catch(_checkNotFoundError);
-  }
+  },
+
+  count(filters = {}) {
+    return BookshelfCampaignParticipation.where(filters).count();
+  },
 };
 
 function _adaptModelToDb(campaignParticipation) {

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -51,7 +51,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'targetProfile']);
+    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'targetProfile', 'campaignReport']);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(reports) {
+    return new Serializer('campaign-report', {
+      attributes: ['participationsCount', 'sharedParticipationsCount'],
+    }).serialize(reports);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -7,17 +7,26 @@ module.exports = {
 
   serialize(campaigns, tokenForCampaignResults) {
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'targetProfile'],
+      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'targetProfile', 'campaignReport'],
       transform: (record) => {
         const campaign = Object.assign({}, record);
         campaign.tokenForCampaignResults = tokenForCampaignResults;
         return campaign;
-      }, 
+      },
       targetProfile: {
         ref: 'id',
         included: true,
         attributes: ['name']
-      }
+      },
+      campaignReport: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/campaigns/${parent.id}/campaign-report`;
+          }
+        }
+      },
 
     }).serialize(campaigns);
   },

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -5,6 +5,7 @@ module.exports = [
   require('./application/authentication'),
   require('./application/cache'),
   require('./application/campaignParticipations'),
+  require('./application/campaignReports'),
   require('./application/campaigns'),
   require('./application/certification-centers'),
   require('./application/certification-center-memberships'),

--- a/api/tests/acceptance/application/campaign-report_test.js
+++ b/api/tests/acceptance/application/campaign-report_test.js
@@ -1,0 +1,60 @@
+const createServer = require('../../../server');
+const { expect, databaseBuilder, generateValidRequestAuhorizationHeader } = require('../../test-helper');
+const _ = require('lodash');
+
+describe('Acceptance | API | Campaign Report', () => {
+
+  let user;
+  let campaign;
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+
+    user = databaseBuilder.factory.buildUser();
+    campaign = databaseBuilder.factory.buildCampaign();
+
+    _.times(5, () => {
+      return databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        isShared: true,
+      });
+    });
+    _.times(7, () => {
+      return databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        isShared: false,
+      });
+    });
+
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await databaseBuilder.clean();
+  });
+
+  describe('GET /api/campaign/{id}/campaign-report', () => {
+    let options;
+
+    beforeEach(() => {
+      options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/campaign-report`,
+        headers: { authorization: generateValidRequestAuhorizationHeader(user.id) },
+      };
+    });
+
+    it('should return the campaignReport of the campaign', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.id).to.equal(campaign.id);
+      expect(response.result.data.attributes['participations-count']).to.be.equal(12);
+      expect(response.result.data.attributes['shared-participations-count']).to.be.equal(5);
+    });
+  });
+});

--- a/api/tests/acceptance/application/campaign-report_test.js
+++ b/api/tests/acceptance/application/campaign-report_test.js
@@ -38,7 +38,7 @@ describe('Acceptance | API | Campaign Report', () => {
   describe('GET /api/campaign/{id}/campaign-report', () => {
     let options;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       options = {
         method: 'GET',
         url: `/api/campaigns/${campaign.id}/campaign-report`,
@@ -52,7 +52,7 @@ describe('Acceptance | API | Campaign Report', () => {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.id).to.equal(campaign.id);
+      expect(response.result.data.id).to.equal(campaign.id.toString());
       expect(response.result.data.attributes['participations-count']).to.be.equal(12);
       expect(response.result.data.attributes['shared-participations-count']).to.be.equal(5);
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -100,7 +100,7 @@ describe('Integration | Repository | Campaign Participation', () => {
       campaign = databaseBuilder.factory.buildCampaign({});
 
       _.times(2, () => {
-        return databaseBuilder.factory.buildCampaignParticipation({ campaignId: 666 });
+        return databaseBuilder.factory.buildCampaignParticipation({ campaignId: 'otherCampaignId' });
       });
       _.times(5, () => {
         return databaseBuilder.factory.buildCampaignParticipation({

--- a/api/tests/unit/application/campaignReports/campaign-report-controller_test.js
+++ b/api/tests/unit/application/campaignReports/campaign-report-controller_test.js
@@ -1,0 +1,29 @@
+const { sinon, expect } = require('../../../test-helper');
+const campaignReportController = require('../../../../lib/application/campaignReports/campaign-report-controller');
+const campaignReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | Controller | campaign-report-controller', () => {
+  describe('#get ', () => {
+
+    const campaignId = 1;
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getCampaignReport');
+      sinon.stub(campaignReportSerializer, 'serialize');
+    });
+
+    it('should returns ok', async () => {
+      // given
+      usecases.getCampaignReport.withArgs({ campaignId }).resolves({});
+      campaignReportSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await campaignReportController.get({ params: { id: campaignId } });
+
+      // then
+      expect(response).to.be.equal('ok');
+    });
+
+  });
+});

--- a/api/tests/unit/application/campaignReports/campaign-report-controller_test.js
+++ b/api/tests/unit/application/campaignReports/campaign-report-controller_test.js
@@ -13,7 +13,7 @@ describe('Unit | Controller | campaign-report-controller', () => {
       sinon.stub(campaignReportSerializer, 'serialize');
     });
 
-    it('should returns ok', async () => {
+    it('should return ok', async () => {
       // given
       usecases.getCampaignReport.withArgs({ campaignId }).resolves({});
       campaignReportSerializer.serialize.withArgs({}).returns('ok');

--- a/api/tests/unit/domain/usecases/get-campaign-report_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-report_test.js
@@ -1,0 +1,29 @@
+const { expect, sinon } = require('../../../test-helper');
+const getCampaignReport = require('../../../../lib/domain/usecases/get-campaign-report');
+const CampaignReport = require('../../../../lib/domain/models/CampaignReport');
+
+describe('Unit | UseCase | get-campaign-report', () => {
+
+  const campaignId = 1;
+  let campaignParticipationRepository;
+
+  beforeEach(() => {
+    campaignParticipationRepository = { count: sinon.stub() };
+  });
+
+  it('should get the campaignReport', async () => {
+    // given
+    campaignParticipationRepository.count.withArgs({ campaignId }).resolves(7);
+    campaignParticipationRepository.count.withArgs({ campaignId, isShared: true }).resolves(4);
+
+    // when
+    const campaignReport = await getCampaignReport({ campaignId, campaignParticipationRepository });
+
+    // then
+    expect(campaignReport).to.be.an.instanceOf(CampaignReport);
+    expect(campaignReport.id).to.be.equal(campaignId);
+    expect(campaignReport.participationsCount).to.be.equal(7);
+    expect(campaignReport.sharedParticipationsCount).to.be.equal(4);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -43,9 +43,14 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
                 id: '123',
                 type: 'targetProfiles'
               }
+            },
+            'campaign-report': {
+              'links': {
+                'related': '/campaigns/5/campaign-report'
+              }
             }
           }
-        }, 
+        },
         included: [
           {
             attributes: {

--- a/orga/app/components/routes/authenticated/campaigns/details-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/details-item.js
@@ -1,8 +1,21 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
 
   tooltipText: "Copier le lien direct",
+
+  participationsCount: computed('campaign.campaignReport.participationsCount', function() {
+    const participationsCount = this.get('campaign.campaignReport.participationsCount');
+
+    return participationsCount > 0 ? participationsCount : '-';
+  }),
+
+  sharedParticipationsCount: computed('campaign.campaignReport.sharedParticipationsCount', function() {
+    const sharedParticipationsCount = this.get('campaign.campaignReport.sharedParticipationsCount');
+
+    return sharedParticipationsCount > 0 ? sharedParticipationsCount : '-';
+  }),
 
   actions: {
     clipboardSuccess() {

--- a/orga/app/models/campaign-report.js
+++ b/orga/app/models/campaign-report.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  participationsCount: DS.attr(),
+  sharedParticipationsCount: DS.attr(),
+});

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -14,6 +14,7 @@ export default DS.Model.extend({
   organization: DS.belongsTo('organization'),
   tokenForCampaignResults: DS.attr('string'),
   targetProfile: DS.belongsTo('target-profile'),
+  campaignReport: DS.belongsTo('campaign-report'),
 
   url: computed('code', function() {
     let code = this.get('code');

--- a/orga/app/routes/authenticated/campaigns/details.js
+++ b/orga/app/routes/authenticated/campaigns/details.js
@@ -3,6 +3,10 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model(params) {
-    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile', reload: true });
+    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile' });
+  },
+
+  afterModel(model) {
+    model.belongsTo('campaignReport').reload();
   }
 });

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -29,4 +29,14 @@
   font-family: $roboto;
   font-size: 1rem;
   word-break: break-word;
+
+  &--bold {
+    color: $nero;
+    font-weight: 700;
+  }
+
+  &--big {
+    font-size: 2rem;
+    font-weight: 300;
+  }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -11,9 +11,31 @@
   margin: 1em 0;
 }
 
-.campaign-details-header__title {
+.campaign-details-header {
+  &__title {
+    display: flex;
+    align-items: center;
+  }
+
+  &__report {
+    display: flex;
+    align-items: center;
+    padding-right: 10px;
+  }
+}
+
+.campaign-details-header-report {
+  &__participants {
+    padding-right: 40px;
+    margin-right: 40px;
+    border-right: 1px solid $alto;
+  }
+}
+
+.campaign-details-csv {
   display: flex;
-  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 15px;
 }
 
 .campaign-details-container {

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -5,6 +5,25 @@
     {{/link-to}}
     <h1 class="page__title page-title">{{campaign.name}}</h1>
   </div>
+
+  <div class="campaign-details-header__report">
+    <div class="campaign-details-header-report__participants">
+      <h4 class="label-text campaign-details-content__label">Participants</h4>
+      <span class="content-text content-text--big campaign-details-content__text">
+        {{participationsCount}}
+      </span>
+    </div>
+
+    <div class="campaign-details-header-report__shared">
+      <h4 class="label-text campaign-details-content__label">Profil reçus</h4>
+      <span class="content-text content-text--big campaign-details-content__text">
+        {{sharedParticipationsCount}}
+      </span>
+    </div>
+  </div>
+</div>
+
+<div class='campaign-details-csv'>
   <a class="button button--link" href="{{campaign.urlToResult}}" target="_blank" download>
     Export résultats (.csv)
   </a>

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details-item-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign | details-item', function(hooks) {
   setupRenderingTest(hooks);
-  
+
   let store;
 
   hooks.beforeEach(function() {
@@ -50,5 +50,51 @@ module('Integration | Component | routes/authenticated/campaign | details-item',
 
     // then
     assert.dom('.campaign-details-content:first-child .campaign-details-content__text').hasText('profil cible de la campagne 1');
+  });
+
+  test('it should display the campaign report', async function(assert) {
+    // given
+    const campaignReport = run(() => store.createRecord('campaignReport', {
+      id: 1,
+      participationsCount: 10,
+      sharedParticipationsCount: 4,
+    }));
+    const campaign = run(() => store.createRecord('campaign', {
+      id: 1,
+      name: 'campagne 1',
+      campaignReport
+    }));
+
+    this.set('campaign', campaign);
+
+    // when
+    await render(hbs`{{routes/authenticated/campaigns/details-item campaign=campaign}}`);
+
+    // then
+    assert.dom('.campaign-details-header-report__participants .campaign-details-content__text').hasText('10');
+    assert.dom('.campaign-details-header-report__shared .campaign-details-content__text').hasText('4');
+  });
+
+  test('it should display - instead of 0 for the campaign report', async function(assert) {
+    // given
+    const campaignReport = run(() => store.createRecord('campaignReport', {
+      id: 1,
+      participationsCount: 0,
+      sharedParticipationsCount: 0,
+    }));
+    const campaign = run(() => store.createRecord('campaign', {
+      id: 1,
+      name: 'campagne 1',
+      campaignReport
+    }));
+
+    this.set('campaign', campaign);
+
+    // when
+    await render(hbs`{{routes/authenticated/campaigns/details-item campaign=campaign}}`);
+
+    // then
+    assert.dom('.campaign-details-header-report__participants .campaign-details-content__text').hasText('-');
+    assert.dom('.campaign-details-header-report__shared .campaign-details-content__text').hasText('-');
   });
 });


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
ETQ Orga Member, JV voir le nb de participants et le nb de profils reçus sur la page de DETAIL d'une campagne.

# :woman_technologist: :man_technologist: Technique :
Création d'un objet campaignReport lié à une campagne, il est récupéré par le front via un 'link' dans le jsonapi de la campagne.
