### PR TITLE
[TECH] Suppression des usages dépréciés de ember-mocha pour les tests unitaires.

### DIFF
--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -3,13 +3,11 @@ import { it, describe } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | subscribers', function() {
-  setupTest('adapter:application', {
-    needs: ['service:session']
-  });
+  setupTest();
 
   it('should specify /api as the root url', function() {
     // Given
-    const applicationAdapter = this.subject();
+    const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
     expect(applicationAdapter.namespace).to.equal('api');
@@ -18,7 +16,7 @@ describe('Unit | Route | subscribers', function() {
   it('should add header with authentication token ', function() {
     // Given
     const expectedToken = '23456789';
-    const applicationAdapter = this.subject();
+    const applicationAdapter = this.owner.lookup('adapter:application');
 
     // When
     applicationAdapter.set('session', { data: { authenticated: { token: expectedToken } } });
@@ -30,7 +28,7 @@ describe('Unit | Route | subscribers', function() {
 
   it('should allow to logout ', function() {
     // Given
-    const applicationAdapter = this.subject();
+    const applicationAdapter = this.owner.lookup('adapter:application');
 
     // Then
     expect(applicationAdapter.get('headers')).to.deep.equal({

--- a/mon-pix/tests/unit/adapters/correction-test.js
+++ b/mon-pix/tests/unit/adapters/correction-test.js
@@ -4,12 +4,10 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Adapters | correction', function() {
 
-  setupTest('adapter:correction', {
-    needs: ['service:session']
-  });
+  setupTest();
 
   it('exists', function() {
-    const adapter = this.subject();
+    const adapter = this.owner.lookup('adapter:correction');
     expect(adapter).to.be.ok;
   });
 

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -4,16 +4,14 @@ import sinon from 'sinon';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | subscribers', function() {
-  setupTest('adapter:user', {
-    needs: ['service:session']
-  });
+  setupTest();
 
   describe('#queryRecord', () => {
 
     let adapter;
 
     beforeEach(function() {
-      adapter = this.subject();
+      adapter = this.owner.lookup('adapter:user');
       adapter.ajax = sinon.stub().resolves();
     });
 

--- a/mon-pix/tests/unit/authenticators/simple-test.js
+++ b/mon-pix/tests/unit/authenticators/simple-test.js
@@ -9,9 +9,7 @@ const expectedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJz
 
 describe('Unit | Authenticator | simple', function() {
 
-  setupTest('authenticator:simple', {
-    needs: ['service:ajax']
-  });
+  setupTest();
 
   const requestStub = sinon.stub().resolves({
     'data': {
@@ -26,17 +24,16 @@ describe('Unit | Authenticator | simple', function() {
   });
 
   beforeEach(function() {
-    this.register('service:ajax', Service.extend({
+    this.owner.register('service:ajax', Service.extend({
       request: requestStub
     }));
-    this.inject.service('ajax', { as: 'ajax' });
   });
 
   it('should post a request to retrieve token', function() {
     // Given
     const email = 'test@example.net';
     const password = 'Hx523è9#';
-    const authenticator = this.subject();
+    const authenticator = this.owner.lookup('authenticator:simple');
 
     // When
     const promise = authenticator.authenticate({ email, password });
@@ -56,7 +53,7 @@ describe('Unit | Authenticator | simple', function() {
     // Given
     const email = 'test@example.net';
     const password = 'Hx523è9#';
-    const authenticator = this.subject();
+    const authenticator = this.owner.lookup('authenticator:simple');
 
     // When
     const promise = authenticator.authenticate({ email, password });
@@ -73,7 +70,7 @@ describe('Unit | Authenticator | simple', function() {
     // Given
     const token = expectedToken;
     const userId = expectedUserId;
-    const authenticator = this.subject();
+    const authenticator = this.owner.lookup('authenticator:simple');
 
     // When
     const promise = authenticator.authenticate({ token, userId });
@@ -90,7 +87,7 @@ describe('Unit | Authenticator | simple', function() {
     it('should extract userId and source from token', function() {
       // given
       const token = 'aaa.eyJ1c2VyX2lkIjoxLCJzb3VyY2UiOiJwaXgiLCJpYXQiOjE1NDUxMjg3NzcsImV4cCI6MTU0NTczMzU3N30.bbbb';
-      const authenticator = this.subject();
+      const authenticator = this.owner.lookup('authenticator:simple');
 
       // when
       const dataFromToken = authenticator.extractDataFromToken(token);

--- a/mon-pix/tests/unit/components/certification-code-validation-test.js
+++ b/mon-pix/tests/unit/components/certification-code-validation-test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 
 describe('Unit | Component | certification-code-value', function() {
 
-  setupTest('component:certification-code-validation', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:certification-code-validation');
   });
 
   describe('#submit', function() {

--- a/mon-pix/tests/unit/components/challenge-statement-test.js
+++ b/mon-pix/tests/unit/components/challenge-statement-test.js
@@ -1,24 +1,24 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import EmberObject from '@ember/object';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | challenge statement', function() {
 
-  setupTest('component:challenge-statement', {
-    needs: ['service:mailGenerator']
-  });
+  setupTest();
 
   describe('[CP] #challengeEmbedDocument', function() {
     it('should return a JSON object with the challenge embedded document when the challenge has a valid one', function() {
       // given
-      const component = this.subject({
-        challenge: {
-          hasValidEmbedDocument: true,
-          embedUrl: 'https://challenge-embed.url',
-          embedTitle: 'Challenge embed document title',
-          embedHeight: 300
-        }
+      const challenge = EmberObject.create({
+        hasValidEmbedDocument: true,
+        embedUrl: 'https://challenge-embed.url',
+        embedTitle: 'Challenge embed document title',
+        embedHeight: 300
       });
+
+      const component = this.owner.lookup('component:challenge-statement');
+      component.set('challenge', challenge);
 
       // when
       const challengeEmbedDocument = component.get('challengeEmbedDocument');
@@ -33,11 +33,12 @@ describe('Unit | Component | challenge statement', function() {
 
     it('should return "undefined" when the challenge does not have a (valid) embedded document', function() {
       // given
-      const component = this.subject({
-        challenge: {
-          hasValidEmbedDocument: false
-        }
+      const challenge = EmberObject.create({
+        hasValidEmbedDocument: false
       });
+
+      const component = this.owner.lookup('component:challenge-statement');
+      component.set('challenge', challenge);
 
       // when
       const challengeEmbedDocument = component.get('challengeEmbedDocument');

--- a/mon-pix/tests/unit/components/competence-area-list-test.js
+++ b/mon-pix/tests/unit/components/competence-area-list-test.js
@@ -4,14 +4,14 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | Competence area list Component', function() {
 
-  setupTest('component:competence-area-list', {});
+  setupTest();
 
   describe('Computed Properties behaviors: ', function() {
 
     describe('#_sanitizedCompetences', function() {
       it('should not return competences', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-area-list');
 
         // when
         component.set('competences', []);
@@ -22,7 +22,7 @@ describe('Unit | Component | Competence area list Component', function() {
 
       it('should return as many competences as provided', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-area-list');
 
         // when
         component.set('competences', [{
@@ -42,7 +42,7 @@ describe('Unit | Component | Competence area list Component', function() {
     describe('#_competencesGroupedByArea', function() {
       it('should return some competences grouped by areas', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-area-list');
         const expectedGroupedCompetences = [
           {
             property: 'areaName',
@@ -70,7 +70,7 @@ describe('Unit | Component | Competence area list Component', function() {
     describe('#_competencesByAreaSorted', function() {
       it('should return some competences grouped by areas and asc sorted', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-area-list');
         const expectedGroupedCompetences = [
           { property: 'areaName', value: '2. area-A', items: [{ id: 2, name: 'competence-2', areaName: '2. area-A' }] },
           { property: 'areaName', value: '4. area-B', items: [{ id: 4, name: 'competence-4', areaName: '4. area-B' }] },

--- a/mon-pix/tests/unit/components/competence-by-area-item-test.js
+++ b/mon-pix/tests/unit/components/competence-by-area-item-test.js
@@ -5,14 +5,14 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | Competence area item Component', function() {
 
-  setupTest('component:competence-by-area-item', {});
+  setupTest();
 
   describe('#Computed Properties behaviors: ', function() {
 
     describe('#_competencesAreaName', function() {
       it('should return Area name related to competences without index number', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-by-area-item');
 
         // when
         component.set('competenceArea', {
@@ -27,7 +27,7 @@ describe('Unit | Component | Competence area item Component', function() {
 
       it('should return empty Area name related to competences when it does not exist', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-by-area-item');
 
         // when
         component.set('competenceArea', {});
@@ -42,7 +42,7 @@ describe('Unit | Component | Competence area item Component', function() {
 
       it('should display sorted competences', function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:competence-by-area-item');
 
         const competencesWithSameArea = [
           EmberObject.create({ id: 2, name: 'competence-name-2', index: '1.2', area: 'area-id-1', level: -1 }),

--- a/mon-pix/tests/unit/components/competence-card-test.js
+++ b/mon-pix/tests/unit/components/competence-card-test.js
@@ -4,12 +4,12 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | competence-card-component', function() {
 
-  setupTest('component:competence-card', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:competence-card');
   });
 
   describe('#displayedLevel', function() {

--- a/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
+++ b/mon-pix/tests/unit/components/competence-level-progress-bar-test.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | Competence-level-progress-bar ', function() {
 
-  setupTest('component:competence-level-progress-bar', {});
+  setupTest();
 
   describe('#Computed Properties behaviors: ', function() {
 
@@ -23,7 +23,7 @@ describe('Unit | Component | Competence-level-progress-bar ', function() {
 
         it(`should return ${expectedValue} when the level is ${level}`, function() {
           // given
-          const component = this.subject();
+          const component = this.owner.lookup('component:competence-level-progress-bar');
           const competence = { level };
 
           // when

--- a/mon-pix/tests/unit/components/course-banner-test.js
+++ b/mon-pix/tests/unit/components/course-banner-test.js
@@ -1,17 +1,17 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
 
 describe('Unit | Component | course-banner', function() {
 
-  setupComponentTest('course-banner', { unit: true });
+  setupTest();
 
   describe('@courseName', () => {
 
     it('should return course name when it exists', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:course-banner');
       const course = EmberObject.create({ name: 'On est en finale !!!' });
       component.set('course', course);
 
@@ -23,7 +23,7 @@ describe('Unit | Component | course-banner', function() {
     });
     it('should return empty string when it does not exist', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:course-banner');
 
       // when
       const courseName = component.get('courseName');

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -4,13 +4,13 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | feedback-panel', function() {
 
-  setupTest('component:feedback-panel', {});
+  setupTest();
 
   describe('#isFormClosed', function() {
 
     it('should return true by default', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
 
       // when
       const isFormClosed = component.get('isFormClosed');
@@ -21,7 +21,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return true if status equals "FORM_CLOSED"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('_status', 'FORM_CLOSED');
 
       // when
@@ -33,7 +33,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return false if status is not equal to "FORM_CLOSED"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('_status', 'FORM_OPENED');
 
       // when
@@ -48,7 +48,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return true if status equals "FORM_OPENED"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('_status', 'FORM_OPENED');
 
       // when
@@ -60,7 +60,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return false if status is not equal to "FORM_OPENED"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('_status', 'FORM_CLOSED');
 
       // when
@@ -76,7 +76,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return empty text, error and back to the default status', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('collapsible', false);
       component.set('_content', 'un contenu');
       component.set('_error', 'une erreur');
@@ -96,7 +96,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should set status to CLOSED and set errors to null', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('_error', 'une erreur');
       component.set('_status', 'FORM_OPENED');
 
@@ -113,7 +113,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return FORM_CLOSED if has property collapsible at "true"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('collapsible', true);
 
       // when
@@ -125,7 +125,7 @@ describe('Unit | Component | feedback-panel', function() {
 
     it('should return FORM_OPENED if has property collapsible at "false"', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:feedback-panel');
       component.set('collapsible', false);
 
       // when

--- a/mon-pix/tests/unit/components/form-textfield-test.js
+++ b/mon-pix/tests/unit/components/form-textfield-test.js
@@ -9,7 +9,7 @@ const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit comport
 
 describe('Unit | Component | signupTextfieldComponent', function() {
 
-  setupTest('component:form-textfield', {});
+  setupTest();
 
   describe('Component should renders :', function() {
 
@@ -21,7 +21,8 @@ describe('Unit | Component | signupTextfieldComponent', function() {
     ].forEach(({ renderingIntent, inputId }) => {
       it(`an ${renderingIntent} when input id is ${inputId}`, function() {
         // given
-        const component = this.subject();
+        const component = this.owner.lookup('component:form-textfield');
+
         // when
         component.set('textfieldName', inputId);
         const inputType = component.get('textfieldType');
@@ -43,7 +44,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
     ].forEach(({ property, expectedValue }) => {
       it(`${property} should return ${expectedValue} `, function() {
         // Given
-        const component = this.subject();
+        const component = this.owner.lookup('component:form-textfield');
         // When
         component.set('validationStatus', 'default');
         component.set('validationMessage', '');
@@ -65,7 +66,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
 
         it(`gets ${message} when ${errorType}`, function(done) {
           // Given
-          const component = this.subject();
+          const component = this.owner.lookup('component:form-textfield');
           // When
           component.set('validationStatus', 'default');
           component.set('validationMessage', message);
@@ -92,7 +93,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
     ].forEach(({ property, expectedValue }) => {
       it(`${property} should return ${expectedValue} `, function() {
         // Given
-        const component = this.subject();
+        const component = this.owner.lookup('component:form-textfield');
         // When
         component.set('validationStatus', 'error');
         const propertyValue = component.get(property);
@@ -113,7 +114,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
 
         it(`gets ${message} when ${errorType}`, function() {
           // Given
-          const component = this.subject();
+          const component = this.owner.lookup('component:form-textfield');
           // When
           component.set('validationStatus', 'error');
           component.set('validationMessage', message);
@@ -139,7 +140,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
     ].forEach(({ property, expectedValue }) => {
       it(`${property} should return ${expectedValue} `, function() {
         // Given
-        const component = this.subject();
+        const component = this.owner.lookup('component:form-textfield');
         // When
         component.set('validationStatus', 'success');
         const propertyValue = component.get(property);
@@ -160,7 +161,7 @@ describe('Unit | Component | signupTextfieldComponent', function() {
 
         it(`gets ${message} when ${errorType}`, function() {
           // Given
-          const component = this.subject();
+          const component = this.owner.lookup('component:form-textfield');
           // When
           component.set('validationStatus', 'error');
           component.set('validationMessage', message);

--- a/mon-pix/tests/unit/components/g-recaptcha-test.js
+++ b/mon-pix/tests/unit/components/g-recaptcha-test.js
@@ -8,13 +8,13 @@ describe('Unit | Component | g-recaptcha', function() {
 
   let serviceResetCalled = false;
 
-  setupTest('component:g-recaptcha', {});
+  setupTest();
 
   beforeEach(function() {
 
     serviceResetCalled = false;
 
-    this.register('service:googleRecaptcha', Service.extend({
+    this.owner.register('service:googleRecaptcha', Service.extend({
       loadScript() {
         return RSVP.resolve();
       },
@@ -28,7 +28,6 @@ describe('Unit | Component | g-recaptcha', function() {
       }
 
     }));
-    this.inject.service('googleRecaptcha', { as: 'googleRecaptcha' });
 
   });
 
@@ -36,7 +35,8 @@ describe('Unit | Component | g-recaptcha', function() {
 
     it('should reset the recaptcha if the token has been used', function() {
       // given
-      const component = this.subject({});
+      const component = this.owner.lookup('component:g-recaptcha');
+
       component.set('recaptchaToken', null);
       component.set('tokenHasBeenUsed', true);
 
@@ -49,7 +49,7 @@ describe('Unit | Component | g-recaptcha', function() {
 
     it('should not reset the recaptcha if the token has not been used', function() {
       // given
-      const component = this.subject({});
+      const component = this.owner.lookup('component:g-recaptcha');
       component.set('recaptchaToken', null);
       component.set('tokenHasBeenUsed', false);
 
@@ -66,7 +66,7 @@ describe('Unit | Component | g-recaptcha', function() {
 
     it('should set the recaptchaToken to the GoogleRecaptchaToken and indicate that he has not been used', function() {
       // given
-      const component = this.subject({});
+      const component = this.owner.lookup('component:g-recaptcha');
       component.set('recaptchaToken', null);
       component.set('tokenHasBeenUsed', true);
       const googleRecaptchaResponse = 'la reponse de recaptcha';
@@ -84,7 +84,7 @@ describe('Unit | Component | g-recaptcha', function() {
 
     it('should set the recaptchaToken to null and indicate that he has not been used', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:g-recaptcha');
       component.set('recaptchaToken', 'un token');
       component.set('tokenHasBeenUsed', true);
 

--- a/mon-pix/tests/unit/components/navbar-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-header-test.js
@@ -4,20 +4,19 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | Navbar Header Component', function() {
-  setupTest('component:navbar-header', {});
+  setupTest();
   const sessionStubResolve = Service.extend({ isAuthenticated: true });
   const sessionStubReject = Service.extend({ isAuthenticated: false });
 
   describe('When user is logged', function() {
     beforeEach(function() {
-      this.register('service:session', sessionStubResolve);
-      this.inject.service('session', { as: 'session' });
+      this.owner.register('service:session', sessionStubResolve);
     });
 
     describe('#isUserLogged', function() {
       it('should return true', function() {
         // when
-        const component = this.subject();
+        const component = this.owner.lookup('component:navbar-header');
 
         // then
         expect(component.get('isUserLogged')).to.equal(true);
@@ -30,7 +29,7 @@ describe('Unit | Component | Navbar Header Component', function() {
         const expectedLoggedUserMenu = [];
 
         // when
-        const component = this.subject();
+        const component = this.owner.lookup('component:navbar-header');
 
         // then
         expect(component.get('menu')).to.deep.equal(expectedLoggedUserMenu);
@@ -40,14 +39,13 @@ describe('Unit | Component | Navbar Header Component', function() {
 
   context('When user is not logged', function() {
     beforeEach(function() {
-      this.register('service:session', sessionStubReject);
-      this.inject.service('session', { as: 'session' });
+      this.owner.register('service:session', sessionStubReject);
     });
 
     context('#isUserLogged', function() {
       it('should return false, when user is unauthenticated', function() {
         // when
-        const component = this.subject();
+        const component = this.owner.lookup('component:navbar-header');
 
         // then
         expect(component.get('isUserLogged')).to.equal(false);
@@ -63,7 +61,7 @@ describe('Unit | Component | Navbar Header Component', function() {
         ];
 
         // when
-        const component = this.subject();
+        const component = this.owner.lookup('component:navbar-header');
 
         // then
         expect(component.get('menu')).to.deep.equal(expectedUnloggedUserMenu);

--- a/mon-pix/tests/unit/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/unit/components/password-reset-demand-form-test.js
@@ -6,7 +6,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | password-reset-demand-form', function() {
 
-  setupTest('component:password-reset-demand-form', {});
+  setupTest();
 
   let component;
   const sentEmail = 'dumb@people.com';
@@ -21,12 +21,11 @@ describe('Unit | Component | password-reset-demand-form', function() {
         save: saveStub
       });
 
-      this.register('service:store', Service.extend({
+      this.owner.register('service:store', Service.extend({
         createRecord: createRecordStub
       }));
-      this.inject.service('store', { as: 'store' });
 
-      component = this.subject();
+      component = this.owner.lookup('component:password-reset-demand-form');
       component.set('email', sentEmail);
     });
 

--- a/mon-pix/tests/unit/components/pix-modal-test.js
+++ b/mon-pix/tests/unit/components/pix-modal-test.js
@@ -7,14 +7,12 @@ import { keyUp } from 'ember-keyboard';
 
 describe('Unit | Component | pix-modal', function() {
 
-  setupTest('component:pix-modal', {
-    needs: ['service:keyboard', 'service:modal-dialog']
-  });
+  setupTest();
 
   describe('#init', () => {
     it('should set the overlay as translucent', function() {
       // Given
-      const component = this.subject();
+      const component = this.owner.lookup('component:pix-modal');
 
       // then
       expect(component.get('translucentOverlay')).to.be.equal(true);
@@ -22,7 +20,7 @@ describe('Unit | Component | pix-modal', function() {
 
     it('should activate keyboard events', function() {
       // Given
-      const component = this.subject();
+      const component = this.owner.lookup('component:pix-modal');
 
       // then
       expect(component.get('keyboardActivated')).to.be.equal(true);
@@ -35,7 +33,7 @@ describe('Unit | Component | pix-modal', function() {
       // Given
       const sendActionStub = sinon.stub();
 
-      const component = this.subject();
+      const component = this.owner.lookup('component:pix-modal');
       component.onClose = sendActionStub;
       component.trigger(keyUp('Escape'));
 

--- a/mon-pix/tests/unit/components/progress-bar-test.js
+++ b/mon-pix/tests/unit/components/progress-bar-test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | progress-bar', function() {
 
-  setupTest('component:progress-bar', {});
+  setupTest();
 
   describe('@progression', function() {
 
@@ -19,7 +19,8 @@ describe('Unit | Component | progress-bar', function() {
           nbChallenges: 10
         }
       });
-      const component = this.subject({ assessment });
+      const component = this.owner.lookup('component:progress-bar');
+      component.set('assessment', assessment);
       component.setProgression();
 
       // when
@@ -44,7 +45,8 @@ describe('Unit | Component | progress-bar', function() {
           nbChallenges: 10
         }
       });
-      const component = this.subject({ assessment });
+      const component = this.owner.lookup('component:progress-bar');
+      component.set('assessment', assessment);
       component.setProgression();
 
       // when

--- a/mon-pix/tests/unit/components/qcu-proposals-test.js
+++ b/mon-pix/tests/unit/components/qcu-proposals-test.js
@@ -4,10 +4,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | QCU proposals', function() {
 
-  setupTest('component:qcu-proposals', {});
-
-  /* Computed property "labeledRadios"
-   ----------------------------------------------------- */
+  setupTest();
 
   describe('Computed property "labeledRadios"', function() {
 
@@ -23,7 +20,7 @@ describe('Unit | Component | QCU proposals', function() {
     });
 
     function initComponent() {
-      component = this.subject();
+      component = this.owner.lookup('component:qcu-proposals');
       component.set('proposals', proposals);
       component.set('answerValue', answerValue);
     }

--- a/mon-pix/tests/unit/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qroc-solution-panel-test.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | qroc-solution-panel', function() {
 
-  setupTest('component:qroc-solution-panel', {});
+  setupTest();
   const rightAnswer = { result: 'ok' };
   const wrongAnswer = { result: 'ko' };
 
@@ -12,7 +12,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
 
     it('should return true when result is ok', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('answer', rightAnswer);
       // when
       const isResultOk = component.get('isResultOk');
@@ -22,7 +22,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
 
     it('should return true when result is not ok', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('answer', wrongAnswer);
       // when
       const isResultOk = component.get('isResultOk');
@@ -39,7 +39,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
       const answer = {
         value: '#ABAND#'
       };
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('answer', answer);
       // when
       const answerToDisplay = component.get('answerToDisplay');
@@ -52,7 +52,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
       const answer = {
         value: 'La Reponse B'
       };
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('answer', answer);
       // when
       const answerToDisplay = component.get('answerToDisplay');
@@ -66,7 +66,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return the first solution if the solution has some variants', function() {
       // given
       const solution = 'Reponse\nreponse\nréponse';
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('solution', solution);
       // when
       const solutionToDisplay = component.get('solutionToDisplay');
@@ -77,7 +77,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return the solution', function() {
       // given
       const solution = 'Reponse';
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('solution', solution);
       // when
       const solutionToDisplay = component.get('solutionToDisplay');
@@ -88,7 +88,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return an empty string if the solution is null', function() {
       // given
       const emptySolution = '';
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('solution', emptySolution);
       // when
       const solutionToDisplay = component.get('solutionToDisplay');
@@ -99,7 +99,7 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return an empty string if the solution is an empty String', function() {
       // given
       const solutionNull = null;
-      const component = this.subject();
+      const component = this.owner.lookup('component:qroc-solution-panel');
       component.set('solution', solutionNull);
       // when
       const solutionToDisplay = component.get('solutionToDisplay');

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | qrocm-solution-panel', function() {
 
-  setupTest('component:qrocm-ind-solution-panel', {});
+  setupTest();
 
   describe('#inputFields', function() {
 
@@ -19,7 +19,7 @@ describe('Unit | Component | qrocm-solution-panel', function() {
     });
 
     function _getComponentInputFields(context) {
-      const component = context.subject();
+      const component = context.owner.lookup('component:qrocm-ind-solution-panel');
       component.set('challenge', challenge);
       component.set('answer', answer);
       component.set('solution', solution);

--- a/mon-pix/tests/unit/components/reset-password-form-test.js
+++ b/mon-pix/tests/unit/components/reset-password-form-test.js
@@ -3,7 +3,7 @@ import { resolve, reject } from 'rsvp';
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.';
 
@@ -27,24 +27,12 @@ const SUBMISSION_MAP = {
 
 describe('Unit | Component | reset password form', function() {
 
-  setupComponentTest('reset-password-form', {
-    needs: ['component:form-textfield'],
-    unit: true
-  });
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
-  });
-
-  it('should be rendered', function() {
-    // when
-    this.render();
-
-    // then
-    expect(component).to.be.ok;
-    expect(this.$()).to.have.length(1);
+    component = this.owner.lookup('component:reset-password-form');
   });
 
   describe('#validatePassword', () => {

--- a/mon-pix/tests/unit/components/result-item-campaign-test.js
+++ b/mon-pix/tests/unit/components/result-item-campaign-test.js
@@ -22,12 +22,12 @@ const answerWithNullResult = {
 
 describe('Unit | Component | result-item-campaign-component', function() {
 
-  setupTest('component:result-item-campaign', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:result-item-campaign');
   });
 
   describe('#resultItem Computed property - undefined case', function() {

--- a/mon-pix/tests/unit/components/result-item-test.js
+++ b/mon-pix/tests/unit/components/result-item-test.js
@@ -30,12 +30,12 @@ const answerWithRandomResult = {
 
 describe('Unit | Component | result-item-component', function() {
 
-  setupTest('component:result-item', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:result-item');
   });
 
   describe('#resultItem Computed property - undefined case', function() {

--- a/mon-pix/tests/unit/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/unit/components/resume-campaign-banner-test.js
@@ -5,7 +5,7 @@ import EmberObject from '@ember/object';
 
 describe('Unit | Component | resume-campaign-banner-component ', function() {
 
-  setupTest('component:resume-campaign-banner', {});
+  setupTest();
 
   let component;
 
@@ -45,7 +45,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
   });
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:resume-campaign-banner');
   });
 
   describe('#campaignToResumeOrShare', function() {

--- a/mon-pix/tests/unit/components/score-pastille-test.js
+++ b/mon-pix/tests/unit/components/score-pastille-test.js
@@ -4,12 +4,12 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | score-pastille-component ', function() {
 
-  setupTest('component:score-pastille', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:score-pastille');
   });
 
   describe('#Test computed Property', function() {

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -1,33 +1,31 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | scorecard-details ', function() {
-  setupComponentTest('scorecard-details', {
-    unit: true
-  });
+  setupTest();
 
-  let controller;
+  let component;
 
   beforeEach(function() {
-    controller = this.subject();
+    component = this.owner.lookup('component:scorecard-details');
   });
 
   describe('#level', function() {
     it('returns null if the scorecard isNotStarted', function() {
       // when
-      controller.set('scorecard', { isNotStarted: true });
+      component.set('scorecard', { isNotStarted: true });
 
       // then
-      expect(controller.get('level')).to.be.equal(null);
+      expect(component.get('level')).to.be.equal(null);
     });
 
     it('returns the level if the scorecard is not isNotStarted', function() {
       // when
-      controller.set('scorecard', { level: 1 });
+      component.set('scorecard', { level: 1 });
 
       // then
-      expect(controller.get('level')).to.be.equal(1);
+      expect(component.get('level')).to.be.equal(1);
     });
 
   });
@@ -35,34 +33,34 @@ describe('Unit | Component | scorecard-details ', function() {
   describe('#isProgressable', function() {
     it('returns false if isMaxLevel', function() {
       // when
-      controller.set('scorecard', { isMaxLevel: true });
+      component.set('scorecard', { isMaxLevel: true });
 
       // then
-      expect(controller.get('isProgressable')).to.be.equal(false);
+      expect(component.get('isProgressable')).to.be.equal(false);
     });
 
     it('returns false if isNotStarted', function() {
       // when
-      controller.set('scorecard', { isNotStarted: true });
+      component.set('scorecard', { isNotStarted: true });
 
       // then
-      expect(controller.get('isProgressable')).to.be.equal(false);
+      expect(component.get('isProgressable')).to.be.equal(false);
     });
 
     it('returns false if isFinished', function() {
       // when
-      controller.set('scorecard', { isFinished: true });
+      component.set('scorecard', { isFinished: true });
 
       // then
-      expect(controller.get('isProgressable')).to.be.equal(false);
+      expect(component.get('isProgressable')).to.be.equal(false);
     });
 
     it('returns true otherwise', function() {
       // when
-      controller.set('scorecard', {});
+      component.set('scorecard', {});
 
       // then
-      expect(controller.get('isProgressable')).to.be.equal(true);
+      expect(component.get('isProgressable')).to.be.equal(true);
     });
   });
 });

--- a/mon-pix/tests/unit/components/scoring-panel-test.js
+++ b/mon-pix/tests/unit/components/scoring-panel-test.js
@@ -4,14 +4,14 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | scoring-panel', function() {
 
-  setupTest('component:scoring-panel', {});
+  setupTest();
 
   describe('#hasATrophy', function() {
 
     it('should be true when level is more than 0', function() {
       // given
       const assessmentWithTrophy = { estimatedLevel: 1 };
-      const component = this.subject();
+      const component = this.owner.lookup('component:scoring-panel');
 
       // when
       component.set('assessment', assessmentWithTrophy);
@@ -24,7 +24,7 @@ describe('Unit | Component | scoring-panel', function() {
     it('should be false when level is equal to 0', function() {
       // given
       const assessmentWithNoTrophy = { estimatedLevel: 0 };
-      const component = this.subject();
+      const component = this.owner.lookup('component:scoring-panel');
 
       // when
       component.set('assessment', assessmentWithNoTrophy);
@@ -40,7 +40,7 @@ describe('Unit | Component | scoring-panel', function() {
     it('should be true when pix score is more than 0', function() {
       // given
       const assessmentWithPix = { pixScore: 1 };
-      const component = this.subject();
+      const component = this.owner.lookup('component:scoring-panel');
 
       // when
       component.set('assessment', assessmentWithPix);
@@ -53,7 +53,7 @@ describe('Unit | Component | scoring-panel', function() {
     it('should be false when pix score is equal to 0', function() {
       // given
       const assessmentWithNoPix = { pixScore: 0 };
-      const component = this.subject();
+      const component = this.owner.lookup('component:scoring-panel');
 
       // when
       component.set('assessment', assessmentWithNoPix);

--- a/mon-pix/tests/unit/components/share-profile-test.js
+++ b/mon-pix/tests/unit/components/share-profile-test.js
@@ -5,12 +5,12 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | share-profile', function() {
 
-  setupTest('component:share-profile', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:share-profile');
   });
 
   describe('#init', () => {

--- a/mon-pix/tests/unit/components/timeout-jauge-test.js
+++ b/mon-pix/tests/unit/components/timeout-jauge-test.js
@@ -4,12 +4,12 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | timeout-jauge-component ', function() {
 
-  setupTest('component:timeout-jauge', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:timeout-jauge');
   });
 
   describe('#Test rendering Property', function() {

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -1,16 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | tutorial item', function() {
-  setupComponentTest('tutorial-item', {
-    unit: true
-  });
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:tutorial-item');
   });
 
   describe('#displayedDuration', function() {

--- a/mon-pix/tests/unit/components/tutorial-panel-test.js
+++ b/mon-pix/tests/unit/components/tutorial-panel-test.js
@@ -1,16 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | tutorial panel', function() {
-  setupComponentTest('tutorial-panel', {
-    unit: true
-  });
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:tutorial-panel');
   });
 
   describe('#shouldDisplayHint', function() {

--- a/mon-pix/tests/unit/components/user-logged-menu-test.js
+++ b/mon-pix/tests/unit/components/user-logged-menu-test.js
@@ -5,14 +5,13 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | User logged Menu', function() {
 
-  setupTest('component:user-logged-menu', {
-    needs: ['service:currentUser', 'service:keyboard', 'service:session', 'service:metrics']
-  });
+  setupTest();
 
   describe('action#toggleUserMenu', function() {
     it('should return true, when user details is clicked', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
+
       // when
       component.send('toggleUserMenu');
       // then
@@ -21,7 +20,7 @@ describe('Unit | Component | User logged Menu', function() {
 
     it('should return false as default value', function() {
       // when
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
 
       // then
       expect(component.get('_canDisplayMenu')).to.equal(false);
@@ -29,7 +28,7 @@ describe('Unit | Component | User logged Menu', function() {
 
     it('should return false, when _canDisplayMenu was previously true', function() {
       // given
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
       // when
       component.send('toggleUserMenu');
       component.send('toggleUserMenu');
@@ -41,25 +40,20 @@ describe('Unit | Component | User logged Menu', function() {
   describe('canDisplayLinkToProfile', function() {
 
     beforeEach(function() {
-
-      this.register('service:current-routed-modal', Service.extend({}));
-      this.inject.service('current-routed-modal', { as: 'current-routed-modal' });
-
+      this.owner.register('service:current-routed-modal', Service.extend({}));
     });
 
     it('should be false if user uses profilV2 and the current route is /profilv2', function() {
       // given
-      this.register('service:-routing', Service.extend({
+      this.owner.register('service:-routing', Service.extend({
         currentRouteName: 'profilv2'
       }));
-      this.inject.service('-routing', { as: '-routing' });
 
-      this.register('service:currentUser', Service.extend({
+      this.owner.register('service:currentUser', Service.extend({
         user: { usesProfileV2: true }
       }));
-      this.inject.service('currentUser');
 
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
 
       // when
       const result = component.get('canDisplayLinkToProfile');
@@ -70,11 +64,10 @@ describe('Unit | Component | User logged Menu', function() {
 
     it('should be false if user does not use profilV2 and the current route is /compte', function() {
       // given
-      this.register('service:-routing', Service.extend({
+      this.owner.register('service:-routing', Service.extend({
         currentRouteName: 'compte'
       }));
-      this.inject.service('-routing', { as: '-routing' });
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
 
       // when
       const result = component.get('canDisplayLinkToProfile');
@@ -85,11 +78,10 @@ describe('Unit | Component | User logged Menu', function() {
 
     it('should be false if the current route is /board', function() {
       // given
-      this.register('service:-routing', Service.extend({
+      this.owner.register('service:-routing', Service.extend({
         currentRouteName: 'board'
       }));
-      this.inject.service('-routing', { as: '-routing' });
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
 
       // when
       const result = component.get('canDisplayLinkToProfile');
@@ -100,11 +92,10 @@ describe('Unit | Component | User logged Menu', function() {
 
     it('should be true otherwise', function() {
       // given
-      this.register('service:-routing', Service.extend({
+      this.owner.register('service:-routing', Service.extend({
         currentRouteName: 'other'
       }));
-      this.inject.service('-routing', { as: '-routing' });
-      const component = this.subject();
+      const component = this.owner.lookup('component:user-logged-menu');
 
       // when
       const result = component.get('canDisplayLinkToProfile');

--- a/mon-pix/tests/unit/components/warning-time-page-test.js
+++ b/mon-pix/tests/unit/components/warning-time-page-test.js
@@ -4,12 +4,12 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Component | warning-page-component ', function() {
 
-  setupTest('component:warning-page', {});
+  setupTest();
 
   let component;
 
   beforeEach(function() {
-    component = this.subject();
+    component = this.owner.lookup('component:warning-page');
   });
 
   describe('#Test rendering Property', function() {

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
@@ -5,9 +5,7 @@ import sinon from 'sinon';
 
 describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', function() {
 
-  setupTest('controller:campaigns/fill-in-id-pix', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   const campaign = { id: 1243 };
   const campaignCode = 'CODECAMPAIGN';
@@ -15,7 +13,7 @@ describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', functi
   let controller;
 
   beforeEach(function() {
-    controller = this.subject();
+    controller = this.owner.lookup('controller:campaigns/fill-in-id-pix');
     controller.set('model', {
       campaign,
       campaignCode,

--- a/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
@@ -5,14 +5,12 @@ import sinon from 'sinon';
 
 describe('Unit | Controller | Campaigns | Skill Review', function() {
 
-  setupTest('controller:campaigns/skill-review', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   let controller;
 
   beforeEach(function() {
-    controller = this.subject();
+    controller = this.owner.lookup('controller:campaigns/skill-review');
 
     const setStub = sinon.stub();
 

--- a/mon-pix/tests/unit/models/answer-test.js
+++ b/mon-pix/tests/unit/models/answer-test.js
@@ -1,17 +1,21 @@
 import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | Answer', function() {
 
-  setupModelTest('answer', {
-    needs: ['model:assessment', 'model:challenge']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
-    // var store = this.store();
+    const model = store.createRecord('competence-result');
+
     expect(model).to.be.ok;
   });
 
@@ -19,7 +23,6 @@ describe('Unit | Model | Answer', function() {
 
     it('should return true when answser.result is ok', function() {
       // given
-      const store = this.store();
       const answer = run(() => store.createRecord('answer', { 'result': 'ok' }));
 
       // when
@@ -30,7 +33,6 @@ describe('Unit | Model | Answer', function() {
 
     it('should return false when answser.result is ko', function() {
       // given
-      const store = this.store();
       const answer = run(() => store.createRecord('answer', { 'result': 'ko' }));
 
       // when
@@ -43,7 +45,6 @@ describe('Unit | Model | Answer', function() {
 
     it('should return true when answser.result is ok', function() {
       // given
-      const store = this.store();
       const answer = run(() => store.createRecord('answer', { 'result': 'ok' }));
 
       // when
@@ -54,7 +55,6 @@ describe('Unit | Model | Answer', function() {
 
     it('should return false when answser.result is ko', function() {
       // given
-      const store = this.store();
       const answer = run(() => store.createRecord('answer', { 'result': 'ko' }));
 
       // when

--- a/mon-pix/tests/unit/models/area-test.js
+++ b/mon-pix/tests/unit/models/area-test.js
@@ -1,14 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | area', function() {
-  setupModelTest('area', {
-    needs: []
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('area');
     expect(model).to.be.ok;
   });
 });

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -1,17 +1,20 @@
 import { expect } from 'chai';
 import { run } from '@ember/runloop';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 import _ from 'lodash';
 
 describe('Unit | Model | Assessment', function() {
+  setupTest();
 
-  setupModelTest('assessment', {
-    needs: ['model:course', 'model:challenge', 'model:answer', 'model:assessment-result']
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('assessment');
     expect(model).to.be.ok;
   });
 
@@ -25,7 +28,7 @@ describe('Unit | Model | Assessment', function() {
 
     it('should return an empty array when no answers has been given', function() {
       // given
-      const assessment = this.subject();
+      const assessment = store.createRecord('assessment');
       assessment.set('answers', []);
 
       // when
@@ -37,8 +40,8 @@ describe('Unit | Model | Assessment', function() {
 
     it('should return the one answer when only one answer has been given', function() {
       // given
-      const answer = run(() => this.store().createRecord('answer'));
-      const assessment = this.subject();
+      const answer = run(() => store.createRecord('answer'));
+      const assessment = store.createRecord('assessment');
       const answers = [answer];
       run(() => assessment.set('answers', answers));
 
@@ -51,9 +54,9 @@ describe('Unit | Model | Assessment', function() {
 
     it('should return the last 2 answers when there is 7 answers', function() {
       // given
-      const answers = newAnswers(this.store(), 7);
+      const answers = newAnswers(store, 7);
       const [answer6, answer7] = answers.slice(5);
-      const assessment = this.subject();
+      const assessment = store.createRecord('assessment');
       run(() => assessment.set('answers', answers));
 
       // when
@@ -65,9 +68,9 @@ describe('Unit | Model | Assessment', function() {
 
     it('should return the last 5 answers when there is 10 answers', function() {
       // given
-      const answers = newAnswers(this.store(), 10);
+      const answers = newAnswers(store, 10);
       const [answer6, answer7, answer8, answer9, answer10] = answers.slice(5);
-      const assessment = this.subject();
+      const assessment = store.createRecord('assessment');
       run(() => assessment.set('answers', answers));
 
       // when
@@ -79,9 +82,9 @@ describe('Unit | Model | Assessment', function() {
 
     it('should return the last 1 answer when there is 11 answers', function() {
       // given
-      const answers = newAnswers(this.store(), 11);
+      const answers = newAnswers(store, 11);
       const answer11 = answers[10];
-      const assessment = this.subject();
+      const assessment = store.createRecord('assessment');
       run(() => assessment.set('answers', answers));
 
       // when
@@ -91,11 +94,11 @@ describe('Unit | Model | Assessment', function() {
       expect(answersSinceLastCheckpoints).to.deep.equal([answer11]);
     });
   });
-  
+
   describe('#isPlacement', function() {
     it('should return true when the assessment type is placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', 'PLACEMENT');
@@ -105,7 +108,7 @@ describe('Unit | Model | Assessment', function() {
     });
     it('should return false when the assessment type is not placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', '_');
@@ -118,7 +121,7 @@ describe('Unit | Model | Assessment', function() {
   describe('#isSmartPlacement', function() {
     it('should return true when the assessment type is a smart placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', 'SMART_PLACEMENT');
@@ -128,7 +131,7 @@ describe('Unit | Model | Assessment', function() {
     });
     it('should return false when the assessment type is not a smart placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', '_');
@@ -141,7 +144,7 @@ describe('Unit | Model | Assessment', function() {
   describe('#isCertification', function() {
     it('should return true when the assessment type is a certification', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', 'CERTIFICATION');
@@ -151,7 +154,7 @@ describe('Unit | Model | Assessment', function() {
     });
     it('should return false when the assessment type is not a certification', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', '_');
@@ -164,7 +167,7 @@ describe('Unit | Model | Assessment', function() {
   describe('#isDemo', function() {
     it('should return true when the assessment type is demo', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', 'DEMO');
@@ -174,7 +177,7 @@ describe('Unit | Model | Assessment', function() {
     });
     it('should return false when the assessment type is not demo', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', '_');
@@ -187,7 +190,7 @@ describe('Unit | Model | Assessment', function() {
   describe('#isPreview', function() {
     it('should return true when the assessment type is placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', 'PREVIEW');
@@ -197,7 +200,7 @@ describe('Unit | Model | Assessment', function() {
     });
     it('should return false when the assessment type is not placement', function() {
       // given
-      const model = this.subject();
+      const model = store.createRecord('assessment');
 
       // when
       model.set('type', '_');

--- a/mon-pix/tests/unit/models/campaign-participation-result-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-result-test.js
@@ -1,22 +1,24 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | Campaign-Participation-Result', function() {
+  setupTest();
 
-  setupModelTest('campaign-participation-result', {
-    needs: ['model:competence-result']
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('campaign-participation-result');
     expect(model).to.be.ok;
   });
 
   describe('maxTotalSkillsCountInCompetences', function() {
 
     it('should calculate max total skills', function() {
-      const store = this.store();
       const competenceResult1 = store.createRecord('competence-result', {
         totalSkillsCount: 2
       });
@@ -27,7 +29,7 @@ describe('Unit | Model | Campaign-Participation-Result', function() {
         totalSkillsCount: 10
       });
 
-      const model = this.subject();
+      const model = store.createRecord('campaign-participation-result');
       model.set('competenceResults', [competenceResult1, competenceResult2, competenceResult3]);
 
       // when
@@ -41,7 +43,7 @@ describe('Unit | Model | Campaign-Participation-Result', function() {
   describe('masteryPercentage', function() {
 
     it('should calculate total validated skills percentage', function() {
-      const model = this.subject();
+      const model = store.createRecord('campaign-participation-result');
       model.set('totalSkillsCount', 45);
       model.set('validatedSkillsCount', 40);
 

--- a/mon-pix/tests/unit/models/certification-test.js
+++ b/mon-pix/tests/unit/models/certification-test.js
@@ -1,16 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | certification', function() {
-  setupModelTest('certification', {
-    needs: ['model:user', 'model:result-competence-tree']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
-  // Replace this with your real tests.
   it('exists', function() {
-    const model = this.subject();
-    // var store = this.store();
+    const model = store.createRecord('certification');
     expect(model).to.be.ok;
   });
 });

--- a/mon-pix/tests/unit/models/challenge-test.js
+++ b/mon-pix/tests/unit/models/challenge-test.js
@@ -1,16 +1,19 @@
 import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | Challenge', function() {
+  setupTest();
 
-  setupModelTest('challenge', {
-    needs: ['model:course']
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('challenge');
     expect(model).to.be.ok;
   });
 
@@ -19,7 +22,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be true when challenge has at least one attachment file', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
@@ -34,7 +36,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be false when challenge has multiple attachment files', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: [] });
 
         // when
@@ -52,7 +53,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be true when challenge has only one attachment file', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
@@ -67,7 +67,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be false when challenge has multiple attachment files', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
         // when
@@ -85,7 +84,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be false when challenge has no attachment file', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: [] });
 
         // when
@@ -100,7 +98,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be false when challenge has only one attachment file', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
         // when
@@ -115,7 +112,6 @@ describe('Unit | Model | Challenge', function() {
     it('Should be true when challenge has multiple attachments files', function() {
       run(() => {
         // given
-        const store = this.store();
         const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
         // when
@@ -142,7 +138,7 @@ describe('Unit | Model | Challenge', function() {
 
     it('should be true when embed data (URL, title and height) are defined', function() {
       // given
-      const challenge = this.subject(embedOptions);
+      const challenge = store.createRecord('challenge', embedOptions);
 
       // when
       const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
@@ -154,7 +150,7 @@ describe('Unit | Model | Challenge', function() {
     it('should be false when embed URL is missing', function() {
       // given
       delete embedOptions.embedUrl;
-      const challenge = this.subject(embedOptions);
+      const challenge = store.createRecord('challenge', embedOptions);
 
       // when
       const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
@@ -166,7 +162,7 @@ describe('Unit | Model | Challenge', function() {
     it('should be false when embed URL is not secured (HTTPS)', function() {
       // given
       embedOptions.embedUrl = 'http://unsecured.url';
-      const challenge = this.subject(embedOptions);
+      const challenge = store.createRecord('challenge', embedOptions);
 
       // when
       const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
@@ -178,7 +174,7 @@ describe('Unit | Model | Challenge', function() {
     it('should be false when embed title is missing', function() {
       // given
       delete embedOptions.embedTitle;
-      const challenge = this.subject(embedOptions);
+      const challenge = store.createRecord('challenge', embedOptions);
 
       // when
       const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');
@@ -190,7 +186,7 @@ describe('Unit | Model | Challenge', function() {
     it('should be false when embed height is missing', function() {
       // given
       delete embedOptions.embedHeight;
-      const challenge = this.subject(embedOptions);
+      const challenge = store.createRecord('challenge', embedOptions);
 
       // when
       const hasValidEmbedDocument = challenge.get('hasValidEmbedDocument');

--- a/mon-pix/tests/unit/models/competence-result-test.js
+++ b/mon-pix/tests/unit/models/competence-result-test.js
@@ -1,55 +1,58 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | Competence-Result', function() {
 
-  setupModelTest('competence-result', {
-    needs: ['model:campaign-participation-result']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
-    expect(model).to.be.ok;
+    const competenceResult = store.createRecord('competence-result');
+
+    expect(competenceResult).to.be.ok;
   });
 
   describe('totalSkillsCountPercentage', function() {
 
     it('should retrieve 100 since the competence is the highest number of total skills count', function() {
-      const store = this.store();
-      const model = this.subject();
+      const competenceResult = store.createRecord('competence-result');
       const otherCompetenceResult = store.createRecord('competence-result', {
         totalSkillsCount: 1
       });
       const campaignParticipationResult = store.createRecord('campaign-participation-result', {
-        competenceResults: [otherCompetenceResult, model]
+        competenceResults: [otherCompetenceResult, competenceResult]
       });
 
-      model.set('totalSkillsCount', 2);
-      model.set('campaignParticipationResult', campaignParticipationResult);
+      competenceResult.set('totalSkillsCount', 2);
+      competenceResult.set('campaignParticipationResult', campaignParticipationResult);
 
       // when
-      const totalSkillsCountPercentage = model.get('totalSkillsCountPercentage');
+      const totalSkillsCountPercentage = competenceResult.get('totalSkillsCountPercentage');
 
       // then
       expect(totalSkillsCountPercentage).to.equal(100);
     });
 
     it('should retrieve 25 since the competence is not the highest number of total skills count', function() {
-      const store = this.store();
-      const model = this.subject();
+      const competenceResult = store.createRecord('competence-result');
       const otherCompetenceResult = store.createRecord('competence-result', {
         totalSkillsCount: 4
       });
       const campaignParticipationResult = store.createRecord('campaign-participation-result', {
-        competenceResults: [otherCompetenceResult, model]
+        competenceResults: [otherCompetenceResult, competenceResult]
       });
 
-      model.set('totalSkillsCount', 1);
-      model.set('campaignParticipationResult', campaignParticipationResult);
+      competenceResult.set('totalSkillsCount', 1);
+      competenceResult.set('campaignParticipationResult', campaignParticipationResult);
 
       // when
-      const totalSkillsCountPercentage = model.get('totalSkillsCountPercentage');
+      const totalSkillsCountPercentage = competenceResult.get('totalSkillsCountPercentage');
 
       // then
       expect(totalSkillsCountPercentage).to.equal(25);
@@ -59,26 +62,26 @@ describe('Unit | Model | Competence-Result', function() {
   describe('validatedSkillsPercentage', function() {
 
     it('should retrieve 100 since the user has validated all the competence', function() {
-      const model = this.subject();
+      const competenceResult = store.createRecord('competence-result');
 
-      model.set('totalSkillsCount', 2);
-      model.set('validatedSkillsCount', 2);
+      competenceResult.set('totalSkillsCount', 2);
+      competenceResult.set('validatedSkillsCount', 2);
 
       // when
-      const validatedSkillsPercentage = model.get('validatedSkillsPercentage');
+      const validatedSkillsPercentage = competenceResult.get('validatedSkillsPercentage');
 
       // then
       expect(validatedSkillsPercentage).to.equal(100);
     });
 
     it('should retrieve 25 since the user has validated half of the competence', function() {
-      const model = this.subject();
+      const competenceResult = store.createRecord('competence-result');
 
-      model.set('totalSkillsCount', 3);
-      model.set('validatedSkillsCount', 1);
+      competenceResult.set('totalSkillsCount', 3);
+      competenceResult.set('validatedSkillsCount', 1);
 
       // when
-      const validatedSkillsPercentage = model.get('validatedSkillsPercentage');
+      const validatedSkillsPercentage = competenceResult.get('validatedSkillsPercentage');
 
       // then
       expect(validatedSkillsPercentage).to.equal(33);
@@ -88,12 +91,12 @@ describe('Unit | Model | Competence-Result', function() {
   describe('areaColor', function() {
 
     it('should retrieve domain color style', function() {
-      const model = this.subject();
+      const competenceResult = store.createRecord('competence-result');
 
-      model.set('index', '5.1');
+      competenceResult.set('index', '5.1');
 
       // when
-      const areaColor = model.get('areaColor');
+      const areaColor = competenceResult.get('areaColor');
 
       // then
       expect(areaColor).to.equal('butterfly-bush');

--- a/mon-pix/tests/unit/models/competence-test.js
+++ b/mon-pix/tests/unit/models/competence-test.js
@@ -2,15 +2,19 @@ import { run } from '@ember/runloop';
 import { get } from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | competence model', function() {
-  setupModelTest('competence', {
-    needs: ['model:area']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('competence');
     expect(model).to.be.ok;
   });
 
@@ -18,7 +22,7 @@ describe('Unit | Model | competence model', function() {
 
     it('should exist', function() {
       // given
-      const Competence = this.store().modelFor('competence');
+      const Competence = store.modelFor('competence');
 
       // when
       const relationship = get(Competence, 'relationshipsByName').get('area');
@@ -34,9 +38,8 @@ describe('Unit | Model | competence model', function() {
     it('should be an alias for "area" relationship on "name" property', function() {
       run(() => {
         // given
-        const store = this.store();
         const area = store.createRecord('area', { name: 'coucou' });
-        const competence = this.subject({ area });
+        const competence = store.createRecord('competence', { area });
 
         // when
         const areaName = competence.get('areaName');
@@ -51,17 +54,17 @@ describe('Unit | Model | competence model', function() {
 
     it('should return true if status is "assessed"', function() {
       // given
-      const competence = this.subject({ status: 'assessed' });
+      const competence = store.createRecord('competence', { status: 'assessed' });
 
-      // when/then
+      // then
       expect(competence.get('isAssessed')).to.be.true;
     });
 
     it('should return false if status is not "assessed"', function() {
       // given
-      const competence = this.subject({ status: 'tralala' });
+      const competence = store.createRecord('competence', { status: 'tralala' });
 
-      // when/then
+      // then
       expect(competence.get('isAssessed')).to.be.false;
     });
 
@@ -71,17 +74,17 @@ describe('Unit | Model | competence model', function() {
 
     it('should return true if status is "notAssessed"', function() {
       // given
-      const competence = this.subject({ status: 'notAssessed' });
+      const competence = store.createRecord('competence', { status: 'notAssessed' });
 
-      // when/then
+      // then
       expect(competence.get('isNotAssessed')).to.be.true;
     });
 
     it('should return false if status is not "notAssessed"', function() {
       // given
-      const competence = this.subject({ status: 'tralala' });
+      const competence = store.createRecord('competence', { status: 'tralala' });
 
-      // when/then
+      // then
       expect(competence.get('isNotAssessed')).to.be.false;
     });
 
@@ -91,17 +94,17 @@ describe('Unit | Model | competence model', function() {
 
     it('should return true if status is "assessmentNotCompleted"', function() {
       // given
-      const competence = this.subject({ status: 'assessmentNotCompleted' });
+      const competence = store.createRecord('competence', { status: 'assessmentNotCompleted' });
 
-      // when/then
+      // then
       expect(competence.get('isBeingAssessed')).to.be.true;
     });
 
     it('should return false if status is not "assessmentNotCompleted"', function() {
       // given
-      const competence = this.subject({ status: 'tralala' });
+      const competence = store.createRecord('competence', { status: 'tralala' });
 
-      // when/then
+      // then
       expect(competence.get('isBeingAssessed')).to.be.false;
     });
 
@@ -111,25 +114,25 @@ describe('Unit | Model | competence model', function() {
 
     it('should be true if there is a courseId status is "notAssessed"', function() {
       // given
-      const competence = this.subject({ courseId: 'recDhfez76uygze', status: 'notAssessed' });
+      const competence = store.createRecord('competence', { courseId: 'recDhfez76uygze', status: 'notAssessed' });
 
-      // when/then
+      // then
       expect(competence.get('isAssessableForTheFirstTime')).to.be.true;
     });
 
     it('should be false if there is a courseId status is not "notAssessed"', function() {
       // given
-      const competence = this.subject({ courseId: 'recDhfez76uygze', status: 'assessed' });
+      const competence = store.createRecord('competence', { courseId: 'recDhfez76uygze', status: 'assessed' });
 
-      // when/then
+      // then
       expect(competence.get('isAssessableForTheFirstTime')).to.be.false;
     });
 
     it('should be false if status is "notAssessed" but there is no courseId', function() {
       // given
-      const competence = this.subject({ status: 'notAssessed' });
+      const competence = store.createRecord('competence', { status: 'notAssessed' });
 
-      // when/then
+      // then
       expect(competence.get('isAssessableForTheFirstTime')).to.be.false;
     });
 

--- a/mon-pix/tests/unit/models/correction-test.js
+++ b/mon-pix/tests/unit/models/correction-test.js
@@ -1,15 +1,19 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 import { run } from '@ember/runloop';
 
 describe('Unit | Model | correction', function() {
-  setupModelTest('correction', {
-    needs: ['model:tutorial']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('correction');
     expect(model).to.be.ok;
   });
 
@@ -25,7 +29,7 @@ describe('Unit | Model | correction', function() {
 
     it('should be true when correction has only solution', function() {
       // given
-      model = this.subject(defaultAttributes);
+      model = store.createRecord('correction', defaultAttributes);
 
       // when
       const result = model.get('noHintsNorTutorialsAtAll');
@@ -36,7 +40,7 @@ describe('Unit | Model | correction', function() {
 
     it('should be false when correction has an hint', function() {
       // given
-      model = this.subject(Object.assign({}, defaultAttributes, {
+      model = store.createRecord('correction', Object.assign({}, defaultAttributes, {
         hint: 'a fake hint',
       }));
 
@@ -49,8 +53,8 @@ describe('Unit | Model | correction', function() {
 
     it('should be false when correction has a tutorial', function() {
       // given
-      const givenTutorial = run(() => this.store().createRecord('tutorial', { title: 'is a fake tutorial' }));
-      model = this.subject(Object.assign({}, defaultAttributes, {
+      const givenTutorial = run(() => store.createRecord('tutorial', { title: 'is a fake tutorial' }));
+      model = store.createRecord('correction', Object.assign({}, defaultAttributes, {
         tutorials: [ givenTutorial ],
       }));
 
@@ -63,8 +67,8 @@ describe('Unit | Model | correction', function() {
 
     it('should be false when correction has a learningMoreTutorial', function() {
       // given
-      const givenTutorial = run(() => this.store().createRecord('tutorial', { title: 'is a fake tutorial' }));
-      model = this.subject(Object.assign({}, defaultAttributes, {
+      const givenTutorial = run(() => store.createRecord('tutorial', { title: 'is a fake tutorial' }));
+      model = store.createRecord('correction', Object.assign({}, defaultAttributes, {
         learningMoreTutorials: [ givenTutorial ],
       }));
 

--- a/mon-pix/tests/unit/models/feedback-test.js
+++ b/mon-pix/tests/unit/models/feedback-test.js
@@ -1,16 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | feedback', function() {
+  setupTest();
 
-  setupModelTest('feedback', {
-    needs: ['model:assessment', 'model:challenge']
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('feedback');
     expect(model).to.be.ok;
   });
-
 });

--- a/mon-pix/tests/unit/models/organization-test.js
+++ b/mon-pix/tests/unit/models/organization-test.js
@@ -1,14 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | organization', function() {
-  setupModelTest('organization', {
-    needs: ['model:user', 'model:snapshot']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('organization');
     expect(model).to.be.ok;
   });
 });

--- a/mon-pix/tests/unit/models/password-reset-demand-test.js
+++ b/mon-pix/tests/unit/models/password-reset-demand-test.js
@@ -1,17 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | password reset demand', function() {
-  setupModelTest('password-reset-demand', {
-    // Specify the other units that are required for this test.
-    needs: []
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
-  // Replace this with your real tests.
   it('exists', function() {
-    const model = this.subject();
-    // var store = this.store();
+    const model = store.createRecord('password-reset-demand');
     expect(model).to.be.ok;
   });
 });

--- a/mon-pix/tests/unit/models/progression-test.js
+++ b/mon-pix/tests/unit/models/progression-test.js
@@ -1,11 +1,20 @@
 import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | Progression', function() {
-  setupModelTest('progression', {
-    needs: []
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
+  });
+
+  it('exists', function() {
+    const model = store.createRecord('progression');
+    expect(model).to.be.ok;
   });
 
   describe('Computed property #completionPercentage', function() {
@@ -13,7 +22,6 @@ describe('Unit | Model | Progression', function() {
     it('should compute a completionRate property in %', function() {
       run(() => {
         // given
-        const store = this.store();
         const progression = store.createRecord('progression', { completionRate: 0.06815 });
 
         // when

--- a/mon-pix/tests/unit/models/result-competence-test.js
+++ b/mon-pix/tests/unit/models/result-competence-test.js
@@ -1,15 +1,19 @@
 import { get } from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | result-competence model', function() {
-  setupModelTest('result-competence', {
-    needs: ['model:area']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('result-competence');
     expect(model).to.be.ok;
   });
 
@@ -17,7 +21,7 @@ describe('Unit | Model | result-competence model', function() {
 
     it('should exist', function() {
       // given
-      const Competence = this.store().modelFor('result-competence');
+      const Competence = store.modelFor('result-competence');
 
       // when
       const relationship = get(Competence, 'relationshipsByName').get('area');

--- a/mon-pix/tests/unit/models/result-competence-tree-test.js
+++ b/mon-pix/tests/unit/models/result-competence-tree-test.js
@@ -1,17 +1,18 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | result competence tree', function() {
-  setupModelTest('result-competence-tree', {
-    // Specify the other units that are required for this test.
-    needs: []
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
-  // Replace this with your real tests.
   it('exists', function() {
-    const model = this.subject();
-    // var store = this.store();
+    const model = store.createRecord('result-competence-tree');
     expect(model).to.be.ok;
   });
 });

--- a/mon-pix/tests/unit/models/snapshot-test.js
+++ b/mon-pix/tests/unit/models/snapshot-test.js
@@ -1,18 +1,19 @@
 import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | snapshot', function() {
-  setupModelTest('snapshot', {
-    // Specify the other units that are required for this test.
-    needs: ['model:organization', 'model:user']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
-  // Replace this with your real tests.
   it('exists', function() {
-    const model = this.subject();
-    // var store = this.store();
+    const model = store.createRecord('snapshot');
     expect(model).to.be.ok;
   });
 
@@ -20,7 +21,7 @@ describe('Unit | Model | snapshot', function() {
     it('should return the number of finished test', function() {
       return run(() => {
         // given
-        const model = this.subject();
+        const model = store.createRecord('snapshot');
         const testsFinished = 5;
         model.set('testsFinished', testsFinished);
         // when
@@ -33,7 +34,7 @@ describe('Unit | Model | snapshot', function() {
     it('should return 0 if the model do not have the number of finished test', function() {
       return run(() => {
         // given
-        const model = this.subject();
+        const model = store.createRecord('snapshot');
         // when
         const numberOfFinishedTests = model.get('numberOfTestsFinished');
         // then

--- a/mon-pix/tests/unit/models/user-test.js
+++ b/mon-pix/tests/unit/models/user-test.js
@@ -1,15 +1,19 @@
 import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Model | user model', function() {
-  setupModelTest('user', {
-    needs: ['model:competence', 'model:organization', 'model:scorecard', 'model:area']
+  setupTest();
+
+  let store;
+
+  beforeEach(function() {
+    store = this.owner.lookup('service:store');
   });
 
   it('exists', function() {
-    const model = this.subject();
+    const model = store.createRecord('user');
     expect(model).to.be.ok;
   });
 
@@ -17,7 +21,7 @@ describe('Unit | Model | user model', function() {
     it('should concatenate user first and last name', function() {
       return run(() => {
         // given
-        const model = this.subject();
+        const model = store.createRecord('user');
         model.set('firstName', 'Manu');
         model.set('lastName', 'Phillip');
 
@@ -35,7 +39,6 @@ describe('Unit | Model | user model', function() {
     it('should return an array of unique areas code', function() {
       return run(() => {
         // given
-        const store = this.store();
         const area1 = store.createRecord('area', { code: 1 });
         const area2 = store.createRecord('area', { code: 2 });
 
@@ -43,7 +46,7 @@ describe('Unit | Model | user model', function() {
         const scorecard2 = store.createRecord('scorecard', { area: area1 });
         const scorecard3 = store.createRecord('scorecard', { area: area2 });
 
-        const model = this.subject();
+        const model = store.createRecord('user');
         model.set('scorecards', [scorecard1, scorecard2, scorecard3]);
 
         // when

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -12,14 +12,13 @@ const SplashServiceStub = EmberObject.extend({
 
 describe('Unit | Route | application splash', function() {
 
-  setupTest('route:application', {
-    needs: ['service:splash', 'service:currentUser', 'service:metrics', 'service:session']
-  });
+  setupTest();
 
   it('hides the splash when the route is activated', function() {
     // Given
     const splashStub = SplashServiceStub.create();
-    const route = this.subject({ splash: splashStub });
+    const route = this.owner.lookup('route:application');
+    route.set('splash', splashStub);
 
     // When
     route.activate();
@@ -36,7 +35,8 @@ describe('Unit | Route | application splash', function() {
         this.called = true;
       }
     };
-    const route = this.subject({ currentUser: currentUserStub });
+    const route = this.owner.lookup('route:application');
+    route.set('currentUser', currentUserStub);
 
     // when
     route.sessionAuthenticated();

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -7,9 +7,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | Assessments | Challenge', function() {
 
-  setupTest('route:assessments.challenge', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   let StoreStub;
@@ -44,11 +42,9 @@ describe('Unit | Route | Assessments | Challenge', function() {
     });
 
     // manage dependency injection context
-    this.register('service:store', StoreStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', StoreStub);
 
-    // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:assessments.challenge');
     route.transitionTo = sinon.stub();
   });
 

--- a/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint-test.js
@@ -3,9 +3,7 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | Assessments | Checkpoint', function() {
-  setupTest('route:assessments/checkpoint', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   describe('#afterModel', function() {
 
@@ -17,8 +15,7 @@ describe('Unit | Route | Assessments | Checkpoint', function() {
     let getCampaignStub;
 
     beforeEach(function() {
-      // instance route object
-      route = this.subject();
+      route = this.owner.lookup('route:assessments/checkpoint');
 
       reloadStub = sinon.stub();
       getCampaignStub = sinon.stub();

--- a/mon-pix/tests/unit/routes/assessments/rating-test.js
+++ b/mon-pix/tests/unit/routes/assessments/rating-test.js
@@ -6,14 +6,7 @@ import EmberService from '@ember/service';
 import sinon from 'sinon';
 
 describe('Unit | Route | Assessments | Rating', function() {
-  setupTest('route:assessments.rating', {
-    needs: ['service:metrics'],
-  });
-
-  it('exists', function() {
-    const route = this.subject();
-    expect(route).to.be.ok;
-  });
+  setupTest();
 
   let route;
   let StoreStub;
@@ -30,12 +23,14 @@ describe('Unit | Route | Assessments | Rating', function() {
     });
 
     // manage dependency injection context
-    this.register('service:store', StoreStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', StoreStub);
 
-    // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:assessments.rating');
     route.replaceWith = sinon.stub();
+  });
+
+  it('exists', function() {
+    expect(route).to.be.ok;
   });
 
   describe('#afterModel', function() {

--- a/mon-pix/tests/unit/routes/assessments/results-test.js
+++ b/mon-pix/tests/unit/routes/assessments/results-test.js
@@ -6,12 +6,10 @@ import EmberObject from '@ember/object';
 
 describe('Unit | Route | Assessments | Results', function() {
 
-  setupTest('route:assessments.results', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   it('exists', function() {
-    const route = this.subject();
+    const route = this.owner.lookup('route:assessments.results');
     expect(route).to.be.ok;
   });
 
@@ -19,7 +17,7 @@ describe('Unit | Route | Assessments | Results', function() {
 
     it('should redirect to homepage if assessment is a certification', function() {
       // given
-      const route = this.subject();
+      const route = this.owner.lookup('route:assessments.results');
       route.transitionTo = sinon.spy();
 
       const assessment = EmberObject.create({ id: 123, isCertification: true });
@@ -33,7 +31,7 @@ describe('Unit | Route | Assessments | Results', function() {
 
     it('should not redirect to homepage if assessment is not a certification', function() {
       // given
-      const route = this.subject();
+      const route = this.owner.lookup('route:assessments.results');
       route.transitionTo = sinon.spy();
 
       const assessment = EmberObject.create({ id: 123, isCertification: false, answers: [] });

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -6,9 +6,7 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | Assessments | Resume', function() {
-  setupTest('route:assessments.resume', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   let route;
   let StoreStub;
@@ -25,16 +23,14 @@ describe('Unit | Route | Assessments | Resume', function() {
     });
 
     // manage dependency injection context
-    this.register('service:store', StoreStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', StoreStub);
 
-    // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:assessments.resume');
     route.replaceWith = sinon.stub();
   });
 
   it('exists', function() {
-    const route = this.subject();
+    route = this.owner.lookup('route:assessments.resume');
     expect(route).to.be.ok;
   });
 

--- a/mon-pix/tests/unit/routes/board-test.js
+++ b/mon-pix/tests/unit/routes/board-test.js
@@ -6,26 +6,22 @@ import sinon from 'sinon';
 
 describe('Unit | Route | board', function() {
 
-  setupTest('route:board', {
-    needs: ['service:metrics', 'service:session']
-  });
+  setupTest();
 
   let route;
 
   context('is organization user', function() {
 
     beforeEach(function() {
-      this.register('service:store', Service.extend({
+      this.owner.register('service:store', Service.extend({
         query: sinon.stub().resolves([{ id: 1 }, { id: 2 }])
       }));
-      this.inject.service('store', { as: 'store' });
 
-      this.register('service:currentUser', Service.extend({
+      this.owner.register('service:currentUser', Service.extend({
         user: { organizations: [{ id: 1 }, { id: 2 }] }
       }));
-      this.inject.service('currentUser', { as: 'currentUser' });
 
-      route = this.subject();
+      route = this.owner.lookup('route:board');
       route.transitionTo = sinon.spy();
     });
 
@@ -44,12 +40,11 @@ describe('Unit | Route | board', function() {
   context('is regular user', function() {
 
     beforeEach(function() {
-      this.register('service:currentUser', Service.extend({
+      this.owner.register('service:currentUser', Service.extend({
         user: { organizations: [] }
       }));
-      this.inject.service('currentUser', { as: 'currentUser' });
 
-      route = this.subject();
+      route = this.owner.lookup('route:board');
       route.transitionTo = sinon.spy();
     });
 

--- a/mon-pix/tests/unit/routes/campaigns/campaign-landing-page-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/campaign-landing-page-test.js
@@ -8,9 +8,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | campaigns/campaign-landing-page', function() {
 
-  setupTest('route:campaigns/campaign-landing-page', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   let storeStub;
   let createRecordStub;
@@ -22,10 +20,9 @@ describe('Unit | Route | campaigns/campaign-landing-page', function() {
     createRecordStub = sinon.stub();
     queryRecordStub = sinon.stub();
     storeStub = Service.extend({ queryRecord: queryRecordStub, query: queryStub, createRecord: createRecordStub });
-    this.register('service:store', storeStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', storeStub);
 
-    this.register('service:session', Service.extend({
+    this.owner.register('service:session', Service.extend({
       isAuthenticated: true,
       data: {
         authenticated: {
@@ -33,14 +30,14 @@ describe('Unit | Route | campaigns/campaign-landing-page', function() {
         }
       }
     }));
-    this.inject.service('session', { as: 'session' });
   });
 
   describe('#model', function() {
 
     it('should retrieve the campaign from its code', function() {
       // given
-      const route = this.subject();
+      const route = this.owner.lookup('route:campaigns/campaign-landing-page');
+
       const params = {
         campaign_code: 'AQST765'
       };
@@ -68,7 +65,7 @@ describe('Unit | Route | campaigns/campaign-landing-page', function() {
       // given
       const campaignParticipation = { save: sinon.stub() };
       campaignParticipation.save.resolves();
-      const route = this.subject();
+      const route = this.owner.lookup('route:campaigns/campaign-landing-page');
       route.transitionTo = sinon.stub();
 
       // when

--- a/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
@@ -8,9 +8,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | campaigns/fill-in-id-pix', function() {
 
-  setupTest('route:campaigns/fill-in-id-pix', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   let storeStub;
@@ -31,16 +29,16 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
     storeStub = Service.extend({
       queryRecord: queryChallengeStub, query: queryStub, createRecord: createCampaignParticipationStub
     });
-    this.register('service:store', storeStub);
-    this.inject.service('store', { as: 'store' });
-    this.register('service:session', EmberService.extend({
+    this.owner.register('service:store', storeStub);
+    this.owner.register('service:session', EmberService.extend({
       invalidate: sinon.stub(),
       isAuthenticated: sinon.stub().returns(true)
     }));
     savedAssessment = EmberObject.create({ id: 1234, codeCampaign: campaignCode, reload: sinon.stub() });
     createdCampaignParticipation = EmberObject.create({ id: 456, assessment: savedAssessment });
     campaign = EmberObject.create({ code: campaignCode });
-    route = this.subject();
+    route = this.owner.lookup('route:campaigns/fill-in-id-pix');
+
   });
 
   describe('#beforeModel', function() {

--- a/mon-pix/tests/unit/routes/campaigns/tutorial-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/tutorial-test.js
@@ -5,9 +5,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | campaigns/tutorial', function() {
 
-  setupTest('route:campaigns/tutorial', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   const tutorialPages = {
@@ -28,7 +26,7 @@ describe('Unit | Route | campaigns/tutorial', function() {
   };
 
   beforeEach(function() {
-    route = this.subject();
+    route = this.owner.lookup('route:campaigns/tutorial');
     route.transitionTo = sinon.stub();
     route.tutorial = tutorialPages.tutorial;
   });

--- a/mon-pix/tests/unit/routes/certifications/results-test.js
+++ b/mon-pix/tests/unit/routes/certifications/results-test.js
@@ -4,15 +4,13 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | Certifications | Results', function() {
 
-  setupTest('route:certifications.results', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   describe('model', function() {
 
     it('should find logged user details', function() {
       // Given
-      const route = this.subject();
+      const route = this.owner.lookup('route:certifications.results');
 
       // When
       const model = route.model({

--- a/mon-pix/tests/unit/routes/certifications/resume-test.js
+++ b/mon-pix/tests/unit/routes/certifications/resume-test.js
@@ -3,16 +3,14 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | Certification | Resume', function() {
-  setupTest('route:certifications.resume', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   let route;
   const certificationCourseId = 'certification_course_id';
 
   beforeEach(function() {
-    // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:certifications.resume');
+
     route.transitionTo = sinon.stub();
   });
 

--- a/mon-pix/tests/unit/routes/certifications/start-test.js
+++ b/mon-pix/tests/unit/routes/certifications/start-test.js
@@ -4,9 +4,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | Certification | Start', function() {
 
-  setupTest('route:certifications.start', {
-    needs: ['service:session', 'service:metrics'],
-  });
+  setupTest();
 
   let route;
 
@@ -14,7 +12,7 @@ describe('Unit | Route | Certification | Start', function() {
 
     it('should redirect to index if error is not 403', function() {
       // given
-      route = this.subject();
+      route = this.owner.lookup('route:certifications.start');
       route.transitionTo = sinon.stub();
       const error = { errors: [{ status: '404' }] };
 
@@ -28,7 +26,7 @@ describe('Unit | Route | Certification | Start', function() {
 
     it('should return the start-error page if error is 403', function() {
       // given
-      route = this.subject();
+      route = this.owner.lookup('route:certifications.start');
       route.render = sinon.stub();
       route.transitionTo = sinon.stub();
       const error = { errors: [{ status: '403' }] };
@@ -47,7 +45,7 @@ describe('Unit | Route | Certification | Start', function() {
 
     it('should replace current route with courses.create-assessment', function() {
       // given
-      route = this.subject();
+      route = this.owner.lookup('route:certifications.start');
       route.replaceWith = sinon.stub();
 
       // when

--- a/mon-pix/tests/unit/routes/challenges/preview-test.js
+++ b/mon-pix/tests/unit/routes/challenges/preview-test.js
@@ -4,12 +4,10 @@ import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | challenges-preview', function() {
 
-  setupTest('route:challenge-preview', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   it('exists', function() {
-    const route = this.subject();
+    const route = this.owner.lookup('route:challenge-preview');
     expect(route).to.be.ok;
   });
 

--- a/mon-pix/tests/unit/routes/competences/results-test.js
+++ b/mon-pix/tests/unit/routes/competences/results-test.js
@@ -6,16 +6,12 @@ import sinon from 'sinon';
 
 describe('Unit | Route | Competences | Results', function() {
 
-  setupTest('route:competences.results', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   beforeEach(function() {
-    this.register('service:session', Service.extend({
+    this.owner.register('service:session', Service.extend({
       isAuthenticated: true,
     }));
-
-    this.inject.service('session', { as: 'session' });
   });
 
   describe('model', function() {
@@ -32,10 +28,9 @@ describe('Unit | Route | Competences | Results', function() {
         query: queryStub
       });
 
-      this.register('service:store', storeStub);
-      this.inject.service('store', { as: 'store' });
+      this.owner.register('service:store', storeStub);
 
-      route = this.subject();
+      route = this.owner.lookup('route:competences.results');
       route.transitionTo = sinon.stub();
     });
 

--- a/mon-pix/tests/unit/routes/competences/resume-test.js
+++ b/mon-pix/tests/unit/routes/competences/resume-test.js
@@ -6,9 +6,7 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | Competence | Resume', function() {
-  setupTest('route:competences.resume', {
-    needs: ['service:session','service:metrics']
-  });
+  setupTest();
 
   let route;
   const competenceId = 'competenceId';
@@ -32,11 +30,10 @@ describe('Unit | Route | Competence | Resume', function() {
     });
 
     // manage dependency injection context
-    this.register('service:store', storeStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', storeStub);
 
     // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:competences.resume');
     route.replaceWith = sinon.stub();
 
   });

--- a/mon-pix/tests/unit/routes/compte-test.js
+++ b/mon-pix/tests/unit/routes/compte-test.js
@@ -6,31 +6,28 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | compte', function() {
-  setupTest('route:compte', {
-    needs: ['service:session', 'service:metrics', 'service:currentUser']
-  });
+  setupTest();
 
   describe('model', function() {
 
     beforeEach(function() {
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         isAuthenticated: true,
       }));
-      this.inject.service('session');
     });
 
     context('when user is an organization', function() {
 
       beforeEach(function() {
-        this.register('service:currentUser', Service.extend({
+        this.owner.register('service:currentUser', Service.extend({
           user: { organizations: [{ id: 1 }] }
         }));
-        this.inject.service('currentUser');
       });
 
       it('should redirect to /board', async function() {
         // Given
-        const route = this.subject();
+        const route = this.owner.lookup('route:compte');
+
         route.transitionTo = sinon.spy();
 
         // When
@@ -47,10 +44,9 @@ describe('Unit | Route | compte', function() {
       let queryRecordStub;
 
       beforeEach(function() {
-        this.register('service:currentUser', Service.extend({
+        this.owner.register('service:currentUser', Service.extend({
           user: { organizations: [] }
         }));
-        this.inject.service('currentUser');
 
         queryRecordStub = sinon.stub();
         storyStub = Service.extend({
@@ -62,11 +58,10 @@ describe('Unit | Route | compte', function() {
         // Given
         const foundUser = EmberObject.create({ id: 'hello' });
 
-        this.register('service:store', storyStub);
-        this.inject.service('store', { as: 'store' });
+        this.owner.register('service:store', storyStub);
 
         queryRecordStub.withArgs('user', { profile: true }).resolves(foundUser);
-        const route = this.subject();
+        const route = this.owner.lookup('route:compte');
 
         // When
         const model = await route.model();
@@ -96,10 +91,9 @@ describe('Unit | Route | compte', function() {
 
     it('should search for an organization', function() {
       // Given
-      this.register('service:store', storeStub);
-      this.inject.service('store', { as: 'store' });
+      this.owner.register('service:store', storeStub);
 
-      const route = this.subject();
+      const route = this.owner.lookup('route:compte');
 
       // When
       route.actions.searchForOrganization.call(route, 'RVSG44');
@@ -116,9 +110,8 @@ describe('Unit | Route | compte', function() {
         // Given
         organizationCollectionStub.returns('THE FIRST OBJECT');
 
-        this.register('service:store', storeStub);
-        this.inject.service('store', { as: 'store' });
-        const route = this.subject();
+        this.owner.register('service:store', storeStub);
+        const route = this.owner.lookup('route:compte');
 
         // When
         const routeActionResult = route.actions.searchForOrganization.call(route, 'RVSG44');
@@ -135,9 +128,8 @@ describe('Unit | Route | compte', function() {
         organizations.content = [];
         organizationCollectionStub.returns('THE FIRST OBJECT');
 
-        this.register('service:store', storeStub);
-        this.inject.service('store', { as: 'store' });
-        const route = this.subject();
+        this.owner.register('service:store', storeStub);
+        const route = this.owner.lookup('route:compte');
 
         // When
         const routeActionResult = route.actions.searchForOrganization.call(route, 'RVSG44');
@@ -167,9 +159,8 @@ describe('Unit | Route | compte', function() {
 
     it('should create and save a new Snapshot', function() {
       // given
-      this.register('service:store', storeStub);
-      this.inject.service('store', { as: 'store' });
-      const route = this.subject();
+      this.owner.register('service:store', storeStub);
+      const route = this.owner.lookup('route:compte');
 
       // when
       const promise = route.actions.shareProfileSnapshot.call(route, organization);

--- a/mon-pix/tests/unit/routes/courses/create-assessment-test.js
+++ b/mon-pix/tests/unit/routes/courses/create-assessment-test.js
@@ -5,9 +5,7 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | Courses | Create Assessment', function() {
-  setupTest('route:courses.create-assessment', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   let queryRecordStub;
@@ -36,9 +34,9 @@ describe('Unit | Route | Courses | Create Assessment', function() {
 
     storeStub = Service.extend({
       queryRecord: queryRecordStub, query: queryStub, createRecord: createRecordStub });
-    this.register('service:store', storeStub);
-    this.inject.service('store', { as: 'store' });
-    route = this.subject();
+    this.owner.register('service:store', storeStub);
+    route = this.owner.lookup('route:courses.create-assessment');
+
     route.replaceWith = sinon.stub();
   });
 

--- a/mon-pix/tests/unit/routes/error-test.js
+++ b/mon-pix/tests/unit/routes/error-test.js
@@ -3,13 +3,10 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | error', function() {
-  setupTest('route:error', {
-    // Specify the other units that are required for this test.
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   it('exists', function() {
-    const route = this.subject();
+    const route = this.owner.lookup('route:error');
     expect(route).to.be.ok;
   });
 
@@ -17,7 +14,7 @@ describe('Unit | Route | error', function() {
     let route;
 
     beforeEach(function() {
-      route = this.subject();
+      route = this.owner.lookup('route:error');
     });
 
     it('finds an unauthorized code in the first error object', function() {

--- a/mon-pix/tests/unit/routes/index-test.js
+++ b/mon-pix/tests/unit/routes/index-test.js
@@ -5,31 +5,27 @@ import Service from '@ember/service';
 
 describe('Unit | Route | index', function() {
 
-  setupTest('route:index', {
-    needs: ['service:metrics', 'service:currentUser', 'service:session']
-  });
+  setupTest();
 
   describe('model', function() {
 
     beforeEach(function() {
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         isAuthenticated: true,
       }));
-      this.inject.service('session');
     });
 
     context('when user uses ProfileV2', function() {
 
       beforeEach(function() {
-        this.register('service:currentUser', Service.extend({
+        this.owner.register('service:currentUser', Service.extend({
           user: { usesProfileV2: true }
         }));
-        this.inject.service('currentUser');
       });
 
       it('should redirect to /profilv2', async function() {
         // Given
-        const route = this.subject();
+        const route = this.owner.lookup('route:index');
         route.transitionTo = sinon.spy();
 
         // When
@@ -44,7 +40,7 @@ describe('Unit | Route | index', function() {
 
       it('should redirect to /compte', async function() {
         // Given
-        const route = this.subject();
+        const route = this.owner.lookup('route:index');
         route.transitionTo = sinon.spy();
 
         // When

--- a/mon-pix/tests/unit/routes/inscription-test.js
+++ b/mon-pix/tests/unit/routes/inscription-test.js
@@ -4,12 +4,10 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Route | inscription', function() {
-  setupTest('route:inscription', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   it('exists', function() {
-    const route = this.subject();
+    const route = this.owner.lookup('route:inscription');
     expect(route).to.be.ok;
   });
 
@@ -22,7 +20,8 @@ describe('Unit | Route | inscription', function() {
     const sessionStub = { authenticate: authenticateStub };
     const storeStub = { queryRecord: queryRecordStub };
 
-    const route = this.subject();
+    const route = this.owner.lookup('route:inscription');
+
     route.set('session', sessionStub);
     route.set('store', storeStub);
 

--- a/mon-pix/tests/unit/routes/login-test.js
+++ b/mon-pix/tests/unit/routes/login-test.js
@@ -6,9 +6,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | login page', function() {
 
-  setupTest('route:login', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   context('when user is not authenticated', function() {
     let authenticateStub;
@@ -19,15 +17,13 @@ describe('Unit | Route | login page', function() {
     beforeEach(function() {
       queryRecordStub = sinon.stub();
       authenticateStub = sinon.stub();
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         authenticate: authenticateStub,
       }));
-      this.inject.service('session', { as: 'session' });
 
-      this.register('service:store', Service.extend({
+      this.owner.register('service:store', Service.extend({
         queryRecord: queryRecordStub
       }));
-      this.inject.service('store', { as: 'store' });
     });
 
     it('should authenticate the user given email and password', async function() {
@@ -36,7 +32,7 @@ describe('Unit | Route | login page', function() {
 
       const foundUser = EmberObject.create({ id: 12 });
       queryRecordStub.resolves(foundUser);
-      const route = this.subject();
+      const route = this.owner.lookup('route:login');
       sinon.stub(route, 'transitionTo').throws('Must not be called');
 
       // When
@@ -54,7 +50,7 @@ describe('Unit | Route | login page', function() {
       // Given
       authenticateStub.resolves();
 
-      const route = this.subject();
+      const route = this.owner.lookup('route:login');
       sinon.stub(route, 'transitionTo');
 
       // When

--- a/mon-pix/tests/unit/routes/logout-test.js
+++ b/mon-pix/tests/unit/routes/logout-test.js
@@ -4,22 +4,19 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | logout', () => {
-  setupTest('route:logout', {
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   it('should disconnect the user', function() {
     // Given
     const invalidateStub = sinon.stub();
-    this.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub, data: {
+    this.owner.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub, data: {
       authenticated: {
         source: 'external'
       }
     }
     }));
-    this.inject.service('session', { as: 'session' });
 
-    const route = this.subject();
+    const route = this.owner.lookup('route:logout');
 
     // When
     route.beforeModel();
@@ -32,10 +29,9 @@ describe('Unit | Route | logout', () => {
     // Given
     const invalidateStub = sinon.stub();
 
-    this.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub }));
-    this.inject.service('session', { as: 'session' });
+    this.owner.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub }));
 
-    const route = this.subject();
+    const route = this.owner.lookup('route:logout');
     route._redirectToHome = sinon.stub();
     route.source = 'pix';
 
@@ -50,10 +46,9 @@ describe('Unit | Route | logout', () => {
     // Given
     const invalidateStub = sinon.stub();
 
-    this.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub }));
-    this.inject.service('session', { as: 'session' });
+    this.owner.register('service:session', Service.extend({ isAuthenticated: true, invalidate: invalidateStub }));
 
-    const route = this.subject();
+    const route = this.owner.lookup('route:logout');
     route._redirectToDisconnectedPage = sinon.stub();
     route.source = 'external';
 

--- a/mon-pix/tests/unit/routes/password-reset-test.js
+++ b/mon-pix/tests/unit/routes/password-reset-test.js
@@ -3,15 +3,12 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
 describe('Unit | Route | password reset', function() {
-  setupTest('route:password-reset-demand', {
-    // Specify the other units that are required for this test.
-    needs: ['service:metrics']
-  });
+  setupTest();
 
   let route;
 
   beforeEach(function() {
-    route = this.subject();
+    route = this.owner.lookup('route:password-reset-demand');
   });
 
   it('exists', function() {

--- a/mon-pix/tests/unit/routes/reset-password-demand-test.js
+++ b/mon-pix/tests/unit/routes/reset-password-demand-test.js
@@ -6,9 +6,7 @@ import sinon from 'sinon';
 
 describe('Unit | Route | changer mot de passe', function() {
 
-  setupTest('route:reset-password', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   describe('Route behavior', function() {
 
@@ -24,13 +22,12 @@ describe('Unit | Route | changer mot de passe', function() {
         findRecord: findRecordStub
       });
 
-      this.register('service:store', storeStub);
-      this.inject.service('store', { as: 'store' });
+      this.owner.register('service:store', storeStub);
     });
 
     it('should exists', function() {
       // when
-      const route = this.subject();
+      const route = this.owner.lookup('route:reset-password');
 
       // then
       expect(route).to.be.ok;
@@ -39,7 +36,7 @@ describe('Unit | Route | changer mot de passe', function() {
     it('should ask password reset demand validity', function() {
       // given
       findRecordStub.resolves();
-      const route = this.subject();
+      const route = this.owner.lookup('route:reset-password');
 
       // when
       const promise = route.model(params);
@@ -73,7 +70,7 @@ describe('Unit | Route | changer mot de passe', function() {
         };
 
         findRecordStub.resolves(fetchedOwnerDetails);
-        const route = this.subject();
+        const route = this.owner.lookup('route:reset-password');
 
         // when
         const promise = route.model(params);

--- a/mon-pix/tests/unit/routes/user-certifications/get-test.js
+++ b/mon-pix/tests/unit/routes/user-certifications/get-test.js
@@ -5,11 +5,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe ('Unit | Route | user certifications/get', function() {
+describe('Unit | Route | user certifications/get', function() {
 
-  setupTest('route:user-certifications/get', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   let StoreStub;
@@ -24,16 +22,14 @@ describe ('Unit | Route | user certifications/get', function() {
     });
 
     // manage dependency injection context
-    this.register('service:store', StoreStub);
-    this.inject.service('store', { as: 'store' });
+    this.owner.register('service:store', StoreStub);
 
-    // instance route object
-    route = this.subject();
+    route = this.owner.lookup('route:user-certifications/get');
     route.replaceWith = sinon.stub().resolves();
   });
 
   it('exists', function() {
-    const route = this.subject();
+    route = this.owner.lookup('route:user-certifications/get');
     expect(route).to.be.ok;
   });
 

--- a/mon-pix/tests/unit/routes/user-certifications/index-test.js
+++ b/mon-pix/tests/unit/routes/user-certifications/index-test.js
@@ -6,9 +6,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 
 describe('Unit | Route | user certifications/index', function() {
-  setupTest('route:user-certifications/index', {
-    needs: ['service:session', 'service:metrics']
-  });
+  setupTest();
 
   let route;
   const findAll = sinon.stub();
@@ -16,13 +14,12 @@ describe('Unit | Route | user certifications/index', function() {
 
   beforeEach(function() {
 
-    this.register('service:store', Service.extend({
+    this.owner.register('service:store', Service.extend({
       findAll: findAll,
       unloadAll: unloadAll
     }));
-    this.inject.service('store', { as: 'store' });
 
-    route = this.subject();
+    route = this.owner.lookup('route:user-certifications/index');
   });
 
   it('exists', function() {

--- a/mon-pix/tests/unit/services/current-user-test.js
+++ b/mon-pix/tests/unit/services/current-user-test.js
@@ -5,22 +5,19 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 
 describe('Unit | Service | current-user', function() {
-  setupTest('service:currentUser');
+  setupTest();
 
   describe('user is authenticated', function() {
     beforeEach(function() {
-      this.register('service:session', Service.extend({ isAuthenticated: true }));
-      this.inject.service('session', { as: 'session' });
-
-      this.register('service:store', Service.extend({
+      this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
+      this.owner.register('service:store', Service.extend({
         queryRecord: sinon.stub().resolves({ id: 1 })
       }));
-      this.inject.service('store', { as: 'store' });
     });
 
     it('should load the current user', async function() {
       // Given
-      const currentUser = this.subject();
+      const currentUser = this.owner.lookup('service:currentUser');
 
       // When
       await currentUser.load();
@@ -33,13 +30,12 @@ describe('Unit | Service | current-user', function() {
   describe('user is not authenticated', function() {
 
     beforeEach(function() {
-      this.register('service:session', Service.extend({ isAuthenticated: false }));
-      this.inject.service('session', { as: 'session' });
+      this.owner.register('service:session', Service.extend({ isAuthenticated: false }));
     });
 
     it('should do nothing', async function() {
       // Given
-      const currentUser = this.subject();
+      const currentUser = this.owner.lookup('service:currentUser');
 
       // When
       await currentUser.load();
@@ -52,21 +48,18 @@ describe('Unit | Service | current-user', function() {
   describe('user token is expired', function() {
 
     beforeEach(function() {
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         isAuthenticated: true,
         invalidate: sinon.stub().resolves('invalidate'),
       }));
-      this.inject.service('session', { as: 'session' });
-
-      this.register('service:store', Service.extend({
+      this.owner.register('service:store', Service.extend({
         queryRecord: sinon.stub().rejects({ errors: [{ code: 401 }] })
       }));
-      this.inject.service('store', { as: 'store' });
     });
 
     it('should redirect to login', async function() {
       // Given
-      const currentUser = this.subject();
+      const currentUser = this.owner.lookup('service:currentUser');
 
       // When
       const result = await currentUser.load();

--- a/mon-pix/tests/unit/services/mail-generator-test.js
+++ b/mon-pix/tests/unit/services/mail-generator-test.js
@@ -4,17 +4,16 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 describe('Unit | Service | mail generator', function() {
-  setupTest('service:mail-generator', {});
+  setupTest();
 
-  // Replace this with your real tests.
   it('exists', function() {
-    const service = this.subject();
+    const service = this.owner.lookup('service:mail-generator');
     expect(service).to.be.ok;
   });
 
   it('should have a generateEmail function', function() {
     // Given
-    const service = this.subject();
+    const service = this.owner.lookup('service:mail-generator');
 
     // When
     expect(service).to.have.property('generateEmail')
@@ -27,7 +26,7 @@ describe('Unit | Service | mail generator', function() {
     const februaryTheFifth = new Date(2017, 1, 5);
 
     beforeEach(function() {
-      service = this.subject();
+      service = this.owner.lookup('service:mail-generator');
       clock = sinon.useFakeTimers(februaryTheFifth);
     });
 

--- a/mon-pix/tests/unit/services/splash-test.js
+++ b/mon-pix/tests/unit/services/splash-test.js
@@ -20,13 +20,13 @@ function hasSplash() {
 }
 
 describe('Unit | Service | splash', function() {
-  setupTest('service:splash');
+  setupTest();
 
   describe('#hide', function() {
     context('when a splash is present in the DOM', function() {
       it('removes the splash from the DOM', function() {
         // Given
-        const splash = this.subject();
+        const splash = this.owner.lookup('service:splash');
         createSplash();
         expect(hasSplash()).to.be.true;
         // When
@@ -39,7 +39,7 @@ describe('Unit | Service | splash', function() {
     context('when there is no splash', function() {
       it('does nothing', function() {
         // Given
-        const splash = this.subject();
+        const splash = this.owner.lookup('service:splash');
         expect(hasSplash()).to.be.false;
         // When
         splash.hide();


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, on ne peut plus monter de version Ember-mocha puisque les usages jusqu'alors dépréciés sont supprimés dans la version supérieure. 

## :robot: Solution
Commencer petit à petit à supprimer les usages dépréciés de Ember-mocha. Cette PR initie ce chantier, et commence par les tests unitaires dans un premier temps (puisque tous les changements d'un coup sont d'une trop grande envergure).

Avant:
```
import { expect } from 'chai';
import { describe, it } from 'mocha';
import { setupTest } from 'ember-mocha';

describe('SidebarController', function() {
  setupTest('controller:sidebar', {
    // Specify the other units that are required for this test.
    // needs: ['controller:foo']
  });

  // Replace this with your real tests.
  it('exists', function() {
    var controller = this.subject();
    expect(controller).to.be.ok;
  });
});
```
Après:
```
import { expect } from 'chai';
import { describe, it } from 'mocha';
import { setupTest } from 'ember-mocha';

describe('SidebarController', function() {
  setupTest();

  // Replace this with your real tests.
  it('exists', function() {
    let controller = this.owner.lookup('controller:sidebar');
    expect(controller).to.be.ok;
  });
});
```
## :rainbow: Remarques
Un fichier de test unitaires est entièrement commenté, celui de `Course`. Qu'en fait-on ?
