### PR TITLE
[BUGFIX] En tant que user, je veux pouvoir appuyer sur "Entrée" pour valider une réponse d'un parcours (PF-566)

### DIFF
--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -24,7 +24,8 @@ export default Component.extend({
     },
 
     validateAnswer() {
-      this.answerValidated();
+      this.answerValidated()
+        .catch(() => null); // No uncaught errors
     },
   },
 });

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -1,8 +1,9 @@
 import { equal } from '@ember/object/computed';
 import Component from '@ember/component';
+import ChallengeItemGeneric from './challenge-item-generic';
 
-const pendingValue = 'pending';
-const enableValue = 'enable';
+const { enabled, pending, offline } = ChallengeItemGeneric.buttonStatuses;
+
 export default Component.extend({
 
   classNames: ['challenge-actions'],
@@ -10,35 +11,20 @@ export default Component.extend({
   challengeSkipped: null, // action
   answerValidated: null, // action
 
-  _validateButtonStatus: enableValue, // enable, pending, offline
-  _skipButtonStatus: enableValue,
-  isValidateButtonEnable: equal('_validateButtonStatus', enableValue),
-  isValidateButtonPending: equal('_validateButtonStatus', pendingValue),
-  isValidateButtonOffline: equal('_validateButtonStatus', 'offline'),
+  isValidateButtonEnable: equal('validateButtonStatus', enabled),
+  isValidateButtonPending: equal('validateButtonStatus', pending),
+  isValidateButtonOffline: equal('validateButtonStatus', offline),
 
-  isSkipButtonEnable: equal('_skipButtonStatus', enableValue),
-  isSkipButtonPending: equal('_skipButtonStatus', pendingValue),
-
-  didUpdateAttrs() {
-    this._super(...arguments);
-    this.set('_validateButtonStatus', enableValue);
-    this.set('_skipButtonStatus', enableValue);
-  },
+  isSkipButtonEnable: equal('skipButtonStatus', enabled),
+  isSkipButtonPending: equal('skipButtonStatus', pending),
 
   actions: {
     skipChallenge() {
-      if (this._validateButtonStatus === enableValue) {
-        this.set('_skipButtonStatus', pendingValue);
-        this.challengeSkipped();
-      }
+      this.challengeSkipped();
     },
 
     validateAnswer() {
-      if (this._skipButtonStatus === enableValue) {
-        this.set('_validateButtonStatus', pendingValue);
-        this.answerValidated()
-          .catch(() => this.set('_validateButtonStatus', enableValue));
-      }
-    }
-  }
+      this.answerValidated();
+    },
+  },
 });

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -1,31 +1,7 @@
-import { equal } from '@ember/object/computed';
 import Component from '@ember/component';
-import ChallengeItemGeneric from './challenge-item-generic';
-
-const { enabled, pending, offline } = ChallengeItemGeneric.buttonStatuses;
 
 export default Component.extend({
 
   classNames: ['challenge-actions'],
-
-  challengeSkipped: null, // action
-  answerValidated: null, // action
-
-  isValidateButtonEnable: equal('validateButtonStatus', enabled),
-  isValidateButtonPending: equal('validateButtonStatus', pending),
-  isValidateButtonOffline: equal('validateButtonStatus', offline),
-
-  isSkipButtonEnable: equal('skipButtonStatus', enabled),
-  isSkipButtonPending: equal('skipButtonStatus', pending),
-
-  actions: {
-    skipChallenge() {
-      this.challengeSkipped();
-    },
-
-    validateAnswer() {
-      this.answerValidated()
-        .catch(() => null); // No uncaught errors
-    },
-  },
 });
+

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -2,7 +2,6 @@ import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { cancel, later } from '@ember/runloop';
 import Component from '@ember/component';
-import callOnlyOnce from '../utils/call-only-once';
 import _ from 'mon-pix/utils/lodash-custom';
 import ENV from 'mon-pix/config/environment';
 
@@ -112,7 +111,7 @@ const ChallengeItemGeneric = Component.extend({
       }
     },
 
