### PR TITLE
[BUGFIX] Unifier l'affichage du cercle de progression d'une compétence (pf-599)

### DIFF
--- a/mon-pix/app/routes/competence-details.js
+++ b/mon-pix/app/routes/competence-details.js
@@ -7,7 +7,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
   session: service(),
 
   model(params) {
-    return this.store.findRecord('scorecard', params.scorecard_id);
+    return this.store.findRecord('scorecard', params.scorecard_id, {
+      reload: true,
+    });
   },
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Le circle chart d'une compétence n'était pas MAJ lors d'un changement de la propriété `pixScoreAheadOfNextLevel` (lors d'une update de `scorecard`).
![image](https://user-images.githubusercontent.com/4154003/57525732-c8227480-732b-11e9-90d2-5e3872ae2b25.png)
![image](https://user-images.githubusercontent.com/4154003/57525736-cce72880-732b-11e9-9205-4bc48d8d842e.png)

## :robot: Solution
Reloader la `scorecard` sur la page de `compétence-details`
