### PR TITLE
[FEATURE] Calculer le Pix Score global de l'utilisateur à afficher dans le profil v2 (PF-537).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -131,7 +131,20 @@ exports.register = async function(server) {
           }
         }, tags: ['api']
       }
-    }
+    },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/pixscore',
+      config: {
+        handler: userController.getPixScore,
+        notes : [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération du nombre total de Pix de l\'utilisateur\n' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -126,5 +126,11 @@ module.exports = {
 
     return usecases.getUserCampaignParticipations({ authenticatedUserId, requestedUserId })
       .then(campaignParticipationSerializer.serialize);
-  }
+  },
+
+  getPixScore(request) {
+    const authenticatedUserId = request.auth.credentials.userId.toString();
+    const requestedUserId = request.params.id;
+    return usecases.getUserPixScore({ authenticatedUserId, requestedUserId });
+  },
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -2,6 +2,7 @@ const userSerializer = require('../../infrastructure/serializers/jsonapi/user-se
 const campaignParticipationSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
+const pixScoreSerializer = require('../../infrastructure/serializers/jsonapi/pix-score-serializer');
 const userService = require('../../domain/services/user-service');
 const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
 const profileService = require('../../domain/services/profile-service');
@@ -131,6 +132,7 @@ module.exports = {
   getPixScore(request) {
     const authenticatedUserId = request.auth.credentials.userId.toString();
     const requestedUserId = request.params.id;
-    return usecases.getUserPixScore({ authenticatedUserId, requestedUserId });
+    return usecases.getUserPixScore({ authenticatedUserId, requestedUserId })
+      .then(pixScoreSerializer.serialize);
   },
 };

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -17,6 +17,7 @@ class User {
     memberships = [],
     certificationCenterMemberships = [],
     pixRoles = [],
+    pixScore,
     // references
   } = {}) {
     this.id = id;
@@ -31,6 +32,7 @@ class User {
     this.samlId = samlId;
     // includes
     this.pixRoles = pixRoles;
+    this.pixScore = pixScore;
     this.memberships = memberships;
     this.certificationCenterMemberships = certificationCenterMemberships;
     // references

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -8,5 +8,5 @@ module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKn
   }
 
   const userKnowledgeElements = await smartPlacementKnowledgeElementRepository.findUniqByUserId(requestedUserId);
-  return { pixScore: _.sumBy(userKnowledgeElements, 'earnedPix') };
+  return { id: requestedUserId, value: _.sumBy(userKnowledgeElements, 'earnedPix') };
 };

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -1,0 +1,12 @@
+const _ = require('lodash');
+const { UserNotAuthorizedToAccessEntity } = require('../errors');
+
+module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKnowledgeElementRepository }) => {
+
+  if (authenticatedUserId !== requestedUserId) {
+    return Promise.reject(new UserNotAuthorizedToAccessEntity());
+  }
+
+  const userKnowledgeElements = await smartPlacementKnowledgeElementRepository.findUniqByUserId(requestedUserId);
+  return _.sumBy(userKnowledgeElements, 'earnedPix');
+};

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -8,5 +8,5 @@ module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKn
   }
 
   const userKnowledgeElements = await smartPlacementKnowledgeElementRepository.findUniqByUserId(requestedUserId);
-  return _.sumBy(userKnowledgeElements, 'earnedPix');
+  return { pixScore: _.sumBy(userKnowledgeElements, 'earnedPix') };
 };

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
 module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKnowledgeElementRepository }) => {
@@ -7,6 +6,6 @@ module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKn
     throw new UserNotAuthorizedToAccessEntity();
   }
 
