### PR TITLE
[FEATURE] Lier le profil v1 et le profil v2 grâce à un lien cliquable (PF-558).

### DIFF
--- a/mon-pix/app/routes/profilv2.js
+++ b/mon-pix/app/routes/profilv2.js
@@ -18,7 +18,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
       return this.transitionTo('board');
     }
 
+    model.belongsTo('pixScore').reload();
+    model.hasMany('scorecards').reload();
     model.hasMany('campaignParticipations').reload();
-    model.scorecards.reload();
   },
 });

--- a/mon-pix/app/styles/components/_results-warning.scss
+++ b/mon-pix/app/styles/components/_results-warning.scss
@@ -1,17 +1,27 @@
 .results-warning {
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   width: 100%;
   max-width: 1190px;
+  margin-bottom: 50px;
+  margin-top: 10px;
+
+  &__icon {
+    font-size: 1.4em;
+  }
 
   &__warning-message {
-    display: flex;
-    align-items: center;
-    margin-bottom: 50px;
-    margin-top: 10px;
+    padding-left: 10px;
+  }
 
-    @include device-is('tablet') {
-      padding-left: 100px;
+  &__link {
+    color: $charcoal-grey;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $pix-blue-hover;
     }
   }
 }

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -74,7 +74,7 @@
 .rounded-panel-body {
   display: flex;
   flex-direction: column;
-  margin: 30px 0;
+  margin: 4px 0;
 
   &__areas {
     display: flex;
@@ -95,6 +95,13 @@
   &__content {
     margin: 10px 0;
   }
+}
+
+.rounded-panel__link {
+  display: flex;
+  justify-content: flex-end;
+  margin: 4px 0;
+  font-family: $font-roboto;
 }
 
 // Text styles

--- a/mon-pix/app/templates/components/results-warning.hbs
+++ b/mon-pix/app/templates/components/results-warning.hbs
@@ -1,6 +1,7 @@
 {{#if hasCampaignParticipations}}
+  {{fa-icon 'exclamation-circle' class="results-warning__icon"}}
   <div class="results-warning__warning-message">
-    <img src="/images/icons/icon-warning.svg" alt="attention">
-    Les résultats de vos parcours ne sont pas encore visibles dans votre profil mais le seront prochainement.
+    Les résultats de vos parcours ne sont pas encore affichés ici. Vous pouvez les retrouver sur&nbsp;
+    {{#link-to "profilv2" class="link results-warning__link"}}le nouveau profil que nous sommes en train de vous construire{{/link-to}}.
   </div>
 {{/if}}

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -21,6 +21,8 @@
       </div>
     </div>
 
+    {{#link-to "compte" class="link link--grey rounded-panel__link"}}Accès à l'ancien profil{{/link-to}}
+
     <div class="rounded-panel-body">
       {{#each model.areasCode as |areaCode|}}
         <div class="rounded-panel-body__areas">

--- a/mon-pix/tests/acceptance/home-page-test.js
+++ b/mon-pix/tests/acceptance/home-page-test.js
@@ -40,5 +40,17 @@ describe('Acceptance | Home page', function() {
     expect(find('.share-profile__share-button')).to.have.lengthOf(0);
   });
 
+  it('should redirect to profilv2 when user clicks on profilv2 link', async function() {
+    // given
+    await authenticateAsSimpleExternalUser();
+    await visit('/compte');
+
+    // when
+    await click('.results-warning__link');
+
+    // then
+    expect(currentURL()).to.equal('/profilv2');
+  });
+
 });
 

--- a/mon-pix/tests/acceptance/home-page-test.js
+++ b/mon-pix/tests/acceptance/home-page-test.js
@@ -42,7 +42,19 @@ describe('Acceptance | Home page', function() {
 
   it('should redirect to profilv2 when user clicks on profilv2 link', async function() {
     // given
-    await authenticateAsSimpleExternalUser();
+    server.create('assessment', {
+      id: 2,
+      type: 'SMART_PLACEMENT',
+      state: 'completed',
+    });
+    server.create('campaign-participation', {
+      id: 1,
+      isShared: false,
+      campaignId: 1,
+      assessmentId: 2,
+      userId: 1,
+    });
+    await authenticateAsSimpleUser();
     await visit('/compte');
 
     // when

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -35,6 +35,17 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       expect(currentURL()).to.equal('/profilv2');
     });
 
+    it('should redirect to /compte', async function() {
+      // given
+      await visit('/profilv2');
+
+      // when
+      await click('.rounded-panel__link');
+
+      // then
+      expect(currentURL()).to.equal('/compte');
+    });
+
     it('should display pixscore', async function() {
       await visit('/profilv2');
 
@@ -125,7 +136,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
 
     context('when user has completed the campaign but not shared', () => {
 
-      it('should display a resume campagin banner for a campaign with no title', async function() {
+      it('should display a resume campaign banner for a campaign with no title', async function() {
         // given
         server.create('assessment', {
           id: 2,
@@ -149,7 +160,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
         expect(find('.resume-campaign-banner__button').text()).to.equal('Continuer');
       });
 
-      it('should display a resume campagin banner for a campaign with a campaign with a title', async function() {
+      it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
         // given
         server.create('assessment', {
           id: 2,


### PR DESCRIPTION
## :unicorn: Problème
En tant qu'utilisateur de Pix, je voudrais pouvoir accéder au profil v2 lorsque je suis sur mon profil v1. Inversement, lorsque je suis sur mon profil v2, je veux pouvoir revenir sur mon profil v1.

## :robot: Solution
- Ajout d'un lien en bas de page du profil v1 vers le profil v2.
- Ajout d'un lien en haut de page du profil v2 vers le profil v1.

## :rainbow: Remarques
Complétion des routes mirage afin de tester en acceptance la redirection.
