### PR TITLE
[TECH] Améliore la probabilité de succès des tests end to end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,9 @@ jobs:
           keys:
             - v7-mon-pix-npm-{{ checksum "~/pix/mon-pix/cachekey-mon-pix" }}
       - run:
+          environment:
+            # See https://git.io/vdao3 for details.
+            JOBS: 2
           working_directory: ~/pix/mon-pix
           background: true
           command: npm ci && npm start


### PR DESCRIPTION
## :unicorn: Problème

Les tests end to end échouent régulièrement au démarrage, avec l'erreur :

> Build Error (broccoli-persistent-filter:Babel > [Babel: ember-lodash]) in lodash/snakeCase.js

C'est dû au fait qu'Ember utilise le nombre de CPUs de la CI, qui est très grand, pour spawner des process de build npm. Or sur la CI, s'il y a beaucoup de CPUs, très peu nous sont réellement assignés.

## :robot: Solution

En suivant cette recommandation, on limite explicitement le nb de jobs créés par Ember pour les fronts :

- https://github.com/ember-cli/ember-cli/blob/master/docs/build-concurrency.md
