### PR TITLE
[FEATURE] Lier la carte de la compétence à la page de détails de cette compétence (PF-554).

### DIFF
--- a/mon-pix/app/routes/competence-details.js
+++ b/mon-pix/app/routes/competence-details.js
@@ -6,13 +6,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   session: service(),
 
-  async model(params) {
-    const user = await this.store.findRecord('user', this.get('session.data.authenticated.userId'));
-
-    if (user.get('organizations.length') > 0) {
-      return this.transitionTo('board');
-    }
-
+  model(params) {
     return this.store.findRecord('scorecard', params.scorecard_id);
   },
 

--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -6,12 +6,12 @@
 
 .circle-chart {
   position: relative;
+  display: flex;
 }
 
 .circle-chart__content {
   width: 100px;
   height: 100px;
-  margin: 2px;
   max-height: 128px;
 
   &--big {

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -95,8 +95,21 @@
 .competence-card__body {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
-  margin-top: 15px;
+  height: 136px;
+  margin-top: 10px;
+  margin-bottom: 4px;
+}
+
+.competence-card__link {
+  border-radius: 50%;
+  border: 0 solid $porcelain-grey;
+  transition: all 0.1s ease-in-out;
+
+  &:hover, &:active, &:focus {
+    border: 8px solid $porcelain-grey;
+  }
 }
 
 .competence-card__level {

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -92,6 +92,26 @@
   }
 }
 
+.icon-button {
+  color: $dove-gray;
+  padding: 4px 8px;
+  border: none;
+  font-size: 1.6rem;
+  background-color: transparent;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.2s ease;
+  border-radius: 50%;
+
+  &:hover, &:active {
+    background-color: $alto-grey;
+  }
+
+  &--link {
+    text-decoration: none;
+  }
+}
+
 .loader-in-button {
   background: url('/images/loader-white.svg');
   background-size: 50px 58px;

--- a/mon-pix/app/styles/pages/_competence-details.scss
+++ b/mon-pix/app/styles/pages/_competence-details.scss
@@ -31,7 +31,8 @@
   &__return-button {
     color: $black;
     font-size: 1.3rem;
-    font-weight: $font-medium;
+    font-weight: $font-semi-bold;
+    text-transform: uppercase;
     letter-spacing: 0.03rem;
     display: flex;
     align-items: center;
@@ -49,7 +50,7 @@
 
 .competence-details-panel-header-return-button {
   &__icon {
-    margin-right: 10px;
+    margin-right: 8px;
   }
 }
 

--- a/mon-pix/app/styles/pages/_competence-details.scss
+++ b/mon-pix/app/styles/pages/_competence-details.scss
@@ -21,6 +21,36 @@
       flex-direction: row;
     }
   }
+
+  &__header {
+    padding: 14px 14px 0 14px;
+  }
+}
+
+.competence-details-panel-header {
+  &__return-button {
+    color: $black;
+    font-size: 1.3rem;
+    font-weight: $font-medium;
+    letter-spacing: 0.03rem;
+    display: flex;
+    align-items: center;
+  }
+
+  &__return-button:hover {
+    text-decoration: none;
+    color: $black;
+
+    > .competence-details-panel-header-return-button__icon {
+      background-color: $alto-grey;
+    }
+  }
+}
+
+.competence-details-panel-header-return-button {
+  &__icon {
+    margin-right: 10px;
+  }
 }
 
 .competence-details-panel-content {

--- a/mon-pix/app/templates/competence-details.hbs
+++ b/mon-pix/app/templates/competence-details.hbs
@@ -8,7 +8,7 @@
         <span class="icon-button competence-details-panel-header-return-button__icon">
           {{fa-icon 'arrow-left'}}
         </span>
-          RETOUR
+        retour
       {{/link-to}}
     </div>
     <div class="competence-details-panel__content">

--- a/mon-pix/app/templates/competence-details.hbs
+++ b/mon-pix/app/templates/competence-details.hbs
@@ -3,6 +3,14 @@
   <div class="background-banner"></div>
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
+    <div class="competence-details-panel__header">
+      {{#link-to "profilv2" class="competence-details-panel-header__return-button"}}
+        <span class="icon-button competence-details-panel-header-return-button__icon">
+          {{fa-icon 'arrow-left'}}
+        </span>
+          RETOUR
+      {{/link-to}}
+    </div>
     <div class="competence-details-panel__content">
       <div class="competence-details-panel-content__left">
         <div class="competence-details-panel-content-left__area competence-details-panel-content-left__area--{{areaColor}}">

--- a/mon-pix/app/templates/components/circle-chart.hbs
+++ b/mon-pix/app/templates/components/circle-chart.hbs
@@ -1,16 +1,12 @@
-<svg viewBox="0 0 36 36" class={{concat "circle-chart__content " chartClass}}>
+<svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " chartClass}}>
   <path class={{concat "circle " thicknessClass}}
-        d="M18 2.0845
-      a 15.9155 15.9155 0 0 1 0 31.831
-      a 15.9155 15.9155 0 0 1 0 -31.831">
+        d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
   </path>
   <!-- wait for value to be ready in order to animate circle under safari -->
   {{#if value}}
     <path class={{concat "circle circle--slice circle--" sliceColor " " thicknessClass}}
           stroke-dasharray="{{value}}, 100"
-          d="M18 2.0845
-      a 15.9155 15.9155 0 0 1 0 31.831
-      a 15.9155 15.9155 0 0 1 0 -31.831">
+          d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
     </path>
   {{/if}}
 </svg>

--- a/mon-pix/app/templates/components/competence-card.hbs
+++ b/mon-pix/app/templates/components/competence-card.hbs
@@ -5,12 +5,15 @@
     <span class="competence-card__competence-name">{{scorecard.name}}</span>
   </header>
   <div class="competence-card__body">
-    {{#circle-chart value=percentageAheadOfNextLevel sliceColor=areaColor chartClass='circle-chart__content--big' thicknessClass='circle--thick'}}
-      <div class="competence-card__level">
-        <span class="competence-card-level__label">Niveau</span>
-        <span class="competence-card-level__value">{{displayedLevel}}</span>
-      </div>
-    {{/circle-chart}}
+    {{#link-to "competence-details" scorecard.id class="competence-card__link"}}
+      {{#circle-chart value=percentageAheadOfNextLevel sliceColor=areaColor chartClass='circle-chart__content--big'
+                      thicknessClass='circle--thick'}}
+        <div class="competence-card__level">
+          <span class="competence-card-level__label">Niveau</span>
+          <span class="competence-card-level__value">{{displayedLevel}}</span>
+        </div>
+      {{/circle-chart}}
+    {{/link-to}}
   </div>
   <footer class="competence-card__footer">
     {{#if (not scorecard.isFinished)}}

--- a/mon-pix/mirage/routes/get-scorecards.js
+++ b/mon-pix/mirage/routes/get-scorecards.js
@@ -5,6 +5,7 @@ export default function(schema, request) {
   const area2 = schema.areas.find(2);
 
   const scorecardN1 = schema.scorecards.create({
+    id: `${userId}_1`,
     name: 'Compétence C1',
     earnedPix: 3,
     level: 2,
@@ -13,6 +14,7 @@ export default function(schema, request) {
     competenceId: 1,
   });
   const scorecardN2 = schema.scorecards.create({
+    id: `${userId}_2`,
     name: 'Compétence C2',
     earnedPix: 7,
     level: 4,
@@ -21,6 +23,7 @@ export default function(schema, request) {
     competenceId: 2,
   });
   const scorecardN3 = schema.scorecards.create({
+    id: `${userId}_3`,
     name: 'Compétence C3',
     earnedPix: 10,
     level: 3,

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -5,7 +5,7 @@ import {
   it,
 } from 'mocha';
 import { expect } from 'chai';
-import { authenticateAsPrescriber, authenticateAsSimpleUser } from '../helpers/testing';
+import { authenticateAsSimpleUser } from '../helpers/testing';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import defaultScenario from '../../mirage/scenarios/default';
@@ -84,20 +84,6 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
 
       // then
       expect(find('.competence-details-panel-content-right__level-info')).to.have.lengthOf(0);
-    });
-  });
-
-  describe('Authenticated cases as user with organization', () => {
-    beforeEach(async () => {
-      await authenticateAsPrescriber();
-    });
-
-    it('can visit /competences/1_1', async () => {
-      // when
-      await visit('/competences/1_1');
-
-      // then
-      expect(currentURL()).to.equal('/board');
     });
   });
 

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -85,6 +85,17 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
       // then
       expect(find('.competence-details-panel-content-right__level-info')).to.have.lengthOf(0);
     });
+
+    it('should transition to /profilv2 when the user clicks on return', async () => {
+      // given
+      await visit('/competences/1_1');
+
+      // when
+      await click('.competence-details-panel-header__return-button');
+
+      // then
+      expect(currentURL()).to.equal('/profilv2');
+    });
   });
 
   describe('Not authenticated cases', () => {

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -73,6 +73,17 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .competence-card-level__value').text()).to.equal('4');
     });
 
+    it('should link to competence-details page on click on level circle', async function() {
+      // given
+      await visit('/profilv2');
+
+      // when
+      await click('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .competence-card__link');
+
+      // then
+      expect(currentURL()).to.equal('/competences/1_2');
+    });
+
     it('should display first competence card of second area', async function() {
       // when
       await visit('/profilv2');


### PR DESCRIPTION
## :unicorn: Problème
En tant qu'utilisateur de Pix, lorsque je vois mon profil V2, je veux pouvoir cliquer sur la carte d'une compétence (le cercle) et être redirigé vers la page de détails d'une compétence.

## :robot: Solution
- Ajout d'un lien sur le cercle
- Modification du svg pour que le bord du rond colle au bord du svg afin qu'on aie un joli rond gris au hover
- Ajout du bouton de retour sur la route competence-details

## :rainbow: Remarques
Le cercle autour est à garder pour la vraie implémentation du hover de la carte entière.
