### PR TITLE
[FEATURE] Changement de wording sur les pages et email du changement de mot de passe (PF-497)

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -68,7 +68,6 @@
 @import 'components/scoring-panel';
 @import 'components/scoring-panel-tantpix';
 @import 'components/share-profile';
-@import 'components/signin-form';
 @import 'components/signup-form';
 @import 'components/snapshot-list';
 @import 'components/timeout-jauge';

--- a/mon-pix/app/styles/components/_password-reset-demand-form.scss
+++ b/mon-pix/app/styles/components/_password-reset-demand-form.scss
@@ -1,28 +1,32 @@
-.sign-form__message {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 30px 10px;
-  color: $charcoal-grey;
-  font-family: $font-open-sans;
-  font-size: 1.5rem;
+.password-reset-demand-form {
 
-  @include device-is('tablet') {
-    margin: 80px;
+  &__body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 30px 20px;
+
+    @include device-is('tablet') {
+      margin: 30px 50px;
+    }
+
+    &--centered {
+      text-align: center;
+    }
   }
+
+  &__cancel-link {
+    align-self: center;
+    margin-top: 40px;
+  }
+
+  &__home-link {
+    align-self: center;
+    margin-bottom: 60px;
+  }
+
 }
 
-.password-reset-demand-form__cancel-link {
-  align-self: center;
-  font-family: $font-roboto;
-  font-size: 1.2rem;
-  margin-top: 40px;
-}
-
-.password-reset-demand-form__home-link {
-  align-self: center;
-  font-family: $font-roboto;
-  font-size: 1.4rem;
-  margin-bottom: 60px;
-  margin-top: 20px;
+.password-reset-demand-body__text {
+  margin-bottom: 15px;
 }

--- a/mon-pix/app/styles/components/_signin-form.scss
+++ b/mon-pix/app/styles/components/_signin-form.scss
@@ -1,7 +1,0 @@
-.signin-form__forgotten-password-link {
-  align-self: flex-end;
-  font-family: $font-roboto;
-  font-size: 1.2rem;
-  margin-bottom: 20px;
-  margin-right: 10px;
-}

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -9,33 +9,138 @@
   align-items: center;
 }
 
-.sign-form__container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  align-items: center;
-  width: 95%;
-  max-width: 609px;
-  border-radius: 10px;
-  padding-top: 10px;
-  background-color: $white;
-  margin: 10px auto;
+.sign-form {
 
-  @include device-is('tablet') {
-    width: 609px;
-    margin: 20px 0;
-    padding-top: 40px;
+  &__container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+    width: 95%;
+    max-width: 609px;
+    border-radius: 10px;
+    padding-top: 10px;
+    background-color: $white;
+    margin: 10px auto;
+
+    @include device-is('tablet') {
+      width: 609px;
+      margin: 20px 0;
+      padding-top: 40px;
+    }
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 20px 0;
+
+    @include device-is('tablet') {
+      padding: 40px 80px;
+    }
+  }
+
+  &__notification-message {
+    max-width: 449px;
+    width: 100%;
+    text-align: center;
+    border-radius: 3px;
+    color: $white;
+    font-size: 1.4rem;
+    padding: 9px;
+    margin: 10px 0;
+
+    &--success {
+      background: $caribbean-green;
+    }
+
+    &--error {
+      background: $pure-orange;
+    }
+  }
+
+  &__validation-error {
+    margin-bottom: 7px;
+    text-align: center;
   }
 }
 
-.sign-form__header-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 20px;
+.sign-form-header {
+
+  &__subtitle {
+    display: flex;
+    padding: 5px 20px;
+    flex-direction: column;
+    text-align: center;
+
+    @include device-is('tablet') {
+      flex-direction: row;
+    }
+  }
+
+  &__instruction {
+    width: 100%;
+    margin: 10px 0 40px;
+
+    @include device-is('tablet') {
+      margin: 28px 0 40px;
+
+      &--short {
+        width: 400px
+      }
+    }
+  }
 }
 
-.sign-form-header__title {
+.sign-form-header-subtitle {
+  margin-right: 3px;
+}
+
+.sign-form-body{
+
+  &__input {
+    max-width: 449px;
+    width: 100%;
+    padding: 0 20px;
+
+    @include device-is('tablet') {
+      padding: 0;
+    }
+  }
+
+  &__bottom-button {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 5px auto 20px;
+
+    &--big {
+      margin: 10px auto;
+
+      @include device-is('desktop') {
+        margin: 30px auto;
+      }
+    }
+  }
+
+  &__forgotten-password-link {
+    align-self: flex-end;
+    margin-bottom: 20px;
+    margin-right: 10px;
+  }
+}
+
+// Text Styles
+
+.sign-form-title {
   font-family: $font-raleway;
   color: $charcoal-grey;
   margin: 0;
@@ -47,89 +152,42 @@
   }
 }
 
-.sign-form-header__instruction {
-  width: 100%;
+.sign-form-subtitle {
   font-family: $font-raleway;
   color: $charcoal-grey;
   font-size: 1.5rem;
   font-weight: $font-light;
   line-height: 28px;
   text-align: center;
-  margin: 10px 0 40px;
 
   @include device-is('tablet') {
-    width: 400px;
     font-size: 2.2rem;
-    margin: 28px 0 40px;
   }
 }
 
-.sign-form-header__subtitle {
+.sign-form-instruction {
   font-family: $font-roboto;
   font-size: 1.3rem;
   font-weight: $font-light;
   color: $charcoal-grey;
-  padding: 5px;
 }
 
-.sign-form__form {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 20px 0;
+.sign-form-text {
+  color: $charcoal-grey;
+  font-family: $font-open-sans;
+  font-size: 1.0rem;
 
   @include device-is('tablet') {
-    padding: 40px 80px;
+    font-size: 1.5rem;
   }
 }
 
-.sign-form__input-container {
-  max-width: 449px;
-  width: 100%;
-  padding: 0 20px;
-
-  @include device-is('tablet') {
-    padding: 0;
-  }
-}
-
-.sign-form__submit-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 5px auto 20px;
-
-  &--big {
-    margin: 10px auto;
-
-    @include device-is('desktop') {
-      margin: 30px auto;
-    }
-  }
-}
-
-.sign-form__notification-message {
-  max-width: 449px;
-  width: 100%;
-  text-align: center;
-  border-radius: 3px;
-  color: $white;
-  font-size: 1.4rem;
-  padding: 9px;
-  margin: 10px 0;
-
-  &--success {
-    background: $caribbean-green;
-  }
-
-  &--error {
-    background: $pure-orange;
-  }
-}
-
-.sign-form__field-message--error {
+.sign-form-validation-error {
   color: $pure-orange;
   font-size: 1.2rem;
-  margin-bottom: 7px;
-  text-align: center;
+}
+
+.sign-form-link {
+  font-family: $font-roboto;
+  font-size: 1.3rem;
 }

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -4,23 +4,25 @@
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
-  <div class="sign-form__header-container">
+  <div class="sign-form__header">
     {{#unless _displaySuccessMessage}}
-      <h1 class="sign-form-header__title">Mot de passe oublié ?</h1>
-      <div class="sign-form-header__instruction">Entrez votre adresse e-mail ci-dessous, et c'est repartix</div>
+      <h1 class="sign-form-title">Mot de passe oublié ?</h1>
+      <div class="sign-form-header__instruction sign-form-header__instruction--short sign-form-subtitle">
+        Entrez votre adresse e-mail ci-dessous, et c'est repartix
+      </div>
     {{/unless}}
   </div>
 
   {{#if _displayErrorMessage}}
     <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
-      L'e-mail entré ne correspond à aucun compte
+      Cette adresse e-mail ne correspond à aucun compte
     </div>
   {{/if}}
 
   {{#unless _displaySuccessMessage}}
-    <form {{action "savePasswordResetDemand" on="submit"}} class="sign-form__form">
+    <form {{action "savePasswordResetDemand" on="submit"}} class="sign-form__body">
 
-      <div class="sign-form__input-container">
+      <div class="sign-form-body__input">
         {{form-textfield
           label="Adresse Email"
           textfieldName="email"
@@ -28,11 +30,11 @@
           inputBindingValue=email}}
       </div>
 
-      <div class="sign-form__submit-container sign-form__submit-container--big">
+      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
         <button type="submit" class="button button--thin button--round button--extra-big">
           Réinitialiser mon mot de passe
         </button>
-        {{#link-to 'login' class="link link--grey password-reset-demand-form__cancel-link"}}
+        {{#link-to 'login' class="link link--grey sign-form-link password-reset-demand-form__cancel-link"}}
           Retour à la page de connexion{{/link-to}}
       </div>
 
@@ -40,15 +42,15 @@
   {{/unless}}
 
   {{#if _displaySuccessMessage}}
-    <div class="sign-form__message" aria-live="polite">
-      Un e-mail vous a été envoyé à l’adresse {{email}}.
-      <br>
-      <br>
-      Il contient un lien, cliquez dessus pour modifier votre mot de passe. Si vous ne recevez pas cet e-mail, vérifiez
-      vos courriers indésirables.
+    <div class="sign-form-header__instruction sign-form-subtitle">Demande de réinitialisation de mot de passe</div>
+
+    <div class="password-reset-demand-form__body" aria-live="polite">
+      <span class="password-reset-demand-body__text sign-form-text">Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe
+        vous a été envoyé à l’adresse {{email}}.</span>
+      <span class="password-reset-demand-body__text sign-form-text">Si vous ne recevez pas cet e-mail, vérifiez vos courriers indésirables.</span>
     </div>
 
-    <div class=" password-reset-demand-form__home-link">
+    <div class="password-reset-demand-form__home-link">
       <a href={{urlHome}} class="link" title="Lien vers la page d'accueil de PIX">Retour à l'accueil</a>
     </div>
   {{/if}}

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -4,18 +4,18 @@
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
-  <div class="sign-form__header-container">
-    <h1 class="sign-form-header__title">{{user.fullName}}</h1>
+  <div class="sign-form__header">
+    <h1 class="sign-form-title">{{user.fullName}}</h1>
 
     {{#unless _displaySuccessMessage}}
-      <div class="sign-form-header__instruction">Saisissez votre nouveau mot de passe</div>
+      <div class="sign-form-header__instruction sign-form-subtitle">Saisissez votre nouveau mot de passe</div>
     {{/unless}}
   </div>
 
   {{#unless _displaySuccessMessage}}
-    <form {{action "handleResetPassword" on="submit"}} class="sign-form__form">
+    <form {{action "handleResetPassword" on="submit"}} class="sign-form__body">
 
-      <div class="sign-form__input-container">
+      <div class="sign-form-body__input">
         {{form-textfield
           label="Mot de passe"
           textfieldName="password"
@@ -25,7 +25,7 @@
           validationMessage=validation.message}}
       </div>
 
-      <div class="sign-form__submit-container sign-form__submit-container--big">
+      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
         <button type="submit" class="button button--thin button--round button--big">
           envoyer
         </button>
@@ -35,12 +35,14 @@
   {{/unless}}
 
   {{#if _displaySuccessMessage}}
-    <div class="sign-form__message" aria-live="polite">
-      Votre mot de passe a été modifié avec succès.
-    </div>
-    <div class="reset-password-form__login">
-      {{#link-to 'login' class="button button--link button--thin button--round button--big"}}
-        connectez-vous{{/link-to}}
+    <div class="sign-form__body">
+      <div class="password-reset-demand-form__body password-reset-demand-form__body--centered sign-form-text" aria-live="polite">
+        Votre mot de passe a été modifié avec succès.
+      </div>
+      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
+        {{#link-to 'login' class="button button--link button--thin button--round button--big"}}
+          connectez-vous{{/link-to}}
+      </div>
     </div>
   {{/if}}
 </div>

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -4,10 +4,11 @@
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
-  <div class="sign-form__header-container">
-    <h1 class="sign-form-header__title">Connectez-vous</h1>
-    <div class="sign-form-header__subtitle">Vous n'avez pas encore de compte Pix ?
-      {{#link-to 'inscription' class="link"}} Créez un compte{{/link-to}}
+  <div class="sign-form__header">
+    <h1 class="sign-form-title">Connectez-vous</h1>
+    <div class="sign-form-header__subtitle">
+      <span class="sign-form-header-subtitle sign-form-instruction">Vous n'avez pas encore de compte Pix ?</span>
+      {{#link-to 'inscription' class="link sign-form-link"}} Créez un compte{{/link-to}}
     </div>
   </div>
 
@@ -17,9 +18,9 @@
     </div>
   {{/if}}
 
-  <form {{action "signin" on="submit"}} class="sign-form__form">
+  <form {{action "signin" on="submit"}} class="sign-form__body">
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Adresse email"
         textfieldName="email"
@@ -27,7 +28,7 @@
         inputBindingValue=email}}
     </div>
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Mot de passe"
         textfieldName="password"
@@ -36,10 +37,10 @@
         inputBindingValue=password}}
     </div>
 
-    {{#link-to 'password-reset-demand' class="link link--grey signin-form__forgotten-password-link"}}
+    {{#link-to 'password-reset-demand' class="link link--grey sign-form-link sign-form-body__forgotten-password-link"}}
       Mot de passe oublié ?{{/link-to}}
 
-    <div class="sign-form__submit-container">
+    <div class="sign-form-body__bottom-button">
       <button type="submit" class="button button--thin button--round button--big">
         Je me connecte
       </button>

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -4,10 +4,11 @@
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
-  <div class="sign-form__header-container">
-    <h1 class="sign-form-header__title">Inscrivez-vous</h1>
-    <div class="sign-form-header__subtitle">ou
-      {{#link-to 'login' class="link"}} connectez-vous à votre compte{{/link-to}}
+  <div class="sign-form__header">
+    <h1 class="sign-form-title">Inscrivez-vous</h1>
+    <div class="sign-form-header__subtitle">
+      <span class="sign-form-header-subtitle">ou</span>
+      {{#link-to 'login' class="link"}}connectez-vous à votre compte{{/link-to}}
     </div>
   </div>
 
@@ -17,9 +18,9 @@
     </div>
   {{/if}}
 
-  <form {{action "signup" on="submit"}} class="sign-form__form">
+  <form {{action "signup" on="submit"}} class="sign-form__body">
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Prénom"
         textfieldName="firstName"
@@ -29,7 +30,7 @@
         validationMessage=validation.firstName.message}}
     </div>
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Nom"
         textfieldName="lastName"
@@ -39,7 +40,7 @@
         validationMessage=validation.lastName.message}}
     </div>
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Adresse Email"
         textfieldName="email"
@@ -49,7 +50,7 @@
         validationMessage=validation.email.message}}
     </div>
 
-    <div class="sign-form__input-container">
+    <div class="sign-form-body__input">
       {{form-textfield
         label="Mot de passe"
         textfieldName="password"
@@ -63,7 +64,7 @@
     <div class="signup-form__cgu-container">
 
       {{#if user.errors.cgu}}
-        <div class="sign-form__field-message--error">
+        <div class="sign-form__validation-error sign-form-validation-error">
           {{user.errors.cgu.firstObject.message}}
         </div>
       {{/if}}
@@ -78,12 +79,12 @@
 
     <div class="signup-form__captcha-container">
       {{#if user.errors.recaptchaToken}}
-        <div class="sign-form__field-message--error">{{user.errors.recaptchaToken.firstObject.message}}</div>
+        <div class="sign-form__validation-error  sign-form-validation-error">{{user.errors.recaptchaToken.firstObject.message}}</div>
       {{/if}}
       {{g-recaptcha recaptchaToken=user.recaptchaToken tokenHasBeenUsed=_tokenHasBeenUsed}}
     </div>
 
-    <div class="sign-form__submit-container">
+    <div class="sign-form-body__bottom-button">
       <button type="submit" class="button button--thin button--round button--big">
         Je m'inscris
       </button>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -91,6 +91,11 @@ export default function() {
     }
   });
 
+  this.get('/password-reset-demands/:key', (schema) => {
+    return schema.passwordResetDemands.first();
+  });
+  this.patch('/password-reset-demands/:id');
+
   this.get('/smart-placement-progressions/:id');
   this.get('/campaigns', getCampaigns);
   this.post('/campaign-participations', postCampaignParticipation);

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -117,6 +117,10 @@ export default function(server) {
     title: 'Le Titre de la campagne'
   });
 
+  server.create('password-reset-demand', {
+    temporaryKey: 'temporaryKey',
+  });
+
   prescriber.organization = company;
   company.user = prescriber;
 

--- a/mon-pix/tests/acceptance/password-reset-test.js
+++ b/mon-pix/tests/acceptance/password-reset-test.js
@@ -54,7 +54,7 @@ describe('Acceptance | Reset Password', function() {
     // then
     return andThen(() => {
       expect(currentURL()).to.equal('/mot-de-passe-oublie');
-      expect(find('.sign-form__message')).to.have.lengthOf(1);
+      expect(find('.password-reset-demand-form__body')).to.have.lengthOf(1);
     });
 
   });

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -19,9 +19,9 @@ describe('Integration | Component | password reset demand form', function() {
 
     // then
     expect(this.$('.pix-logo__link')).to.have.length(1);
-    expect(this.$('.sign-form-header__title')).to.have.length(1);
+    expect(this.$('.sign-form-title')).to.have.length(1);
     expect(this.$('.sign-form-header__instruction')).to.have.length(1);
-    expect(this.$('.sign-form__form')).to.have.length(1);
+    expect(this.$('.sign-form__body')).to.have.length(1);
     expect(this.$('.form-textfield__label')).to.have.length(1);
     expect(this.$('.form-textfield__input-field-container')).to.have.length(1);
     expect(this.$('.button')).to.have.length(1);
@@ -46,7 +46,7 @@ describe('Integration | Component | password reset demand form', function() {
     this.render(hbs`{{password-reset-demand-form _displaySuccessMessage=_displaySuccessMessage}}`);
 
     // then
-    expect(this.$('.sign-form__message')).to.have.length(1);
+    expect(this.$('.password-reset-demand-form__body')).to.have.length(1);
   });
 
 });

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -23,9 +23,9 @@ describe('Integration | Component | reset password form', function() {
 
       [
         { item: '.pix-logo__link' },
-        { item: '.sign-form-header__title' },
+        { item: '.sign-form-title' },
         { item: '.sign-form-header__instruction' },
-        { item: '.sign-form__form' },
+        { item: '.sign-form__body' },
         { item: '.form-textfield__label' },
         { item: '.form-textfield__input-field-container' },
         { item: '.button' }
@@ -48,7 +48,7 @@ describe('Integration | Component | reset password form', function() {
         this.render(hbs`{{reset-password-form user=user}}`);
 
         // then
-        expect(this.$('.sign-form-header__title').text().trim()).to.equal(user.fullName);
+        expect(this.$('.sign-form-title').text().trim()).to.equal(user.fullName);
       });
 
     });
@@ -99,7 +99,7 @@ describe('Integration | Component | reset password form', function() {
           expect(isSaveMethodCalled).to.be.true;
           expect(this.get('user.password')).to.eql(null);
           expect(this.$(PASSWORD_INPUT_CLASS).val()).to.equal(undefined);
-          expect(this.$('.sign-form__message')).to.have.lengthOf(1);
+          expect(this.$('.password-reset-demand-form__body')).to.have.lengthOf(1);
         });
 
         it('should get an error, when button is clicked and saving return error', async function() {

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -41,7 +41,7 @@ describe('Integration | Component | signin form', function() {
       this.render(hbs`{{signin-form}}`);
 
       // then
-      expect(document.querySelector('a.signin-form__forgotten-password-link')).to.exist;
+      expect(document.querySelector('a.sign-form-body__forgotten-password-link')).to.exist;
     });
 
     it('should not display any error by default', function() {

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -11,11 +11,11 @@ import sinon from 'sinon';
 import $ from 'jquery';
 
 const FORM_CONTAINER = '.sign-form__container';
-const FORM_HEADER_CONTAINER = '.sign-form__header-container';
-const FORM_HEADER = '.sign-form-header__title';
+const FORM_HEADER_CONTAINER = '.sign-form__header';
+const FORM_HEADER = '.sign-form-title';
 const EXPECTED_FORM_HEADER_CONTENT = 'Inscrivez-vous';
 
-const INPUT_TEXT_FIELD = '.sign-form__input-container';
+const INPUT_TEXT_FIELD = '.sign-form-body__input';
 const INPUT_TEXT_FIELD_CLASS_DEFAULT = 'form-textfield__input-container--default';
 
 const CHECKBOX_CGU_CONTAINER = '.signup-form__cgu-container';
@@ -26,7 +26,7 @@ const UNCHECKED_CHECKBOX_CGU_ERROR = 'Veuillez accepter les conditions général
 const CGU_LINK = '.signup-form__cgu .link';
 const CGU_LINK_CONTENT = 'conditions d\'​utilisation de Pix';
 
-const SUBMIT_BUTTON_CONTAINER = '.sign-form__submit-container';
+const SUBMIT_BUTTON_CONTAINER = '.sign-form-body__bottom-button';
 const SUBMIT_BUTTON = '.button';
 const SUBMIT_BUTTON_CONTENT = 'Je m\'inscris';
 
@@ -341,7 +341,7 @@ describe('Integration | Component | signup form', function() {
         this.$('.button').click();
         // then
         return wait().then(() => {
-          expect(this.$('.sign-form__field-message--error')).to.have.lengthOf(1);
+          expect(this.$('.sign-form__validation-error')).to.have.lengthOf(1);
         });
       });
     });


### PR DESCRIPTION
# 👨‍🎨 Besoin :
Changer du wording sur les pages de reset de mot de passe + email (sur MailJet).
Pour plus de détails : https://1024pix.atlassian.net/browse/PF-497

# :nerd_face: Bon à savoir :
Du refacto a été fait dans le html/css des pages de login et reset de mot de passe.
La logique suivie est la même que pour Pix Orga : on fait du BEM-like et on sépare le style du positionnement.
On y gagne : réutilisation des éléments de style, pour plus de cohérence dans le design et dans le code. Positionnement spécifique en fonction des pages, avec des possibilité de réutilisation de positionnement si on retrouve les mêmes structures (d'où un fichier sign-form.scss commun au login et aux différentes étapes du workflow de reset de mot de passe).

> sign-form-header__instruction pour le positionnement (.Block__Element)
> sign-form-title2 pour le style

Il y a encore de mon point de vue encore quelques améliorations à apporter, mais j'ai préféré m'arrêter là pour le moment (sinon ça peut être sans fin ...).