### PR TITLE
[FEATURE] Désactiver l'autocomplétion des QROC et QROCM (PF-627)

### DIFF
--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -10,6 +10,7 @@
            for="qroc_input"
            name={{block.input}}
            placeholder={{block.placeholder}}
+           autocomplete="off"
            value="{{userAnswer}}"
            data-uid="qroc-proposal-uid">
   {{/if}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,14 +1,16 @@
 {{#each _blocks as |block|}}
 
   {{#if block.text}}
-    <span>{{block.text}}</span>
+    <span id="qrocm_input">{{block.text}}</span>
   {{/if}}
 
   {{#if block.input}}
     <input class="challenge-response__proposal-input"
            type="text"
+           for="qrocm_input"
            name={{block.input}}
-             placeholder={{block.placeholder}}
+           placeholder={{block.placeholder}}
+           autocomplete="off"
            value={{property-of answersValue block.input}}>
   {{/if}}
 

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -14,6 +14,20 @@ describe('Integration | Component | QROC proposal', function() {
     expect(this.$()).to.have.lengthOf(1);
   });
 
+  describe('Component behavior when the user clicks on the input:', function() {
+
+    it('should not display autocompletion answers', function() {
+      // given
+      const proposals = '${myInput}';
+      this.set('proposals', proposals);
+      this.set('answerValue', '');
+      // when
+      this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+      // then
+      expect(this.$('.challenge-response__proposal-input').attr('autocomplete')).to.equal('off');
+    });
+  });
+
   describe('Component behavior when user fill input of challenge:', function() {
 
     it('should display a value when a non-empty value is providing by user', function() {

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -15,4 +15,18 @@ describe('Integration | Component | QrocmProposalComponent', function() {
     expect(this.$()).to.have.lengthOf(1);
   });
 
+  describe('Component behavior when the user clicks on the input:', function() {
+
+    it('should not display autocompletion answers', function() {
+      // given
+      const proposals = '${myInput}';
+      this.set('proposals', proposals);
+      this.set('answerValue', '');
+      // when
+      this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+      // then
+      expect(this.$('.challenge-response__proposal-input').attr('autocomplete')).to.equal('off');
+    });
+  });
+
 });


### PR DESCRIPTION
## :mouse: Problème
L'autocomplétion des QROC et QROCM n'est pas désactivé.
![image](https://user-images.githubusercontent.com/4154003/59021630-739be780-884c-11e9-8dac-7b6cac853108.png)

## :cat: Solution
Rajouter `autocomplete="off"` sur les inputs des QROC et QROCM.

## :honeybee: Remarques
J'ai rajouté un élément d'accessibilité manquant sur QROCM.
