### PR TITLE
[TECH] DatabaseBuilder: reverse the deletion order

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -111,6 +111,7 @@
     "start:watch": "npx nodemon bin/www",
     "test": "npm run test:api",
     "test:api": "NODE_ENV=test npm run db:migrate && NODE_ENV=test mocha --recursive --exit --reporter dot tests",
+    "test:api:unit": "env NODE_ENV=test mocha --recursive --exit --reporter dot tests/unit",
     "test:api:debug": "NODE_ENV=test npx mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test npx mocha --recursive tests --watch --reporter dot",
     "test:scripts": "NODE_ENV=test npx mocha --recursive --reporter dot ./tests/unit/scripts",

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -21,11 +21,12 @@ module.exports = class DatabaseBuilder {
 
   clean() {
     const initialPromise = Promise.resolve();
+    const objectsToDelete = this.databaseBuffer.objectsToInsert.slice().reverse();
 
-    return this.databaseBuffer.objectsToInsert.reduce((promise, objectToInsert) => {
+    return objectsToDelete.reduce((promise, objectToDelete) => {
 
       return promise
-        .then(() => this.knex(objectToInsert.tableName).delete());
+        .then(() => this.knex(objectToDelete.tableName).delete());
 
     }, initialPromise)
       .then(() => {


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin :

The tables where deleted in the order of insertion, generating foreign key constraint errors in PG.

## :woman_technologist: :man_technologist: Technique :

This commit reverses the order for the deletion, fixing 18 tests for PG.

## :nerd_face: Bon à savoir :

Les girafes ont la langue bleue.