### PR TITLE
[BUGFIX] Ajout d'un filtre sur l'accès aux knowledge-elements

### DIFF
--- a/api/tests/acceptance/application/campaign-participations-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations-controller_test.js
@@ -225,6 +225,7 @@ describe('Acceptance | API | Campaign Participations', () => {
       // And starts answering questions
       _([
         { skillId: skillIds1[0], status: 'validated' },
+        { skillId: skillIds1[0], status: 'validated' },
         { skillId: skillIds1[1], status: 'validated' },
         { skillId: skillIds1[2], status: 'validated' },
         { skillId: skillIds1[3], status: 'invalidated' },

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -342,7 +342,7 @@ describe('Integration | Repository | Campaign Participation', () => {
     beforeEach(async () => {
 
       const pixMembers = [
-        { firstName: 'Mélanie', lastName: 'Darboo', assessmentId: assessmentId2, knowledgeElements: [{ skillId: '@web3' }, { skillId: '@web4' }] },
+        { firstName: 'Mélanie', lastName: 'Darboo', assessmentId: assessmentId2, knowledgeElements: [{ skillId: '@web3' }, { skillId: '@web3' }, { skillId: '@web4' }] },
         { firstName: 'Matteo', lastName: 'Lorenzio', knowledgeElements: [] },
         { firstName: 'Jérémy', lastName: 'Bugietta', assessmentId: assessmentId1, knowledgeElements: [{ skillId: '@web2' }, { skillId: '@web1' }] },
         { firstName: 'Léo', lastName: 'Subzéro', knowledgeElements: [] },
@@ -366,7 +366,7 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.clean();
     });
 
-    it('should return paginated campaign participations including users sorted by name, lastname', async () => {
+    it('should return paginated campaign participations including users sorted by name, lastname, their assessment and uniq knowledge elements', async () => {
       // given
       const options = { filter: { campaignId }, sort: [], include: ['user'], page: { number: 1, size: 2 } };
       // when


### PR DESCRIPTION

## :unicorn: Problème
Les `knowledge-elements` que remontent le repository doivent être unique par `skillId` et triés par date de création.

## 😍 Solution
Rajouter un filtrage applicatif comme c'est le cas dans le `knowledge-elements-repository`.
