### PR TITLE
[FEATURE] Ajout d'un champs status aux compétences évaluations (PF-579-3).

### DIFF
--- a/api/db/migrations/20190520161908_add_status_to_competence_evaluations.js
+++ b/api/db/migrations/20190520161908_add_status_to_competence_evaluations.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'competence-evaluations';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string('status');
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('status');
+  });
+};

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -2,4 +2,3 @@ module.exports = {
   MAX_REACHABLE_LEVEL: 5,
   PIX_COUNT_BY_LEVEL: 8,
 };
-

--- a/api/lib/domain/models/CompetenceEvaluation.js
+++ b/api/lib/domain/models/CompetenceEvaluation.js
@@ -1,3 +1,7 @@
+const statuses = {
+  STARTED: 'started',
+};
+
 class CompetenceEvaluation {
 
   constructor({
@@ -5,6 +9,7 @@ class CompetenceEvaluation {
     // attributes
     createdAt,
     updatedAt,
+    status,
     // includes
     assessment,
     scorecard,
@@ -17,6 +22,7 @@ class CompetenceEvaluation {
     // attributes
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.status = status;
     //includes
     this.assessment = assessment;
     this.scorecard = scorecard;
@@ -26,5 +32,6 @@ class CompetenceEvaluation {
     this.userId = userId;
   }
 }
+CompetenceEvaluation.statuses = statuses;
 
 module.exports = CompetenceEvaluation;

--- a/api/lib/domain/models/CompetenceEvaluation.js
+++ b/api/lib/domain/models/CompetenceEvaluation.js
@@ -1,5 +1,6 @@
 const statuses = {
   STARTED: 'started',
+  RESET: 'reset',
 };
 
 class CompetenceEvaluation {
@@ -32,6 +33,7 @@ class CompetenceEvaluation {
     this.userId = userId;
   }
 }
+
 CompetenceEvaluation.statuses = statuses;
 
 module.exports = CompetenceEvaluation;

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -1,4 +1,5 @@
 const Assessment = require('./Assessment');
+const CompetenceEvaluation = require('./CompetenceEvaluation');
 const constants = require('../constants');
 const _ = require('lodash');
 
@@ -57,8 +58,10 @@ class Scorecard {
 }
 
 function _getScorecardStatus(competenceEvaluation) {
-
   if (!competenceEvaluation) {
+    return { status: statuses.NOT_STARTED };
+  }
+  if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
     return { status: statuses.NOT_STARTED };
   }
   const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -43,58 +43,47 @@ class Scorecard {
 
   static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
 
-    const scorecardIdData = { id: `${userId}_${competence.id}` };
-    const scoringData = _computeScoringDatas(knowledgeElements);
-    const statusData = _getScorecardStatus(competenceEvaluation);
-    const competenceData = _getCompetenceDatas(competence);
+    const totalEarnedPix = _getTotalEarnedPix(knowledgeElements);
 
     return new Scorecard({
-      ...scorecardIdData,
-      ...competenceData,
-      ...statusData,
-      ...scoringData,
+      id: `${userId}_${competence.id}`,
+      name: competence.name,
+      description: competence.description,
+      competenceId: competence.id,
+      index: competence.index,
+      area: competence.area,
+      earnedPix: totalEarnedPix,
+      level: _getCompetenceLevel(totalEarnedPix),
+      pixScoreAheadOfNextLevel: _getPixScoreAheadOfNextLevel(totalEarnedPix),
+      status: _getScorecardStatus(competenceEvaluation),
     });
   }
 }
 
 function _getScorecardStatus(competenceEvaluation) {
   if (!competenceEvaluation) {
-    return { status: statuses.NOT_STARTED };
+    return statuses.NOT_STARTED;
   }
   if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
-    return { status: statuses.NOT_STARTED };
+    return statuses.NOT_STARTED;
   }
   const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
   if (stateOfAssessment === Assessment.states.COMPLETED) {
-    return { status: statuses.COMPLETED };
+    return statuses.COMPLETED;
   }
-  return { status: statuses.STARTED };
+  return statuses.STARTED;
 }
 
-function _getCompetenceDatas(competence) {
-  return {
-    name: competence.name,
-    description: competence.description,
-    competenceId: competence.id,
-    index: competence.index,
-    area: competence.area
-  };
-}
-
-function _computeScoringDatas(knowledgeElements) {
-  const totalEarnedPix = _.floor(_(knowledgeElements).sumBy('earnedPix'));
-  const level = _getCompetenceLevel(totalEarnedPix);
-  const pixScoreAheadOfNextLevel = _getpixScoreAheadOfNextLevel(totalEarnedPix);
-
-  return { earnedPix: totalEarnedPix, level, pixScoreAheadOfNextLevel };
+function _getTotalEarnedPix(knowledgeElements) {
+  return _.floor(_(knowledgeElements).sumBy('earnedPix'));
 }
 
 function _getCompetenceLevel(earnedPix) {
-  const userLevel = Math.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
+  const userLevel = _.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
   return Math.min(constants.MAX_REACHABLE_LEVEL, userLevel);
 }
 
-function _getpixScoreAheadOfNextLevel(earnedPix) {
+function _getPixScoreAheadOfNextLevel(earnedPix) {
   return earnedPix % constants.PIX_COUNT_BY_LEVEL;
 }
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -57,7 +57,7 @@ class Scorecard {
   
   static computeStatus(competenceEvaluation) {
     if (!competenceEvaluation) {
-      return ScorecardStatusType.NOT_STARTED;
+      return statuses.NOT_STARTED;
     }
     const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
     if (stateOfAssessment === Assessment.states.COMPLETED) {

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -29,8 +29,8 @@ class Scorecard {
     this.index = index;
     this.area = area;
     this.earnedPix = roundedEarnedPix;
-    this.level = this._getCompetenceLevel(roundedEarnedPix);
-    this.pixScoreAheadOfNextLevel = this._getpixScoreAheadOfNextLevel(roundedEarnedPix);
+    this.level = _getCompetenceLevel(roundedEarnedPix);
+    this.pixScoreAheadOfNextLevel = _getpixScoreAheadOfNextLevel(roundedEarnedPix);
     this.status = status;
   }
 
@@ -41,7 +41,7 @@ class Scorecard {
 
   static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
     const totalEarnedPixByCompetence = _.sumBy(knowledgeElements, 'earnedPix');
-    const status = Scorecard.computeStatus(competenceEvaluation);
+    const status = _computeStatus(competenceEvaluation);
 
     return new Scorecard({
       id: `${userId}_${competence.id}`,
@@ -54,26 +54,27 @@ class Scorecard {
       status,
     });
   }
-  
-  static computeStatus(competenceEvaluation) {
-    if (!competenceEvaluation) {
-      return statuses.NOT_STARTED;
-    }
-    const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
-    if (stateOfAssessment === Assessment.states.COMPLETED) {
-      return statuses.COMPLETED;
-    }
-    return statuses.STARTED;
-  }
 
-  _getCompetenceLevel(earnedPix) {
-    const userLevel = Math.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
-    return Math.min(constants.MAX_REACHABLE_LEVEL, userLevel);
-  }
+}
 
-  _getpixScoreAheadOfNextLevel(earnedPix) {
-    return earnedPix % constants.PIX_COUNT_BY_LEVEL;
+function _computeStatus(competenceEvaluation) {
+  if (!competenceEvaluation) {
+    return statuses.NOT_STARTED;
   }
+  const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
+  if (stateOfAssessment === Assessment.states.COMPLETED) {
+    return statuses.COMPLETED;
+  }
+  return statuses.STARTED;
+}
+
+function _getCompetenceLevel(earnedPix) {
+  const userLevel = Math.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
+  return Math.min(constants.MAX_REACHABLE_LEVEL, userLevel);
+}
+
+function _getpixScoreAheadOfNextLevel(earnedPix) {
+  return earnedPix % constants.PIX_COUNT_BY_LEVEL;
 }
 
 Scorecard.statuses = statuses;

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -34,12 +34,16 @@ class Scorecard {
     this.status = status;
   }
 
-  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluations }) {
+  static parseId(scorecardId) {
+    const [userId, competenceId] = scorecardId.split('_');
+    return { userId: _.parseInt(userId), competenceId };
+  }
+
+  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
     const totalEarnedPixByCompetence = _.sumBy(knowledgeElements, 'earnedPix');
     const status = Scorecard.computeStatus({
       knowledgeElements,
-      competenceId: competence.id,
-      competenceEvaluations
+      competenceEvaluation
     });
 
     return new Scorecard({
@@ -54,14 +58,11 @@ class Scorecard {
     });
   }
 
-  static computeStatus({ knowledgeElements, competenceId, competenceEvaluations }) {
+  static computeStatus({ knowledgeElements, competenceEvaluation }) {
     if (_.isEmpty(knowledgeElements)) {
       return ScorecardStatusType.NOT_STARTED;
     }
-
-    const competenceEvaluationForCompetence = _.find(competenceEvaluations, { competenceId });
-    const stateOfAssessment = _.get(competenceEvaluationForCompetence, 'assessment.state');
-
+    const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
     if (stateOfAssessment === Assessment.states.COMPLETED) {
       return ScorecardStatusType.COMPLETED;
     }
@@ -70,7 +71,6 @@ class Scorecard {
 
   _getCompetenceLevel(earnedPix) {
     const userLevel = Math.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
-
     return Math.min(constants.MAX_REACHABLE_LEVEL, userLevel);
   }
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -56,7 +56,7 @@ class Scorecard {
   }
   static computeStatus(competenceEvaluation) {
     if (!competenceEvaluation) {
-      return statuses.NOT_STARTED;
+      return ScorecardStatusType.NOT_STARTED;
     }
     const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
     if (stateOfAssessment === Assessment.states.COMPLETED) {

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -2,11 +2,11 @@ const _ = require('lodash');
 const constants = require('../constants');
 const Assessment = require('./Assessment');
 
-const ScorecardStatusType = Object.freeze({
+const statuses = {
   NOT_STARTED: 'NOT_STARTED',
   STARTED: 'STARTED',
   COMPLETED: 'COMPLETED',
-});
+};
 
 class Scorecard {
   constructor({
@@ -54,15 +54,16 @@ class Scorecard {
       status,
     });
   }
+  
   static computeStatus(competenceEvaluation) {
     if (!competenceEvaluation) {
       return ScorecardStatusType.NOT_STARTED;
     }
     const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
     if (stateOfAssessment === Assessment.states.COMPLETED) {
-      return ScorecardStatusType.COMPLETED;
+      return statuses.COMPLETED;
     }
-    return ScorecardStatusType.STARTED;
+    return statuses.STARTED;
   }
 
   _getCompetenceLevel(earnedPix) {
@@ -75,6 +76,6 @@ class Scorecard {
   }
 }
 
-Scorecard.StatusType = ScorecardStatusType;
+Scorecard.statuses = statuses;
 
 module.exports = Scorecard;

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -41,10 +41,7 @@ class Scorecard {
 
   static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
     const totalEarnedPixByCompetence = _.sumBy(knowledgeElements, 'earnedPix');
-    const status = Scorecard.computeStatus({
-      knowledgeElements,
-      competenceEvaluation
-    });
+    const status = Scorecard.computeStatus(competenceEvaluation);
 
     return new Scorecard({
       id: `${userId}_${competence.id}`,
@@ -57,10 +54,9 @@ class Scorecard {
       status,
     });
   }
-
-  static computeStatus({ knowledgeElements, competenceEvaluation }) {
-    if (_.isEmpty(knowledgeElements)) {
-      return ScorecardStatusType.NOT_STARTED;
+  static computeStatus(competenceEvaluation) {
+    if (!competenceEvaluation) {
+      return statuses.NOT_STARTED;
     }
     const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
     if (stateOfAssessment === Assessment.states.COMPLETED) {

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -35,11 +35,9 @@ class Scorecard {
   }
 
   static buildFrom({ userId, knowledgeElements, competence, competenceEvaluations }) {
-    const sortedKEGroupedByCompetence = _.groupBy(knowledgeElements, 'competenceId');
-    const knowledgeElementsOfCompetence = sortedKEGroupedByCompetence[competence.id];
-    const totalEarnedPixByCompetence = _.sumBy(knowledgeElementsOfCompetence, 'earnedPix');
+    const totalEarnedPixByCompetence = _.sumBy(knowledgeElements, 'earnedPix');
     const status = Scorecard.computeStatus({
-      knowledgeElements: knowledgeElementsOfCompetence,
+      knowledgeElements,
       competenceId: competence.id,
       competenceEvaluations
     });

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -1,5 +1,6 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 const Scorecard = require('../models/Scorecard');
+const _ = require('lodash');
 
 module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepository, competenceRepository, competenceEvaluationRepository }) => {
 
@@ -14,6 +15,7 @@ module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepo
     competenceEvaluationRepository.findByUserId(authenticatedUserId),
   ]);
 
-  return Scorecard.buildFrom({ userId: authenticatedUserId, knowledgeElements, competence, competenceEvaluations });
+  const knowledgeElementsForCompetence = _.groupBy(knowledgeElements, 'competenceId')[competence.id];
+  return Scorecard.buildFrom({ userId: authenticatedUserId, knowledgeElements: knowledgeElementsForCompetence, competence, competenceEvaluations });
 };
 

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -1,5 +1,6 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 const Scorecard = require('../models/Scorecard');
+const _ = require('lodash');
 
 module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepository, competenceRepository, competenceEvaluationRepository }) => {
 
@@ -15,7 +16,14 @@ module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepo
     competenceEvaluationRepository.findByUserId(authenticatedUserId),
   ]);
 
-  const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competence.id];
-  return Scorecard.buildFrom({ userId: authenticatedUserId, knowledgeElements, competence, competenceEvaluations });
+  const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competenceId];
+  const competenceEvaluation = _.find(competenceEvaluations, { competenceId: competence.id });
+
+  return Scorecard.buildFrom({
+    userId: authenticatedUserId,
+    knowledgeElements,
+    competenceEvaluation,
+    competence,
+  });
 };
 

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -3,7 +3,8 @@ const Scorecard = require('../models/Scorecard');
 
 module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepository, competenceRepository, competenceEvaluationRepository }) => {
 
-  const [userId, competenceId] = scorecardId.split('_');
+  const { userId, competenceId } = Scorecard.parseId(scorecardId);
+
   if (parseInt(authenticatedUserId) !== parseInt(userId)) {
     throw new UserNotAuthorizedToAccessEntity();
   }

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -1,6 +1,5 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 const Scorecard = require('../models/Scorecard');
-const _ = require('lodash');
 
 module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepository, competenceRepository, competenceEvaluationRepository }) => {
 
@@ -9,13 +8,13 @@ module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepo
     throw new UserNotAuthorizedToAccessEntity();
   }
 
-  const [knowledgeElements, competence, competenceEvaluations] = await Promise.all([
-    knowledgeElementRepository.findUniqByUserId({ userId: authenticatedUserId }),
+  const [knowledgeElementsGroupedByCompetenceId, competence, competenceEvaluations] = await Promise.all([
+    knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId: authenticatedUserId }),
     competenceRepository.get(competenceId),
     competenceEvaluationRepository.findByUserId(authenticatedUserId),
   ]);
 
-  const knowledgeElementsForCompetence = _.groupBy(knowledgeElements, 'competenceId')[competence.id];
-  return Scorecard.buildFrom({ userId: authenticatedUserId, knowledgeElements: knowledgeElementsForCompetence, competence, competenceEvaluations });
+  const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competence.id];
+  return Scorecard.buildFrom({ userId: authenticatedUserId, knowledgeElements, competence, competenceEvaluations });
 };
 

--- a/api/lib/domain/usecases/get-user-scorecards.js
+++ b/api/lib/domain/usecases/get-user-scorecards.js
@@ -8,13 +8,11 @@ module.exports = async ({ authenticatedUserId, requestedUserId, knowledgeElement
     throw new UserNotAuthorizedToAccessEntity();
   }
 
-  const [knowledgeElements, competencesWithArea, competenceEvaluations] = await Promise.all([
-    knowledgeElementRepository.findUniqByUserId({ userId: requestedUserId }),
+  const [knowledgeElementsGroupedByCompetenceId, competencesWithArea, competenceEvaluations] = await Promise.all([
+    knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId: requestedUserId }),
     competenceRepository.list(),
     competenceEvaluationRepository.findByUserId(requestedUserId),
   ]);
-
-  const knowledgeElementsGroupedByCompetenceId = _.groupBy(knowledgeElements, 'competenceId');
 
   return _.map(competencesWithArea, (competence) => {
     const knowledgeElementsForCompetence = knowledgeElementsGroupedByCompetenceId[competence.id];

--- a/api/lib/domain/usecases/get-user-scorecards.js
+++ b/api/lib/domain/usecases/get-user-scorecards.js
@@ -15,8 +15,16 @@ module.exports = async ({ authenticatedUserId, requestedUserId, knowledgeElement
   ]);
 
   return _.map(competencesWithArea, (competence) => {
-    const knowledgeElementsForCompetence = knowledgeElementsGroupedByCompetenceId[competence.id];
-    return Scorecard.buildFrom({ userId: requestedUserId, knowledgeElements: knowledgeElementsForCompetence, competence, competenceEvaluations });
+    const competenceId = competence.id;
+    const knowledgeElementsForCompetence = knowledgeElementsGroupedByCompetenceId[competenceId];
+    const competenceEvaluation = _.find(competenceEvaluations, { competenceId });
+
+    return Scorecard.buildFrom({
+      userId: requestedUserId,
+      knowledgeElements: knowledgeElementsForCompetence,
+      competence,
+      competenceEvaluation,
+    });
   });
 };
 

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -10,8 +10,8 @@ module.exports = async function startOrResumeCompetenceEvaluation({ competenceId
     return { created: false, competenceEvaluation };
   } catch (error) {
     if (error instanceof NotFoundError) {
-      const assessment = await _createAssessmentForCompetenceEvaluation(userId, assessmentRepository);
-      const competenceEvaluation = await _saveCompetenceEvaluation(competenceId, assessment.id, userId, competenceEvaluationRepository);
+      const assessment = await _createAssessment(userId, assessmentRepository);
+      const competenceEvaluation = await _createCompetenceEvaluation(competenceId, assessment.id, userId, competenceEvaluationRepository);
       return { created: true, competenceEvaluation };
     } else {
       throw error;
@@ -26,7 +26,7 @@ function _checkCompetenceExists(competenceId, competenceRepository) {
     });
 }
 
-function _createAssessmentForCompetenceEvaluation(userId, assessmentRepository) {
+function _createAssessment(userId, assessmentRepository) {
   const assessment = new Assessment({
     userId,
     state: Assessment.states.STARTED,
@@ -36,7 +36,7 @@ function _createAssessmentForCompetenceEvaluation(userId, assessmentRepository) 
   return assessmentRepository.save(assessment);
 }
 
-function _saveCompetenceEvaluation(competenceId, assessmentId, userId, competenceEvaluationRepository) {
+function _createCompetenceEvaluation(competenceId, assessmentId, userId, competenceEvaluationRepository) {
   const competenceEvaluation = new CompetenceEvaluation({
     userId,
     assessmentId,

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -18,6 +18,10 @@ module.exports = async function startOrResumeCompetenceEvaluation({ competenceId
 
 async function _resumeCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }) {
   const competenceEvaluation = await competenceEvaluationRepository.getLastByCompetenceIdAndUserId(competenceId, userId);
+
+  if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
+    await competenceEvaluationRepository.updateStatusByCompetenceId(competenceId, CompetenceEvaluation.statuses.STARTED);
+  }
   return {
     created: false,
     competenceEvaluation,

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -17,7 +17,7 @@ module.exports = async function startOrResumeCompetenceEvaluation({ competenceId
 };
 
 async function _resumeCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }) {
-  const competenceEvaluation = await competenceEvaluationRepository.getLastByCompetenceIdAndUserId(competenceId, userId);
+  const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId(competenceId, userId);
 
   if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
     await competenceEvaluationRepository.updateStatusByCompetenceId(competenceId, CompetenceEvaluation.statuses.STARTED);

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -55,6 +55,7 @@ function _createCompetenceEvaluation(competenceId, assessmentId, userId, compete
     userId,
     assessmentId,
     competenceId,
+    status: CompetenceEvaluation.statuses.STARTED,
   });
   return competenceEvaluationRepository.save(competenceEvaluation);
 }

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -11,8 +11,8 @@ module.exports = async function startOrResumeCompetenceEvaluation({ competenceId
   } catch (error) {
     if (error instanceof NotFoundError) {
       const assessment = await _createAssessmentForCompetenceEvaluation(userId, assessmentRepository);
-      const freshCompetenceEvaluation = await _saveCompetenceEvaluation(competenceId, assessment, userId, competenceEvaluationRepository);
-      return { created: true, competenceEvaluation: freshCompetenceEvaluation };
+      const competenceEvaluation = await _saveCompetenceEvaluation(competenceId, assessment.id, userId, competenceEvaluationRepository);
+      return { created: true, competenceEvaluation };
     } else {
       throw error;
     }
@@ -36,10 +36,10 @@ function _createAssessmentForCompetenceEvaluation(userId, assessmentRepository) 
   return assessmentRepository.save(assessment);
 }
 
-function _saveCompetenceEvaluation(competenceId, assessment, userId, competenceEvaluationRepository) {
-  const competenceEvaluation = new  CompetenceEvaluation({
+function _saveCompetenceEvaluation(competenceId, assessmentId, userId, competenceEvaluationRepository) {
+  const competenceEvaluation = new CompetenceEvaluation({
     userId,
-    assessmentId: assessment.id,
+    assessmentId,
     competenceId,
   });
   return competenceEvaluationRepository.save(competenceEvaluation);

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -146,10 +146,7 @@ module.exports = {
       .where({ userId })
       .where('type', 'IN', ['SMART_PLACEMENT', 'COMPETENCE_EVALUATION'])
       .fetchAll()
-      .then((bookshelfAssessmentCollection) => {
-        return Boolean(bookshelfAssessmentCollection.length);
-      });
-
+      .then((bookshelfAssessmentCollection) => bookshelfAssessmentCollection.length > 0);
   }
 };
 

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -143,10 +143,8 @@ module.exports = {
   // TODO: maybe obsolete after v1 be finished
   hasCampaignOrCompetenceEvaluation(userId) {
     return BookshelfAssessment
-      .query((qb) => {
-        qb.where({ userId });
-        qb.where('type', 'IN', ['SMART_PLACEMENT', 'COMPETENCE_EVALUATION']);
-      })
+      .where({ userId })
+      .where('type', 'IN', ['SMART_PLACEMENT', 'COMPETENCE_EVALUATION'])
       .fetchAll()
       .then((bookshelfAssessmentCollection) => {
         return Boolean(bookshelfAssessmentCollection.length);

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -12,6 +12,17 @@ module.exports = {
       .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result));
   },
 
+  updateStatusByAssessmentId(assessmentId, status) {
+    return BookshelfCompetenceEvaluation
+      .where({ assessmentId })
+      .fetch({ require: true })
+      .then((competenceEvaluation) => {
+        competenceEvaluation.set('status', status);
+        return competenceEvaluation.save();
+      })
+      .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
+  },
+
   getByAssessmentId(assessmentId) {
     return BookshelfCompetenceEvaluation
       .where({ assessmentId })

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -23,6 +23,17 @@ module.exports = {
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
 
+  updateStatusByUserIdAndCompetenceId(userId, competenceId, status) {
+    return BookshelfCompetenceEvaluation
+      .where({ userId, competenceId })
+      .fetch({ require: true })
+      .then((competenceEvaluation) => {
+        competenceEvaluation.set('status', status);
+        return competenceEvaluation.save();
+      })
+      .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
+  },
+
   getByAssessmentId(assessmentId) {
     return BookshelfCompetenceEvaluation
       .where({ assessmentId })

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -47,11 +47,9 @@ module.exports = {
       });
   },
 
-  getLastByCompetenceIdAndUserId(competenceId, userId) {
+  getByCompetenceIdAndUserId(competenceId, userId) {
     return BookshelfCompetenceEvaluation
       .where({ competenceId, userId })
-      .orderBy('createdAt', 'desc')
-      .query((qb) => qb.limit(1))
       .fetch({ require: true, withRelated: ['assessment'] })
       .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result))
       .catch((bookshelfError) => {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -42,6 +42,11 @@ module.exports = {
       });
   },
 
+  findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {
+    return this.findUniqByUserId({ userId, limitDate })
+      .then((knowledgeElements) => _.groupBy(knowledgeElements, 'competenceId'));
+  },
+
   getSumOfPixFromUserKnowledgeElements(userId) {
     return Bookshelf.knex.with('earnedPixWithRankPerSkill',
       (qb) => {

--- a/api/lib/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
         competenceEvaluation.assessment = { id: current.assessmentId };
         return competenceEvaluation;
       },
-      attributes: ['createdAt', 'updatedAt', 'userId', 'competenceId', 'assessment', 'scorecard'],
+      attributes: ['createdAt', 'updatedAt', 'userId', 'competenceId', 'assessment', 'scorecard', 'status'],
       assessment: {
         ref: 'id',
         included: false,

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -117,7 +117,7 @@ describe('Acceptance | API | Competence Evaluations', () => {
       assessment = databaseBuilder.factory.buildAssessment({ userId });
       competenceEvaluation = databaseBuilder.factory.buildCompetenceEvaluation({
         assessmentId: assessment.id,
-        status: 'initialized',
+        status: 'started',
         userId,
       });
 

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -117,6 +117,7 @@ describe('Acceptance | API | Competence Evaluations', () => {
       assessment = databaseBuilder.factory.buildAssessment({ userId });
       competenceEvaluation = databaseBuilder.factory.buildCompetenceEvaluation({
         assessmentId: assessment.id,
+        status: 'initialized',
         userId,
       });
 
@@ -142,6 +143,7 @@ describe('Acceptance | API | Competence Evaluations', () => {
             'competence-id': competenceEvaluation.competenceId,
             'created-at': competenceEvaluation.createdAt,
             'updated-at': competenceEvaluation.updatedAt,
+            'status': competenceEvaluation.status,
           },
           id: competenceEvaluation.id.toString(),
           type: 'competence-evaluations',

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -90,6 +90,13 @@ describe('Acceptance | Controller | scorecard-controller', () => {
           competenceId: competence.id,
         });
 
+        const assessmentId = databaseBuilder.factory.buildAssessment({ state: 'started' }).id;
+        databaseBuilder.factory.buildCompetenceEvaluation({
+          userId,
+          assessmentId,
+          competenceId: competence.id
+        });
+
         await databaseBuilder.commit();
       });
 

--- a/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
@@ -94,6 +94,13 @@ describe('Acceptance | Controller | users-controller-get-user-scorecards', () =>
           competenceId: competence.id,
         });
 
+        const assessmentId = databaseBuilder.factory.buildAssessment({ state: 'started' }).id;
+        databaseBuilder.factory.buildCompetenceEvaluation({
+          userId,
+          assessmentId,
+          competenceId: competence.id
+        });
+
         await databaseBuilder.commit();
       });
 

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -6,6 +6,8 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const _ = require('lodash');
 
 describe('Integration | Repository | Competence Evaluation', () => {
+
+  const status = 'initialized';
   describe('#save', () => {
 
     afterEach(() => {
@@ -17,6 +19,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
       const competenceEvaluationToSave = new CompetenceEvaluation({
         assessmentId: 12,
         competenceId: 'recABCD1234',
+        status,
         userId: 1,
       });
 
@@ -28,6 +31,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
         expect(savedCompetenceEvaluation).to.be.instanceof(CompetenceEvaluation);
         expect(savedCompetenceEvaluation.id).to.exist;
         expect(savedCompetenceEvaluation.createdAt).to.exist;
+        expect(savedCompetenceEvaluation.status).to.equal(status);
         expect(savedCompetenceEvaluation.assessmentId).to.equal(competenceEvaluationToSave.assessmentId);
         expect(savedCompetenceEvaluation.competenceId).to.equal(competenceEvaluationToSave.competenceId);
         expect(savedCompetenceEvaluation.userId).to.equal(competenceEvaluationToSave.userId);
@@ -39,6 +43,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
       const competenceEvaluationToSave = new CompetenceEvaluation({
         assessmentId: 12,
         competenceId: 'recABCD1234',
+        status,
         userId: 1,
       });
 
@@ -47,7 +52,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
 
       // then
       return promise.then((savedCompetenceEvaluation) => {
-        return knex.select('id', 'assessmentId', 'competenceId', 'userId')
+        return knex.select('id', 'assessmentId', 'competenceId', 'userId', 'status')
           .from('competence-evaluations')
           .where({ id: savedCompetenceEvaluation.id })
           .then(([competenceEvaluationInDb]) => {
@@ -55,6 +60,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
             expect(competenceEvaluationInDb.assessmentId).to.equal(competenceEvaluationToSave.assessmentId);
             expect(competenceEvaluationInDb.competenceId).to.equal(competenceEvaluationToSave.competenceId);
             expect(competenceEvaluationInDb.userId).to.equal(competenceEvaluationToSave.userId);
+            expect(competenceEvaluationInDb.status).to.equal('initialized');
           });
       });
     });
@@ -70,16 +76,23 @@ describe('Integration | Repository | Competence Evaluation', () => {
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser({});
 
-      assessmentForExpectedCompetenceEvaluation = databaseBuilder.factory.buildAssessment({ userId: user.id, type: Assessment.types.COMPETENCE_EVALUATION });
-      assessmentNotExpected = databaseBuilder.factory.buildAssessment({ userId: user.id, type: Assessment.types.COMPETENCE_EVALUATION });
-
+      assessmentForExpectedCompetenceEvaluation = databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      });
+      assessmentNotExpected = databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      });
       competenceEvaluationExpected = databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
         assessmentId: assessmentForExpectedCompetenceEvaluation.id,
+        status,
       });
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
-        assessmentId: assessmentNotExpected.id
+        assessmentId: assessmentNotExpected.id,
+        status,
       });
 
       await databaseBuilder.commit();
@@ -119,16 +132,21 @@ describe('Integration | Repository | Competence Evaluation', () => {
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser({});
 
-      assessmentExpected = databaseBuilder.factory.buildAssessment({ userId: user.id, type: Assessment.types.COMPETENCE_EVALUATION });
+      assessmentExpected = databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      });
 
       competenceEvaluationExpected = databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
         competenceId: '1',
-        assessmentId: assessmentExpected.id
+        assessmentId: assessmentExpected.id,
+        status,
       });
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
-        competenceId: '2'
+        competenceId: '2',
+        status,
       });
 
       await databaseBuilder.commit();
@@ -170,23 +188,29 @@ describe('Integration | Repository | Competence Evaluation', () => {
       user = databaseBuilder.factory.buildUser({});
       const otherUser = databaseBuilder.factory.buildUser({});
 
-      assessmentExpected = databaseBuilder.factory.buildAssessment({ userId: user.id, type: Assessment.types.COMPETENCE_EVALUATION });
+      assessmentExpected = databaseBuilder.factory.buildAssessment({
+        userId: user.id,
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      });
 
       competenceEvaluationExpected = databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
         competenceId: '1',
         assessmentId: assessmentExpected.id,
-        createdAt: new Date('2018-01-01')
+        createdAt: new Date('2018-01-01'),
+        status,
       });
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId: user.id,
         competenceId: '2',
-        createdAt: new Date('2017-01-01')
+        createdAt: new Date('2017-01-01'),
+        status,
       });
 
       databaseBuilder.factory.buildCompetenceEvaluation({
         userId: otherUser.id,
-        competenceId: '2'
+        competenceId: '2',
+        status,
       });
 
       await databaseBuilder.commit();
@@ -205,7 +229,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
         expect(competenceEvaluation).to.have.length(2);
         expect(_.omit(competenceEvaluation[0], ['assessment', 'scorecard'])).to.deep.equal(_.omit(competenceEvaluationExpected, ['assessment']));
         expect(competenceEvaluation[0].assessment.id).to.deep.equal(assessmentExpected.id);
-
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 
 describe('Integration | Repository | Competence Evaluation', () => {
 
-  const status = 'initialized';
+  const status = 'started';
   describe('#save', () => {
 
     afterEach(() => {
@@ -60,7 +60,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
             expect(competenceEvaluationInDb.assessmentId).to.equal(competenceEvaluationToSave.assessmentId);
             expect(competenceEvaluationInDb.competenceId).to.equal(competenceEvaluationToSave.competenceId);
             expect(competenceEvaluationInDb.userId).to.equal(competenceEvaluationToSave.userId);
-            expect(competenceEvaluationInDb.status).to.equal('initialized');
+            expect(competenceEvaluationInDb.status).to.equal('started');
           });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -253,4 +253,29 @@ describe('Integration | Repository | Competence Evaluation', () => {
     });
   });
 
+  describe('#updateStatusByUserIdAndCompetenceId', () => {
+    const competenceId = 'recABCD1234';
+    const userId = 123;
+    const otherUserId = 456;
+
+    beforeEach(async () => {
+      databaseBuilder.factory.buildCompetenceEvaluation({ userId, competenceId, status: 'current_status' });
+      databaseBuilder.factory.buildCompetenceEvaluation({ userId: otherUserId, competenceId, status: 'current_status' });
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should update the competence status', async () => {
+      const updatedCompetenceEvaluation = await competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId(userId, competenceId, 'new_status');
+      const unchangedCompetenceEvaluation = await competenceEvaluationRepository.getLastByCompetenceIdAndUserId(competenceId, otherUserId);
+
+      expect(updatedCompetenceEvaluation).to.be.instanceOf(CompetenceEvaluation);
+      expect(updatedCompetenceEvaluation.status).to.equal('new_status');
+      expect(unchangedCompetenceEvaluation.status).to.equal('current_status');
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -233,4 +233,24 @@ describe('Integration | Repository | Competence Evaluation', () => {
     });
   });
 
+  describe('#updateStatusByAssessmentId', () => {
+    const assessmentId = 'some id';
+
+    beforeEach(async () => {
+      databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, status: 'current_status' });
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should update the competence status', async () => {
+      const updatedCompetenceEvaluation = await competenceEvaluationRepository.updateStatusByAssessmentId(assessmentId, 'new_status');
+
+      expect(updatedCompetenceEvaluation).to.be.instanceOf(CompetenceEvaluation);
+      expect(updatedCompetenceEvaluation.status).to.equal('new_status');
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -125,7 +125,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
 
   });
 
-  describe('#getLastByCompetenceIdAndUserId', () => {
+  describe('#getByCompetenceIdAndUserId', () => {
     let user;
     let competenceEvaluationExpected, assessmentExpected;
 
@@ -158,7 +158,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
 
     it('should return the competence evaluation linked to the competence id', () => {
       // when
-      const promise = competenceEvaluationRepository.getLastByCompetenceIdAndUserId(1, user.id);
+      const promise = competenceEvaluationRepository.getByCompetenceIdAndUserId(1, user.id);
 
       // then
       return promise.then((competenceEvaluation) => {
@@ -170,7 +170,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
 
     it('should return an error when there is no competence evaluation', () => {
       // when
-      const promise = catchErr(competenceEvaluationRepository.getLastByCompetenceIdAndUserId)('fakeId', user.id);
+      const promise = catchErr(competenceEvaluationRepository.getByCompetenceIdAndUserId)('fakeId', user.id);
 
       // then
       return promise.then((error) => {
@@ -270,7 +270,7 @@ describe('Integration | Repository | Competence Evaluation', () => {
 
     it('should update the competence status', async () => {
       const updatedCompetenceEvaluation = await competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId(userId, competenceId, 'new_status');
-      const unchangedCompetenceEvaluation = await competenceEvaluationRepository.getLastByCompetenceIdAndUserId(competenceId, otherUserId);
+      const unchangedCompetenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId(competenceId, otherUserId);
 
       expect(updatedCompetenceEvaluation).to.be.instanceOf(CompetenceEvaluation);
       expect(updatedCompetenceEvaluation.status).to.equal('new_status');

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -198,6 +198,39 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
   });
 
+  describe('#findUniqByUserIdGroupedByCompetenceId', () => {
+
+    let userId;
+
+    beforeEach(async () => {
+      // given
+      userId = databaseBuilder.factory.buildUser().id;
+
+      _.each([
+        { id: 1, competenceId: 1, userId, skillId: 'web1' },
+        { id: 2, competenceId: 1, userId, skillId: 'web2' },
+        { id: 3, competenceId: 2, userId, skillId: 'url1' },
+      ], (ke) => {
+        databaseBuilder.factory.buildKnowledgeElement(ke);
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should find the knowledge elements grouped by competence id', async () => {
+      // when
+      const actualKnowledgeElementsGroupedByCompetenceId = await KnowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
+      expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.length(2);
+      expect(actualKnowledgeElementsGroupedByCompetenceId[2]).to.have.length(1);
+      expect(actualKnowledgeElementsGroupedByCompetenceId[1][0]).to.be.instanceOf(KnowledgeElement);
+    });
+
+  });
+
   describe('#getSumOfPixFromUserKnowledgeElements', () => {
 
     let userId;

--- a/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
@@ -7,13 +7,20 @@ module.exports = function buildCompetenceEvaluation({
   id = faker.random.number(),
   assessmentId = buildAssessment().id,
   competenceId = `recABC${faker.random.number}`,
+  status,
   createdAt = faker.date.past(),
   updatedAt = new Date(),
   userId = buildUser().id,
 } = {}) {
 
   const values = {
-    id, assessmentId, competenceId, userId, createdAt, updatedAt
+    id,
+    assessmentId,
+    competenceId,
+    userId,
+    createdAt,
+    updatedAt,
+    status,
   };
 
   databaseBuffer.pushInsertable({

--- a/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
@@ -2,16 +2,19 @@ const faker = require('faker');
 const buildAssessment = require('./build-assessment');
 const buildUser = require('./build-user');
 const databaseBuffer = require('../database-buffer');
+const _ = require('lodash');
 
 module.exports = function buildCompetenceEvaluation({
   id = faker.random.number(),
-  assessmentId = buildAssessment().id,
+  assessmentId,
   competenceId = `recABC${faker.random.number}`,
   status,
   createdAt = faker.date.past(),
   updatedAt = new Date(),
   userId = buildUser().id,
 } = {}) {
+
+  assessmentId = _.isNil(assessmentId) ? buildAssessment().id : assessmentId;
 
   const values = {
     id,

--- a/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
@@ -9,7 +9,7 @@ module.exports = function buildCompetenceEvaluation(
     id = 1,
     assessmentId,
     assessment,
-    status = 'initialized',
+    status = 'started',
     userId = buildUser().id,
     competenceId = 'recsvLz0W2ShyfD63',
     createdAt = faker.date.recent(),

--- a/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
@@ -7,12 +7,34 @@ const faker = require('faker');
 module.exports = function buildCompetenceEvaluation(
   {
     id = 1,
-    assessmentId = buildAssessment().id,
-    assessment = buildAssessment(),
+    assessmentId,
+    assessment,
+    status = 'initialized',
     userId = buildUser().id,
     competenceId = 'recsvLz0W2ShyfD63',
     createdAt = faker.date.recent(),
     updatedAt = faker.date.recent(),
   } = {}) {
-  return new CompetenceEvaluation({ id, assessmentId: assessmentId || assessment.id , userId, competenceId, createdAt, updatedAt, assessment });
+
+  if (assessment && !assessmentId) {
+    assessmentId = assessment.id;
+  }
+  if (assessmentId && !assessment) {
+    assessmentId = buildAssessment({ id: assessmentId });
+  }
+  if (!assessmentId && !assessment) {
+    assessment = buildAssessment();
+    assessmentId = assessment.id;
+  }
+
+  return new CompetenceEvaluation({
+    id,
+    assessmentId,
+    userId,
+    competenceId,
+    createdAt,
+    updatedAt,
+    assessment,
+    status,
+  });
 };

--- a/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -40,10 +40,10 @@ describe('Unit | Application | Controller | Competence-Evaluation', () => {
       // then
       expect(usecases.startOrResumeCompetenceEvaluation).to.have.been.calledOnce;
 
-      const args = usecases.startOrResumeCompetenceEvaluation.firstCall.args[0];
+      const { userId, competenceId } = usecases.startOrResumeCompetenceEvaluation.firstCall.args[0];
 
-      expect(args.userId).to.equal(userId);
-      expect(args.competenceId).to.equal(competenceId);
+      expect(userId).to.equal(userId);
+      expect(competenceId).to.equal(competenceId);
     });
 
     it('should return the serialized competence evaluation when it has been successfully created', async () => {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -1,255 +1,88 @@
-const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
-const constants = require('../../../../lib/domain/constants');
 
 describe('Unit | Domain | Models | Scorecard', () => {
 
-  describe('#constructor', () => {
-
-    it('should build a Scorecard from raw JSON', () => {
-      // given
-      const rawData = {
-        id: 1,
-        name: 'Competence name',
-        description: 'Competence description',
-        index: 'Competence index',
-        area: {},
-        earnedPix: 10,
-      };
-
-      // when
-      const scorecard = new Scorecard(rawData);
-
-      // then
-      expect(scorecard.id).to.equal(1);
-      expect(scorecard.name).to.equal(rawData.name);
-      expect(scorecard.description).to.equal(rawData.description);
-      expect(scorecard.index).to.equal(rawData.index);
-      expect(scorecard.area).to.equal(rawData.area);
-      expect(scorecard.earnedPix).to.equal(rawData.earnedPix);
-      expect(scorecard.level).to.equal(1);
-      expect(scorecard.pixScoreAheadOfNextLevel).to.equal(2);
-    });
-  });
-
   describe('#buildFrom', () => {
-    const authenticatedUserId = 2;
-    const maxLevel = 5;
-    const competenceId = 1;
-    const scorecardId = `${authenticatedUserId}_${competenceId}`;
-    const computeStatusStub = sinon.stub(Scorecard, 'computeStatus');
 
-    afterEach(() => {
-      computeStatusStub.restore();
-    });
+    let competenceEvaluation;
+    let knowledgeElements;
+    let actualScorecard;
 
-    it('should return the user scorecard with level limited to 5', async () => {
-      // given
-      computeStatusStub.returns(Scorecard.StatusType.STARTED);
-      const earnedPixNeededForLevelSixLimitedToFive = 50;
-      const pixScoreAheadOfNextLevel = 2;
+    const userId = '123';
+    const competence = {
+      id: 1,
+      name: 'Évaluer',
+      description: 'Les compétences numériques',
+      area: 'area',
+      index: 'index',
+    };
 
-      const competence = domainBuilder.buildCompetence({ id: competenceId });
-
-      const knowledgeElementList = [
-        domainBuilder.buildKnowledgeElement({
-          competenceId,
-          earnedPix: earnedPixNeededForLevelSixLimitedToFive
-        })
-      ];
-
-      const expectedUserScorecard = domainBuilder.buildUserScorecard({
-        id: scorecardId,
-        name: competence.name,
-        description: competence.description,
-        competenceId,
-        index: competence.index,
-        area: competence.area,
-        earnedPix: earnedPixNeededForLevelSixLimitedToFive,
-        level: maxLevel,
-        pixScoreAheadOfNextLevel,
-        status: Scorecard.StatusType.STARTED,
-      });
-
-      // when
-      const userScorecard = Scorecard.buildFrom({
-        userId: authenticatedUserId,
-        knowledgeElements: knowledgeElementList,
-        competence,
-        competenceEvaluation: null
-      });
-
-      //then
-      expect(userScorecard).to.deep.equal(expectedUserScorecard);
-    });
-
-    context('when there is no knowledge elements', async () => {
-
-      it('should return the user scorecard with score null', async () => {
+    context('with existing competence evaluation and assessment', () => {
+      beforeEach(() => {
         // given
-        computeStatusStub.returns(Scorecard.StatusType.NOT_STARTED);
-
-        const competence = domainBuilder.buildCompetence({ id: competenceId });
-
-        const expectedUserScorecard = domainBuilder.buildUserScorecard({
-          id: scorecardId,
-          name: competence.name,
-          description: competence.description,
-          competenceId,
-          index: competence.index,
-          area: competence.area,
-          earnedPix: 0,
-          level: 0,
-          pixScoreAheadOfNextLevel: 0,
-          status: Scorecard.StatusType.NOT_STARTED,
-        });
-
+        competenceEvaluation = {
+          status: 'started',
+          assessment: { state: 'started' },
+        };
+        knowledgeElements = [{ earnedPix: 5.5 }, { earnedPix: 3.6 }];
         // when
-        const userScorecard = Scorecard.buildFrom({
-          userId: authenticatedUserId,
-          knowledgeElements: null,
-          competence,
-          competenceEvaluation: null
-        });
-
-        //then
-        expect(userScorecard).to.deep.equal(expectedUserScorecard);
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
       });
-    });
-
-    context('when there are some knowledge elements', async () => {
-      const earnedPix = 10;
-
-      it('should return the user scorecard with computed level and pix', async () => {
-        // given
-        computeStatusStub.returns(Scorecard.StatusType.COMPLETED);
-
-        const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId, earnedPix })];
-        const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
-          competenceId,
-          assessmentId: assessment.id,
-          assessment
-        })
-        ;
-        const competence = domainBuilder.buildCompetence({ id: competenceId });
-
-        const expectedUserScorecard = domainBuilder.buildUserScorecard({
-          id: scorecardId,
-          name: competence.name,
-          description: competence.description,
-          competenceId,
-          index: competence.index,
-          area: competence.area,
-          earnedPix,
-          level: 1,
-          pixScoreAheadOfNextLevel: 2,
-          status: Scorecard.StatusType.COMPLETED,
-        });
-
-        // when
-        const userScorecard = Scorecard.buildFrom({
-          userId: authenticatedUserId,
-          knowledgeElements: knowledgeElementList,
-          competence,
-          competenceEvaluation
-        });
-
-        //then
-        expect(userScorecard).to.deep.equal(expectedUserScorecard);
-      });
-    });
-  });
-
-  describe('#computeStatus', () => {
-    const competenceId = 1;
-
-    context('when there is no knowledge elements', async () => {
-
-      it('should return the user scorecard with status NOT_STARTED', async () => {
-        // given
-        const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
-          competenceId: 1,
-          assessmentId: assessment.id,
-          assessment
-        });
-
-        // when
-        const status = Scorecard.computeStatus({ knowledgeElements: null, competenceId, competenceEvaluation });
-
-        //then
-        expect(status).to.equal(Scorecard.StatusType.NOT_STARTED);
-      });
-    });
-
-    context('when assessment is completed', async () => {
-
-      it('should return the user scorecard with status COMPLETED', async () => {
-        // given
-        const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId })];
-        const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
-          competenceId,
-          assessmentId: assessment.id,
-          assessment
-        });
-
-        // when
-        const status = Scorecard.computeStatus({
-          knowledgeElements: knowledgeElementList,
-          competenceId,
-          competenceEvaluation
-        });
-
-        //then
-        expect(status).to.equal(Scorecard.StatusType.COMPLETED);
-      });
-    });
-
-    context('when there are some knowledge-elements and assessment is not completed', async () => {
-
-      it('should return the user scorecard with status STARTED', async () => {
-        // given
-        const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId })];
-        const assessment = domainBuilder.buildAssessment({ state: 'started', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
-          competenceId,
-          assessmentId: assessment.id,
-          assessment
-        });
-
-        // when
-        const status = Scorecard.computeStatus({
-          knowledgeElements: knowledgeElementList,
-          competenceId,
-          competenceEvaluation
-        });
-
-        //then
-        expect(status).to.equal(Scorecard.StatusType.STARTED);
-      });
-    });
-  });
-
-  describe('#_getCompetenceLevel', () => {
-
-    it('should be capped at a maximum reachable level', () => {
-      // given
-      const rawData = {
-        id: 1,
-        name: 'Competence name',
-        description: 'Competence description',
-        index: 'Competence index',
-        area: {},
-        earnedPix: 99999999,
-      };
-
-      // when
-      const scorecard = new Scorecard(rawData);
-
       // then
-      expect(scorecard.level).to.equal(constants.MAX_REACHABLE_LEVEL);
+      it('should build an object of Scorecard type', () => {
+        expect(actualScorecard).to.be.instanceOf(Scorecard);
+      });
+      it('should build a scorecard id from a combination of userId and competenceId', () => {
+        expect(actualScorecard.id).to.equal(userId + '_' + competence.id);
+      });
+      it('should competence datas to the scorecard object', () => {
+        expect(actualScorecard.name).to.equal(competence.name);
+        expect(actualScorecard.competenceId).to.equal(competence.id);
+        expect(actualScorecard.area).to.equal(competence.area);
+        expect(actualScorecard.index).to.equal(competence.index);
+        expect(actualScorecard.description).to.equal(competence.description);
+      });
+      it('should have earned pix as a rounded sum of all knowledge elements earned pixes', () => {
+        expect(actualScorecard.earnedPix).to.equal(9);
+      });
+      it('should have a level computed from the number of pixes', () => {
+        expect(actualScorecard.earnedPix).to.equal(9);
+      });
+      it('should have set the number of pix ahead of the next level', () => {
+        expect(actualScorecard.pixScoreAheadOfNextLevel).to.equal(1);
+      });
+      it('should have set the scorecard status based on the competence evaluation status', () => {
+        expect(actualScorecard.status).to.equal('STARTED');
+      });
     });
+
+    context('when the competence evaluation has never been started', () => {
+      beforeEach(() => {
+        // given
+        competenceEvaluation = undefined;
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+      });
+      // then
+      it('should have set the scorecard status based on the competence evaluation status', () => {
+        expect(actualScorecard.status).to.equal('NOT_STARTED');
+      });
+    });
+
+    context('when the user level is beyond the upper limit allowed', () => {
+      beforeEach(() => {
+        // given
+        knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+      });
+      // then
+      it('should have the competence level capped at the maximum value', () => {
+        expect(actualScorecard.level).to.equal(5);
+      });
+    });
+
   });
+
 });

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -76,7 +76,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
         userId: authenticatedUserId,
         knowledgeElements: knowledgeElementList,
         competence,
-        competenceEvaluations: null
+        competenceEvaluation: null
       });
 
       //then
@@ -109,7 +109,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
           userId: authenticatedUserId,
           knowledgeElements: null,
           competence,
-          competenceEvaluations: null
+          competenceEvaluation: null
         });
 
         //then
@@ -126,11 +126,12 @@ describe('Unit | Domain | Models | Scorecard', () => {
 
         const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId, earnedPix })];
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
           competenceId,
           assessmentId: assessment.id,
           assessment
-        })];
+        })
+        ;
         const competence = domainBuilder.buildCompetence({ id: competenceId });
 
         const expectedUserScorecard = domainBuilder.buildUserScorecard({
@@ -151,7 +152,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
           userId: authenticatedUserId,
           knowledgeElements: knowledgeElementList,
           competence,
-          competenceEvaluations
+          competenceEvaluation
         });
 
         //then
@@ -168,14 +169,14 @@ describe('Unit | Domain | Models | Scorecard', () => {
       it('should return the user scorecard with status NOT_STARTED', async () => {
         // given
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
           competenceId: 1,
           assessmentId: assessment.id,
           assessment
-        })];
+        });
 
         // when
-        const status = Scorecard.computeStatus({ knowledgeElements: null, competenceId, competenceEvaluations });
+        const status = Scorecard.computeStatus({ knowledgeElements: null, competenceId, competenceEvaluation });
 
         //then
         expect(status).to.equal(Scorecard.StatusType.NOT_STARTED);
@@ -188,17 +189,17 @@ describe('Unit | Domain | Models | Scorecard', () => {
         // given
         const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId })];
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
           competenceId,
           assessmentId: assessment.id,
           assessment
-        })];
+        });
 
         // when
         const status = Scorecard.computeStatus({
           knowledgeElements: knowledgeElementList,
           competenceId,
-          competenceEvaluations
+          competenceEvaluation
         });
 
         //then
@@ -212,17 +213,17 @@ describe('Unit | Domain | Models | Scorecard', () => {
         // given
         const knowledgeElementList = [domainBuilder.buildKnowledgeElement({ competenceId })];
         const assessment = domainBuilder.buildAssessment({ state: 'started', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
           competenceId,
           assessmentId: assessment.id,
           assessment
-        })];
+        });
 
         // when
         const status = Scorecard.computeStatus({
           knowledgeElements: knowledgeElementList,
           competenceId,
-          competenceEvaluations
+          competenceEvaluation
         });
 
         //then

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -70,6 +70,19 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
 
+    context('when the competence evaluation has been reset', () => {
+      beforeEach(() => {
+        // given
+        competenceEvaluation = { status: 'reset' };
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+      });
+      // then
+      it('should have set the scorecard status based on the competence evaluation status', () => {
+        expect(actualScorecard.status).to.equal('NOT_STARTED');
+      });
+    });
+
     context('when the user level is beyond the upper limit allowed', () => {
       beforeEach(() => {
         // given

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -73,13 +73,13 @@ describe('Unit | UseCase | get-scorecard', () => {
         knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({ '1': knowledgeElementList });
 
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
-        const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
           competenceId: 1,
           assessmentId: assessment.id,
           assessment
-        })];
+        });
 
-        competenceEvaluationRepository.findByUserId.resolves(competenceEvaluations);
+        competenceEvaluationRepository.findByUserId.resolves([competenceEvaluation]);
 
         const expectedUserScorecard = domainBuilder.buildUserScorecard({
           name: competence.name,
@@ -92,7 +92,7 @@ describe('Unit | UseCase | get-scorecard', () => {
           userId: authenticatedUserId,
           knowledgeElements: knowledgeElementList,
           competence,
-          competenceEvaluations
+          competenceEvaluation
         }).returns(expectedUserScorecard);
 
         // when

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | get-scorecard', () => {
 
   beforeEach(() => {
     competenceRepository = { get: sinon.stub() };
-    knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
     competenceEvaluationRepository = { findByUserId: sinon.stub() };
     buildFromStub = sinon.stub(Scorecard, 'buildFrom');
   });
@@ -30,7 +30,7 @@ describe('Unit | UseCase | get-scorecard', () => {
       it('should resolve', () => {
         // given
         competenceRepository.get.resolves([]);
-        knowledgeElementRepository.findUniqByUserId.resolves([]);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
 
         // when
         const promise = getScorecard({
@@ -60,7 +60,7 @@ describe('Unit | UseCase | get-scorecard', () => {
           domainBuilder.buildKnowledgeElement({ competenceId: 1 }),
         ];
 
-        knowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({ '1': knowledgeElementList });
 
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
         const competenceEvaluations = [domainBuilder.buildCompetenceEvaluation({
@@ -105,7 +105,7 @@ describe('Unit | UseCase | get-scorecard', () => {
         const authenticatedUserId = 34;
 
         competenceRepository.get.resolves([]);
-        knowledgeElementRepository.findUniqByUserId.resolves([]);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
 
         // when
         const promise = getScorecard({

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
 
   beforeEach(() => {
     competenceRepository = { list: sinon.stub() };
-    knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
     competenceEvaluationRepository = { findByUserId: sinon.stub() };
     sinon.stub(Scorecard, 'buildFrom').returns(scorecard);
   });
@@ -38,7 +38,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
       it('should resolve', () => {
         // given
         competenceRepository.list.resolves([]);
-        knowledgeElementRepository.findUniqByUserId.resolves([]);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
         competenceEvaluationRepository.findByUserId.resolves([]);
 
         // when
@@ -98,6 +98,11 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           })
         ];
 
+        const knowledgeElementGroupedByCompetenceId = {
+          '1': [ knowledgeElementList[0], knowledgeElementList[1] ],
+          '2': [ knowledgeElementList[2] ],
+        };
+
         const expectedUserScorecard = [
           domainBuilder.buildUserScorecard({
             name: competenceList[0].name,
@@ -123,19 +128,19 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           }),
         ];
 
-        knowledgeElementRepository.findUniqByUserId.resolves(knowledgeElementList);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves(knowledgeElementGroupedByCompetenceId);
         competenceEvaluationRepository.findByUserId.resolves([competenceEvaluationOfCompetence1]);
 
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
-          knowledgeElements: [knowledgeElementList[0], knowledgeElementList[1]],
+          knowledgeElements: knowledgeElementGroupedByCompetenceId[1],
           competence: competenceList[0],
           competenceEvaluations: [competenceEvaluationOfCompetence1]
         }).returns(expectedUserScorecard[0]);
 
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
-          knowledgeElements: [knowledgeElementList[2]],
+          knowledgeElements: knowledgeElementGroupedByCompetenceId[2],
           competence: competenceList[1],
           competenceEvaluations: [competenceEvaluationOfCompetence1]
         }).returns(expectedUserScorecard[1]);
@@ -169,7 +174,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
         const requestedUserId = 34;
 
         competenceRepository.list.resolves([]);
-        knowledgeElementRepository.findUniqByUserId.resolves([]);
+        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
 
         // when
         const promise = getUserScorecard({

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -1,7 +1,7 @@
 const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
-const getUserScorecard = require('../../../../lib/domain/usecases/get-user-scorecards');
+const getUserScorecards = require('../../../../lib/domain/usecases/get-user-scorecards');
 
 function assertScorecard(userScorecard, expectedUserScorecard) {
   expect(userScorecard.earnedPix).to.equal(expectedUserScorecard.earnedPix);
@@ -42,7 +42,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
         competenceEvaluationRepository.findByUserId.resolves([]);
 
         // when
-        const promise = getUserScorecard({
+        const promise = getUserScorecards({
           authenticatedUserId,
           requestedUserId,
           knowledgeElementRepository,
@@ -153,7 +153,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
         }).returns(expectedUserScorecard[2]);
 
         // when
-        const userScorecard = await getUserScorecard({
+        const userScorecard = await getUserScorecards({
           authenticatedUserId,
           requestedUserId,
           knowledgeElementRepository,
@@ -177,7 +177,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
         knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
 
         // when
-        const promise = getUserScorecard({
+        const promise = getUserScorecards({
           authenticatedUserId,
           requestedUserId,
           knowledgeElementRepository,

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -128,19 +128,21 @@ describe('Unit | UseCase | get-user-scorecard', () => {
 
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
-          knowledgeElements: knowledgeElementList,
+          knowledgeElements: [knowledgeElementList[0], knowledgeElementList[1]],
           competence: competenceList[0],
           competenceEvaluations: [competenceEvaluationOfCompetence1]
         }).returns(expectedUserScorecard[0]);
+
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
-          knowledgeElements: knowledgeElementList,
+          knowledgeElements: [knowledgeElementList[2]],
           competence: competenceList[1],
           competenceEvaluations: [competenceEvaluationOfCompetence1]
         }).returns(expectedUserScorecard[1]);
+
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
-          knowledgeElements: knowledgeElementList,
+          knowledgeElements: undefined,
           competence: competenceList[2],
           competenceEvaluations: [competenceEvaluationOfCompetence1]
         }).returns(expectedUserScorecard[2]);

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -135,21 +135,21 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           userId: authenticatedUserId,
           knowledgeElements: knowledgeElementGroupedByCompetenceId[1],
           competence: competenceList[0],
-          competenceEvaluations: [competenceEvaluationOfCompetence1]
+          competenceEvaluation: competenceEvaluationOfCompetence1,
         }).returns(expectedUserScorecard[0]);
 
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
           knowledgeElements: knowledgeElementGroupedByCompetenceId[2],
           competence: competenceList[1],
-          competenceEvaluations: [competenceEvaluationOfCompetence1]
+          competenceEvaluation: undefined,
         }).returns(expectedUserScorecard[1]);
 
         Scorecard.buildFrom.withArgs({
           userId: authenticatedUserId,
           knowledgeElements: undefined,
           competence: competenceList[2],
-          competenceEvaluations: [competenceEvaluationOfCompetence1]
+          competenceEvaluation: undefined,
         }).returns(expectedUserScorecard[2]);
 
         // when

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -9,13 +9,13 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
   const userId = 19837482;
   const competenceId = 'recABC123';
   const competenceRepository = { get: () => undefined };
-  const competenceEvaluationRepository = { save: () => undefined, getLastByCompetenceIdAndUserId: () => undefined, };
+  const competenceEvaluationRepository = { save: () => undefined, getByCompetenceIdAndUserId: () => undefined, };
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
     sinon.stub(competenceRepository, 'get');
     sinon.stub(competenceEvaluationRepository, 'save');
-    sinon.stub(competenceEvaluationRepository, 'getLastByCompetenceIdAndUserId');
+    sinon.stub(competenceEvaluationRepository, 'getByCompetenceIdAndUserId');
     sinon.stub(assessmentRepository, 'save');
 
     competenceRepository.get.resolves(domainBuilder.buildCompetence());
@@ -40,7 +40,7 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
 
   context('When user start a new competence evaluation', () => {
     beforeEach(() => {
-      competenceEvaluationRepository.getLastByCompetenceIdAndUserId.rejects(new NotFoundError);
+      competenceEvaluationRepository.getByCompetenceIdAndUserId.rejects(new NotFoundError);
     });
 
     it('should create an assessment for competence evaluation', () => {
@@ -124,7 +124,7 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
       const assessmentId = 987654321;
       const createdCompetenceEvaluation = domainBuilder.buildCompetenceEvaluation();
       assessmentRepository.save.resolves({ id: assessmentId });
-      competenceEvaluationRepository.getLastByCompetenceIdAndUserId.resolves(createdCompetenceEvaluation);
+      competenceEvaluationRepository.getByCompetenceIdAndUserId.resolves(createdCompetenceEvaluation);
 
       // when
       const promise = usecases.startOrResumeCompetenceEvaluation({

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -91,6 +91,7 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
         expect(competenceEvaluationToSave.userId).to.equal(userId);
         expect(competenceEvaluationToSave.assessmentId).to.equal(assessmentId);
         expect(competenceEvaluationToSave.competenceId).to.equal(competenceId);
+        expect(competenceEvaluationToSave.status).to.equal('started');
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/competence-evaluation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/competence-evaluation-serializer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Serializer | JSONAPI | competence-evaluation-serializer', funct
             'created-at': new Date(competenceEvaluation.createdAt),
             'user-id': competenceEvaluation.userId,
             'competence-id': competenceEvaluation.competenceId,
+            'status': competenceEvaluation.status,
           },
           relationships: {
             assessment: {

--- a/mon-pix/app/components/competence-card.js
+++ b/mon-pix/app/components/competence-card.js
@@ -8,7 +8,7 @@ export default Component.extend({
     if (this.scorecard.isNotStarted) {
       return null;
     } else if (!this.scorecard.level) {
-      return '–';
+      return '-';
     }
     return this.scorecard.level;
   }),

--- a/mon-pix/app/components/competence-card.js
+++ b/mon-pix/app/components/competence-card.js
@@ -7,8 +7,6 @@ export default Component.extend({
   displayedLevel: computed('scorecard.{level,isNotStarted}', function() {
     if (this.scorecard.isNotStarted) {
       return null;
-    } else if (!this.scorecard.level) {
-      return '-';
     }
     return this.scorecard.level;
   }),

--- a/mon-pix/app/models/competence-evaluation.js
+++ b/mon-pix/app/models/competence-evaluation.js
@@ -4,6 +4,7 @@ const { Model, attr, belongsTo } = DS;
 
 export default Model.extend({
   competenceId: attr('string'),
+  status: attr('string'),
   createdAt: attr('date'),
   updatedAt: attr('date'),
   user: belongsTo('user'),

--- a/mon-pix/tests/unit/components/competence-card-test.js
+++ b/mon-pix/tests/unit/components/competence-card-test.js
@@ -16,8 +16,7 @@ describe('Unit | Component | competence-card-component', function() {
     [
       { level: null, isNotStarted: true, expectedLevel: null },
       { level: 1, isNotStarted: false, expectedLevel: 1 },
-      { level: 0, isNotStarted: false, expectedLevel: '–' },
-      { level: 0, isNotStarted: false, expectedLevel: '–' },
+      { level: 0, isNotStarted: false, expectedLevel: 0 },
       { level: 3, isNotStarted: false, expectedLevel: 3 }
     ].forEach((data) => {
 


### PR DESCRIPTION
## 🔥 Problème
A l'heure actuelle, l'objet `competenceEvaluation` ne possède pas de champs explicite permettant de connaître son état. Ce dernier est reconstitué dynamiquement à travers notamment l'objet du domaine `Scorecard` de sorte que : 
- Si au moins un `knowledgeElement` pour la compétence existe, alors il est en `not_started`
- Si l'`assessment` existe et est `completed` alors il sera en `completed` 
- Autrement il sera en `started`

## 👨‍🚒 Solution
Cette PR embarque une migration de schéma ajoutant un champs `status` aux compétences évaluations et gère les 3 états de façon explicite et au plus proche des cas d'utilisations qui déclenchent les transitions, plutôt qu'en les reconstituant de façon ad-hoc à postériori.
Les nouveaux états sont 
- `started` lorsqu'une compétence évaluation est créée pour la première fois 
- `reset` lorsqu'une action de remise à zéro est effectuée dessus. 

Attention, il y a donc un changement mineur de fonctionnel. A l'heure actuelle, si on démarre un positionnement V2 et _qu'on ne répond à aucune question_, vu que l'api se base sur les `knowledgeElements`, la Scorecard associé sera considérée comme _not started_ ce qui est un peu bizarre quelque part. Avec le nouveau comportement, dès qu'on a cliqué sur démarrer, on sera toujours dans l'état `started` 

## 🇫🇷 Refactoring
Cette PR embarque un nombre conséquent de refactoring, notamment de l'objet `Scorecard`, ses tests unitaires et les deux `usecase` qui font appel à lui.
- des méthodes de répo quand on avait besoin au moins deux fois de faire la même chose 
- augmentation de la _cohésion fonctionnelle_ de certaines méthodes (c'est un une façon un peu fancy de dire faire une seule et une seule, mais ya des nuances intéressantes dans le bouquin dont je vous ai parlé, dont j'avais jamais entendu parler)
- Ne pas exposer des méthodes privées juste pour des tests 