### PR TITLE
[BUGFIX] Corriger la disposition des réponses d'un QCROQM-ind (PF-570).

### DIFF
--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/template';
 import Component from '@ember/component';
 import _ from 'lodash';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
@@ -27,7 +28,8 @@ const QrocmIndSolutionPanel = Component.extend({
 
   inputFields: computed('challenge.proposals', 'answer.value', 'solution', function() {
 
-    const labels = labelsAsObject(this.get('challenge.proposals'));
+    const escapedProposals = this.get('challenge.proposals').replace(/(\n\n|\n)/gm, '<br>');
+    const labels = labelsAsObject(htmlSafe(escapedProposals).string);
     const answers = answersAsObject(this.get('answer.value'), _.keys(labels));
     const solutions = solutionsAsObject(this.solution);
     const resultDetails = resultDetailsAsObject(this.get('answer.resultDetails'));
@@ -41,6 +43,7 @@ const QrocmIndSolutionPanel = Component.extend({
       if (answers[labelKey] === '') {
         answers[labelKey] = 'Pas de réponse';
       }
+
       const inputField = {
         label: labels[labelKey],
         answer: answers[labelKey],

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -1,50 +1,48 @@
 .correction-qrocm {
-  padding: 10px;
-  display: flex;
-  flex-direction: row;
-}
+  &__text {
+    display: inline-block;
+    font-family: $font-lato;
+    font-size: 1.6rem;
+    line-height: 2.8rem;
+    color: $charcoal-grey;
+  }
 
-.correction-qrocm__text {
-  display: inline-block;
-  font-family: $font-lato;
-  font-size: 1.6rem;
-  line-height: 2.8rem;
-  color: $charcoal-grey;
-}
+  &__answer {
+    &-solution {
+      display: inline-block;
+      vertical-align: top;
+    }
 
-.correction-qrocm__answer-solution {
-  display: inline-block;
-  vertical-align: top;
-}
+    &-input {
+      width: 160px;
+      height: 26px;
+      line-height: 26px;
+      border-radius: 3px;
+      background-color: $white;
+      box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
+      border: solid 1px $alto-grey;
+      padding: 0 10px;
+    }
+  }
 
-.correction-qrocm__answer-input {
-  width: 160px;
-  height: 26px;
-  line-height: 26px;
-  border-radius: 3px;
-  background-color: $white;
-  box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
-  border: solid 1px $alto-grey;
-  padding: 0 10px;
-}
+  &__solution {
+    display: flex;
+    align-items: center;
+    margin-top: 4px;
 
-.correction-qrocm__solution {
-  display: flex;
-  align-items: center;
-  margin-top: 4px;
-}
+    &-img {
+      width: 18px;
+      height: 18px;
+    }
 
-.correction-qrocm__solution-img {
-  width: 18px;
-  height: 18px;
-}
+    &-text {
+      font-family: $font-lato;
+      font-weight: $font-bold;
+      color: $caribbean-green;
+      font-size: 16px;
+      margin-left: 3px;
+      padding-bottom: 1px;
+    }
+  }
 
-.correction-qrocm__solution-text {
-  font-family: $font-lato;
-  font-weight: $font-bold;
-  color: $caribbean-green;
-  font-size: 16px;
-  margin-left: 3px;
-  padding-bottom: 1px;
 }
-

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -4,7 +4,7 @@
   flex-direction: row;
 }
 
-.correction-qrocm__label {
+.correction-qrocm__text {
   display: inline-block;
   font-family: $font-lato;
   font-size: 16px;
@@ -14,7 +14,7 @@
 
 .correction-qrocm__answer-solution {
   display: inline-block;
-  vertical-align: middle;
+  vertical-align: top;
 }
 
 .correction-qrocm__answer-input {

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -4,7 +4,7 @@
   flex-direction: row;
 }
 
-.correction-qrocm__text {
+.correction-qrocm__label {
   display: inline-block;
   font-family: $font-lato;
   font-size: 16px;

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -4,17 +4,21 @@
   flex-direction: row;
 }
 
-.correction-qrocm__label {
+.correction-qrocm__text {
+  display: inline-block;
   font-family: $font-lato;
   font-size: 16px;
   color: $charcoal-grey;
+  line-height: 2.8rem;
 }
 
 .correction-qrocm__answer-solution {
-  margin-left: 10px;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .correction-qrocm__answer-input {
+  width: 160px;
   height: 26px;
   line-height: 26px;
   border-radius: 3px;

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -7,9 +7,9 @@
 .correction-qrocm__text {
   display: inline-block;
   font-family: $font-lato;
-  font-size: 16px;
-  color: $charcoal-grey;
+  font-size: 1.6rem;
   line-height: 2.8rem;
+  color: $charcoal-grey;
 }
 
 .correction-qrocm__answer-solution {

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,31 +1,19 @@
 <div class="qrocm-solution-panel rounded-panel">
-  <div class="rounded-panel__row ">
+  <div class="rounded-panel__row correction-qrocm__text">
+    {{#each inputFields as |field|}}
+      {{{field.label}}}
 
-    <div>
-      {{#each inputFields as |field|}}
-        <div class="correction-qrocm">
+      <div class="correction-qrocm__answer-solution">
+        <input value="{{field.answer}}" class="correction-qrocm__answer-input {{field.inputClass}}" disabled>
 
-          <div class="correction-qrocm__label">
-            <span>{{field.label}}</span>
+        {{#if field.emptyOrWrongAnswer}}
+          <div class="correction-qrocm__solution">
+            <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+            <div class="correction-qrocm__solution-text">{{field.solution}}</div>
           </div>
-
-          <div class="correction-qrocm__answer-solution">
-            <div class="correction-qrocm__answer">
-              <input value="{{field.answer}}" class="correction-qrocm__answer-input {{field.inputClass}}" disabled>
-            </div>
-
-            {{#if field.emptyOrWrongAnswer}}
-              <div class="correction-qrocm__solution">
-                <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
-                <div class="correction-qrocm__solution-text">{{field.solution}}</div>
-              </div>
-            {{/if}}
-          </div>
-
-        </div>
-      {{/each}}
-    </div>
-
+        {{/if}}
+      </div>
+    {{/each}}
   </div>
 </div>
 

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,5 +1,5 @@
 <div class="qrocm-solution-panel rounded-panel">
-  <div class="rounded-panel__row correction-qrocm__text">
+  <div class="rounded-panel__row">
     {{#each inputFields as |field|}}
       {{{field.label}}}
 

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,5 +1,5 @@
 <div class="qrocm-solution-panel rounded-panel">
-  <div class="rounded-panel__row">
+  <div class="rounded-panel__row correction-qrocm__text">
     {{#each inputFields as |field|}}
       {{{field.label}}}
 

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -4,11 +4,25 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-const FIRST_CORRECTION_BLOCK = '.correction-qrocm:nth-child(1)';
-const SECOND_CORRECTION_BLOCK = '.correction-qrocm:nth-child(2)';
-const THIRD_CORRECTION_BLOCK = '.correction-qrocm:nth-child(3)';
+function getLabels(panelElement) {
+  const labels = [];
+  let currentLabel = '';
+
+  for (const node of panelElement.childNodes) {
+    if (node.nodeName === '#text' || node.nodeName === 'BR') {
+      currentLabel += node.textContent;
+    }
+    if (node.nodeName === 'DIV') {
+      labels.push(currentLabel);
+      currentLabel = '';
+    }
+  }
+
+  return labels;
+}
+
+const PANEL = '.rounded-panel__row';
 const SOLUTION_BLOCK = '.correction-qrocm__solution';
-const LABEL = '.correction-qrocm__label';
 const INPUT = '.correction-qrocm__answer-input';
 const SOLUTION_TEXT = '.correction-qrocm__solution-text';
 
@@ -52,8 +66,11 @@ describe('Integration | Component | qrocm solution panel', function() {
     // when
     this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
 
+    const panelElement = document.querySelector(PANEL);
+    const labels = getLabels(panelElement);
+
     // then
-    expect(document.querySelectorAll(LABEL)).to.have.lengthOf(3);
+    expect(labels).to.have.lengthOf(3);
   });
 
   describe('comparison of a qrocm-ind with a right answer, a wrong answer and one empty answer', function() {
@@ -65,11 +82,10 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        const answerBlock = document.querySelector(FIRST_CORRECTION_BLOCK);
-        const answerLabel = document.querySelector(FIRST_CORRECTION_BLOCK + ' ' + LABEL);
-        const answerInput = document.querySelector(FIRST_CORRECTION_BLOCK + ' ' + INPUT);
+        const panelElement = document.querySelector(PANEL);
+        const answerLabel = getLabels(panelElement)[0];
+        const answerInput = document.querySelector(INPUT);
 
-        expect(answerBlock).to.exist;
         expect(answerLabel).to.exist;
         expect(answerInput).to.exist;
 
@@ -82,7 +98,9 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        expect(document.querySelector(FIRST_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK)).to.not.exist;
+        const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK);
+
+        expect(solutionBlock).to.have.lengthOf(2);
       });
     });
 
@@ -93,11 +111,10 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        const answerBlock = document.querySelector(SECOND_CORRECTION_BLOCK);
-        const answerLabel = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + LABEL);
-        const answerInput = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + INPUT);
+        const panelElement = document.querySelector(PANEL);
+        const answerLabel = getLabels(panelElement)[1];
+        const answerInput = document.querySelectorAll(INPUT)[1];
 
-        expect(answerBlock).to.exist;
         expect(answerLabel).to.exist;
         expect(answerInput).to.exist;
 
@@ -110,8 +127,8 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        const solutionBlock = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK);
-        const solutionText = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK + ' ' + SOLUTION_TEXT);
+        const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK)[1];
+        const solutionText = document.querySelectorAll(SOLUTION_TEXT)[1];
 
         expect(solutionBlock).to.exist;
         expect(solutionText).to.exist;
@@ -128,11 +145,10 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        const answerBlock = document.querySelector(THIRD_CORRECTION_BLOCK);
-        const answerLabel = document.querySelector(THIRD_CORRECTION_BLOCK + ' ' + LABEL);
-        const answerInput = document.querySelector(THIRD_CORRECTION_BLOCK + ' ' + INPUT);
+        const panelElement = document.querySelector(PANEL);
+        const answerLabel = getLabels(panelElement)[2];
+        const answerInput = document.querySelectorAll(INPUT)[2];
 
-        expect(answerBlock).to.exist;
         expect(answerLabel).to.exist;
         expect(answerInput).to.exist;
 
@@ -145,8 +161,8 @@ describe('Integration | Component | qrocm solution panel', function() {
         this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
-        const solutionBlock = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK);
-        const solutionText = document.querySelector(SECOND_CORRECTION_BLOCK + ' ' + SOLUTION_BLOCK + ' ' + SOLUTION_TEXT);
+        const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK)[1];
+        const solutionText = document.querySelectorAll(SOLUTION_TEXT)[1];
 
         expect(solutionBlock).to.exist;
         expect(solutionText).to.exist;

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -39,7 +39,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: false,
         inputClass: 'correction-qroc-box__input-right-answer',
       }, {
-        label: 'triste : ',
+        label: '<br>triste : ',
         answer: ':(',
         solution: ':-(',
         emptyOrWrongAnswer: false,
@@ -65,7 +65,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: 'Carte mémoire (SD) : ',
+        label: '<br>Carte mémoire (SD) : ',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
@@ -93,7 +93,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-no-answer',
       }, {
-        label: 'Carte mémoire (SD) : ',
+        label: '<br>Carte mémoire (SD) : ',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
@@ -123,31 +123,31 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: '- leonie@pix.fr : ',
+        label: '<br>- leonie@pix.fr : ',
         answer: '2',
         solution: '3',
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: '- Programme_Pix.pdf : ',
+        label: '<br>- Programme_Pix.pdf : ',
         answer: '3',
         solution: '6',
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: '- lucie@pix.fr : ',
+        label: '<br>- lucie@pix.fr : ',
         answer: '4',
         solution: '1',
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: '- Programme du festival Pix : ',
+        label: '<br>- Programme du festival Pix : ',
         answer: '5',
         solution: '5',
         emptyOrWrongAnswer: false,
         inputClass: 'correction-qroc-box__input-right-answer',
       }, {
-        label: '- jeremy@pix.fr : ',
+        label: '<br>- jeremy@pix.fr : ',
         answer: '6',
         solution: '2',
         emptyOrWrongAnswer: true,
@@ -174,7 +174,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-wrong-answer',
       }, {
-        label: '- Combien le dossier "images" contient-il de fichiers ? ',
+        label: '<br>- Combien le dossier "images" contient-il de fichiers ? ',
         answer: '3',
         solution: '6',
         emptyOrWrongAnswer: true,
@@ -201,7 +201,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         emptyOrWrongAnswer: true,
         inputClass: 'correction-qroc-box__input-no-answer',
       }, {
-        label: 'Carte mémoire (SD) : ',
+        label: '<br>Carte mémoire (SD) : ',
         answer: 'Pas de réponse',
         solution: '1',
         emptyOrWrongAnswer: true,


### PR DESCRIPTION
## :unicorn: Problème
Le texte des réponses à un QCROQM-ind s'affiche mal, il était optimisé pour les QCROQM-ind sous forme le liste:
![image](https://user-images.githubusercontent.com/4154003/56890048-9f22f980-6a78-11e9-924a-4c857a20cd93.png)
![image](https://user-images.githubusercontent.com/4154003/56890088-beba2200-6a78-11e9-8e6a-4b8e2acddf32.png)

## :robot: Solution
Corriger la disposition des réponses, remplacer les listes (div) par des blocks de texte inline:
![image](https://user-images.githubusercontent.com/4154003/56890347-7b13e800-6a79-11e9-97ac-a56da1302e30.png)
![image](https://user-images.githubusercontent.com/4154003/56890316-66375480-6a79-11e9-85ea-c4c995688124.png)



## :rainbow: Remarques
Un compromis a été fait sur la margin entre deux labels