### PR TITLE
[TECH] Migration des données de V1 vers V2.

### DIFF
--- a/api/scripts/extract-challenge-with-skills.js
+++ b/api/scripts/extract-challenge-with-skills.js
@@ -1,0 +1,108 @@
+#! /usr/bin/env node
+const _ = require('lodash');
+const challengeRepository = require('../lib/infrastructure/repositories/challenge-repository');
+const skillsRepository = require('../lib/infrastructure/repositories/skill-repository');
+const competencesRepository = require('../lib/infrastructure/repositories/competence-repository');
+
+async function main () {
+
+  // Récupération des challenges
+  let challenges = await challengeRepository.list();
+
+  // Récupération des compétences (pour les acquis)
+  const competences = await competencesRepository.list();
+
+  // Récupération des acquis par compétences
+  let skills = await Promise.all(
+    _.map(competences, (competence) => {
+     return skillsRepository.findByCompetenceId(competence.id);
+    })
+  );
+  skills = _.flatten(skills);
+
+  // Ajout du niveau et du tube sur les objets sur les skills
+  // Ajout des acquis inférieurs et supérieurs
+  _(skills)
+    .forEach((skill) => {
+      skill.level = skill.name.slice(-1);
+      skill.tube = skill.name.substring(1, skill.name.length-1);
+    })
+    .forEach((skill) => {
+      skill.lowerSkills = _.filter(skills,(s) => {
+          return s.tube === skill.tube && s.level < skill.level;
+        });
+      skill.higherSkills = _.filter(skills,(s) => {
+        return s.tube === skill.tube && s.level > skill.level;
+      });
+    });
+
+  // Filtres des challenges pour ne garder que ceux qui ont des acquis et qui sont valides
+  _(challenges).filter((c) => {
+    return c.skills.length > 0;
+  });
+
+
+  // Création des objets qui nous permettront de créer les knowledges elements
+  const informationForKnowledgeElements = _.map(challenges, (challenge) => {
+
+    const skillsFromChallenge =  challenge.skills;
+
+    // Ajout des acquis gagnés si la question est validé
+    const skillsValidated = _(skillsFromChallenge)
+      .map((skillGivenByChallenge) => {
+        const skill = _.find(skills, { id: skillGivenByChallenge.id });
+        return skill.lowerSkills;
+      })
+      .flatten()
+      .remove((skillValidated) => {
+        return !_.some(skillsFromChallenge, (skill) => {return skill.id === skillValidated.id});
+      })
+      .uniqBy('id')
+      .value();
+
+    // Ajout des acquis invalidé si la question n'est pas réussi
+    const skillsInvalidated = _(skillsFromChallenge)
+      .map((skillGivenByChallenge) => {
+        const skill = _.find(skills, { id: skillGivenByChallenge.id });
+        return skill.higherSkills;
+      })
+      .flatten()
+      .remove((skillValidated) => {
+        return !_.some(skillsFromChallenge, (skill) => {return skill.id === skillValidated.id});
+      })
+      .uniqBy('id')
+      .value();
+
+    return {
+      challengeId: challenge.id,
+      skillsFromChallenge,
+      skillsValidated,
+      skillsInvalidated,
+    };
+  });
+  console.log(`ChallengeId;source;status;skillId;earnedPix;skillName`);
+
+  _.forEach(informationForKnowledgeElements, (challengeWithSkills) => {
+    const challengeId = challengeWithSkills.challengeId;
+    _.forEach(challengeWithSkills.skillsFromChallenge, (directSkills) => {
+      console.log(`${challengeId};direct;validated;${directSkills.id};${directSkills.pixValue};${directSkills.name}`)
+    });
+    _.forEach(challengeWithSkills.skillsValidated, (inferredValidatedSkills) => {
+      console.log(`${challengeId};inferred;validated;${inferredValidatedSkills.id};${inferredValidatedSkills.pixValue};${inferredValidatedSkills.name}`)
+    });
+    _.forEach(challengeWithSkills.skillsFromChallenge, (directSkills) => {
+      console.log(`${challengeId};direct;invalidated;${directSkills.id};0;${directSkills.name}`)
+    });
+    _.forEach(challengeWithSkills.skillsInvalidated, (inferredInvalidatedSkills) => {
+      console.log(`${challengeId};inferred;invalidated;${inferredInvalidatedSkills.id};0;${inferredInvalidatedSkills.name}`)
+    });
+  });
+  process.exit(1);
+
+}
+
+/*=================== tests =============================*/
+
+if (require.main === module) {
+  main();
+}

--- a/api/scripts/migrate-v1-to-v2.js
+++ b/api/scripts/migrate-v1-to-v2.js
@@ -6,7 +6,6 @@ const { knex } = require('../db/knex-database-connection');
 const bluebird = require('bluebird');
 const logger = require('../lib/infrastructure/logger');
 