-  const userKnowledgeElements = await smartPlacementKnowledgeElementRepository.findUniqByUserId(requestedUserId);
-  return { id: requestedUserId, value: _.sumBy(userKnowledgeElements, 'earnedPix') };
+  const userPixScore = await smartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(requestedUserId);
+  return { id: requestedUserId, value: userPixScore };
 };

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -4,7 +4,7 @@ const { UserNotAuthorizedToAccessEntity } = require('../errors');
 module.exports = async ({ authenticatedUserId, requestedUserId, smartPlacementKnowledgeElementRepository }) => {
 
   if (authenticatedUserId !== requestedUserId) {
-    return Promise.reject(new UserNotAuthorizedToAccessEntity());
+    throw new UserNotAuthorizedToAccessEntity();
   }
 
   const userKnowledgeElements = await smartPlacementKnowledgeElementRepository.findUniqByUserId(requestedUserId);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -94,6 +94,7 @@ module.exports = injectDependencies({
   getUserCertification: require('./get-user-certification'),
   getUserCertificationWithResultTree: require('./get-user-certification-with-result-tree'),
   getUserCertificationCenterMemberships: require('./get-user-certification-center-memberships'),
+  getUserPixScore: require('./get-user-pix-score'),
   getUserWithMemberships: require('./get-user-with-memberships'),
   preloadCacheEntries: require('./preload-cache-entries'),
   reloadCacheEntry: require('./reload-cache-entry'),

--- a/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
@@ -41,6 +41,7 @@ module.exports = {
       });
   },
 
+  // TODO improve sum with pg request
   getSumOfPixFromUserKnowledgeElements(userId) {
     return BookshelfKnowledgeElement
       .query((qb) => {

--- a/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
@@ -47,12 +47,12 @@ module.exports = {
       (qb) => {
         qb.select('earnedPix', Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rnum', ['skillId', 'createdAt']))
           .from('knowledge-elements')
-          .where({ userId })
+          .where({ userId });
       })
       .sum('earnedPix AS earnedPix')
       .from('temp')
       .where({ rnum: 1 })
       .then((result) => result.rows ? result.rows : result)
-      .then(([{earnedPix}]) => earnedPix);
+      .then(([{ earnedPix }]) => earnedPix);
   }
 };

--- a/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
@@ -27,7 +27,7 @@ module.exports = {
     return BookshelfKnowledgeElement
       .query((qb) => {
         qb.where({ userId });
-        if(limitDate) {
+        if (limitDate) {
           qb.where('knowledge-elements.createdAt', '<', limitDate);
         }
       })
@@ -38,6 +38,17 @@ module.exports = {
           .orderBy('createdAt', 'desc')
           .uniqBy('skillId')
           .value();
+      });
+  },
+
+  getSumOfPixFromUserKnowledgeElements(userId) {
+    return BookshelfKnowledgeElement
+      .query((qb) => {
+        qb.select('earnedPix').where({ userId }).orderBy('createdAt', 'desc').distinct('skillId');
+      })
+      .fetchAll()
+      .then((pixValues) => {
+        return _.sumBy(pixValues.toJSON(), 'earnedPix');
       });
   }
 };

--- a/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/smart-placement-knowledge-element-repository.js
@@ -43,15 +43,15 @@ module.exports = {
   },
 
   getSumOfPixFromUserKnowledgeElements(userId) {
-    return Bookshelf.knex.with('temp',
+    return Bookshelf.knex.with('earnedPixWithRankPerSkill',
       (qb) => {
-        qb.select('earnedPix', Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rnum', ['skillId', 'createdAt']))
+        qb.select('earnedPix', Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', ['skillId', 'createdAt']))
           .from('knowledge-elements')
           .where({ userId });
       })
       .sum('earnedPix AS earnedPix')
-      .from('temp')
-      .where({ rnum: 1 })
+      .from('earnedPixWithRankPerSkill')
+      .where({ rank: 1 })
       .then((result) => result.rows ? result.rows : result)
       .then(([{ earnedPix }]) => earnedPix);
   }

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -203,7 +203,7 @@ module.exports = {
   },
 
   create(domainUser) {
-    const userToCreate = _.omit(domainUser, ['pixRoles', 'memberships', 'certificationCenterMemberships']);
+    const userToCreate = _.omit(domainUser, ['pixRoles', 'memberships', 'certificationCenterMemberships', 'pixScore']);
     return new BookshelfUser(userToCreate)
       .save()
       .then((bookshelfUser) => bookshelfUser.toDomainEntity());
@@ -232,7 +232,7 @@ module.exports = {
   },
 
   updateUser(domainUser) {
-    const userToUpdate = _.omit(domainUser, ['pixRoles', 'memberships', 'certificationCenterMemberships']);
+    const userToUpdate = _.omit(domainUser, ['pixRoles', 'memberships', 'certificationCenterMemberships', 'pixScore']);
     return BookshelfUser.where({ id: domainUser.id })
       .save(userToUpdate, {
         patch: true,

--- a/api/lib/infrastructure/serializers/jsonapi/pix-score-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/pix-score-serializer.js
@@ -1,0 +1,12 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(pixscore) {
+    return new Serializer('pixscores', {
+      attributes: ['pixScore']
+    }).serialize(pixscore);
+  }
+
+};
+

--- a/api/lib/infrastructure/serializers/jsonapi/pix-score-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/pix-score-serializer.js
@@ -3,8 +3,8 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
 
   serialize(pixscore) {
-    return new Serializer('pixscores', {
-      attributes: ['pixScore']
+    return new Serializer('pix-score', {
+      attributes: ['value']
     }).serialize(pixscore);
   }
 

--- a/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
@@ -30,6 +30,7 @@ class ProfileSerializer extends JSONAPISerializer {
     this._serializeRelationships(competencesEntity, 'competences', data);
     this._serializeRelationships(organizationsEntity, 'organizations', data);
     this._serializeCampaignParticipationsLink(data, entity);
+    this._serializePixScoreLink(data, entity);
     return data;
   }
 
@@ -37,6 +38,14 @@ class ProfileSerializer extends JSONAPISerializer {
     data.relationships['campaign-participations'] = {
       links: {
         related: `/users/${entity.id}/campaign-participations`
+      }
+    };
+  }
+
+  _serializePixScoreLink(data, entity) {
+    data.relationships['pix-score'] = {
+      links: {
+        related: `/api/users/${entity.id}/pixscore`
       }
     };
   }

--- a/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
@@ -45,7 +45,7 @@ class ProfileSerializer extends JSONAPISerializer {
   _serializePixScoreLink(data, entity) {
     data.relationships['pix-score'] = {
       links: {
-        related: `/api/users/${entity.id}/pixscore`
+        related: `/users/${entity.id}/pixscore`
       }
     };
   }

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -33,6 +33,9 @@ module.exports = {
           }
         }
       },
+      transform(model) {
+        return (model instanceof User) ? model : model.toJSON();
+      },
       meta
     }).serialize(users);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -5,7 +5,7 @@ module.exports = {
 
   serialize(users, meta) {
     return new Serializer('user', {
-      attributes: ['firstName', 'lastName', 'email', 'cgu', 'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted', 'memberships', 'certificationCenterMemberships'],
+      attributes: ['firstName', 'lastName', 'email', 'cgu', 'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted', 'memberships', 'certificationCenterMemberships', 'pixScore'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,
@@ -24,9 +24,20 @@ module.exports = {
           }
         }
       },
+      pixScore: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function(record, current, parent) {
+            return `/users/${parent.id}/pixscore`;
+          }
+        }
+      },
       transform(model) {
         // FIXME: Used to make it work in both cases
-        return (model instanceof User) ? model : model.toJSON();
+        const userModel = (model instanceof User) ? model : model.toJSON();
+        userModel.pixScore = null;
+        return userModel;
       },
       meta
     }).serialize(users);

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -33,12 +33,6 @@ module.exports = {
           }
         }
       },
-      transform(model) {
-        // FIXME: Used to make it work in both cases
-        const userModel = (model instanceof User) ? model : model.toJSON();
-        userModel.pixScore = null;
-        return userModel;
-      },
       meta
     }).serialize(users);
   },

--- a/api/package.json
+++ b/api/package.json
@@ -95,7 +95,7 @@
     "db:migrate": "knex --knexfile db/knexfile.js migrate:latest",
     "db:pg:create": "node scripts/database/create-database",
     "db:pg:delete": "node scripts/database/drop-database",
-    "db:pg:reset": "npm run db:pg:delete && npm run db:pg:create && npm run db:migrate",
+    "db:pg:reset": "npm run db:pg:delete && npm run db:pg:create && npm run db:migrate && npm run db:seed",
     "db:reset": "npm run db:delete && npm run db:migrate && npm run db:seed",
     "db:rollback": "npx knex --knexfile db/knexfile.js migrate:rollback",
     "db:seed": "knex --knexfile db/knexfile.js seed:run",

--- a/api/package.json
+++ b/api/package.json
@@ -95,7 +95,7 @@
     "db:migrate": "knex --knexfile db/knexfile.js migrate:latest",
     "db:pg:create": "node scripts/database/create-database",
     "db:pg:delete": "node scripts/database/drop-database",
-    "db:pg:reset": "npm run db:pg:delete && npm run db:pg:create && npm run db:migrate && npm run db:seed",
+    "db:pg:reset": "npm run db:pg:delete && npm run db:pg:create && npm run db:migrate",
     "db:reset": "npm run db:delete && npm run db:migrate && npm run db:seed",
     "db:rollback": "npx knex --knexfile db/knexfile.js migrate:rollback",
     "db:seed": "knex --knexfile db/knexfile.js seed:run",

--- a/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
@@ -12,7 +12,6 @@ describe('Acceptance | users-controller-get-pix-score', () => {
 
     const user = databaseBuilder.factory.buildUser();
 
-    // Insert 2 more users
     databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 3 });
     databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 4 });
 

