### PR TITLE
[FEATURE] Renommer PIX en Pix (PF-609)

### DIFF
--- a/mon-pix/app/index.html
+++ b/mon-pix/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Pix – Mesurez, développez et valorisez vos compétences numériques</title>
-    <meta name="description" content="PIX est une plateforme en ligne d'évaluation et de certification des compétences numériques des citoyens francophones (élèves, étudiant•e•s, décrocheur•se•s, demandeur•se•s d'emploi, sénior•e•s).">
+    <meta name="description" content="Pix est une plateforme en ligne d'évaluation et de certification des compétences numériques des citoyens francophones (élèves, étudiant•e•s, décrocheur•se•s, demandeur•se•s d'emploi, sénior•e•s).">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/mon-pix/app/templates/components/learning-more-panel.hbs
+++ b/mon-pix/app/templates/components/learning-more-panel.hbs
@@ -9,7 +9,7 @@
         {{tutorial-item tutorial=learningMoreTutorial}}
       {{/each}}
       <div class="learning-more-panel__tutorial-info">
-        Ces liens ont été proposés par des utilisateurs de PIX.
+        Ces liens ont été proposés par des utilisateurs de Pix.
       </div>
     </div>
   </div>

--- a/mon-pix/app/templates/components/modal-mobile.hbs
+++ b/mon-pix/app/templates/components/modal-mobile.hbs
@@ -8,7 +8,7 @@
           </h4>
         </div>
         <div class="modal-body">
-          <p>Certaines épreuves PIX peuvent être difficiles à réussir sur mobile. Pour une meilleure expérience, nous vous conseillons de passer ce test sur un ordinateur.</p>
+          <p>Certaines épreuves Pix peuvent être difficiles à réussir sur mobile. Pour une meilleure expérience, nous vous conseillons de passer ce test sur un ordinateur.</p>
         </div>
         <div class="modal-footer">
           <div class="modal-button-container">

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de PIX">
+  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
@@ -51,7 +51,7 @@
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{urlHome}} class="link" title="Lien vers la page d'accueil de PIX">Retour à l'accueil</a>
+      <a href={{urlHome}} class="link" title="Lien vers la page d'accueil de Pix">Retour à l'accueil</a>
     </div>
   {{/if}}
 

--- a/mon-pix/app/templates/components/pix-logo.hbs
+++ b/mon-pix/app/templates/components/pix-logo.hbs
@@ -1,3 +1,3 @@
-{{#link-to "index" class="pix-logo__link" title="Lien vers la page d'accueil de PIX"}}
+{{#link-to "index" class="pix-logo__link" title="Lien vers la page d'accueil de Pix"}}
   <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
 {{/link-to}}

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de PIX">
+  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de PIX">
+  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de PIX">
+  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 

--- a/mon-pix/app/templates/components/tutorial-panel.hbs
+++ b/mon-pix/app/templates/components/tutorial-panel.hbs
@@ -21,7 +21,7 @@
         {{/each}}
       </div>
       <div class="tutorial-panel__tutorial-info">
-        Ces liens ont été proposés par des utilisateurs de PIX.
+        Ces liens ont été proposés par des utilisateurs de Pix.
       </div>
     {{/if}}
   </div>

--- a/mon-pix/tests/integration/components/modal-mobile-test.js
+++ b/mon-pix/tests/integration/components/modal-mobile-test.js
@@ -28,7 +28,7 @@ describe('Integration | Component | modal mobile', function() {
     this.render(hbs`{{modal-mobile}}`);
 
     // then
-    const expected = 'Certaines épreuves PIX peuvent être difficiles à réussir sur mobile. Pour une meilleure expérience, nous vous conseillons de passer ce test sur un ordinateur.';
+    const expected = 'Certaines épreuves Pix peuvent être difficiles à réussir sur mobile. Pour une meilleure expérience, nous vous conseillons de passer ce test sur un ordinateur.';
     expect(this.$('.modal-body').text().trim()).to.equal(expected);
   });
 });

--- a/mon-pix/tests/integration/components/pix-logo-test.js
+++ b/mon-pix/tests/integration/components/pix-logo-test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | pix logo', function() {
   });
 
   it('should have a title in the link', function() {
-    expect(this.$('.pix-logo__link').attr('title')).to.equal('Lien vers la page d\'accueil de PIX');
+    expect(this.$('.pix-logo__link').attr('title')).to.equal('Lien vers la page d\'accueil de Pix');
   });
 
 });


### PR DESCRIPTION
## 🦄  Problème
Le mot "PIX" c'est un peu lourd, on a préféré "Pix".

## :robot: Solution
Remplacer "PIX" par "Pix".

## :rainbow: Remarques
J'ai modifié les Terms of Services de Orga et Certif car ils utilisaient Pix et PIX pour désigner Pix sous toutes ses formes. J'ai donc voulu unifier mais si pour des raisons légales il n'est pas permis de changer ces documents j'enlève les commits en question.
