### PR TITLE
[TECH] Amélioration du database builder et des tests cassants aléatoirement

### DIFF
--- a/api/db/batchTreatment.js
+++ b/api/db/batchTreatment.js
@@ -13,7 +13,7 @@ function batch(knex, elementsToUpdate, treatment) {
 
     const assessments = remainingElementsToUpdate.splice(0, BATCH_SIZE);
     const promises = assessments.map((assessment) => {
-      return treatment(assessment).catch(err => {
+      return treatment(assessment).catch((err) => {
         console.error('Treatment failed for :', assessment);
 
         throw err;

--- a/api/db/migrations/20170105153948_update_answers_timeout.js
+++ b/api/db/migrations/20170105153948_update_answers_timeout.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'answers';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.integer('timeout');
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('timeout');
     })
   ]);

--- a/api/db/migrations/20170329112753_add_elapsedTime_to_answers.js
+++ b/api/db/migrations/20170329112753_add_elapsedTime_to_answers.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'answers';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.integer('elapsedTime');
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('elapsedTime');
     })
   ]);

--- a/api/db/migrations/20170329153349_update_answers--add_column_result_details.js
+++ b/api/db/migrations/20170329153349_update_answers--add_column_result_details.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'answers';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.text('resultDetails');
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('resultDetails');
     })
   ]);

--- a/api/db/migrations/20170418114929_remove_login_from_users.js
+++ b/api/db/migrations/20170418114929_remove_login_from_users.js
@@ -3,7 +3,7 @@ const TABLE_NAME = 'users';
 exports.up = function(knex, Promise) {
 
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('login');
       table.boolean('cgu');
       table.unique('email');
@@ -14,8 +14,8 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
-      table.string('login').defaultTo("").notNullable();
+    knex.schema.table(TABLE_NAME, function(table) {
+      table.string('login').defaultTo('').notNullable();
       table.dropColumn('cgu');
     })
   ]);

--- a/api/db/migrations/20170703105035_create_link_between_user_and_assessment.js
+++ b/api/db/migrations/20170703105035_create_link_between_user_and_assessment.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'assessments';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
+    knex.schema.table(TABLE_NAME, function(table) {
       table.bigInteger('userId').index().references('users.id');
       table.dropColumn('userName');
       table.dropColumn('userEmail');
@@ -12,7 +12,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('userId');
       table.string('userName').notNull();
       table.string('userEmail').notNull();

--- a/api/db/migrations/20170703163243_update_assessment_with_level_and_score.js
+++ b/api/db/migrations/20170703163243_update_assessment_with_level_and_score.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'assessments';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
+    knex.schema.table(TABLE_NAME, function(table) {
       table.integer('estimatedLevel');
       table.integer('pixScore');
     })
@@ -11,7 +11,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function (table) {
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('estimatedLevel');
       table.dropColumn('pixScore');
     })

--- a/api/db/migrations/20170728141316_add_code_to_organization.js
+++ b/api/db/migrations/20170728141316_add_code_to_organization.js
@@ -1,5 +1,5 @@
 exports.up = function(knex) {
-  return knex.schema.table('organizations', function (table) {
+  return knex.schema.table('organizations', function(table) {
     table.string('code', 6).default('').notNullable();
   });
 };

--- a/api/db/migrations/20171113103608_add_type_to_assessments.js
+++ b/api/db/migrations/20171113103608_add_type_to_assessments.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'assessments';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.string('type');
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('type');
     })
   ]);

--- a/api/db/migrations/20171204102525_add_userId_to_certification_course.js
+++ b/api/db/migrations/20171204102525_add_userId_to_certification_course.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.integer('userId').references('users.id').index();
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('userId');
     })
   ]);

--- a/api/db/migrations/20171212144653_add_status_to_certification_course.js
+++ b/api/db/migrations/20171212144653_add_status_to_certification_course.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.string('status');
     })
   ]);
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
 
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.table(TABLE_NAME, function(table){
+    knex.schema.table(TABLE_NAME, function(table) {
       table.dropColumn('status');
     })
   ]);

--- a/api/db/migrations/20180116161332_modify_column_completedPercentage_to_tests_finished_in_snapshots.js
+++ b/api/db/migrations/20180116161332_modify_column_completedPercentage_to_tests_finished_in_snapshots.js
@@ -5,7 +5,7 @@ const MULTIPLICATOR_PERCENTAGE_TO_COMPETENCES = NUMBER_OF_COMPETENCES / 100;
 const MULTIPLICATOR_COMPETENCES_TO_PERCENTAGE = 100 / NUMBER_OF_COMPETENCES;
 
 exports.up = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
