### PR TITLE
[BUGFIX] Corriger l'affichage des résultats "unimplemented/ABAND" (PA-86).

### DIFF
--- a/admin/app/components/certification-details-competence.js
+++ b/admin/app/components/certification-details-competence.js
@@ -21,10 +21,12 @@ export default Component.extend({
     const positionedLevel = this.competence.positionedLevel;
     return htmlSafe('width:' + Math.round((positionedLevel / 8) * 100) + '%');
   }),
+
   answers: computed('competence', function() {
     const competence = this.competence;
-    return competence.answers;
+    return this._replaceUnimplementedByAband(competence.answers);
   }),
+
   competenceJury: computed('juryRate', function() {
     const juryRate = this.juryRate;
     const competence = this.competence;
@@ -108,5 +110,15 @@ export default Component.extend({
         }
         return { score: 0, level: -1 };
     }
-  }
+  },
+
+  _replaceUnimplementedByAband: function(answers) {
+    return answers.map((answer) => {
+      if (answer.result === 'unimplemented' && answer.value === '#ABAND#') {
+        answer.result = 'aband';
+      }
+      return answer;
+    });
+  },
+
 });

--- a/admin/tests/unit/components/certification-details-competence-test.js
+++ b/admin/tests/unit/components/certification-details-competence-test.js
@@ -7,10 +7,10 @@ module('Unit | Component | certification-details-competence', function(hooks) {
 
   const answer = (result) => {
     return {
-      skill:'@skill1',
-      challengeId:'rec12345',
-      order:'1',
-      result:result
+      skill: '@skill1',
+      challengeId: 'rec12345',
+      order: '1',
+      result: result,
     };
   };
 
@@ -338,6 +338,48 @@ module('Unit | Component | certification-details-competence', function(hooks) {
 
     // then
     assert.deepEqual(component.get('answers'), [answer('ok'), answer('partially'), answer('ko')]);
+  });
+
+  test('it should replace unimplemented by aband and retrieve answers from competence', async function(assert) {
+    // given
+    const answer = (data) => {
+      const { value, result } = data;
+      return {
+        skill: '@skill1',
+        challengeId: 'rec12345',
+        order: '1',
+        result: result,
+        value: value,
+      };
+    };
+
+    const competence = (result1, result2, result3) => {
+      return {
+        name: 'Une compétence',
+        index: '1.1',
+        positionedLevel: 3,
+        positionedScore: 25,
+        obtainedLevel: -1,
+        obtainedScore: 0,
+        answers: [answer(result1), answer(result2), answer(result3)]
+      };
+    };
+
+    const component = this.owner.factoryFor('component:certification-details-competence').create();
+
+    // when
+    component.set('competence', competence(
+      { result: 'unimplemented', value: '#ABAND#' },
+      { result: 'ok' },
+      { result: 'ko' }
+    ));
+
+    // then
+    assert.deepEqual(component.get('answers'), [
+      answer({ result: 'aband', value: '#ABAND#' }),
+      answer({ result: 'ok' }),
+      answer({ result: 'ko' })
+    ]);
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Des réponses, ayant un "result" égal à `unimplemented` sont affichées comme "OK" dans Admin.
Le calcul des pix est correct. Ce n'est qu'un problème d'affichage.

## :robot: Solution
L'épreuve doit être affichée comme "Abandon" (si la "value" est bien égale à "#ABAND#").

## :rainbow: Remarques
En prod, depuis le 1er mai, il y a 3433 answers avec value=#ABAND# & result=unimplemented
