### PR TITLE
[TECH] Ajout de scénarios Cypress.

### DIFF
--- a/high-level-tests/e2e/cypress/integration/profilv2.feature
+++ b/high-level-tests/e2e/cypress/integration/profilv2.feature
@@ -1,0 +1,11 @@
+Feature: Profilv2
+
+  Background:
+    Given les données de test sont chargées
+
+  Scenario: J'accède à la page de détails d'une compétence
+    Given je vais sur Pix
+    And je suis connecté à Pix
+    When j'accède à mon profil v2
+    And je clique sur le rond de niveau de la compétence "Traiter des données"
+    Then je vois la page de détails de la compétence "Traiter des données"

--- a/high-level-tests/e2e/cypress/support/step_definitions/profilv2.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/profilv2.js
@@ -1,0 +1,7 @@
+when(`je clique sur le rond de niveau de la compétence {string}`, (competenceName) => {
+  cy.contains('.competence-card', competenceName).find('.competence-card__link').click();
+});
+
+then(`je vois la page de détails de la compétence {string}`, (competenceName) => {
+  cy.get('.competence-details').should('contain', competenceName);
+});


### PR DESCRIPTION
## :unicorn: Problème
On manque de scénarios Cypress.

## :robot: Solution
Ajout d'un scénario d'accès à la page de détails d'une compétence via le profilv2