### PR TITLE
[TECH] Remise en place des Answers dans les seeds.

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,5 +1,6 @@
 'use strict';
 const DatabaseBuilder = require('../../tests/tooling/database-builder/database-builder');
+const answersBuilder = require('./data/answers-builder');
 const assessmentsBuilder = require('./data/assessments-builder');
 const assessmentResultsBuilder = require('./data/assessment-results-builder');
 const campaignParticipationsBuilder = require('./data/campaign-participations-builder');
@@ -37,6 +38,7 @@ exports.seed = (knex) => {
   certificationCoursesBuilder({ databaseBuilder });
   certificationChallengesBuilder({ databaseBuilder });
   assessmentsBuilder({ databaseBuilder });
+  answersBuilder({ databaseBuilder });
   assessmentResultsBuilder({ databaseBuilder });
   competenceMarksBuilder({ databaseBuilder });
 


### PR DESCRIPTION
## :unicorn: Problème
Les seeds ne remplissaient plus la table Answers

## :robot: Solution
Remise en place de l'appel à `answersBuilder`

## :rainbow: Remarques
Ce changement permet de re-tester les certifications avec UserPix1