### PR TITLE
[TECH] Ajout d'un mécanisme pour les épreuves intégrant un simulateur (embed) permettant d'indiquer à l'iframe quand l'utilisateur lance le simulateur.

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -19,9 +19,11 @@ export default Component.extend({
   // Actions
   actions: {
     launchSimulator() {
-      const event = new CustomEvent('launch-embed');
+      const iframe = this._getIframe();
 
-      document.dispatchEvent(event);
+      // TODO: use correct targetOrigin once the embeds are hosted behind our domain
+      iframe.contentWindow.postMessage('launch', '*');
+      iframe.focus();
 
       this.toggleProperty('_isSimulatorNotYetLaunched');
       this._unblurSimulator();
@@ -35,12 +37,22 @@ export default Component.extend({
   // Internals
   _isSimulatorNotYetLaunched: true,
 
+  _getIframe() {
+    return this.element.querySelector('.challenge-embed-simulator__iframe');
+  },
+
   /* This method is not tested because it would be too difficult (add an observer on a complicated stubbed DOM API element!) */
   _reloadSimulator() {
-    const iframe = this.element.getElementsByClassName('challenge-embed-simulator__iframe').item(0);
+    const iframe = this._getIframe();
     const tmpSrc = iframe.src;
-    iframe.onload = function() {
-      iframe.onload = '';
+
+    // First onload: when we reset the iframe
+    iframe.onload = () => {
+      // Second onload: when we re-assign the iframe's src to its original value
+      iframe.onload = () => {
+        iframe.contentWindow.postMessage('reload', '*');
+        iframe.focus();
+      };
       iframe.src = tmpSrc;
     };
     iframe.src = '';


### PR DESCRIPTION
## :unicorn: Problème
*Pourquoi le CustomEvent n'a pas marché:* Parce que les iframes des embed ont pour origine `github.com` qui n'est pas l'origine de l'application. Pour des raisons de sécurité on ne peut écouter les events en cross-origin.
*Pourquoi postMessage marchera:* Car cette technique fonctionne en cross-origin.
*Pourquoi doit-on merger cette PR pour voir si ça marche:* Parceque Jeremie n'a pas d'environement de developpement. Il utilise staging.pix.fr.

## :robot: Solution
postMessage https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage