### PR TITLE
[BUGFIX] Corriger le problème d'affichage des niveaux sous IE. (PF-595)

### DIFF
--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -64,4 +64,5 @@
   width: 100%;
   height: 100%;
   top: 0;
+  left: 0;
 }


### PR DESCRIPTION
## :unicorn: Problème
Avant les niveau d'une compétence s'affichaient mal sous IE:
![image](https://user-images.githubusercontent.com/4154003/57435172-f412fc80-723c-11e9-95f3-31441fb14682.png)
![image](https://user-images.githubusercontent.com/4154003/57435181-f8d7b080-723c-11e9-8928-585252b96457.png)


## :robot: Solution
Contraindre `left` à `0` sur le text des cercles de progression pour rétablir un affichage correct.
