### PR TITLE
[FEATURE] Ajout du délai de 7 jours pour réinitialiser une évaluation de compétence (PF-579-6).

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -1,4 +1,5 @@
 module.exports = {
   MAX_REACHABLE_LEVEL: 5,
   PIX_COUNT_BY_LEVEL: 8,
+  MINIMUM_DELAY_IN_DAYS_FOR_RESET: 7,
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -52,6 +52,12 @@ class CampaignWithoutOrganizationError extends DomainError {
   }
 }
 
+class CompetenceResetError extends DomainError {
+  constructor(remainingDaysBeforeReset) {
+    super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence. Un peu de patience !`);
+  }
+}
+
 class AssessmentEndedError extends DomainError {
   constructor() {
     super();
@@ -284,6 +290,7 @@ module.exports = {
   AssessmentStartError,
   CampaignCodeError,
   CampaignWithoutOrganizationError,
+  CompetenceResetError,
   CertificationCenterMembershipCreationError,
   CertificationComputeError,
   ChallengeAlreadyAnsweredError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -54,7 +54,7 @@ class CampaignWithoutOrganizationError extends DomainError {
 
 class CompetenceResetError extends DomainError {
   constructor(remainingDaysBeforeReset) {
-    super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence. Un peu de patience !`);
+    super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence.`);
   }
 }
 

--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -1,5 +1,6 @@
 const Skill = require('../models/Skill');
 const _ = require('lodash');
+const moment = require('moment');
 
 const KnowledgeElementStatusType = Object.freeze({
   VALIDATED: 'validated',
@@ -82,6 +83,12 @@ class KnowledgeElement {
       targetSkills,
       userId
     });
+  }
+
+  static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
+    const lastKnowledgeElement = _(knowledgeElements).sortBy('createdAt').last();
+    const precise = true;
+    return moment().diff(lastKnowledgeElement.createdAt, 'days', precise);
   }
 }
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -64,7 +64,7 @@ class Scorecard {
   }
 
   static getRemainingDaysBeforeReset(knowledgeElements) {
-    if (!knowledgeElements) {
+    if (!knowledgeElements || knowledgeElements.length === 0) {
       return null;
     }
     const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -68,7 +68,7 @@ class Scorecard {
       return null;
     }
     const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();
-    const daysSinceLastKnowledgeElement = moment.utc().diff(lastKnowledgeElement.createdAt, 'days', true);
+    const daysSinceLastKnowledgeElement = moment().diff(lastKnowledgeElement.createdAt, 'days', true);
 
     const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -45,8 +45,9 @@ class Scorecard {
   }
 
   static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
-
     const totalEarnedPix = _getTotalEarnedPix(knowledgeElements);
+
+    const remainingDaysBeforeReset = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 
     return new Scorecard({
       id: `${userId}_${competence.id}`,
@@ -59,15 +60,11 @@ class Scorecard {
       level: _getCompetenceLevel(totalEarnedPix),
       pixScoreAheadOfNextLevel: _getPixScoreAheadOfNextLevel(totalEarnedPix),
       status: _getScorecardStatus(competenceEvaluation),
-      remainingDaysBeforeReset: Scorecard.computeRemainingDaysBeforeReset(knowledgeElements),
+      remainingDaysBeforeReset,
     });
   }
 
-  static computeRemainingDaysBeforeReset(knowledgeElements = []) {
-    if (_.isEmpty(knowledgeElements)) {
-      return null;
-    }
-
+  static computeRemainingDaysBeforeReset(knowledgeElements) {
     const daysSinceLastKnowledgeElement = KnowledgeElement.computeDaysSinceLastKnowledgeElement(knowledgeElements);
     const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -59,8 +59,20 @@ class Scorecard {
       level: _getCompetenceLevel(totalEarnedPix),
       pixScoreAheadOfNextLevel: _getPixScoreAheadOfNextLevel(totalEarnedPix),
       status: _getScorecardStatus(competenceEvaluation),
-      daysBeforeReset: _getRemainingDaysBeforeReset(knowledgeElements),
+      daysBeforeReset: Scorecard.getRemainingDaysBeforeReset(knowledgeElements),
     });
+  }
+
+  static getRemainingDaysBeforeReset(knowledgeElements) {
+    if (!knowledgeElements) {
+      return null;
+    }
+    const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();
+    const daysSinceLastKnowledgeElement = moment.utc().diff(lastKnowledgeElement.createdAt, 'days', true);
+
+    const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
+
+    return remainingDaysToWait > 0 ? remainingDaysToWait : 0;
   }
 }
 
@@ -89,15 +101,6 @@ function _getCompetenceLevel(earnedPix) {
 
 function _getPixScoreAheadOfNextLevel(earnedPix) {
   return earnedPix % constants.PIX_COUNT_BY_LEVEL;
-}
-
-function _getRemainingDaysBeforeReset(knowledgeElements) {
-  const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();
-  const daysSinceLastKnowledgeElement = moment.utc().diff(lastKnowledgeElement.createdAt, 'days', true);
-
-  const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
-
-  return remainingDaysToWait > 0 ? remainingDaysToWait : 0;
 }
 
 Scorecard.statuses = statuses;

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -22,7 +22,7 @@ class Scorecard {
     pixScoreAheadOfNextLevel,
     earnedPix,
     status,
-    daysBeforeReset,
+    remainingDaysBeforeReset,
   } = {}) {
 
     this.id = id;
@@ -36,7 +36,7 @@ class Scorecard {
     this.level = level;
     this.pixScoreAheadOfNextLevel = pixScoreAheadOfNextLevel;
     this.status = status;
-    this.daysBeforeReset = daysBeforeReset;
+    this.remainingDaysBeforeReset = remainingDaysBeforeReset;
   }
 
   static parseId(scorecardId) {
@@ -59,12 +59,12 @@ class Scorecard {
       level: _getCompetenceLevel(totalEarnedPix),
       pixScoreAheadOfNextLevel: _getPixScoreAheadOfNextLevel(totalEarnedPix),
       status: _getScorecardStatus(competenceEvaluation),
-      daysBeforeReset: Scorecard.getRemainingDaysBeforeReset(knowledgeElements),
+      remainingDaysBeforeReset: Scorecard.computeRemainingDaysBeforeReset(knowledgeElements),
     });
   }
 
-  static getRemainingDaysBeforeReset(knowledgeElements) {
-    if (!knowledgeElements || knowledgeElements.length === 0) {
+  static computeRemainingDaysBeforeReset(knowledgeElements = []) {
+    if (_.isEmpty(knowledgeElements)) {
       return null;
     }
     const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -1,8 +1,8 @@
 const Assessment = require('./Assessment');
 const CompetenceEvaluation = require('./CompetenceEvaluation');
+const KnowledgeElement = require('./KnowledgeElement');
 const constants = require('../constants');
 const _ = require('lodash');
-const moment = require('moment');
 
 const statuses = {
   NOT_STARTED: 'NOT_STARTED',
@@ -67,9 +67,8 @@ class Scorecard {
     if (_.isEmpty(knowledgeElements)) {
       return null;
     }
-    const lastKnowledgeElement = _(knowledgeElements).sortBy(['createdAt']).last();
-    const daysSinceLastKnowledgeElement = moment().diff(lastKnowledgeElement.createdAt, 'days', true);
 
+    const daysSinceLastKnowledgeElement = KnowledgeElement.computeDaysSinceLastKnowledgeElement(knowledgeElements);
     const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
 
     return remainingDaysToWait > 0 ? remainingDaysToWait : 0;

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -10,13 +10,12 @@ module.exports = async ({ authenticatedUserId, scorecardId, knowledgeElementRepo
     throw new UserNotAuthorizedToAccessEntity();
   }
 
-  const [knowledgeElementsGroupedByCompetenceId, competence, competenceEvaluations] = await Promise.all([
-    knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId: authenticatedUserId }),
+  const [knowledgeElements, competence, competenceEvaluations] = await Promise.all([
+    knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId: authenticatedUserId, competenceId }),
     competenceRepository.get(competenceId),
     competenceEvaluationRepository.findByUserId(authenticatedUserId),
   ]);
 
-  const knowledgeElements = knowledgeElementsGroupedByCompetenceId[competenceId];
   const competenceEvaluation = _.find(competenceEvaluations, { competenceId: competence.id });
 
   return Scorecard.buildFrom({

--- a/api/lib/domain/usecases/reset-competence-evaluation.js
+++ b/api/lib/domain/usecases/reset-competence-evaluation.js
@@ -15,7 +15,8 @@ module.exports = async function resetCompetenceEvaluation({
 
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId: authenticatedUserId, competenceId });
 
-  const remainingDaysBeforeReset = Scorecard.getRemainingDaysBeforeReset(knowledgeElements);
+  const remainingDaysBeforeReset = Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
+
   if (remainingDaysBeforeReset > 0) {
     throw new CompetenceResetError(remainingDaysBeforeReset);
   }

--- a/api/lib/domain/usecases/reset-competence-evaluation.js
+++ b/api/lib/domain/usecases/reset-competence-evaluation.js
@@ -1,6 +1,7 @@
 const CompetenceEvaluation = require('../models/CompetenceEvaluation');
 const Scorecard = require('../models/Scorecard');
 const { UserNotAuthorizedToAccessEntity, CompetenceResetError, NotFoundError } = require('../errors');
+const _ = require('lodash');
 
 module.exports = async function resetCompetenceEvaluation({
   authenticatedUserId,
@@ -14,6 +15,11 @@ module.exports = async function resetCompetenceEvaluation({
   }
 
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId: authenticatedUserId, competenceId });
+
+  const nothingToReset = _.isEmpty(knowledgeElements);
+  if (nothingToReset) {
+    return null;
+  }
 
   const remainingDaysBeforeReset = Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -20,7 +20,7 @@ async function _resumeCompetenceEvaluation({ userId, competenceId, competenceEva
   const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId(competenceId, userId);
 
   if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
-    await competenceEvaluationRepository.updateStatusByCompetenceId(competenceId, CompetenceEvaluation.statuses.STARTED);
+    await competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId(userId, competenceId, CompetenceEvaluation.statuses.STARTED);
   }
   return {
     created: false,

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -47,6 +47,19 @@ module.exports = {
       .then((knowledgeElements) => _.groupBy(knowledgeElements, 'competenceId'));
   },
 
+  findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
+    return BookshelfKnowledgeElement
+      .where({ userId, competenceId })
+      .fetchAll()
+      .then((knowledgeElements) => knowledgeElements.map(_toDomain))
+      .then((knowledgeElements) => {
+        return _(knowledgeElements)
+          .orderBy('createdAt', 'desc')
+          .uniqBy('skillId')
+          .value();
+      });
+  },
+
   getSumOfPixFromUserKnowledgeElements(userId) {
     return Bookshelf.knex.with('earnedPixWithRankPerSkill',
       (qb) => {

--- a/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
@@ -14,7 +14,7 @@ module.exports = {
         'level',
         'pixScoreAheadOfNextLevel',
         'status',
-        'daysBeforeReset'
+        'remainingDaysBeforeReset'
       ],
 
       area: {

--- a/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
@@ -13,7 +13,8 @@ module.exports = {
         'earnedPix',
         'level',
         'pixScoreAheadOfNextLevel',
-        'status'
+        'status',
+        'daysBeforeReset'
       ],
 
       area: {

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -26,6 +26,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {
     return new InfraErrors.PreconditionFailedError('Assessment is already rated.');
   }
+  if (error instanceof DomainErrors.CompetenceResetError) {
+    return new InfraErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.ChallengeAlreadyAnsweredError) {
     return new InfraErrors.ConflictError('This challenge has already been answered.');
   }

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -128,6 +128,7 @@ describe('Acceptance | Controller | scorecard-controller', () => {
               level: Math.round(knowledgeElement.earnedPix / 8),
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
               status: 'STARTED',
+              'days-before-reset': 7,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -128,7 +128,7 @@ describe('Acceptance | Controller | scorecard-controller', () => {
               level: Math.round(knowledgeElement.earnedPix / 8),
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
               status: 'STARTED',
-              'days-before-reset': 7,
+              'remaining-days-before-reset': 7,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
@@ -132,7 +132,7 @@ describe('Acceptance | Controller | users-controller-get-user-scorecards', () =>
               level: Math.round(knowledgeElement.earnedPix / 8),
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
               status: 'STARTED',
-              'days-before-reset': 7,
+              'remaining-days-before-reset': 7,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
@@ -131,7 +131,8 @@ describe('Acceptance | Controller | users-controller-get-user-scorecards', () =>
               'earned-pix': knowledgeElement.earnedPix,
               level: Math.round(knowledgeElement.earnedPix / 8),
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
-              status: 'STARTED'
+              status: 'STARTED',
+              'days-before-reset': 7,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
@@ -65,8 +65,6 @@ describe('Acceptance | Controller | users-controller-reset-competence-evaluation
       });
 
       it('should respond with a 421 - precondition failed - if last knowledge element date is not old enough', () => {
-        // given
-
         // when
         const promise = server.inject(options);
 

--- a/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-competence-evaluation_test.js
@@ -6,8 +6,8 @@ describe('Acceptance | Controller | users-controller-reset-competence-evaluation
 
   let options;
   let server;
-  const userId = 1234;
-  const competenceId = 5678;
+  const userId = 5678;
+  const competenceId = 1234;
 
   beforeEach(async () => {
 
@@ -18,10 +18,6 @@ describe('Acceptance | Controller | users-controller-reset-competence-evaluation
       headers: {},
     };
     server = await createServer();
-  });
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
   });
 
   describe('GET /users/:id/competences/:id/reset', () => {
@@ -42,12 +38,12 @@ describe('Acceptance | Controller | users-controller-reset-competence-evaluation
       });
     });
 
-    describe('Success case', () => {
+    describe('Precondition verification', () => {
 
       const competenceEvaluationId = 111;
 
       beforeEach(async () => {
-        options.headers.authorization = generateValidRequestAuhorizationHeader();
+        options.headers.authorization = generateValidRequestAuhorizationHeader(userId);
 
         databaseBuilder.factory.buildCompetenceEvaluation({
           id: competenceEvaluationId,
@@ -55,7 +51,57 @@ describe('Acceptance | Controller | users-controller-reset-competence-evaluation
           competenceId,
         });
 
+        databaseBuilder.factory.buildKnowledgeElement({
+          id: 1,
+          userId,
+          competenceId,
+        });
+
         await databaseBuilder.commit();
+      });
+
+      afterEach(async () => {
+        await databaseBuilder.clean();
+      });
+
+      it('should respond with a 421 - precondition failed - if last knowledge element date is not old enough', () => {
+        // given
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(421);
+        });
+      });
+    });
+
+    describe('Success case', () => {
+
+      const competenceEvaluationId = 111;
+
+      beforeEach(async () => {
+        options.headers.authorization = generateValidRequestAuhorizationHeader(userId);
+
+        databaseBuilder.factory.buildCompetenceEvaluation({
+          id: competenceEvaluationId,
+          userId,
+          competenceId,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          id: 1,
+          userId,
+          competenceId,
+          createdAt: new Date('2018-02-15T15:15:52Z'),
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      afterEach(async () => {
+        await databaseBuilder.clean();
       });
 
       it('should return 204', async () => {

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -106,6 +106,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       // when
       const promise = KnowledgeElementRepository.findByAssessmentId(assessmentId);
 
+      // then
       return promise
         .then((knowledgeElementsFound) => {
           expect(knowledgeElementsFound).have.lengthOf(2);
@@ -175,6 +176,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
         // when
         const promise = KnowledgeElementRepository.findUniqByUserId({ userId });
 
+        // then
         return promise
           .then((knowledgeElementsFound) => {
             expect(knowledgeElementsFound).have.lengthOf(3);
@@ -188,6 +190,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
         // when
         const promise = KnowledgeElementRepository.findUniqByUserId({ userId, limitDate: today });
 
+        // then
         return promise
           .then((knowledgeElementsFound) => {
             expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWantedWithLimitDate);
@@ -224,6 +227,8 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     it('should find the knowledge elements grouped by competence id', async () => {
       // when
       const actualKnowledgeElementsGroupedByCompetenceId = await KnowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
+
+      // then
       expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.length(2);
       expect(actualKnowledgeElementsGroupedByCompetenceId[2]).to.have.length(1);
       expect(actualKnowledgeElementsGroupedByCompetenceId[1][0]).to.be.instanceOf(KnowledgeElement);
@@ -264,6 +269,8 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     it('should find the knowledge elements', async () => {
       // when
       const actualKnowledgeElements = await KnowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+
+      // then
       expect(actualKnowledgeElements).to.have.length(1);
       expect(actualKnowledgeElements[0]).to.be.instanceOf(KnowledgeElement);
       expect(actualKnowledgeElements[0].id).to.equal(2);
@@ -278,7 +285,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     const yesterday = moment(today).subtract(1, 'days').toDate();
 
     beforeEach(async () => {
-
       // given
       userId = databaseBuilder.factory.buildUser().id;
       const userId_tmp = databaseBuilder.factory.buildUser().id;
@@ -337,6 +343,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       // when
       const earnedPix = await KnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
 
+      // then
       expect(earnedPix).to.equal(18);
     });
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -231,6 +231,46 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
   });
 
+  describe('#findUniqByUserIdAndCompetenceId', () => {
+
+    let userId;
+    let competenceId;
+
+    beforeEach(async () => {
+      // given
+      userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = 'fakeId';
+      competenceId = 2;
+
+      const today = moment.utc().toDate();
+      const yesterday = moment.utc().subtract(1, 'day').toDate();
+
+      _.each([
+        { id: 1, competenceId: 1, userId, skillId: 'web1', createdAt: today },
+        { id: 2, competenceId, userId, skillId: 'url1', createdAt: today },
+        { id: 3, competenceId, userId, skillId: 'url1', createdAt: yesterday },
+        { id: 4, competenceId, userId: otherUserId, skillId: 'url2', createdAt: today },
+      ], (ke) => {
+        databaseBuilder.factory.buildKnowledgeElement(ke);
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should find the knowledge elements', async () => {
+      // when
+      const actualKnowledgeElements = await KnowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+      expect(actualKnowledgeElements).to.have.length(1);
+      expect(actualKnowledgeElements[0]).to.be.instanceOf(KnowledgeElement);
+      expect(actualKnowledgeElements[0].id).to.equal(2);
+    });
+
+  });
+
   describe('#getSumOfPixFromUserKnowledgeElements', () => {
 
     let userId;

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -5,13 +5,17 @@ const moment = require('moment');
 
 describe('Unit | Domain | Models | Scorecard', () => {
 
+  let computeDaysSinceLastKnowledgeElementStub;
+  let knowledgeElements;
+
+  beforeEach(() => {
+    computeDaysSinceLastKnowledgeElementStub = sinon.stub(KnowledgeElement, 'computeDaysSinceLastKnowledgeElement');
+  });
+
   describe('#buildFrom', () => {
 
     let competenceEvaluation;
-    let knowledgeElements;
     let actualScorecard;
-    let testCurrentDate;
-    let computeDaysSinceLastKnowledgeElementStub;
 
     const userId = '123';
     const competence = {
@@ -21,12 +25,6 @@ describe('Unit | Domain | Models | Scorecard', () => {
       area: 'area',
       index: 'index',
     };
-
-    beforeEach(() => {
-      testCurrentDate = new Date('2018-01-10T05:00:00Z');
-      sinon.useFakeTimers(testCurrentDate.getTime());
-      computeDaysSinceLastKnowledgeElementStub = sinon.stub(KnowledgeElement, 'computeDaysSinceLastKnowledgeElement');
-    });
 
     context('with existing competence evaluation and assessment', () => {
       beforeEach(() => {
@@ -127,6 +125,28 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
 
+    context('when there is no knowledge elements', () => {
+      it('should return null', () => {
+        knowledgeElements = [];
+
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+
+        // then
+        expect(actualScorecard.remainingDaysBeforeReset).to.equal(null);
+      });
+    });
+  });
+
+  describe('#computeDaysSinceLastKnowledgeElement', () => {
+
+    let testCurrentDate;
+
+    beforeEach(() => {
+      testCurrentDate = new Date('2018-01-10T05:00:00Z');
+      sinon.useFakeTimers(testCurrentDate.getTime());
+    });
+
     [
       { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeReset: 7 },
       { daysSinceLastKnowledgeElement: 1, expectedDaysBeforeReset: 6 },
@@ -146,13 +166,11 @@ describe('Unit | Domain | Models | Scorecard', () => {
         computeDaysSinceLastKnowledgeElementStub.returns(daysSinceLastKnowledgeElement);
 
         // when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        const remainingDaysBeforeReset = Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 
         // then
-        expect(actualScorecard.remainingDaysBeforeReset).to.equal(expectedDaysBeforeReset);
+        expect(remainingDaysBeforeReset).to.equal(expectedDaysBeforeReset);
       });
     });
-
   });
-
 });

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -93,6 +93,19 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
 
+    context('when the user has no knowledge elements for the competence', () => {
+      beforeEach(() => {
+        // given
+        competenceEvaluation = { status: 'reset' };
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements: [], competenceEvaluation, competence });
+      });
+      // then
+      it('should have a dayBeforeReset at null', () => {
+        expect(actualScorecard.daysBeforeReset).to.be.null;
+      });
+    });
+
     context('when the user level is beyond the upper limit allowed', () => {
       beforeEach(() => {
         // given

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -62,8 +62,8 @@ describe('Unit | Domain | Models | Scorecard', () => {
       it('should have set the scorecard status based on the competence evaluation status', () => {
         expect(actualScorecard.status).to.equal('STARTED');
       });
-      it('should have set the scorecard daysBeforeReset based on last knowledge element date', () => {
-        expect(actualScorecard.daysBeforeReset).to.equal(7);
+      it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', () => {
+        expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
       });
     });
 
@@ -102,7 +102,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
       // then
       it('should have a dayBeforeReset at null', () => {
-        expect(actualScorecard.daysBeforeReset).to.be.null;
+        expect(actualScorecard.remainingDaysBeforeReset).to.be.null;
       });
     });
 
@@ -141,7 +141,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
         actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
 
         // then
-        expect(actualScorecard.daysBeforeReset).to.equal(expectedDaysBeforeReset);
+        expect(actualScorecard.remainingDaysBeforeReset).to.equal(expectedDaysBeforeReset);
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-scorecard', () => {
     competenceId = 1;
     authenticatedUserId = 1;
     competenceRepository = { get: sinon.stub() };
-    knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIdAndCompetenceId: sinon.stub() };
     competenceEvaluationRepository = { findByUserId: sinon.stub() };
     buildFromStub = sinon.stub(Scorecard, 'buildFrom');
     parseIdStub = sinon.stub(Scorecard, 'parseId');
@@ -40,7 +40,7 @@ describe('Unit | UseCase | get-scorecard', () => {
       it('should resolve', () => {
         // given
         competenceRepository.get.resolves([]);
-        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves({});
 
         // when
         const promise = getScorecard({
@@ -70,7 +70,7 @@ describe('Unit | UseCase | get-scorecard', () => {
           domainBuilder.buildKnowledgeElement({ competenceId: 1 }),
         ];
 
-        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({ '1': knowledgeElementList });
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves(knowledgeElementList);
 
         const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
         const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
@@ -114,7 +114,7 @@ describe('Unit | UseCase | get-scorecard', () => {
         // given
         const unauthorizedUserId = 42;
         competenceRepository.get.resolves([]);
-        knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves({});
 
         // when
         const promise = getScorecard({

--- a/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
     competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId = sinon.stub();
     competenceEvaluationRepository.getByCompetenceIdAndUserId = sinon.stub();
     knowledgeElementRepository.findUniqByUserIdAndCompetenceId = sinon.stub();
-    getRemainingDaysBeforeResetStub = sinon.stub(Scorecard, 'getRemainingDaysBeforeReset');
+    getRemainingDaysBeforeResetStub = sinon.stub(Scorecard, 'computeRemainingDaysBeforeReset');
 
     knowledgeElements = [{}, {}];
     competenceEvaluation = {

--- a/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
@@ -136,4 +136,21 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
       expect(requestErr).to.be.instanceOf(CompetenceResetError);
     });
   });
+
+  context('when there is no knowledge elements', () => {
+    it('should do nothing', async () => {
+      // given
+      requestedUserId = 456;
+      knowledgeElementRepository.findUniqByUserIdAndCompetenceId
+        .withArgs({ userId: authenticatedUserId, competenceId })
+        .resolves([]);
+
+      // when
+      const response = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
+
+      // then
+      sinon.assert.neverCalledWith(competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId, competenceId, authenticatedUserId);
+      expect(response).to.equal(null);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Je veux pouvoir réinitialiser une compétence, seulement après un délai de 7 jours durant lequel je n'ai répondu à aucune question portant sur cette même compétence.

## :robot: Solution
- Calcul de ce délai et ajout de celui-ci au sein de la Scorecard pour qu'il soit affiché côté front (dans une PR ultérieure)
- Vérification lors du reset que ce délai est respecté
