### PR TITLE
[TECH] Correction du build CircleCI en forçant Chrome 72

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
 jobs:
   checkout:
     docker:
-      - image: circleci/node:10.15
+      - image: circleci/node:10.15.1
     working_directory: ~/pix
     steps:
       - checkout
@@ -82,7 +82,7 @@ jobs:
 
   api_build_and_test:
     docker:
-      - image: circleci/node:10.15
+      - image: circleci/node:10.15.1
       - image: postgres:10-alpine
         environment:
           POSTGRES_USER: circleci
@@ -112,7 +112,7 @@ jobs:
 
   mon_pix_build_and_test:
     docker:
-      - image: circleci/node:10.15-browsers
+      - image: circleci/node:10.15.1-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
@@ -135,7 +135,7 @@ jobs:
 
   orga_build_and_test:
     docker:
-      - image: circleci/node:10.15-browsers
+      - image: circleci/node:10.15.1-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
@@ -156,7 +156,7 @@ jobs:
 
   certif_build_and_test:
     docker:
-      - image: circleci/node:10.15-browsers
+      - image: circleci/node:10.15.1-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
@@ -177,7 +177,7 @@ jobs:
 
   admin_build_and_test:
     docker:
-      - image: circleci/node:10.15-browsers
+      - image: circleci/node:10.15.1-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 

Faire de nouveau fonctionner les tests _front_ sur CircleCI, qui ne démarrent plus depuis que l'image `circleci/node:10.15-browsers` a été mise à jour (il y a 3 jours) pour inclure Chrome 73. Le problème a été rencontré par d'autres : https://github.com/GoogleChrome/puppeteer/issues/3774 mais la solution n'est pas encore claire.

## :woman_technologist: :man_technologist: Technique :

En attendant, on force CircleCI à utiliser une version plus ancienne de l'image (`10.15.1-browsers` alors que la dernière est `10.15.3-browsers`) qui fournit Chrome 72 avec lequel les tests fonctionnent bien.

C'est un peu dommage d'avoir à changer la version de Node pour changer la version de Chrome, et on pourrait contourner ça en construisant notre propre image, mais ça ne vaut pas vraiment le coup ici. De plus, en production on utilise actuellement Node 10.15.1 (spécifié par nos `package.json`).