+  return knex.schema.table(TABLE_NAME, function(table) {
     table.integer('testsFinished');
   }).then(() => {
     return knex(TABLE_NAME)
@@ -21,7 +21,7 @@ exports.up = function(knex, Promise) {
 };
 
 exports.down = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
+  return knex.schema.table(TABLE_NAME, function(table) {
     table.integer('completionPercentage');
   })
     .then(() => {
@@ -29,7 +29,7 @@ exports.down = function(knex, Promise) {
         .update({
           // XXX : the '??' bind the row value
           completionPercentage: knex.raw('CAST(?? as numeric) * ' + MULTIPLICATOR_COMPETENCES_TO_PERCENTAGE, ['testsFinished'])
-        })})
+        });})
     .then(() => {
       return knex.schema.table(TABLE_NAME, function(table) {
         table.dropColumn('testsFinished');

--- a/api/db/migrations/20180306151846_add_type_to_all_assessments.js
+++ b/api/db/migrations/20180306151846_add_type_to_all_assessments.js
@@ -26,73 +26,73 @@ const TYPE_PREVIEW = 'PREVIEW';
 exports.up = function(knex, Promise) {
 
   // XXX : Modify PREVIEW assessments
-    return knex(TABLE_NAME_ASSESSMENTS)
-      .select('id', 'courseId', 'type')
-      .whereNull('type')
-      .where('courseId', 'LIKE', 'null%')
-      .then((allAssessmentsPreview) => {
-        return batch(knex, allAssessmentsPreview, (assessment) => {
-          return knex(TABLE_NAME_ASSESSMENTS)
-            .where('id', '=', assessment.id)
-            .update({
-              type: TYPE_PREVIEW
-            });
-        });
-
-      })
-      .then(() => {
-        // XXX : Modify PLACEMENT assessments
+  return knex(TABLE_NAME_ASSESSMENTS)
+    .select('id', 'courseId', 'type')
+    .whereNull('type')
+    .where('courseId', 'LIKE', 'null%')
+    .then((allAssessmentsPreview) => {
+      return batch(knex, allAssessmentsPreview, (assessment) => {
         return knex(TABLE_NAME_ASSESSMENTS)
-          .select('id', 'courseId', 'type')
-          .whereNull('type')
-          .where('courseId', 'IN', LIST_COMPETENCES_PLACEMENT);
-      })
-      .then((allAssessmentsPlacement) => {
-        return batch(knex, allAssessmentsPlacement, (assessment) => {
-          return knex(TABLE_NAME_ASSESSMENTS)
-            .where('id', '=', assessment.id)
-            .update({
-              type: TYPE_PLACEMENT
-            });
-        });
-
-      }).then(() => {
-        // XXX : Modify CERTIFICATION assessments
-        return knex(TABLE_NAME_CERTIFICATIONS)
-          .select('id');
-      }).then((allCertifications) => {
-        const certificationsId = allCertifications.map(certification => certification.id.toString());
-        return knex(TABLE_NAME_ASSESSMENTS)
-          .select('id', 'courseId', 'type')
-          .whereNull('type')
-          .where('courseId', 'IN', certificationsId);
-      })
-      .then((allAssessmentsCertifications) => {
-        return batch(knex, allAssessmentsCertifications, (assessment) => {
-          return knex(TABLE_NAME_ASSESSMENTS)
-            .where('id', '=', assessment.id)
-            .update({
-              type: TYPE_CERTIFICATION
-            });
-        });
-
-      }).then(() => {
-        // XXX : Modify DEMO assessments
-
-        return knex(TABLE_NAME_ASSESSMENTS)
-          .select('id', 'courseId', 'type')
-          .whereNull('type');
-      })
-      .then((allAssessmentsDemo) => {
-        return batch(knex, allAssessmentsDemo, (assessment) => {
-          return knex(TABLE_NAME_ASSESSMENTS)
-            .where('id', '=', assessment.id)
-            .update({
-              type: TYPE_DEMO
-            });
-        });
-
+          .where('id', '=', assessment.id)
+          .update({
+            type: TYPE_PREVIEW
+          });
       });
+
+    })
+    .then(() => {
+      // XXX : Modify PLACEMENT assessments
+      return knex(TABLE_NAME_ASSESSMENTS)
+        .select('id', 'courseId', 'type')
+        .whereNull('type')
+        .where('courseId', 'IN', LIST_COMPETENCES_PLACEMENT);
+    })
+    .then((allAssessmentsPlacement) => {
+      return batch(knex, allAssessmentsPlacement, (assessment) => {
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .where('id', '=', assessment.id)
+          .update({
+            type: TYPE_PLACEMENT
+          });
+      });
+
+    }).then(() => {
+      // XXX : Modify CERTIFICATION assessments
+      return knex(TABLE_NAME_CERTIFICATIONS)
+        .select('id');
+    }).then((allCertifications) => {
+      const certificationsId = allCertifications.map((certification) => certification.id.toString());
+      return knex(TABLE_NAME_ASSESSMENTS)
+        .select('id', 'courseId', 'type')
+        .whereNull('type')
+        .where('courseId', 'IN', certificationsId);
+    })
+    .then((allAssessmentsCertifications) => {
+      return batch(knex, allAssessmentsCertifications, (assessment) => {
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .where('id', '=', assessment.id)
+          .update({
+            type: TYPE_CERTIFICATION
+          });
+      });
+
+    }).then(() => {
+      // XXX : Modify DEMO assessments
+
+      return knex(TABLE_NAME_ASSESSMENTS)
+        .select('id', 'courseId', 'type')
+        .whereNull('type');
+    })
+    .then((allAssessmentsDemo) => {
+      return batch(knex, allAssessmentsDemo, (assessment) => {
+        return knex(TABLE_NAME_ASSESSMENTS)
+          .where('id', '=', assessment.id)
+          .update({
+            type: TYPE_DEMO
+          });
+      });
+
+    });
 
 };
 

--- a/api/db/migrations/20180315164634_add-column-access-code-on-sessions.js
+++ b/api/db/migrations/20180315164634_add-column-access-code-on-sessions.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'sessions';
 
 exports.up = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
-      table.string('accessCode');
-    });
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.string('accessCode');
+  });
 };
 
 exports.down = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
-      table.dropColumn('accessCode');
-    });
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn('accessCode');
+  });
 };

