### PR TITLE
[FEATURE] Modifier un message d'erreur et l'affichage d'un libellé dans pix Orga (PO-191).

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -35,18 +35,11 @@
   flex-direction: column;
   padding: 22px 38px;
 
-  &--multiple {
-    &:first-child {
-      width: 40%;
-    }
-
-    &:nth-child(2) {
-      width: 15%;
-    }
-
-    &:nth-child(3) {
-      width: 40%;
-    }
+  &--large-entry {
+    width: 40%;
+  }
+  &--small-entry {
+    width: 15%;
   }
 
   &--single {

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -12,17 +12,19 @@
 
 <div class="panel panel--strong-shadow campaign-details-container">
   <div class="campaign-details-row">
-    <div class="campaign-details-content campaign-details-content--multiple">
+    <div class="campaign-details-content campaign-details-content--large-entry">
       <h4 class="label-text campaign-details-content__label">Profil cible</h4>
       <p class="content-text campaign-details-content__text">{{campaign.targetProfile.name}}</p>
     </div>
 
-    <div class="campaign-details-content campaign-details-content--multiple">
-      <h4 class="label-text campaign-details-content__label">Identifiant</h4>
-      <p class="content-text campaign-details-content__text">{{campaign.idPixLabel}}</p>
-    </div>
+    {{#if campaign.idPixLabel}}
+      <div class="campaign-details-content campaign-details-content--small-entry">
+        <h4 class="label-text campaign-details-content__label">Libellé de l'identifiant</h4>
+        <p class="content-text campaign-details-content__text">{{campaign.idPixLabel}}</p>
+      </div>
+    {{/if}}
 
-    <div class="campaign-details-content campaign-details-content--multiple">
+    <div class="campaign-details-content campaign-details-content--large-entry">
       <h4 class="label-text campaign-details-content__label">Lien direct</h4>
       <div class="campaign-details-content__clipboard">
         <p class="content-text campaign-details-content__text">{{campaign.url}}</p>

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -65,7 +65,7 @@
                 aria-required='true'
                 placeholder="Libellé de l'identifiant"}}
         {{#each campaign.errors.idPixLabel as |error|}}
-          <div class='campaign-form__error'>
+          <div class='campaign-form__error error-message'>
             {{error.message}}
           </div>
         {{/each}}


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
- Faire que le message d'erreur lorsque la personne ne rentre pas de libellé soit le même que les autres erreurs
- Dans les détails d'une campagne, renommé "Identifiant" en "Libellé de l'identifiant" et ne pas afficher du tout la zone quand il n'y a pas d'identifiant

# :woman_technologist: :man_technologist: Technique :
- Utiliser la même class `error-message` pour l'erreur
- Mettre la `div` du libellé dans un `if`, et changer le CSS pour que la largeur de la colonne pour l'URL soit toujours la même (40%), et ne devienne pas le 2eme enfant (et se retrouver avec 15%)

# :nerd_face: Bon à savoir :
:smirk_cat: 