-
 async function migration() {
   const start = new Date();
 
@@ -15,7 +14,7 @@ async function migration() {
   const listOfUsers = await _findUsers();
   const result = await bluebird.map(listOfUsers,
     async (userId) => await _createKnowledgeElementsForUser( userId, challengesWithKnowledgeElementsToAdd),
-    { concurrency: parseInt(process.env.MIGRATE_CONCURRENCY,10) || 4 });
+    { concurrency: parseInt(process.env.MIGRATE_CONCURRENCY, 10) || 4 });
 
   console.log(`Migration réussie : ${_.sum(result)} sur ${listOfUsers.length} utilisateurs.`);
   const end = new Date();
@@ -25,7 +24,9 @@ async function migration() {
 }
 
 async function _findUsers() {
-  const usersId = await knex('users').select('id').where('isProfileV2', false).orderBy('createdAt', 'asc').limit(process.env.MAX_USERS_MIGRATE);
+  const numberOfUserMigrate = parseInt(process.env.MAX_USERS_MIGRATE, 10) || 1;
+  console.log(`Migration commencée pour ${numberOfUserMigrate} personnes.`);
+  const usersId = await knex('users').select('id').where('isProfileV2', false).orderBy('createdAt', 'asc').limit(numberOfUserMigrate);
   return _.map(usersId, 'id');
 }
 

--- a/api/scripts/migrate-v1-to-v2.js
+++ b/api/scripts/migrate-v1-to-v2.js
@@ -30,7 +30,7 @@ function _terminate(client) {
 }
 
 async function _findUser(client) {
-  const usersId = await client.query_and_log(`SELECT id FROM USERS LIMIT 10;`);
+  const usersId = await client.query_and_log(`SELECT id FROM USERS where "isMigratedToV2" = false ORDER BY "createdAt" ASC LIMIT 100;`);
   return _.map(usersId.rows, 'id');
 }
 
@@ -45,6 +45,8 @@ async function _createKnowledgeElementsForUser(client, userId, challengesWithKno
       await _createKnowledgeElements(client, knowledgeElementsToCreate);
     }
   }
+  await _indicateMigrationOk(client, userId);
+
   console.log('END FOR USER ' + userId);
 }
 
@@ -92,6 +94,12 @@ function _createKnowledgeElementObject(answer, userId, status, skillInformation)
     competenceId: skillInformation.competenceId
   };
 }
