### PR TITLE
[TECH] Empêcher la redirection vers le site vitrine une exécution de Pix App dans un environnement "development" ou "test".

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -94,6 +94,7 @@ module.exports = function(environment) {
 
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
     ENV.APP.API_HOST = 'http://localhost:3000';
+    ENV.APP.HOME_HOST = '/';
   }
 
   if (environment === 'test') {
@@ -109,6 +110,7 @@ module.exports = function(environment) {
 
     ENV.googleFonts = null;
     ENV.APP.API_HOST = 'http://localhost:3000';
+    ENV.APP.HOME_HOST = '/';
     ENV.APP.isChallengeTimerEnable = false;
     ENV.APP.MESSAGE_DISPLAY_DURATION = 0;
     ENV.APP.isMobileSimulationEnabled = true;


### PR DESCRIPTION
# :woman_shrugging: :man_shrugging: Besoin : 
Empêcher la redirection vers pix.fr lorsqu'on ne se trouve pas en production.

# :woman_technologist: :man_technologist: Technique :
Exemple: Dans un environnement local, ou une review app, se déconnecter de app redirige systématiquement vers pix.fr. On redirige maintenant vers la page de connexion de l'environnement.

