### PR TITLE
[BUGFIX] Corriger l'alignement des listes à puces pour les phrases trop longues (PF-141)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -14,4 +14,6 @@
 .proposal-text {
   font-weight: $font-normal;
   width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }

--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -16,4 +16,5 @@
   width: 100%;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  line-height: 2.6rem;
 }

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -172,6 +172,7 @@ input[type=radio]:focus:before {
   left: -11px;
   top: 3px;
 }
+
 .qcm-panel__proposal-label {
   display: inline-block;
   line-height: 21px;
@@ -181,8 +182,21 @@ input[type=radio]:focus:before {
 .proposal-comparison-window {
   margin-left: 10px;
 }
+
 .proposal-paragraph {
   margin-left: 7px;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.proposal-paragraph > input[type=radio] {
+  margin-top: 3px;
+}
+
+.proposal-paragraph > input[type=checkbox] {
+  margin-top: 6px;
 }
 /*cursor: pointer is disabled here*/
 .label-proposal-comparison-window {

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -192,11 +192,13 @@ input[type=radio]:focus:before {
 }
 
 .proposal-paragraph > input[type=radio] {
-  margin-top: 3px;
+  margin-top: 7px;
+  flex-shrink: 0;
 }
 
 .proposal-paragraph > input[type=checkbox] {
-  margin-top: 6px;
+  margin-top: 7px;
+  flex-shrink: 0;
 }
 /*cursor: pointer is disabled here*/
 .label-proposal-comparison-window {


### PR DESCRIPTION
## :unicorn: Problème
Avant on avait ça:
![image](https://user-images.githubusercontent.com/4154003/56722456-6832a800-6747-11e9-9975-b79fb107a5ea.png)

## :robot: Solution
Maintenant c'est aligné:
![FireShot Capture 007 - Pix – Mesurez, développez et valorisez vos compétences numériques - localhost](https://user-images.githubusercontent.com/4154003/56722560-a334db80-6747-11e9-86d5-41c88a34a5a1.png)