--- a/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
@@ -5,12 +5,13 @@ describe('Acceptance | users-controller-get-pix-score', () => {
 
   let server;
   let options;
+  let user;
 
   beforeEach(async () => {
     // create server
     server = await createServer();
 
-    const user = databaseBuilder.factory.buildUser();
+    user = databaseBuilder.factory.buildUser();
 
     databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 3 });
     databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 4 });
@@ -53,10 +54,11 @@ describe('Acceptance | users-controller-get-pix-score', () => {
         // given
         const pixScoreExpected = {
           data: {
-            type: 'pixscores',
             attributes: {
-              'pix-score': 7
-            }
+              value: 7
+            },
+            id: `${user.id}`,
+            type: 'pix-scores'
           }
         };
 

--- a/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
@@ -13,13 +13,13 @@ describe('Acceptance | users-controller-get-pix-score', () => {
     const user = databaseBuilder.factory.buildUser();
 
     // Insert 2 more users
-    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({userId: user.id, earnedPix: 3 });
-    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({userId: user.id, earnedPix: 4 });
+    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 3 });
+    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ userId: user.id, earnedPix: 4 });
 
     options = {
       method: 'GET',
       url: `/api/users/${user.id}/pixscore`,
-      payload: { },
+      payload: {},
       headers: { authorization: generateValidRequestAuhorizationHeader(user.id) },
     };
 
@@ -52,6 +52,14 @@ describe('Acceptance | users-controller-get-pix-score', () => {
 
       it('should return a 200 status code response with JSON API serialized PixScore', () => {
         // given
+        const pixScoreExpected = {
+          data: {
+            type: 'pixscores',
+            attributes: {
+              'pix-score': 7
+            }
+          }
+        };
 
         // when
         const promise = server.inject(options);
@@ -59,7 +67,7 @@ describe('Acceptance | users-controller-get-pix-score', () => {
         // then
         return promise.then((response) => {
           expect(response.statusCode).to.equal(200);
-          expect(response.result).to.equal(7);
+          expect(response.result).to.deep.equal(pixScoreExpected);
         });
       });
     });

--- a/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
@@ -1,0 +1,67 @@
+const { expect, generateValidRequestAuhorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | users-controller-get-pix-score', () => {
+
+  let server;
+  let options;
+
+  beforeEach(async () => {
+    // create server
+    server = await createServer();
+
+    const user = databaseBuilder.factory.buildUser();
+
+    // Insert 2 more users
+    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({userId: user.id, earnedPix: 3 });
+    databaseBuilder.factory.buildSmartPlacementKnowledgeElement({userId: user.id, earnedPix: 4 });
+
+    options = {
+      method: 'GET',
+      url: `/api/users/${user.id}/pixscore`,
+      payload: { },
+      headers: { authorization: generateValidRequestAuhorizationHeader(user.id) },
+    };
+
+    return databaseBuilder.commit();
+  });
+
+  afterEach(() => {
+    return databaseBuilder.clean();
+  });
+
+  describe('GET /users/:id/pixscore', () => {
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(401);
+        });
+      });
+    });
+
+    describe('Success case', () => {
+
+      it('should return a 200 status code response with JSON API serialized PixScore', () => {
+        // given
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).to.equal(7);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-profile_test.js
@@ -45,7 +45,11 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
             related: '/users/1234/campaign-participations'
           },
         },
-
+        'pix-score': {
+          'links': {
+            'related': '/users/1234/pixscore'
+          }
+        }
       }
     },
     included: [

--- a/api/tests/acceptance/application/users/users-controller-get-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user_test.js
@@ -62,7 +62,12 @@ describe('Acceptance | Controller | users-controller-get-user', () => {
               links: {
                 related: '/users/1234/certification-center-memberships'
               }
-            }
+            },
+            'pix-score' : {
+              links: {
+                related: '/users/1234/pixscore'
+              }
+            },
           }
         }
       };

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -75,6 +75,11 @@ describe('Acceptance | Controller | users-controller', () => {
                 '"links":{'+
                   '"related":"/users/(\\d+)/certification-center-memberships"'+
                 '}'+
+              '},'+
+              '"pix-score":{'+
+                '"links":{'+
+                  '"related":"/users/(\\d+)/pixscore"'+
+                '}'+
               '}'+
             '}'+
             '}' +

--- a/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
@@ -7,9 +7,6 @@ const moment = require('moment');
 
 describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', () => {
 
-  const SMART_PLACEMENT = 'SMART_PLACEMENT';
-  const PLACEMENT = 'PLACEMENT';
-
   afterEach(() => {
     return knex('knowledge-elements').delete()
       .then(() => (databaseBuilder.clean()));
@@ -124,7 +121,7 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
       userId = databaseBuilder.factory.buildUser().id;
 
       knowledgeElementsWantedWithLimitDate = [
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 1, createdAt: yesterday, skillId: '1' , userId}),
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 1, createdAt: yesterday, skillId: '1' , userId }),
         databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 2, createdAt: yesterday, skillId: '3', status: 'validated', userId })
       ];
 