+
+async function _indicateMigrationOk(client, userId) {
+  return client.query_and_log(`UPDATE USERS SET "isMigratedToV2"=true WHERE id = ${userId}`);
+}
+
+
 
 function _createKnowledgeElementObjects(answersForMigration, challengesWithKnowledgeElementsToAdd, userId) {
   return _.map(answersForMigration, (answer) => {

--- a/api/scripts/migrate-v1-to-v2.js
+++ b/api/scripts/migrate-v1-to-v2.js
@@ -49,7 +49,9 @@ async function _createKnowledgeElementsForUser( userId, challengesWithKnowledgeE
     }
   }
   if(migrationOk) {
-    await _indicatedDateOfMigration(userId);
+    if(knowledgeElementsToCreate.length > 0) {
+      await _indicatedDateOfMigration(userId);
+    }
     logger.trace(logContext, `END FOR USER ${userId} : STATUS : OK, KE : ${knowledgeElementsToCreate.length}.`);
     return 1;
   } else {

--- a/api/scripts/migrate-v1-to-v2.js
+++ b/api/scripts/migrate-v1-to-v2.js
@@ -1,0 +1,103 @@
+#! /usr/bin/env node
+/* eslint no-console: ["off"] */
+const _ = require('lodash');
+const moment = require('moment');
+const PgClient = require('./PgClient');
+const findChallengesWithSkills = require('./extract-challenge-with-skills.js');
+
+function initialize() {
+  return new PgClient(process.env.DATABASE_URL);
+}
+
+function terminate(client) {
+  client.end();
+  console.log('END');
+}
+
+async function main() {
+
+  const client = initialize();
+  const challengesWithSkills = await findChallengesWithSkills();
+
+  const listOfUsers = await _findUser(client);
+  const promiseToCreateKnowledgeElements = Promise.all(_.map(listOfUsers,
+    (userId) => _createKnowledgeElementsForUser(client, userId, challengesWithSkills)));
+
+  return promiseToCreateKnowledgeElements
+    .then(() => terminate(client))
+    .then(() => process.exit(1));
+
+}
+
+async function _createKnowledgeElementsForUser(client, userId, challengesWithSkills) {
+  console.log('BEGIN FOR USER ' + userId);
+  const assessmentsId = await _getAssessmentsForUser(client, userId);
+  if(assessmentsId.length>0) {
+    const answersForMigration = await _findAnswersForMigration(client, assessmentsId);
+    if (answersForMigration.length > 0) {
+      const knowledgeElementsForEachAnswers = _createKnowledgeElementObjects(answersForMigration, challengesWithSkills, userId);
+      const knowledgeElementsToCreate = _.compact(_.flatten(knowledgeElementsForEachAnswers));
+      await _createKnowledgeElements(client, knowledgeElementsToCreate);
+    }
+  }
+  console.log('END FOR USER ' + userId);
+}
+
+async function _findUser(client) {
+  const usersId = await client.query_and_log(`SELECT id FROM USERS LIMIT 10;`);
+  return _.map(usersId.rows, 'id');
+}
+
+async function _getAssessmentsForUser(client, userId) {
+  const assessmentsFromDb = await client.query_and_log(`SELECT * FROM ASSESSMENTS WHERE "userId" = ${userId} AND type='PLACEMENT' ORDER BY "createdAt" DESC;`);
+  const assessmentsForUser =  assessmentsFromDb.rows;
+  const assessmentsGroupedByCourse = _.groupBy(assessmentsForUser,
+    (assessment) => assessment.courseId);
+  const lastAssessmentsForEachCourse = _.map(assessmentsGroupedByCourse, _.head);
+  return _.map(lastAssessmentsForEachCourse, 'id');
+}
+
+async function _findAnswersForMigration(client, assessmentsId) {
+  const answersFromDB = await client.query_and_log(`SELECT * FROM ANSWERS WHERE "assessmentId" IN (${assessmentsId.toString()});`);
+  const answersForMigration = answersFromDB.rows;
+  return _.map(answersForMigration, (answer) => _.omit(answer, 'updatedAt', 'timeout', 'elapsedTime', 'resultDetails', 'value'));
+}
+
+async function _createKnowledgeElements(client, knowledgeElements) {
+  let knowledgeElementsForDB = _.reduce(knowledgeElements, (textForDb, ke) => {
+    return textForDb+`('${moment(ke.createdAt).utc()}', '${ke.source}', '${ke.status}', ${ke.earnedPix}, ${ke.answerId}, '${ke.skillId}', ${ke.assessmentId}, ${ke.userId}, '${ke.competenceId}'),`;
+  }, '');
+  knowledgeElementsForDB = knowledgeElementsForDB.substring(0, knowledgeElementsForDB.length-1);
+
+  await client.query_and_log(`INSERT INTO "knowledge-elements" ("createdAt", "source", "status", "earnedPix", "answerId", "skillId", "assessmentId", "userId", "competenceId") VALUES ${knowledgeElementsForDB};`);
+}
+
+function _createKnowledgeElementObject(answer, userId, status, skillInformation) {
+  return {
+    createdAt: answer.createdAt,
+    source: skillInformation.source,
+    status: status,
+    earnedPix: skillInformation.earnedPix,
+    answerId: answer.id,
+    skillId: skillInformation.skillId,
+    assessmentId: answer.assessmentId,
+    userId: userId,
+    competenceId: skillInformation.competenceId
+  };
+}
+
+
+function _createKnowledgeElementObjects(answersForMigration, challengesWithSkills, userId) {
+  return _.map(answersForMigration, (answer) => {
+    const challengeId = answer.challengeId;
+    const status = answer.result === 'ok' ? 'validated' : 'invalidated';
+    if(challengesWithSkills[challengeId]) {
+      const listOfSkillsForKnowledgeElements = challengesWithSkills[challengeId][status];
+      return _.map(listOfSkillsForKnowledgeElements, (skillInformation) => _createKnowledgeElementObject(answer, userId, status, skillInformation));
+    }
+  });
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## :unicorn: Problème
- Les utilisateurs qui ont déjà répondus à des questions en V1 doivent pouvoir avoir des pix en V2, liés aux acquis qu'ils ont validés
- On veut prendre en considération les réponses données lors du dernier `assessment` de chaque compétence (on ignore les `answers` des compétences que l'on a retenté).
- On veut éviter une trop grosse coupure de la plateforme : pour cela, se préparer et lancer possiblement le script en juillet (moins d'utilisateurs)

## :robot: Solution
- `extract-challenge-with-skills.js` : permet de récupérer un tableau avec, pour un challenge et la résultat de l'utilisateur, toutes les informations dont on a besoin sur les skills pour les knowledge-elements
- ` migration-v1-v2.js` : Un cron qui actuellement, prend MAX_USERS_MIGRATE utilisateurs, récupère leurs assessments et les answers associés, et crée les knowledges elements.

## :rainbow: Remarques
