### PR TITLE
Ajoute un indexe sur la colonne courseId de la table assessments

### DIFF
--- a/api/db/migrations/20190503173617_add_courseId_index_to_assessments_table.js
+++ b/api/db/migrations/20190503173617_add_courseId_index_to_assessments_table.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => {
+  return knex.raw('CREATE INDEX "assessment_courseid_index" ON assessments ("courseId");');
+};
+
+exports.down = (knex) => {
+  return knex.raw('DROP INDEX "assessment_courseid_index";');
+};


### PR DESCRIPTION
## :unicorn: Problème
De nombreuses requêtes du types : `select assessments.* from assessments where assessments."courseId" in ('1234');`
Prennent du temps à s'exécuter sur notre environnement de production.

## :robot: Solution
Ajout d'un indexe sur la colonne `courseId`.

## :rainbow: Remarques
Une page du Pix wiki documente le sujet -> [page du Wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/883851310/2019-05-03+Blocages+de+la+prod+pb+de+CPU+Postgres)
