### PR TITLE
[FEATURE] Création d'une route pour reset une CompetenceEvaluation (PF-579-4).

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -170,6 +170,19 @@ exports.register = async function(server) {
         tags: ['api']
       }
     },
+    {
+      method: 'PATCH',
+      path: '/api/users/{userId}/competences/{competenceId}/reset',
+      config: {
+        handler: userController.resetCompetenceEvaluation,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Cette route réinitilise l\'évaluation de compétences identifiée par **userId** et **competenceId**',
+
+        ],
+        tags: ['api', 'competence-evaluations']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -152,4 +152,13 @@ module.exports = {
     return usecases.getUserScorecards({ authenticatedUserId, requestedUserId })
       .then(scorecardSerializer.serialize);
   },
+
+  resetCompetenceEvaluation(request) {
+    const authenticatedUserId = request.auth.credentials.userId.toString();
+    const requestedUserId = request.params.userId;
+    const competenceId = request.params.competenceId;
+
+    return usecases.resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId })
+      .then(() => null);
+  }
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -108,6 +108,7 @@ module.exports = injectDependencies({
   preloadCacheEntries: require('./preload-cache-entries'),
   reloadCacheEntry: require('./reload-cache-entry'),
   removeAllCacheEntries: require('./remove-all-cache-entries'),
+  resetCompetenceEvaluation: require('./reset-competence-evaluation'),
   retrieveLastOrCreateCertificationCourse : require('./retrieve-last-or-create-certification-course'),
   saveCertificationCenter: require('./save-certification-center'),
   shareCampaignResult: require('./share-campaign-result'),

--- a/api/lib/domain/usecases/reset-competence-evaluation.js
+++ b/api/lib/domain/usecases/reset-competence-evaluation.js
@@ -1,5 +1,5 @@
 const CompetenceEvaluation = require('../models/CompetenceEvaluation');
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntity, NotFoundError } = require('../errors');
 
 module.exports = async function resetCompetenceEvaluation({
   authenticatedUserId,
@@ -9,6 +9,17 @@ module.exports = async function resetCompetenceEvaluation({
 }) {
   if (authenticatedUserId !== requestedUserId) {
     throw new UserNotAuthorizedToAccessEntity();
+  }
+
+  try {
+    await competenceEvaluationRepository.getByCompetenceIdAndUserId(competenceId, authenticatedUserId);
+  } catch (err) {
+    // If user wants to reset its knowledge elements on a competence, but has only validated or invalidated them on campaigns
+    if (err instanceof NotFoundError) {
+      return null;
+    } else {
+      throw err;
+    }
   }
 
   return competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId(authenticatedUserId, competenceId, CompetenceEvaluation.statuses.RESET);

--- a/api/lib/domain/usecases/reset-competence-evaluation.js
+++ b/api/lib/domain/usecases/reset-competence-evaluation.js
@@ -1,0 +1,15 @@
+const CompetenceEvaluation = require('../models/CompetenceEvaluation');
+const { UserNotAuthorizedToAccessEntity } = require('../errors');
+
+module.exports = async function resetCompetenceEvaluation({
+  authenticatedUserId,
+  requestedUserId,
+  competenceId,
+  competenceEvaluationRepository,
+}) {
+  if (authenticatedUserId !== requestedUserId) {
+    throw new UserNotAuthorizedToAccessEntity();
+  }
+
+  return competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId(authenticatedUserId, competenceId, CompetenceEvaluation.statuses.RESET);
+};

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -15,20 +15,14 @@ module.exports = {
   updateStatusByAssessmentId(assessmentId, status) {
     return BookshelfCompetenceEvaluation
       .where({ assessmentId })
-      .fetch({ require: true })
-      .then((competenceEvaluation) => {
-        return competenceEvaluation.save({ status, updatedAt: new Date() }, { patch: true, require: true });
-      })
+      .save({ status }, { require: true, patch: true })
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
 
   updateStatusByUserIdAndCompetenceId(userId, competenceId, status) {
     return BookshelfCompetenceEvaluation
       .where({ userId, competenceId })
-      .fetch({ require: true })
-      .then((competenceEvaluation) => {
-        return competenceEvaluation.save({ status, updatedAt: new Date() }, { patch: true, require: true });
-      })
+      .save({ status }, { require: true, patch: true })
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
 

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -17,8 +17,7 @@ module.exports = {
       .where({ assessmentId })
       .fetch({ require: true })
       .then((competenceEvaluation) => {
-        competenceEvaluation.set('status', status);
-        return competenceEvaluation.save();
+        return competenceEvaluation.save({ status, updatedAt: new Date() }, { patch: true, require: true });
       })
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
@@ -28,8 +27,7 @@ module.exports = {
       .where({ userId, competenceId })
       .fetch({ require: true })
       .then((competenceEvaluation) => {
-        competenceEvaluation.set('status', status);
-        return competenceEvaluation.save();
+        return competenceEvaluation.save({ status, updatedAt: new Date() }, { patch: true, require: true });
       })
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },

--- a/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
@@ -1,0 +1,71 @@
+const { databaseBuilder, expect, generateValidRequestAuhorizationHeader } = require('../../../test-helper');
+
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-reset-competence-evaluation', () => {
+
+  let options;
+  let server;
+  const userId = 1234;
+  const competenceId = 5678;
+
+  beforeEach(async () => {
+
+    options = {
+      method: 'PATCH',
+      url: `/api/users/${userId}/competences/${competenceId}/reset`,
+      payload: {},
+      headers: {},
+    };
+    server = await createServer();
+  });
+
+  afterEach(async () => {
+    await databaseBuilder.clean();
+  });
+
+  describe('GET /users/:id/competences/:id/reset', () => {
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(401);
+        });
+      });
+    });
+
+    describe('Success case', () => {
+
+      const competenceEvaluationId = 111;
+
+      beforeEach(async () => {
+        options.headers.authorization = generateValidRequestAuhorizationHeader();
+
+        databaseBuilder.factory.buildCompetenceEvaluation({
+          id: competenceEvaluationId,
+          userId,
+          competenceId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return 204', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+        expect(response.result).to.be.null;
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
@@ -1,0 +1,59 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
+const resetCompetenceEvaluation = require('../../../../lib/domain/usecases/reset-competence-evaluation');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | reset-competence-evaluation', () => {
+
+  let competenceEvaluation;
+  const competenceEvaluationId = 111;
+  const competenceId = 123;
+  const authenticatedUserId = 456;
+  let requestedUserId = 456;
+
+  const competenceEvaluationRepository = {};
+
+  beforeEach(() => {
+    competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId = sinon.stub();
+
+    competenceEvaluation = {
+      id: competenceEvaluationId,
+      competenceId,
+      userId: authenticatedUserId,
+      status: CompetenceEvaluation.statuses.STARTED,
+    };
+  });
+
+  context('when the user owns the competenceEvaluation', () => {
+    it('should update the competenceEvaluation', async () => {
+      // given
+      const expectedCompetenceEvaluation = {
+        ...competenceEvaluation,
+        status: CompetenceEvaluation.statuses.RESET,
+      };
+
+      competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId
+        .withArgs(authenticatedUserId, competenceId, CompetenceEvaluation.statuses.RESET)
+        .resolves(expectedCompetenceEvaluation);
+
+      // when
+      const updatedCompetenceEvaluation = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository });
+
+      // then
+      expect(updatedCompetenceEvaluation).to.deep.equal(expectedCompetenceEvaluation);
+    });
+  });
+
+  context('when the user does not own the competenceEvaluation', () => {
+    it('should throw an UserNotAuthorizedToUpdateResourceError error', async () => {
+      // given
+      requestedUserId = 789;
+
+      // when
+      const requestErr = await catchErr(resetCompetenceEvaluation)({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository });
+
+      // then
+      expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
 const resetCompetenceEvaluation = require('../../../../lib/domain/usecases/reset-competence-evaluation');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntity, NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | reset-competence-evaluation', () => {
 
@@ -9,12 +9,13 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
   const competenceEvaluationId = 111;
   const competenceId = 123;
   const authenticatedUserId = 456;
-  let requestedUserId = 456;
+  let requestedUserId;
 
   const competenceEvaluationRepository = {};
 
   beforeEach(() => {
     competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId = sinon.stub();
+    competenceEvaluationRepository.getByCompetenceIdAndUserId = sinon.stub();
 
     competenceEvaluation = {
       id: competenceEvaluationId,
@@ -27,11 +28,15 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
   context('when the user owns the competenceEvaluation', () => {
     it('should update the competenceEvaluation', async () => {
       // given
+      requestedUserId = 456;
       const expectedCompetenceEvaluation = {
         ...competenceEvaluation,
         status: CompetenceEvaluation.statuses.RESET,
       };
 
+      competenceEvaluationRepository.getByCompetenceIdAndUserId
+        .withArgs(competenceId, authenticatedUserId)
+        .resolves(competenceEvaluation);
       competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId
         .withArgs(authenticatedUserId, competenceId, CompetenceEvaluation.statuses.RESET)
         .resolves(expectedCompetenceEvaluation);
@@ -54,6 +59,24 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
 
       // then
       expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('when there is no competenceEvaluation', () => {
+    it('should do nothing', async () => {
+      // given
+      requestedUserId = 456;
+
+      competenceEvaluationRepository.getByCompetenceIdAndUserId
+        .withArgs(competenceId, authenticatedUserId)
+        .rejects(new NotFoundError());
+
+      // when
+      const response = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository });
+
+      // then
+      sinon.assert.neverCalledWith(competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId, competenceId, authenticatedUserId);
+      expect(response).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour l'instant, il n'existe aucune manière de réinitialiser une compétence dans le cadre du profil v2.

## :robot: Solution
Créer une route `/api/users/:id/competences/:id/reset`, son controller, et un usecase `resetCompetenceEvaluation` afin de permettre à l'utilisateur de réinitialiser une compétence.
