### PR TITLE
[BUGFIX] Ne pas garder en mémoire les réponses dont l'enregistrement a échoué (PF-555)

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -96,7 +96,10 @@ export default BaseRoute.extend({
       return answer.save()
         .then(
           () => this.transitionTo('assessments.resume', assessment.get('id')),
-          () => this.send('error')
+          () => {
+            answer.rollbackAttributes();
+            return this.send('error');
+          }
         );
     },
     error() {

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -159,6 +159,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
       answerToChallengeOne = EmberObject.create({ challenge: challengeOne });
       answerToChallengeOne.save = sinon.stub().resolves();
       answerToChallengeOne.setProperties = sinon.stub();
+      answerToChallengeOne.rollbackAttributes = sinon.stub();
     });
 
     context('when the answer is already known', function() {
@@ -227,7 +228,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
     });
 
     context('when saving fails', function() {
-      it('should send error', async function() {
+      it('should remove temporary answer and send error', async function() {
         // given
         answerToChallengeOne.save.rejects();
         route.actions.error = sinon.stub();
@@ -240,6 +241,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
         // then
         await expect(promise).to.be.rejected;
         sinon.assert.called(route.actions.error);
+        sinon.assert.called(answerToChallengeOne.rollbackAttributes);
       });
     });
   });


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 

Quand l'enregistrement d'une réponse échoue, la réponse reste dans le _store_ Ember Data, et dans la collection des réponses de l'_assessment_ en cours, mais sans `id` puisque l'enregistrement n'a pas eu lieu.

Si on continue ensuite (sans recharger la page) l'évaluation jusqu'à la page de résultats, alors celle-ci présente des réponses malformées. Et quand on demande le détail d'une de ces réponses la requête envoyée au serveur est invalide (`answerId` vide).

## :woman_technologist: :man_technologist: Technique :
On s'assure d'oublier la réponse créée en mémoire (ou d'annuler les modifications s'il s'agissait d'une modification de réponse) avec un `rollbackAttributes` bien senti.

Le test colle très exactement à l'implémentation 😿, j'aimerais bien savoir faire autrement.

## :nerd_face: Bon à savoir :
⌚️ Jusqu'à l'occupation allemande, la France utilisait le même fuseau horaire que le Royaume-Uni.
