### PR TITLE
[BUGFIX] Affiche 100% d'avancement quoiqu'il arrive sur le dernier checkpoint. (PF-542)

### DIFF
--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -14,6 +14,10 @@ export default Controller.extend({
     return this.get('finalCheckpoint') ? 'Voir mes résultats' : 'Continuer mon parcours';
   }),
 
+  completionPercentage: computed('finalCheckpoint', 'model.smartPlacementProgression.completionPercentage', function() {
+    return this.finalCheckpoint ? 100 : this.get('model.smartPlacementProgression.completionPercentage');
+  }),
+
   actions: {
     async openComparisonWindow(answer) {
       const store = this.get('store');

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -11,9 +11,9 @@
 
       <div class="checkpoint-progression-gauge-wrapper">
 
-        {{#progression-gauge total=100 value=model.smartPlacementProgression.completionPercentage
+        {{#progression-gauge total=100 value=completionPercentage
                              progressionClass="progression-gauge--white progression-gauge--tooltip-left"}}
-          <p class="sr-only">Vous avez effectué</p>{{model.smartPlacementProgression.completionPercentage}}%<p
+          <p class="sr-only">Vous avez effectué</p>{{completionPercentage}}%<p
           class="sr-only"> de votre parcours.</p>
         {{/progression-gauge}}
 

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
@@ -17,4 +17,29 @@ describe('Unit | Controller | Assessments | Checkpoint', function() {
       expect(controller.get('finalCheckpoint')).to.be.false;
     });
   });
+
+  describe('#completionPercentage', () => {
+    it('should equal 100 if it is the final checkpoint', function() {
+      // when
+      const controller = this.subject();
+      controller.set('finalCheckpoint', true);
+
+      // then
+      expect(controller.get('completionPercentage')).to.equal(100);
+    });
+
+    it('should equal the smartPlacementProgression completionPercentage', function() {
+      // when
+      const controller = this.subject();
+      const model = {
+        smartPlacementProgression: {
+          completionPercentage: 73,
+        }
+      };
+      controller.set('model', model);
+
+      // then
+      expect(controller.get('completionPercentage')).to.equal(73);
+    });
+  });
 });


### PR DESCRIPTION
## :nerd_face: Bon à savoir :
Le completionPercentage de smartPlacementProgression est censé être complet quand l'assessment est 'completed' mais l'action de mettre l'assessment à completed se fait après le final checkpoint.
