### PR TITLE
[BUGFIX] Afficher le bon message coté front quand l'utilisateur n'a pas partagé sa campagne (PF-541).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -50,7 +50,7 @@ module.exports = {
     return BookshelfCampaignParticipation
       .where({ userId })
       .orderBy('createdAt', 'DESC')
-      .fetchAll({ withRelated: ['campaign'] })
+      .fetchAll({ withRelated: ['campaign', 'assessment'] })
       .then((bookshelfCampaignParticipation) => bookshelfCampaignParticipation.models)
       .then(fp.map(_toDomain));
   },

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
 
   serialize(campaignParticipation, meta) {
     return new Serializer('campaign-participation', {
-      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId',  'campaign', 'user', 'campaignParticipationResult'],
+      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId',  'campaign', 'user', 'campaignParticipationResult', 'assessment'],
       campaign: {
         ref: 'id',
         attributes: ['code', 'title']
@@ -15,6 +15,10 @@ module.exports = {
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName'],
+      },
+      assessment: {
+        ref: 'id',
+        included: false,
       },
       campaignParticipationResult: {
         ref: 'id',

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -58,6 +58,9 @@ describe('Acceptance | API | Campaign Participations', () => {
           campaign: {
             data: null
           },
+          assessment: {
+            data: null
+          },
           user: {
             data: {
               id: `${user.id}`,
@@ -126,6 +129,9 @@ describe('Acceptance | API | Campaign Participations', () => {
                   type: 'campaigns',
                   id: campaign.id.toString()
                 }
+              },
+              assessment: {
+                data: null
               },
               'user': {
                 'data': {

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -73,6 +73,10 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                   data:
                     { type: 'campaigns', id: `${campaign2.id}` },
                 },
+                assessment: {
+                  data:
+                    { type: 'assessments', id: `${campaignParticipation2.assessmentId}` },
+                },
                 user: {
                   data: null
                 },
@@ -97,6 +101,11 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                   data:
                     { type: 'campaigns', id: `${campaign1.id}` },
                 },
+                assessment: {
+                  data:
+                    { type: 'assessments', id: `${campaignParticipation1.assessmentId}` },
+                },
+
                 user: {
                   data: null
                 },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -41,6 +41,9 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
             user: {
               data: null
             },
+            assessment: {
+              data: null,
+            },
             'campaign-participation-result': {
               links: {
                 'related': '/campaign-participations/5/campaign-participation-result'


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
Une régression était apparu coté front : lorsqu'un utilisateur avait fini sa campagne mais ne l'avait pas partager à son organisation, le bandeau de reprise affichait le message "Vous n'avez pas terminé", plutôt que le message "Vous avez terminé ! Partagez vos résultats".

## :woman_technologist: :man_technologist: Technique :
Savoir si une `campaign-participation` est terminé revient à voir si l'`assessment` lié a un status `completed`. Il faut donc que l'objet `campaign-participation` ait un lien vers son assessment.
Durant nos récents développement, on avait retiré coté API un lien vers l'assessment sur la route `/api/users/{id}/campaign-participations`.
J'ai remis ce lien, et tout refonctionne correctement :) 
