### PR TITLE
[BUGFIX] Afficher le bon message coté front quand l'utilisateur n'a pas partagé sa campagne (PF-541).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
 
   serialize(campaignParticipation, meta) {
     return new Serializer('campaign-participation', {
-      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId',  'campaign', 'user', 'campaignParticipationResult'],
+      attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId',  'campaign', 'user', 'campaignParticipationResult', 'assessment'],
       campaign: {
         ref: 'id',
         attributes: ['code', 'title']
@@ -15,6 +15,15 @@ module.exports = {
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName'],
+      },
+      assessment: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record) {
+            return `/assessments/${record.assessmentId}`;
+          }
+        }
       },
       campaignParticipationResult: {
         ref: 'id',

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -64,9 +64,14 @@ describe('Acceptance | API | Campaign Participations', () => {
               type: 'users',
             }
           },
+          assessment: {
+            links: {
+              related: `/assessments/${assessment.id}`
+            }
+          },
           'campaign-participation-result': {
             links: {
-              'related': `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+              related: `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
             }
           },
         }
@@ -131,6 +136,11 @@ describe('Acceptance | API | Campaign Participations', () => {
                 'data': {
                   'id': user.id.toString(),
                   'type': 'users'
+                }
+              },
+              assessment: {
+                links: {
+                  related: `/assessments/${assessment.id}`
                 }
               },
               'campaign-participation-result': {

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -76,6 +76,11 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                 user: {
                   data: null
                 },
+                assessment: {
+                  links: {
+                    related: `/assessments/${campaignParticipation2.assessmentId}`
+                  }
+                },
                 'campaign-participation-result': {
                   links: {
                     'related': `/campaign-participations/${campaignParticipation2.id}/campaign-participation-result`
@@ -99,6 +104,11 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                 },
                 user: {
                   data: null
+                },
+                assessment: {
+                  links: {
+                    related: `/assessments/${campaignParticipation1.assessmentId}`
+                  }
                 },
                 'campaign-participation-result': {
                   links: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -41,6 +41,11 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
             user: {
               data: null
             },
+            assessment: {
+              links: {
+                related: `/assessments/${campaignParticipation.assessmentId}`
+              }
+            },
             'campaign-participation-result': {
               links: {
                 'related': '/campaign-participations/5/campaign-participation-result'

--- a/mon-pix/app/routes/compte.js
+++ b/mon-pix/app/routes/compte.js
@@ -19,9 +19,7 @@ export default BaseRoute.extend(AuthenticatedRouteMixin, {
   },
 
   afterModel(model) {
-
-    return model.get('campaignParticipations')
-      .then(model);
+    return model.hasMany('campaignParticipations').reload();
   },
 
   actions: {


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
Une régression était apparu coté front : lorsqu'un utilisateur avait fini sa campagne mais ne l'avait pas partager à son organisation, le bandeau de reprise affichait le message "Vous n'avez pas terminé", plutôt que le message "Vous avez terminé ! Partagez vos résultats".

## :woman_technologist: :man_technologist: Technique :
Savoir si une `campaign-participation` est terminé revient à voir si l'`assessment` lié a un status `completed`. Il faut donc que l'objet `campaign-participation` ait un lien vers son assessment.
Durant nos récents développement, on avait retiré coté API un lien vers l'assessment sur la route `/api/users/{id}/campaign-participations`.
J'ai ajouté un links dans le serializer et Ember fait le reste.