--- a/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
@@ -82,10 +82,21 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
       const answer3Id = databaseBuilder.factory.buildAnswer({ assessmentId: assessmentIdOther }).id;
 
       knowledgeElementsWanted = [
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ assessmentId, answerId: answer1Id, createdAt: '' }),
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ assessmentId, answerId: answer2Id, createdAt: '' })
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+          assessmentId,
+          answerId: answer1Id,
+          createdAt: ''
+        }),
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+          assessmentId,
+          answerId: answer2Id,
+          createdAt: ''
+        })
       ];
-      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ assessmentId: assessmentIdOther, answerId: answer3Id });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        assessmentId: assessmentIdOther,
+        answerId: answer3Id
+      });
       await databaseBuilder.commit();
     });
 
@@ -121,15 +132,36 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
       userId = databaseBuilder.factory.buildUser().id;
 
       knowledgeElementsWantedWithLimitDate = [
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 1, createdAt: yesterday, skillId: '1' , userId }),
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 2, createdAt: yesterday, skillId: '3', status: 'validated', userId })
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+          id: 1,
+          createdAt: yesterday,
+          skillId: '1',
+          userId
+        }),
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+          id: 2,
+          createdAt: yesterday,
+          skillId: '3',
+          status: 'validated',
+          userId
+        })
       ];
 
       knowledgeElementsWanted = knowledgeElementsWantedWithLimitDate.concat([
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 3, createdAt: tomorrow, skillId: '2', userId })
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+          id: 3,
+          createdAt: tomorrow,
+          skillId: '2',
+          userId
+        })
       ]);
 
-      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 4, createdAt: dayBeforeYesterday, skillId: '3', status: 'invalidated' }),
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 4,
+        createdAt: dayBeforeYesterday,
+        skillId: '3',
+        status: 'invalidated'
+      }),
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 5, createdAt: yesterday }),
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 6, createdAt: yesterday }),
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 7, createdAt: today });
@@ -167,5 +199,73 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
       });
     });
 
+  });
+
+  describe('#getSumOfPixFromUserKnowledgeElements', () => {
+
+    let userId;
+    const today = new Date('2018-08-01T12:34:56Z');
+    const yesterday = moment(today).subtract(1, 'days').toDate();
+
+    beforeEach(async () => {
+      // given
+      userId = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 1,
+        skillId: '1',
+        userId,
+        earnedPix: 1,
+      });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 2,
+        skillId: '2',
+        status: 'validated',
+        userId,
+        earnedPix: 1,
+        createdAt: today,
+      });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 3,
+        skillId: '2',
+        userId,
+        earnedPix: 1,
+        createdAt: yesterday,
+      });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 4,
+        skillId: '2',
+        status: 'validated',
+        userId,
+        earnedPix: 1,
+        createdAt: yesterday,
+      });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 5,
+        skillId: '3',
+        userId,
+        earnedPix: 1,
+      });
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
+        id: 6,
+        skillId: '1',
+        status: 'invalidated',
+        userId: userId + 1,
+        earnedPix: 1,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should return the right sum of Pix from user knowledge elements', async () => {
+      // when
+      const result = await SmartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
+
+      expect(result).to.be.equal(3);
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
@@ -122,22 +122,19 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
     beforeEach(async () => {
       // given
       userId = databaseBuilder.factory.buildUser().id;
-      const assessment1Id = databaseBuilder.factory.buildAssessment({ userId, type: SMART_PLACEMENT }).id;
-      const assessment2Id = databaseBuilder.factory.buildAssessment({ userId, type: SMART_PLACEMENT }).id;
-      const assessment3Id = databaseBuilder.factory.buildAssessment({ userId, type: PLACEMENT }).id;
 
       knowledgeElementsWantedWithLimitDate = [
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 1, assessmentId: assessment1Id, createdAt: yesterday, skillId: '1' }),
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 2, assessmentId: assessment2Id, createdAt: yesterday, skillId: '3', status: 'validated' })
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 1, createdAt: yesterday, skillId: '1' , userId}),
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 2, createdAt: yesterday, skillId: '3', status: 'validated', userId })
       ];
 
       knowledgeElementsWanted = knowledgeElementsWantedWithLimitDate.concat([
-        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 3, assessmentId: assessment1Id, createdAt: tomorrow, skillId: '2' })
+        databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 3, createdAt: tomorrow, skillId: '2', userId })
       ]);
 
-      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 4, assessmentId: assessment2Id, createdAt: dayBeforeYesterday, skillId: '3', status: 'invalidated' }),
-      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 5, assessmentId: assessment3Id, createdAt: yesterday }),
-      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 6, assessmentId: assessment3Id, createdAt: yesterday }),
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 4, createdAt: dayBeforeYesterday, skillId: '3', status: 'invalidated' }),
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 5, createdAt: yesterday }),
+      databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 6, createdAt: yesterday }),
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({ id: 7, createdAt: today });
 
       await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