-    skipChallenge: callOnlyOnce(function() {
+    skipChallenge() {
       if (this.validateButtonStatus === buttonStatuses.enabled && this.skipButtonStatus === buttonStatuses.enabled) {
         this.set('errorMessage', null);
         this.set('_isUserAwareThatChallengeIsTimed', false);
@@ -121,7 +120,7 @@ const ChallengeItemGeneric = Component.extend({
         return this.answerValidated(this.challenge, this.assessment, '#ABAND#', this._getTimeout(), this._getElapsedTime())
           .finally(() => this.set('skipButtonStatus', buttonStatuses.enabled));
       }
-    }),
+    },
 
     setUserConfirmation() {
       this._start();

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -2,7 +2,6 @@ import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { cancel, later } from '@ember/runloop';
 import Component from '@ember/component';
-import RSVP from 'rsvp';
 import callOnlyOnce from '../utils/call-only-once';
 import _ from 'mon-pix/utils/lodash-custom';
 import ENV from 'mon-pix/config/environment';
@@ -100,8 +99,8 @@ const ChallengeItemGeneric = Component.extend({
           const errorMessage = this._getErrorMessage();
           
           this.set('errorMessage', errorMessage);
-          
-          return RSVP.reject(errorMessage).catch(() => null);
+
+          return;
         }
         
         this.set('errorMessage', null);
@@ -109,11 +108,8 @@ const ChallengeItemGeneric = Component.extend({
         this.set('validateButtonStatus', buttonStatuses.pending);
         
         return this.answerValidated(this.challenge, this.assessment, this._getAnswerValue(), this._getTimeout(), this._getElapsedTime())
-          .then(() => this.set('validateButtonStatus', buttonStatuses.enabled))
-          .catch(() => this.set('validateButtonStatus', buttonStatuses.enabled));
+          .finally(() => this.set('validateButtonStatus', buttonStatuses.enabled));
       }
-
-      return RSVP.resolve();
     },
 
     skipChallenge: callOnlyOnce(function() {
@@ -123,11 +119,8 @@ const ChallengeItemGeneric = Component.extend({
         this.set('skipButtonStatus', buttonStatuses.pending);
 
         return this.answerValidated(this.challenge, this.assessment, '#ABAND#', this._getTimeout(), this._getElapsedTime())
-          .then(() => this.set('skipButtonStatus', buttonStatuses.enabled))
-          .catch(() => this.set('skipButtonStatus', buttonStatuses.enabled));
+          .finally(() => this.set('skipButtonStatus', buttonStatuses.enabled));
       }
-      
-      return RSVP.resolve();
     }),
 
     setUserConfirmation() {
@@ -138,7 +131,5 @@ const ChallengeItemGeneric = Component.extend({
     },
   },
 });
-
-ChallengeItemGeneric.buttonStatuses = buttonStatuses;
 
 export default ChallengeItemGeneric;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,15 +1,8 @@
 import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
 import { cancel, later } from '@ember/runloop';
 import Component from '@ember/component';
 import _ from 'mon-pix/utils/lodash-custom';
 import ENV from 'mon-pix/config/environment';
-
-const buttonStatuses = {
-  enabled: 'ENABLED',
-  pending: 'PENDING',
-  offline: 'OFFLINE',
-};
 
 const ChallengeItemGeneric = Component.extend({
 
@@ -17,11 +10,8 @@ const ChallengeItemGeneric = Component.extend({
   classNames: ['challenge-item'],
   attributeBindings: ['challenge.id:data-challenge-id'],
 
-  validateButtonStatus: buttonStatuses.enabled,
-  skipButtonStatus: buttonStatuses.enabled,
-
-  isValidateButtonEnabled: equal('validateButtonStatus', buttonStatuses.enabled),
-  isSkipButtonEnabled: equal('skipButtonStatus', buttonStatuses.enabled),
+  isValidateButtonEnabled: true,
+  isSkipButtonEnabled: true,
 
   _elapsedTime: null,
   _timer: null,
@@ -92,7 +82,7 @@ const ChallengeItemGeneric = Component.extend({
 
   actions: {
     validateAnswer() {
-      if (this.validateButtonStatus === buttonStatuses.enabled && this.skipButtonStatus === buttonStatuses.enabled) {
+      if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
         if (this._hasError()) {
 
           const errorMessage = this._getErrorMessage();
@@ -104,21 +94,21 @@ const ChallengeItemGeneric = Component.extend({
         
         this.set('errorMessage', null);
         this.set('_isUserAwareThatChallengeIsTimed', false);
-        this.set('validateButtonStatus', buttonStatuses.pending);
+        this.set('isValidateButtonEnabled', false);
         
         return this.answerValidated(this.challenge, this.assessment, this._getAnswerValue(), this._getTimeout(), this._getElapsedTime())
-          .finally(() => this.set('validateButtonStatus', buttonStatuses.enabled));
+          .finally(() => this.set('isValidateButtonEnabled', true));
       }
     },
 
     skipChallenge() {
-      if (this.validateButtonStatus === buttonStatuses.enabled && this.skipButtonStatus === buttonStatuses.enabled) {
+      if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
         this.set('errorMessage', null);
         this.set('_isUserAwareThatChallengeIsTimed', false);
-        this.set('skipButtonStatus', buttonStatuses.pending);
+        this.set('isSkipButtonEnabled', false);
 
         return this.answerValidated(this.challenge, this.assessment, '#ABAND#', this._getTimeout(), this._getElapsedTime())
-          .finally(() => this.set('skipButtonStatus', buttonStatuses.enabled));
+          .finally(() => this.set('isSkipButtonEnabled', true));
       }
     },
 

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -113,7 +113,7 @@ const ChallengeItemGeneric = Component.extend({
           .catch(() => this.set('validateButtonStatus', buttonStatuses.enabled));
       }
 
-      return Promise.resolve();
+      return RSVP.resolve();
     },
 
     skipChallenge: callOnlyOnce(function() {
@@ -127,7 +127,7 @@ const ChallengeItemGeneric = Component.extend({
           .catch(() => this.set('skipButtonStatus', buttonStatuses.enabled));
       }
       
-      return Promise.resolve();
+      return RSVP.resolve();
     }),
 
     setUserConfirmation() {

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import { cancel, later } from '@ember/runloop';
 import Component from '@ember/component';
 import RSVP from 'rsvp';
@@ -21,7 +22,8 @@ const ChallengeItemGeneric = Component.extend({
   validateButtonStatus: buttonStatuses.enabled,
   skipButtonStatus: buttonStatuses.enabled,
 
-  answerValidated: null, // action
+  isValidateButtonEnabled: equal('validateButtonStatus', buttonStatuses.enabled),
+  isSkipButtonEnabled: equal('skipButtonStatus', buttonStatuses.enabled),
 
   _elapsedTime: null,
   _timer: null,
@@ -99,7 +101,7 @@ const ChallengeItemGeneric = Component.extend({
           
           this.set('errorMessage', errorMessage);
           
-          return RSVP.reject(errorMessage);
+          return RSVP.reject(errorMessage).catch(() => null);
         }
         
         this.set('errorMessage', null);

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -94,8 +94,9 @@ const ChallengeItemGeneric = Component.extend({
     validateAnswer() {
       if (this.validateButtonStatus === buttonStatuses.enabled && this.skipButtonStatus === buttonStatuses.enabled) {
         if (this._hasError()) {
-          const errorMessage = this._getErrorMessage();
 
+          const errorMessage = this._getErrorMessage();
+          
           this.set('errorMessage', errorMessage);
           
           return RSVP.reject(errorMessage);
@@ -109,6 +110,8 @@ const ChallengeItemGeneric = Component.extend({
           .then(() => this.set('validateButtonStatus', buttonStatuses.enabled))
           .catch(() => this.set('validateButtonStatus', buttonStatuses.enabled));
       }
+
+      return Promise.resolve();
     },
 
     skipChallenge: callOnlyOnce(function() {
@@ -121,6 +124,8 @@ const ChallengeItemGeneric = Component.extend({
           .then(() => this.set('skipButtonStatus', buttonStatuses.enabled))
           .catch(() => this.set('skipButtonStatus', buttonStatuses.enabled));
       }
+      
+      return Promise.resolve();
     }),
 
     setUserConfirmation() {

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,5 +1,5 @@
-{{#if isValidateButtonEnable}}
-  <a class="challenge-actions__action challenge-actions__action-validate" {{action "validateAnswer"}} href="#">
+{{#if isValidateButtonEnabled}}
+  <a class="challenge-actions__action challenge-actions__action-validate" {{action validateAnswer}} href="#">
     <span class="challenge-actions__action-validate-text">Je valide</span>
   </a>
 {{else}}
@@ -7,8 +7,8 @@
     <div class="challenge-actions__action-validate__loader-bar"></div>
   </div>
 {{/if}}
-{{#if isSkipButtonEnable}}
-  <a class="challenge-actions__action challenge-actions__action-skip" {{action "skipChallenge"}} href="#">
+{{#if isSkipButtonEnabled}}
+  <a class="challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}} href="#">
     <span class="challenge-actions__action-skip-text">Je passe</span>
   </a>
 {{else}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -5,35 +5,41 @@
 {{/if}}
 
 {{#unless hasChallengeTimer}}
+  <form {{action "validateAnswer" on="submit"}}>
+    {{challenge-statement challenge=challenge assessment=assessment}}
 
-  {{challenge-statement challenge=challenge assessment=assessment}}
-
-  <div class="rounded-panel challenge-response">
-    <div class="rounded-panel__row challenge-proposals">
-      {{qcm-proposals
-        answersValue=answers.value
-        proposals=challenge.proposals
-        answerChanged=(action 'answerChanged')}}
-    </div>
-    {{#if challenge.timer}}
-      {{#if hasUserConfirmWarning}}
-      <div class="rounded-panel__row timeout-jauge-wrapper">
-        {{timeout-jauge allotedTime=challenge.timer}}
+    <div class="rounded-panel challenge-response">
+      <div class="rounded-panel__row challenge-proposals">
+        {{qcm-proposals
+          answersValue=answers.value
+          proposals=challenge.proposals
+          answerChanged=(action 'answerChanged')}}
       </div>
+      {{#if challenge.timer}}
+        {{#if hasUserConfirmWarning}}
+          <div class="rounded-panel__row timeout-jauge-wrapper">
+            {{timeout-jauge allotedTime=challenge.timer}}
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
-
-  {{#if errorMessage}}
-    <div class="alert alert-danger" role="alert">
-      {{errorMessage}}
     </div>
-  {{/if}}
 
-  {{#if assessment}}
-    {{challenge-actions challenge=challenge challengeSkipped=(action "skipChallenge") answerValidated=(action "validateAnswer")}}
-  {{/if}}
+    {{#if errorMessage}}
+      <div class="alert alert-danger" role="alert">
+        {{errorMessage}}
+      </div>
+    {{/if}}
 
+    {{#if assessment}}
+      {{challenge-actions 
+        challenge=challenge 
+        challengeSkipped=(action "skipChallenge") 
+        answerValidated=(action "validateAnswer") 
+        skipButtonStatus=skipButtonStatus 
+        validateButtonStatus=validateButtonStatus
+      }}
+    {{/if}}
+  </form>
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -33,10 +33,10 @@
     {{#if assessment}}
       {{challenge-actions 
         challenge=challenge 
-        challengeSkipped=(action "skipChallenge") 
-        answerValidated=(action "validateAnswer") 
-        skipButtonStatus=skipButtonStatus 
-        validateButtonStatus=validateButtonStatus
+        validateAnswer=(action "validateAnswer") 
+        skipChallenge=(action "skipChallenge") 
+        isValidateButtonEnabled=isValidateButtonEnabled
+        isSkipButtonEnabled=isSkipButtonEnabled 
       }}
     {{/if}}
   </form>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -33,10 +33,10 @@
     {{#if assessment}}
       {{challenge-actions 
         challenge=challenge 
-        challengeSkipped=(action "skipChallenge") 
-        answerValidated=(action "validateAnswer") 
-        skipButtonStatus=skipButtonStatus 
-        validateButtonStatus=validateButtonStatus
+        validateAnswer=(action "validateAnswer") 
+        skipChallenge=(action "skipChallenge") 
+        isValidateButtonEnabled=isValidateButtonEnabled
+        isSkipButtonEnabled=isSkipButtonEnabled 
       }}
     {{/if}}
   </form>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -5,34 +5,41 @@
 {{/if}}
 
 {{#unless hasChallengeTimer}}
+  <form {{action "validateAnswer" on="submit"}}>
+    {{challenge-statement challenge=challenge assessment=assessment}}
 
-  {{challenge-statement challenge=challenge assessment=assessment}}
-
-  <div class="rounded-panel challenge-response">
-    <div class="rounded-panel__row challenge-proposals">
-      {{qcu-proposals
-        answersValue=answers.value
-        proposals=challenge.proposals
-        answerChanged=(action 'answerChanged')}}
-    </div>
-    {{#if challenge.timer}}
-      {{#if hasUserConfirmWarning}}
-        <div class="rounded-panel__row timeout-jauge-wrapper">
-          {{timeout-jauge allotedTime=challenge.timer}}
-        </div>
+    <div class="rounded-panel challenge-response">
+      <div class="rounded-panel__row challenge-proposals">
+        {{qcu-proposals
+          answersValue=answers.value
+          proposals=challenge.proposals
+          answerChanged=(action 'answerChanged')}}
+      </div>
+      {{#if challenge.timer}}
+        {{#if hasUserConfirmWarning}}
+          <div class="rounded-panel__row timeout-jauge-wrapper">
+            {{timeout-jauge allotedTime=challenge.timer}}
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
-
-  {{#if errorMessage}}
-    <div class="alert alert-danger" role="alert">
-      {{errorMessage}}
     </div>
-  {{/if}}
 
-  {{#if assessment}}
-    {{challenge-actions challenge=challenge challengeSkipped=(action "skipChallenge") answerValidated=(action "validateAnswer")}}
-  {{/if}}
+    {{#if errorMessage}}
+      <div class="alert alert-danger" role="alert">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    {{#if assessment}}
+      {{challenge-actions 
+        challenge=challenge 
+        challengeSkipped=(action "skipChallenge") 
+        answerValidated=(action "validateAnswer") 
+        skipButtonStatus=skipButtonStatus 
+        validateButtonStatus=validateButtonStatus
+      }}
+    {{/if}}
+  </form>
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -33,10 +33,10 @@
     {{#if assessment}}
       {{challenge-actions 
         challenge=challenge 
-        challengeSkipped=(action "skipChallenge") 
-        answerValidated=(action "validateAnswer") 
-        skipButtonStatus=skipButtonStatus 
-        validateButtonStatus=validateButtonStatus
+        validateAnswer=(action "validateAnswer") 
+        skipChallenge=(action "skipChallenge") 
+        isValidateButtonEnabled=isValidateButtonEnabled
+        isSkipButtonEnabled=isSkipButtonEnabled 
       }}
     {{/if}}
   </form>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -5,34 +5,41 @@
 {{/if}}
 
 {{#unless hasChallengeTimer}}
+  <form {{action "validateAnswer" on="submit"}}>
+    {{challenge-statement challenge=challenge assessment=assessment}}
 
-  {{challenge-statement challenge=challenge assessment=assessment}}
-
-  <div class="rounded-panel challenge-response">
-    <div class="rounded-panel__row challenge-proposals">
-      {{qroc-proposal
-        proposals=challenge.proposals
-        answerValue=answers.value
-        answerChanged=(action 'answerChanged')}}
-    </div>
-    {{#if challenge.timer}}
-      {{#if hasUserConfirmWarning}}
-        <div class="rounded-panel__row timeout-jauge-wrapper">
-          {{timeout-jauge allotedTime=challenge.timer}}
-        </div>
+    <div class="rounded-panel challenge-response">
+      <div class="rounded-panel__row challenge-proposals">
+        {{qroc-proposal
+          proposals=challenge.proposals
+          answerValue=answers.value
+          answerChanged=(action 'answerChanged')}}
+      </div>
+      {{#if challenge.timer}}
+        {{#if hasUserConfirmWarning}}
+          <div class="rounded-panel__row timeout-jauge-wrapper">
+            {{timeout-jauge allotedTime=challenge.timer}}
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
-
-  {{#if errorMessage}}
-    <div class="alert alert-danger" role="alert">
-      {{errorMessage}}
     </div>
-  {{/if}}
 
-  {{#if assessment}}
-    {{challenge-actions challenge=challenge challengeSkipped=(action "skipChallenge") answerValidated=(action "validateAnswer")}}
-  {{/if}}
+    {{#if errorMessage}}
+      <div class="alert alert-danger" role="alert">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    {{#if assessment}}
+      {{challenge-actions 
+        challenge=challenge 
+        challengeSkipped=(action "skipChallenge") 
+        answerValidated=(action "validateAnswer") 
+        skipButtonStatus=skipButtonStatus 
+        validateButtonStatus=validateButtonStatus
+      }}
+    {{/if}}
+  </form>
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -33,10 +33,10 @@
     {{#if assessment}}
       {{challenge-actions 
         challenge=challenge 
-        challengeSkipped=(action "skipChallenge") 
-        answerValidated=(action "validateAnswer") 
-        skipButtonStatus=skipButtonStatus 
-        validateButtonStatus=validateButtonStatus
+        validateAnswer=(action "validateAnswer") 
+        skipChallenge=(action "skipChallenge") 
+        isValidateButtonEnabled=isValidateButtonEnabled
+        isSkipButtonEnabled=isSkipButtonEnabled 
       }}
     {{/if}}
   </form>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -5,34 +5,41 @@
 {{/if}}
 
 {{#unless hasChallengeTimer}}
+  <form {{action "validateAnswer" on="submit"}}>
+    {{challenge-statement challenge=challenge assessment=assessment}}
 
-  {{challenge-statement challenge=challenge assessment=assessment}}
-
-  <div class="rounded-panel challenge-response">
-    <div class="rounded-panel__row challenge-proposals">
-      {{qrocm-proposal
-        proposals=challenge.proposals
-        answersValue=answers._valuesAsMap
-        answerChanged=(action 'answerChanged') }}
-    </div>
-    {{#if challenge.timer}}
-      {{#if hasUserConfirmWarning}}
-        <div class="rounded-panel__row timeout-jauge-wrapper">
-          {{timeout-jauge allotedTime=challenge.timer}}
-        </div>
+    <div class="rounded-panel challenge-response">
+      <div class="rounded-panel__row challenge-proposals">
+        {{qrocm-proposal
+          proposals=challenge.proposals
+          answersValue=answers._valuesAsMap
+          answerChanged=(action 'answerChanged') }}
+      </div>
+      {{#if challenge.timer}}
+        {{#if hasUserConfirmWarning}}
+          <div class="rounded-panel__row timeout-jauge-wrapper">
+            {{timeout-jauge allotedTime=challenge.timer}}
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
-
-  {{#if errorMessage}}
-    <div class="alert alert-danger" role="alert">
-      {{errorMessage}}
     </div>
-  {{/if}}
 
-  {{#if assessment}}
-    {{challenge-actions challenge=challenge challengeSkipped=(action "skipChallenge") answerValidated=(action "validateAnswer")}}
-  {{/if}}
+    {{#if errorMessage}}
+      <div class="alert alert-danger" role="alert">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    {{#if assessment}}
+      {{challenge-actions 
+        challenge=challenge 
+        challengeSkipped=(action "skipChallenge") 
+        answerValidated=(action "validateAnswer") 
+        skipButtonStatus=skipButtonStatus 
+        validateButtonStatus=validateButtonStatus
+      }}
+    {{/if}}
+  </form>
 {{/unless}}
 
 {{#if canDisplayFeedbackPanel}}

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -22,7 +22,9 @@ describe('Integration | Component | challenge actions', function() {
 
     it('should be displayed and enabled by default but not loader', function() {
       // when
-      this.render(hbs`{{challenge-actions validateButtonStatus="ENABLED"}}`);
+      this.set('isValidateButtonEnabled', true);
+      this.set('externalAction', () => {});
+      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction) isValidateButtonEnabled=isValidateButtonEnabled}}`);
       // then
       expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(1);
       expect(this.$('.challenge-actions__action-validate__loader-bar')).to.have.lengthOf(0);
@@ -30,11 +32,8 @@ describe('Integration | Component | challenge actions', function() {
 
     it('should be replaced by a loader during treatment', function() {
       // given
-      this.set('externalAction', function() {
-        return new RSVP.Promise(() => {
-        });
-      });
-      this.render(hbs`{{challenge-actions answerValidated=(action externalAction)}}`);
+      this.set('externalAction', () => {});
+      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction)}}`);
 
       // when
       this.$(VALIDATE_BUTTON).click();
@@ -46,10 +45,11 @@ describe('Integration | Component | challenge actions', function() {
 
     it('should be enabled again when the treatment failed', function() {
       // given
-      this.set('externalAction', function() {
-        return RSVP.reject('Some error');
-      });
-      this.render(hbs`{{challenge-actions answerValidated=(action externalAction) validateButtonStatus="ENABLED" skipButtonStatus="ENABLED"}}`);
+      this.set('isValidateButtonEnabled', true);
+      this.set('isSkipButtonEnabled', true);
+      this.set('externalAction', () => RSVP.reject('Some error').catch(() => null));
+      this.set('externalAction2', () => {});
+      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction) skipChallenge=(action externalAction2) isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled}}`);
 
       // when
       this.$(VALIDATE_BUTTON).click();
@@ -64,17 +64,17 @@ describe('Integration | Component | challenge actions', function() {
 
     it('should be displayed and enabled by default', function() {
       // when
-      this.render(hbs`{{challenge-actions skipButtonStatus="ENABLED"}}`);
+      this.set('isSkipButtonEnabled', true);
+      this.set('externalAction', () => {});
+      this.render(hbs`{{challenge-actions skipChallenge=(action externalAction) isSkipButtonEnabled=isSkipButtonEnabled}}`);
       // then
       expect(this.$(SKIP_BUTTON)).to.have.lengthOf(1);
     });
 
     it('should be replaced by a loader during treatment', function() {
       // given
-      this.set('externalAction', function() {
-        return new RSVP.Promise(() => {});
-      });
-      this.render(hbs`{{challenge-actions challengeSkipped=(action externalAction)}}`);
+      this.set('externalAction', () => {});
+      this.render(hbs`{{challenge-actions skipChallenge=(action externalAction)}}`);
 
       // when
       this.$(SKIP_BUTTON).click();

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -20,9 +20,9 @@ describe('Integration | Component | challenge actions', function() {
 
   describe('Validate button (and placeholding loader)', function() {
 
-    it('should be displayed and enable by default but not loader', function() {
+    it('should be displayed and enabled by default but not loader', function() {
       // when
-      this.render(hbs`{{challenge-actions}}`);
+      this.render(hbs`{{challenge-actions validateButtonStatus="ENABLED"}}`);
       // then
       expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(1);
       expect(this.$('.challenge-actions__action-validate__loader-bar')).to.have.lengthOf(0);
@@ -44,16 +44,16 @@ describe('Integration | Component | challenge actions', function() {
       expect(this.$('.challenge-actions__action-validate__loader-bar')).to.have.lengthOf(1);
     });
 
-    it('should be enable again when the treatment failed', function() {
+    it('should be enabled again when the treatment failed', function() {
       // given
       this.set('externalAction', function() {
         return RSVP.reject('Some error');
       });
-      this.render(hbs`{{challenge-actions answerValidated=(action externalAction)}}`);
+      this.render(hbs`{{challenge-actions answerValidated=(action externalAction) validateButtonStatus="ENABLED" skipButtonStatus="ENABLED"}}`);
 
       // when
       this.$(VALIDATE_BUTTON).click();
-
+      
       // then
       expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(1);
       expect(this.$('.challenge-actions__action-skip__loader-bar')).to.have.lengthOf(0);
@@ -62,9 +62,9 @@ describe('Integration | Component | challenge actions', function() {
 
   describe('Skip button', function() {
 
-    it('should be displayed and enable by default', function() {
+    it('should be displayed and enabled by default', function() {
       // when
-      this.render(hbs`{{challenge-actions}}`);
+      this.render(hbs`{{challenge-actions skipButtonStatus="ENABLED"}}`);
       // then
       expect(this.$(SKIP_BUTTON)).to.have.lengthOf(1);
     });


### PR DESCRIPTION
## :woman_shrugging: :man_shrugging: Besoin : 
En tant que user, je veux pouvois appuyer sur "Entrée" pour valider une réponse d'un parcours.

## :woman_technologist: :man_technologist: Technique :
Désormais, les status des boutons "skip" (je passe) et "validate" (je valide) sont passés depuis `challenge-item-generic` jusqu'à `challenge-actions` pour pouvoir gérer l'état de la `<form />` nouvellement insérée dans le dom.

## :nerd_face: Bon à savoir :
Les embeds (applications customs) écoutent le keypress Enter et volent la faculté de submit la form en appuyant sur Enter.