### PR TITLE
[FEATURE] Modification du design de scorecard-details (PF-594)

### DIFF
--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+function dashIfZero(number) {
+  return number === 0 ? '–' : number;
+}
+
+export default Component.extend({
+
+  scorecard: null,
+
+  level: computed('scorecard.{level,isNotStarted}', function() {
+    return this.scorecard.isNotStarted ? null : dashIfZero(this.scorecard.level);
+  }),
+
+  earnedPix: computed('scorecard.earnedPix', function() {
+    return dashIfZero(this.scorecard.earnedPix);
+  }),
+
+});

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,24 +1,16 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-function replaceZeroByDash(number) {
-  return number === 0 ? '–' : number;
-}
-
 export default Component.extend({
 
   scorecard: null,
 
   level: computed('scorecard.{level,isNotStarted}', function() {
-    return this.get('scorecard.isNotStarted') ? null : replaceZeroByDash(this.get('scorecard.level'));
+    return this.get('scorecard.isNotStarted') ? null : this.get('scorecard.level');
   }),
 
-  earnedPix: computed('scorecard.earnedPix', function() {
-    return replaceZeroByDash(this.get('scorecard.earnedPix'));
-  }),
-
-  buttonClass: computed('scorecard.isNotStarted', function() {
-    return `button button--thin button--link button--green ${this.get('scorecard.isNotStarted') ? '' : 'scorecard-details__button'}`;
+  isProgressable: computed('scorecard.{isMaxLevel,isNotStarted}', function() {
+    return !(this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
   }),
 
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-function dashIfZero(number) {
+function replaceZeroByDash(number) {
   return number === 0 ? '–' : number;
 }
 
@@ -10,11 +10,11 @@ export default Component.extend({
   scorecard: null,
 
   level: computed('scorecard.{level,isNotStarted}', function() {
-    return this.scorecard.isNotStarted ? null : dashIfZero(this.scorecard.level);
+    return this.scorecard.isNotStarted ? null : replaceZeroByDash(this.scorecard.level);
   }),
 
   earnedPix: computed('scorecard.earnedPix', function() {
-    return dashIfZero(this.scorecard.earnedPix);
+    return replaceZeroByDash(this.scorecard.earnedPix);
   }),
 
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -10,11 +10,11 @@ export default Component.extend({
   scorecard: null,
 
   level: computed('scorecard.{level,isNotStarted}', function() {
-    return this.scorecard.isNotStarted ? null : replaceZeroByDash(this.scorecard.level);
+    return this.get('scorecard.isNotStarted') ? null : replaceZeroByDash(this.get('scorecard.level'));
   }),
 
   earnedPix: computed('scorecard.earnedPix', function() {
-    return replaceZeroByDash(this.scorecard.earnedPix);
+    return replaceZeroByDash(this.get('scorecard.earnedPix'));
   }),
 
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -17,4 +17,8 @@ export default Component.extend({
     return replaceZeroByDash(this.get('scorecard.earnedPix'));
   }),
 
+  buttonClass: computed('scorecard.isNotStarted', function() {
+    return `button button--thin button--link button--green ${this.get('scorecard.isNotStarted') ? '' : 'scorecard-details__button'}`;
+  }),
+
 });

--- a/mon-pix/app/helpers/replace-zero-by-dash.js
+++ b/mon-pix/app/helpers/replace-zero-by-dash.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+
+export function replaceZeroByDash(params) {
+  const param = params[0];
+
+  return param === 0 ? '–' : param;
+}
+
+export default helper(replaceZeroByDash);

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -15,6 +15,7 @@
 @import 'globals/pix-page';
 @import 'globals/buttons';
 @import 'globals/tables';
+@import 'globals/text';
 /* components */
 @import 'components/background-banner';
 @import 'components/_blue-ribbon';

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -10,20 +10,6 @@
   font-weight: $font-medium;
 }
 
-@mixin competence-card-level-label {
-  color: $nero;
-  font-size: 1rem;
-  letter-spacing: 0.25rem;
-  text-transform: uppercase;
-}
-
-@mixin competence-card-level-value {
-  color: $black;
-  font-family: $font-open-sans;
-  font-size: 4.6rem;
-  line-height: 4.6rem;
-}
-
 .competence-card {
   width: 210px;
   height: 300px;
@@ -118,12 +104,7 @@
   align-items: center;
 }
 
-.competence-card-level__label {
-  @include competence-card-level-label;
-}
-
-.competence-card-level__value {
-  @include competence-card-level-value;
+.competence-card-score-value {
   min-height: 44px;
 }
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -98,19 +98,6 @@
   }
 }
 
-.scorecard-details-content-right-score-container-pix-earned {
-  &__number {
-    font-size: 4.6rem;
-    line-height: 4.6rem;
-    font-family: $font-open-sans;
-  }
-
-  &__info {
-    font-size: 1rem;
-    letter-spacing: 0.25rem;
-  }
-}
-
 .scorecard-details__button {
   margin-top: 20px;
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -82,6 +82,7 @@
     color: $grayish-grey;
     text-transform: uppercase;
     letter-spacing: 0.03rem;
+    white-space: nowrap;
   }
 }
 
@@ -107,4 +108,8 @@
     font-size: 1rem;
     letter-spacing: 0.25rem;
   }
+}
+
+.scorecard-details__button {
+  margin-top: 20px;
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -16,6 +16,7 @@
   &__left {
     flex-grow: 1;
     padding: 0px 30px 30px 30px;
+    max-width: 100%;
 
     @include device-is('desktop') {
       padding: 0 30px;

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -88,30 +88,23 @@
 .scorecard-details-content-right-score-container {
   &__pix-earned {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
-    margin-left: 30px;
+    margin-left: 60px;
     text-transform: uppercase;
     color: $grayish-grey;
   }
 }
 
-@mixin pix-earned-number-text {
-  font-size: 3.2rem;
-  line-height: 3.2rem;
-  font-family: $font-open-sans;
-  font-weight: $font-semi-bold;
-}
-
 .scorecard-details-content-right-score-container-pix-earned {
   &__number {
-    margin-right: 5px;
-    margin-bottom: 4px;
-    @include pix-earned-number-text;
+    font-size: 4.6rem;
+    line-height: 4.6rem;
+    font-family: $font-open-sans;
   }
 
   &__info {
-    line-height: 1.4rem;
-    letter-spacing: 0.12rem;
+    font-size: 1rem;
+    letter-spacing: 0.25rem;
   }
 }

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -1,0 +1,13 @@
+.score-label {
+  font-size: 1rem;
+  letter-spacing: 0.25rem;
+  text-transform: uppercase;
+  color: $nero;
+}
+
+.score-value {
+  font-size: 4.6rem;
+  line-height: 4.6rem;
+  font-family: $font-open-sans;
+  color: $black;
+}

--- a/mon-pix/app/templates/components/competence-card.hbs
+++ b/mon-pix/app/templates/components/competence-card.hbs
@@ -11,8 +11,8 @@
                       chartClass='circle-chart__content--big'
                       thicknessClass='circle--thick'}}
         <div class="competence-card__level">
-          <span class="competence-card-level__label">Niveau</span>
-          <span class="competence-card-level__value">{{displayedLevel}}</span>
+          <span class="score-label">Niveau</span>
+          <span class="score-value competence-card-score-value">{{replace-zero-by-dash displayedLevel}}</span>
         </div>
       {{/circle-chart}}
     {{/link-to}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -12,24 +12,24 @@
   </div>
 
   <div class="scorecard-details-content__right">
-    <div class="scorecard-details-content-right__score-container">
 
-      {{#circle-chart value=scorecard.percentageAheadOfNextLevel
-                      sliceColor=scorecard.areaColor
-                      chartClass='circle-chart__content--big'
-                      thicknessClass='circle--thick'}}
-        <div class="competence-card__level">
-          <span class="competence-card-level__label">Niveau</span>
-          <span class="competence-card-level__value">{{level}}</span>
-        </div>
-      {{/circle-chart}}
-      {{#unless scorecard.isNotStarted}}
+    {{#unless scorecard.isNotStarted}}
+      <div class="scorecard-details-content-right__score-container">
+        {{#circle-chart value=scorecard.percentageAheadOfNextLevel
+                        sliceColor=scorecard.areaColor
+                        chartClass='circle-chart__content--big'
+                        thicknessClass='circle--thick'}}
+          <div class="competence-card__level">
+            <span class="competence-card-level__label">Niveau</span>
+            <span class="competence-card-level__value">{{level}}</span>
+          </div>
+        {{/circle-chart}}
         <div class="scorecard-details-content-right-score-container__pix-earned">
           <div class="scorecard-details-content-right-score-container-pix-earned__info">pix</div>
           <div class="scorecard-details-content-right-score-container-pix-earned__number">{{earnedPix}}</div>
         </div>
-      {{/unless}}
-    </div>
+      </div>
+    {{/unless}}
 
     {{#unless (or scorecard.isMaxLevel scorecard.isNotStarted)}}
       <div class="scorecard-details-content-right__level-info">
@@ -39,7 +39,7 @@
 
     {{#unless scorecard.isFinished}}
       {{#link-to "competences.resume" scorecard.competenceId
-                  class="button button--thin button--link button--green scorecard-details__button"}}
+                  class=buttonClass}}
         {{#if scorecard.isStarted}}
           Reprendre
         {{else}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -13,24 +13,41 @@
 
   <div class="scorecard-details-content__right">
     <div class="scorecard-details-content-right__score-container">
+
       {{#circle-chart value=scorecard.percentageAheadOfNextLevel
                       sliceColor=scorecard.areaColor
                       chartClass='circle-chart__content--big'
                       thicknessClass='circle--thick'}}
         <div class="competence-card__level">
           <span class="competence-card-level__label">Niveau</span>
-          <span class="competence-card-level__value">{{scorecard.level}}</span>
+          <span class="competence-card-level__value">{{level}}</span>
         </div>
       {{/circle-chart}}
-      <div class="scorecard-details-content-right-score-container__pix-earned">
-        <div class="scorecard-details-content-right-score-container-pix-earned__info">pix</div>
-        <div class="scorecard-details-content-right-score-container-pix-earned__number">{{scorecard.earnedPix}}</div>
-      </div>
+      {{#unless scorecard.isNotStarted}}
+        <div class="scorecard-details-content-right-score-container__pix-earned">
+          <div class="scorecard-details-content-right-score-container-pix-earned__info">pix</div>
+          <div class="scorecard-details-content-right-score-container-pix-earned__number">{{earnedPix}}</div>
+        </div>
+      {{/unless}}
     </div>
-    {{#unless scorecard.isMaxLevel}}
+
+    {{#unless (or scorecard.isMaxLevel scorecard.isNotStarted)}}
       <div class="scorecard-details-content-right__level-info">
         {{scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc scorecard.level}}
       </div>
     {{/unless}}
+
+    {{#unless scorecard.isFinished}}
+      {{#link-to "competences.resume" scorecard.competenceId
+                  class="button button--thin button--link button--green scorecard-details__button"}}
+        {{#if scorecard.isStarted}}
+          Reprendre
+        {{else}}
+          Commencer
+        {{/if}}
+      {{/link-to}}
+    {{/unless}}
+
   </div>
+
 </div>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -20,26 +20,26 @@
                         chartClass='circle-chart__content--big'
                         thicknessClass='circle--thick'}}
           <div class="competence-card__level">
-            <span class="competence-card-level__label">Niveau</span>
-            <span class="competence-card-level__value">{{level}}</span>
+            <span class="score-label">Niveau</span>
+            <span class="score-value">{{replace-zero-by-dash level}}</span>
           </div>
         {{/circle-chart}}
         <div class="scorecard-details-content-right-score-container__pix-earned">
-          <div class="scorecard-details-content-right-score-container-pix-earned__info">pix</div>
-          <div class="scorecard-details-content-right-score-container-pix-earned__number">{{earnedPix}}</div>
+          <div class="score-label">pix</div>
+          <div class="score-value">{{replace-zero-by-dash scorecard.earnedPix}}</div>
         </div>
       </div>
     {{/unless}}
 
-    {{#unless (or scorecard.isMaxLevel scorecard.isNotStarted)}}
+    {{#if isProgressable}}
       <div class="scorecard-details-content-right__level-info">
         {{scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc scorecard.level}}
       </div>
-    {{/unless}}
+    {{/if}}
 
     {{#unless scorecard.isFinished}}
       {{#link-to "competences.resume" scorecard.competenceId
-                  class=buttonClass}}
+          class=(concat "button button--thin button--link button--green " (if scorecard.isNotStarted "" "scorecard-details__button"))}}
         {{#if scorecard.isStarted}}
           Reprendre
         {{else}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -23,8 +23,8 @@
         </div>
       {{/circle-chart}}
       <div class="scorecard-details-content-right-score-container__pix-earned">
-        <div class="scorecard-details-content-right-score-container-pix-earned__number">{{scorecard.earnedPix}}</div>
         <div class="scorecard-details-content-right-score-container-pix-earned__info">pix</div>
+        <div class="scorecard-details-content-right-score-container-pix-earned__number">{{scorecard.earnedPix}}</div>
       </div>
     </div>
     {{#unless scorecard.isMaxLevel}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14015,14 +14015,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14037,20 +14035,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -14167,8 +14162,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -14180,7 +14174,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14195,7 +14188,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14203,14 +14195,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14229,7 +14219,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14310,8 +14299,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14323,7 +14311,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14445,7 +14432,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -63,8 +63,8 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
       expect(find('.scorecard-details-content-left__area').attr('class')).to.contain('scorecard-details-content-left__area--jaffa');
       expect(find('.scorecard-details-content-left__name').text()).to.contain(name);
       expect(find('.scorecard-details-content-left__description').text()).to.contain(description);
-      expect(find('.competence-card-level__value').text()).to.contain(level);
-      expect(find('.scorecard-details-content-right-score-container-pix-earned__number').text()).to.contain(earnedPix);
+      expect(find('.score-value').text()).to.contain(level);
+      expect(find('.score-value').text()).to.contain(earnedPix);
       expect(find('.scorecard-details-content-right__level-info').text()).to.contain(`${8 - pixScoreAheadOfNextLevel} pix avant le niveau ${level + 1}`);
     });
 

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -60,7 +60,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       // then
       expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card__area-name').text()).to.equal('Information et données');
       expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card__competence-name').text()).to.equal('Compétence C1');
-      expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card-level__value').text()).to.equal('2');
+      expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .score-value').text()).to.equal('2');
     });
 
     it('should display second competence card of first area', async function() {
@@ -70,7 +70,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       // then
       expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .competence-card__area-name').text()).to.equal('Information et données');
       expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .competence-card__competence-name').text()).to.equal('Compétence C2');
-      expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .competence-card-level__value').text()).to.equal('4');
+      expect(find('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:nth-child(2) .score-value').text()).to.equal('4');
     });
 
     it('should link to competence-details page on click on level circle', async function() {
@@ -91,7 +91,7 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       // then
       expect(find('.rounded-panel-body__areas:nth-child(2) .rounded-panel-body__competence-card:first-child .competence-card__area-name').text()).to.equal('Communication et collaboration');
       expect(find('.rounded-panel-body__areas:nth-child(2) .rounded-panel-body__competence-card:first-child .competence-card__competence-name').text()).to.equal('Compétence C3');
-      expect(find('.rounded-panel-body__areas:nth-child(2) .rounded-panel-body__competence-card:first-child .competence-card-level__value').text()).to.equal('3');
+      expect(find('.rounded-panel-body__areas:nth-child(2) .rounded-panel-body__competence-card:first-child .score-value').text()).to.equal('3');
     });
 
     context('when user has not completed the campaign', () => {

--- a/mon-pix/tests/integration/components/competence-card-test.js
+++ b/mon-pix/tests/integration/components/competence-card-test.js
@@ -77,8 +77,8 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card-level__label').textContent).to.equal('Niveau');
-      expect(this.element.querySelector('.competence-card-level__value').textContent).to.equal(scorecard.level.toString());
+      expect(this.element.querySelector('.score-label').textContent).to.equal('Niveau');
+      expect(this.element.querySelector('.score-value').textContent).to.equal(scorecard.level.toString());
     });
 
     context('when user can start the competence', async function() {

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -94,7 +94,7 @@ describe('Integration | Component | scorecard-details', function() {
       expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
     });
 
-    it('should not display remainingPixToNextLevel if scorecard.isNotStarted is true', async function() {
+    it('should not display the level and remainingPixToNextLevel if scorecard.isNotStarted is true', async function() {
       // given
       const scorecard = {
         remainingPixToNextLevel: 1,
@@ -107,6 +107,7 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
+      expect(this.element.querySelector('.scorecard-details-content-right__score-container')).to.not.exist;
       expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
     });
 

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -1,0 +1,182 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | scorecard-details', function() {
+  setupRenderingTest();
+
+  describe('Component rendering', function() {
+
+    it('should render component', async function() {
+      // given
+      const scorecard = {};
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details-content')).to.exist;
+    });
+
+    it('should display the scorecard header with area color', async function() {
+      // given
+      const scorecard = {
+        areaColor: 'jaffa',
+        area: {
+          title: 'Area title',
+        },
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      const element = this.element.querySelector('.scorecard-details-content-left__area');
+      expect(element.getAttribute('class')).to.contains('scorecard-details-content-left__area--jaffa');
+      expect(element.textContent).to.contains(scorecard.area.title);
+    });
+
+    it('should display the competence informations', async function() {
+      // given
+      const scorecard = {
+        name: 'Scorecard name',
+        description: 'Scorecard description',
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details-content-left__name').textContent).to.contain(scorecard.name);
+      expect(this.element.querySelector('.scorecard-details-content-left__description').textContent).to.contain(scorecard.description);
+    });
+
+    it('should display the scorecard level, earnedPix and remainingPixToNextLevel', async function() {
+      // given
+      const scorecard = {
+        level: 2,
+        earnedPix: 22,
+        remainingPixToNextLevel: 2,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.competence-card-level__value').textContent).to.contain(scorecard.level);
+      expect(this.element.querySelector('.scorecard-details-content-right-score-container-pix-earned__number').textContent).to.contain(scorecard.earnedPix);
+      expect(this.element.querySelector('.scorecard-details-content-right__level-info').textContent).to.contain(`${scorecard.remainingPixToNextLevel} pix avant le niveau 3`);
+    });
+
+    it('should not display remainingPixToNextLevel if scorecard.isMaxLevel is true', async function() {
+      // given
+      const scorecard = {
+        remainingPixToNextLevel: 1,
+        isMaxLevel: true,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
+    });
+
+    it('should not display remainingPixToNextLevel if scorecard.isNotStarted is true', async function() {
+      // given
+      const scorecard = {
+        remainingPixToNextLevel: 1,
+        isNotStarted: true,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
+    });
+
+    it('should display a dash instead of the scorecard level and earnedPix if they are set to zero', async function() {
+      // given
+      const scorecard = {
+        level: 0,
+        earnedPix: 0,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.competence-card-level__value').textContent).to.contain('–');
+      expect(this.element.querySelector('.scorecard-details-content-right-score-container-pix-earned__number').textContent).to.contain('–');
+    });
+
+    it('should not display a button to ompetences.resume if scorecard.isFinished', async function() {
+      // given
+      const scorecard = {
+        isFinished: true,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details__button')).to.not.exist;
+    });
+
+    it('should display a button stating "Commencer" if scorecard.isStarted is false', async function() {
+      // given
+      const scorecard = {
+        competenceId: 1,
+        isStarted: false,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      const element = this.element.querySelector('.scorecard-details__button');
+      expect(element).to.exist;
+      expect(element.textContent).to.contain('Commencer');
+    });
+
+    it('should display a button stating "Reprendre" if scorecard.isStarted is true', async function() {
+      // given
+      const scorecard = {
+        competenceId: 1,
+        isStarted: true,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      const element = this.element.querySelector('.scorecard-details__button');
+      expect(element).to.exist;
+      expect(element.textContent).to.contain('Reprendre');
+    });
+
+  });
+});

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -73,9 +73,9 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card-level__value').textContent).to.contain(scorecard.level);
-      expect(this.element.querySelector('.scorecard-details-content-right-score-container-pix-earned__number').textContent).to.contain(scorecard.earnedPix);
-      expect(this.element.querySelector('.scorecard-details-content-right__level-info').textContent).to.contain(`${scorecard.remainingPixToNextLevel} pix avant le niveau 3`);
+      expect(this.element.querySelector('.score-value').textContent).to.contain(scorecard.level);
+      expect(this.element.getElementsByClassName('score-value')[1].textContent).to.contain(scorecard.earnedPix);
+      expect(this.element.querySelector('.scorecard-details-content-right__level-info').textContent).to.contain(`${scorecard.remainingPixToNextLevel} pix avant le niveau ${scorecard.level + 1}`);
     });
 
     it('should not display remainingPixToNextLevel if scorecard.isMaxLevel is true', async function() {
@@ -124,11 +124,11 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card-level__value').textContent).to.contain('–');
-      expect(this.element.querySelector('.scorecard-details-content-right-score-container-pix-earned__number').textContent).to.contain('–');
+      expect(this.element.querySelector('.score-value').textContent).to.contain('–');
+      expect(this.element.querySelector('.score-value').textContent).to.contain('–');
     });
 
-    it('should not display a button to ompetences.resume if scorecard.isFinished', async function() {
+    it('should not display a button if scorecard.isFinished', async function() {
       // given
       const scorecard = {
         isFinished: true,

--- a/mon-pix/tests/unit/components/scorecard-details.js
+++ b/mon-pix/tests/unit/components/scorecard-details.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Component | scorecard-details ', function() {
+  setupTest();
+
+  describe('#level', function() {
+    it('returns null if the scorecard isNotStarted', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { isNotStarted: true });
+
+      // then
+      expect(controller.get('level')).to.be.equal(null);
+    });
+
+    it('returns the level if the scorecard level is over zero', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { level: 1 });
+
+      // then
+      expect(controller.get('level')).to.be.equal(1);
+    });
+
+    it('returns a dash if the scorecard level is over zero', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { level: 0 });
+
+      // then
+      expect(controller.get('level')).to.be.equal('–');
+    });
+  });
+
+  describe('#earnedPix', function() {
+    it('returns the earnedPix if the scorecard earnedPix is over zero', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { earnedPix: 1 });
+
+      // then
+      expect(controller.get('earnedPix')).to.be.equal(1);
+    });
+
+    it('returns a dash if the scorecard earnedPix is over zero', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { earnedPix: 0 });
+
+      // then
+      expect(controller.get('earnedPix')).to.be.equal('–');
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/scorecard-details.js
+++ b/mon-pix/tests/unit/components/scorecard-details.js
@@ -17,7 +17,7 @@ describe('Unit | Component | scorecard-details ', function() {
       expect(controller.get('level')).to.be.equal(null);
     });
 
-    it('returns the level if the scorecard level is over zero', function() {
+    it('returns the level if the scorecard is not isNotStarted', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');
 
@@ -28,39 +28,40 @@ describe('Unit | Component | scorecard-details ', function() {
       expect(controller.get('level')).to.be.equal(1);
     });
 
-    it('returns a dash if the scorecard level is zero', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
-      // when
-      controller.set('scorecard', { level: 0 });
-
-      // then
-      expect(controller.get('level')).to.be.equal('–');
-    });
   });
 
-  describe('#earnedPix', function() {
-    it('returns the earnedPix if the scorecard earnedPix is over zero', function() {
+  describe('#isProgressable', function() {
+    it('returns false if isMaxLevel', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');
 
       // when
-      controller.set('scorecard', { earnedPix: 1 });
+      controller.set('scorecard', { isMaxLevel: true });
 
       // then
-      expect(controller.get('earnedPix')).to.be.equal(1);
+      expect(controller.get('isProgressable')).to.be.equal(false);
     });
 
-    it('returns a dash if the scorecard earnedPix is zero', function() {
+    it('returns false if isNotStarted', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');
 
       // when
-      controller.set('scorecard', { earnedPix: 0 });
+      controller.set('scorecard', { isNotStarted: true });
 
       // then
-      expect(controller.get('earnedPix')).to.be.equal('–');
+      expect(controller.get('isProgressable')).to.be.equal(false);
+    });
+
+    it('returns true otherwise', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', {});
+
+      // then
+      expect(controller.get('isProgressable')).to.be.equal(true);
     });
   });
 });

--- a/mon-pix/tests/unit/components/scorecard-details.js
+++ b/mon-pix/tests/unit/components/scorecard-details.js
@@ -28,7 +28,7 @@ describe('Unit | Component | scorecard-details ', function() {
       expect(controller.get('level')).to.be.equal(1);
     });
 
-    it('returns a dash if the scorecard level is over zero', function() {
+    it('returns a dash if the scorecard level is zero', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');
 
@@ -52,7 +52,7 @@ describe('Unit | Component | scorecard-details ', function() {
       expect(controller.get('earnedPix')).to.be.equal(1);
     });
 
-    it('returns a dash if the scorecard earnedPix is over zero', function() {
+    it('returns a dash if the scorecard earnedPix is zero', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');
 

--- a/mon-pix/tests/unit/helpers/replace-zero-by-dash-test.js
+++ b/mon-pix/tests/unit/helpers/replace-zero-by-dash-test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { replaceZeroByDash } from 'mon-pix/helpers/replace-zero-by-dash';
+
+describe('Unit | Helpers | replaceZeroByDash', function() {
+
+  it('does not change null values', function() {
+    const value = replaceZeroByDash([null]);
+    expect(value).to.equal(null);
+  });
+
+  it('does not change number non-zero values', function() {
+    const value1 = replaceZeroByDash([1]);
+    const value2 = replaceZeroByDash([111]);
+    const value3 = replaceZeroByDash([0.0001]);
+    expect(value1).to.equal(1);
+    expect(value2).to.equal(111);
+    expect(value3).to.equal(0.0001);
+  });
+
+  it('replaces zero by dash', function() {
+    const value = replaceZeroByDash([0]);
+    expect(value).to.equal('–');
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Le design de scorecard-details n'était pas à jour. En plus il était offensant pour les utilisateurs car il affichait des zéros partout, ce qui peut faire très mal d'après les experts en psychologix.

## :robot: Solution
Remplacer ces vilains zéros par des tirets PC, ajouter un bouton "Commencer/Reprendre".