### PR TITLE
[BUGFIX] Suppression du namespace `/api` dans Pix Admin.

### DIFF
--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -3,8 +3,7 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'pix-admin/config/environment';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: ENV.APP.API_HOST,
-  namespace: 'api',
+  host: `${ENV.APP.API_HOST}/api`,
 
   authorize(xhr) {
     let { access_token } = this.get('session.data.authenticated');

--- a/admin/app/adapters/certification-details.js
+++ b/admin/app/adapters/certification-details.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   urlForFindRecord(id) {
-    return `${this.host}/api/admin/certifications/${id}/details`;
+    return `${this.host}/admin/certifications/${id}/details`;
   }
 });

--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -2,15 +2,15 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   urlForFindRecord(id) {
-    return `${this.host}/api/admin/certifications/${id}`;
+    return `${this.host}/admin/certifications/${id}`;
   },
 
   urlForUpdateMarks() {
-    return `${this.host}/api/admin/assessment-results/`;
+    return `${this.host}/admin/assessment-results/`;
   },
 
   urlForUpdateRecord(id) {
-    return `${this.host}/api/certification-courses/${id}`;
+    return `${this.host}/certification-courses/${id}`;
   },
 
   updateRecord(store, type, snapshot) {

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -69,6 +69,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
+    ENV.APP.API_HOST = 'http://localhost:3000';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -27,6 +27,7 @@ export default function() {
 
     http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
   */
+  this.urlPrefix = 'http://localhost:3000';
   this.namespace = '/api';
 
   this.post('/memberships', createMembership);

--- a/admin/mirage/serializers/organization.js
+++ b/admin/mirage/serializers/organization.js
@@ -5,7 +5,7 @@ export default ApplicationSerializer.extend({
   links(organization) {
     return {
       'memberships': {
-        related: `/api/organizations/${organization.id}/memberships`
+        related: `/organizations/${organization.id}/memberships`
       }
     };
   }


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
En tant qu'utilisateur de Pix Admin, je veux pouvoir y accéder et que cela fonctionne :)

## :woman_technologist: :man_technologist: Technique :
Suppression du namespace `/api` dans Pix Admin, de la même manière que les autres appli.

## :nerd_face: Bon à savoir :
Ce sera mis dans l'api dans PF-551.
