### PR TITLE
[FEATURE] Possibilité de remettre à zéro une compétence après 7 jours (PF-579-7).

### DIFF
--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -61,7 +61,9 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
       answerId,
       source: KnowledgeElement.SourceType.INFERRED,
     });
-    databaseBuilder.factory.buildCampaignParticipation({ campaignId: 1, userId, assessmentId, participantExternalId, isShared: isShared  });
+
+    const sharedAt = isShared ? new Date() : null;
+    databaseBuilder.factory.buildCampaignParticipation({ campaignId: 1, userId, assessmentId, participantExternalId, isShared, sharedAt });
   };
 
   pixMembersNotCompleted.forEach((member) => startCampaign(member, 'STARTED', false));

--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -6,11 +6,24 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     name: 'Tyrion SUP',
     code: 'SUPTY'
   });
+
+  databaseBuilder.factory.buildMembership({
+    userId: 3,
+    organizationId: 2,
+    organizationRoleId: 1,
+  });
+
   databaseBuilder.factory.buildOrganization({
     id: 3,
     userId: 4,
     type: 'SCO',
     name: 'SCOw',
     code: 'SCO12'
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: 4,
+    organizationId: 3,
+    organizationRoleId: 1,
   });
 };

--- a/api/db/seeds/data/pix-aile-profilev2-builder.js
+++ b/api/db/seeds/data/pix-aile-profilev2-builder.js
@@ -101,4 +101,13 @@ module.exports = function buildPixAileProfilev2({ databaseBuilder }) {
     remainingDays: 0,
     remainingHours: 1,
   });
+
+  // competence 3.1 - campaign - assessment not completed - 0 days remaining
+  buildKnowledgeElements({
+    competenceId: 'recOdC9UDVJbAXHAm',
+    challengeId: 'recQJ8lx3xyKCvFOh',
+    skillId: 'rec5V9gp65a58nnco',
+    assessmentId: assessmentIdForCampaign,
+    remainingDays: 0,
+  });
 };

--- a/api/db/seeds/data/pix-aile-profilev2-builder.js
+++ b/api/db/seeds/data/pix-aile-profilev2-builder.js
@@ -1,0 +1,104 @@
+const Assessment = require('../../../lib/domain/models/Assessment');
+const CompetenceEvaluation = require('../../../lib/domain/models/CompetenceEvaluation');
+const moment = require('moment');
+
+module.exports = function buildPixAileProfilev2({ databaseBuilder }) {
+
+  const userId = 1;
+
+  const buildKnowledgeElements = ({ competenceId, challengeId, skillId, assessmentId, remainingDays, remainingHours }) => {
+    const { id: answerId } = databaseBuilder.factory.buildAnswer({
+      result: 'ok',
+      assessmentId,
+      challengeId,
+    });
+
+    const delay = 7 - remainingDays;
+
+    databaseBuilder.factory.buildKnowledgeElement({
+      skillId,
+      assessmentId,
+      userId,
+      competenceId,
+      answerId,
+      createdAt: moment().subtract(delay, 'day').add(remainingHours, 'hour').toDate(),
+    });
+  };
+
+  const buildCampaignParticipation = () => {
+
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
+      userId,
+      type: Assessment.types.SMARTPLACEMENT,
+      state: Assessment.states.STARTED
+    });
+
+    databaseBuilder.factory.buildCampaignParticipation({
+      id: 1,
+      campaignId: 3,
+      userId,
+      assessmentId,
+      isShared: false,
+      sharedAt: null,
+    });
+
+    return { assessmentId };
+  };
+
+  const buildCompetenceEvaluation = ({ competenceId, assessmentState }) => {
+
+    const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
+      userId,
+      competenceId,
+      type: Assessment.types.COMPETENCE_EVALUATION,
+      state: assessmentState
+    });
+
+    databaseBuilder.factory.buildCompetenceEvaluation({
+      assessmentId,
+      competenceId,
+      status: assessmentState === Assessment.states.COMPLETED ? CompetenceEvaluation.statuses.COMPLETED : CompetenceEvaluation.statuses.STARTED,
+      userId,
+    });
+
+    return { assessmentId };
+  };
+
+  // competence 1.1 - competenceEvaluation - assessment not completed - 4 days remaining
+  const { assessmentId: assessmentIdForCompetenceEvaluation1 } = buildCompetenceEvaluation({
+    competenceId: 'recsvLz0W2ShyfD63',
+    assessmentState: Assessment.states.STARTED,
+  });
+  buildKnowledgeElements({
+    competenceId: 'recsvLz0W2ShyfD63',
+    challengeId: 'rec4mYfhm45A222ab',
+    skillId: 'recybd8jWDNiFpbgq',
+    assessmentId: assessmentIdForCompetenceEvaluation1,
+    remainingDays: 4,
+  });
+
+  // competence 1.3 - competenceEvaluation - assessment completed - 0 days remaining
+  const { assessmentId: assessmentIdForCompetenceEvaluation2 } = buildCompetenceEvaluation({
+    competenceId: 'recNv8qhaY887jQb2',
+    assessmentState: Assessment.states.COMPLETED,
+  });
+  buildKnowledgeElements({
+    competenceId: 'recNv8qhaY887jQb2',
+    challengeId: 'recPVnm4VSMQUJmq3',
+    skillId: 'recJKLhRCjl9zizHr',
+    assessmentId: assessmentIdForCompetenceEvaluation2,
+    remainingDays: 0,
+  });
+
+  const { assessmentId: assessmentIdForCampaign } = buildCampaignParticipation();
+
+  // competence 1.2 - campaign - assessment not completed - 0.1 days remaining
+  buildKnowledgeElements({
+    competenceId: 'recIkYm646lrGvLNT',
+    challengeId: 'recilaoo1zSM4U7nM',
+    skillId: 'recagUd44RPEWti0X',
+    assessmentId: assessmentIdForCampaign,
+    remainingDays: 0,
+    remainingHours: 1,
+  });
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -13,6 +13,7 @@ const competenceMarksBuilder = require('./data/competence-marks-builder');
 const dragonAndCoBuilder = require('./data/dragon-and-co-builder');
 const organizationsBuilder = require('./data/organizations-builder');
 const pixAileBuilder = require('./data/pix-aile-builder');
+const buildPixAileProfilev2 = require('./data/pix-aile-profilev2-builder');
 const sessionsBuilder = require('./data/sessions-builder');
 const snapshotsBuilder = require('./data/snapshots-builder');
 const usersBuilder = require('./data/users-builder');
