### PR TITLE
Fix a few integration tests on PG

### DIFF
--- a/api/tests/integration/infrastructure/utils/query-builder_test.js
+++ b/api/tests/integration/infrastructure/utils/query-builder_test.js
@@ -87,7 +87,7 @@ describe('Integration | Infrastructure | Utils | Query Builder', function() {
           number: 2,
           size: 3,
         },
-        sort: [],
+        sort: ['id'],
         include: [],
       });
 
@@ -107,7 +107,7 @@ describe('Integration | Infrastructure | Utils | Query Builder', function() {
           number: 3,
           size: 2,
         },
-        sort: [],
+        sort: ['id'],
         include: ['user', 'organization'],
       });
 
@@ -159,7 +159,7 @@ describe('Integration | Infrastructure | Utils | Query Builder', function() {
 
     it('should throw a NotFoundError if snapshot can not be found', function() {
       // when
-      const promise = queryBuilder.get(BookshelfSnapshot, 'errorId');
+      const promise = queryBuilder.get(BookshelfSnapshot, -1);
 
       // then
       return expect(promise).to.have.been.rejectedWith(NotFoundError);


### PR DESCRIPTION
## :unicorn: Problème

Environ 150 tests d'intégration et d'acceptance échouent sur PG.

## :robot: Solution

Corrige une dizaine de tests d'intégration sur PG, en ajoutant les valeurs nécessaires aux foreign keys dans le setup de la base, ou en ajoutant des critères de tri pour garantir l'ordre de recherche dans PG.
