### PR TITLE
[TECH] Ajout d'un script pour analyser le contenu des bundles générés pour les applications front-end.

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -17,6 +17,7 @@
     "test": "tests"
   },
   "scripts": {
+    "analyze": "npx source-map-explorer './dist/assets/*.js'",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
     "coverage": "COVERAGE=true ember test",

--- a/certif/package.json
+++ b/certif/package.json
@@ -17,6 +17,7 @@
     "test": "tests"
   },
   "scripts": {
+    "analyze": "npx source-map-explorer './dist/assets/*.js'",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -17,6 +17,7 @@
     "test": "tests"
   },
   "scripts": {
+    "analyze": "npx source-map-explorer './dist/assets/*.js'",
     "ci:test": "COVERAGE=true ember test --reporter dot",
     "clean": "rm -rf tmp dist node_modules",
     "coverage": "npm run coverage:check && npm run coverage:convert && npm run coverage:rename",

--- a/orga/package.json
+++ b/orga/package.json
@@ -17,6 +17,7 @@
     "test": "tests"
   },
   "scripts": {
+    "analyze": "npx source-map-explorer './dist/assets/*.js'",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
**Analyser le build des différents repo, surtout mon-pix**
Afin de procéder, dans le futur, à des optimisations pour la prod. 

## :woman_technologist: :man_technologist: Technique :
Un analyseur de source maps.
```
cd mon-pix
npm run build
npm run analyze
```
Résultat:
![FireShot Capture 003 -  combined  - Source Map Explorer - ](https://user-images.githubusercontent.com/4154003/55322843-b53f9900-547d-11e9-976b-cd0681be2753.png)

## :nerd_face: Bon à savoir :
Une appli ember en prod importe deux fichiers JS: `vendor.js` et `nom-de-l-app.js`.
- `mon-pix.js`: 500KB
- `vendor.js` 7.55MB

Il y a un gros travail à faire sur les dépendances pour réduire la taille de vendor.  Cette PR informe sur ce besoin, quelle dépendance pèse combien dans le build final. Les mêmes résultats se retrouvent pour orga, certif et admin mais la taille du bundle importe moins car ces applis sont moins customer-facing.