### PR TITLE
[FEATURE] Afficher les pix dans le rond par niveau de 8(PF-568).

### DIFF
--- a/mon-pix/app/components/competence-card.js
+++ b/mon-pix/app/components/competence-card.js
@@ -13,7 +13,7 @@ export default Component.extend({
   }),
 
   percentageAheadOfNextLevel: computed('scorecard.pixScoreAheadOfNextLevel', function() {
-    const percentage = this.scorecard.pixScoreAheadOfNextLevel / NUMBER_OF_PIX_BY_LEVEL * 100;
+    const percentage = Math.floor(this.scorecard.pixScoreAheadOfNextLevel) / NUMBER_OF_PIX_BY_LEVEL * 100;
     return percentage >= MAX_DISPLAYED_PERCENTAGE ? MAX_DISPLAYED_PERCENTAGE : percentage;
   }),
 

--- a/mon-pix/tests/unit/components/competence-card-test.js
+++ b/mon-pix/tests/unit/components/competence-card-test.js
@@ -15,9 +15,11 @@ describe('Unit | Component | competence-card-component', function() {
   describe('#percentageAheadOfNextLevel', function() {
     [
       { pixScoreAheadOfNextLevel: 0, expectedPercentageAheadOfNextLevel: 0 },
+      { pixScoreAheadOfNextLevel: 0.8, expectedPercentageAheadOfNextLevel: 0 },
       { pixScoreAheadOfNextLevel: 4, expectedPercentageAheadOfNextLevel: 50 },
-      { pixScoreAheadOfNextLevel: 3.33, expectedPercentageAheadOfNextLevel: 41.625 },
-      { pixScoreAheadOfNextLevel: 7.8, expectedPercentageAheadOfNextLevel: 95 }
+      { pixScoreAheadOfNextLevel: 3.33, expectedPercentageAheadOfNextLevel: 37.5 },
+      { pixScoreAheadOfNextLevel: 3.8, expectedPercentageAheadOfNextLevel: 37.5 },
+      { pixScoreAheadOfNextLevel: 7.8, expectedPercentageAheadOfNextLevel: 87.5 }
     ].forEach((data) => {
 
       it(`should return ${data.expectedPercentageAheadOfNextLevel} when pixScoreAheadOfNextLevel is ${data.pixScoreAheadOfNextLevel}`, function() {


### PR DESCRIPTION
## :unicorn: Problème
Pour une meilleure visualisation, on souhaite afficher dans le cercle des pix des résultats arrondis : 
- Si l'utilisateur a entre 0 et 0,99 pix, on lui affiche 0 sur le cercle
- Si l'utilisateur a entre 3 et 3,99 pix, on lui affiche 3 sur le cercle

## :robot: Solution
Utiliser Math.floor sur le nombre de pix du niveau

