### PR TITLE
[TECH] Ajout d'un namespace "/api" dans les resources exposées par l'API ainsi que les adapters des apps front-end (PF-551).

### DIFF
--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -3,7 +3,8 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'pix-admin/config/environment';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: `${ENV.APP.API_HOST}/api`,
+  host: ENV.APP.API_HOST,
+  namespace: 'api',
 
   authorize(xhr) {
     const { access_token } = this.get('session.data.authenticated');

--- a/admin/app/adapters/certification-details.js
+++ b/admin/app/adapters/certification-details.js
@@ -2,6 +2,6 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   urlForFindRecord(id) {
-    return `${this.host}/admin/certifications/${id}/details`;
+    return `${this.host}/${this.namespace}/admin/certifications/${id}/details`;
   }
 });

--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -2,15 +2,15 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   urlForFindRecord(id) {
-    return `${this.host}/admin/certifications/${id}`;
+    return `${this.host}/${this.namespace}/admin/certifications/${id}`;
   },
 
   urlForUpdateMarks() {
-    return `${this.host}/admin/assessment-results/`;
+    return `${this.host}/${this.namespace}/admin/assessment-results/`;
   },
 
   urlForUpdateRecord(id) {
-    return `${this.host}/certification-courses/${id}`;
+    return `${this.host}/${this.namespace}/certification-courses/${id}`;
   },
 
   updateRecord(store, type, snapshot) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -28,7 +28,7 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
   */
   this.urlPrefix = 'http://localhost:3000';
-  this.namespace = '/api';
+  this.namespace = 'api';
 
   this.post('/memberships', createMembership);
   this.get('/organizations/:id');

--- a/admin/mirage/serializers/organization.js
+++ b/admin/mirage/serializers/organization.js
@@ -5,7 +5,7 @@ export default ApplicationSerializer.extend({
   links(organization) {
     return {
       'memberships': {
-        related: `/organizations/${organization.id}/memberships`
+        related: `/api/organizations/${organization.id}/memberships`
       }
     };
   }

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -46,7 +46,7 @@ module.exports = {
         ref: 'id',
         relationshipLinks: {
           related(record, current) {
-            return `/progressions/${current.id}`;
+            return `/api/progressions/${current.id}`;
           }
         }
       }

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -21,7 +21,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related(record) {
-            return `/assessments/${record.assessmentId}`;
+            return `/api/assessments/${record.assessmentId}`;
           }
         },
       },
@@ -30,7 +30,7 @@ module.exports = {
         ignoreRelationshipData: ignoreCampaignParticipationResultsRelationshipData,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/campaign-participations/${parent.id}/campaign-participation-result`;
+            return `/api/campaign-participations/${parent.id}/campaign-participation-result`;
           }
         },
         attributes: ['id', 'isCompleted', 'totalSkillsCount', 'testedSkillsCount', 'validatedSkillsCount', 'competenceResults'],

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -25,7 +25,7 @@ module.exports = {
         ignoreRelationshipData: ignoreCampaignReportRelationshipData,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/campaigns/${parent.id}/campaign-report`;
+            return `/api/campaigns/${parent.id}/campaign-report`;
           }
         }
       },

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -18,7 +18,7 @@ module.exports = {
           ignoreRelationshipData: true,
           relationshipLinks: {
             related: function(record, current, parent) {
-              return `/certification-centers/${parent.id}/sessions`;
+              return `/api/certification-centers/${parent.id}/sessions`;
             }
           }
         }

--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -23,7 +23,7 @@ module.exports = {
           ignoreRelationshipData: true,
           relationshipLinks: {
             related: function(record, current, parent) {
-              return `/organizations/${parent.id}/campaigns`;
+              return `/api/organizations/${parent.id}/campaigns`;
             }
           }
         },
