### PR TITLE
[BUGFIX] Rétablir l'affichage de la barre de progression d'un checkpoint. (PF-597)

### DIFF
--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -19,7 +19,7 @@ export default Controller.extend({
   }),
 
   shouldDisplayAnswers: computed('model.answersSinceLastCheckpoints', function() {
-    return !!this.model.answersSinceLastCheckpoints.length;
+    return !!this.get('model.answersSinceLastCheckpoints.length');
   }),
 
   actions: {

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -15,7 +15,7 @@ export default Controller.extend({
   }),
 
   completionPercentage: computed('finalCheckpoint', 'model.progression.completionPercentage', function() {
-    return this.finalCheckpoint ? 100 : this.model.progression.completionPercentage;
+    return this.finalCheckpoint ? 100 : this.get('model.progression.completionPercentage');
   }),
 
   shouldDisplayAnswers: computed('model.answersSinceLastCheckpoints', function() {


### PR DESCRIPTION
## :unicorn: Problème
La barre de progression est cassée:
```
Uncaught Error: Assertion Failed: You attempted to access the `completionPercentage` property (of <(unknown):ember640>).
Since Ember 3.1, this is usually fine as you no longer need to use `.get()`
to access computed properties. However, in this case, the object in question
is a special kind of Ember object (a proxy). Therefore, it is still necessary
to use `.get('completionPercentage')` in this case.
```

## :robot: Solution
Réutiliser `this.get`.
