### PR TITLE
[TECH] Ajoute le premier enregistrement d'architecture (ADR)

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/docs/adr/0001-enregistrer-les-decisions-concernant-l-architecture.md
+++ b/docs/adr/0001-enregistrer-les-decisions-concernant-l-architecture.md
@@ -1,0 +1,26 @@
+# 1. Enregistrer les décisions concernant l'architecture
+
+Date : 2019-04-25
+
+## État
+
+Accepté
+
+## Contexte
+
+Sur ce projet, nous avons besoin de :
+
+- prendre des décisions concernant l'architecture facilement
+- prendre des décisions qui modifient des décisions précédentes facilement
+- savoir qu'une décision donnée a été modifiée ou remplacé par une décision ultérieure
+- pouvoir comprendre pourquoi une décision a été prise dans le passé
+
+## Décision
+
+Nous utiliserons les ADR (Architecture Decision Records), telles que [décrites par Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+Voir aussi la discussion de l'issue Github #480.
+
+## Conséquences
+
+Voir l'article de Michael Nygard ci-dessus. Pour un outillage léger autour des ADR, voir [adr-tools](https://github.com/npryce/adr-tools) de Nat Pryce.


### PR DESCRIPTION
Architecture Decision Records = enregistrements de décisions d'architecture.

## :unicorn: Problème

Le besoin est de pouvoir :

- prendre des décisions concernant l'architecture facilement
- prendre des décisions qui modifient des décisions précédentes facilement
- savoir qu'une décision donnée a été modifiée ou remplacé par une décision ultérieure
- pouvoir comprendre pourquoi une décision a été prise dans le passé.


## :robot: Solution

Pour ça, une pratique qui fonctionne bien est de matérialiser lesdites décisions par des fichiers texte au format Markdown, versionnés avec le code.

Chaque décision suit un formalisme simple et court, avec des images si nécessaire.

- Titre
- Contexte
- Décision
- Status (pas forcément utile, le mécanisme PR peut remplacer ce paragraphe)
- Conséquences


## :rainbow: Remarques

Voir aussi :

- http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
- https://github.com/joelparkerhenderson/architecture_decision_record
- #480.
