### PR TITLE
[BUGFIX] Correction d'une typo dans la modale de prévention sur support mobile.

### DIFF
--- a/mon-pix/app/templates/components/warning-page.hbs
+++ b/mon-pix/app/templates/components/warning-page.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <div class="challenge-item-warning__intruction-secondary">
-    Vous pourrez continuer à répondre ensuite, mais l’épreuve ne sera pas considérée comme réussie.
+    Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie.
   </div>
   <div class="challenge-item-warning__allocated-time">
     <div class="challenge__allocated-time__jauge">


### PR DESCRIPTION
suite à la démo, y'a eu un petit feedback sur le ticket PF-115. Tu peux remplacer le mot 'épreuve' par 'question' dans la phrase suivante please: 'Vous pourrez continuer à répondre ensuite, mais l’épreuve ne sera pas considérée comme réussie.' C'est pour la V2.41.0, pour rester cohérent. Thanks!