### PR TITLE
[TECH] Create script to dump and restore database

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -109,6 +109,7 @@
     "lint:fix": "eslint lib tests --fix",
     "preinstall": "test \"$(npm --version)\" = 6.4.1",
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",
+    "scalingo-replication-job": "sh scripts/reload-database-replication.sh",
     "scalingo-postbuild": "echo 'nothing to do'",
     "scalingo-post-ra-creation": "npm run db:pg:seed",
     "scalingo-start": "npm run db:pg:migrate && npm start",

--- a/api/scripts/reload-database-replication.sh
+++ b/api/scripts/reload-database-replication.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Start dump database and restore in replication database"
+
+pg_dump --clean --if-exists --format c -d $DATABASE_URL --no-owner --no-privileges --exclude-schema 'information_schema' --exclude-schema '^pg_*' --file dump.pgsql
+
+pg_restore --clean --if-exists -d $DATABASE_REPLICATION_URL --no-owner --no-privileges dump.pgsql
+
+rm dump.pgsql
+
+echo "Finished reload database replication"
+
+


### PR DESCRIPTION
## :unicorn: Problème
- Pouvoir, chaque nuit, mettre à jour une base de données répliqua de la base de production pour pouvoir faire fonctionner Metabase dessus sans impacter la base de production 

## :robot: Solution
- Ajouter un cron qui tourne la nuit, qui fait un dump de la base de données et qui remplit la base de répliqua avec les informations
- Actuellement : Ajout d'un script qui fait un dump d'une base et remplit une autre base. Déjà testé entre une Review App et la base de réplication.

## :rainbow: Remarques
- Plusieurs questions : Est-ce qu'on le met sur le cron qui remplit le redis ? Est-ce qu'on fait un cron à part ? Actuellement, on recrée un dump alors qu'il y a déjà des dumps (mais pas atteignable sur le serveur direction.
- Sur son poste, récupérer le dernier back-up : 
-- APP : nom de l'application scalingo
-- PG_ADDON : uuid de l'add on PG sur scalingo, récupérable via `--addons`
-- Requete : 
`uuiddump=$(scalingo --app <APP> --addon <PG_ADDON> backups | head -4 | tail -1 | cut -c3-26)`
--Puis : `scalingo --app <APP> --addon <PG_ADDON> backup-download --backup $uuiddump `

