### PR TITLE
[TECH] Dispatch d'un CustomEvent au lancement d'un Embed (PF-567)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -19,6 +19,10 @@ export default Component.extend({
   // Actions
   actions: {
     launchSimulator() {
+      const event = new CustomEvent('launch-embed');
+
+      document.dispatchEvent(event);
+
       this.toggleProperty('_isSimulatorNotYetLaunched');
       this._unblurSimulator();
     },


### PR DESCRIPTION
## :unicorn: Problème
Jérémy Jade voulais un moyen de savoir quand un embed était lancé pour exécuter une action au démarrage de l'expérience. ✌

## :robot: Solution
Un CustomEvent (https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent).