@@ -208,50 +208,52 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
     const yesterday = moment(today).subtract(1, 'days').toDate();
 
     beforeEach(async () => {
+
       // given
       userId = databaseBuilder.factory.buildUser().id;
+      const userId_tmp = databaseBuilder.factory.buildUser().id;
 
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 1,
-        skillId: '1',
+        skillId: 'rec1',
         userId,
-        earnedPix: 1,
+        earnedPix: 5,
       });
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 2,
-        skillId: '2',
+        skillId: 'rec2',
         status: 'validated',
         userId,
-        earnedPix: 1,
+        earnedPix: 10,
         createdAt: today,
       });
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 3,
-        skillId: '2',
+        skillId: 'rec2',
         userId,
-        earnedPix: 1,
+        earnedPix: 1000,
         createdAt: yesterday,
       });
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 4,
-        skillId: '2',
+        skillId: 'rec2',
         status: 'validated',
         userId,
-        earnedPix: 1,
+        earnedPix: 1000,
         createdAt: yesterday,
       });
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 5,
-        skillId: '3',
+        skillId: 'rec3',
         userId,
-        earnedPix: 1,
+        earnedPix: 3,
       });
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
         id: 6,
-        skillId: '1',
+        skillId: 'rec1',
         status: 'invalidated',
-        userId: userId + 1,
-        earnedPix: 1,
+        userId: userId_tmp,
+        earnedPix: 500,
       });
 
       await databaseBuilder.commit();
@@ -263,9 +265,10 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
 
     it('should return the right sum of Pix from user knowledge elements', async () => {
       // when
-      const result = await SmartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
+      const earnedPix = await SmartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
 
-      expect(result).to.be.equal(3);
+      expect(earnedPix).to.equal(18);
     });
+
   });
 });

--- a/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-knowledge-element-repository_test.js
@@ -85,12 +85,10 @@ describe('Integration | Repository | SmartPlacementKnowledgeElementRepository', 
         databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
           assessmentId,
           answerId: answer1Id,
-          createdAt: ''
         }),
         databaseBuilder.factory.buildSmartPlacementKnowledgeElement({
           assessmentId,
           answerId: answer2Id,
-          createdAt: ''
         })
       ];
       databaseBuilder.factory.buildSmartPlacementKnowledgeElement({

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -274,4 +274,25 @@ describe('Unit | Router | user-router', () => {
       });
     });
   });
