### PR TITLE
[TECH] Remaniement de la génération du profil de certification v1

### DIFF
--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -72,11 +72,11 @@ function _filterAssessmentWithEstimatedLevelGreaterThanZero(assessments) {
   return _(assessments).filter((assessment) => assessment.getLastAssessmentResult().level >= 1).values();
 }
 
-async function _addChallengesToUserCompetences({ userCompetences, challengeIdsCorrectlyAnswered }) {
+async function _pickChallengesForUserCompetences({ userCompetences, challengeIdsCorrectlyAnswered }) {
   const allChallenges = await challengeRepository.list();
+  const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => _getChallengeById(allChallenges, challengeId));
 
-  challengeIdsCorrectlyAnswered.forEach((challengeId) => {
-    const challenge = _getChallengeById(allChallenges, challengeId);
+  challengesAlreadyAnswered.forEach((challenge) => {
     const competence = _getCompetenceByChallengeCompetenceId(userCompetences, challenge);
 
     if (challenge && competence) {
@@ -87,7 +87,6 @@ async function _addChallengesToUserCompetences({ userCompetences, challengeIdsCo
   });
 
   userCompetences = _orderSkillsOfCompetenceByDifficulty(userCompetences);
-  const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => _getChallengeById(allChallenges, challengeId));
 
   userCompetences.forEach((userCompetence) => {
     const testedSkills = [];
@@ -147,7 +146,7 @@ module.exports = {
     const { userCompetences, correctAnswers } = await _getUserCompetencesAndAnswers({ userId, limitDate });
 
     // From here, only userCompetences and answers are needed
-    return _addChallengesToUserCompetences({
+    return _pickChallengesForUserCompetences({
       userCompetences,
       challengeIdsCorrectlyAnswered: _.map(correctAnswers, 'challengeId')
     });

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -10,19 +10,13 @@ const answerRepository = require('../../../lib/infrastructure/repositories/answe
 const competenceRepository = require('../../../lib/infrastructure/repositories/competence-repository');
 const courseRepository = require('../../../lib/infrastructure/repositories/course-repository');
 
-function _findCorrectAnswersByAssessments(assessments) {
+async function _findCorrectAnswersByAssessments(assessments) {
+  const answersByAssessmentsPromises = assessments.map((assessment) =>
+    answerRepository.findCorrectAnswersByAssessment(assessment.id));
 
-  const answersByAssessmentsPromises = assessments.map((assessment) => answerRepository.findCorrectAnswersByAssessment(assessment.id));
+  const answersByAssessments = await Promise.all(answersByAssessmentsPromises);
 
-  return Promise.all(answersByAssessmentsPromises)
-    .then((answersByAssessments) => {
-      return answersByAssessments.reduce((answersInJSON, answersByAssessment) => {
-        answersByAssessment.forEach((answer) => {
-          answersInJSON.push(answer);
-        });
-        return answersInJSON;
-      }, []);
-    });
+  return _.flatten(answersByAssessments);
 }
 
 function _getCompetenceByChallengeCompetenceId(competences, challenge) {

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -119,8 +119,9 @@ async function _getUserCompetencesAndAnswers({ userId, limitDate }) {
   const userCompetences = _createUserCompetences({ allCompetences, allAdaptativeCourses, userLastAssessments });
   const filteredAssessments = _filterAssessmentWithEstimatedLevelGreaterThanZero(userLastAssessments);
   const correctAnswers = await _findCorrectAnswersByAssessments(filteredAssessments);
+  const challengeIdsCorrectlyAnswered = _.map(correctAnswers, 'challengeId');
 
-  return { userCompetences, correctAnswers };
+  return { userCompetences, challengeIdsCorrectlyAnswered };
 }
 
 module.exports = {
@@ -143,12 +144,12 @@ module.exports = {
   },
 
   async getProfileToCertify(userId, limitDate) {
-    const { userCompetences, correctAnswers } = await _getUserCompetencesAndAnswers({ userId, limitDate });
+    const { userCompetences, challengeIdsCorrectlyAnswered } = await _getUserCompetencesAndAnswers({ userId, limitDate });
 
     // From here, only userCompetences and answers are needed
     return _pickChallengesForUserCompetences({
       userCompetences,
-      challengeIdsCorrectlyAnswered: _.map(correctAnswers, 'challengeId')
+      challengeIdsCorrectlyAnswered,
     });
   },
 };


### PR DESCRIPTION
## :unicorn: Problème

Pour pouvoir certifier un profil v2, on doit désormais créer un `course` en fonction des `knowledge elements` et non plus à partir du dernier positionnement (v1) par compétence.

Or, cet `assessment` est utilisé à plusieurs endroits dans la fonction qui sélectionne les questions à poser pour créer le `course` de certification.

De plus, ladite fonction utilise des promesses qui font parfois passe-plat, ce qui rend la compréhension du code difficile.

## :robot: Solution

Cette PR est un remaniement qui permet de s'appuyer le moins possible sur les positionnements.

## :rainbow: Remarques

Comme tout bon remaniement, cette PR ne modifie pas le comportement. Jonathan a généré et comparé les courses des 500 dernières personnes à avoir été certifiées avant et après le remaniement, il n'y a pas de régression.

La deuxième édition du livre Refactoring de Martin Fowler est sortie il y a quelques mois, et elle est en JavaScript ❤️