@@ -32,7 +32,7 @@ module.exports = {
           ignoreRelationshipData: true,
           relationshipLinks: {
             related: function(record, current, parent) {
-              return `/organizations/${parent.id}/target-profiles`;
+              return `/api/organizations/${parent.id}/target-profiles`;
             }
           }
         }

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -14,7 +14,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/organizations/${parent.id}/memberships`;
+            return `/api/organizations/${parent.id}/memberships`;
           }
         }
       },

--- a/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/profile-serializer.js
@@ -38,7 +38,7 @@ class ProfileSerializer extends JSONAPISerializer {
   _serializeCampaignParticipationsLink(data, entity) {
     data.relationships['campaign-participations'] = {
       links: {
-        related: `/users/${entity.id}/campaign-participations`
+        related: `/api/users/${entity.id}/campaign-participations`
       }
     };
   }
@@ -46,7 +46,7 @@ class ProfileSerializer extends JSONAPISerializer {
   _serializePixScoreLink(data, entity) {
     data.relationships['pix-score'] = {
       links: {
-        related: `/users/${entity.id}/pixscore`
+        related: `/api/users/${entity.id}/pixscore`
       }
     };
   }
@@ -54,7 +54,7 @@ class ProfileSerializer extends JSONAPISerializer {
   _serializeScorecardsLink(data, entity) {
     data.relationships['scorecards'] = {
       links: {
-        related: `/users/${entity.id}/scorecards`
+        related: `/api/users/${entity.id}/scorecards`
       }
     };
   }
@@ -163,7 +163,7 @@ class ProfileSerializer extends JSONAPISerializer {
         relationships: {
           snapshots: {
             links: {
-              related: `/organizations/${organizationJson.id}/snapshots`
+              related: `/api/organizations/${organizationJson.id}/snapshots`
             }
           }
         }

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -11,7 +11,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/users/${parent.id}/memberships`;
+            return `/api/users/${parent.id}/memberships`;
           }
         }
       },
@@ -20,7 +20,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related: function(record, current, parent) {
-            return `/users/${parent.id}/certification-center-memberships`;
+            return `/api/users/${parent.id}/certification-center-memberships`;
           }
         }
       },
@@ -29,7 +29,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related: function(record, current, parent) {
-            return `/users/${parent.id}/pixscore`;
+            return `/api/users/${parent.id}/pixscore`;
           }
         }
       },
@@ -38,7 +38,7 @@ module.exports = {
         ignoreRelationshipData: true,
         relationshipLinks: {
           related: function(record, current, parent) {
-            return `/users/${parent.id}/scorecards`;
+            return `/api/users/${parent.id}/scorecards`;
           }
         }
       },

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -66,12 +66,12 @@ describe('Acceptance | API | Campaign Participations', () => {
           },
           assessment: {
             links: {
-              related: `/assessments/${assessment.id}`
+              related: `/api/assessments/${assessment.id}`
             }
           },
           'campaign-participation-result': {
             links: {
-              related: `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+              related: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
             }
           },
         }
@@ -140,12 +140,12 @@ describe('Acceptance | API | Campaign Participations', () => {
               },
               assessment: {
                 links: {
-                  related: `/assessments/${assessment.id}`
+                  related: `/api/assessments/${assessment.id}`
                 }
               },
               'campaign-participation-result': {
                 links: {
-                  'related': `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+                  'related': `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
                 }
               }
             }

--- a/api/tests/acceptance/application/campaign-participations-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations-controller_test.js
@@ -66,12 +66,12 @@ describe('Acceptance | API | Campaign Participations', () => {
           },
           assessment: {
             links: {
-              related: `/assessments/${assessment.id}`
+              related: `/api/assessments/${assessment.id}`
             }
           },
           'campaign-participation-result': {
             links: {
-              related: `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+              related: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
             }
           },
         }