+
+  describe('GET /api/users/{id}/pixscore', function() {
+    beforeEach(() => {
+      sinon.stub(userController, 'getPixScore').returns('ok');
+      startServer();
+    });
+
+    it('should exist', () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/users/42/pixscore',
+      };
+
+      // when
+      return server.inject(options).then(() => {
+        // then
+        sinon.assert.calledOnce(userController.getPixScore);
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -470,4 +470,34 @@ describe('Unit | Controller | user-controller', () => {
       expect(usecases.findUsers).to.have.been.calledWithMatch({ pagination: expectedPagination });
     });
   });
+
+  describe('#getPixScore', () => {
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getUserPixScore').resolves();
+    });
+
+    it('should return the user Pix score', async () => {
+      // given
+      const authenticatedUserId= '76';
+      const requestedUserId= '76';
+
+      const request = {
+        auth: {
+          credentials: {
+            userId: authenticatedUserId
+          }
+        },
+        params: {
+          id: requestedUserId
+        }
+      };
+
+      // when
+      await userController.getPixScore(request, hFake);
+
+      // then
+      expect(usecases.getUserPixScore).to.have.been.calledWith({ authenticatedUserId, requestedUserId });
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -474,13 +474,13 @@ describe('Unit | Controller | user-controller', () => {
   describe('#getPixScore', () => {
 
     beforeEach(() => {
-      sinon.stub(usecases, 'getUserPixScore').resolves();
+      sinon.stub(usecases, 'getUserPixScore').resolves({ pixScore: 10 });
     });
 
     it('should return the user Pix score', async () => {
       // given
-      const authenticatedUserId= '76';
-      const requestedUserId= '76';
+      const authenticatedUserId = '76';
+      const requestedUserId = '76';
 
       const request = {
         auth: {

--- a/api/tests/unit/domain/usecases/get-user-pix-score_test.js
+++ b/api/tests/unit/domain/usecases/get-user-pix-score_test.js
@@ -14,72 +14,65 @@ describe('Unit | UseCase | get-user-pix-score', () => {
     sinon.restore();
   });
 
-  context('Access management', () => {
+  it('should resolve when authenticated user is the same as asked', () => {
+    // given
+    const authenticatedUserId = 2;
+    const requestedUserId = 2;
+    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
 
-    beforeEach(() => {
-      smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
+    // when
+    const promise = getUserPixScore({
+      authenticatedUserId,
+      requestedUserId,
+      smartPlacementKnowledgeElementRepository,
     });
 
-    it('should resolve when authenticated user is the same as asked', () => {
-      // given
-      const authenticatedUserId = 2;
-      const requestedUserId = 2;
-
-      // when
-      const promise = getUserPixScore({
-        authenticatedUserId,
-        requestedUserId,
-        smartPlacementKnowledgeElementRepository,
-      });
-
-      // then
-      return expect(promise).to.be.fulfilled;
-    });
-
-    it('should reject a "UserNotAuthorizedToAccessEntity" domain error when authenticated user is not the one asked', () => {
-      // given
-      const authenticatedUserId = 34;
-      const requestedUserId = 2;
-
-      // when
-      const promise = getUserPixScore({
-        authenticatedUserId,
-        requestedUserId,
-        smartPlacementKnowledgeElementRepository,
-      });
-
-      // then
-      return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
-    });
+    // then
+    return expect(promise).to.be.fulfilled;
   });
 
-  context('Output checking', () => {
+  it('should reject a "UserNotAuthorizedToAccessEntity" domain error when authenticated user is not the one asked', () => {
+    // given
+    const authenticatedUserId = 34;
+    const requestedUserId = 2;
+    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
 
-    it('should return the user Pix score', async () => {
-      // given
-      const authenticatedUserId = 2;
-      const requestedUserId = 2;
-      const sumOfPixKnowledgeElement = 6;
-      const pixScoreExpected = {
-        pixScore: sumOfPixKnowledgeElement
-      };
-
-      const knowledgeElementList = [
-        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 1, earnedPix: 1 }),
-        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 2, earnedPix: 2 }),
-        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 3, earnedPix: 3 }),
-      ];
-      smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
-
-      // when
-      const userPixScore = await getUserPixScore({
-        authenticatedUserId,
-        requestedUserId,
-        smartPlacementKnowledgeElementRepository,
-      });
-
-      //then
-      expect(userPixScore).to.deep.equal(pixScoreExpected);
+    // when
+    const promise = getUserPixScore({
+      authenticatedUserId,
+      requestedUserId,
+      smartPlacementKnowledgeElementRepository,
     });
+
+    // then
+    return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
+  });
+
+  it('should return the user Pix score', async () => {
+    // given
+    const authenticatedUserId = 2;
+    const requestedUserId = 2;
+    const sumOfPixKnowledgeElement = 6;
+    const pixScoreExpected = {
+      id: requestedUserId,
+      value: sumOfPixKnowledgeElement
+    };
+
+    const knowledgeElementList = [
+      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 1, earnedPix: 1 }),
+      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 2, earnedPix: 2 }),
+      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 3, earnedPix: 3 }),
+    ];
+    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
+
+    // when
+    const userPixScore = await getUserPixScore({
+      authenticatedUserId,
+      requestedUserId,
+      smartPlacementKnowledgeElementRepository,
+    });
+
+    //then
+    expect(userPixScore).to.deep.equal(pixScoreExpected);
   });
 });

--- a/api/tests/unit/domain/usecases/get-user-pix-score_test.js
+++ b/api/tests/unit/domain/usecases/get-user-pix-score_test.js
@@ -1,0 +1,82 @@
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const getUserPixScore = require('../../../../lib/domain/usecases/get-user-pix-score');
+
+describe('Unit | UseCase | get-user-pix-score', () => {
+
+  let smartPlacementKnowledgeElementRepository;
+
+  beforeEach(() => {
+    smartPlacementKnowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  context('Access management', () => {
+
+    beforeEach(() => {
+      smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
+    });
+
+    it('should resolve when authenticated user is the same as asked', () => {
+      // given
+      const authenticatedUserId = 2;
+      const requestedUserId = 2;
+
+      // when
+      const promise = getUserPixScore({
+        authenticatedUserId,
+        requestedUserId,
+        smartPlacementKnowledgeElementRepository,
+      });
+
+      // then
+      return expect(promise).to.be.fulfilled;
+    });
+
+    it('should reject a "UserNotAuthorizedToAccessEntity" domain error when authenticated user is not the one asked', () => {
+      // given
+      const authenticatedUserId = 34;
+      const requestedUserId = 2;
+
+      // when
+      const promise = getUserPixScore({
+        authenticatedUserId,
+        requestedUserId,
+        smartPlacementKnowledgeElementRepository,
+      });
+
+      // then
+      return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('Output checking', () => {
+
+    it('should return the user Pix score', async () => {
+      // given
+      const authenticatedUserId = 2;
+      const requestedUserId = 2;
+      const sumOfPixKnowledgeElement = 6;
+
+      const knowledgeElementList = [
+        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 1, earnedPix: 1 }),
+        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 2, earnedPix: 2 }),
+        domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 3, earnedPix: 3 }),
+      ];
+      smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
+
+      // when
+      const userPixScore = await getUserPixScore({
+        authenticatedUserId,
+        requestedUserId,
+        smartPlacementKnowledgeElementRepository,
+      });
+
+      //then
+      expect(userPixScore).to.equal(sumOfPixKnowledgeElement);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-user-pix-score_test.js
+++ b/api/tests/unit/domain/usecases/get-user-pix-score_test.js
@@ -60,6 +60,9 @@ describe('Unit | UseCase | get-user-pix-score', () => {
       const authenticatedUserId = 2;
       const requestedUserId = 2;
       const sumOfPixKnowledgeElement = 6;
+      const pixScoreExpected = {
+        pixScore: sumOfPixKnowledgeElement
+      };
 
       const knowledgeElementList = [
         domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 1, earnedPix: 1 }),
@@ -76,7 +79,7 @@ describe('Unit | UseCase | get-user-pix-score', () => {
       });
 
       //then
-      expect(userPixScore).to.equal(sumOfPixKnowledgeElement);
+      expect(userPixScore).to.deep.equal(pixScoreExpected);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-user-pix-score_test.js
+++ b/api/tests/unit/domain/usecases/get-user-pix-score_test.js
@@ -1,4 +1,4 @@
-const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 const getUserPixScore = require('../../../../lib/domain/usecases/get-user-pix-score');
 
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-user-pix-score', () => {
   let smartPlacementKnowledgeElementRepository;
 
   beforeEach(() => {
-    smartPlacementKnowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    smartPlacementKnowledgeElementRepository = { getSumOfPixFromUserKnowledgeElements: sinon.stub() };
   });
 
   afterEach(() => {
@@ -18,7 +18,7 @@ describe('Unit | UseCase | get-user-pix-score', () => {
     // given
     const authenticatedUserId = 2;
     const requestedUserId = 2;
-    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
+    smartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements.resolves([]);
 
     // when
     const promise = getUserPixScore({
@@ -35,7 +35,7 @@ describe('Unit | UseCase | get-user-pix-score', () => {
     // given
     const authenticatedUserId = 34;
     const requestedUserId = 2;
-    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves([]);
+    smartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements.resolves([]);
 
     // when
     const promise = getUserPixScore({
@@ -58,12 +58,7 @@ describe('Unit | UseCase | get-user-pix-score', () => {
       value: sumOfPixKnowledgeElement
     };
 
-    const knowledgeElementList = [
-      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 1, earnedPix: 1 }),
-      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 2, earnedPix: 2 }),
-      domainBuilder.buildSmartPlacementKnowledgeElement({ competenceId: 3, earnedPix: 3 }),
-    ];
-    smartPlacementKnowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
+    smartPlacementKnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements.resolves(sumOfPixKnowledgeElement);
 
     // when
     const userPixScore = await getUserPixScore({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -166,6 +166,11 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
                 related: '/users/user_id/campaign-participations'
               },
             },
+            'pix-score': {
+              links: {
+                related: '/users/user_id/pixscore'
+              }
+            },
           },
         },
         included: [
@@ -307,6 +312,11 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
               links: {
                 related: '/users/user_id/campaign-participations'
               },
+            },
+            'pix-score': {
+              links: {
+                related: '/users/user_id/pixscore'
+              }
             },
           },
         },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -53,6 +53,13 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
               'pix-certif-terms-of-service-accepted': false
             },
             id: '234567',
+            'relationships': {
+              'pix-score': {
+                'links': {
+                  'related': '/users/234567/pixscore'
+                }
+              }
+            },
             type: 'users'
           },
           meta: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -103,8 +103,12 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
                 'links': {
                   'related': '/users/234567/certification-center-memberships'
                 }
+              },
+              'pix-score': {
+                'links': {
+                  'related': '/users/234567/pixscore'
+                }
               }
-
             }
           }
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -110,11 +110,6 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
                 'links': {
                   'related': '/users/234567/certification-center-memberships'
                 }
-              },
-              'pix-score': {
-                'links': {
-                  'related': '/users/234567/pixscore'
-                }
               }
             }
           }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -35,7 +35,10 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
           password: '',
           cgu: true,
           pixOrgaTermsOfServiceAccepted: false,
-          pixCertifTermsOfServiceAccepted: false
+          pixCertifTermsOfServiceAccepted: false,
+          memberships: undefined,
+          certificationCenterMemberships: undefined,
+          pixScore: undefined,
         });
         const meta = { some: 'meta' };
         // when
@@ -54,6 +57,16 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             },
             id: '234567',
             'relationships': {
+              'memberships': {
+                'links': {
+                  'related': '/users/234567/memberships'
+                }
+              },
+              'certification-center-memberships': {
+                'links': {
+                  'related': '/users/234567/certification-center-memberships'
+                }
+              },
               'pix-score': {
                 'links': {
                   'related': '/users/234567/pixscore'
@@ -110,7 +123,12 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
                 'links': {
                   'related': '/users/234567/certification-center-memberships'
                 }
-              }
+              },
+              'pix-score': {
+                'links': {
+                  'related': '/users/234567/pixscore'
+                }
+              },
             }
           }
         });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,13 @@ services:
     environment:
       POSTGRES_DB: pix
 
+  postgres_test:
+    image: postgres:10
+    ports:
+      - "6432:5432"
+    environment:
+      POSTGRES_DB: pix_test
+
   redis:
     image: redis
     ports:

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -6,6 +6,6 @@ export default Component.extend({
   pixScore: null,
 
   score: computed('pixScore', function() {
-    return isNone(this.pixScore) ? '--' : this.pixScore;
+    return (isNone(this.pixScore) || this.pixScore === 0) ? '--' : Math.floor(this.pixScore);
   })
 });

--- a/mon-pix/app/models/pix-score.js
+++ b/mon-pix/app/models/pix-score.js
@@ -3,5 +3,5 @@ import DS from 'ember-data';
 const { Model, attr } = DS;
 
 export default Model.extend({
-  value: attr()
+  value: attr('number')
 });

--- a/mon-pix/app/models/pix-score.js
+++ b/mon-pix/app/models/pix-score.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default Model.extend({
+  value: attr()
+});

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -1,7 +1,7 @@
 import { computed } from '@ember/object';
 import DS from 'ember-data';
 
-const { Model, attr, hasMany } = DS;
+const { Model, attr, hasMany, belongsTo } = DS;
 
 export default Model.extend({
   firstName: attr('string'),
@@ -10,9 +10,9 @@ export default Model.extend({
   password: attr('string'),
   cgu: attr('boolean'),
   recaptchaToken: attr('string'),
-  competences: hasMany('competence'),
-  pixScore: attr('number'),
   totalPixScore: attr('number'),
+  pixScore: belongsTo('pix-score'),
+  competences: hasMany('competence'),
   organizations: hasMany('organization'),
   certifications: hasMany('certification'),
   campaignParticipations: hasMany('campaign-participation'),

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -11,6 +11,7 @@ export default Model.extend({
   cgu: attr('boolean'),
   recaptchaToken: attr('string'),
   competences: hasMany('competence'),
+  pixScore: attr('number'),
   totalPixScore: attr('number'),
   organizations: hasMany('organization'),
   certifications: hasMany('certification'),

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -15,7 +15,7 @@
       </div>
 
       <div class="rounded-panel-header__right-wrapper">
-        {{hexagon-score pixScore=model.pixScore}}
+        {{hexagon-score pixScore=model.pixScore.value}}
       </div>
     </div>
 

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -15,7 +15,7 @@
       </div>
 
       <div class="rounded-panel-header__right-wrapper">
-        {{hexagon-score pixScore=model.totalPixScore}}
+        {{hexagon-score pixScore=model.pixScore}}
       </div>
     </div>
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -12,6 +12,7 @@ import getCourse from './routes/get-course';
 import getCourses from './routes/get-courses';
 import getNextChallenge from './routes/get-next-challenge';
 import getOrganizations from './routes/get-organizations';
+import getPixScore from './routes/get-pix-score';
 import getSnapshots from './routes/get-snapshots';
 import getCorrections from './routes/get-corrections';
 import patchAnswer from './routes/patch-answer';
@@ -62,6 +63,7 @@ export default function() {
 
   this.post('/authentications', postAuthentications);
   this.get('/users/me', getAuthenticatedUser);
+  this.get('/users/:id/pixscore', getPixScore);
   this.get('/competences/:id');
   this.get('/areas/:id');
   this.get('/organizations/:id');

--- a/mon-pix/mirage/routes/get-pix-score.js
+++ b/mon-pix/mirage/routes/get-pix-score.js
@@ -1,5 +1,13 @@
 export default function(schema, request) {
   const userId = request.params.id;
-  const user = schema.users.find(userId);
-  return user.pixScore;
+
+  return {
+    data: {
+      type: 'pix-score',
+      id: userId,
+      attributes: {
+        value: 196
+      }
+    }
+  };
 }

--- a/mon-pix/mirage/routes/get-pix-score.js
+++ b/mon-pix/mirage/routes/get-pix-score.js
@@ -1,0 +1,5 @@
+export default function(schema, request) {
+  const userId = request.params.id;
+  const user = schema.users.find(userId);
+  return user.pixScore;
+}

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -17,6 +17,7 @@ export default function(server) {
     recaptchaToken: 'recaptcha-token-xxxxxx',
     totalPixScore: 456,
     competenceIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    pixScore: 196,
   });
 
   server.create('user', {

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -17,7 +17,6 @@ export default function(server) {
     recaptchaToken: 'recaptcha-token-xxxxxx',
     totalPixScore: 456,
     competenceIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    pixScore: 196,
   });
 
   server.create('user', {

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -5,7 +5,7 @@ export default BaseSerializer.extend({
   links(user) {
     return {
       pixScore: {
-        related: `/api/users/${user.id}/pixscore`
+        related: `/users/${user.id}/pixscore`
       }
     };
   }

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -1,5 +1,12 @@
 import BaseSerializer from './application';
 
 export default BaseSerializer.extend({
-  include: ['competences', 'organizations']
+  include: ['competences', 'organizations'],
+  links(user) {
+    return {
+      pixScore: {
+        related: `/api/users/${user.id}/pixscore`
+      }
+    };
+  }
 });

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -25,7 +25,7 @@
     "coverage:rename": "mv coverage/lcov.info ../coverage/mon-pix_lcov.info",
     "dev": "ember server",
     "lint": "eslint app mirage tests",
-    "lint:fix": "npm run lint --fix",
+    "lint:fix": "eslint --fix app mirage tests",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "build": "ember build --environment $BUILD_ENVIRONMENT",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -25,7 +25,7 @@
     "coverage:rename": "mv coverage/lcov.info ../coverage/mon-pix_lcov.info",
     "dev": "ember server",
     "lint": "eslint app mirage tests",
-    "lint:fix": "eslint --fix app mirage tests",
+    "lint:fix": "npm run lint -- --fix",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "build": "ember build --environment $BUILD_ENVIRONMENT",

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -32,9 +32,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       await visit('/profilv2');
 
       // then
-      return andThen(() => {
-        expect(currentURL()).to.equal('/profilv2');
-      });
+      expect(currentURL()).to.equal('/profilv2');
     });
 
     it('should display pixscore', async function() {
@@ -55,9 +53,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       await visit('/profilv2');
 
       // then
-      return andThen(() => {
-        expect(currentURL()).to.equal('/board');
-      });
+      expect(currentURL()).to.equal('/board');
     });
   });
 
@@ -65,24 +61,20 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
     it('should redirect to home, when user is not authenticated', async function() {
       // when
       await visit('/profilv2');
-      return andThen(() => {
-        expect(currentURL()).to.equal('/connexion');
-      });
+      expect(currentURL()).to.equal('/connexion');
     });
 
     it('should stay in /connexion, when authentication failed', async function() {
       // given
       await visit('/connexion');
-      fillIn('#email', 'anyone@pix.world');
-      fillIn('#password', 'Pix20!!');
+      await fillIn('#email', 'anyone@pix.world');
+      await fillIn('#password', 'Pix20!!');
 
       // when
-      click('.button');
+      await click('.button');
 
       // then
-      return andThen(function() {
-        expect(currentURL()).to.equal('/connexion');
-      });
+      expect(currentURL()).to.equal('/connexion');
     });
   });
 });

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -36,6 +36,13 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
         expect(currentURL()).to.equal('/profilv2');
       });
     });
+
+    it('should display pixscore', async function() {
+      await visit('/profilv2');
+
+      // then
+      expect(find('.hexagon-score-content__pix-score').text()).to.contains('196');
+    });
   });
 
   describe('Authenticated cases as user with organization', function() {


### PR DESCRIPTION
## Objectif  🌔 : 
Afficher dans la page profil v2 le total de Pix de l'utilisateur. En utilisant ses `Knowledge Elements`.

## Technique  🚀 :
Ajout d'un endpoint permettant de récupérer le total de Pix (en utilisant ces K.E.).
Et affichage dans l'hexagone de la #403.

## Bon à savoir  👩‍🚀 :
Cette PR est une sous partie de l'US PF_371.
Nous avons dé-corrélé la route du Pix Score de celle du calcul du profil V2, car le total de Pix à terme devra aussi s'afficher sur la page intermédiaire en parcours.