### PR TITLE
[BUGFIX] Correction de l'affichage des détails d'une certification pour une réponse "Abandon" (PA-82).

### DIFF
--- a/api/lib/domain/models/Answer.js
+++ b/api/lib/domain/models/Answer.js
@@ -63,4 +63,8 @@ class Answer {
   }
 }
 
+// FIXME: DO NOT accept "#ABAND#" as an answer, give this information with a boolean,
+//  and transform it to an AnswerStatus "aband" in the api
+Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS = '#ABAND#';
+
 module.exports = Answer;

--- a/api/lib/domain/models/AnswerStatus.js
+++ b/api/lib/domain/models/AnswerStatus.js
@@ -1,7 +1,7 @@
 
 const OK = 'ok';
 const KO = 'ko';
-const SKIPPED = '#ABAND#';
+const SKIPPED = 'aband';
 const TIMEDOUT = 'timedout';
 const PARTIALLY = 'partially';
 const UNIMPLEMENTED = 'unimplemented';

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -22,7 +22,7 @@ class Examiner {
 
     const correctedAnswer = new Answer(answer);
 
-    if (AnswerStatus.isSKIPPED(answer.value)) {
+    if (answer.value === Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
       correctedAnswer.result = AnswerStatus.SKIPPED;
       correctedAnswer.resultDetails = null;
 

--- a/api/lib/domain/services/solution-service.js
+++ b/api/lib/domain/services/solution-service.js
@@ -1,4 +1,5 @@
-const Answer = require('../../infrastructure/data/answer');
+const BookshelfAnswer = require('../../infrastructure/data/answer');
+const Answer = require('../../domain/models/Answer');
 const AnswerStatus = require('../../domain/models/AnswerStatus');
 const AnswerStatusJsonApiAdapter = require('../../infrastructure/adapters/answer-status-json-api-adapter');
 const _ = require('../../infrastructure/utils/lodash-utils');
@@ -38,7 +39,7 @@ module.exports = {
       .getByChallengeId(existingAnswer.get('challengeId'))
       .then((solution) => {
         const answerCorrectness = this.validate(existingAnswer, solution);
-        return new Answer({
+        return new BookshelfAnswer({
           id: existingAnswer.id,
           result: answerCorrectness.result,
           resultDetails: answerCorrectness.resultDetails
@@ -64,7 +65,7 @@ module.exports = {
     let answerStatus;
     let resultDetails = null;
 
-    if (AnswerStatus.isSKIPPED(answerValue)) {
+    if (answerValue === Answer.FAKE_VALUE_FOR_SKIPPED_QUESTIONS) {
       answerStatus = AnswerStatus.SKIPPED;
     } else {
       answerStatus = _adaptAnswerMatcherToSolutionType(solution, answerValue);

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -1343,7 +1343,7 @@ describe('Unit | Service | Certification Service', function() {
 
       it('should has a success rate at 50% with 2W and 1R', () => {
         // given
-        const answers = [new Answer({ result: 'ok' }), new Answer({ result: '#ABAND#' }), new Answer({ result: 'ko' })];
+        const answers = [new Answer({ result: 'ok' }), new Answer({ result: 'aband' }), new Answer({ result: 'ko' })];
 
         // when
         const successRate = certificationService._computeAnswersSuccessRate(answers);

--- a/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/assessment-adapter_test.js
@@ -124,14 +124,14 @@ describe('Unit | Adapter | Assessment', () => {
         const challenge = Object.assign({}, defaultRawChallengeAttrs, { skills });
         const expectedChallenge = defaultCatChallenge;
 
-        const answersGiven = [new Answer({ id: 42, challengeId: challenge.id, result: '#ABAND#' })];
+        const answersGiven = [new Answer({ id: 42, challengeId: challenge.id, result: 'aband' })];
 
         // when
         const adaptedAssessment = assessmentAdapter.getAdaptedAssessment(assessmentId, answersGiven, [challenge], skills);
 
         // then
         const { answers } = adaptedAssessment;
-        expect(answers).to.deep.equal([new CatAnswer(expectedChallenge, '#ABAND#')]);
+        expect(answers).to.deep.equal([new CatAnswer(expectedChallenge, 'aband')]);
       });
     });
   });

--- a/mon-pix/mirage/fixtures/answers.js
+++ b/mon-pix/mirage/fixtures/answers.js
@@ -3,9 +3,9 @@ export default [
   { id: 'ref_answer_qcu_id', value: '2', result:'ok', challengeId: 'ref_qcu_challenge_id', assessment: 'ref_assessment_id' },
   { id: 'ref_answer_qroc_id', value: 'Bill', result:'pending', challengeId: 'ref_qroc_challenge_id', assessment: 'ref_assessment_id' },
   { id: 'ref_answer_qrocm_id', value: 'logiciel1: word\nlogiciel2: excel\nlogiciel3: powerpoint', result:'partially', challengeId: 'ref_qrocm_challenge_id', assessment: 'ref_assessment_id' },
-  { id: 'ref_timed_answer_id', value: '', result:'aband', challengeId: 'ref_timed_challenge_id', assessment: 'ref_timed_challenge_assessment_id' },
-  { id: 'ref_timed_answer_bis_id', value: '', result:'aband', challengeId: 'ref_timed_challenge_bis_id', assessment: 'ref_timed_challenge_assessment_id' },
+  { id: 'ref_timed_answer_id', value: '#ABAND#', result:'aband', challengeId: 'ref_timed_challenge_id', assessment: 'ref_timed_challenge_assessment_id' },
+  { id: 'ref_timed_answer_bis_id', value: '#ABAND#', result:'aband', challengeId: 'ref_timed_challenge_bis_id', assessment: 'ref_timed_challenge_assessment_id' },
 
-  { id: 'first_challenge_answer_id', value: '', result:'aband', challengeId: 'first_challenge_id', assessment: 'numeroted_assessment_id' },
+  { id: 'first_challenge_answer_id', value: '#ABAND#', result:'aband', challengeId: 'first_challenge_id', assessment: 'numeroted_assessment_id' },
   { id: 'second_challenge_answer_id', value: 'Jerem', result:'ok', challengeId: 'second_challenge_id', assessment: 'numeroted_assessment_id' }
 ];


### PR DESCRIPTION
## :unicorn: Problème
En tant qu'utilisateur de Pix Admin, je voyais une réponse affichée comme "OK" alors que le futur certifié a passé la question.

## :robot: Solution
Correction côté api, parce que cette dernière confondait les status et les values.

## :rainbow: Remarques
Si un utilisateur rentre `#ABAND#` dans sa réponse et valide, la question est enregistrée comme "passée"
