### PR TITLE
[FEATURE] Afficher un lien temporaire d'explications pour Profil v2(PF-589).

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -46,7 +46,7 @@
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  padding-bottom: 32px;
+  padding-bottom: 18px;
   border-bottom: 1px dashed $silver-grey;
 
   @include device-is('tablet') {
@@ -108,21 +108,8 @@
 .rounded-panel-title {
   font-weight: $font-light;
   font-family: $font-open-sans;
-  color: $nero;
-  font-size: 1.8rem;
-  letter-spacing: 0.03rem;
-  line-height: 1.8rem;
-  text-transform: uppercase;
-
-  @include device-is('tablet') {
-    font-size: 1.3rem;
-  }
-}
-
-.rounded-panel-subtitle {
-  font-weight: $font-light;
-  font-family: $font-open-sans;
   color: $black;
   font-size: 3.2rem;
   line-height: 4.5rem;
+  margin-bottom: 26px;
 }

--- a/mon-pix/app/styles/pages/_profilv2.scss
+++ b/mon-pix/app/styles/pages/_profilv2.scss
@@ -26,9 +26,4 @@
   color: $black;
   font-size: 1.8rem;
   line-height: 2.1rem;
-
-  &__link {
-    cursor: pointer;
-    color: $pix-blue;
-  }
 }

--- a/mon-pix/app/styles/pages/_profilv2.scss
+++ b/mon-pix/app/styles/pages/_profilv2.scss
@@ -11,6 +11,9 @@
     padding-right: 30px;
   }
 
+}
+
+.profilv2-panel {
   &__link-to-compte {
     display: flex;
     justify-content: flex-end;

--- a/mon-pix/app/styles/pages/_profilv2.scss
+++ b/mon-pix/app/styles/pages/_profilv2.scss
@@ -19,3 +19,16 @@
     justify-content: flex-end;
   }
 }
+
+.profilv2-panel-header-information {
+  font-weight: $font-light;
+  font-family: $font-roboto;
+  color: $black;
+  font-size: 1.8rem;
+  line-height: 2.1rem;
+
+  &__link {
+    cursor: pointer;
+    color: $pix-blue;
+  }
+}

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -13,7 +13,7 @@
 
         <h2 class="rounded-panel-header-text__content profilv2-panel-header-information">
           Le profil Pix évolue.
-          <a class="profilv2-panel-header-information__link"
+          <a class="link"
              href="https://pix.fr/actualites/votre-profil-evolue"
              target="Actualité Pix">
             Découvrez ce qui change.

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -8,11 +8,16 @@
     <div class="rounded-panel-header-with-components">
       <div class="rounded-panel-header__left-wrapper">
         <h1 class="rounded-panel-header-text__content rounded-panel-title">
-          votre profil
+          Vous avez 16 compétences à tester.<br>On se concentre et c'est partix !
         </h1>
 
-        <h2 class="rounded-panel-header-text__content rounded-panel-subtitle">
-          Vous avez 16 compétences à tester.<br>On se concentre et c'est partix !
+        <h2 class="rounded-panel-header-text__content profilv2-panel-header-information">
+          Le profil Pix évolue.
+          <a class="profilv2-panel-header-information__link"
+             href="https://pix.fr/actualites/votre-profil-evolue"
+             target="Actualité Pix">
+            Découvrez ce qui change.
+          </a>
         </h2>
       </div>
 

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <div class="profilv2__link-to-compte">
+    <div class="profilv2-panel__link-to-compte">
       {{#link-to "compte" class="link link--grey rounded-panel__link"}}Accès à l'ancien profil{{/link-to}}
     </div>
 

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -51,10 +51,10 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       await visit('/profilv2');
 
       // then
-      expect(document.querySelector('.profilv2-panel-header-information__link'))
+      expect(document.querySelector('.profilv2-panel-header-information > .link'))
         .to.have.attr('href', 'https://pix.fr/actualites/votre-profil-evolue');
 
-      expect(document.querySelector('.profilv2-panel-header-information__link'))
+      expect(document.querySelector('.profilv2-panel-header-information > .link'))
         .to.have.attr('target', 'Actualité Pix');
     });
 

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -46,6 +46,18 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       expect(currentURL()).to.equal('/compte');
     });
 
+    it('should contains references to pix.fr/actualites/votre-profil-evolue', async function() {
+      // when
+      await visit('/profilv2');
+
+      // then
+      expect(document.querySelector('.profilv2-panel-header-information__link'))
+        .to.have.attr('href', 'https://pix.fr/actualites/votre-profil-evolue');
+
+      expect(document.querySelector('.profilv2-panel-header-information__link'))
+        .to.have.attr('target', 'Actualité Pix');
+    });
+
     it('should display pixscore', async function() {
       await visit('/profilv2');
 


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs vont progressivement découvrir un tout nouvel affichage de leur profil. Il est essentiel de leur expliquer son fonctionnement.

## :robot: Solution
Nous affichons un lien vers https://pix.fr/actualites/votre-profil-evolue en mode target pour renseigner l'utilisateur.

## :rainbow: Remarques
Le clic sur le lien ouvre automatiquement un nouvel onglet.
