### PR TITLE
[FEATURE] Modifier le wording de la page d'avertissement du chronomètre. (PF-115)

### DIFF
--- a/mon-pix/app/templates/components/warning-page.hbs
+++ b/mon-pix/app/templates/components/warning-page.hbs
@@ -1,7 +1,6 @@
 <div class="challenge-item-warning">
   <div class="challenge-item-warning__instruction-primary">
-    Vous disposerez de <span class="challenge-item-warning__instruction-time">{{allocatedHumanTime}}</span> pour
-    réussir l’épreuve.
+    Vous disposerez de <span class="challenge-item-warning__instruction-time">{{allocatedHumanTime}}</span> pour réussir la question suivante.
   </div>
 
   <div class="challenge-item-warning__intruction-secondary">
@@ -14,6 +13,6 @@
     </div>
   </div>
   <div class="challenge-item-warning__action">
-    <button {{action hasUserConfirmWarning}} class="challenge-item-warning__confirm-btn">Commencer l'épreuve</button>
+    <button {{action hasUserConfirmWarning}} class="challenge-item-warning__confirm-btn">Commencer</button>
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le wording de la page d'avertissement du chronomètre laissait sous-entendre que toute la suite du parcours serait chronométré. 

## :robot: Solution
Modifier le wording pour préciser qu'uniquement la question suivante sera chronométrée.