### PR TITLE
[BUGFIX] Correction de l'affichage du pourcentage dans le cercle de progression sous IE (PF-552).

### DIFF
--- a/mon-pix/app/components/circle-chart.js
+++ b/mon-pix/app/components/circle-chart.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+
+  classNames: ['skill-review__circle-chart'],
+
+});

--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -22,9 +22,11 @@
 }
 
 .circle-chart__text {
-  display: flex;
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: 100%;
   height: 100%;
-  bottom: 0;
+  top: 0;
 }

--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -1,5 +1,5 @@
 @keyframes progress {
-  0% {
+  to {
     stroke-dasharray: 0 100;
   }
 }
@@ -16,7 +16,7 @@
 
     &--slice {
       stroke: $dark-orange;
-      animation: progress 1s ease-out forwards;
+      animation: progress 1s ease-out reverse;
     }
   }
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -139,5 +139,4 @@
   color: $nero;
   font-family: $font-roboto;
   font-size: 3.1rem;
-  margin: auto;
 }

--- a/mon-pix/app/templates/campaigns/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/skill-review.hbs
@@ -30,11 +30,11 @@
 
   <div class="skill-review-results__header">
     <h2 class="rounded-panel-subtitle">Vos résultats détaillés</h2>
-    <div class="skill-review__circle-chart">
-      {{#circle-chart value=model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
-        <span class="skill-review__circle-chart-value">{{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%</span>
-      {{/circle-chart}}
-    </div>
+    {{#circle-chart value=model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+      <span class="skill-review__circle-chart-value">
+        {{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
+      </span>
+    {{/circle-chart}}
   </div>
 
   <table>


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
En tant qu'utilisateur de mon-pix sous Internet Explorer, je veux pouvoir visualiser correctement ma page de détails de résultats d'un parcours.