@@ -41,6 +42,7 @@ exports.seed = (knex) => {
   answersBuilder({ databaseBuilder });
   assessmentResultsBuilder({ databaseBuilder });
   competenceMarksBuilder({ databaseBuilder });
+  buildPixAileProfilev2({ databaseBuilder });
 
   return databaseBuilder.commit()
     .then(() => alterSequenceIfPG(knex));

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -177,10 +177,11 @@ exports.register = async function(server) {
         handler: userController.resetScorecard,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Cette route réinitilise l\'évaluation de compétences identifiée par **userId** et **competenceId**',
+          '- Cette route réinitilise le niveau d\'un utilisateur donné (**userId**) pour une compétence donnée (**competenceId**)',
+          '- Cette route retourne les nouvelles informations de niveau de la compétence',
 
         ],
-        tags: ['api', 'competence-evaluations']
+        tags: ['api', 'scorecard']
       }
     },
   ]);

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -174,7 +174,7 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/users/{userId}/competences/{competenceId}/reset',
       config: {
-        handler: userController.resetCompetenceEvaluation,
+        handler: userController.resetScorecard,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Cette route réinitilise l\'évaluation de compétences identifiée par **userId** et **competenceId**',

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -158,7 +158,11 @@ module.exports = {
     const requestedUserId = request.params.userId;
     const competenceId = request.params.competenceId;
 
-    return usecases.resetScorecard({ authenticatedUserId, requestedUserId, competenceId })
-      .then(() => null);
+    await usecases.resetScorecard({ authenticatedUserId, requestedUserId, competenceId });
+
+    const scorecardId = `${authenticatedUserId}_${competenceId}`;
+
+    return usecases.getScorecard({ authenticatedUserId, scorecardId })
+      .then(scorecardSerializer.serialize);
   }
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -153,12 +153,12 @@ module.exports = {
       .then(scorecardSerializer.serialize);
   },
 
-  resetCompetenceEvaluation(request) {
+  async resetScorecard(request) {
     const authenticatedUserId = request.auth.credentials.userId.toString();
     const requestedUserId = request.params.userId;
     const competenceId = request.params.competenceId;
 
-    return usecases.resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId })
+    return usecases.resetScorecard({ authenticatedUserId, requestedUserId, competenceId })
       .then(() => null);
   }
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -158,11 +158,7 @@ module.exports = {
     const requestedUserId = request.params.userId;
     const competenceId = request.params.competenceId;
 
-    await usecases.resetScorecard({ authenticatedUserId, requestedUserId, competenceId });
-
-    const scorecardId = `${authenticatedUserId}_${competenceId}`;
-
-    return usecases.getScorecard({ authenticatedUserId, scorecardId })
+    return usecases.resetScorecard({ authenticatedUserId, requestedUserId, competenceId })
       .then(scorecardSerializer.serialize);
   }
 };

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -12,6 +12,7 @@ const courseIdMessage = {
 const states = {
   COMPLETED: 'completed',
   STARTED: 'started',
+  ABORTED: 'aborted',
 };
 
 const types = {

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -33,10 +33,6 @@ class CampaignParticipation {
     this.userId = userId;
   }
 
-  isAboutCampaignCode(code) {
-    return this.campaign.code === code;
-  }
-
   getTargetProfileId() {
     return _.get(this, 'campaign.targetProfileId', null);
   }

--- a/api/lib/domain/models/SmartPlacementAssessment.js
+++ b/api/lib/domain/models/SmartPlacementAssessment.js
@@ -3,6 +3,7 @@ const SMART_PLACEMENT_TYPE = 'SMART_PLACEMENT';
 const SmartPlacementAssessmentState = Object.freeze({
   COMPLETED: 'completed',
   STARTED: 'started',
+  ABORTED: 'aborted',
 });
 
 /**

--- a/api/lib/domain/services/competence-evaluation-service.js
+++ b/api/lib/domain/services/competence-evaluation-service.js
@@ -5,14 +5,19 @@ const _ = require('lodash');
 async function resetCompetenceEvaluation({
   userId,
   competenceId,
+  isCompetenceEvaluationExists,
   knowledgeElementRepository,
   competenceEvaluationRepository,
 }) {
 
-  return Promise.all([
-    _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }),
-    _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }),
-  ]);
+  if (isCompetenceEvaluationExists) {
+    return Promise.all([
+      _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }),
+      _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }),
+    ]);
+  }
+
+  return _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository });
 }
 
 async function _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }) {

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -2,7 +2,7 @@ const CompetenceEvaluation = require('../models/CompetenceEvaluation');
 const KnowledgeElement = require('../models/KnowledgeElement');
 const _ = require('lodash');
 
-async function resetCompetenceEvaluation({
+async function resetScorecard({
   userId,
   competenceId,
   isCompetenceEvaluationExists,
@@ -46,5 +46,5 @@ function _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluation
 }
 
 module.exports = {
-  resetCompetenceEvaluation,
+  resetScorecard,
 };

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -1,3 +1,4 @@
+const Assessment = require('../models/Assessment');
 const CompetenceEvaluation = require('../models/CompetenceEvaluation');
 const KnowledgeElement = require('../models/KnowledgeElement');
 const Scorecard = require('../models/Scorecard');
@@ -25,19 +26,25 @@ async function resetScorecard({
   userId,
   competenceId,
   shouldResetCompetenceEvaluation,
+  assessmentRepository,
   knowledgeElementRepository,
   competenceEvaluationRepository,
+  campaignParticipationRepository,
 }) {
 
   // user can have only answered to questions in campaign, in that case, competenceEvaluation does not exists
   if (shouldResetCompetenceEvaluation) {
     return Promise.all([
+      _resetSmartPlacementAssessments({ userId, assessmentRepository, campaignParticipationRepository }),
       _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }),
       _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }),
     ]);
   }
 
-  return _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository });
+  return Promise.all([
+    _resetSmartPlacementAssessments({ userId, assessmentRepository, campaignParticipationRepository }),
+    _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }),
+  ]);
 }
 
 async function _resetKnowledgeElements({ userId, competenceId, knowledgeElementRepository }) {
@@ -62,6 +69,43 @@ function _resetKnowledgeElement({ knowledgeElement, knowledgeElementRepository }
 function _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluationRepository }) {
   return competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId({
     competenceId, userId, status: CompetenceEvaluation.statuses.RESET
+  });
+}
+
+async function _resetSmartPlacementAssessments({ userId, assessmentRepository, campaignParticipationRepository }) {
+  const smartPlacementAssessments = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+
+  if (!smartPlacementAssessments) {
+    return null;
+  }
+
+  const resetSmartPlacementAssessmentsPromises = _.map(smartPlacementAssessments,
+    (smartPlacementAssessment) => _resetSmartPlacementAssessment({ assessment: smartPlacementAssessment, assessmentRepository, campaignParticipationRepository })
+  );
+  return Promise.all(resetSmartPlacementAssessmentsPromises);
+}
+
+async function _resetSmartPlacementAssessment({ assessment, assessmentRepository, campaignParticipationRepository }) {
+  const campaignParticipation = await campaignParticipationRepository.findOneByAssessmentId(assessment.id);
+
+  if (!campaignParticipation || campaignParticipation.isShared) {
+    return null;
+  }
+
+  const newAssessment = new Assessment({
+    userId: assessment.userId,
+    state: Assessment.states.STARTED,
+    type: Assessment.types.SMARTPLACEMENT,
+    courseId: 'Smart Placement Tests CourseId Not Used'
+  });
+
+  const [, newAssessmentSaved ] = await Promise.all([
+    assessmentRepository.updateStateById({ id: assessment.id, state: Assessment.states.ABORTED }),
+    assessmentRepository.save(newAssessment)
+  ]);
+
+  return campaignParticipationRepository.updateAssessmentIdByOldAssessmentId({
+    oldAssessmentId: assessment.id, assessmentId: newAssessmentSaved.id
   });
 }
 

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -124,7 +124,7 @@ async function _resetSmartPlacementAssessment({ assessment, resetSkills, assessm
   ]);
 
   return campaignParticipationRepository.updateAssessmentIdByOldAssessmentId({
-    oldAssessmentId: assessment.id, assessmentId: newAssessmentSaved.id
+    oldAssessmentId: assessment.id, newAssessmentId: newAssessmentSaved.id
   });
 }
 

--- a/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
+++ b/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
@@ -82,7 +82,7 @@ function _saveAssessmentResult({
   return Promise.all([
     assessmentResultRepository.save(assessmentResult),
     assessmentScore.competenceMarks,
-    assessmentRepository.save(assessment),
+    assessmentRepository.updateStateById({ id: assessment.id, state: Assessment.states.COMPLETED }),
   ])
     .then(([assessmentResult, competenceMarks]) => {
       const assessmentResultId = assessmentResult.id;
@@ -147,11 +147,10 @@ function _saveResultAfterComputingError({
   }
 
   const assessmentResult = AssessmentResult.BuildAlgoErrorResult(error, assessmentId);
-  assessment.setCompleted();
 
   return Promise.all([
     assessmentResultRepository.save(assessmentResult),
-    assessmentRepository.save(assessment),
+    assessmentRepository.updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }),
   ])
     .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository));
 }

--- a/api/lib/domain/usecases/find-smart-placement-assessments.js
+++ b/api/lib/domain/usecases/find-smart-placement-assessments.js
@@ -1,13 +1,12 @@
 module.exports = function findSmartPlacementAssessments({ userId, filters, assessmentRepository }) {
 
   const campaignCode = filters.codeCampaign;
-  return assessmentRepository.findSmartPlacementAssessmentsByUserId(userId)
-    .then((assessments)=> {
-      return assessments.filter((assessment) => {
-        if (assessment.campaignParticipation) {
-          return assessment.campaignParticipation.isAboutCampaignCode(campaignCode);
-        }
-        return false;
-      });
+
+  return assessmentRepository.findLastSmartPlacementAssessmentByUserIdAndCampaignCode({ userId, campaignCode, includeCampaign: true })
+    .then((assessment) => {
+      if (!assessment) {
+        return [];
+      }
+      return [assessment];
     });
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -108,7 +108,7 @@ module.exports = injectDependencies({
   preloadCacheEntries: require('./preload-cache-entries'),
   reloadCacheEntry: require('./reload-cache-entry'),
   removeAllCacheEntries: require('./remove-all-cache-entries'),
-  resetCompetenceEvaluation: require('./reset-competence-evaluation'),
+  resetScorecard: require('./reset-scorecard'),
   retrieveLastOrCreateCertificationCourse : require('./retrieve-last-or-create-certification-course'),
   saveCertificationCenter: require('./save-certification-center'),
   shareCampaignResult: require('./share-campaign-result'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -30,6 +30,7 @@ const dependencies = {
   resetPasswordService: require('../../domain/services/reset-password-service'),
   reCaptchaValidator: require('../../infrastructure/validators/grecaptcha-validator'),
   scoringService: require('../../domain/services/scoring/scoring-service'),
+  scorecardService: require('../../domain/services/scorecard-service'),
   settings: require('../../settings'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   smartPlacementAssessmentRepository: require('../../infrastructure/repositories/smart-placement-assessment-repository'),

--- a/api/lib/domain/usecases/reset-competence-evaluation.js
+++ b/api/lib/domain/usecases/reset-competence-evaluation.js
@@ -27,6 +27,8 @@ module.exports = async function resetCompetenceEvaluation({
     throw new CompetenceResetError(remainingDaysBeforeReset);
   }
 
+  let isCompetenceEvaluationExists = true;
+
   try {
     await competenceEvaluationRepository.getByCompetenceIdAndUserId({
       competenceId, userId: authenticatedUserId
@@ -35,7 +37,7 @@ module.exports = async function resetCompetenceEvaluation({
     // If user wants to reset its knowledge elements on a competence,
     // but has only validated or invalidated them on campaigns.
     if (err instanceof NotFoundError) {
-      return null;
+      isCompetenceEvaluationExists = false;
     } else {
       throw err;
     }
@@ -46,5 +48,6 @@ module.exports = async function resetCompetenceEvaluation({
     knowledgeElementRepository,
     competenceId,
     userId: authenticatedUserId,
+    isCompetenceEvaluationExists
   });
 };

--- a/api/lib/domain/usecases/reset-scorecard.js
+++ b/api/lib/domain/usecases/reset-scorecard.js
@@ -1,9 +1,9 @@
 const Scorecard = require('../models/Scorecard');
 const { UserNotAuthorizedToAccessEntity, CompetenceResetError, NotFoundError } = require('../errors');
 const _ = require('lodash');
-const competenceEvaluationService = require('../services/competence-evaluation-service');
+const scorecardService = require('../services/scorecard-service');
 
-module.exports = async function resetCompetenceEvaluation({
+module.exports = async function resetScorecard({
   authenticatedUserId,
   requestedUserId,
   competenceId,
@@ -43,7 +43,7 @@ module.exports = async function resetCompetenceEvaluation({
     }
   }
 
-  return competenceEvaluationService.resetCompetenceEvaluation({
+  return scorecardService.resetScorecard({
     competenceEvaluationRepository,
     knowledgeElementRepository,
     competenceId,

--- a/api/lib/domain/usecases/reset-scorecard.js
+++ b/api/lib/domain/usecases/reset-scorecard.js
@@ -28,7 +28,6 @@ module.exports = async function resetScorecard({
   }
 
   const remainingDaysBeforeReset = Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
-
   if (remainingDaysBeforeReset > 0) {
     throw new CompetenceResetError(remainingDaysBeforeReset);
   }

--- a/api/lib/domain/usecases/reset-scorecard.js
+++ b/api/lib/domain/usecases/reset-scorecard.js
@@ -10,6 +10,8 @@ module.exports = async function resetScorecard({
   competenceRepository,
   competenceEvaluationRepository,
   knowledgeElementRepository,
+  assessmentRepository,
+  campaignParticipationRepository,
 }) {
   if (authenticatedUserId !== requestedUserId) {
     throw new UserNotAuthorizedToAccessEntity();
@@ -40,9 +42,11 @@ module.exports = async function resetScorecard({
     competenceId,
     userId: authenticatedUserId,
     shouldResetCompetenceEvaluation: isCompetenceEvaluationExists,
+    assessmentRepository,
+    campaignParticipationRepository,
     competenceRepository,
     competenceEvaluationRepository,
-    knowledgeElementRepository
+    knowledgeElementRepository,
   });
 
   return scorecardService.computeScorecard({

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -33,5 +33,5 @@ module.exports = async function shareCampaignResult({
     throw new AssessmentNotCompletedError();
   }
 
-  return campaignParticipationRepository.updateCampaignParticipation(assessment.campaignParticipation);
+  return campaignParticipationRepository.share(assessment.campaignParticipation);
 };

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -147,6 +147,13 @@ module.exports = {
       .where('type', 'IN', ['SMART_PLACEMENT', 'COMPETENCE_EVALUATION'])
       .fetchAll()
       .then((bookshelfAssessmentCollection) => bookshelfAssessmentCollection.length > 0);
+  },
+
+  updateStateById({ id, state }) {
+    return BookshelfAssessment
+      .where({ id })
+      .save({ state }, { require: true, patch: true })
+      .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   }
 };
 
@@ -194,8 +201,10 @@ function _selectAssessmentsHavingAnAssessmentResult(bookshelfAssessments) {
 
 function _adaptModelToDb(assessment) {
   return _.omit(assessment, [
+    'id',
     'course',
     'createdAt',
+    'updatedAt',
     'successRate',
     'answers',
     'assessmentResults',

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -113,7 +113,7 @@ module.exports = {
       });
   },
 
-  updateCampaignParticipation(campaignParticipation) {
+  share(campaignParticipation) {
     return new BookshelfCampaignParticipation(campaignParticipation)
       .save({ isShared: true, sharedAt: new Date() }, { patch: true, require: true })
       .then(_toDomain)

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -133,10 +133,10 @@ module.exports = {
       .catch(_checkNotFoundError);
   },
 
-  updateAssessmentIdByOldAssessmentId({ oldAssessmentId, assessmentId }) {
+  updateAssessmentIdByOldAssessmentId({ oldAssessmentId, newAssessmentId }) {
     return BookshelfCampaignParticipation
       .where({ assessmentId: oldAssessmentId })
-      .save({ assessmentId }, { patch: true, require: true })
+      .save({ assessmentId: newAssessmentId }, { patch: true, require: true })
       .then(_toDomain)
       .catch(_checkNotFoundError);
   },

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -56,6 +56,13 @@ module.exports = {
       .then(fp.map(_toDomain));
   },
 
+  findOneByAssessmentId(assessmentId) {
+    return BookshelfCampaignParticipation
+      .where({ assessmentId })
+      .fetch({ required: false })
+      .then(_toDomain);
+  },
+
   find(options) {
     return queryBuilder.find(BookshelfCampaignParticipation, options);
   },
@@ -116,6 +123,14 @@ module.exports = {
   share(campaignParticipation) {
     return new BookshelfCampaignParticipation(campaignParticipation)
       .save({ isShared: true, sharedAt: new Date() }, { patch: true, require: true })
+      .then(_toDomain)
+      .catch(_checkNotFoundError);
+  },
+
+  updateAssessmentIdByOldAssessmentId({ oldAssessmentId, assessmentId }) {
+    return BookshelfCampaignParticipation
+      .where({ assessmentId: oldAssessmentId })
+      .save({ assessmentId }, { patch: true, require: true })
       .then(_toDomain)
       .catch(_checkNotFoundError);
   },

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -71,4 +71,19 @@ module.exports = {
   find(options) {
     return queryBuilder.find(BookshelfCompetenceEvaluation, options);
   },
+
+  async existsByCompetenceIdAndUserId({ competenceId, userId }) {
+    let isCompetenceEvaluationExists = true;
+    try {
+      await this.getByCompetenceIdAndUserId({ competenceId, userId });
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        isCompetenceEvaluationExists = false;
+      } else {
+        throw err;
+      }
+    }
+
+    return isCompetenceEvaluationExists;
+  },
 };

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -25,7 +25,7 @@ module.exports = {
 
   save(knowledgeElement) {
 
-    return Promise.resolve(_.omit(knowledgeElement, 'createdAt'))
+    return Promise.resolve(_.omit(knowledgeElement, ['id', 'createdAt']))
       .then((knowledgeElement) => new BookshelfKnowledgeElement(knowledgeElement))
       .then((knowledgeElementBookshelf) => knowledgeElementBookshelf.save())
       .then(_toDomain);

--- a/api/lib/infrastructure/utils/bookshelf-to-domain-converter.js
+++ b/api/lib/infrastructure/utils/bookshelf-to-domain-converter.js
@@ -13,7 +13,10 @@ function buildDomainObjects(BookshelfClass, bookshelfObjects) {
 }
 
 function buildDomainObject(BookshelfClass, bookshelfObject) {
-  return _buildDomainObject(BookshelfClass.prototype, bookshelfObject.toJSON());
+  if (bookshelfObject) {
+    return _buildDomainObject(BookshelfClass.prototype, bookshelfObject.toJSON());
+  }
+  return null;
 }
 
 function _buildDomainObject(bookshelfPrototype, bookshelfObjectJson) {

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -1,9 +1,9 @@
-const { knex, databaseBuilder, expect, generateValidRequestAuhorizationHeader, sinon } = require('../../../test-helper');
+const { knex, airtableBuilder, databaseBuilder, expect, generateValidRequestAuhorizationHeader, sinon } = require('../../../test-helper');
 const _ = require('lodash');
 
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | users-controller-reset-competence-evaluation', () => {
+describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
 
   let options;
   let server;

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -20,7 +20,8 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
   function inspectKnowledgeElementsInDb({ userId, competenceId }) {
     return knex.select('*')
       .from('knowledge-elements')
-      .where({ userId, competenceId });
+      .where({ userId, competenceId })
+      .orderBy('createdAt', 'DESC');
   }
 
   beforeEach(async () => {
@@ -155,6 +156,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
 
       afterEach(async () => {
         await databaseBuilder.clean();
+        await knex('knowledge-elements').delete();
         airtableBuilder.cleanAll();
       });
 
@@ -223,7 +225,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
         const knowledgeElement = await inspectKnowledgeElementsInDb({ userId, competenceId });
         const knowledgeElementsOtherCompetence = await inspectKnowledgeElementsInDb({ userId, competenceId: otherStartedCompetenceId });
 
-        expect(knowledgeElement).to.have.length(5);
+        expect(knowledgeElement).to.have.length(10);
         expect(knowledgeElement[0].earnedPix).to.equal(0);
         expect(knowledgeElement[0].status).to.equal('reset');
         expect(knowledgeElementsOtherCompetence[0].earnedPix).to.equal(3);

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -700,16 +700,56 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
     });
 
+    beforeEach(async () => {
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        assessmentId,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    after(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should returns the assessment with campaign when it matches with userId', async () => {
+      // when
+      const assessmentsReturned = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+
+      // then
+      expect(assessmentsReturned[0]).to.be.an.instanceOf(Assessment);
+      expect(assessmentsReturned[0].id).to.equal(assessmentId);
+    });
+  });
+
+  describe('#findLastSmartPlacementAssessmentByUserIdAndCampaignCode', () => {
+    let assessmentId;
+    let userId;
+    let campaign;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+
+      assessmentId = databaseBuilder.factory.buildAssessment({
+        userId,
+        type: Assessment.types.SMARTPLACEMENT,
+      }).id;
+
+      await databaseBuilder.commit();
+    });
+
     context('when assessment do have campaign', () => {
       beforeEach(async () => {
-        const campaignId = databaseBuilder.factory.buildCampaign({
+        campaign = databaseBuilder.factory.buildCampaign({
           name: 'Campagne',
-        }).id;
+          code: 'AZERTY',
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           userId,
           assessmentId,
-          campaignId,
+          campaignId: campaign.id,
         });
 
         await databaseBuilder.commit();
@@ -719,30 +759,32 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         await databaseBuilder.clean();
       });
 
-      it('should returns the assessment with campaign when it matches with userId', async () => {
+      it('should returns the assessment with campaign when asked', async () => {
         // when
-        const assessmentsReturned = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+        const assessmentReturned = await assessmentRepository.findLastSmartPlacementAssessmentByUserIdAndCampaignCode({ userId, campaignCode: campaign.code, includeCampaign: true });
 
         // then
-        expect(assessmentsReturned[0]).to.be.an.instanceOf(Assessment);
-        expect(assessmentsReturned[0].id).to.equal(assessmentId);
-        expect(assessmentsReturned[0].campaignParticipation.campaign.name).to.equal('Campagne');
-      });
-    });
-
-    context('when assessment do not have campaign', () => {
-      after(async () => {
-        await databaseBuilder.clean();
+        expect(assessmentReturned).to.be.an.instanceOf(Assessment);
+        expect(assessmentReturned.id).to.equal(assessmentId);
+        expect(assessmentReturned.campaignParticipation.campaign.name).to.equal('Campagne');
       });
 
-      it('should returns the assessment without campaign when matches with userId', async () => {
+      it('should returns the assessment without campaign', async () => {
         // when
-        const assessmentsReturned = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+        const assessmentReturned = await assessmentRepository.findLastSmartPlacementAssessmentByUserIdAndCampaignCode({ userId, campaignCode: campaign.code, includeCampaign: false });
 
         // then
-        expect(assessmentsReturned[0]).to.be.an.instanceOf(Assessment);
-        expect(assessmentsReturned[0].id).to.equal(assessmentId);
-        expect(assessmentsReturned[0].campaignParticipation).to.equal(null);
+        expect(assessmentReturned).to.be.an.instanceOf(Assessment);
+        expect(assessmentReturned.id).to.equal(assessmentId);
+        expect(assessmentReturned.campaignParticipation).to.equal(undefined);
+      });
+
+      it('should returns null', async () => {
+        // when
+        const assessmentReturned = await assessmentRepository.findLastSmartPlacementAssessmentByUserIdAndCampaignCode({ userId, campaignCode: 'fakeCampaignCode', includeCampaign: false });
+
+        // then
+        expect(assessmentReturned).to.equal(null);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -518,7 +518,7 @@ describe('Integration | Repository | Campaign Participation', () => {
 
     it('should return the updated campaign-participation of the given assessmentId', async () => {
       // when
-      const updatedCampaignParticipation = await campaignParticipationRepository.updateAssessmentIdByOldAssessmentId({ oldAssessmentId: campaignParticipation.assessmentId, assessmentId: assessment.id });
+      const updatedCampaignParticipation = await campaignParticipationRepository.updateAssessmentIdByOldAssessmentId({ oldAssessmentId: campaignParticipation.assessmentId, newAssessmentId: assessment.id });
 
       // then
       expect(updatedCampaignParticipation.assessmentId).to.equal(assessment.id);

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -251,6 +251,32 @@ describe('Integration | Repository | Campaign Participation', () => {
     });
   });
 
+  describe('#findOneByAssessmentId', () => {
+
+    const assessmentId = 12345;
+
+    beforeEach(async () => {
+      databaseBuilder.factory.buildCampaignParticipation({ assessmentId });
+      databaseBuilder.factory.buildCampaignParticipation({ assessmentId: 67890 });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should return the campaign-participation link to the given assessment', async () => {
+      // given
+
+      // when
+      const campaignParticipationFound = await campaignParticipationRepository.findOneByAssessmentId(assessmentId);
+
+      // then
+      expect(campaignParticipationFound.assessmentId).to.deep.equal(assessmentId);
+    });
+  });
+
   describe('#find', () => {
 
     const campaignId = 'my campaign id';
@@ -435,6 +461,31 @@ describe('Integration | Repository | Campaign Participation', () => {
         expect(updatedCampaignParticipation.assessmentId).to.equal(campaignParticipation.assessmentId);
         expect(updatedCampaignParticipation.sharedAt).to.deep.equal(frozenTime);
       });
+    });
+  });
+
+  describe('#updateAssessmentIdByOldAssessmentId', () => {
+
+    let campaignParticipation;
+    let assessment;
+
+    beforeEach(async () => {
+      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      assessment = databaseBuilder.factory.buildAssessment();
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should return the updated campaign-participation of the given assessmentId', async () => {
+      // when
+      const updatedCampaignParticipation = await campaignParticipationRepository.updateAssessmentIdByOldAssessmentId({ oldAssessmentId: campaignParticipation.assessmentId, assessmentId: assessment.id });
+
+      // then
+      expect(updatedCampaignParticipation.assessmentId).to.equal(assessment.id);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -405,7 +405,7 @@ describe('Integration | Repository | Campaign Participation', () => {
     });
   });
 
-  describe('#updateCampaignParticipation', () => {
+  describe('#share', () => {
 
     let campaignParticipation;
     const frozenTime = new Date('1987-09-01T00:00:00Z');
@@ -425,9 +425,9 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.clean();
     });
 
-    it('should return the shared campaign-participation of the given assessmentId', () => {
+    it('should return the shared campaign-participation', () => {
       // when
-      const promise = campaignParticipationRepository.updateCampaignParticipation(campaignParticipation);
+      const promise = campaignParticipationRepository.share(campaignParticipation);
 
       // then
       return promise.then((updatedCampaignParticipation) => {

--- a/api/tests/tooling/database-builder/factory/build-assessment.js
+++ b/api/tests/tooling/database-builder/factory/build-assessment.js
@@ -10,7 +10,7 @@ module.exports = function buildAssessment({
   userId,
   type = Assessment.types.PLACEMENT,
   state = Assessment.states.COMPLETED,
-  competenceId = 'recsvLz0W2ShyfD63',
+  competenceId = null,
   createdAt = faker.date.past(),
   updatedAt = faker.date.past(),
 } = {}) {

--- a/api/tests/tooling/domain-builder/factory/build-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment.js
@@ -21,6 +21,7 @@ function buildAssessment({
   answers = [buildAnswer()],
   assessmentResults = [buildAssessmentResult()],
   campaignParticipation = null,
+  competenceId = null,
 } = {}) {
 
   return new Assessment({
@@ -32,6 +33,7 @@ function buildAssessment({
     title,
     type,
     state,
+    competenceId,
 
     // relationships
     answers,
@@ -47,7 +49,7 @@ buildAssessment.ofTypeSmartPlacement = function({
   courseId = 'courseId',
   createdAt = new Date('1992-06-12T01:02:03Z'),
   userId = faker.random.number(),
-  competenceId = faker.random.number(),
+  competenceId = null,
   state = Assessment.states.COMPLETED,
 
   answers = [buildAnswer()],
@@ -93,7 +95,8 @@ buildAssessment.ofTypeCompetenceEvaluation = function({
   course = buildCourse({ id: 'courseId' }),
   targetProfile = buildTargetProfile(),
   knowledgeElements = [buildKnowledgeElement()],
-  campaignParticipation = buildCampaignParticipation(),
+  campaignParticipation = null,
+  competenceId = faker.random.number(),
 } = {}) {
   return new Assessment({
     // attributes
@@ -101,6 +104,7 @@ buildAssessment.ofTypeCompetenceEvaluation = function({
     courseId,
     createdAt,
     userId,
+    competenceId,
     title,
     type: Assessment.types.COMPETENCE_EVALUATION,
     state,

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -1,9 +1,9 @@
 const { expect, sinon } = require('../../../test-helper');
 
 const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
-const competenceEvaluationService = require('../../../../lib/domain/services/competence-evaluation-service');
+const scorecardService = require('../../../../lib/domain/services/scorecard-service');
 
-describe('Unit | Service | CompetenceEvaluationService', function() {
+describe('Unit | Service | ScorecardService', function() {
 
   let resetKnowledgeElements;
   let resetCompetenceEvaluation;
@@ -42,7 +42,7 @@ describe('Unit | Service | CompetenceEvaluationService', function() {
         .onFirstCall().resolves(resetKnowledgeElement1)
         .onSecondCall().resolves(resetKnowledgeElement2);
 
-      [resetCompetenceEvaluation, resetKnowledgeElements] = await competenceEvaluationService.resetCompetenceEvaluation({
+      [resetCompetenceEvaluation, resetKnowledgeElements] = await scorecardService.resetScorecard({
         userId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository,
       });
     });
@@ -76,7 +76,7 @@ describe('Unit | Service | CompetenceEvaluationService', function() {
         .onFirstCall().resolves(resetKnowledgeElement1)
         .onSecondCall().resolves(resetKnowledgeElement2);
 
-      resetKnowledgeElements = await competenceEvaluationService.resetCompetenceEvaluation({
+      resetKnowledgeElements = await scorecardService.resetScorecard({
         userId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository,
       });
     });

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -236,10 +236,10 @@ describe('Unit | Service | ScorecardService', function() {
         campaignParticipationRepository.findOneByAssessmentId.withArgs(oldAssessment2.id).resolves(campaignParticipation2);
 
         campaignParticipationRepository.updateAssessmentIdByOldAssessmentId
-          .withArgs({ oldAssessmentId: oldAssessment1.id, assessmentId: newAssessment1Saved.id })
+          .withArgs({ oldAssessmentId: oldAssessment1.id, newAssessmentId: newAssessment1Saved.id })
           .resolves(campaignParticipation1Updated);
         campaignParticipationRepository.updateAssessmentIdByOldAssessmentId
-          .withArgs({ oldAssessmentId: oldAssessment2.id, assessmentId: newAssessment2Saved.id })
+          .withArgs({ oldAssessmentId: oldAssessment2.id, newAssessmentId: newAssessment2Saved.id })
           .resolves(campaignParticipation2Updated);
 
         knowledgeElementRepository.findUniqByUserIdAndCompetenceId

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -1,91 +1,173 @@
-const { expect, sinon } = require('../../../test-helper');
-
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
 const scorecardService = require('../../../../lib/domain/services/scorecard-service');
 
 describe('Unit | Service | ScorecardService', function() {
 
-  let resetKnowledgeElements;
-  let resetCompetenceEvaluation;
-  let knowledgeElementRepository;
-  let competenceEvaluationRepository;
+  describe('#computeScorecard', function() {
 
-  const userId = 1;
-  const competenceId = 2;
-  const knowledgeElements = [{ id: 1 }, { id: 2 }];
-  const resetKnowledgeElement1 = Symbol('reset knowledge element 1');
-  const resetKnowledgeElement2 = Symbol('reset knowledge element 2');
-  const updatedCompetenceEvaluation = Symbol('updated competence evaluation');
+    let competenceRepository;
+    let knowledgeElementRepository;
+    let competenceEvaluationRepository;
+    let buildFromStub;
+    let competenceId;
+    let authenticatedUserId;
 
-  context('when competence evaluation exists', function() {
+    beforeEach(() => {
+      competenceId = 1;
+      authenticatedUserId = 1;
+      competenceRepository = { get: sinon.stub() };
+      knowledgeElementRepository = { findUniqByUserIdAndCompetenceId: sinon.stub() };
+      competenceEvaluationRepository = { findByUserId: sinon.stub() };
+      buildFromStub = sinon.stub(Scorecard, 'buildFrom');
+    });
 
-    beforeEach(async () => {
-      // when
-      const isCompetenceEvaluationExists = true;
-      competenceEvaluationRepository = {
-        updateStatusByUserIdAndCompetenceId: sinon.stub(),
-      };
+    afterEach(() => {
+      sinon.restore();
+    });
 
-      knowledgeElementRepository = {
-        save: sinon.stub(),
-        findUniqByUserIdAndCompetenceId: sinon.stub(),
-      };
+    context('And user asks for his own scorecard', () => {
 
-      competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId
-        .withArgs({ userId, competenceId, status: CompetenceEvaluation.statuses.RESET })
-        .resolves(updatedCompetenceEvaluation);
+      it('should return the user scorecard', async () => {
+        // given
+        const earnedPixForCompetenceId1 = 8;
+        const levelForCompetenceId1 = 1;
+        const pixScoreAheadOfNextLevelForCompetenceId1 = 0;
 
-      knowledgeElementRepository.findUniqByUserIdAndCompetenceId
-        .withArgs({ userId, competenceId }).resolves(knowledgeElements);
+        const competence = domainBuilder.buildCompetence({ id: 1 });
 
-      knowledgeElementRepository.save
-        .onFirstCall().resolves(resetKnowledgeElement1)
-        .onSecondCall().resolves(resetKnowledgeElement2);
+        competenceRepository.get.resolves(competence);
 
-      [resetCompetenceEvaluation, resetKnowledgeElements] = await scorecardService.resetScorecard({
-        userId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository,
+        const knowledgeElementList = [
+          domainBuilder.buildKnowledgeElement({ competenceId: 1 }),
+          domainBuilder.buildKnowledgeElement({ competenceId: 1 }),
+        ];
+
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves(knowledgeElementList);
+
+        const assessment = domainBuilder.buildAssessment({ state: 'completed', type: 'COMPETENCE_EVALUATION' });
+        const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({
+          competenceId: 1,
+          assessmentId: assessment.id,
+          assessment
+        });
+
+        competenceEvaluationRepository.findByUserId.resolves([competenceEvaluation]);
+
+        const expectedUserScorecard = domainBuilder.buildUserScorecard({
+          name: competence.name,
+          earnedPix: earnedPixForCompetenceId1,
+          level: levelForCompetenceId1,
+          pixScoreAheadOfNextLevel: pixScoreAheadOfNextLevelForCompetenceId1
+        });
+
+        buildFromStub.withArgs({
+          userId: authenticatedUserId,
+          knowledgeElements: knowledgeElementList,
+          competence,
+          competenceEvaluation
+        }).returns(expectedUserScorecard);
+
+        // when
+        const userScorecard = await scorecardService.computeScorecard({
+          userId: authenticatedUserId,
+          competenceId,
+          competenceRepository,
+          competenceEvaluationRepository,
+          knowledgeElementRepository
+        });
+
+        //then
+        expect(userScorecard).to.deep.equal(expectedUserScorecard);
       });
-    });
-
-    // then
-    it('should reset each knowledge elements', async () => {
-      expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-      expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
-      expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
-    });
-
-    it('should reset the competence evaluation', () => {
-      expect(resetCompetenceEvaluation).to.deep.equal(updatedCompetenceEvaluation);
     });
   });
 
-  context('when competence evaluation does not exists - there is only knowledge elements thanks to campaign', function() {
+  describe('#resetScorecard', function() {
 
-    beforeEach(async () => {
-      // when
-      const isCompetenceEvaluationExists = false;
-      knowledgeElementRepository = {
-        save: sinon.stub(),
-        findUniqByUserIdAndCompetenceId: sinon.stub(),
-      };
+    let resetKnowledgeElements;
+    let resetCompetenceEvaluation;
+    let knowledgeElementRepository;
+    let competenceEvaluationRepository;
 
-      knowledgeElementRepository.findUniqByUserIdAndCompetenceId
-        .withArgs({ userId, competenceId }).resolves(knowledgeElements);
+    const userId = 1;
+    const competenceId = 2;
+    const knowledgeElements = [{ id: 1 }, { id: 2 }];
+    const resetKnowledgeElement1 = Symbol('reset knowledge element 1');
+    const resetKnowledgeElement2 = Symbol('reset knowledge element 2');
+    const updatedCompetenceEvaluation = Symbol('updated competence evaluation');
 
-      knowledgeElementRepository.save
-        .onFirstCall().resolves(resetKnowledgeElement1)
-        .onSecondCall().resolves(resetKnowledgeElement2);
+    context('when competence evaluation exists', function() {
 
-      resetKnowledgeElements = await scorecardService.resetScorecard({
-        userId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository,
+      beforeEach(async () => {
+        // when
+        const shouldResetCompetenceEvaluation = true;
+        competenceEvaluationRepository = {
+          updateStatusByUserIdAndCompetenceId: sinon.stub(),
+        };
+
+        knowledgeElementRepository = {
+          save: sinon.stub(),
+          findUniqByUserIdAndCompetenceId: sinon.stub(),
+        };
+
+        competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId
+          .withArgs({ userId, competenceId, status: CompetenceEvaluation.statuses.RESET })
+          .resolves(updatedCompetenceEvaluation);
+
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId
+          .withArgs({ userId, competenceId }).resolves(knowledgeElements);
+
+        knowledgeElementRepository.save
+          .onFirstCall().resolves(resetKnowledgeElement1)
+          .onSecondCall().resolves(resetKnowledgeElement2);
+
+        [resetCompetenceEvaluation, resetKnowledgeElements] = await scorecardService.resetScorecard({
+          userId, competenceId, shouldResetCompetenceEvaluation, knowledgeElementRepository, competenceEvaluationRepository,
+        });
+      });
+
+      // then
+      it('should reset each knowledge elements', async () => {
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
+      });
+
+      it('should reset the competence evaluation', () => {
+        expect(resetCompetenceEvaluation).to.deep.equal(updatedCompetenceEvaluation);
       });
     });
 
-    // then
-    it('should reset each knowledge elements', async () => {
-      expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-      expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
-      expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
+    context('when competence evaluation does not exists - there is only knowledge elements thanks to campaign', function() {
+
+      beforeEach(async () => {
+        // when
+        const shouldResetCompetenceEvaluation = false;
+        knowledgeElementRepository = {
+          save: sinon.stub(),
+          findUniqByUserIdAndCompetenceId: sinon.stub(),
+        };
+
+        knowledgeElementRepository.findUniqByUserIdAndCompetenceId
+          .withArgs({ userId, competenceId }).resolves(knowledgeElements);
+
+        knowledgeElementRepository.save
+          .onFirstCall().resolves(resetKnowledgeElement1)
+          .onSecondCall().resolves(resetKnowledgeElement2);
+
+        resetKnowledgeElements = await scorecardService.resetScorecard({
+          userId, competenceId, shouldResetCompetenceEvaluation, knowledgeElementRepository, competenceEvaluationRepository,
+        });
+      });
+
+      // then
+      it('should reset each knowledge elements', async () => {
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
   };
   const assessmentRepository = {
     get: () => undefined,
-    save: () => undefined,
+    updateStateById: () => undefined,
   };
   const assessmentResultRepository = {
     save: () => undefined,
@@ -139,7 +139,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
     };
 
     sinon.stub(scoringService, 'calculateAssessmentScore').resolves(assessmentScore);
-    sinon.stub(assessmentRepository, 'save').resolves();
+    sinon.stub(assessmentRepository, 'updateStateById').resolves({ ...assessment, state: Assessment.states.COMPLETED });
     sinon.stub(assessmentResultRepository, 'save').resolves({ id: assessmentResultId });
     sinon.stub(assessmentRepository, 'get').resolves(assessment);
     sinon.stub(courseRepository, 'get').resolves(course);
@@ -243,7 +243,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
     // then
     return expect(promise).to.have.been.rejectedWith(NotFoundError);
   });
-    
+
   it('should change the assessment status', () => {
     // when
     const promise = createAssessmentResultForCompletedAssessment({
@@ -257,8 +257,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
     // then
     return promise.then(() => {
-      const savedCompetenceMark = assessmentRepository.save.firstCall.args;
-      expect(savedCompetenceMark[0].state).to.deep.equal('completed');
+      expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
     });
   });
 
@@ -614,18 +613,6 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       });
 
       it('should save assessment with status completed', () => {
-        const expectedAssessment = domainBuilder.buildAssessment({
-          id: assessmentId,
-          courseId: assessmentCourseId,
-          userId: 5,
-          state: 'completed',
-          type: Assessment.types.CERTIFICATION,
-        });
-        expectedAssessment.campaignParticipation = undefined;
-        expectedAssessment.course = undefined;
-        expectedAssessment.answers = [];
-        expectedAssessment.assessmentResults = [];
-
         // when
         const promise = createAssessmentResultForCompletedAssessment({
           assessmentId,
@@ -638,10 +625,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
         // then
         return promise.then(() => {
-          expect(assessmentRepository.save).to.have.been.calledWith(expectedAssessment);
-
-          const savedAssessment = assessmentRepository.save.firstCall.args;
-          expect(savedAssessment[0]).to.deep.equal(expectedAssessment);
+          expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
         });
       });
 
@@ -720,18 +704,6 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       });
 
       it('should save assessment with status completed', () => {
-        const expectedAssessment = domainBuilder.buildAssessment({
-          id: assessmentId,
-          courseId: assessmentCourseId,
-          userId: 5,
-          state: 'completed',
-          type: Assessment.types.CERTIFICATION,
-        });
-        expectedAssessment.campaignParticipation = undefined;
-        expectedAssessment.course = undefined;
-        expectedAssessment.answers = [];
-        expectedAssessment.assessmentResults = [];
-
         // when
         const promise = createAssessmentResultForCompletedAssessment({
           assessmentId,
@@ -744,10 +716,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
         // then
         return promise.then(() => {
-          expect(assessmentRepository.save).to.have.been.calledWith(expectedAssessment);
-
-          const savedAssessment = assessmentRepository.save.firstCall.args;
-          expect(savedAssessment[0]).to.deep.equal(expectedAssessment);
+          expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
         });
       });
 

--- a/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
@@ -4,7 +4,7 @@ const findSmartPlacementAssessments = require('../../../../lib/domain/usecases/f
 describe('Unit | UseCase | find-smart-placement-assessments', () => {
 
   const assessmentRepository = {
-    findSmartPlacementAssessmentsByUserId: () => {
+    findLastSmartPlacementAssessmentByUserIdAndCampaignCode: () => {
     },
   };
 
@@ -12,11 +12,11 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
     // given
     const userId = 1234;
     const filters = { type: 'SMART_PLACEMENT', codeCampaign: 'Code' };
-    const assessment = domainBuilder.buildAssessment.ofTypeSmartPlacement({
-      ...filters,
+    domainBuilder.buildAssessment.ofTypeSmartPlacement({
       userId,
+      campaignParticipation: null,
     });
-    sinon.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
+    sinon.stub(assessmentRepository, 'findLastSmartPlacementAssessmentByUserIdAndCampaignCode').resolves(null);
 
     // when
     const promise = findSmartPlacementAssessments({ userId, filters, assessmentRepository });
@@ -38,7 +38,7 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
       userId,
       campaignParticipation
     });
-    sinon.stub(assessmentRepository, 'findSmartPlacementAssessmentsByUserId').resolves([assessment]);
+    sinon.stub(assessmentRepository, 'findLastSmartPlacementAssessmentByUserIdAndCampaignCode').resolves(assessment);
 
     // when
     const promise = findSmartPlacementAssessments({ userId, filters, assessmentRepository });

--- a/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/reset-competence-evaluation_test.js
@@ -32,13 +32,14 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
     it('should reset the competenceEvaluation', async () => {
       // given
       requestedUserId = 456;
+      const isCompetenceEvaluationExists = true;
 
       competenceEvaluationRepository.getByCompetenceIdAndUserId
         .withArgs({ competenceId, userId: authenticatedUserId })
         .resolves();
 
       sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation')
-        .withArgs({ userId: authenticatedUserId, competenceId, knowledgeElementRepository, competenceEvaluationRepository })
+        .withArgs({ userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository })
         .resolves(resetCompetenceEvaluationResult);
 
       knowledgeElementRepository.findUniqByUserIdAndCompetenceId
@@ -60,9 +61,9 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
 
       // then
       expect(competenceEvaluationService.resetCompetenceEvaluation).to.have.been.calledWithExactly({
-        userId: authenticatedUserId, competenceId, knowledgeElementRepository, competenceEvaluationRepository
+        userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository
       });
-      expect(response).to.deep.equal(resetCompetenceEvaluationResult);
+      expect(response).to.equal(resetCompetenceEvaluationResult);
     });
   });
 
@@ -86,15 +87,18 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
   });
 
   context('when there is no competenceEvaluation', () => {
-    it('should do nothing', async () => {
+    it('should reset knowledge elements', async () => {
       // given
       requestedUserId = 456;
+      const isCompetenceEvaluationExists = false;
 
       knowledgeElementRepository.findUniqByUserIdAndCompetenceId
         .withArgs({ userId: authenticatedUserId, competenceId })
         .resolves(knowledgeElements);
 
-      sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation');
+      sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation')
+        .withArgs({ userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository })
+        .resolves(resetCompetenceEvaluationResult);
 
       competenceEvaluationRepository.getByCompetenceIdAndUserId
         .withArgs({ competenceId, userId: authenticatedUserId })
@@ -104,8 +108,8 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
       const response = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
 
       // then
-      sinon.assert.notCalled(competenceEvaluationService.resetCompetenceEvaluation);
-      expect(response).to.equal(null);
+      sinon.assert.called(competenceEvaluationService.resetCompetenceEvaluation);
+      expect(response).to.equal(resetCompetenceEvaluationResult);
     });
   });
 

--- a/api/tests/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/reset-scorecard_test.js
@@ -15,6 +15,8 @@ describe('Unit | UseCase | reset-scorecard', () => {
   const competenceEvaluationRepository = {};
   const knowledgeElementRepository = {};
   const competenceRepository = {};
+  const assessmentRepository = {};
+  const campaignParticipationRepository = {};
   const scorecardService = {};
   let getRemainingDaysBeforeResetStub;
 
@@ -43,7 +45,7 @@ describe('Unit | UseCase | reset-scorecard', () => {
         .resolves(true);
 
       scorecardService.resetScorecard
-        .withArgs({ userId: authenticatedUserId, competenceId, shouldResetCompetenceEvaluation, knowledgeElementRepository, competenceEvaluationRepository })
+        .withArgs({ userId: authenticatedUserId, competenceId, shouldResetCompetenceEvaluation, knowledgeElementRepository, competenceEvaluationRepository, assessmentRepository, campaignParticipationRepository })
         .resolves(resetScorecardResult);
 
       scorecardService.computeScorecard
@@ -64,6 +66,8 @@ describe('Unit | UseCase | reset-scorecard', () => {
         requestedUserId,
         competenceId,
         scorecardService,
+        assessmentRepository,
+        campaignParticipationRepository,
         competenceRepository,
         competenceEvaluationRepository,
         knowledgeElementRepository
@@ -71,7 +75,7 @@ describe('Unit | UseCase | reset-scorecard', () => {
 
       // then
       expect(scorecardService.resetScorecard).to.have.been.calledWithExactly({
-        userId: authenticatedUserId, competenceId, shouldResetCompetenceEvaluation, competenceRepository, knowledgeElementRepository, competenceEvaluationRepository
+        userId: authenticatedUserId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, campaignParticipationRepository, competenceRepository, knowledgeElementRepository, competenceEvaluationRepository
       });
       expect(response).to.equal(scorecard);
     });

--- a/api/tests/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/reset-scorecard_test.js
@@ -1,17 +1,17 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
-const competenceEvaluationService = require('../../../../lib/domain/services/competence-evaluation-service');
-const resetCompetenceEvaluation = require('../../../../lib/domain/usecases/reset-competence-evaluation');
+const scorecardService = require('../../../../lib/domain/services/scorecard-service');
+const resetScorecard = require('../../../../lib/domain/usecases/reset-scorecard');
 const { UserNotAuthorizedToAccessEntity, CompetenceResetError, NotFoundError } = require('../../../../lib/domain/errors');
 
-describe('Unit | UseCase | reset-competence-evaluation', () => {
+describe('Unit | UseCase | reset-scorecard', () => {
 
   let requestedUserId;
   let knowledgeElements;
 
   const competenceId = 123;
   const authenticatedUserId = 456;
-  const resetCompetenceEvaluationResult = Symbol('reset competence evaluation result');
+  const resetScorecardResult = Symbol('reset scorecard result');
   const competenceEvaluationRepository = {};
   const knowledgeElementRepository = {};
   let getRemainingDaysBeforeResetStub;
@@ -38,9 +38,9 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
         .withArgs({ competenceId, userId: authenticatedUserId })
         .resolves();
 
-      sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation')
+      sinon.stub(scorecardService, 'resetScorecard')
         .withArgs({ userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository })
-        .resolves(resetCompetenceEvaluationResult);
+        .resolves(resetScorecardResult);
 
       knowledgeElementRepository.findUniqByUserIdAndCompetenceId
         .withArgs({ userId: authenticatedUserId, competenceId })
@@ -51,7 +51,7 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
         .returns(0);
 
       // when
-      const response = await resetCompetenceEvaluation({
+      const response = await resetScorecard({
         authenticatedUserId,
         requestedUserId,
         competenceId,
@@ -60,10 +60,10 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
       });
 
       // then
-      expect(competenceEvaluationService.resetCompetenceEvaluation).to.have.been.calledWithExactly({
+      expect(scorecardService.resetScorecard).to.have.been.calledWithExactly({
         userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository
       });
-      expect(response).to.equal(resetCompetenceEvaluationResult);
+      expect(response).to.equal(resetScorecardResult);
     });
   });
 
@@ -73,7 +73,7 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
       requestedUserId = 789;
 
       // when
-      const requestErr = await catchErr(resetCompetenceEvaluation)({
+      const requestErr = await catchErr(resetScorecard)({
         authenticatedUserId,
         requestedUserId,
         competenceId,
@@ -96,20 +96,20 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
         .withArgs({ userId: authenticatedUserId, competenceId })
         .resolves(knowledgeElements);
 
-      sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation')
+      sinon.stub(scorecardService, 'resetScorecard')
         .withArgs({ userId: authenticatedUserId, competenceId, isCompetenceEvaluationExists, knowledgeElementRepository, competenceEvaluationRepository })
-        .resolves(resetCompetenceEvaluationResult);
+        .resolves(resetScorecardResult);
 
       competenceEvaluationRepository.getByCompetenceIdAndUserId
         .withArgs({ competenceId, userId: authenticatedUserId })
         .rejects(new NotFoundError());
 
       // when
-      const response = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
+      const response = await resetScorecard({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
 
       // then
-      sinon.assert.called(competenceEvaluationService.resetCompetenceEvaluation);
-      expect(response).to.equal(resetCompetenceEvaluationResult);
+      sinon.assert.called(scorecardService.resetScorecard);
+      expect(response).to.equal(resetScorecardResult);
     });
   });
 
@@ -126,7 +126,7 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
         .returns(4);
 
       // when
-      const requestErr = await catchErr(resetCompetenceEvaluation)({
+      const requestErr = await catchErr(resetScorecard)({
         authenticatedUserId,
         requestedUserId,
         competenceId,
@@ -147,14 +147,14 @@ describe('Unit | UseCase | reset-competence-evaluation', () => {
         .withArgs({ userId: authenticatedUserId, competenceId })
         .resolves([]);
 
-      sinon.stub(competenceEvaluationService, 'resetCompetenceEvaluation');
+      sinon.stub(scorecardService, 'resetScorecard');
 
       // when
-      const response = await resetCompetenceEvaluation({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
+      const response = await resetScorecard({ authenticatedUserId, requestedUserId, competenceId, competenceEvaluationRepository, knowledgeElementRepository });
 
       // then
       expect(response).to.equal(null);
-      sinon.assert.notCalled(competenceEvaluationService.resetCompetenceEvaluation);
+      sinon.assert.notCalled(scorecardService.resetScorecard);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
   let campaignParticipation;
   let expectedCampaignParticipation;
   const campaignParticipationRepository = {
-    updateCampaignParticipation() {
+    share() {
     },
   };
   const smartPlacementAssessmentRepository = {
@@ -55,7 +55,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
           isShared: true
         });
 
-        sinon.stub(campaignParticipationRepository, 'updateCampaignParticipation')
+        sinon.stub(campaignParticipationRepository, 'share')
           .resolves(expectedCampaignParticipation);
       });
 

--- a/mon-pix/app/adapters/scorecard.js
+++ b/mon-pix/app/adapters/scorecard.js
@@ -1,0 +1,13 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    if (adapterOptions.resetCompetence) {
+      delete adapterOptions.resetCompetence;
+      return `${this.host}/${this.namespace}/users/${adapterOptions.userId}/competences/${adapterOptions.competenceId}/reset`;
+    }
+
+    return this._super(...arguments);
+  }
+});

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -19,13 +19,4 @@ export default ApplicationAdapter.extend({
 
     return this._super(...arguments);
   },
-
-  urlForUpdateRecord(id, modelName, { adapterOptions }) {
-    if (adapterOptions.resetCompetence) {
-      delete adapterOptions.resetCompetence;
-      return `${this._super(...arguments)}/competences/${adapterOptions.competenceId}/reset`;
-    }
-
-    return this._super(...arguments);
-  }
 });

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -18,5 +18,14 @@ export default ApplicationAdapter.extend({
     }
 
     return this._super(...arguments);
+  },
+
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    if (adapterOptions.resetCompetence) {
+      delete adapterOptions.resetCompetence;
+      return `${this._super(...arguments)}/competences/${adapterOptions.competenceId}/reset`;
+    }
+
+    return this._super(...arguments);
   }
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,9 +1,14 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
 
+  currentUser: service(),
+  store: service(),
+
   scorecard: null,
+  showResetModal: false,
 
   level: computed('scorecard.{level,isNotStarted}', function() {
     return this.get('scorecard.isNotStarted') ? null : this.get('scorecard.level');
@@ -25,5 +30,24 @@ export default Component.extend({
     const daysBeforeReset = this.get('scorecard.remainingDaysBeforeReset');
     return `Remise à zéro disponible dans ${daysBeforeReset} ${daysBeforeReset <= 1 ? 'jour' : 'jours'}`;
   }),
+
+  actions: {
+    openModal() {
+      this.set('showResetModal', true);
+    },
+
+    closeModal() {
+      this.set('showResetModal', false);
+    },
+
+    reset() {
+      this.currentUser.user.save({ adapterOptions: { resetCompetence: true, competenceId: this.get('scorecard.competenceId') } })
+        .then(() => {
+          this.get('scorecard').reload();
+        });
+
+      this.set('showResetModal', false);
+    }
+  },
 
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -13,4 +13,17 @@ export default Component.extend({
     return !(this.get('scorecard.isFinished') || this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
   }),
 
+  displayWaitSentence: computed('scorecard.remainingDaysBeforeReset', function() {
+    return this.get('scorecard.remainingDaysBeforeReset') > 0;
+  }),
+
+  displayResetButton: computed('scorecard.remainingDaysBeforeReset', function() {
+    return this.get('scorecard.remainingDaysBeforeReset') === 0;
+  }),
+
+  remainingDaysText: computed('scorecard.remainingDaysBeforeReset', function() {
+    const daysBeforeReset = this.get('scorecard.remainingDaysBeforeReset');
+    return `Remise à zéro disponible dans ${daysBeforeReset} ${daysBeforeReset <= 1 ? 'jour' : 'jours'}`;
+  }),
+
 });

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -41,10 +41,7 @@ export default Component.extend({
     },
 
     reset() {
-      this.currentUser.user.save({ adapterOptions: { resetCompetence: true, competenceId: this.get('scorecard.competenceId') } })
-        .then(() => {
-          this.get('scorecard').reload();
-        });
+      this.scorecard.save({ adapterOptions: { resetCompetence: true, userId: this.currentUser.user.id, competenceId: this.get('scorecard.competenceId') } });
 
       this.set('showResetModal', false);
     }

--- a/mon-pix/app/controllers/campaigns/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/skill-review.js
@@ -18,6 +18,7 @@ export default Controller.extend({
           this.set('displayLoadingButton', false);
         }.bind(this))
         .catch(() => {
+          campaignParticipation.rollbackAttributes();
           this.set('displayLoadingButton', false);
           this.set('displayErrorMessage', true);
         });

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -32,6 +32,7 @@ export default Model.extend({
   isSmartPlacement: equal('type', 'SMART_PLACEMENT'),
   isStarted: equal('state', 'started'),
   isCompleted: equal('state', 'completed'),
+  isAborted: equal('state', 'aborted'),
 
   showProgressBar: computed('isPreview', 'isPlacement', function() {
     return (this.isCompetenceEvaluation || this.isSmartPlacement || this.isDemo || this.isCertification);

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -17,6 +17,7 @@ export default Model.extend({
   level: attr('number'),
   pixScoreAheadOfNextLevel: attr('number'),
   status: attr('string'),
+  remainingDaysBeforeReset: attr('number'),
 
   area: belongsTo('area'),
 

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -45,8 +45,7 @@
   }
 }
 
-.competence-card:hover
-.competence-card__header {
+.competence-card:hover .competence-card__header {
   height: 179px;
   transition: height 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
@@ -116,8 +115,7 @@
   }
 }
 
-.competence-card:hover
-.competence-card__body {
+.competence-card:hover .competence-card__body {
   top: 32px;
 }
 
@@ -160,8 +158,7 @@
   }
 }
 
-.competence-card__link:hover
-.competence-card__score-details {
+.competence-card__link:hover .competence-card__score-details {
   opacity: 1;
 }
 
@@ -181,23 +178,18 @@
   }
 }
 
-.competence-card:hover
-.competence-card__footer {
+.competence-card:hover .competence-card__footer {
   transition-delay: 0.15s;
   bottom: 22px;
 }
 
 .competence-card__button {
-  text-transform: none;
-  height: 34px;
-  border-radius: 17px;
-  padding-top: 8px;
-  padding-bottom: 8px;
   position: relative;
+  height: 34px;
   min-width: 140px;
 }
 
-.competence-card__button-label {
+.competence-card-button__label {
   position: absolute;
   top: 0;
   bottom: 2px;
@@ -209,12 +201,11 @@
   transition: left 0.1s ease-out;
 }
 
-.competence-card__button:hover
-.competence-card__button-label {
+.competence-card__button:hover .competence-card-button__label {
   left: -20px;
 }
 
-.competence-card__button-arrow {
+.competence-card-button__arrow {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -227,8 +218,7 @@
   transition: all 0.1s linear;
 }
 
-.competence-card__button:hover
-.competence-card__button-arrow {
+.competence-card__button:hover .competence-card-button__arrow {
   opacity: 1;
   right: 24px;
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -3,7 +3,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
     border-radius: 6.75px;
     font-family: $font-roboto;
     background-color: $alabaster-grey;
@@ -19,8 +18,13 @@
     padding: 14px 14px 0 14px;
   }
 
-  &__button {
-    margin-top: 20px;
+  &__resume-or-start-button {
+    margin-top: 30px;
+  }
+
+  &__reset-button {
+    color: $dusty-grey;
+    margin-top: 50px;
   }
 
   &__reset-modal {
@@ -52,13 +56,15 @@
 
 .scorecard-details-content {
   &__left {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     flex-grow: 1;
     padding: 0 30px 30px 30px;
     max-width: 100%;
 
     @include device-is('desktop') {
       padding: 0 30px;
-      border-bottom: none;
       border-right: 2px dashed $silver-grey;
     }
   }
@@ -69,6 +75,7 @@
     justify-content: center;
     align-items: center;
     padding: 0 30px;
+    white-space: nowrap;
   }
 }
 
@@ -123,6 +130,13 @@
     letter-spacing: 0.03rem;
     white-space: nowrap;
   }
+
+  &__reset-message {
+    padding-top: 50px;
+    color: $dusty-grey;
+    font-family: $font-roboto;
+    font-size: 1.3rem;
+  }
 }
 
 .scorecard-details-content-right-score-container {
@@ -139,5 +153,27 @@
 .scorecard-details-header-return-button {
   &__icon {
     margin-right: 8px;
+  }
+}
+
+.scorecard-details-reset-modal {
+  &__important-message {
+    padding: 20px 0;
+    color: $black;
+    font-family: $font-roboto;
+    font-weight: $font-medium;
+    font-size: 2.2rem;
+
+    @include device-is('desktop') {
+      padding: 50px 0 20px 0;
+    }
+  }
+
+  &__warning {
+    padding-bottom: 10px;
+    color: $grayish-grey;
+    font-family: $font-roboto;
+    font-weight: $font-light;
+    font-size: 1.6rem;
   }
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -22,6 +22,12 @@
   &__button {
     margin-top: 20px;
   }
+
+  &__reset-modal {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }
 
 .scorecard-details-header {

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -26,6 +26,11 @@
     }
   }
 
+  &--uppercase {
+    text-transform: uppercase;
+    font-size: 1.3rem;
+  }
+
   &--round {
     padding-left: 20px;
     padding-right: 20px;
@@ -35,8 +40,12 @@
   &--thin {
     padding-top: 11px;
     padding-bottom: 11px;
-    text-transform: uppercase;
-    font-size: 1.3rem;
+  }
+
+  &--extra-thin {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    font-size: 1.5rem;
   }
 
   &--regular {
@@ -66,6 +75,15 @@
 
     &:hover, &:active, &:focus {
       background-color: $jade;
+    }
+  }
+
+  &--red {
+    background: $pomegranate;
+    color: $white;
+
+    &:hover, &:active, &:focus {
+      background-color: $monza;
     }
   }
 
@@ -120,6 +138,9 @@
 
 
 .link {
+  outline: none;
+  border: none;
+  background-color: inherit;
   color: $pix-blue;
   text-decoration: none;
 
@@ -128,6 +149,10 @@
   &:active {
     text-decoration: underline;
     color: $pix-blue-hover;
+  }
+
+  &--underline {
+    text-decoration: underline;
   }
 
   &--grey {

--- a/mon-pix/app/styles/globals/_palette.scss
+++ b/mon-pix/app/styles/globals/_palette.scss
@@ -45,6 +45,8 @@ $eucalyptus: #228C5E;
 
 $mandy-red: #E14956;
 $vermilion: #FF4B00;
+$pomegranate: #F52222;
+$monza: #D60606;
 
 $purple: #985FFF;
 

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -16,6 +16,12 @@ $pix-modal-border-radius: 5px;
       width: 800px;
     }
 
+    &--wide {
+      @include device-is('desktop') {
+        width: 950px;
+      }
+    }
+
     .pix-modal__close-link {
       color: $white;
       text-align: right;
@@ -36,29 +42,44 @@ $pix-modal-border-radius: 5px;
       border-radius: $pix-modal-border-radius;
       background-color: $porcelain-grey;
       box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.2);
-      font-size: 16px;
+      font-size: 1.6rem;
       position: relative;
       margin: auto;
+
+      &--white {
+        background-color: $white;
+      }
+
+      &--with-padding {
+        @include device-is('desktop') {
+          padding: 40px 0;
+        }
+      }
 
       .pix-modal-header {
         background: $white;
         border-top-left-radius: $pix-modal-border-radius;
         border-top-right-radius: $pix-modal-border-radius;
 
-        .pix-modal-header__title {
+        &__title {
           margin: 0;
           text-align: center;
           padding: 15px;
-          font-family: $font-open-sans;
+          font-family: $font-roboto;
           font-size: 2.8rem;
+
+          &--thin {
+            font-weight: $font-light;
+          }
         }
 
-        .pix-modal-header__subtitle {
+        &__subtitle {
           margin: 0;
           text-align: center;
-          padding: 15px;
-          font-family: $font-open-sans;
-          font-size: 2.8rem;
+          color: $nero;
+          font-family: $font-roboto;
+          font-weight: $font-normal;
+          font-size: 1.6rem;
         }
       }
 
@@ -77,16 +98,19 @@ $pix-modal-border-radius: 5px;
         border-bottom-left-radius: $pix-modal-border-radius;
         border-bottom-right-radius: $pix-modal-border-radius;
 
-        &--with-centered--buttons {
+        &--with-centered-buttons {
           padding: 15px 0;
           display: flex;
           flex-direction: row-reverse;
           justify-content: center;
-          border-top: 1px solid $alto-grey;
 
           >.button {
             margin: 0 10px;
           }
+        }
+
+        &--border {
+          border-top: 1px solid $alto-grey;
         }
       }
     }
@@ -102,7 +126,7 @@ $pix-modal-border-radius: 5px;
   background-color: $white;
   border: 2px solid $alto-grey;
   color: $slate-grey;
-  letter-spacing: 2px;
+  letter-spacing: 0.2rem;
   box-sizing: border-box;
   margin-bottom: 5px;
   outline: none;

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -52,6 +52,14 @@ $pix-modal-border-radius: 5px;
           font-family: $font-open-sans;
           font-size: 2.8rem;
         }
+
+        .pix-modal-header__subtitle {
+          margin: 0;
+          text-align: center;
+          padding: 15px;
+          font-family: $font-open-sans;
+          font-size: 2.8rem;
+        }
       }
 
       .pix-modal-body {

--- a/mon-pix/app/templates/components/competence-card.hbs
+++ b/mon-pix/app/templates/components/competence-card.hbs
@@ -21,15 +21,15 @@
   <footer class="competence-card__footer">
     {{#if (not scorecard.isFinished)}}
       {{#link-to "competences.resume" scorecard.competenceId
-                 class="button button--thin button--link button--green competence-card__button"}}
-        <span class="competence-card__button-label">
+                 class="button button--extra-thin button--round button--link button--green competence-card__button"}}
+        <span class="competence-card-button__label">
           {{#if scorecard.isStarted}}
             Reprendre
           {{else}}
             Commencer
           {{/if}}
         </span>
-        <span class="competence-card__button-arrow">
+        <span class="competence-card-button__arrow">
           {{fa-icon 'long-arrow-alt-right'}}
         </span>
       {{/link-to}}

--- a/mon-pix/app/templates/components/competence-level-progress-bar.hbs
+++ b/mon-pix/app/templates/components/competence-level-progress-bar.hbs
@@ -17,7 +17,7 @@
           </button>
         {{else}}
 
-          {{# pix-modal containerClass="second-chance__modal" onClose=(action "closeModal") }}
+          {{#pix-modal containerClass="second-chance__modal" onClose=(action "closeModal") }}
             <div class="pix-modal__close-link">
               <a href="#" {{action "closeModal"}}>Fermer
                 <img src="/images/icon-close-modal.svg" alt="Fermer la fenêtre modale" width="24" height="24">
@@ -43,7 +43,7 @@
                 <button class="button button--grey competence-level-progress-bar__modal-link-cancel" {{action "closeModal"}}>Annuler</button>
               </div>
             </div>
-          {{/ pix-modal}}
+          {{/pix-modal}}
 
         {{/unless}}
       </div>

--- a/mon-pix/app/templates/components/competence-level-progress-bar.hbs
+++ b/mon-pix/app/templates/components/competence-level-progress-bar.hbs
@@ -36,7 +36,7 @@
                 </div>
               </div>
 
-              <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+              <div class="pix-modal-footer pix-modal-footer--with-centered-buttons pix-modal-footer--border">
                 {{#link-to "courses.create-assessment" competence.courseId class="button button--link competence-level-progress-bar__modal-link-validate" }}
                   J’ai compris
                 {{/link-to}}

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -31,7 +31,7 @@
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <button type="submit" class="button button--thin button--round button--extra-big">
+        <button type="submit" class="button button--uppercase button--thin button--round button--extra-big">
           Réinitialiser mon mot de passe
         </button>
         {{#link-to 'login' class="link link--grey sign-form-link password-reset-demand-form__cancel-link"}}

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -26,7 +26,7 @@
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <button type="submit" class="button button--thin button--round button--big">
+        <button type="submit" class="button button--uppercase button--thin button--round button--big">
           envoyer
         </button>
       </div>
@@ -40,7 +40,7 @@
         Votre mot de passe a été modifié avec succès.
       </div>
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        {{#link-to 'login' class="button button--link button--thin button--round button--big"}}
+        {{#link-to 'login' class="button button--link button--uppercase button--thin button--round button--big"}}
           connectez-vous{{/link-to}}
       </div>
     </div>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -57,6 +57,14 @@
       {{/link-to}}
     {{/unless}}
 
+    {{#if displayResetButton}}
+      <button class="button button--no-color" {{action "openModal"}}>
+        Remettre à zéro <div class="sr-only">la compétence "{{scorecard.name}}"</div>
+      </button>
+    {{else if displayWaitSentence}}
+      {{remainingDaysText}}
+    {{/if}}
+
   </div>
 
 </div>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -50,9 +50,9 @@
       {{#link-to "competences.resume" scorecard.competenceId
                  class=(concat "button button--big button--thin button--round button--link button--green " (if scorecard.isNotStarted "" "scorecard-details__resume-or-start-button"))}}
         {{#if scorecard.isStarted}}
-          Reprendre
+          Reprendre <div class="sr-only">la compétence "{{scorecard.name}}"</div>
         {{else}}
-          Commencer
+          Commencer <div class="sr-only">la compétence "{{scorecard.name}}"</div>
         {{/if}}
       {{/link-to}}
     {{/unless}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -65,6 +65,42 @@
       {{remainingDaysText}}
     {{/if}}
 
+    {{#if showResetModal}}
+      {{#pix-modal containerClass="scorecard-details__reset-modal" onClose=(action "closeModal") }}
+        <div class="pix-modal__close-link">
+          <a href="#" {{action "closeModal"}}>Fermer
+            <img src="/images/icon-close-modal.svg" alt="Fermer la fenêtre modale" width="24" height="24">
+          </a>
+        </div>
+
+        <div class="pix-modal__container">
+          <div class="pix-modal-header">
+            <h1 class="pix-modal-header__title">Remise à zéro de la compétence</h1>
+            <h2 class="pix-modal-header__subtitle">{{scorecard.name}}</h2>
+          </div>
+
+          <div class="pix-modal-body pix-modal-body--with-padding">
+            <div class="">
+              {{#if scorecard.hasNotReachLevelOne}}
+                Vos {{scorecard.earnedPix}} Pix vont être supprimés.
+              {{else if scorecard.hasReachAtLeastLevelOne}}
+                Votre niveau {{scorecard.level}} et vos {{scorecard.earnedPix}} Pix vont être supprimés.
+              {{/if}}
+            </div>
+            <div class="">
+              <p>Attention : Si vous participez à un parcours de test, celui-ci pourrait être affecté.</p>
+              <p>Vous devrez reprendre ce parcours pour refaire les questions de cette compétence. </p>
+            </div>
+          </div>
+
+          <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+            <button class="button button--grey" {{action "closeModal"}}>Annuler</button>
+            <button class="button" {{action "reset"}}>Remettre à zéro</button>
+          </div>
+        </div>
+      {{/pix-modal}}
+    {{/if}}
+
   </div>
 
 </div>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -48,7 +48,7 @@
 
     {{#unless scorecard.isFinished}}
       {{#link-to "competences.resume" scorecard.competenceId
-                 class=(concat "button button--thin button--link button--green " (if scorecard.isNotStarted "" "scorecard-details__button"))}}
+                 class=(concat "button button--big button--thin button--round button--link button--green " (if scorecard.isNotStarted "" "scorecard-details__resume-or-start-button"))}}
         {{#if scorecard.isStarted}}
           Reprendre
         {{else}}
@@ -58,49 +58,49 @@
     {{/unless}}
 
     {{#if displayResetButton}}
-      <button class="button button--no-color" {{action "openModal"}}>
+      <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
         Remettre à zéro <div class="sr-only">la compétence "{{scorecard.name}}"</div>
       </button>
     {{else if displayWaitSentence}}
-      {{remainingDaysText}}
-    {{/if}}
-
-    {{#if showResetModal}}
-      {{#pix-modal containerClass="scorecard-details__reset-modal" onClose=(action "closeModal") }}
-        <div class="pix-modal__close-link">
-          <a href="#" {{action "closeModal"}}>Fermer
-            <img src="/images/icon-close-modal.svg" alt="Fermer la fenêtre modale" width="24" height="24">
-          </a>
-        </div>
-
-        <div class="pix-modal__container">
-          <div class="pix-modal-header">
-            <h1 class="pix-modal-header__title">Remise à zéro de la compétence</h1>
-            <h2 class="pix-modal-header__subtitle">{{scorecard.name}}</h2>
-          </div>
-
-          <div class="pix-modal-body pix-modal-body--with-padding">
-            <div class="">
-              {{#if scorecard.hasNotReachLevelOne}}
-                Vos {{scorecard.earnedPix}} Pix vont être supprimés.
-              {{else if scorecard.hasReachAtLeastLevelOne}}
-                Votre niveau {{scorecard.level}} et vos {{scorecard.earnedPix}} Pix vont être supprimés.
-              {{/if}}
-            </div>
-            <div class="">
-              <p>Attention : Si vous participez à un parcours de test, celui-ci pourrait être affecté.</p>
-              <p>Vous devrez reprendre ce parcours pour refaire les questions de cette compétence. </p>
-            </div>
-          </div>
-
-          <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
-            <button class="button button--grey" {{action "closeModal"}}>Annuler</button>
-            <button class="button" {{action "reset"}}>Remettre à zéro</button>
-          </div>
-        </div>
-      {{/pix-modal}}
+      <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
     {{/if}}
 
   </div>
 
 </div>
+
+{{#if showResetModal}}
+  {{#pix-modal containerClass="scorecard-details__reset-modal pix-modal-dialog--wide" onClose=(action "closeModal") }}
+    <div class="pix-modal__close-link">
+      <a href="#" {{action "closeModal"}}>Fermer
+        <img src="/images/icon-close-modal.svg" alt="Fermer la fenêtre modale" width="24" height="24">
+      </a>
+    </div>
+
+    <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
+      <div class="pix-modal-header">
+        <h1 class="pix-modal-header__title pix-modal-header__title--thin">Remise à zéro de la compétence</h1>
+        <h2 class="pix-modal-header__subtitle">{{scorecard.name}}</h2>
+      </div>
+
+      <div class="pix-modal-body pix-modal-body--with-padding">
+        <div class="scorecard-details-reset-modal__important-message">
+          {{#if scorecard.hasNotReachLevelOne}}
+            Vos {{scorecard.earnedPix}} Pix vont être supprimés.
+          {{else if scorecard.hasReachAtLeastLevelOne}}
+            Votre niveau {{scorecard.level}} et vos {{scorecard.earnedPix}} Pix vont être supprimés.
+          {{/if}}
+        </div>
+        <div class="scorecard-details-reset-modal__warning">
+          <p> Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être
+            reposées.</p>
+        </div>
+      </div>
+
+      <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
+        <button class="button button--big button--extra-thin button--red" {{action "reset"}}>Remettre à zéro</button>
+        <button class="button button--regular button--extra-thin button--grey" {{action "closeModal"}}>Annuler</button>
+      </div>
+    </div>
+  {{/pix-modal}}
+{{/if}}

--- a/mon-pix/app/templates/components/share-profile.hbs
+++ b/mon-pix/app/templates/components/share-profile.hbs
@@ -40,7 +40,7 @@
             </section>
          </div>
 
-         <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+         <div class="pix-modal-footer pix-modal-footer--with-centered-buttons pix-modal-footer--border">
            <button class="button share-profile__continue-button" {{action "findOrganizationAndGoToSharingConfirmationView"}}>Continuer</button>
            <button class="button button--grey share-profile__cancel-button" {{action "closeModal"}}>Annuler</button>
          </div>
@@ -78,7 +78,7 @@
             </section>
          </div>
 
-         <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+         <div class="pix-modal-footer pix-modal-footer--with-centered-buttons pix-modal-footer--border">
            <button class="button share-profile__confirm-button" {{action "shareSnapshotAndGoToSuccessNotificationView"}}>Envoyer</button>
            <button class="button button--grey share-profile__cancel-button" {{action "cancelSharingAndGoBackToOrganizationCodeEntryView"}}>Annuler</button>
          </div>
@@ -93,7 +93,7 @@
             </section>
          </div>
 
-         <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+         <div class="pix-modal-footer pix-modal-footer--with-centered-buttons pix-modal-footer--border">
            <button class="button share-profile__close-button" {{action "closeModal"}}>Fermer</button>
          </div>
        {{/if}}

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -43,7 +43,7 @@
       Mot de passe oublié ?{{/link-to}}
 
     <div class="sign-form-body__bottom-button">
-      <button type="submit" class="button button--thin button--round button--big">
+      <button type="submit" class="button button--uppercase button--thin button--round button--big">
         Je me connecte
       </button>
     </div>

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -91,7 +91,7 @@
     {{/if}}
 
     <div class="sign-form-body__bottom-button {{if isRecaptchaEnabled "" "sign-form-body__bottom-button--margin-top"}}">
-      <button type="submit" class="button button--thin button--round button--big">
+      <button type="submit" class="button button--uppercase button--thin button--round button--big">
         Je m'inscris
       </button>
     </div>

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -34,7 +34,7 @@
               </div>
             </li>
             <li class="logged-user-menu__item user-menu-item__logout">
-              {{#link-to 'logout' class="button button--thin button--grey" tagName='button'}}
+              {{#link-to 'logout' class="button button--uppercase button--thin button--grey" tagName='button'}}
                 se déconnecter
               {{/link-to}}
             </li>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -39,7 +39,7 @@ module.exports = function(environment) {
       'Lato:300,400,700,900', // main font, Challenge instructions
       'Open+Sans:300,400,600', // used for ex. on buttons
       'Raleway:100,300,400,600,700,800', // used for index page titles
-      'Roboto:400,500', // used for campaign
+      'Roboto:300,400,500', // used for campaign
       'Overpass' //used on the trophy
     ],
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -27,7 +27,7 @@ import postCampaignParticipation from './routes/post-campaign-participation';
 import postCertificationCourse from './routes/post-certification-course';
 import postCompetenceEvaluation from './routes/post-competence-evaluation';
 import postFeedbacks from './routes/post-feedbacks';
-import resetCompetenceEvaluation from './routes/reset-competence-evaluation';
+import resetScorecard from './routes/reset-scorecard';
 
 import { Response } from 'ember-cli-mirage';
 
@@ -73,7 +73,7 @@ export default function() {
   this.get('/users/:id/pixscore', getPixScore);
   this.get('/users/:id/scorecards', getScorecards);
   this.get('/users/:id/campaign-participations', getUserCampaignParticipations);
-  this.patch('/users/:userId/competences/:competenceId/reset', resetCompetenceEvaluation);
+  this.patch('/users/:userId/competences/:competenceId/reset', resetScorecard);
   this.get('/scorecards/:id', getScorecard);
   this.get('/competences/:id');
   this.get('/areas/:id');

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -27,6 +27,7 @@ import postCampaignParticipation from './routes/post-campaign-participation';
 import postCertificationCourse from './routes/post-certification-course';
 import postCompetenceEvaluation from './routes/post-competence-evaluation';
 import postFeedbacks from './routes/post-feedbacks';
+import resetCompetenceEvaluation from './routes/reset-competence-evaluation';
 
 import { Response } from 'ember-cli-mirage';
 
@@ -72,6 +73,7 @@ export default function() {
   this.get('/users/:id/pixscore', getPixScore);
   this.get('/users/:id/scorecards', getScorecards);
   this.get('/users/:id/campaign-participations', getUserCampaignParticipations);
+  this.patch('/users/:userId/competences/:competenceId/reset', resetCompetenceEvaluation);
   this.get('/scorecards/:id', getScorecard);
   this.get('/competences/:id');
   this.get('/areas/:id');

--- a/mon-pix/mirage/routes/reset-competence-evaluation.js
+++ b/mon-pix/mirage/routes/reset-competence-evaluation.js
@@ -1,0 +1,15 @@
+export default function(schema, request) {
+  const competenceId = request.params.competenceId;
+
+  const scorecard = schema.scorecards.findBy({ competenceId });
+
+  scorecard.update({
+    status: 'NOT_STARTED',
+    level: 0,
+    earnedPix: 0,
+    pixScoreAheadOfNextLevel: 0,
+    remainingDaysBeforeReset: null,
+  });
+
+  return { data: null };
+}

--- a/mon-pix/mirage/routes/reset-scorecard.js
+++ b/mon-pix/mirage/routes/reset-scorecard.js
@@ -11,5 +11,5 @@ export default function(schema, request) {
     remainingDaysBeforeReset: null,
   });
 
-  return { data: null };
+  return scorecard;
 }

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -10,7 +10,7 @@ import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import defaultScenario from '../../mirage/scenarios/default';
 
-describe('Acceptance | Competence details | Afficher la page de detail d\'une compétence', () => {
+describe('Acceptance | Competence details | Afficher la page de détails d\'une compétence', () => {
   let application;
 
   beforeEach(() => {
@@ -24,11 +24,22 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
 
   describe('Authenticated cases as simple user', () => {
 
+    let scorecard;
+    let area;
+    let earnedPix;
+    let level;
+    let status;
+    let pixScoreAheadOfNextLevel;
+    let remainingDaysBeforeReset;
+    const name = 'Super compétence';
+    const description = 'Super description de la compétence';
+
     beforeEach(async () => {
       await authenticateAsSimpleUser();
+      area = server.schema.areas.find(1);
     });
 
-    it('can visit /competences/1_1', async () => {
+    it('should be able to visit /competences/1_1', async () => {
       // when
       await visit('/competences/1_1');
 
@@ -36,16 +47,9 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
       expect(currentURL()).to.equal('/competences/1_1');
     });
 
-    it('displays the competence details', async () => {
+    it('should display the competence details', async () => {
       // given
-      const name = 'Super compétence';
-      const description = 'Super description de la compétence';
-      const earnedPix = 7;
-      const level = 4;
-      const pixScoreAheadOfNextLevel = 5;
-      const area = server.schema.areas.find(1);
-
-      const scorecard = server.create('scorecard', {
+      scorecard = server.create('scorecard', {
         id: '1_1',
         name,
         description,
@@ -53,6 +57,8 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
         level,
         pixScoreAheadOfNextLevel,
         area,
+        status,
+        remainingDaysBeforeReset,
       });
 
       // when
@@ -63,27 +69,6 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
       expect(find('.scorecard-details-content-left__area').attr('class')).to.contain('scorecard-details-content-left__area--jaffa');
       expect(find('.scorecard-details-content-left__name').text()).to.contain(name);
       expect(find('.scorecard-details-content-left__description').text()).to.contain(description);
-      expect(find('.score-value').text()).to.contain(level);
-      expect(find('.score-value').text()).to.contain(earnedPix);
-      expect(find('.scorecard-details-content-right__level-info').text()).to.contain(`${8 - pixScoreAheadOfNextLevel} pix avant le niveau ${level + 1}`);
-    });
-
-    it('Does not display pixScoreAheadOfNextLevelwhen next level is over the max level', async () => {
-      // given
-      const scorecard = server.create('scorecard', {
-        id: '1_1',
-        name: 'Super compétence',
-        earnedPix: 7,
-        level: 999,
-        pixScoreAheadOfNextLevel: 5,
-        area: server.schema.areas.find(1),
-      });
-
-      // when
-      await visit(`/competence/${scorecard.id}`);
-
-      // then
-      expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
     });
 
     it('should transition to /profilv2 when the user clicks on return', async () => {
@@ -96,6 +81,219 @@ describe('Acceptance | Competence details | Afficher la page de detail d\'une c
       // then
       expect(currentURL()).to.equal('/profilv2');
     });
+
+    context('when there is no knowledge element', () => {
+
+      beforeEach(() => {
+        earnedPix = 0;
+        level = 0;
+        pixScoreAheadOfNextLevel = 0;
+        remainingDaysBeforeReset = null;
+        status = 'NOT_STARTED';
+      });
+
+      it('should not display level or score', async () => {
+        // given
+        scorecard = server.create('scorecard', {
+          id: '1_1',
+          name,
+          description,
+          earnedPix,
+          level,
+          pixScoreAheadOfNextLevel,
+          area,
+          status,
+          remainingDaysBeforeReset,
+        });
+
+        // when
+        await visit(`/competences/${scorecard.id}`);
+
+        // then
+        expect(find('.competence-card__level .score-value')).to.have.lengthOf(0);
+        expect(find('.scorecard-details-content-right-score-container__pix-earned .score-value')).to.have.lengthOf(0);
+        expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
+      });
+
+      it('should not display reset button nor reset sentence', async () => {
+        // given
+        scorecard = server.create('scorecard', {
+          id: '1_1',
+          name,
+          description,
+          earnedPix,
+          level,
+          pixScoreAheadOfNextLevel,
+          area,
+          status,
+          remainingDaysBeforeReset,
+        });
+
+        // when
+        await visit(`/competences/${scorecard.id}`);
+
+        // then
+        expect(find('.scorecard-details__reset-button')).to.have.lengthOf(0);
+        expect(find('.scorecard-details-content-right__reset-message')).to.have.lengthOf(0);
+      });
+    });
+
+    context('when there are some knowledge elements', () => {
+
+      beforeEach(() => {
+        earnedPix = 13;
+        level = 2;
+        pixScoreAheadOfNextLevel = 5;
+        status = 'STARTED';
+      });
+      it('should display level and score', async () => {
+        // given
+        scorecard = server.create('scorecard', {
+          id: '1_1',
+          name,
+          description,
+          earnedPix,
+          level,
+          pixScoreAheadOfNextLevel,
+          area,
+          status,
+          remainingDaysBeforeReset,
+        });
+
+        // when
+        await visit(`/competences/${scorecard.id}`);
+
+        // then
+        expect(find('.competence-card__level .score-value').text()).to.equal(level.toString());
+        expect(find('.scorecard-details-content-right-score-container__pix-earned .score-value').text()).to.equal(earnedPix.toString());
+        expect(find('.scorecard-details-content-right__level-info').text()).to.contain(`${8 - pixScoreAheadOfNextLevel} pix avant le niveau ${level + 1}`);
+      });
+
+      it('should not display pixScoreAheadOfNextLevel when next level is over the max level', async () => {
+        // given
+        scorecard = server.create('scorecard', {
+          id: '1_1',
+          name: 'Super compétence',
+          earnedPix: 7,
+          level: 999,
+          pixScoreAheadOfNextLevel: 5,
+          area: server.schema.areas.find(1),
+        });
+
+        // when
+        await visit(`/competence/${scorecard.id}`);
+
+        // then
+        expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
+      });
+
+      context('when it is remaining some days before reset', () => {
+
+        beforeEach(() => {
+          remainingDaysBeforeReset = 5;
+        });
+
+        it('should display remaining days before reset', async () => {
+          // given
+          scorecard = server.create('scorecard', {
+            id: '1_1',
+            name,
+            description,
+            earnedPix,
+            level,
+            pixScoreAheadOfNextLevel,
+            area,
+            status,
+            remainingDaysBeforeReset,
+          });
+
+          // when
+          await visit(`/competences/${scorecard.id}`);
+
+          // then
+          expect(find('.scorecard-details-content-right__reset-message').text()).to.contain(`Remise à zéro disponible dans ${remainingDaysBeforeReset} jours`);
+          expect(find('.scorecard-details__reset-button')).to.have.lengthOf(0);
+        });
+      });
+
+      context('when it is not remaining days before reset', () => {
+
+        beforeEach(() => {
+          remainingDaysBeforeReset = 0;
+        });
+
+        it('should display reset button', async () => {
+          // given
+          scorecard = server.create('scorecard', {
+            id: '1_1',
+            name,
+            description,
+            earnedPix,
+            level,
+            pixScoreAheadOfNextLevel,
+            area,
+            status,
+            remainingDaysBeforeReset,
+          });
+
+          // when
+          await visit(`/competences/${scorecard.id}`);
+
+          // then
+          expect(find('.scorecard-details__reset-button').text()).to.contain('Remettre à zéro');
+          expect(find('.scorecard-details-content-right__reset-message')).to.have.lengthOf(0);
+        });
+
+        it('should display popup to validate reset', async () => {
+          // given
+          scorecard = server.create('scorecard', {
+            id: '1_1',
+            name,
+            description,
+            earnedPix,
+            level,
+            pixScoreAheadOfNextLevel,
+            area,
+            status,
+            remainingDaysBeforeReset,
+          });
+          await visit(`/competences/${scorecard.id}`);
+
+          // when
+          await click('.scorecard-details__reset-button');
+
+          // then
+          expect(find('.scorecard-details-reset-modal__important-message').text()).to.contain(`Votre niveau ${level} et vos ${earnedPix} Pix vont être supprimés.`);
+        });
+
+        it('should reset competence when user clicks on reset', async () => {
+          // given
+          scorecard = server.create('scorecard', {
+            id: '1_1',
+            name,
+            description,
+            earnedPix,
+            level,
+            pixScoreAheadOfNextLevel,
+            area,
+            status,
+            remainingDaysBeforeReset,
+            competenceId: 1,
+          });
+          await visit(`/competences/${scorecard.id}`);
+          await click('.scorecard-details__reset-button');
+
+          // when
+          await click('.button--red');
+
+          // then
+          expect(find('.competence-card__level .score-value')).to.have.lengthOf(0);
+          expect(find('.scorecard-details-content-right-score-container__pix-earned .score-value')).to.have.lengthOf(0);
+          expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
+        });
+      });
+    });
+
   });
 
   describe('Not authenticated cases', () => {

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -156,7 +156,7 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.scorecard-details__button')).to.not.exist;
+      expect(this.element.querySelector('.scorecard-details__resume-or-start-button')).to.not.exist;
     });
 
     it('should display a button stating "Commencer" if scorecard.isStarted is false', async function() {
@@ -172,7 +172,7 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
-      const element = this.element.querySelector('.scorecard-details__button');
+      const element = this.element.querySelector('.scorecard-details__resume-or-start-button');
       expect(element).to.exist;
       expect(element.textContent).to.contain('Commencer');
     });
@@ -190,7 +190,7 @@ describe('Integration | Component | scorecard-details', function() {
       await render(hbs`{{scorecard-details scorecard=scorecard}}`);
 
       // then
-      const element = this.element.querySelector('.scorecard-details__button');
+      const element = this.element.querySelector('.scorecard-details__resume-or-start-button');
       expect(element).to.exist;
       expect(element.textContent).to.contain('Reprendre');
     });


### PR DESCRIPTION
## :unicorn: Problème
Un utilisateur de Pix veut pouvoir remettre à zéro toutes ses connaissances sur une compétence donnée.

## :robot: Solution
- Ajout d'un bouton pour pouvoir remettre à zéro une compétence.
- Affichage de ce bouton seulement après 7 jours d'inactivité sur cette compétence (campagnes comprises).
- Ajout d'une popup pour être sûre qu'il veut le faire.
- Appel au endpoint précédemment créé.

## :rainbow: Remarques
Avez-vous des propositions plus satisfaisantes pour l'appel au endpoint ?