@@ -140,12 +140,12 @@ describe('Acceptance | API | Campaign Participations', () => {
               },
               assessment: {
                 links: {
-                  related: `/assessments/${assessment.id}`
+                  related: `/api/assessments/${assessment.id}`
                 }
               },
               'campaign-participation-result': {
                 links: {
-                  related: `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+                  related: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
                 }
               }
             }
@@ -271,7 +271,7 @@ describe('Acceptance | API | Campaign Participations', () => {
             relationships: {
               assessment: {
                 links: {
-                  related: '/assessments/1',
+                  related: '/api/assessments/1',
                 }
               },
               campaign: {
@@ -283,7 +283,7 @@ describe('Acceptance | API | Campaign Participations', () => {
                   type: 'campaignParticipationResults',
                 },
                 links: {
-                  'related': '/campaign-participations/1/campaign-participation-result'
+                  'related': '/api/campaign-participations/1/campaign-participation-result'
                 },
               },
               user: {

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -519,7 +519,7 @@ describe('Acceptance | Application | organization-controller', () => {
               },
               'memberships': {
                 'links': {
-                  'related': `/organizations/${organization.id}/memberships`
+                  'related': `/api/organizations/${organization.id}/memberships`
                 }
               }
             },

--- a/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
@@ -63,7 +63,7 @@ describe('Acceptance | Controller | users-controller-get-certification-center-me
               relationships: {
                 sessions: {
                   links: {
-                    related: `/certification-centers/${certificationCenter.id.toString()}/sessions`
+                    related: `/api/certification-centers/${certificationCenter.id.toString()}/sessions`
                   }
                 }
               }

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -113,12 +113,12 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
               relationships: {
                 campaigns: {
                   links: {
-                    related: `/organizations/${organizationId.toString()}/campaigns`
+                    related: `/api/organizations/${organizationId.toString()}/campaigns`
                   }
                 },
                 'target-profiles': {
                   links: {
-                    related: `/organizations/${organizationId.toString()}/target-profiles`
+                    related: `/api/organizations/${organizationId.toString()}/target-profiles`
                   }
                 }
               }

--- a/api/tests/acceptance/application/users/users-controller-get-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-profile_test.js
@@ -42,17 +42,17 @@ describe('Acceptance | Controller | users-controller-get-profile', () => {
         },
         'campaign-participations': {
           links: {
-            related: '/users/1234/campaign-participations'
+            related: '/api/users/1234/campaign-participations'
           },
         },
         'pix-score': {
           'links': {
-            'related': '/users/1234/pixscore'
+            'related': '/api/users/1234/pixscore'
           }
         },
         'scorecards': {
           'links': {
-            'related': '/users/1234/scorecards'
+            'related': '/api/users/1234/scorecards'
           }
         },
       }

--- a/api/tests/acceptance/application/users/users-controller-get-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user_test.js
@@ -55,22 +55,22 @@ describe('Acceptance | Controller | users-controller-get-user', () => {
           relationships: {
             'memberships': {
               links: {
-                related: '/users/1234/memberships'
+                related: '/api/users/1234/memberships'
               }
             },
             'certification-center-memberships': {
               links: {
-                related: '/users/1234/certification-center-memberships'
+                related: '/api/users/1234/certification-center-memberships'
               }
             },
             'pix-score' : {
               links: {
-                related: '/users/1234/pixscore'
+                related: '/api/users/1234/pixscore'
               }
             },
             scorecards: {
               links: {
-                related: '/users/1234/scorecards'
+                related: '/api/users/1234/scorecards'
               }
             }
           }

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -68,22 +68,22 @@ describe('Acceptance | Controller | users-controller', () => {
             '"relationships":{' +
               '"memberships":{' +
                 '"links":{' +
-                  '"related":"/users/(\\d+)/memberships"' +
+                  '"related":"/api/users/(\\d+)/memberships"' +
                 '}' +
               '},' +
               '"certification-center-memberships":{' +
                 '"links":{' +
-                  '"related":"/users/(\\d+)/certification-center-memberships"' +
+                  '"related":"/api/users/(\\d+)/certification-center-memberships"' +
                 '}' +
               '},' +
               '"pix-score":{' +
                 '"links":{' +
-                  '"related":"/users/(\\d+)/pixscore"' +
+                  '"related":"/api/users/(\\d+)/pixscore"' +
                 '}' +
               '},' +
               '"scorecards":{' +
                 '"links":{' +
-                  '"related":"/users/(\\d+)/scorecards"' +
+                  '"related":"/api/users/(\\d+)/scorecards"' +
                 '}' +
               '}' +
             '}' +

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -78,12 +78,12 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                 },
                 assessment: {
                   links: {
-                    related: `/assessments/${campaignParticipation2.assessmentId}`
+                    related: `/api/assessments/${campaignParticipation2.assessmentId}`
                   }
                 },
                 'campaign-participation-result': {
                   links: {
-                    'related': `/campaign-participations/${campaignParticipation2.id}/campaign-participation-result`
+                    'related': `/api/campaign-participations/${campaignParticipation2.id}/campaign-participation-result`
                   }
                 },
               },
@@ -107,12 +107,12 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                 },
                 assessment: {
                   links: {
-                    related: `/assessments/${campaignParticipation1.assessmentId}`
+                    related: `/api/assessments/${campaignParticipation1.assessmentId}`
                   }
                 },
                 'campaign-participation-result': {
                   links: {
-                    'related': `/campaign-participations/${campaignParticipation1.id}/campaign-participation-result`
+                    'related': `/api/campaign-participations/${campaignParticipation1.id}/campaign-participation-result`
                   }
                 }
               },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -65,7 +65,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
           type: 'progressions',
         },
         links: {
-          related: `/progressions/progression-${assessment.id}`,
+          related: `/api/progressions/progression-${assessment.id}`,
         }
       };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -53,12 +53,12 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
             },
             assessment: {
               links: {
-                related: `/assessments/${campaignParticipation.assessmentId}`
+                related: `/api/assessments/${campaignParticipation.assessmentId}`
               }
             },
             'campaign-participation-result': {
               links: {
-                'related': '/campaign-participations/5/campaign-participation-result'
+                'related': '/api/campaign-participations/5/campaign-participation-result'
               }
             },
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -49,7 +49,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               },
               'campaign-report': {
                 'links': {
-                  'related': '/campaigns/5/campaign-report'
+                  'related': '/api/campaigns/5/campaign-report'
                 }
               }
             }
@@ -121,7 +121,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
                   type: 'campaignReports'
                 },
                 'links': {
-                  'related': '/campaigns/5/campaign-report'
+                  'related': '/api/campaigns/5/campaign-report'
                 }
               }
             }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -41,7 +41,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
             relationships: {
               sessions: {
                 links: {
-                  related: '/certification-centers/1/sessions'
+                  related: '/api/certification-centers/1/sessions'
                 }
               }
             },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -49,12 +49,12 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
           relationships: {
             campaigns: {
               links: {
-                related: '/organizations/10293/campaigns'
+                related: '/api/organizations/10293/campaigns'
               }
             },
             'target-profiles': {
               links: {
-                related: '/organizations/10293/target-profiles'
+                related: '/api/organizations/10293/target-profiles'
               }
             }
           }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -27,7 +27,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             user: { data: null },
             memberships: {
               links: {
-                related: `/organizations/${organization.id}/memberships`
+                related: `/api/organizations/${organization.id}/memberships`
               }
             }
           }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/profile-serializer_test.js
@@ -166,17 +166,17 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
             },
             'campaign-participations': {
               links: {
-                related: '/users/user_id/campaign-participations'
+                related: '/api/users/user_id/campaign-participations'
               },
             },
             'pix-score': {
               links: {
-                related: '/users/user_id/pixscore'
+                related: '/api/users/user_id/pixscore'
               }
             },
             'scorecards': {
               links: {
-                related: '/users/user_id/scorecards'
+                related: '/api/users/user_id/scorecards'
               }
             },
           },
@@ -321,17 +321,17 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
             },
             'campaign-participations': {
               links: {
-                related: '/users/user_id/campaign-participations'
+                related: '/api/users/user_id/campaign-participations'
               },
             },
             'pix-score': {
               links: {
-                related: '/users/user_id/pixscore'
+                related: '/api/users/user_id/pixscore'
               }
             },
             'scorecards': {
               links: {
-                related: '/users/user_id/scorecards'
+                related: '/api/users/user_id/scorecards'
               }
             },
           },
@@ -348,7 +348,7 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
             relationships: {
               snapshots: {
                 links: {
-                  related: '/organizations/organizationId1/snapshots',
+                  related: '/api/organizations/organizationId1/snapshots',
                 },
               },
             },
@@ -364,7 +364,7 @@ describe('Unit | Serializer | JSONAPI | profile-serializer', () => {
             relationships: {
               snapshots: {
                 links: {
-                  related: '/organizations/organizationId2/snapshots',
+                  related: '/api/organizations/organizationId2/snapshots',
                 },
               },
             },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -59,17 +59,17 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'relationships': {
               'memberships': {
                 'links': {
-                  'related': '/users/234567/memberships'
+                  'related': '/api/users/234567/memberships'
                 }
               },
               'certification-center-memberships': {
                 'links': {
-                  'related': '/users/234567/certification-center-memberships'
+                  'related': '/api/users/234567/certification-center-memberships'
                 }
               },
               'pix-score': {
                 'links': {
-                  'related': '/users/234567/pixscore'
+                  'related': '/api/users/234567/pixscore'
                 }
               }
             },
@@ -116,22 +116,22 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'relationships': {
               'memberships': {
                 'links': {
-                  'related': '/users/234567/memberships'
+                  'related': '/api/users/234567/memberships'
                 }
               },
               'certification-center-memberships': {
                 'links': {
-                  'related': '/users/234567/certification-center-memberships'
+                  'related': '/api/users/234567/certification-center-memberships'
                 }
               },
               'pix-score': {
                 'links': {
-                  'related': '/users/234567/pixscore'
+                  'related': '/api/users/234567/pixscore'
                 }
               },
               scorecards: {
                 links: {
-                  related: '/users/234567/scorecards'
+                  related: '/api/users/234567/scorecards'
                 }
               }
             }

--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -3,9 +3,8 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'pix-certif/config/environment';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: ENV.APP.API_HOST + '/api',
-  // FIXME we should use namespace property but this doesn't work
-  // namespace: 'api',
+  host: ENV.APP.API_HOST,
+  namespace: 'api',
 
   /*
   * Appelé uniquement lorsqu'on est connecté

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -12,7 +12,7 @@ function parseQueryString(queryString) {
 export default function() {
 
   this.urlPrefix = 'http://localhost:3000';
-  this.namespace = '/api';
+  this.namespace = 'api';
   this.timing = 0;
 
   this.post('/token', (schema, request) => {

--- a/certif/mirage/serializers/certification-center.js
+++ b/certif/mirage/serializers/certification-center.js
@@ -4,7 +4,7 @@ export default JSONAPISerializer.extend({
   links(certificationCenter) {
     return {
       'sessions': {
-        related: `/certification-centers/${certificationCenter.id}/sessions`
+        related: `/api/certification-centers/${certificationCenter.id}/sessions`
       }
     };
   }

--- a/certif/mirage/serializers/user.js
+++ b/certif/mirage/serializers/user.js
@@ -4,7 +4,7 @@ export default JSONAPISerializer.extend({
   links(user) {
     return {
       'certificationCenterMemberships': {
-        related: `/users/${user.id}/certification-center-memberships`
+        related: `/api/users/${user.id}/certification-center-memberships`
       }
     };
   }

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -5,7 +5,8 @@ import config from '../config/environment';
 
 export default DS.JSONAPIAdapter.extend({
 
-  host: config.APP.API_HOST + '/api',
+  host: config.APP.API_HOST,
+  namespace: 'api',
 
   session: service(),
 

--- a/mon-pix/app/adapters/challenge.js
+++ b/mon-pix/app/adapters/challenge.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default ApplicationAdapter.extend({
 
   queryRecord(store, type, query) {
-    const url = `${this.host}/assessments/${query.assessmentId}/next`;
+    const url = `${this.host}/${this.namespace}/assessments/${query.assessmentId}/next`;
     return this.ajax(url, 'GET');
   }
 

--- a/mon-pix/app/adapters/correction.js
+++ b/mon-pix/app/adapters/correction.js
@@ -4,7 +4,7 @@ export default ApplicationAdapter.extend({
 
   // refresh cache
   refreshRecord(type, challenge) {
-    const url = `${this.host}/cache`;
+    const url = `${this.host}/${this.namespace}/cache`;
     const payload = {
       'cache-key': `Épreuves_${challenge.challengeId}`
     };

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -37,7 +37,8 @@ export default function() {
   this.post('https://fonts.googleapis.com/**', () => {
   });
 
-  this.urlPrefix = 'http://localhost:3000/api';
+  this.urlPrefix = 'http://localhost:3000';
+  this.namespace = 'api';
   this.timing = 0; // response delay
 
   this.get('/courses', getCourses);

--- a/mon-pix/mirage/serializers/campaign-participation.js
+++ b/mon-pix/mirage/serializers/campaign-participation.js
@@ -5,7 +5,7 @@ export default JSONAPISerializer.extend({
   links(campaignParticipation) {
     return {
       'campaignParticipationResult': {
-        related: `/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
+        related: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
       },
     };
   }

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -5,13 +5,13 @@ export default BaseSerializer.extend({
   links(user) {
     return {
       pixScore: {
-        related: `/users/${user.id}/pixscore`
+        related: `/api/users/${user.id}/pixscore`
       },
       scorecards: {
-        related: `/users/${user.id}/scorecards`
+        related: `/api/users/${user.id}/scorecards`
       },
       campaignParticipations: {
-        related: `/users/${user.id}/campaign-participations`
+        related: `/api/users/${user.id}/campaign-participations`
       }
     };
   }

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -7,6 +7,14 @@ describe('Unit | Route | subscribers', function() {
     needs: ['service:session']
   });
 
+  it('should precise /api as the root url', function() {
+    // Given
+    const applicationAdapter = this.subject();
+
+    // Then
+    expect(applicationAdapter.namespace).to.equal('api');
+  });
+
   it('should add header with authentication token ', function() {
     // Given
     const expectedToken = '23456789';

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -7,7 +7,7 @@ describe('Unit | Route | subscribers', function() {
     needs: ['service:session']
   });
 
-  it('should precise /api as the root url', function() {
+  it('should specify /api as the root url', function() {
     // Given
     const applicationAdapter = this.subject();
 

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -3,9 +3,8 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'pix-orga/config/environment';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: ENV.APP.API_HOST + '/api',
-  // FIXME we should use namespace property but this doesn't work
-  // namespace: 'api',
+  host: ENV.APP.API_HOST,
+  namespace: 'api',
 
   /*
   * Appelé uniquement lorsqu'on est connecté

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -12,7 +12,7 @@ function parseQueryString(queryString) {
 export default function() {
 
   this.urlPrefix = 'http://localhost:3000';
-  this.namespace = '/api';
+  this.namespace = 'api';
   this.timing = 0;
 
   this.post('/token', (schema, request) => {

--- a/orga/mirage/serializers/campaign.js
+++ b/orga/mirage/serializers/campaign.js
@@ -4,7 +4,7 @@ export default JSONAPISerializer.extend({
   links(campaign) {
     return {
       'campaignReport': {
-        related: `/campaigns/${campaign.id}/campaign-report`
+        related: `/api/campaigns/${campaign.id}/campaign-report`
       },
     };
   }

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -4,10 +4,10 @@ export default JSONAPISerializer.extend({
   links(organization) {
     return {
       'campaigns': {
-        related: `/organizations/${organization.id}/campaigns`
+        related: `/api/organizations/${organization.id}/campaigns`
       },
       'targetProfiles': {
-        related: `/organizations/${organization.id}/target-profiles`
+        related: `/api/organizations/${organization.id}/target-profiles`
       }
     };
   }

--- a/orga/mirage/serializers/user.js
+++ b/orga/mirage/serializers/user.js
@@ -4,7 +4,7 @@ export default JSONAPISerializer.extend({
   links(user) {
     return {
       'memberships': {
-        related: `/users/${user.id}/memberships`
+        related: `/api/users/${user.id}/memberships`
       }
     };
   }


### PR DESCRIPTION
## :unicorn: Problème
'/api' était rajouté dans le `host`, ce qui n'est pas correct.

## :robot: Solution
Ajout d'un namespace `api`.

## :rainbow: Remarques
Dans les related links renvoyé pas le back, NE PAS OUBLIER le `/` dans `/api/users/1/scorecards`, pour qu'il formatte correctement l'url en `http://localhost:3000/api/users/1/scorecards` (sinon ça donne `http://localhost:3000/api/users/1/api/users/1/scorecards`).
