### PR TITLE
[TECH] Spécification de la politique de cache des ressources statiques

### DIFF
--- a/admin/nginx.conf.erb
+++ b/admin/nginx.conf.erb
@@ -1,27 +1,47 @@
-# exactly match the / URI
-location = / {
+root /app/dist/;
 
-  root /app/dist/;
+# in case of 503, serve this URI
+error_page 503 /maintenance_page.html;
+location = /maintenance_page.html {
+  # maintenance page is at the root of the project
+  root /app/;
 }
 
-# all the other URIs
-location / {
+<% if ENV['MAINTENANCE'] == 'enabled' %>
 
-  root /app/dist/;
-  # try_files try to load the file of the URI, and if it fails, it serve the / URI
-  # => in our case, if the uri is not found, it means that's an Ember URL and just return the index
-  # => BECAUSE / is not a file, this would make a infinite redirection loop. So we need the first block without try_files
-  try_files $uri /;
+location / {
+  return 503;
+}
+
+<% else %>
+
+location = /index.html {
+  # index.html should never be cached
+  expires -1;
+}
+
+location /assets/ {
+  # Files in /assets/ are hash-suffixed, so it's safe to cache them indefinitely
+  expires max;
+}
+
+location / {
+  # Fall back to index.html for routes that don't match an existing file
+  try_files $uri /index.html;
+
+  # Let clients cache these files for a bit
+  expires 24h;
 }
 
 location /api/ {
   <%
   # We compute the API host from the front app name, examples:
-  #   pix-app-integration       -> pix-api-integration.scalingo.io
-  #   pix-app-integration-pr123 -> pix-api-integration-pr123.scalingo.io
-  #   pix-app-production        -> pix-api-production.scalingo.io
+  #   pix-orga-integration       -> pix-api-integration.scalingo.io
+  #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
+  #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/-admin-/, "-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
   proxy_redirect default;
 }
 
+<% end %>

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -1,20 +1,36 @@
-set $maintenance_mode <%= ENV['MAINTENANCE'] %>;
+root /app/dist/;
 
 # in case of 503, serve this URI
 error_page 503 /maintenance_page.html;
 location = /maintenance_page.html {
-    # maintenance page is at the root of the project
-    root /app/;
+  # maintenance page is at the root of the project
+  root /app/;
+}
+
+<% if ENV['MAINTENANCE'] == 'enabled' %>
+
+location / {
+  return 503;
+}
+
+<% else %>
+
+location = /index.html {
+  # index.html should never be cached
+  expires -1;
+}
+
+location /assets/ {
+  # Files in /assets/ are hash-suffixed, so it's safe to cache them indefinitely
+  expires max;
 }
 
 location / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
+  # Fall back to index.html for routes that don't match an existing file
+  try_files $uri /index.html;
 
-  root /app/dist/;
-
-  try_files $uri /index.html =404;
+  # Let clients cache these files for a bit
+  expires 24h;
 }
 
 location /api/ {
@@ -28,3 +44,4 @@ location /api/ {
   proxy_redirect default;
 }
 
+<% end %>

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -1,20 +1,36 @@
-set $maintenance_mode <%= ENV['MAINTENANCE'] %>;
+root /app/dist/;
 
 # in case of 503, serve this URI
 error_page 503 /maintenance_page.html;
 location = /maintenance_page.html {
-    # maintenance page is at the root of the project
-    root /app/;
+  # maintenance page is at the root of the project
+  root /app/;
+}
+
+<% if ENV['MAINTENANCE'] == 'enabled' %>
+
+location / {
+  return 503;
+}
+
+<% else %>
+
+location = /index.html {
+  # index.html should never be cached
+  expires -1;
+}
+
+location /assets/ {
+  # Files in /assets/ are hash-suffixed, so it's safe to cache them indefinitely
+  expires max;
 }
 
 location / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
+  # Fall back to index.html for routes that don't match an existing file
+  try_files $uri /index.html;
 
-  root /app/dist/;
-
-  try_files $uri /index.html =404;
+  # Let clients cache these files for a bit
+  expires 24h;
 }
 
 location /api/ {
@@ -28,3 +44,4 @@ location /api/ {
   proxy_redirect default;
 }
 
+<% end %>

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -2,4 +2,6 @@ location ~ ^/(?<app>[^/]+)/.*$ {
   root /app/dist/;
 
   try_files $uri /$app/index.html =404;
+
+  expires -1;
 }

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -1,20 +1,36 @@
-set $maintenance_mode <%= ENV['MAINTENANCE'] %>;
+root /app/dist/;
 
 # in case of 503, serve this URI
 error_page 503 /maintenance_page.html;
 location = /maintenance_page.html {
-    # maintenance page is at the root of the project
-    root /app/;
+  # maintenance page is at the root of the project
+  root /app/;
+}
+
+<% if ENV['MAINTENANCE'] == 'enabled' %>
+
+location / {
+  return 503;
+}
+
+<% else %>
+
+location = /index.html {
+  # index.html should never be cached
+  expires -1;
+}
+
+location /assets/ {
+  # Files in /assets/ are hash-suffixed, so it's safe to cache them indefinitely
+  expires max;
 }
 
 location / {
-  if ($maintenance_mode = enabled) {
-        return 503;
-  }
+  # Fall back to index.html for routes that don't match an existing file
+  try_files $uri /index.html;
 
-  root /app/dist/;
-
-  try_files $uri /index.html =404;
+  # Let clients cache these files for a bit
+  expires 24h;
 }
 
 location /api/ {
@@ -28,3 +44,4 @@ location /api/ {
   proxy_redirect default;
 }
 
+<% end %>


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
On a constaté qu'un nombre non négligeables de navigateurs mettaient en cache le contenu du fichier `index.html` qui sert à démarrer les applications Ember de Pix. En conséquence, ils mettent plus longtemps à se mettre à jour lorsqu'une nouvelle version est déployée, avec le risque d'avoir une application _front_ désynchronisée avec l'API. Pire, on a vu des navigateurs utiliser un ancien `index.html` pour ensuite demander des ressources statiques (ex. `/assets/mon-pix-f54959fb48bfffe11ec408af4553fa60.js`) qui n'existent plus sur le serveur : le résultat étant une erreur ou une page blanche affichée à l'utilisateur.

## :woman_technologist: :man_technologist: Technique :
On utilise les directives Nginx appropriées (`expire`) pour générer les _headers_ de contrôle de cache qui indiquent aux navigateurs quelles ressources peuvent être mises en cache.

Pour `index.html` on indique au navigateur de ne jamais le mettre en cache (`Cache-Control: no-cache`). Cela s'applique aussi aux routes Ember (ex. `/connexion`) qui sont routées en interne vers `/index.html`.

Pour `/assets/*` on indique au navigateur de mettre ces ressources en cache aussi longtemps que possible. En effet, le _build_ Ember s'assure que les fichiers de ce répertoire changent de nom à chaque version, il n'y a donc pas de risque de récupérer un ancien contenu sous un nouveau nom.

Pour les autres fichier (qui devraient peut-être être mieux rangés… ?) on laisse le navigateur les mettre en cache 24h.

Enfin pour les _review apps_, qui ont leur propre configuration Nginx, on désactive la mise en cache pour toutes les ressources.

## 🔬 Comment on sait que ça marche ?

J'ai déclenché manuellement des _review apps_  en mode iso-prod : http://pix-app-integration-pr440.scalingo.io/, http://pix-certif-integration-pr440.scalingo.io/, etc.

On peut ensuite vérifier le _header_ `Cache-Control` sur différentes ressources :
 * https://pix-app-integration-pr440.scalingo.io/ => Cache-Control: no-cache
 * https://pix-app-integration-pr440.scalingo.io/connexion => Cache-Control: no-cache
 * https://pix-app-integration-pr440.scalingo.io/assets/mon-pix-f54959fb48bfffe11ec408af4553fa60.js => Cache-Control: max-age=315360000
 * https://pix-app-integration-pr440.scalingo.io/favicon.ico => Cache-Control: max-age=86400

## :nerd_face: Bon à savoir :

Ça ne résout pas tous les problèmes potentiels de désynchronisation ! Si un utilisateur a chargé l'application, est en train de l'utiliser dans son navigateur, et qu'on déploie une nouvelle version, le navigateur n'a aucune raison de subitement recharger la page. Une piste pour ça serait d'ajouter par exemple un _header_ de version à toutes les réponses de l'API, que l'application _front_ pourrait vérifier à chaque réponse du serveur (par exemple dans l'`adapter` Ember) pour savoir qu'elle est désynchronisée. Il reste à trouver une façon élégante de recharger l'application alors qu'elle est en cours d'utilisation…
