### PR TITLE
[BUGFIX] Mise à jour de la barre de progression au bon moment (PF-508).

### DIFF
--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -4,17 +4,25 @@ import Component from '@ember/component';
 import AssessmentProgression from '../models/assessment-progression';
 
 export default Component.extend({
+
   classNames: ['progress'],
 
-  progression: computed('assessment.{type,answers,course.nbChallenges}', function() {
-    return new AssessmentProgression({
+  progression: new AssessmentProgression(),
+
+  setProgression() {
+    this.set('progression', new AssessmentProgression({
       assessmentType: this.get('assessment.type'),
       nbAnswers: this.get('assessment.answers.length'),
       nbChallenges: this.get('assessment.course.nbChallenges')
-    });
-  }),
+    }));
+  },
 
   barStyle: computed('progression', function() {
     return htmlSafe(`width: ${this.get('progression.valueNow')}%`);
-  })
+  }),
+
+  willRender() {
+    this.setProgression();
+  }
+
 });

--- a/mon-pix/app/models/answer.js
+++ b/mon-pix/app/models/answer.js
@@ -16,4 +16,5 @@ export default Model.extend(ValueAsArrayOfString, {
 
   isResultOk: computed.equal('result', 'ok'),
   isResultNotOk: computed.not('isResultOk'),
+
 });

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -26,10 +26,6 @@ export default Model.extend({
   codeCampaign: attr('string'),
   participantExternalId: attr('string'),
 
-  nbCurrentAnswers: computed('', function() {
-    return this.get('answers.length');
-  }),
-
   answersSinceLastCheckpoints: computed('answers.[]', function() {
     const answers = this.get('answers').toArray();
     const howManyAnswersSinceTheLastCheckpoint = answers.length % ENV.APP.NUMBER_OF_CHALLENGE_BETWEEN_TWO_CHECKPOINTS_IN_SMART_PLACEMENT;

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -93,7 +93,6 @@ export default BaseRoute.extend({
   },
 
   _routeToNextChallenge(assessment, nextChallengeId) {
-    assessment.incrementProperty('nbCurrentAnswers');
     return this.replaceWith('assessments.challenge', assessment.get('id'), nextChallengeId);
   },
 
@@ -102,7 +101,6 @@ export default BaseRoute.extend({
   },
 
   _routeToCheckpoint(assessment) {
-    assessment.set('nbCurrentAnswers', 0);
     return this.replaceWith('assessments.checkpoint', assessment.get('id'));
   },
 

--- a/mon-pix/tests/unit/components/progress-bar-test.js
+++ b/mon-pix/tests/unit/components/progress-bar-test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import AssessmentProgression from 'mon-pix/models/assessment-progression';
 import EmberObject from '@ember/object';
 import { setupTest } from 'ember-mocha';
 
@@ -20,6 +19,7 @@ describe('Unit | Component | progress-bar', function() {
         }
       });
       const component = this.subject({ assessment });
+      component.setProgression();
 
       // when
       const progression = component.get('progression');
@@ -35,12 +35,15 @@ describe('Unit | Component | progress-bar', function() {
 
     it('should return the good CSS style value according to progression', function() {
       // given
-      const progression = new AssessmentProgression({
-        assessmentType: 'DEMO',
-        nbAnswers: 5,
-        nbChallenges: 10
+      const assessment = EmberObject.create({
+        type: 'DEMO',
+        answers: [{}, {}, {}, {}, {}],
+        course: {
+          nbChallenges: 10
+        }
       });
-      const component = this.subject({ progression });
+      const component = this.subject({ assessment });
+      component.setProgression();
 
       // when
       const barStyle = component.get('barStyle');


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
Les positionnements concernant les campagnes, ainsi que les démo et les preview affichent une barre de progression indiquant le nombre de questions restantes avant le prochain _checkpoint_. Le problème étant que dès que l'utilisateur donne sa réponse, la barre se met à jour instantanément. 

La manifestation la plus laide de problème étant lors de la validation d'une question juste avant le checkpoint, où la barre pleine revient subitement à 1/5, avant que la vue ne soit complètement remplacé par le checkpoint. 

En image ça donne ça : https://1024pix.atlassian.net/secure/RapidBoard.jspa?rapidView=33&projectKey=PIX&modal=detail&selectedIssue=PF-508

# :woman_technologist: :man_technologist: Technique :
Le problème vient d'une des principales forces d'Ember, les `computed properties`. Ces dernières permettent d'être observées et donc de garantir que tout est toujours synchronisé. En l'occurence ici, dès qu'on crée une answer localement - avant même qu'on l'envoit au server - la barre de progression se met à jour en conséquence. 

Actuellement, le composant (UI) est en permanence synchronisé à partir d'une propriété `progression`, elle même tout le temps synchronisée avec les `assessment.answers` de l'assessment courant. 

La solution consiste à ne pas laisser Ember synchroniser à tout instant les `answers` avec la propriété `progression`, mais à setté cette dernière le plus tard possible. En fait, à la setté juste avant le rendu du composant, dans le hook `willRender`. 

**Avant** 😞 
`Answers  <---- *always sync* ----> progression <---- *always sync* ----> <ProgressBar>`

**Maintenant** 😀 
`Answers  <---- *manually sync* ----> progression <---- *always sync* ----> <ProgressBar>` 
