### PR TITLE
[FEATURE] Cacher "n Pix avant le niveau x" si le parcours est terminé (PF-610)

### DIFF
--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -9,8 +9,8 @@ export default Component.extend({
     return this.get('scorecard.isNotStarted') ? null : this.get('scorecard.level');
   }),
 
-  isProgressable: computed('scorecard.{isMaxLevel,isNotStarted}', function() {
-    return !(this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
+  isProgressable: computed('scorecard.{isMaxLevel,isNotStarted,isFinished}', function() {
+    return !(this.get('scorecard.isFinished') || this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
   }),
 
 });

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -94,6 +94,22 @@ describe('Integration | Component | scorecard-details', function() {
       expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
     });
 
+    it('should not display remainingPixToNextLevel if scorecard.isFinished is true', async function() {
+      // given
+      const scorecard = {
+        remainingPixToNextLevel: 1,
+        isFinished: true,
+      };
+
+      this.set('scorecard', scorecard);
+
+      // when
+      await render(hbs`{{scorecard-details scorecard=scorecard}}`);
+
+      // then
+      expect(this.element.querySelector('.scorecard-details-content-right__level-info')).to.not.exist;
+    });
+
     it('should not display the level and remainingPixToNextLevel if scorecard.isNotStarted is true', async function() {
       // given
       const scorecard = {

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -1,15 +1,20 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from 'ember-mocha';
+import { setupComponentTest } from 'ember-mocha';
 
 describe('Unit | Component | scorecard-details ', function() {
-  setupTest();
+  setupComponentTest('scorecard-details', {
+    unit: true
+  });
+
+  let controller;
+
+  beforeEach(function() {
+    controller = this.subject();
+  });
 
   describe('#level', function() {
     it('returns null if the scorecard isNotStarted', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', { isNotStarted: true });
 
@@ -18,9 +23,6 @@ describe('Unit | Component | scorecard-details ', function() {
     });
 
     it('returns the level if the scorecard is not isNotStarted', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', { level: 1 });
 
@@ -32,9 +34,6 @@ describe('Unit | Component | scorecard-details ', function() {
 
   describe('#isProgressable', function() {
     it('returns false if isMaxLevel', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', { isMaxLevel: true });
 
@@ -43,9 +42,6 @@ describe('Unit | Component | scorecard-details ', function() {
     });
 
     it('returns false if isNotStarted', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', { isNotStarted: true });
 
@@ -54,9 +50,6 @@ describe('Unit | Component | scorecard-details ', function() {
     });
 
     it('returns false if isFinished', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', { isFinished: true });
 
@@ -65,9 +58,6 @@ describe('Unit | Component | scorecard-details ', function() {
     });
 
     it('returns true otherwise', function() {
-      // given
-      const controller = this.owner.lookup('controller:scorecard-details');
-
       // when
       controller.set('scorecard', {});
 

--- a/mon-pix/tests/unit/components/scorecard-details.js
+++ b/mon-pix/tests/unit/components/scorecard-details.js
@@ -53,6 +53,17 @@ describe('Unit | Component | scorecard-details ', function() {
       expect(controller.get('isProgressable')).to.be.equal(false);
     });
 
+    it('returns false if isFinished', function() {
+      // given
+      const controller = this.owner.lookup('controller:scorecard-details');
+
+      // when
+      controller.set('scorecard', { isFinished: true });
+
+      // then
+      expect(controller.get('isProgressable')).to.be.equal(false);
+    });
+
     it('returns true otherwise', function() {
       // given
       const controller = this.owner.lookup('controller:scorecard-details');


### PR DESCRIPTION
## :unicorn: Problème
La mention "n Pix avant le niveau x" était visible lorsque le parcours était terminé et que l'utilisateur ne disposait pas de moyen de progresser ce qui pouvait être frustrant.

## :robot: Solution
La cacher si scorecard.isFinished

## :rainbow: Remarques
Elle réapparaîtra au bout de 7 jours dans les PRs suivantes lorsque l'utilisateur pourra reset sa competenceEvaluation.
