### PR TITLE
[TECH] Add state of the art markers in the code

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,6 +28,8 @@
 * [-> Components](#components)
 * [-> Routes](#routes)
 
+[Flags du code à l'état de l'art](#flags-du-code-à-létat-de-lart)
+
 ## Notre utilisation de Git
 
 ### Branche `dev`
@@ -379,3 +381,15 @@ export default Route.extend({
     }
 });
 ```
+
+## Flags du code à l'état de l'art
+
+Dans le code Pix, les bouts de code exemplaires, qui illustrent l’état de l’art actuel pour nous, sont signalés par le commentaire `// @exemplary`.
+
+Objectifs :
+
+- faciliter l’accès à l’information (`Ctrl-Shift-F` ou `grep` permet de lister ces bouts de code),
+- accélérer les choix d’implém,
+- et fluidifier la montée en compétence des nouveaux
+
+Pour mettre à jour ces flags, nous soumettons une PR qui suit la même validation que pour la mise à jour du `CONTRIBUTING.md`.


### PR DESCRIPTION
## :unicorn: Problème
> Dans le code il y a régulièrement plusieurs façons de faire.

## :rainbow: Solution
> Afin de pouvoir marquer et retrouver des blocs de code exemplaire, à l'état de l'art du jour, cette PR propose d'ajouter le marqueur `// @exemplary` pour identifier ces parties du code.
