### PR TITLE
Réparer le script `npm run start:watch` de l'API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -104,7 +104,7 @@
     "db:pg:prepare": "npm run db:pg:delete && npm run db:pg:create && npm run db:pg:migrate",
     "db:pg:seed": "knex --knexfile db/knexfile.js seed:run",
     "db:pg:reset": "npm run db:pg:prepare && npm run db:pg:seed",
-    "dev": "nodemon bin/www",
+    "dev": "nodemon --signal SIGTERM bin/www",
     "lint": "eslint lib tests",
     "lint:fix": "eslint lib tests --fix",
     "preinstall": "test \"$(npm --version)\" = 6.4.1",


### PR DESCRIPTION
## :unicorn: Problème

Depuis l'intégration de `node-heapdump` dans #478, le script `npm run start:watch` de l'API ne fonctionne plus : l'application ne redémarre plus quand un fichier est modifié, et au lieu de ça un fichier `heapdump-….heapsnapshot` est créé dans le répertoire `api`.

## :robot: Solution

Il s'avère que `node-heapdump` installe un gestionnaire du signal `SIGUSR2` pour pouvoir déclencher des _dumps_. Mais `nodemon` utilise par défaut le signal `SIGUSR2` pour arrêter le processus de l'application en cas de changement.

On ajoute donc une option à la ligne de commande de `nodemon` pour éviter le conflit en utilisant `SIGTERM` à la place.

## :rainbow: Remarques

![Signals](https://drawings.jvns.ca/drawings/signals.jpeg)

Pour en savoir plus : https://jvns.ca/blog/2016/06/13/should-you-be-scared-of-signals/