--- a/api/db/migrations/20180315164647_add-column-session-id-on-certifications.js
+++ b/api/db/migrations/20180315164647_add-column-session-id-on-certifications.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
+  return knex.schema.table(TABLE_NAME, function(table) {
     table.integer('sessionId').references('sessions.id').index();
   });
 };
 
 exports.down = function(knex, Promise) {
-  return knex.schema.table(TABLE_NAME, function(table){
+  return knex.schema.table(TABLE_NAME, function(table) {
     table.integer('sessionId').references('sessions.id').index();
   });
 };

--- a/api/db/migrations/20180329113849_add-indexes-on-many-tables.js
+++ b/api/db/migrations/20180329113849_add-indexes-on-many-tables.js
@@ -7,7 +7,7 @@ const indexes = {
   snapshots : ['organizationId'],
 };
 exports.up = function(knex, Promise) {
-  const promises = Object.keys(indexes).map(tableForIndexes => {
+  const promises = Object.keys(indexes).map((tableForIndexes) => {
     return knex.schema.table(tableForIndexes, (table) => {
       indexes[tableForIndexes].forEach((column) => table.index(column));
     });
@@ -16,7 +16,7 @@ exports.up = function(knex, Promise) {
 };
 
 exports.down = function(knex, Promise) {
-  const promises = Object.keys(indexes).map(tableForIndexes => {
+  const promises = Object.keys(indexes).map((tableForIndexes) => {
     return knex.schema.table(tableForIndexes, (table) => {
       indexes[tableForIndexes].forEach((column) => table.dropIndex(column));
     });

--- a/api/db/migrations/20180405100452_migrate_assessments_info_to_assessment_results.js
+++ b/api/db/migrations/20180405100452_migrate_assessments_info_to_assessment_results.js
@@ -25,7 +25,7 @@ exports.up = function(knex) {
       });
 
     }).then(() => {
-      return knex.schema.table(TABLE_NAME_ASSESSMENTS, function (table) {
+      return knex.schema.table(TABLE_NAME_ASSESSMENTS, function(table) {
         table.dropColumn('pixScore');
         table.dropColumn('estimatedLevel');
       });

--- a/api/db/migrations/20180405100655_migrate_old_marks_in_competence-marks.js
+++ b/api/db/migrations/20180405100655_migrate_old_marks_in_competence-marks.js
@@ -42,7 +42,7 @@ exports.down = function(knex) {
     .then(() => knex(TABLE_NAME_COMPETENCE_MARKS).select('id', 'level', 'score', 'area_code', 'competence_code', 'correctionId'))
     .then((allMarks) => {
 
-      return batch(knex, allMarks, mark => {
+      return batch(knex, allMarks, (mark) => {
         return knex(TABLE_NAME_MARKS)
           .insert({
             level: mark.level,

--- a/api/db/migrations/20180731102046_create_target_profiles_table.js
+++ b/api/db/migrations/20180731102046_create_target_profiles_table.js
@@ -2,13 +2,13 @@ const TABLE_NAME_TARGET_PROFILES = 'target-profiles';
 const TABLE_NAME_TARGET_PROFILES_SKILLS = 'target-profiles_skills';
 const TABLE_NAME_CAMPAIGNS = 'campaigns';
 
-let targetProfile = {
+const targetProfile = {
   name: 'PIC - Diagnostic Initial',
   isPublic: true,
   organizationId: null
 };
 
-let associatedSkills = [
+const associatedSkills = [
   { skillId: 'rectL2ZZeWPc7yezp' },
   { skillId: 'recndXqXiv4pv2Ukp' },
   { skillId: 'recMOy4S8XnaWblYI' },

--- a/api/db/migrations/20181128103517_add_column_create_at_to_knowledge_elements.js
+++ b/api/db/migrations/20181128103517_add_column_create_at_to_knowledge_elements.js
@@ -3,7 +3,7 @@ const TABLE_NAME = 'knowledge-elements';
 exports.up = async (knex) =>  {
 
   const info = await knex(TABLE_NAME).columnInfo();
-  if(!info.createdAt){
+  if (!info.createdAt) {
     return knex.schema.table(TABLE_NAME, (table) => table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now()))
       .then(() => knex.raw('update "knowledge-elements" set "createdAt" = (select "createdAt" from answers where "knowledge-elements"."answerId" = answers.id);'));
   }

--- a/api/package.json
+++ b/api/package.json
@@ -91,7 +91,7 @@
     "coverage:check": "NODE_ENV=test npm run db:migrate && NODE_ENV=test nyc --silent _mocha --recursive --exit --reporter dot tests && nyc report --reporter=lcovonly --report-dir=../coverage",
     "coverage:rename": "mv ../coverage/lcov.info ../coverage/api_lcov.info",
     "coverage": "npm run coverage:check && npm run coverage:rename",
-    "db:sqlite:delete": "rm -f db/dev.sqlite3 db/dev.sqlite3-journal db/test.sqlite3 db/test.sqlite3-journal",
+    "db:sqlite:delete": "rm -f db/${NODE_ENV:-dev}.sqlite3*",
     "db:sqlite:empty": "node scripts/database/empty-database",
     "db:sqlite:migrate": "knex --knexfile db/knexfile.js migrate:latest",
     "db:sqlite:prepare": "npm run db:sqlite:delete && npm run db:sqlite:migrate",

--- a/api/plop/generators/usecase.js
+++ b/api/plop/generators/usecase.js
@@ -15,7 +15,7 @@ module.exports = {
       type: 'modify',
       path: 'lib/domain/usecases/index.js',
       pattern: '});\n',
-      template: "  {{camelCase name}}: require('./{{name}}.js'),\n});\n"
+      template: '  {{camelCase name}}: require(\'./{{name}}.js\'),\n});\n'
     },
     {
       type: 'add',

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -15,4 +15,4 @@ client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`)
     console.log('Database dropped');
     client.end();
     process.exit(0);
-  })
+  });

--- a/api/scripts/delete-user.js
+++ b/api/scripts/delete-user.js
@@ -98,7 +98,7 @@ class UserEraser {
       .then(() => this.queryBuilder.count_certifications_from_user_id(this.userId))
       .then((query) => this.client.query_and_log(query))
       .then((result) => {
-        if(this.clientQueryAdapter.count(result) > 0)
+        if (this.clientQueryAdapter.count(result) > 0)
           return Promise.reject('The user has been certified, deletion impossible');
       });
   }

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -37,8 +37,8 @@ function main() {
   const baseUrl = process.argv[2];
   const ids = parseArgs(process.argv);
   const requests = Promise.all(
-    ids.map(id => buildRequestObject(baseUrl, id))
-      .map(requestObject => request(requestObject))
+    ids.map((id) => buildRequestObject(baseUrl, id))
+      .map((requestObject) => request(requestObject))
   );
 
   return requests.then(() => {

--- a/api/scripts/get-results-certifications-old.js
+++ b/api/scripts/get-results-certifications-old.js
@@ -39,7 +39,7 @@ function makeRequest(config) {
 }
 
 function findCompetence(profile, competenceName) {
-  const result = profile.find(competence => competence.index === competenceName);
+  const result = profile.find((competence) => competence.index === competenceName);
   return (result || { obtainedLevel: '' }).obtainedLevel;
 }
 
@@ -55,7 +55,7 @@ function toCSVRow(rowJSON) {
   }
 
   res[noteColumn] = rowJSON.totalScore;
-  competencesColumns.forEach(column => {
+  competencesColumns.forEach((column) => {
     res[column] = findCompetence(rowJSON.competencesWithMark, column);
   });
   return res;
@@ -66,17 +66,17 @@ function main() {
   const authToken = process.argv[3];
   const ids = parseArgs(process.argv.slice(4));
   const requests = Promise.all(
-    ids.map(id => buildRequestObject(baseUrl, authToken, id))
-      .map(requestObject => makeRequest(requestObject))
+    ids.map((id) => buildRequestObject(baseUrl, authToken, id))
+      .map((requestObject) => makeRequest(requestObject))
   );
 
-  requests.then(certificationResults => certificationResults.map(toCSVRow))
-    .then(res => json2csv({
+  requests.then((certificationResults) => certificationResults.map(toCSVRow))
+    .then((res) => json2csv({
       data: res,
       fieldNames: HEADERS,
       del: ';',
     }))
-    .then(csv => {
+    .then((csv) => {
       console.log(`\n\n${csv}\n\n`);
       return csv;
     });

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -42,12 +42,12 @@ function buildCertificationRequest(baseUrl, authToken, certificationId) {
 }
 
 function findCompetence(profile, competenceName) {
-  const result = profile.find(competence => competence['competence-code'] === competenceName);
+  const result = profile.find((competence) => competence['competence-code'] === competenceName);
   return (result || { level: '' }).level;
 }
 
 function toCSVRow(rowJSON) {
-  if(!rowJSON.data) {
+  if (!rowJSON.data) {
     return {};
   }
   const certificationData = rowJSON.data.attributes;
@@ -98,7 +98,7 @@ function toCSVRow(rowJSON) {
 
   res[note] = certificationData['pix-score'];
 
-  competencess.forEach(column => {
+  competencess.forEach((column) => {
     res[column] = findCompetence(certificationData['competences-with-mark'], column);
   });
 
@@ -127,23 +127,23 @@ function main() {
     .catch((err) => {
       if (err.statusCode === 404) {
         console.error(err);
-        throw new Error(`L'id session n'existe pas`);
+        throw new Error('L\'id session n\'existe pas');
       }
     })
     .then((certificationIds) => {
       const certificationsRequests = Promise.all(
-        certificationIds.map(certificationId => buildCertificationRequest(baseUrl, authToken, certificationId))
-          .map(requestObject => request(requestObject))
+        certificationIds.map((certificationId) => buildCertificationRequest(baseUrl, authToken, certificationId))
+          .map((requestObject) => request(requestObject))
       );
 
-      return certificationsRequests.then(certificationResults => certificationResults.map(toCSVRow))
-        .then(certificationResult => json2csv({
+      return certificationsRequests.then((certificationResults) => certificationResults.map(toCSVRow))
+        .then((certificationResult) => json2csv({
           data: certificationResult,
           fieldNames: HEADERS,
           del: ';',
           withBOM: true,
         }))
-        .then(csv => {
+        .then((csv) => {
           saveInFile(csv, sessionId);
           console.log(`\n\n${csv}\n\n`);
           return csv;

--- a/api/scripts/import-certifications-from-csv.js
+++ b/api/scripts/import-certifications-from-csv.js
@@ -112,7 +112,7 @@ function main() {
     assertFileValidity(filePath);
     console.log('Test de validité du fichier : OK');
 
-    fs.readFile(filePath, 'utf8', function (err, data) {
+    fs.readFile(filePath, 'utf8', function(err, data) {
       console.log('\nTéléversement des certifications sur le serveur...');
 
       // We delete the BOM UTF8 at the beginning of the CSV,

--- a/api/scripts/make-saml-env.js
+++ b/api/scripts/make-saml-env.js
@@ -138,7 +138,6 @@ la propriété `encPrivateKey` de `SAML_SP_CONFIG`.
   * De même l'attribut `Location` de `SingleLogoutService` désigne le service de consommation
     de requêtes de déconnexion, mais il n'est pas actuellement implémenté.
 
-
 # Utilisation du script `make-saml-env.js`
 
 La syntaxe d'une valeur de variable d'environnement contenant du XML à

--- a/api/scripts/recompute-all-score.js
+++ b/api/scripts/recompute-all-score.js
@@ -10,20 +10,20 @@ function buildRequestObject(baseUrl, authToken, assessmentId) {
     },
     baseUrl: baseUrl,
     body: {
-      "data": {
-        "attributes": {
+      'data': {
+        'attributes': {
         },
-        "relationships": {
-          "assessment": {
-            "data":{
-              "id":assessmentId
+        'relationships': {
+          'assessment': {
+            'data':{
+              'id':assessmentId
             }
 
           }
         }
       }
     },
-    url: `/api/assessment-results?recompute=true`,
+    url: '/api/assessment-results?recompute=true',
     json: true
   };
   return request;
@@ -41,8 +41,8 @@ function main() {
     listCertif.push(i);
   }
   const requests = Promise.all(
-    listCertif.map(id => buildRequestObject(baseUrl, authToken, id))
-      .map(requestObject => request(requestObject)));
+    listCertif.map((id) => buildRequestObject(baseUrl, authToken, id))
+      .map((requestObject) => request(requestObject)));
 
   requests
     .then((result) => console.log(result))

--- a/api/scripts/reload-cache-everyday.js
+++ b/api/scripts/reload-cache-everyday.js
@@ -49,7 +49,7 @@ cron.schedule(process.env.CACHE_RELOAD_TIME, () => {
   console.log('Starting daily cache reload');
 
   return request(authenticationTokenRequest())
-    .then(response => authToken = response.data.attributes.token)
+    .then((response) => authToken = response.data.attributes.token)
     .then(() => request(cacheFlushingRequest(authToken)))
     .then(() => request(cacheWarmupRequest(authToken)))
     .then(() => console.log('Daily cache reload done'))

--- a/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
@@ -21,8 +21,8 @@ describe('Acceptance | API | Assessments POST', () => {
 
     beforeEach(() => {
       return insertUserWithStandardRole()
-        .then((ids) => {
-          userId = ids[0];
+        .then(({ id }) => {
+          userId = id;
           options = {
             method: 'POST',
             url: '/api/assessments',

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -5,26 +5,27 @@ const settings = require('../../../lib/settings');
 const areaRawAirTableFixture = require('../../tooling/fixtures/infrastructure/areaRawAirTableFixture');
 const _ = require('lodash');
 
-function _insertOrganization(userId) {
-  const organizationRaw = {
+async function _insertOrganization(userId) {
+  const organization = databaseBuilder.factory.buildOrganization({
     name: 'The name of the organization',
     type: 'SUP',
     code: 'AAA111',
     userId
-  };
-
-  return knex('organizations').insert(organizationRaw).returning('id');
+  });
+  await databaseBuilder.commit();
+  return organization;
 }
 
-function _insertUser() {
-  const userRaw = {
+async function _insertUser() {
+  const user = databaseBuilder.factory.buildUser({
     firstName: 'john',
     lastName: 'Doe',
     email: 'john.Doe@internet.fr',
     password: 'Pix2017!'
-  };
+  });
 
-  return knex('users').insert(userRaw).returning('id');
+  await databaseBuilder.commit();
+  return user;
 }
 
 function _insertSnapshot(organizationId, userId) {
@@ -291,14 +292,13 @@ describe('Acceptance | Application | organization-controller', () => {
 
     beforeEach(() => {
       return _insertUser()
-        .then(([id]) => userId = id)
+        .then(({ id }) => userId = id)
         .then(() => options.headers.authorization = generateValidRequestAuhorizationHeader(userId))
         .then(() => _insertOrganization(userId));
     });
 
     afterEach(() => {
-      return knex('organizations').delete()
-        .then(() => knex('organizations').delete());
+      return databaseBuilder.clean();
     });
 
     it('should return 200 HTTP status code', () => {
@@ -347,10 +347,10 @@ describe('Acceptance | Application | organization-controller', () => {
 
     beforeEach(() => {
       return _insertUser()
-        .then(([id]) => userId = id)
+        .then(({ id }) => userId = id)
         .then(() => userToken = _createToken(userId))
         .then(() => _insertOrganization(userId))
-        .then(([id]) => organizationId = id)
+        .then(({ id }) => organizationId = id)
         .then(() => _insertSnapshot(organizationId, userId));
     });
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -43,41 +43,36 @@ function generateValidRequestAuhorizationHeader(userId = 1234) {
   return `Bearer ${accessToken}`;
 }
 
-function insertUserWithRolePixMaster() {
-  let userId;
+async function insertUserWithRolePixMaster() {
 
-  return knex('users').insert({
+  databaseBuilder.factory.buildUser.withPixRolePixMaster({
     id: 1234,
     firstName: 'Super',
     lastName: 'Papa',
     email: 'super.papa@example.net',
     password: 'abcd1234',
-  }).returning('id')
-    .then((insertUserId) => {
-      userId = insertUserId[0];
-      return knex('pix_roles').insert({ name: 'PIX_MASTER' }).returning('id');
-    })
-    .then((insertRoleId) => {
-      return knex('users_pix_roles').insert({ user_id: userId, pix_role_id: insertRoleId[0] });
-    });
+  });
+
+  return databaseBuilder.commit();
+
 }
 
-function insertUserWithStandardRole() {
-  return knex('users').insert({
+async function insertUserWithStandardRole() {
+  const user = databaseBuilder.factory.buildUser({
     id: 4444,
     firstName: 'Classic',
     lastName: 'Papa',
     email: 'classic.papa@example.net',
     password: 'abcd1234',
-  }).returning('id');
+  });
+
+  await databaseBuilder.commit();
+
+  return user;
 }
 
 function cleanupUsersAndPixRolesTables() {
-  return knex('users_pix_roles').delete()
-    .then(() => Promise.all([
-      knex('users').delete(),
-      knex('pix_roles').delete(),
-    ]));
+  return databaseBuilder.clean();
 }
 
 // Hapi

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -1,5 +1,6 @@
 module.exports = {
   objectsToInsert: [],
+  objectsToDelete: [],
 
   pushInsertable({ tableName, values }) {
     this.objectsToInsert.push({ tableName, values });
@@ -7,5 +8,6 @@ module.exports = {
 
   purge() {
     this.objectsToInsert = [];
+    this.objectsToDelete = [];
   },
 };

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -1,9 +1,17 @@
+const INITIAL_ID = 100000;
+
 module.exports = {
   objectsToInsert: [],
   objectsToDelete: [],
+  nextId: INITIAL_ID,
 
   pushInsertable({ tableName, values }) {
+    if (!values.id) {
+      values = { ...values, id: this.nextId++ };
+    }
     this.objectsToInsert.push({ tableName, values });
+
+    return values;
   },
 
   purge() {

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -13,6 +13,7 @@ module.exports = class DatabaseBuilder {
       await this.knex(objectToInsert.tableName).insert(objectToInsert.values);
       this.databaseBuffer.objectsToDelete.unshift(objectToInsert);
     }
+    this.databaseBuffer.objectsToInsert = [];
   }
 
   async clean() {

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -11,12 +11,12 @@ module.exports = class DatabaseBuilder {
   async commit() {
     for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
       await this.knex(objectToInsert.tableName).insert(objectToInsert.values);
+      this.databaseBuffer.objectsToDelete.unshift(objectToInsert);
     }
   }
 
   async clean() {
-    const objectsToDelete = this.databaseBuffer.objectsToInsert.slice().reverse();
-    for (const objectToDelete of objectsToDelete) {
+    for (const objectToDelete of this.databaseBuffer.objectsToDelete) {
       await this.knex(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete();
     }
     this.databaseBuffer.purge();

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -8,29 +8,17 @@ module.exports = class DatabaseBuilder {
     this.factory = factory;
   }
 
-  commit() {
-    const initialPromise = Promise.resolve();
-
-    return this.databaseBuffer.objectsToInsert.reduce((promise, objectToInsert) => {
-
-      return promise
-        .then(() => this.knex(objectToInsert.tableName).insert(objectToInsert.values));
-
-    }, initialPromise);
+  async commit() {
+    for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
+      await this.knex(objectToInsert.tableName).insert(objectToInsert.values);
+    }
   }
 
-  clean() {
-    const initialPromise = Promise.resolve();
+  async clean() {
     const objectsToDelete = this.databaseBuffer.objectsToInsert.slice().reverse();
-
-    return objectsToDelete.reduce((promise, objectToDelete) => {
-
-      return promise
-        .then(() => this.knex(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete());
-
-    }, initialPromise)
-      .then(() => {
-        this.databaseBuffer.purge();
-      });
+    for (const objectToDelete of objectsToDelete) {
+      await this.knex(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete();
+    }
+    this.databaseBuffer.purge();
   }
 };

--- a/api/tests/tooling/database-builder/factory/build-answer.js
+++ b/api/tests/tooling/database-builder/factory/build-answer.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildAnswer({
-  id = faker.random.number(),
+  id,
   value = 'default value',
   result = 'ok',
   assessmentId,
@@ -16,11 +16,8 @@ module.exports = function buildAnswer({
   const values = {
     id, value, result, assessmentId, challengeId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'answers',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-answer.js
+++ b/api/tests/tooling/database-builder/factory/build-answer.js
@@ -1,4 +1,3 @@
-const faker = require('faker');
 const buildAssessment = require('./build-assessment');
 const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');

--- a/api/tests/tooling/database-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/database-builder/factory/build-assessment-result.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildAssessmentResult({
-  id = faker.random.number(),
+  id,
   pixScore = faker.random.number(),
   level = faker.random.number({ min: 0, max: 5 }),
   status = 'validated',
@@ -23,11 +23,8 @@ module.exports = function buildAssessmentResult({
     id, pixScore, level, status, emitter, commentForJury, commentForCandidate, commentForOrganization, juryId,
     assessmentId, createdAt,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'assessment-results',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-assessment.js
+++ b/api/tests/tooling/database-builder/factory/build-assessment.js
@@ -5,7 +5,7 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 const _ = require('lodash');
 
 module.exports = function buildAssessment({
-  id = faker.random.number(),
+  id,
   courseId = 'recDefaultCourseIdValue',
   userId,
   type = Assessment.types.PLACEMENT,
@@ -19,12 +19,9 @@ module.exports = function buildAssessment({
   const values = {
     id, courseId, userId, type, state, createdAt, updatedAt,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'assessments',
     values,
   });
-
-  return values;
 };
 

--- a/api/tests/tooling/database-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/database-builder/factory/build-campaign-participation.js
@@ -6,7 +6,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCampaignParticipation({
-  id = faker.random.number(),
+  id,
   assessmentId,
   campaignId,
   isShared = faker.random.boolean(),
@@ -23,11 +23,8 @@ module.exports = function buildCampaignParticipation({
   const values = {
     id, assessmentId, campaignId, userId, isShared, createdAt, sharedAt, participantExternalId
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'campaign-participations',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-campaign.js
+++ b/api/tests/tooling/database-builder/factory/build-campaign.js
@@ -6,7 +6,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCampaign({
-  id = faker.random.number(),
+  id,
   name = faker.company.companyName(),
   code = faker.random.alphaNumeric(9),
   title = faker.random.word(),
@@ -34,11 +34,8 @@ module.exports = function buildCampaign({
     creatorId,
     targetProfileId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'campaigns',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-center-membership.js
@@ -5,7 +5,7 @@ const faker = require('faker');
 const _ = require('lodash');
 
 module.exports = function buildCertificationCenterMembership({
-  id = faker.random.number(),
+  id,
   userId,
   certificationCenterId,
 } = {}) {
@@ -16,12 +16,9 @@ module.exports = function buildCertificationCenterMembership({
   const values = {
     id, userId, certificationCenterId
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'certification-center-memberships',
     values,
   });
-
-  return values;
 };
 

--- a/api/tests/tooling/database-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-center-membership.js
@@ -1,7 +1,6 @@
 const buildUser = require('./build-user');
 const buildCertficationCenter = require('./build-certification-center');
 const databaseBuffer = require('../database-buffer');
-const faker = require('faker');
 const _ = require('lodash');
 
 module.exports = function buildCertificationCenterMembership({

--- a/api/tests/tooling/database-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-center.js
@@ -2,7 +2,7 @@ const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildCertificationCenter({
-  id = faker.random.number(),
+  id,
   name = faker.company.companyName(),
   createdAt = faker.date.recent(),
 } = {}) {
@@ -12,11 +12,8 @@ module.exports = function buildCertificationCenter({
     name,
     createdAt,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'certification-centers',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-challenge.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCertificationChallenge({
-  id = faker.random.number(),
+  id,
   associatedSkill = '@twi8',
   associatedSkillId = `rec${faker.random.uuid()}`,
   challengeId = `rec${faker.random.uuid()}`,
@@ -26,11 +26,8 @@ module.exports = function buildCertificationChallenge({
     createdAt,
     updatedAt,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'certification-challenges',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-course.js
@@ -5,7 +5,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCertificationCourse({
-  id = faker.random.number(),
+  id,
   userId,
   completedAt = faker.date.recent(),
   firstName = faker.name.firstName(),
@@ -34,11 +34,8 @@ module.exports = function buildCertificationCourse({
     sessionId,
     userId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-evaluation.js
@@ -5,7 +5,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCompetenceEvaluation({
-  id = faker.random.number(),
+  id,
   assessmentId,
   competenceId = `recABC${faker.random.number}`,
   status,
@@ -26,10 +26,8 @@ module.exports = function buildCompetenceEvaluation({
     status,
   };
 
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'competence-evaluations',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-competence-mark.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-mark.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildCompetenceMark({
-  id = faker.random.number(),
+  id,
   level = faker.random.number(),
   score = faker.random.number(),
   area_code = faker.random.number(),
@@ -17,11 +17,8 @@ module.exports = function buildCompetenceMark({
   const values = {
     id, level, score, area_code, competence_code, assessmentResultId
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'competence-marks',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-knowledge-element.js
+++ b/api/tests/tooling/database-builder/factory/build-knowledge-element.js
@@ -7,7 +7,7 @@ const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement
 const _ = require('lodash');
 
 module.exports = function buildKnowledgeElement({
-  id = faker.random.number(),
+  id,
   source = KnowledgeElement.SourceType.DIRECT,
   status = KnowledgeElement.StatusType.VALIDATED,
   createdAt = faker.date.recent(),
@@ -35,12 +35,9 @@ module.exports = function buildKnowledgeElement({
     userId,
     competenceId
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'knowledge-elements',
     values,
   });
-
-  return values;
 };
 

--- a/api/tests/tooling/database-builder/factory/build-membership.js
+++ b/api/tests/tooling/database-builder/factory/build-membership.js
@@ -3,18 +3,15 @@ const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildMembership(
   {
-    id = faker.random.number(),
+    id,
     organizationId,
     organizationRoleId,
     userId,
   } = {}) {
 
   const values = { id, organizationId, organizationRoleId, userId };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'memberships',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-membership.js
+++ b/api/tests/tooling/database-builder/factory/build-membership.js
@@ -1,4 +1,3 @@
-const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildMembership(

--- a/api/tests/tooling/database-builder/factory/build-organization-role.js
+++ b/api/tests/tooling/database-builder/factory/build-organization-role.js
@@ -2,20 +2,17 @@ const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 const buildOrganizationRole = function buildOrganizationRole({
-  id = faker.random.number(),
+  id,
   name = 'ADMIN',
 } = {}) {
 
   const values = {
     id, name,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'organization-roles',
     values,
   });
-
-  return values;
 };
 
 module.exports = buildOrganizationRole;

--- a/api/tests/tooling/database-builder/factory/build-organization-role.js
+++ b/api/tests/tooling/database-builder/factory/build-organization-role.js
@@ -1,4 +1,3 @@
-const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 const buildOrganizationRole = function buildOrganizationRole({

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 const buildOrganization = function buildOrganization({
-  id = faker.random.number(),
+  id,
   type = 'PRO',
   name = faker.company.companyName(),
   code = 'ABCD12',
@@ -14,17 +14,14 @@ const buildOrganization = function buildOrganization({
 } = {}) {
 
   const values = { id, type, name, code, logoUrl, createdAt, userId };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'organizations',
     values,
   });
-
-  return values;
 };
 
 buildOrganization.withUser = function buildOrganizationWithUser({
-  id = faker.random.number(),
+  id,
   type = 'PRO',
   name = faker.company.companyName(),
   code = 'ABCD12',
@@ -36,13 +33,10 @@ buildOrganization.withUser = function buildOrganizationWithUser({
   userId = _.isNil(userId) ? buildUser().id : userId;
 
   const values = { id, type, name, code, logoUrl, createdAt, userId };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'organizations',
     values,
   });
-
-  return values;
 };
 
 module.exports = buildOrganization;

--- a/api/tests/tooling/database-builder/factory/build-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-pix-role.js
@@ -1,21 +1,17 @@
-const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 const buildPixRole = function buildPixRole({
-  id = faker.random.number(),
+  id,
   name = 'PIX_MASTER',
 } = {}) {
 
   const values = {
     id, name,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'pix_roles',
     values,
   });
-
-  return values;
 };
 
 module.exports = buildPixRole;

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -2,7 +2,7 @@ const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildSession({
-  id = faker.random.number(),
+  id,
   certificationCenter = faker.company.companyName(),
   certificationCenterId,
   accessCode = faker.random.alphaNumeric(9),
@@ -28,11 +28,8 @@ module.exports = function buildSession({
     description,
     createdAt,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'sessions',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-snapshot.js
+++ b/api/tests/tooling/database-builder/factory/build-snapshot.js
@@ -5,7 +5,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildSnapshot({
-  id = faker.random.number(),
+  id,
   profile = '{}',
   organizationId,
   userId,
@@ -18,11 +18,8 @@ module.exports = function buildSnapshot({
   const values = {
     id, profile, organizationId, userId, createdAt
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'snapshots',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-target-profile-share.js
+++ b/api/tests/tooling/database-builder/factory/build-target-profile-share.js
@@ -5,7 +5,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildTargetProfileShare({
-  id = faker.random.number(),
+  id,
   targetProfileId,
   organizationId,
 } = {}) {
@@ -18,11 +18,8 @@ module.exports = function buildTargetProfileShare({
     targetProfileId,
     organizationId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'target-profile-shares',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-target-profile-share.js
+++ b/api/tests/tooling/database-builder/factory/build-target-profile-share.js
@@ -1,4 +1,3 @@
-const faker = require('faker');
 const buildTargetProfile = require('./build-target-profile');
 const buildOrganization = require('./build-organization');
 const databaseBuffer = require('../database-buffer');

--- a/api/tests/tooling/database-builder/factory/build-target-profile-skill.js
+++ b/api/tests/tooling/database-builder/factory/build-target-profile-skill.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildTargetProfileSkill({
-  id = faker.random.number(),
+  id,
   targetProfileId,
   skillId = `rec${faker.random.uuid()}`,
 } = {}) {
@@ -16,11 +16,8 @@ module.exports = function buildTargetProfileSkill({
     targetProfileId,
     skillId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'target-profiles_skills',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/database-builder/factory/build-target-profile.js
@@ -4,7 +4,7 @@ const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
 module.exports = function buildTargetProfile({
-  id = faker.random.number(),
+  id,
   name = faker.name.jobTitle(),
   isPublic = faker.random.boolean(),
   organizationId,
@@ -18,11 +18,8 @@ module.exports = function buildTargetProfile({
     isPublic,
     organizationId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'target-profiles',
     values,
   });
-
-  return values;
 };

--- a/api/tests/tooling/database-builder/factory/build-user-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-user-pix-role.js
@@ -1,7 +1,6 @@
 const buildUser = require('./build-user');
 const buildPixRole = require('./build-pix-role');
 const databaseBuffer = require('../database-buffer');
-const faker = require('faker');
 const _ = require('lodash');
 
 const buildUserPixRole = function buildUserPixRole({

--- a/api/tests/tooling/database-builder/factory/build-user-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-user-pix-role.js
@@ -12,9 +12,6 @@ const buildUserPixRole = function buildUserPixRole({
   userId = _.isNil(userId) ? buildUser().id : userId;
   pixRoleId = _.isNil(pixRoleId) ? buildPixRole().id : pixRoleId;
 
-  const values = {
-    id, userId, pixRoleId,
-  };
   return databaseBuffer.pushInsertable({
     tableName: 'users_pix_roles',
     values: {

--- a/api/tests/tooling/database-builder/factory/build-user-pix-role.js
+++ b/api/tests/tooling/database-builder/factory/build-user-pix-role.js
@@ -5,7 +5,7 @@ const faker = require('faker');
 const _ = require('lodash');
 
 const buildUserPixRole = function buildUserPixRole({
-  id = faker.random.number(),
+  id,
   userId,
   pixRoleId,
 } = {}) {
@@ -16,8 +16,7 @@ const buildUserPixRole = function buildUserPixRole({
   const values = {
     id, userId, pixRoleId,
   };
-
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'users_pix_roles',
     values: {
       id,
@@ -25,8 +24,6 @@ const buildUserPixRole = function buildUserPixRole({
       'pix_role_id': pixRoleId
     },
   });
-
-  return values;
 };
 
 module.exports = buildUserPixRole;

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -9,7 +9,7 @@ const buildMembership = require('./build-membership');
 const _ = require('lodash');
 
 const buildUser = function buildUser({
-  id = faker.random.number(),
+  id,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   email = faker.internet.exampleEmail().toLowerCase(),
@@ -21,16 +21,14 @@ const buildUser = function buildUser({
     id, firstName, lastName, email, password, cgu,
   };
 
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'users',
     values,
   });
-
-  return values;
 };
 
 buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
-  id = faker.random.number(),
+  id,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   email = faker.internet.email(),
@@ -44,16 +42,14 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
     id, firstName, lastName, email, password, cgu,
   };
 
-  databaseBuffer.pushInsertable({
+  return databaseBuffer.pushInsertable({
     tableName: 'users',
     values,
   });
-
-  return values;
 };
 
 buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
-  id = faker.random.number(),
+  id,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   email = faker.internet.email(),
@@ -65,11 +61,9 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
     id, firstName, lastName, email, password, cgu,
   };
 
-  const pixRolePixMaster = buildPixRole({ id: 1, name: 'PIX_MASTER' });
+  const pixRolePixMaster = buildPixRole({ name: 'PIX_MASTER' });
 
-  buildUserPixRole({ userId: id, pixRoleId: pixRolePixMaster.id });
-
-  databaseBuffer.pushInsertable({
+  const user = databaseBuffer.pushInsertable({
     tableName: 'users',
     values,
   });
@@ -78,7 +72,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
 };
 
 buildUser.withMembership = function buildUserWithMemberships({
-  id = faker.random.number(),
+  id,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   email = faker.internet.email(),

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -68,7 +68,9 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
     values,
   });
 
-  return values;
+  buildUserPixRole({ userId: user.id, pixRoleId: pixRolePixMaster.id });
+
+  return user;
 };
 
 buildUser.withMembership = function buildUserWithMemberships({
@@ -89,18 +91,18 @@ buildUser.withMembership = function buildUserWithMemberships({
   organizationId = _.isNil(organizationId) ? buildOrganization({ name: faker.companyName() }).id : organizationId;
   organizationRoleId = _.isNil(organizationRoleId) ? buildOrganizationRole({ name: 'ADMIN' }).id : organizationRoleId;
 
-  buildMembership({ 
-    userId: id, 
-    organizationId,
-    organizationRoleId
-  });
-  
-  databaseBuffer.pushInsertable({
+  const user = databaseBuffer.pushInsertable({
     tableName: 'users',
     values,
   });
 
-  return values;
+  buildMembership({
+    userId: user.id,
+    organizationId,
+    organizationRoleId
+  });
+
+  return user;
 };
 
 module.exports = buildUser;


### PR DESCRIPTION
## 🎬  Lint (README.md)
J'ai fais tourné `eslint` par erreur sur tout `/api` en mode `--fix` et il a régler plein de petites choses sur les autres dossiers non lintés, (migrations, scripts..) je me suis dis que ça ne faisait pas de mal alors j'ai laissé. C'est dans un `commit` https://github.com/1024pix/pix/pull/537/commits/413b3f483dab8cebbefed445ed10ee313f4dc02a à part donc il ne gênera pas la lecture par `commit` et peut facilement être drop si besoin.

---

## 👎  Problème
Le `databaseBuilder` présente plusieurs problèmes devenu de plus en plus réguliers en `CI` à cause de la génération aléatoire d'identifiants avec l'expression : `faker.random.number()` générant un nombre entre `0` et `100 000` qui rentrait souvent en collision avec d'autres identifiants. 

## 👍 Solution
La solution consiste a faire en sorte que chaque fois qu'on génère un identifiant, il s'incrémente de 1. L'identifiant de départ est suffisamment haut pour ne pas interférer avec la plage d'identifiants utilisés par les tests, les migrations ou les seeds. 

## 🍰 Bonus
- Le `databaseBuilder` a été asyncifié en lieu et place d'un `Promise.reduce` des plus éxotique 🌤  
- Le `commit()` peut désormais être appelés plusieurs fois, il vide son `buffer` à chaque fois.
- Quelques `knex` dans des tests d'acceptance ont été remplacé par le `databaseBuilder`

## 😞 Remarques
Dela n'a en revanche presque rien changé au problèmes que l'on rencontre avec `PG` causés par des `foreignKey`, des double suppressions de la même table, des comparaison d'id en `string` ou `number` etc.