### PR TITLE
[TECH] Suppression des usages dépréciés de ember-mocha pour les tests d'intégration.

### DIFF
--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -9,6 +9,7 @@ export default Component.extend({
   answerValue: null,
   proposals: null,
   answerChanged: null,
+  classNames: ['qcm-proposals'],
 
   labeledCheckboxes: computed('proposals', 'answerValue', function() {
     const arrayOfProposals = proposalsAsArray(this.proposals);

--- a/mon-pix/tests/helpers/responsive.js
+++ b/mon-pix/tests/helpers/responsive.js
@@ -1,7 +1,6 @@
 import { A as EmberArray } from '@ember/array';
 import { computed } from '@ember/object';
 import { classify } from '@ember/string';
-import { getOwner } from '@ember/application';
 import MediaService from 'ember-responsive/media';
 import { registerAsyncHelper } from '@ember/test';
 
@@ -51,7 +50,7 @@ export default registerAsyncHelper('setBreakpoint', function(app, breakpoint) {
 });
 
 export function setBreakpointForIntegrationTest(container, breakpoint) {
-  const mediaService = getOwner(container).lookup('service:media');
+  const mediaService = container.owner.lookup('service:media');
   mediaService._forceSetBreakpoint(breakpoint);
   container.set('media', mediaService);
 

--- a/mon-pix/tests/integration/components/campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/campaign-banner-test.js
@@ -1,48 +1,47 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | campaign-banner', function() {
-  setupComponentTest('campaign-banner', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{campaign-banner}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{campaign-banner}}`);
+    expect(find('.campaign-banner')).to.exist;
   });
 
   context('When campaign has a title', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('campaignTitle', 'My campaign');
-      this.render(hbs`{{campaign-banner title=campaignTitle}}`);
+      await render(hbs`{{campaign-banner title=campaignTitle}}`);
     });
 
     it('should render the banner with a title', function() {
-      expect(this.$('.campaign-banner__title')).to.have.length(1);
-      expect(this.$('.campaign-banner__title').text()).to.equal('My campaign');
+      expect(find('.campaign-banner__title')).to.exist;
+      expect(find('.campaign-banner__title').textContent).to.equal('My campaign');
     });
 
     it('should render the banner with a splitter', function() {
-      expect(this.$('.campaign-banner__splitter')).to.have.length(1);
+      expect(find('.campaign-banner__splitter')).to.exist;
     });
 
   });
 
   context('When campaign doesn\'t have a title', function() {
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('campaignTitle', null);
-      this.render(hbs`{{campaign-banner title=campaignTitle}}`);
+      await render(hbs`{{campaign-banner title=campaignTitle}}`);
     });
 
     it('should not render the banner with a title', function() {
-      expect(this.$('.campaign-banner__title')).to.have.length(0);
+      expect(find('.campaign-banner__title')).to.not.exist;
     });
 
     it('should not render the banner with a splitter', function() {
-      expect(this.$('.campaign-banner__splitter')).to.have.length(0);
+      expect(find('.campaign-banner__splitter')).to.not.exist;
     });
 
   });

--- a/mon-pix/tests/integration/components/certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banner-test.js
@@ -1,34 +1,32 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Certification Banner', function() {
 
-  setupComponentTest('certification-banner', {
-    integration: true
-  });
+  setupRenderingTest();
 
   context('On component rendering', function() {
     const fullName = 'shi fu';
     const certificationNumber = 'certification-number';
 
     beforeEach(function() {
-      this.register('service:currentUser', Service.extend({ user: { fullName } }));
-      this.inject.service('currentUser', { as: 'currentUser' });
+      this.owner.register('service:currentUser', Service.extend({ user: { fullName } }));
     });
 
-    it('should render component with user fullName and certificationNumber', function() {
+    it('should render component with user fullName and certificationNumber', async function() {
       // when
       this.set('certificationNumber', certificationNumber);
-      this.render(hbs`{{certification-banner certificationNumber=certificationNumber}}`);
+      await render(hbs`{{certification-banner certificationNumber=certificationNumber}}`);
 
       // then
-      expect(this.$('.certification-banner__container .certification-banner__user-fullname')).to.have.lengthOf(1);
-      expect(this.$('.certification-banner__container .certification-banner__user-fullname').text().trim()).to.equal(fullName);
-      expect(this.$('.certification-banner__container .certification-banner__certification-number')).to.have.lengthOf(1);
-      expect(this.$('.certification-banner__container .certification-banner__certification-number').text().trim()).to.equal(`#${certificationNumber}`);
+      expect(find('.certification-banner__container .certification-banner__user-fullname')).to.exist;
+      expect(find('.certification-banner__container .certification-banner__user-fullname').textContent.trim()).to.equal(fullName);
+      expect(find('.certification-banner__container .certification-banner__certification-number')).to.exist;
+      expect(find('.certification-banner__container .certification-banner__certification-number').textContent.trim()).to.equal(`#${certificationNumber}`);
     });
 
   });

--- a/mon-pix/tests/integration/components/certification-code-validation-test.js
+++ b/mon-pix/tests/integration/components/certification-code-validation-test.js
@@ -1,57 +1,56 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | certification-code-validation', function() {
 
-  setupComponentTest('certification-code-validation', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Error management', () => {
 
-    it('should not display an error message by default', function() {
+    it('should not display an error message by default', async function() {
       // when
-      this.render(hbs`{{certification-code-validation}}`);
+      await render(hbs`{{certification-code-validation}}`);
 
       // then
-      expect(this.$('.certification-course-page__errors')).to.have.length(0);
+      expect(find('.certification-course-page__errors')).to.not.exist;
     });
 
-    it('should display an error message when it exists', function() {
+    it('should display an error message when it exists', async function() {
       // given
       this.set('_errorMessage', 'Un lapin ne peut pas s’enamourer d’une belette :(');
 
       // when
-      this.render(hbs`{{certification-code-validation _errorMessage=_errorMessage}}`);
+      await render(hbs`{{certification-code-validation _errorMessage=_errorMessage}}`);
 
       // then
-      expect(this.$('.certification-course-page__errors')).to.have.length(1);
+      expect(find('.certification-course-page__errors')).to.exist;
     });
   });
 
   describe('Loading management', () => {
 
-    it('should not display any loading spinner by default', function() {
+    it('should not display any loading spinner by default', async function() {
       // when
-      this.render(hbs`{{certification-code-validation}}`);
+      await render(hbs`{{certification-code-validation}}`);
 
       // then
-      expect(this.$('.certification-course-page__field-button__loader-bar')).to.have.length(0);
-      expect(this.$('.certification-course-page__submit_button')).to.have.length(1);
+      expect(find('.certification-course-page__field-button__loader-bar')).to.not.exist;
+      expect(find('.certification-course-page__submit_button')).to.exist;
     });
 
-    it('should display a loading spinner when loading certification', function() {
+    it('should display a loading spinner when loading certification', async function() {
       // given
       this.set('_loadingCertification', true);
 
       // when
-      this.render(hbs`{{certification-code-validation _loadingCertification=_loadingCertification}}`);
+      await render(hbs`{{certification-code-validation _loadingCertification=_loadingCertification}}`);
 
       // then
-      expect(this.$('.certification-course-page__field-button__loader-bar')).to.have.length(1);
-      expect(this.$('.certification-course-page__submit_button')).to.have.length(0);
+      expect(find('.certification-course-page__field-button__loader-bar')).to.exist;
+      expect(find('.certification-course-page__submit_button')).to.not.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/certification-results-page-test.js
+++ b/mon-pix/tests/integration/components/certification-results-page-test.js
@@ -1,14 +1,13 @@
 import { alias } from '@ember/object/computed';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import LinkComponent from '@ember/routing/link-component';
 
 describe('Integration | Component | certification results template', function() {
-  setupComponentTest('certification-results-page', {
-    integration: true
-  });
+  setupRenderingTest();
 
   context('When component is rendered', function() {
     const certificationNumber = 'certification-number';
@@ -17,40 +16,40 @@ describe('Integration | Component | certification results template', function() 
       this.set('certificationNumber', certificationNumber);
     });
 
-    it('should not be able to click on validation button when the verification is unchecked ', function() {
+    it('should not be able to click on validation button when the verification is unchecked ', async function() {
       // when
-      this.render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
 
       // then
-      expect(this.$('.result-content__validation-button')).to.have.lengthOf(0);
-      expect(this.$('.result-content__button-blocked')).to.have.lengthOf(1);
+      expect(find('.result-content__validation-button')).to.not.exist;
+      expect(find('.result-content__button-blocked')).to.exist;
     });
 
-    it('should be able to click on validation when we check to show the last message', function() {
+    it('should be able to click on validation when we check to show the last message', async function() {
       // when
-      this.render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
-      this.$('#validSupervisor').click();
-      this.$('.result-content__validation-button').click();
+      await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      await click('#validSupervisor');
+      await click('.result-content__validation-button');
 
       // then
-      expect(this.$('.result-content__panel-description').text()).to.contains('Vos résultats seront prochainement disponibles depuis votre compte.');
+      expect(find('.result-content__panel-description').textContent).to.contains('Vos résultats seront prochainement disponibles depuis votre compte.');
     });
 
-    it('should have a button to logout at the end of certification', function() {
+    it('should have a button to logout at the end of certification', async function() {
       // given
       LinkComponent.reopen({
         href: alias('qualifiedRouteName')
       });
 
       // when
-      this.render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
-      this.$('#validSupervisor').click();
-      this.$('.result-content__validation-button').click();
+      await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      await click('#validSupervisor');
+      await click('.result-content__validation-button');
 
       // then
-      expect(this.$('.result-content__logout-button')).to.have.lengthOf(1);
-      expect(this.$('.result-content__logout-button').text()).to.equal('Se déconnecter');
-      expect(this.$('.result-content__logout-button').attr('href')).to.equal('logout');
+      expect(find('.result-content__logout-button')).to.exist;
+      expect(find('.result-content__logout-button').textContent).to.equal('Se déconnecter');
+      expect(find('.result-content__logout-button').getAttribute('href')).to.equal('logout');
     });
 
   });

--- a/mon-pix/tests/integration/components/certifications-list-item-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item-test.js
@@ -1,25 +1,23 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { run } from '@ember/runloop';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | certifications list item', function() {
-  setupComponentTest('certifications-list-item', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   let certification;
 
-  it('renders', function() {
-    this.render(hbs`{{certifications-list-item certification=certification}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{certifications-list-item certification=certification}}`);
+    expect(find('.certifications-list-item__row-presentation')).to.exist;
   });
 
   context('when the certification is not published', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -32,24 +30,24 @@ describe('Integration | Component | certifications list item', function() {
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{certifications-list-item certification=certification}}`);
+      await render(hbs`{{certifications-list-item certification=certification}}`);
     });
 
     // then
     it('should render a certifications-list-item__unpublished-item div', function() {
-      expect(this.$('.certifications-list-item__unpublished-item')).to.have.lengthOf(1);
+      expect(find('.certifications-list-item__unpublished-item')).to.exist;
     });
 
     it('should show en attente de résultat', function() {
-      expect(this.$('img.certifications-list-item__hourglass-img')).to.have.lengthOf(1);
-      expect(this.$('.certifications-list-item').text()).to.include('En attente du résultat');
+      expect(find('img.certifications-list-item__hourglass-img')).to.exist;
+      expect(find('.certifications-list-item').textContent).to.include('En attente du résultat');
     });
   });
 
   context('when the certification is published and rejected', function() {
 
     context('without commentForCandidate', function() {
-      beforeEach(function() {
+      beforeEach(async function() {
         // given
         certification = EmberObject.create({
           id: 1,
@@ -63,28 +61,28 @@ describe('Integration | Component | certifications list item', function() {
         this.set('certification', certification);
 
         // when
-        this.render(hbs`{{certifications-list-item certification=certification}}`);
+        await render(hbs`{{certifications-list-item certification=certification}}`);
       });
 
       // then
       it('should render a certifications-list-item__published-item div', function() {
-        expect(this.$('.certifications-list-item__published-item')).to.have.lengthOf(1);
+        expect(find('.certifications-list-item__published-item')).to.exist;
       });
 
       it('should show Certification non obtenue', function() {
-        expect(this.$('img.certifications-list-item__cross-img')).to.have.lengthOf(1);
-        expect(this.$('.certifications-list-item').text()).to.include('Certification non obtenue');
+        expect(find('img.certifications-list-item__cross-img')).to.exist;
+        expect(find('.certifications-list-item').textContent).to.include('Certification non obtenue');
       });
 
       it('should not show Détail in last column', function() {
-        expect(this.$('.certifications-list-item__cell-detail-button')).to.have.lengthOf(0);
+        expect(find('.certifications-list-item__cell-detail-button')).to.not.exist;
       });
 
       it('should not show comment for candidate panel when clicked on row', async function() {
 
-        run(() => document.querySelector(('.certifications-list-item__cell')).click());
+        await click('.certifications-list-item__cell');
 
-        expect(this.$('.certifications-list-item__row-comment-cell')).to.have.lengthOf(0);
+        expect(find('.certifications-list-item__row-comment-cell')).to.not.exist;
       });
     });
 
@@ -92,7 +90,7 @@ describe('Integration | Component | certifications list item', function() {
 
       const commentForCandidate = 'Commentaire pour le candidat';
 
-      beforeEach(function() {
+      beforeEach(async function() {
         // given
         certification = EmberObject.create({
           id: 1,
@@ -106,37 +104,37 @@ describe('Integration | Component | certifications list item', function() {
         this.set('certification', certification);
 
         // when
-        this.render(hbs`{{certifications-list-item certification=certification}}`);
+        await render(hbs`{{certifications-list-item certification=certification}}`);
       });
 
       // then
       it('should render a certifications-list-item__published-item div', function() {
-        expect(this.$('.certifications-list-item__published-item')).to.have.lengthOf(1);
+        expect(find('.certifications-list-item__published-item')).to.exist;
       });
 
       it('should show Certification non obtenue', function() {
-        expect(this.$('img.certifications-list-item__cross-img')).to.have.lengthOf(1);
-        expect(this.$('.certifications-list-item').text()).to.include('Certification non obtenue');
+        expect(find('img.certifications-list-item__cross-img')).to.exist;
+        expect(find('.certifications-list-item').textContent).to.include('Certification non obtenue');
       });
 
       it('should show Détail in last column', function() {
-        expect(this.$('.certifications-list-item__cell-detail-button')).to.have.lengthOf(1);
-        expect(this.$('.certifications-list-item__cell-detail-button').text()).to.include('DÉTAIL');
+        expect(find('.certifications-list-item__cell-detail-button')).to.exist;
+        expect(find('.certifications-list-item__cell-detail-button').textContent).to.include('DÉTAIL');
       });
 
       it('should show comment for candidate panel when clicked on row', async function() {
 
-        run(() => document.querySelector(('.certifications-list-item__cell')).click());
+        await click('.certifications-list-item__cell');
 
-        expect(this.$('.certifications-list-item__row-comment-cell')).to.have.lengthOf(1);
-        expect(this.$('.certifications-list-item__row-comment-cell').text()).to.include(commentForCandidate);
+        expect(find('.certifications-list-item__row-comment-cell')).to.exist;
+        expect(find('.certifications-list-item__row-comment-cell').textContent).to.include(commentForCandidate);
       });
     });
   });
 
   context('when the certification is published and validated', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -149,27 +147,27 @@ describe('Integration | Component | certifications list item', function() {
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{certifications-list-item certification=certification}}`);
+      await render(hbs`{{certifications-list-item certification=certification}}`);
     });
 
     // then
     it('should render certifications-list-item__published-item with a link inside', function() {
-      expect(this.$('.certifications-list-item__published-item a')).to.have.lengthOf(1);
+      expect(find('.certifications-list-item__published-item a')).to.exist;
     });
 
     it('should show Certification obtenue', function() {
-      expect(this.$('img.certifications-list-item__green-check-img')).to.have.lengthOf(1);
-      expect(this.$('.certifications-list-item').text()).to.include('Certification obtenue');
+      expect(find('img.certifications-list-item__green-check-img')).to.exist;
+      expect(find('.certifications-list-item').textContent).to.include('Certification obtenue');
     });
 
     it('should show the Pix Score', function() {
-      expect(this.$('.certifications-list-item__pix-score')).to.have.lengthOf(1);
-      expect(this.$('.certifications-list-item__pix-score').text()).to.include('231');
+      expect(find('.certifications-list-item__pix-score')).to.exist;
+      expect(find('.certifications-list-item__pix-score').textContent).to.include('231');
     });
 
     it('should show link to certification page in last column', function() {
-      expect(this.$('.certifications-list-item__cell-detail-link')).to.have.lengthOf(1);
-      expect(this.$('.certifications-list-item__cell-detail-link').text()).to.include('RÉSULTATS');
+      expect(find('.certifications-list-item__cell-detail-link')).to.exist;
+      expect(find('.certifications-list-item__cell-detail-link').textContent).to.include('RÉSULTATS');
     });
   });
 });

--- a/mon-pix/tests/integration/components/certifications-list-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-test.js
@@ -1,17 +1,16 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | certifications list', function() {
-  setupComponentTest('certifications-list', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{certifications-list}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{certifications-list}}`);
+    expect(find('.certifications-list__table')).to.exist;
   });
 
   context('when there is some completed certifications', function() {
@@ -33,15 +32,15 @@ describe('Integration | Component | certifications list', function() {
       pixScore: 231
     });
 
-    it('should render two certification items when there is 2 completed certifications', function() {
+    it('should render two certification items when there is 2 completed certifications', async function() {
       const completedCertifications = [certification1, certification2];
       this.set('certifications', completedCertifications);
 
       // when
-      this.render(hbs`{{certifications-list certifications=certifications}}`);
+      await render(hbs`{{certifications-list certifications=certifications}}`);
 
       // then
-      expect(this.$('.certifications-list__table-body .certifications-list-item')).to.have.lengthOf(2);
+      expect(findAll('.certifications-list__table-body .certifications-list-item').length).to.equal(2);
     });
   });
 });

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -1,7 +1,8 @@
 import RSVP from 'rsvp';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const VALIDATE_BUTTON = '.challenge-actions__action-validate';
@@ -9,79 +10,77 @@ const SKIP_BUTTON = '.challenge-actions__action-skip';
 
 describe('Integration | Component | challenge actions', function() {
 
-  setupComponentTest('challenge-actions', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{challenge-actions}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{challenge-actions}}`);
+    expect(find('.challenge-actions__action')).to.exist;
   });
 
   describe('Validate button (and placeholding loader)', function() {
 
-    it('should be displayed and enabled by default but not loader', function() {
+    it('should be displayed and enabled by default but not loader', async function() {
       // when
       this.set('isValidateButtonEnabled', true);
+      this.set('isSkipButtonEnabled', true);
       this.set('externalAction', () => {});
-      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction) isValidateButtonEnabled=isValidateButtonEnabled}}`);
+      await render(hbs`{{challenge-actions validateAnswer=(action externalAction) isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled}}`);
+
       // then
-      expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(1);
-      expect(this.$('.challenge-actions__action-validate__loader-bar')).to.have.lengthOf(0);
+      expect(find(VALIDATE_BUTTON)).to.exist;
+      expect(find('.challenge-actions__action-validate__loader-bar')).to.not.exist;
     });
 
-    it('should be replaced by a loader during treatment', function() {
+    it('should be replaced by a loader during treatment', async function() {
       // given
+      this.set('isValidateButtonEnabled', false);
+      this.set('isSkipButtonEnabled', true);
       this.set('externalAction', () => {});
-      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction)}}`);
-
-      // when
-      this.$(VALIDATE_BUTTON).click();
+      await render(hbs`{{challenge-actions validateAnswer=(action externalAction) isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled}}`);
 
       // then
-      expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(0);
-      expect(this.$('.challenge-actions__action-validate__loader-bar')).to.have.lengthOf(1);
+      expect(find(VALIDATE_BUTTON)).to.not.exist;
+      expect(find('.challenge-actions__action-validate__loader-bar')).to.exist;
     });
 
-    it('should be enabled again when the treatment failed', function() {
+    it('should be enabled again when the treatment failed', async function() {
       // given
       this.set('isValidateButtonEnabled', true);
       this.set('isSkipButtonEnabled', true);
       this.set('externalAction', () => RSVP.reject('Some error').catch(() => null));
       this.set('externalAction2', () => {});
-      this.render(hbs`{{challenge-actions validateAnswer=(action externalAction) skipChallenge=(action externalAction2) isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled}}`);
+      await render(hbs`{{challenge-actions validateAnswer=(action externalAction) skipChallenge=(action externalAction2) isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled}}`);
 
       // when
-      this.$(VALIDATE_BUTTON).click();
-      
+      await click(VALIDATE_BUTTON);
+
       // then
-      expect(this.$(VALIDATE_BUTTON)).to.have.lengthOf(1);
-      expect(this.$('.challenge-actions__action-skip__loader-bar')).to.have.lengthOf(0);
+      expect(find(VALIDATE_BUTTON)).to.exist;
+      expect(find('.challenge-actions__action-skip__loader-bar')).to.not.exist;
     });
   });
 
   describe('Skip button', function() {
 
-    it('should be displayed and enabled by default', function() {
+    it('should be displayed and enabled by default', async function() {
       // when
       this.set('isSkipButtonEnabled', true);
       this.set('externalAction', () => {});
-      this.render(hbs`{{challenge-actions skipChallenge=(action externalAction) isSkipButtonEnabled=isSkipButtonEnabled}}`);
+      await render(hbs`{{challenge-actions skipChallenge=(action externalAction) isSkipButtonEnabled=isSkipButtonEnabled}}`);
       // then
-      expect(this.$(SKIP_BUTTON)).to.have.lengthOf(1);
+      expect(find(SKIP_BUTTON)).to.exist;
     });
 
-    it('should be replaced by a loader during treatment', function() {
+    it('should be replaced by a loader during treatment', async function() {
       // given
+      this.set('isValidateButtonEnabled', true);
+      this.set('isSkipButtonEnabled', false);
       this.set('externalAction', () => {});
-      this.render(hbs`{{challenge-actions skipChallenge=(action externalAction)}}`);
-
-      // when
-      this.$(SKIP_BUTTON).click();
+      await render(hbs`{{challenge-actions skipChallenge=(action externalAction)}} isValidateButtonEnabled=isValidateButtonEnabled isSkipButtonEnabled=isSkipButtonEnabled`);
 
       // then
-      expect(this.$(SKIP_BUTTON)).to.have.lengthOf(0);
-      expect(this.$('.challenge-actions__action-skip__loader-bar')).to.have.lengthOf(1);
+      expect(find(SKIP_BUTTON)).to.not.exist;
+      expect(find('.challenge-actions__action-skip__loader-bar')).to.exist;
     });
 
   });

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -1,78 +1,73 @@
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import { run } from '@ember/runloop';
+import { describe, it, beforeEach } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, findAll, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | challenge embed simulator', function() {
 
-  setupComponentTest('challenge-embed-simulator', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Aknowledgment overlay', function() {
 
-    it('should be displayed when component has just been rendered', function() {
+    it('should be displayed when component has just been rendered', async function() {
       // when
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(this.$('.challenge-embed-simulator__aknowledgment-overlay')).to.have.lengthOf(1);
+      expect(find('.challenge-embed-simulator__aknowledgment-overlay')).to.exist;
     });
 
-    it('should contain a button to launch the simulator', function() {
+    it('should contain a button to launch the simulator', async function() {
       // when
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      const $launchSimulatorButton = this.$('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button');
-      expect($launchSimulatorButton).to.have.lengthOf(1);
+      expect(find('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button')).to.exist;
     });
   });
 
   describe('Launch simulator button', () => {
 
-    it('should have text "Je lance le simulateur"', function() {
+    it('should have text "Je lance le simulateur"', async function() {
       // when
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      const $launchSimulatorButton = this.$('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button');
-      expect($launchSimulatorButton.text().trim()).to.equal('Je lance l’application');
+      expect(find('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button').textContent).to.equal('Je lance l’application');
     });
 
     it('should close the aknowledgment overlay when clicked', async function() {
       // given
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // when
-      run(() => document.querySelector('.challenge-embed-simulator__launch-simulator-button').click());
+      await click('.challenge-embed-simulator__launch-simulator-button');
 
       // then
-      expect(this.$('.challenge-embed-simulator__aknowledgment-overlay')).to.have.lengthOf(0);
+      expect(find('.challenge-embed-simulator__aknowledgment-overlay')).to.not.exist;
     });
   });
 
   describe('Reload simulator button', () => {
 
-    it('should have text "Recharger le simulateur"', function() {
+    it('should have text "Recharger le simulateur"', async function() {
       // when
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      const $reloadSimulatorButton = this.$('.challenge-embed-simulator__reload-button');
-      expect($reloadSimulatorButton.text().trim()).to.equal('Recharger l’application');
+      expect(find('.challenge-embed-simulator__reload-button').textContent).to.equal('Recharger l’application');
     });
 
     it('should reload simulator when user clicked on button reload', async function() {
       // given
       const stubReloadSimulator = sinon.stub();
       this.set('stubReloadSimulator', stubReloadSimulator);
-      this.render(hbs`{{challenge-embed-simulator _reloadSimulator=stubReloadSimulator}}`);
+      await render(hbs`{{challenge-embed-simulator _reloadSimulator=stubReloadSimulator}}`);
 
       // when
-      run(() => document.querySelector('.challenge-embed-simulator__reload-button').click());
+      await click('.challenge-embed-simulator__reload-button');
 
       // then
       sinon.assert.calledOnce(stubReloadSimulator);
@@ -81,25 +76,23 @@ describe('Integration | Component | challenge embed simulator', function() {
 
   describe('Blur effect on simulator panel', function() {
 
-    it('should be active when component is first rendered', function() {
+    it('should be active when component is first rendered', async function() {
       // when
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      const $simulator = this.$('.challenge-embed-simulator__simulator')[0];
-      expect($simulator.classList.contains('blurred')).to.be.true;
+      expect(findAll('.challenge-embed-simulator__simulator')[0].classList.contains('blurred')).to.be.true;
     });
 
-    it('should be removed when simulator was launched', function() {
+    it('should be removed when simulator was launched', async function() {
       // given
-      this.render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`{{challenge-embed-simulator}}`);
 
       // when
-      run(() => document.querySelector('.challenge-embed-simulator__launch-simulator-button').click());
+      await click('.challenge-embed-simulator__launch-simulator-button');
 
       // then
-      const $simulator = this.$('.challenge-embed-simulator__simulator')[0];
-      expect($simulator.classList.contains('blurred')).to.be.false;
+      expect(findAll('.challenge-embed-simulator__simulator')[0].classList.contains('blurred')).to.be.false;
     });
   });
 
@@ -111,26 +104,26 @@ describe('Integration | Component | challenge embed simulator', function() {
       height: 200
     };
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       this.set('embedDocument', embedDocument);
 
       // when
-      this.render(hbs`{{challenge-embed-simulator embedDocument=embedDocument}}`);
+      await render(hbs`{{challenge-embed-simulator embedDocument=embedDocument}}`);
 
       // then
     });
 
     it('should have an height that is the one defined in the referential', function() {
-      expect(this.$('.challenge-embed-simulator')[0].style.cssText).to.equal('height: 200px;');
+      expect(findAll('.challenge-embed-simulator')[0].style.cssText).to.equal('height: 200px;');
     });
 
     it('should define a title attribute on the iframe element that is the one defined in the referential for field "Embed title"', function() {
-      expect(this.$('.challenge-embed-simulator__iframe')[0].title).to.equal('Embed simulator');
+      expect(findAll('.challenge-embed-simulator__iframe')[0].title).to.equal('Embed simulator');
     });
 
     it('should define a src attribute on the iframe element that is the one defined in the referential for field "Embed URL"', function() {
-      expect(this.$('.challenge-embed-simulator__iframe')[0].src).to.equal('http://embed-simulator.url/');
+      expect(findAll('.challenge-embed-simulator__iframe')[0].src).to.equal('http://embed-simulator.url/');
     });
   });
 

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -1,14 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 describe('Integration | Component | ChallengeStatement', function() {
 
-  setupComponentTest('challenge-statement', {
-    integration: true
-  });
+  setupRenderingTest();
 
   function addChallengeToContext(component, challenge) {
     component.set('challenge', challenge);
@@ -18,8 +17,8 @@ describe('Integration | Component | ChallengeStatement', function() {
     component.set('assessment', assessment);
   }
 
-  function renderChallengeStatement(component) {
-    return component.render(hbs`{{challenge-statement challenge=challenge assessment=assessment}}`);
+  function renderChallengeStatement() {
+    return render(hbs`{{challenge-statement challenge=challenge assessment=assessment}}`);
   }
 
   /*
@@ -41,31 +40,31 @@ describe('Integration | Component | ChallengeStatement', function() {
     });
 
     // Inspired from: https://github.com/emberjs/ember-mocha/blob/0790a78d7464655fee0c103d2fa960fa53a056ca/tests/setup-component-test-test.js#L118-L122
-    it('should render challenge instruction if it exists', function() {
+    it('should render challenge instruction if it exists', async function() {
       // given
       addChallengeToContext(this, {
         instruction: 'La consigne de mon test'
       });
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-statement__instruction').text().trim()).to.equal('La consigne de mon test');
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal('La consigne de mon test');
     });
 
-    it('should not render challenge instruction if it does not exist', function() {
+    it('should not render challenge instruction if it does not exist', async function() {
       // given
       addChallengeToContext(this, {});
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-statement__instruction')).to.have.lengthOf(0);
+      expect(find('.challenge-statement__instruction')).to.not.exist;
     });
 
-    it('should replace ${EMAIL} by a generated email', function() {
+    it('should replace ${EMAIL} by a generated email', async function() {
       // given
       addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {
@@ -74,10 +73,10 @@ describe('Integration | Component | ChallengeStatement', function() {
       });
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-statement__instruction').text().trim())
+      expect(find('.challenge-statement__instruction').textContent.trim())
         .to.equal('Veuillez envoyer un email à l\'adresse recigAYl5bl96WGXj-267845-0502@pix-infra.ovh pour valider cette épreuve');
     });
   });
@@ -88,30 +87,29 @@ describe('Integration | Component | ChallengeStatement', function() {
    */
 
   describe('Illustration section', function() {
-    it('should display challenge illustration (and alt) if it exists', function() {
+    it('should display challenge illustration (and alt) if it exists', async function() {
       // given
       addChallengeToContext(this, {
         illustrationUrl: '/images/pix-logo.svg'
       });
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      const $illustration = this.$('.challenge-statement__illustration');
-      expect($illustration.prop('src')).to.match(/\/images\/pix-logo.svg$/);
-      expect($illustration.prop('alt')).to.equal('Illustration de l\'épreuve');
+      expect(find('.challenge-statement__illustration').src).to.match(/\/images\/pix-logo.svg$/);
+      expect(find('.challenge-statement__illustration').alt).to.equal('Illustration de l\'épreuve');
     });
 
-    it('should not display challenge illustration if it does not exist', function() {
+    it('should not display challenge illustration if it does not exist', async function() {
       // given
       addChallengeToContext(this, {});
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-statement__illustration')).to.have.lengthOf(0);
+      expect(find('.challenge-statement__illustration')).to.not.exist;
     });
   });
 
@@ -124,23 +122,23 @@ describe('Integration | Component | ChallengeStatement', function() {
 
     describe('if challenge has no file', function() {
 
-      it('should not display attachements section', function() {
+      it('should not display attachements section', async function() {
         addChallengeToContext(this, {
           attachments: [],
           hasAttachment: false
         });
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        expect(this.$('.challenge-statement__attachments-section')).to.have.lengthOf(0);
+        expect(find('.challenge-statement__attachments-section')).to.not.exist;
       });
     });
 
     describe('if challenge has only one file', function() {
 
-      it('should display only one link button', function() {
+      it('should display only one link button', async function() {
         // given
         addChallengeToContext(this, {
           attachments: ['http://challenge.file.url'],
@@ -150,12 +148,11 @@ describe('Integration | Component | ChallengeStatement', function() {
         });
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        const $downloadLink = this.$('.challenge-statement__action-link');
-        expect($downloadLink).to.have.lengthOf(1);
-        expect($downloadLink.prop('href')).to.equal('http://challenge.file.url/');
+        expect(find('.challenge-statement__action-link')).to.exist;
+        expect(find('.challenge-statement__action-link').href).to.equal('http://challenge.file.url/');
       });
 
     });
@@ -180,78 +177,74 @@ describe('Integration | Component | ChallengeStatement', function() {
         attachments: ['http://dl.airtable.com/EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt', 'http://dl.airtable.com/VGAwZSilQji6Spm9C9Tf_PIX_parchemin.odp']
       };
 
-      it('should display as many radio button as attachments', function() {
+      it('should display as many radio button as attachments', async function() {
         // given
         addChallengeToContext(this, challenge);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        expect(this.$('.challenge-statement__file-option_input')).to.have.lengthOf(challenge.attachments.length);
+        expect(findAll('.challenge-statement__file-option_input')).to.have.lengthOf(challenge.attachments.length);
       });
 
-      it('should display radio buttons with right label', function() {
+      it('should display radio buttons with right label', async function() {
         // given
         addChallengeToContext(this, challenge);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        expect(this.$('.challenge-statement__file-option-label').get(0).textContent.trim()).to.equal('fichier .docx');
-        expect(this.$('.challenge-statement__file-option-label').get(1).textContent.trim()).to.equal('fichier .odt');
+        expect(findAll('.challenge-statement__file-option-label')[0].textContent.trim()).to.equal('fichier .docx');
+        expect(findAll('.challenge-statement__file-option-label')[1].textContent.trim()).to.equal('fichier .odt');
 
       });
 
-      it('should select first attachment as default selected radio buton', function() {
+      it('should select first attachment as default selected radio button', async function() {
         // given
         addChallengeToContext(this, challenge);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        const $firstRadioButton = this.$('.challenge-statement__file-option_input')[0];
-        const $secondRadioButton = this.$('.challenge-statement__file-option_input')[1];
-        expect($firstRadioButton.checked).to.be.true;
-        expect($secondRadioButton.checked).to.be.false;
+        expect(findAll('.challenge-statement__file-option_input')[0].checked).to.be.true;
+        expect(findAll('.challenge-statement__file-option_input')[1].checked).to.be.false;
       });
 
-      it('should select first attachment as default selected radio button', function() {
+      it('should select first attachment as default selected radio button when QROC', async function() {
         // given
         addChallengeToContext(this, challengeQROC);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        const $firstRadioButton = this.$('.challenge-statement__file-option_input')[0];
-        const $secondRadioButton = this.$('.challenge-statement__file-option_input')[1];
-        expect($firstRadioButton.checked).to.be.true;
-        expect($secondRadioButton.checked).to.be.false;
+        expect(findAll('.challenge-statement__file-option_input')[0].checked).to.be.true;
+        expect(findAll('.challenge-statement__file-option_input')[1].checked).to.be.false;
       });
 
-      it('should display attachements paragraph text', function() {
+      it('should display attachements paragraph text', async function() {
         // given
         addChallengeToContext(this, challenge);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        expect(this.$('.challenge-statement__text-content').text().trim()).to.equal('Choisissez le type de fichier que vous voulez utiliser');
+        expect(find('.challenge-statement__text-content').textContent.trim()).to.equal('Choisissez le type de fichier que vous voulez utiliser');
       });
 
-      it('should display help icon next to attachements paragraph', function() {
+      it('should display help icon next to attachements paragraph', async function() {
         // given
         addChallengeToContext(this, challenge);
 
         // when
-        renderChallengeStatement(this);
+        await renderChallengeStatement();
 
         // then
-        expect(this.$('.challenge-statement__help-icon')).to.have.lengthOf(1);
+        expect(find('.challenge-statement__help-icon')).to.exist;
       });
 
     });
@@ -265,26 +258,26 @@ describe('Integration | Component | ChallengeStatement', function() {
 
   describe('Embed simulator section:', function() {
 
-    it('should be displayed when the challenge has a valid Embed object', function() {
+    it('should be displayed when the challenge has a valid Embed object', async function() {
       // given
       addChallengeToContext(this, { hasValidEmbedDocument: true });
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-embed-simulator')).to.have.lengthOf(1);
+      expect(find('.challenge-embed-simulator')).to.exist;
     });
 
-    it('should not be displayed when the challenge does not have a valid Embed object', function() {
+    it('should not be displayed when the challenge does not have a valid Embed object', async function() {
       // given
       addChallengeToContext(this, { hasValidEmbedDocument: false });
 
       // when
-      renderChallengeStatement(this);
+      await renderChallengeStatement();
 
       // then
-      expect(this.$('.challenge-embed-simulator')).to.have.lengthOf(0);
+      expect(find('.challenge-embed-simulator')).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/checkpoint-continue-test.js
+++ b/mon-pix/tests/integration/components/checkpoint-continue-test.js
@@ -1,15 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | checkpoint-continue', function() {
-  setupComponentTest('checkpoint-continue', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{checkpoint-continue}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{checkpoint-continue}}`);
+    expect(find('.checkpoint__continue')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -1,7 +1,8 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const FEEDBACK_FORM = '.feedback-panel__view--form';
@@ -9,9 +10,7 @@ const LINK_OPEN_FORM = '.feedback-panel__view--link';
 
 describe('Integration | Component | comparison-window', function() {
 
-  setupComponentTest('comparison-window', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('rendering', function() {
 
@@ -41,78 +40,78 @@ describe('Integration | Component | comparison-window', function() {
       this.set('closeComparisonWindow', () => {});
     });
 
-    it('renders', function() {
+    it('renders', async function() {
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.pix-modal-overlay')).to.exist;
     });
 
-    it('should render challenge result in the header', function() {
+    it('should render challenge result in the header', async function() {
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(document.querySelectorAll('.comparison-window-header')).to.have.lengthOf(1);
-      expect(document.querySelectorAll('.comparison-window__result-icon')).to.have.lengthOf(1);
+      expect(find('.comparison-window-header')).to.exist;
+      expect(find('.comparison-window__result-icon')).to.exist;
     });
 
-    it('should render challenge instruction', function() {
+    it('should render challenge instruction', async function() {
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(document.querySelectorAll('.comparison-window__instruction')).to.have.lengthOf(1);
+      expect(find('.comparison-window__instruction')).to.exist;
     });
 
-    it('should not render corrected answers when challenge has no type', function() {
+    it('should not render corrected answers when challenge has no type', async function() {
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
       // then
-      expect(document.querySelectorAll('.comparison-window__corrected-answers--qroc')).to.have.lengthOf(0);
+      expect(find('.comparison-window__corrected-answers--qroc')).to.not.exist;
     });
 
-    it('should render corrected answers when challenge type is QROC', function() {
+    it('should render corrected answers when challenge type is QROC', async function() {
       // given
       challenge = EmberObject.create({ type: 'QROC' });
       answer.set('challenge', challenge);
 
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(document.querySelectorAll('.comparison-window__corrected-answers--qroc')).to.have.lengthOf(1);
+      expect(find('.comparison-window__corrected-answers--qroc')).to.exist;
     });
 
-    it('should render corrected answers when challenge type is QROCM-ind', function() {
+    it('should render corrected answers when challenge type is QROCM-ind', async function() {
       // given
       challenge = EmberObject.create({ type: 'QROCM-ind', proposals: '' });
       correction.set('solution',  '');
       answer.set('challenge', challenge);
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
       // then
-      expect(document.querySelectorAll('.comparison-window__corrected-answers--qrocm')).to.have.lengthOf(1);
+      expect(find('.comparison-window__corrected-answers--qrocm')).to.exist;
     });
 
-    it('should render corrected answers when challenge type is QCM', function() {
+    it('should render corrected answers when challenge type is QCM', async function() {
       // given
       challenge = EmberObject.create({ type: 'QCM' });
       answer.set('challenge', challenge);
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
       // then
-      expect(document.querySelectorAll('.qcm-solution-panel')).to.have.lengthOf(1);
+      expect(find('.qcm-solution-panel')).to.exist;
     });
 
-    it('should render a feedback panel already opened', function() {
+    it('should render a feedback panel already opened',async  function() {
       //when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
       //then
-      expect(document.querySelectorAll('.comparison-window__feedback-panel')).to.have.lengthOf(1);
-      expect(document.querySelectorAll(FEEDBACK_FORM)).to.have.lengthOf(1);
-      expect(document.querySelectorAll(LINK_OPEN_FORM)).to.have.lengthOf(0);
+      expect(find('.comparison-window__feedback-panel')).to.exist;
+      expect(find(FEEDBACK_FORM)).to.exist;
+      expect(find(LINK_OPEN_FORM)).to.not.exist;
     });
 
     [
@@ -124,7 +123,7 @@ describe('Integration | Component | comparison-window', function() {
       { status: 'default' }
     ].forEach(function(data) {
 
-      it(`should display the good icon in title when answer's result is "${data.status}"`, function() {
+      it(`should display the good icon in title when answer's result is "${data.status}"`, async function() {
         // given
         answer.setProperties({
           result: data.status,
@@ -132,42 +131,41 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
         // then
-        const $icon = document.querySelector('.comparison-window__result-icon');
-        expect(document.querySelectorAll(`.comparison-window__result-icon--${data.status}`)).to.have.lengthOf(1);
-        expect($icon.src).to.have.string(`/images/answer-validation/icon-${data.status}.svg`);
+        expect(find(`.comparison-window__result-icon--${data.status}`)).to.exist;
+        expect(find('.comparison-window__result-icon').src).to.have.string(`/images/answer-validation/icon-${data.status}.svg`);
       });
     });
 
-    it('should render a tutorial panel with a hint', function() {
+    it('should render a tutorial panel with a hint', async function() {
       // given
       answer.set('result', 'ko');
       correction.set('hint', 'Conseil : mangez des épinards.');
 
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(document.querySelector('.tutorial-panel')).to.contain.text('Conseil : mangez des épinards.');
+      expect(find('.tutorial-panel')).to.contain.text('Conseil : mangez des épinards.');
     });
 
-    it('should render a learningMoreTutorials panel when correction has a list of LearningMoreTutorials elements', function() {
+    it('should render a learningMoreTutorials panel when correction has a list of LearningMoreTutorials elements', async function() {
       // given
       correction.setProperties({
         learningMoreTutorials: [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }],
       });
 
       // when
-      this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
       // then
-      expect(document.querySelectorAll('.learning-more-panel__container')).to.have.lengthOf(1);
+      expect(find('.learning-more-panel__container')).to.exist;
     });
 
     context('when the answer is OK', () => {
-      it('should neither display “Bientot ici des tutos“ nor hints nor any tutorials', function() {
+      it('should neither display “Bientot ici des tutos“ nor hints nor any tutorials', async function() {
         // given
         answer.setProperties({
           result: 'ok',
@@ -175,17 +173,17 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
         // then
-        expect(document.querySelectorAll('.tutorial-panel')).to.have.lengthOf(0);
-        expect(document.querySelectorAll('.learning-more-panel__container')).to.have.lengthOf(0);
-        expect(document.querySelectorAll('.comparison-window__default-message-container')).to.have.lengthOf(0);
+        expect(find('.tutorial-panel')).to.not.exist;
+        expect(find('.learning-more-panel__container')).to.not.exist;
+        expect(find('.comparison-window__default-message-container')).to.not.exist;
       });
     });
 
     context('the correction has no hints nor tutoriasl at all', function() {
-      it('should render “Bientot des tutos”', function() {
+      it('should render “Bientot des tutos”', async function() {
         // given
         correction.setProperties({
           solution: '2,3',
@@ -193,30 +191,30 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
         // then
-        expect(document.querySelectorAll('.comparison-windows__default-message-container')).to.have.lengthOf(1);
-        expect(document.querySelectorAll('.comparison-windows__default-message-title')).to.have.lengthOf(1);
-        expect(document.querySelectorAll('.comparison-windows__default-message-picto-container')).to.have.lengthOf(1);
-        expect(document.querySelectorAll('.comparison-windows__default-message-picto')).to.have.lengthOf(1);
+        expect(find('.comparison-windows__default-message-container')).to.exist;
+        expect(find('.comparison-windows__default-message-title')).to.exist;
+        expect(find('.comparison-windows__default-message-picto-container')).to.exist;
+        expect(find('.comparison-windows__default-message-picto')).to.exist;
       });
     });
 
     context('when the correction has a hint or a tutorial or a learninMoreTutorial', function() {
-      it('should not render a hint or a tutorial', function() {
+      it('should not render a hint or a tutorial', async function() {
         // given
         correction.setProperties({
           learningMoreTutorials: [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }],
         });
 
         // when
-        this.render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
 
         // then
-        expect(document.querySelectorAll('.tutorial-panel')).to.have.lengthOf(1);
-        expect(document.querySelectorAll('.tutorial-panel__hint-container')).to.have.lengthOf(0);
-        expect(document.querySelectorAll('.tutorial-panel__tutorial-item')).to.have.lengthOf(0);
+        expect(find('.tutorial-panel')).to.exist;
+        expect(find('.tutorial-panel__hint-container')).to.not.exist;
+        expect(find('.tutorial-panel__tutorial-item')).to.not.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/competence-area-list-test.js
+++ b/mon-pix/tests/integration/components/competence-area-list-test.js
@@ -1,35 +1,34 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence area list', function() {
-  setupComponentTest('competence-area-list', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Component rendering', function() {
-    it('renders', function() {
+    it('renders', async function() {
       // when
-      this.render(hbs`{{competence-area-list}}`);
+      await render(hbs`{{competence-area-list}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.competence-area-list')).to.exist;
     });
 
-    it('should render a wrapper', function() {
+    it('should render a wrapper', async function() {
       // when
-      this.render(hbs`{{competence-area-list}}`);
+      await render(hbs`{{competence-area-list}}`);
 
       // then
       const WRAPPER_CLASS = '.competence-area-list';
-      expect(this.$(WRAPPER_CLASS)).to.have.lengthOf(1);
+      expect(find(WRAPPER_CLASS)).to.exist;
     });
 
     describe('Rendering when different areas', function() {
 
-      it('should render 5 competence areas, when there are 5 competences with different area for each one', function() {
+      it('should render 5 competence areas, when there are 5 competences with different area for each one', async function() {
         // given
         const competencesWithDifferentAreas = [
           EmberObject.create({ id: 1, name: 'competence-1', areaName: 'area-A' }),
@@ -41,13 +40,13 @@ describe('Integration | Component | competence area list', function() {
         this.set('competences', competencesWithDifferentAreas);
 
         // when
-        this.render(hbs`{{competence-area-list competences=competences}}`);
+        await render(hbs`{{competence-area-list competences=competences}}`);
 
         // then
-        expect(this.$('.competence-area-list__item')).to.have.lengthOf(5);
+        expect(findAll('.competence-area-list__item')).to.have.lengthOf(5);
       });
 
-      it('should render 2 competence areas, when there are 5 competences related to 2 different areas', function() {
+      it('should render 2 competence areas, when there are 5 competences related to 2 different areas', async function() {
         // given
         const competencesWithDifferentAreas = [
           EmberObject.create({ id: 1, name: 'competence-1', areaName: 'area-A' }),
@@ -59,15 +58,15 @@ describe('Integration | Component | competence area list', function() {
         this.set('competences', competencesWithDifferentAreas);
 
         // when
-        this.render(hbs`{{competence-area-list competences=competences}}`);
+        await render(hbs`{{competence-area-list competences=competences}}`);
 
         // then
-        expect(this.$('.competence-area-list__item')).to.have.lengthOf(2);
+        expect(findAll('.competence-area-list__item')).to.have.lengthOf(2);
       });
     });
 
     describe('Rendering when same area', function() {
-      it('should render only 1 competence area, when there are 5 competences with the same area', function() {
+      it('should render only 1 competence area, when there are 5 competences with the same area', async function() {
         // given
         const competencesWithSameArea = [
           EmberObject.create({ id: 1, name: 'competence-1', areaName: 'area-A' }),
@@ -79,9 +78,9 @@ describe('Integration | Component | competence area list', function() {
 
         // when
         this.set('competences', competencesWithSameArea);
-        this.render(hbs`{{competence-area-list competences=competences}}`);
+        await render(hbs`{{competence-area-list competences=competences}}`);
         // then
-        expect(this.$('.competence-area-list__item')).to.have.lengthOf(1);
+        expect(find('.competence-area-list__item')).to.exist;
       });
     });
 

--- a/mon-pix/tests/integration/components/competence-by-area-item-test.js
+++ b/mon-pix/tests/integration/components/competence-by-area-item-test.js
@@ -1,34 +1,33 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence area item', function() {
-  setupComponentTest('competence-by-area-item', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('should render', function() {
+  it('should render', async function() {
     // when
-    this.render(hbs`{{competence-by-area-item}}`);
+    await render(hbs`{{competence-by-area-item}}`);
 
     // then
-    expect(this.$('.competence-by-area-item')).to.have.lengthOf(1);
+    expect(find('.competence-by-area-item')).to.exist;
   });
 
-  it('should render a title', function() {
+  it('should render a title', async function() {
     // Given
     const competence = EmberObject.create({ name: 'competence-A', level: 1 });
     const areaWithOnlyOneCompetence = { property: 'area', value: '1. Information et données', items: [competence] };
     this.set('competenceArea', areaWithOnlyOneCompetence);
     // when
-    this.render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
+    await render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
     // then
-    expect(this.$('.area__name').text().trim()).to.equal('Information et données');
+    expect(find('.area__name').textContent.trim()).to.equal('Information et données');
   });
 
-  it('should render as many competences as received', function() {
+  it('should render as many competences as received', async function() {
     // given
     const competencesWithSameArea = [
       EmberObject.create({ id: 1, name: 'competence-name-1', area: 'area-id-1' }),
@@ -45,37 +44,37 @@ describe('Integration | Component | competence area item', function() {
 
     this.set('competenceArea', areaWithManyCompetences);
     // when
-    this.render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
+    await render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
 
     // then
-    expect(this.$('.competence__name')).to.have.lengthOf(5);
+    expect(findAll('.competence__name')).to.have.lengthOf(5);
   });
 
   describe('Competence rendering', function() {
-    it('should render its name', function() {
+    it('should render its name', async function() {
       // given
       const competence = EmberObject.create({ name: 'Mener une recherche et une veille d’information' });
       const areaWithOnlyOneCompetence = { property: 'area', value: '1. Information et données', items: [competence] };
       this.set('competenceArea', areaWithOnlyOneCompetence);
 
       // when
-      this.render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
+      await render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
 
       // then
-      expect(this.$('.competence__name').text().trim()).to.equal('Mener une recherche et une veille d’information');
+      expect(find('.competence__name').textContent.trim()).to.equal('Mener une recherche et une veille d’information');
     });
 
-    it('should render the relative level progress bar for user', function() {
+    it('should render the relative level progress bar for user', async function() {
       // given
       const competence = EmberObject.create();
       const areaWithOnlyOneCompetence = { property: 'area', value: '1. Information et données', items: [competence] };
       this.set('competenceArea', areaWithOnlyOneCompetence);
 
       // when
-      this.render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
+      await render(hbs`{{competence-by-area-item competenceArea=competenceArea}}`);
 
       // then
-      expect(this.$('.competence__progress-bar')).to.have.lengthOf(1);
+      expect(find('.competence__progress-bar')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/competence-card-test.js
+++ b/mon-pix/tests/integration/components/competence-card-test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import  EmberObject  from '@ember/object';
-import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence-card', function() {
@@ -25,7 +25,7 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card')).to.exist;
+      expect(find('.competence-card')).to.exist;
     });
 
     it('should display the competence card header with scorecard color', async function() {
@@ -40,7 +40,7 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card__color').getAttribute('class'))
+      expect(find('.competence-card__color').getAttribute('class'))
         .to.contains('competence-card__color--jaffa');
     });
 
@@ -53,7 +53,7 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card__area-name').textContent).to.equal(scorecard.area.title);
+      expect(find('.competence-card__area-name').textContent).to.equal(scorecard.area.title);
     });
 
     it('should display the competence name', async function() {
@@ -65,7 +65,7 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.competence-card__competence-name').textContent).to.equal(scorecard.name);
+      expect(find('.competence-card__competence-name').textContent).to.equal(scorecard.name);
     });
 
     it('should display the level', async function() {
@@ -77,8 +77,8 @@ describe('Integration | Component | competence-card', function() {
       await render(hbs`{{competence-card scorecard=scorecard}}`);
 
       // then
-      expect(this.element.querySelector('.score-label').textContent).to.equal('Niveau');
-      expect(this.element.querySelector('.score-value').textContent).to.equal(scorecard.level.toString());
+      expect(find('.score-label').textContent).to.equal('Niveau');
+      expect(find('.score-value').textContent).to.equal(scorecard.level.toString());
     });
 
     context('when user can start the competence', async function() {
@@ -92,7 +92,7 @@ describe('Integration | Component | competence-card', function() {
         await render(hbs`{{competence-card scorecard=scorecard}}`);
 
         // then
-        expect(this.element.querySelector('.competence-card__button').textContent).to.contains('Commencer');
+        expect(find('.competence-card__button').textContent).to.contains('Commencer');
       });
 
     });
@@ -107,7 +107,7 @@ describe('Integration | Component | competence-card', function() {
         await render(hbs`{{competence-card scorecard=scorecard}}`);
 
         // then
-        expect(this.element.querySelector('.competence-card__button').textContent).to.contains('Reprendre');
+        expect(find('.competence-card__button').textContent).to.contains('Reprendre');
       });
     });
 
@@ -122,7 +122,7 @@ describe('Integration | Component | competence-card', function() {
         await render(hbs`{{competence-card scorecard=scorecard}}`);
 
         // then
-        expect(this.element.querySelector('.competence-card__button')).to.be.null;
+        expect(find('.competence-card__button')).to.be.null;
       });
     });
   });

--- a/mon-pix/tests/integration/components/competence-level-progress-bar-test.js
+++ b/mon-pix/tests/integration/components/competence-level-progress-bar-test.js
@@ -1,52 +1,51 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence level progress bar', function() {
 
-  setupComponentTest('competence-level-progress-bar', {
-    integration: true,
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{competence-level-progress-bar}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{competence-level-progress-bar}}`);
+    expect(find('.competence-level-progress-bar')).to.exist;
   });
 
   describe('progress bar', function() {
 
     context('if the competence is not assessed', function() {
 
-      it('should not display the background of progress bar which display limit and max level', function() {
+      it('should not display the background of progress bar which display limit and max level', async function() {
         //Given
         const competence = { level: -1, isAssessed: false };
         this.set('competence', competence);
 
         //When
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         //Then
-        expect(this.$('.competence-level-progress-bar__background')).to.have.lengthOf(0);
+        expect(findAll('.competence-level-progress-bar__background')).to.have.lengthOf(0);
       });
 
-      it('should not display a progress bar if level is not defined (-1)', function() {
+      it('should not display a progress bar if level is not defined (-1)', async function() {
         //Given
         const competence = { level: undefined, isAssessed: false };
         this.set('competence', competence);
 
         //When
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         //Then
-        expect(this.$('.competence-level-progress-bar__level')).to.have.lengthOf(0);
+        expect(findAll('.competence-level-progress-bar__level')).to.have.lengthOf(0);
       });
 
     });
 
     context('if the competence is assessed', function() {
 
-      it('should indicate the limit level and the max level reachable in the progress bar', function() {
+      it('should indicate the limit level and the max level reachable in the progress bar', async function() {
         // given
         const MAX_LEVEL = 8;
         const LIMIT_LEVEL = 5;
@@ -54,37 +53,37 @@ describe('Integration | Component | competence level progress bar', function() {
         this.set('competence', competence);
 
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__background-level-limit-indicator')).to.have.lengthOf(1);
-        expect(this.$('.competence-level-progress-bar__background-level-limit-indicator').text().trim()).to.equal(LIMIT_LEVEL.toString());
-        expect(this.$('.competence-level-progress-bar__background-level-limit-max-indicator')).to.have.lengthOf(1);
-        expect(this.$('.competence-level-progress-bar__background-level-limit-max-indicator').text().trim()).to.equal(MAX_LEVEL.toString());
+        expect(findAll('.competence-level-progress-bar__background-level-limit-indicator')).to.have.lengthOf(1);
+        expect(find('.competence-level-progress-bar__background-level-limit-indicator').textContent.trim()).to.equal(LIMIT_LEVEL.toString());
+        expect(findAll('.competence-level-progress-bar__background-level-limit-max-indicator')).to.have.lengthOf(1);
+        expect(find('.competence-level-progress-bar__background-level-limit-max-indicator').textContent.trim()).to.equal(MAX_LEVEL.toString());
       });
 
-      it('should display a progress bar if level is defined (equal or more than 0)', function() {
+      it('should display a progress bar if level is defined (equal or more than 0)', async function() {
         //Given
         const competence = { level: 1, isAssessed: true };
         this.set('competence', competence);
 
         //When
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         //Then
-        expect(this.$('.competence-level-progress-bar__level')).to.have.lengthOf(1);
+        expect(findAll('.competence-level-progress-bar__level')).to.have.lengthOf(1);
       });
 
-      it('should indicate the level passed to the component at the end of the progress bar', function() {
+      it('should indicate the level passed to the component at the end of the progress bar', async function() {
         // given
         const competence = { level: 5, isAssessed: true };
         this.set('competence', competence);
 
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__level-indicator').text().trim()).to.be.equal('5');
+        expect(find('.competence-level-progress-bar__level-indicator').textContent.trim()).to.be.equal('5');
       });
     });
 
@@ -92,7 +91,7 @@ describe('Integration | Component | competence level progress bar', function() {
 
   describe('start course link', function() {
 
-    it('should display ’commencer’ in progress bar when the competence is assessable for the first time', function() {
+    it('should display ’commencer’ in progress bar when the competence is assessable for the first time', async function() {
       // given
       const competence = {
         name: 'Premier test de positionnement',
@@ -102,15 +101,15 @@ describe('Integration | Component | competence level progress bar', function() {
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+      await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
       // then
-      expect(this.$('.competence-level-progress-bar__link')).to.have.lengthOf(1);
-      expect(this.$('a.competence-level-progress-bar__link-start')).to.have.lengthOf(1);
-      expect(this.$('a.competence-level-progress-bar__link-start').text().trim()).to.contains('Commencer le test "Premier test de positionnement"');
+      expect(findAll('.competence-level-progress-bar__link')).to.have.lengthOf(1);
+      expect(findAll('a.competence-level-progress-bar__link-start')).to.have.lengthOf(1);
+      expect(find('a.competence-level-progress-bar__link-start').textContent.trim()).to.contains('Commencer le test "Premier test de positionnement"');
     });
 
-    it('should not display ’commencer’ in progress bar when the competence is not assessable for the first time', function() {
+    it('should not display ’commencer’ in progress bar when the competence is not assessable for the first time', async function() {
       // given
       const competence = {
         name: 'Premier test de positionnement',
@@ -120,28 +119,28 @@ describe('Integration | Component | competence level progress bar', function() {
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+      await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
       // then
-      expect(this.$('a.competence-level-progress-bar__link-start')).to.have.lengthOf(0);
+      expect(findAll('a.competence-level-progress-bar__link-start')).to.have.lengthOf(0);
     });
 
   });
 
   describe('resume assessment link', function() {
 
-    it('should display `Reprendre` if competence is being evaluated and there is an assessment related', function() {
+    it('should display `Reprendre` if competence is being evaluated and there is an assessment related', async function() {
       // given
       const competence = { name: 'deuxième test', assessmentId: 'awesomeId', isBeingAssessed: true };
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+      await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
       // then
-      expect(this.$('.competence-level-progress-bar__link')).to.have.lengthOf(1);
-      expect(this.$('a.competence-level-progress-bar__link-resume')).to.have.lengthOf(1);
-      expect(this.$('a.competence-level-progress-bar__link-resume').text().trim()).to.be.equal('Reprendre le test "deuxième test"');
+      expect(findAll('.competence-level-progress-bar__link')).to.have.lengthOf(1);
+      expect(findAll('a.competence-level-progress-bar__link-resume')).to.have.lengthOf(1);
+      expect(find('a.competence-level-progress-bar__link-resume').textContent.trim()).to.be.equal('Reprendre le test "deuxième test"');
     });
 
   });
@@ -163,36 +162,36 @@ describe('Integration | Component | competence level progress bar', function() {
         this.set('competence', competence);
       });
 
-      it('should display `Retenter` button', function() {
+      it('should display `Retenter` button', async function() {
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__link')).to.have.lengthOf(1);
-        expect(this.$('button.competence-level-progress-bar__retry-link')).to.have.lengthOf(1);
-        expect(this.$('.competence-level-progress-bar__retry-link').text().trim()).to.be.equal('Retenter le test "deuxième test"');
+        expect(findAll('.competence-level-progress-bar__link')).to.have.lengthOf(1);
+        expect(findAll('button.competence-level-progress-bar__retry-link')).to.have.lengthOf(1);
+        expect(find('.competence-level-progress-bar__retry-link').textContent.trim()).to.be.equal('Retenter le test "deuxième test"');
       });
 
       it('should display a modal when clicked', async function() {
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
-        await this.$('.competence-level-progress-bar__retry-link').click();
-        const $modal = document.querySelector('.pix-modal__container');
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await click('.competence-level-progress-bar__retry-link');
+        const modal = document.querySelector('.pix-modal__container');
 
         // then
-        expect($modal).to.be.ok;
-        expect($modal.querySelector('.pix-modal-header__title').textContent).to.contains('Retenter');
-        expect($modal.querySelector('.competence-level-progress-bar__modal-body').textContent).to.contains('Votre niveau actuel sera remplacé par celui de ce nouveau test');
-        expect($modal.querySelector('.competence-level-progress-bar__modal-link-cancel').textContent).to.contains('Annuler');
-        expect($modal.querySelector('.competence-level-progress-bar__modal-link-validate').textContent).to.contains('J’ai compris');
+        expect(modal).to.be.ok;
+        expect(modal.querySelector('.pix-modal-header__title').textContent).to.contains('Retenter');
+        expect(modal.querySelector('.competence-level-progress-bar__modal-body').textContent).to.contains('Votre niveau actuel sera remplacé par celui de ce nouveau test');
+        expect(modal.querySelector('.competence-level-progress-bar__modal-link-cancel').textContent).to.contains('Annuler');
+        expect(modal.querySelector('.competence-level-progress-bar__modal-link-validate').textContent).to.contains('J’ai compris');
       });
 
-      it('should not display remaining days info', function() {
+      it('should not display remaining days info', async function() {
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__retry-delay')).to.have.lengthOf(0);
+        expect(findAll('.competence-level-progress-bar__retry-delay')).to.have.lengthOf(0);
       });
 
     });
@@ -212,39 +211,39 @@ describe('Integration | Component | competence level progress bar', function() {
         this.set('competence', competence);
       });
 
-      it('should display `Retenter` text but not clickable', function() {
+      it('should display `Retenter` text but not clickable', async function() {
         // given
         competence.daysBeforeNewAttempt = 5;
 
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('button.competence-level-progress-bar__retry-link')).to.have.lengthOf(0);
-        expect(this.$('.competence-level-progress-bar__link')).to.have.lengthOf(1);
-        expect(this.$('.competence-level-progress-bar__link').text().trim()).to.be.equal('Retenter le test "deuxième test"');
+        expect(findAll('button.competence-level-progress-bar__retry-link')).to.have.lengthOf(0);
+        expect(findAll('.competence-level-progress-bar__link')).to.have.lengthOf(1);
+        expect(find('.competence-level-progress-bar__link').textContent.trim()).to.be.equal('Retenter le test "deuxième test"');
       });
 
-      it('should display `1 day` if there is one day left to wait', function() {
+      it('should display `1 day` if there is one day left to wait', async function() {
         // given
         competence.daysBeforeNewAttempt = 1;
 
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__retry-delay').text().trim()).to.equal('dans 1 jour');
+        expect(find('.competence-level-progress-bar__retry-delay').textContent.trim()).to.equal('dans 1 jour');
       });
 
-      it('should display `4 days` if there are 4 days left to wait', function() {
+      it('should display `4 days` if there are 4 days left to wait', async function() {
         // given
         competence.daysBeforeNewAttempt = 4;
 
         // when
-        this.render(hbs`{{competence-level-progress-bar competence=competence}}`);
+        await render(hbs`{{competence-level-progress-bar competence=competence}}`);
 
         // then
-        expect(this.$('.competence-level-progress-bar__retry-delay').text().trim()).to.equal('dans 4 jours');
+        expect(find('.competence-level-progress-bar__retry-delay').textContent.trim()).to.equal('dans 4 jours');
       });
 
     });

--- a/mon-pix/tests/integration/components/corner-ribbon-test.js
+++ b/mon-pix/tests/integration/components/corner-ribbon-test.js
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
-import { setupComponentTest, it } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | CornerRibbonComponent', function() {
 
-  setupComponentTest('corner-ribbon', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{corner-ribbon}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{corner-ribbon}}`);
+    expect(find('.corner-ribbon')).to.exist;
   });
 
 });

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, fillIn, triggerEvent, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
 describe('Integration | Component | form textfield', function() {
-  setupComponentTest('form-textfield', {
-    integration: true
-  });
+  setupRenderingTest();
 
   const LABEL = '.form-textfield__label';
   const LABEL_TEXT = 'NOM';
@@ -23,26 +22,25 @@ describe('Integration | Component | form textfield', function() {
   const INPUT_ERROR_CLASS = 'form-textfield__input--error';
 
   describe('#Component rendering', function() {
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('label', 'nom');
       this.set('validationStatus', '');
       this.set('textfieldName', 'firstname');
 
       // When
-      this.render(hbs`{{form-textfield label=label validationStatus=validationStatus textfieldName=textfieldName}}`);
+      await render(hbs`{{form-textfield label=label validationStatus=validationStatus textfieldName=textfieldName}}`);
     });
 
     [
       { expectedRendering: 'label', item: LABEL, expectedLength: 1 },
       { expectedRendering: 'div', item: MESSAGE, expectedLength: 1 },
       { expectedRendering: 'input', item: INPUT, expectedLength: 1 },
-      { expectedRendering: 'div', item: '', expectedLength: 1 },
 
     ].forEach(function({ expectedRendering, item, expectedLength }) {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
-        expect(this.$(item)).to.have.length(expectedLength);
-        expect(this.$(item).prop('nodeName')).to.equal(expectedRendering.toUpperCase());
+        expect(findAll(item)).to.have.length(expectedLength);
+        expect(find(item).nodeName).to.equal(expectedRendering.toUpperCase());
       });
     });
 
@@ -53,7 +51,7 @@ describe('Integration | Component | form textfield', function() {
     ].forEach(function({ item, expectedRendering, expectedText }) {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
-        expect(this.$(item).text().toUpperCase()).to.equal(expectedText);
+        expect(find(item).textContent.toUpperCase()).to.equal(expectedText);
       });
     });
 
@@ -62,13 +60,13 @@ describe('Integration | Component | form textfield', function() {
   //behavior
   describe('#Component Interactions', function() {
 
-    it('should handle action <validate> when input lost focus', function() {
+    it('should handle action <validate> when input lost focus', async function() {
       // given
       let isActionValidateHandled = false;
       let inputValueToValidate;
       const expectedInputValue = 'firstname';
 
-      this.on('validate', function(arg) {
+      this.set('validate', function(arg) {
         isActionValidateHandled = true;
         inputValueToValidate = arg;
       });
@@ -77,10 +75,10 @@ describe('Integration | Component | form textfield', function() {
       this.set('validationStatus', '');
       this.set('textfieldName', 'firstname');
 
-      this.render(hbs`{{form-textfield label=label validationStatus=validationStatus textfieldName=textfieldName onValidate=(action "validate")}}`);
+      await render(hbs`{{form-textfield label=label validationStatus=validationStatus textfieldName=textfieldName onValidate=(action validate)}}`);
       // when
-      this.$(INPUT).val('pix');
-      this.$(INPUT).trigger('focusout');
+      await fillIn(INPUT, 'pix');
+      await triggerEvent(INPUT, 'blur');
       // then
       return wait().then(() => {
         expect(isActionValidateHandled).to.be.true;
@@ -89,31 +87,31 @@ describe('Integration | Component | form textfield', function() {
     });
 
     describe('#When validationStatus gets "default", Component should ', function() {
-      beforeEach(function() {
+      beforeEach(async function() {
         this.set('label', 'nom');
         this.set('validationStatus', 'default');
         this.set('textfieldName', 'firstname');
         this.set('validationMessage', '');
 
         // When
-        this.render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
+        await render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
       });
 
       it('return true if any svg doesn\'t exist', function() {
         // then
-        expect(this.$('img')).to.have.lengthOf(0);
+        expect(findAll('img')).to.have.lengthOf(0);
       });
 
       it(`contain an input with an additional class ${INPUT_DEFAULT_CLASS}`, function() {
-        const input = this.$(INPUT);
+        const input = find(INPUT);
         // then
-        expect(input.attr('class')).to.contain(INPUT_DEFAULT_CLASS);
-        expect(input.val()).to.contain('');
+        expect(input.getAttribute('class')).to.contain(INPUT_DEFAULT_CLASS);
+        expect(input.value).to.contain('');
       });
 
       it('should not show a div for message validation status  when validationStatus is default', function() {
         // then
-        expect(this.$(MESSAGE)).to.lengthOf(0);
+        expect(find(MESSAGE)).to.not.exist;
       });
 
     });
@@ -121,21 +119,21 @@ describe('Integration | Component | form textfield', function() {
   });
 
   describe('#When validationStatus gets "error", Component should ', function() {
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('label', 'nom');
       this.set('validationStatus', 'error');
       this.set('textfieldName', 'firstname');
 
       // When
-      this.render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
+      await render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
       this.set('validationMessage', '');
     });
 
     it('return true if any img does exist', function() {
       // then
       return wait().then(() => {
-        expect(this.$('img')).to.have.lengthOf(1);
-        expect(this.$('img').attr('class')).to.contain('form-textfield__icon--error');
+        expect(findAll('img')).to.have.lengthOf(1);
+        expect(find('img').getAttribute('class')).to.contain('form-textfield__icon--error');
       });
     });
 
@@ -147,27 +145,27 @@ describe('Integration | Component | form textfield', function() {
     ].forEach(({ item, itemSelector, expectedClass }) => {
       it(`contain an ${item} with an additional class ${expectedClass}`, function() {
         // then
-        expect(this.$(itemSelector).attr('class')).to.contain(expectedClass);
+        expect(find(itemSelector).getAttribute('class')).to.contain(expectedClass);
       });
     });
 
   });
 
   describe('#When validationStatus gets "success", Component should ', function() {
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('label', 'nom');
       this.set('validationStatus', 'success');
       this.set('validationMessage', '');
       this.set('textfieldName', 'firstname');
 
       // When
-      this.render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
+      await render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName}}`);
     });
 
     it('return true if any img does exist', function() {
       // then
-      expect(this.$('img')).to.have.lengthOf(1);
-      expect(this.$('img').attr('class')).to.contain('form-textfield__icon--success');
+      expect(findAll('img')).to.have.lengthOf(1);
+      expect(find('img').getAttribute('class')).to.contain('form-textfield__icon--success');
     });
 
     [
@@ -177,7 +175,7 @@ describe('Integration | Component | form textfield', function() {
     ].forEach(({ item, itemSelector, expectedClass }) => {
       it(`contain an ${item} with an additional class ${expectedClass}`, function() {
         // then
-        expect(this.$(itemSelector).attr('class')).to.contain(expectedClass);
+        expect(find(itemSelector).getAttribute('class')).to.contain(expectedClass);
       });
     });
   });

--- a/mon-pix/tests/integration/components/g-recaptcha-test.js
+++ b/mon-pix/tests/integration/components/g-recaptcha-test.js
@@ -1,11 +1,12 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find,render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import RSVP from 'rsvp';
 
-const StubGoogleRecaptchaService = Service.extend({
+const stubGoogleRecaptchaService = Service.extend({
 
   loadScript() {
     return RSVP.resolve();
@@ -28,27 +29,28 @@ const StubGoogleRecaptchaService = Service.extend({
 
 describe('Integration | Component | g recaptcha', function() {
 
-  setupComponentTest('g-recaptcha', {
-    integration: true
-  });
+  setupRenderingTest();
 
   beforeEach(function() {
-    this.register('service:google-recaptcha', StubGoogleRecaptchaService);
-    this.inject.service('google-recaptcha', { as: 'googleRecaptchaService' });
+    this.owner.register('service:google-recaptcha', stubGoogleRecaptchaService);
   });
 
-  it('renders', function() {
-    this.render(hbs`{{g-recaptcha}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{g-recaptcha}}`);
+    expect(find('.gg-recaptcha')).to.exist;
   });
 
   // XXX Inspired of https://guides.emberjs.com/v2.13.0/tutorial/service/#toc_integration-testing-the-map-component
-  it('should append recaptcha element to container element', function() {
+  it('should append recaptcha element to container element', async function() {
+    // given
+    const googleRecaptcha = this.owner.lookup('service:googleRecaptcha');
+
     // when
-    this.render(hbs`{{g-recaptcha}}`);
+    await render(hbs`{{g-recaptcha}}`);
+
     // then
-    expect(this.$('#g-recaptcha-container').children()).to.have.lengthOf(1);
-    expect(this.get('googleRecaptchaService.calledWithContainerId')).to.equal('g-recaptcha-container');
+    expect(find('#g-recaptcha-container')).to.exist;
+    expect(googleRecaptcha.get('calledWithContainerId')).to.equal('g-recaptcha-container');
   });
 
 });

--- a/mon-pix/tests/integration/components/learning-more-panel-test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel-test.js
@@ -1,34 +1,33 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | learning-more-panel', function() {
-  setupComponentTest('learning-more-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders a list item when there is at least one learningMore item', function() {
+  it('renders a list item when there is at least one learningMore item', async function() {
     // given
     this.set('learningMoreTutorials', [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }]);
 
     // when
-    this.render(hbs`{{learning-more-panel learningMoreTutorials=learningMoreTutorials}}`);
+    await render(hbs`{{learning-more-panel learningMoreTutorials=learningMoreTutorials}}`);
 
     // then
-    expect(this.$('.learning-more-panel__container')).to.have.length(1);
-    expect(this.$('.learning-more-panel__list-container')).to.have.length(1);
-    expect(this.$('.learning-more-panel__container').text()).to.contains('Pour en apprendre davantage');
+    expect(findAll('.learning-more-panel__container')).to.have.length(1);
+    expect(findAll('.learning-more-panel__list-container')).to.have.length(1);
+    expect(find('.learning-more-panel__container').textContent).to.contains('Pour en apprendre davantage');
   });
 
-  it('should not render a list when there is no LearningMore elements', function() {
+  it('should not render a list when there is no LearningMore elements', async function() {
     // given
     this.set('learningMoreTutorials', null);
 
     // when
-    this.render(hbs`{{learning-more-panel learningMoreTutorials=learningMoreTutorials}}`);
+    await render(hbs`{{learning-more-panel learningMoreTutorials=learningMoreTutorials}}`);
 
     // then
-    expect(this.$('.learning-more-panel__container')).to.have.lengthOf(0);
+    expect(findAll('.learning-more-panel__container')).to.have.lengthOf(0);
   });
 });

--- a/mon-pix/tests/integration/components/logged-user-profile-banner-test.js
+++ b/mon-pix/tests/integration/components/logged-user-profile-banner-test.js
@@ -1,38 +1,36 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | logged user profile banner', function() {
-  setupComponentTest('logged-user-profile-banner', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('should display a banner', function() {
+  it('should display a banner', async function() {
     // when
-    this.render(hbs`{{logged-user-profile-banner}}`);
+    await render(hbs`{{logged-user-profile-banner}}`);
 
     // then
-    expect(this.$()).to.have.lengthOf(1);
-    expect(this.$('.logged-user-profile-banner')).to.have.lengthOf(1);
+    expect(find('.logged-user-profile-banner')).to.exist;
   });
 
-  it('should have a content text container', function() {
+  it('should have a content text container', async function() {
     // when
-    this.render(hbs`{{logged-user-profile-banner}}`);
+    await render(hbs`{{logged-user-profile-banner}}`);
 
     // then
-    expect(this.$('.profile-banner__content-text-container')).to.have.lengthOf(1);
+    expect(findAll('.profile-banner__content-text-container')).to.have.lengthOf(1);
   });
 
-  it('should a button cta to scroll to profile section', function() {
+  it('should a button cta to scroll to profile section', async function() {
     // when
-    this.render(hbs`{{logged-user-profile-banner}}`);
+    await render(hbs`{{logged-user-profile-banner}}`);
 
     // then
-    expect(this.$('.profile-banner__button-scroll-container')).to.have.lengthOf(1);
-    expect(this.$('.button-scroll-to-profile')).to.have.lengthOf(1);
-    expect(this.$('.button-scroll-to-profile').text()).to.equal('choisir un test');
+    expect(findAll('.profile-banner__button-scroll-container')).to.have.lengthOf(1);
+    expect(findAll('.button-scroll-to-profile')).to.have.lengthOf(1);
+    expect(find('.button-scroll-to-profile').textContent).to.equal('choisir un test');
   });
 
 });

--- a/mon-pix/tests/integration/components/medal-item-test.js
+++ b/mon-pix/tests/integration/components/medal-item-test.js
@@ -1,36 +1,35 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | medal item', function() {
-  setupComponentTest('medal-item', {
-    integration: true
+  setupRenderingTest();
+
+  it('renders', async function() {
+    await render(hbs`{{medal-item}}`);
+    expect(find('.medal-item')).to.exist;
   });
 
-  it('renders', function() {
-    this.render(hbs`{{medal-item}}`);
-    expect(this.$()).to.have.lengthOf(1);
-  });
-
-  it('should contain the number of pix passed in the component', function() {
+  it('should contain the number of pix passed in the component', async function() {
     // given
     const pixScore = 20;
     this.set('pixScore', pixScore);
 
     // when
-    this.render(hbs`{{medal-item pixScore=pixScore}}`);
+    await render(hbs`{{medal-item pixScore=pixScore}}`);
 
     // then
-    expect(this.$('.medal-item__pix-score').text()).to.contain(pixScore.toString());
+    expect(find('.medal-item__pix-score').textContent).to.contain(pixScore.toString());
   });
 
-  it('should contain an image of a medal with the text pix', function() {
+  it('should contain an image of a medal with the text pix', async function() {
     // when
-    this.render(hbs`{{medal-item pixScore=pixScore}}`);
+    await render(hbs`{{medal-item pixScore=pixScore}}`);
 
     // then
-    expect(this.$('.medal-item__medal-img').length).to.equal(1);
-    expect(this.$('.medal-item__pix-score').text()).to.contain('pix');
+    expect(findAll('.medal-item__medal-img').length).to.equal(1);
+    expect(find('.medal-item__pix-score').textContent).to.contain('pix');
   });
 });

--- a/mon-pix/tests/integration/components/modal-mobile-test.js
+++ b/mon-pix/tests/integration/components/modal-mobile-test.js
@@ -1,34 +1,32 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | modal mobile', function() {
 
-  setupComponentTest('modal-mobile', {
-    integration: true
+  setupRenderingTest();
+
+  it('renders', async function() {
+    await render(hbs`{{modal-mobile}}`);
+    expect(find('.modal-mobile')).to.exist;
   });
 
-  it('renders', function() {
-    this.render(hbs`{{modal-mobile}}`);
-    expect(this.$()).to.have.lengthOf(1);
-  });
-
-  it('should display a title with a "warning" icon', function() {
+  it('should display a title with a "warning" icon', async function() {
     // when
-    this.render(hbs`{{modal-mobile}}`);
+    await render(hbs`{{modal-mobile}}`);
 
     // then
-    const $titleWarningIcon = this.$('.modal-title__warning-icon');
-    expect($titleWarningIcon.attr('src')).to.equal('/images/icon-mobile-support-warning.svg');
+    expect(find('.modal-title__warning-icon').getAttribute('src')).to.equal('/images/icon-mobile-support-warning.svg');
   });
 
-  it('should display a message', function() {
+  it('should display a message', async function() {
     // when
-    this.render(hbs`{{modal-mobile}}`);
+    await render(hbs`{{modal-mobile}}`);
 
     // then
     const expected = 'Certaines épreuves Pix peuvent être difficiles à réussir sur mobile. Pour une meilleure expérience, nous vous conseillons de passer ce test sur un ordinateur.';
-    expect(this.$('.modal-body').text().trim()).to.equal(expected);
+    expect(find('.modal-body').textContent.trim()).to.equal(expected);
   });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
@@ -1,18 +1,17 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | navbar desktop menu', function() {
-  setupComponentTest('navbar-desktop-menu', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('should be rendered', function() {
+  it('should be rendered', async function() {
     // when
-    this.render(hbs`{{navbar-desktop-menu}}`);
+    await render(hbs`{{navbar-desktop-menu}}`);
 
     // then
-    expect(this.$()).to.have.length(1);
+    expect(find('.navbar-desktop-menu')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -1,50 +1,48 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpointForIntegrationTest } from 'mon-pix/tests/helpers/responsive';
 
 describe('Integration | Component | navbar-header', function() {
 
-  setupComponentTest('header-navbar', {
-    integration: true
-  });
+  setupRenderingTest();
 
   context('when user is not logged', function() {
     beforeEach(function() {
-      this.register('service:session', Service.extend({ isAuthenticated: false }));
-      this.inject.service('session', { as: 'session' });
+      this.owner.register('service:session', Service.extend({ isAuthenticated: false }));
     });
 
-    it('should be rendered', function() {
+    it('should be rendered', async function() {
       // when
-      this.render(hbs`{{navbar-header}}`);
+      await render(hbs`{{navbar-header}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.navbar-header')).to.exist;
     });
 
-    it('should display the Pix logo', function() {
+    it('should display the Pix logo', async function() {
       // when
-      this.render(hbs`{{navbar-header}}`);
+      await render(hbs`{{navbar-header}}`);
 
       // then
-      expect(this.$('.navbar-header-logo')).to.have.lengthOf(1);
-      expect(this.$('.pix-logo')).to.have.lengthOf(1);
+      expect(find('.navbar-header-logo')).to.exist;
+      expect(find('.pix-logo')).to.exist;
     });
 
     context('when screen has a desktop size', function() {
-      it('should display a desktop menu', function() {
+      it('should display a desktop menu', async function() {
         // given
         setBreakpointForIntegrationTest(this, 'desktop');
 
         // when
-        this.render(hbs`{{navbar-header media=media}}`);
+        await render(hbs`{{navbar-header media=media}}`);
 
         // then
-        expect(this.$('.navbar-desktop-menu')).to.have.lengthOf(1);
-        expect(this.$('.navbar-mobile-menu')).to.have.lengthOf(0);
+        expect(find('.navbar-desktop-menu')).to.exist;
+        expect(find('.navbar-mobile-menu')).to.not.exist;
       });
     });
 
@@ -52,8 +50,8 @@ describe('Integration | Component | navbar-header', function() {
 
   context('When user is logged', function() {
 
-    beforeEach(function() {
-      this.register('service:session', Service.extend({
+    beforeEach(async function() {
+      this.owner.register('service:session', Service.extend({
         isAuthenticated: true,
         data: {
           authenticated: {
@@ -63,40 +61,39 @@ describe('Integration | Component | navbar-header', function() {
           }
         }
       }));
-      this.inject.service('session', { as: 'session' });
 
-      this.render(hbs`{{navbar-header}}`);
+      await render(hbs`{{navbar-header}}`);
     });
 
     it('should display logged user details informations', function() {
       // then
-      expect(this.$('.logged-user-details')).to.have.lengthOf(1);
+      expect(find('.logged-user-details')).to.exist;
     });
 
     it('should not display link to inscription page', function() {
       // then
-      expect(this.$('.navbar-menu-signup-link')).to.have.lengthOf(0);
+      expect(find('.navbar-menu-signup-link')).to.not.exist;
     });
 
     it('should not display link to connection page', function() {
       // then
-      expect(this.$('.navbar-menu-signin-link')).to.have.lengthOf(0);
+      expect(find('.navbar-menu-signin-link')).to.not.exist;
     });
 
     it('should be rendered', function() {
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.navbar-header')).to.exist;
     });
-    
+
     context('when screen has a desktop size', function() {
-      it('should display a desktop menu', function() {
+      it('should display a desktop menu', async function() {
         // given
         setBreakpointForIntegrationTest(this, 'desktop');
 
         // when
-        this.render(hbs`{{navbar-header media=media}}`);
+        await render(hbs`{{navbar-header media=media}}`);
 
         // then
-        expect(this.$('.navbar-desktop-menu')).to.have.lengthOf(1);
+        expect(find('.navbar-desktop-menu')).to.exist;
       });
     });
 

--- a/mon-pix/tests/integration/components/no-certification-panel-test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel-test.js
@@ -1,15 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | no certification panel', function() {
-  setupComponentTest('no-certification-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{no-certification-panel}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{no-certification-panel}}`);
+    expect(find('.no-certification-panel')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -1,52 +1,51 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | password reset demand form', function() {
-  setupComponentTest('password-reset-demand-form', {
-    integration: true
+  setupRenderingTest();
+
+  it('renders', async function() {
+    await render(hbs`{{password-reset-demand-form}}`);
+    expect(find('.sign-form__container')).to.exist;
   });
 
-  it('renders', function() {
-    this.render(hbs`{{password-reset-demand-form}}`);
-    expect(this.$()).to.have.length(1);
-  });
-
-  it('renders all the necessary elements of the form ', function() {
+  it('renders all the necessary elements of the form ', async function() {
     // when
-    this.render(hbs`{{password-reset-demand-form}}`);
+    await render(hbs`{{password-reset-demand-form}}`);
 
     // then
-    expect(this.$('.pix-logo__link')).to.have.length(1);
-    expect(this.$('.sign-form-title')).to.have.length(1);
-    expect(this.$('.sign-form-header__instruction')).to.have.length(1);
-    expect(this.$('.sign-form__body')).to.have.length(1);
-    expect(this.$('.form-textfield__label')).to.have.length(1);
-    expect(this.$('.form-textfield__input-field-container')).to.have.length(1);
-    expect(this.$('.button')).to.have.length(1);
+    expect(find('.pix-logo__link')).to.exist;
+    expect(find('.sign-form-title')).to.exist;
+    expect(find('.sign-form-header__instruction')).to.exist;
+    expect(find('.sign-form__body')).to.exist;
+    expect(find('.form-textfield__label')).to.exist;
+    expect(find('.form-textfield__input-field-container')).to.exist;
+    expect(find('.button')).to.exist;
   });
 
-  it('should display error message when there is an error on password reset demand', function() {
+  it('should display error message when there is an error on password reset demand', async function() {
     // given
     this.set('_displayErrorMessage', true);
 
     // when
-    this.render(hbs`{{password-reset-demand-form _displayErrorMessage=_displayErrorMessage}}`);
+    await render(hbs`{{password-reset-demand-form _displayErrorMessage=_displayErrorMessage}}`);
 
     // then
-    expect(this.$('.sign-form__notification-message--error')).to.have.length(1);
+    expect(find('.sign-form__notification-message--error')).to.exist;
   });
 
-  it('should display success message when there is an error on password reset demand', function() {
+  it('should display success message when there is an error on password reset demand', async function() {
     // given
     this.set('_displaySuccessMessage', true);
 
     // when
-    this.render(hbs`{{password-reset-demand-form _displaySuccessMessage=_displaySuccessMessage}}`);
+    await render(hbs`{{password-reset-demand-form _displaySuccessMessage=_displaySuccessMessage}}`);
 
     // then
-    expect(this.$('.password-reset-demand-form__body')).to.have.length(1);
+    expect(find('.password-reset-demand-form__body')).to.exist;
   });
 
 });

--- a/mon-pix/tests/integration/components/pix-logo-test.js
+++ b/mon-pix/tests/integration/components/pix-logo-test.js
@@ -1,32 +1,31 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | pix logo', function() {
 
-  setupComponentTest('pix-logo', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  beforeEach(function() {
-    this.render(hbs`{{pix-logo}}`);
+  beforeEach(async function() {
+    await render(hbs`{{pix-logo}}`);
   });
 
   it('renders', function() {
-    expect(this.$()).to.have.lengthOf(1);
+    expect(find('.pix-logo')).to.exist;
   });
 
   it('should display the logo', function() {
-    expect(this.$('.pix-logo__image').attr('src')).to.equal('/images/pix-logo.svg');
+    expect(find('.pix-logo__image').getAttribute('src')).to.equal('/images/pix-logo.svg');
   });
 
   it('should have a textual alternative', function() {
-    expect(this.$('.pix-logo__image').attr('alt')).to.equal('Pix');
+    expect(find('.pix-logo__image').getAttribute('alt')).to.equal('Pix');
   });
 
   it('should have a title in the link', function() {
-    expect(this.$('.pix-logo__link').attr('title')).to.equal('Lien vers la page d\'accueil de Pix');
+    expect(find('.pix-logo__link').getAttribute('title')).to.equal('Lien vers la page d\'accueil de Pix');
   });
 
 });

--- a/mon-pix/tests/integration/components/placement-banner-test.js
+++ b/mon-pix/tests/integration/components/placement-banner-test.js
@@ -1,15 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | placement-banner', function() {
-  setupComponentTest('placement-banner', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{placement-banner}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{placement-banner}}`);
+    expect(find('.placement-banner')).to.exist;
   });
 });

--- a/mon-pix/tests/integration/components/profile-panel-test.js
+++ b/mon-pix/tests/integration/components/profile-panel-test.js
@@ -1,72 +1,69 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | profile panel', function() {
-  setupComponentTest('profile-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('(Rendering behavior) Component: ', function() {
 
     beforeEach(function() {
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         data: { authenticated: { userId: 123, source: 'pix' } }
       }));
-      this.inject.service('session', { as: 'session' });
-
     });
 
-    it('should be rendered', function() {
+    it('should be rendered', async function() {
       // when
-      this.render(hbs`{{profile-panel}}`);
+      await render(hbs`{{profile-panel}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.profile-panel')).to.exist;
     });
 
-    it('should render a wrapper', function() {
+    it('should render a wrapper', async function() {
       // when
-      this.render(hbs`{{profile-panel}}`);
+      await render(hbs`{{profile-panel}}`);
 
       // then
       const WRAPPER_CLASS = '.profile-panel';
-      expect(this.$(WRAPPER_CLASS)).to.have.lengthOf(1);
+      expect(find(WRAPPER_CLASS)).to.exist;
     });
 
-    it('should render a profile header', function() {
+    it('should render a profile header', async function() {
       // when
-      this.render(hbs`{{profile-panel}}`);
+      await render(hbs`{{profile-panel}}`);
 
       // Then
       const HEADER_CLASS = '.profile-panel__header';
       const HEADER_TITLE = '.profile-header__title';
-      expect(this.$(HEADER_CLASS)).to.have.lengthOf(1);
-      expect(this.$(HEADER_TITLE).text().trim()).to.be.equal('Votre profil');
+      expect(find(HEADER_CLASS)).to.exist;
+      expect(find(HEADER_TITLE).textContent.trim()).to.equal('Votre profil');
     });
 
-    it('should render a competence profile block', function() {
+    it('should render a competence profile block', async function() {
       // when
-      this.render(hbs`{{profile-panel}}`);
+      await render(hbs`{{profile-panel}}`);
 
       // Then
       const COMPETENCY_BLOCK = '.profile-panel__competence-areas';
-      expect(this.$(COMPETENCY_BLOCK)).to.have.lengthOf(1);
+      expect(find(COMPETENCY_BLOCK)).to.exist;
     });
 
     describe('behavior according to totalPixScore value', function() {
-      it('should display two dashes instead of zero in total pix score, when user has’nt yet assessed on placement test', function() {
+      it('should display two dashes instead of zero in total pix score, when user has’nt yet assessed on placement test', async function() {
         // given
         const totalPixScore = '';
 
         this.set('totalPixScore', totalPixScore);
         // when
-        this.render(hbs`{{profile-panel totalPixScore=totalPixScore}}`);
+        await render(hbs`{{profile-panel totalPixScore=totalPixScore}}`);
 
         // then
-        expect(this.$('.profile-header__score-pastille-wrapper')).to.have.lengthOf(1);
+        expect(find('.profile-header__score-pastille-wrapper')).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/qcm-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals-test.js
@@ -1,17 +1,16 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCM proposals', function() {
 
-  setupComponentTest('qcm-proposals', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{qcm-proposals}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{qcm-proposals}}`);
+    expect(find('.qcm-proposals')).to.exist;
   });
 
 });

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -1,44 +1,27 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, before } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
-import $ from 'jquery';
-
-const CHECKBOX_CORRECT_AND_CHECKED = 'input[type=checkbox]:eq(1)';
-const LABEL_CORRECT_AND_CHECKED = '.qcm-proposal-label__oracle:eq(1)';
-
-const CHECKBOX_CORRECT_AND_UNCHECKED = '.qcm-proposal-label__checkbox-picture:eq(2)';
-const LABEL_CORRECT_AND_UNCHECKED = '.qcm-proposal-label__oracle:eq(2)';
-
-const LABEL_INCORRECT_AND_CHECKED = '.qcm-proposal-label__oracle:eq(0)';
-const LABEL_INCORRECT_AND_UNCHECKED = '.qcm-proposal-label__oracle:eq(0)';
-
-const CSS_LINETHROUGH_ON = 'line-through';
-const CSS_LINETHROUGH_OFF = 'none';
 
 const assessment = {};
 let challenge = null;
 let answer = null;
 let solution = null;
 
-function charCount(str) {
-  return str.match(/[a-zA-Z]/g).length;
-}
-
 describe('Integration | Component | qcm-solution-panel.js', function() {
 
-  setupComponentTest('qcm-solution-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('#Component should renders: ', function() {
 
-    it('Should renders', function() {
-      this.render(hbs`{{qcm-solution-panel}}`);
-      expect(this.$()).to.have.lengthOf(1);
-      expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(0);
+    it('Should renders', async function() {
+      await render(hbs`{{qcm-solution-panel}}`);
+
+      expect(find('.qcm-solution-panel')).to.exist;
+      expect(findAll('.qcm-proposal-label__oracle')).to.have.lengthOf(0);
     });
 
     describe('checkbox state', function() {
@@ -62,39 +45,36 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         answer = EmberObject.create(correctAnswer);
       });
 
-      it('QCM, la réponse correcte est cochée', function() {
+      it('QCM, la réponse correcte est cochée', async function() {
         // Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(1);
-        expect($(CHECKBOX_CORRECT_AND_CHECKED)).to.have.lengthOf(1);
-
-        expect($(CHECKBOX_CORRECT_AND_CHECKED).attr('disabled')).to.equal('disabled');
-        expect(charCount($(LABEL_CORRECT_AND_CHECKED).text())).to.be.above(0);
-        expect($(LABEL_CORRECT_AND_CHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
+        expect(findAll('input[type=checkbox]')[1].getAttribute('disabled')).to.equal('disabled');
+        expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-goodness')).to.equal('good');
       });
 
-      it('QCM, aucune réponse incorrecte n\'est cochée', function() {
+      it('QCM, une réponse incorrecte n\'est pas cochée', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect(charCount($(LABEL_INCORRECT_AND_UNCHECKED).text())).to.be.above(0);
-        expect($(LABEL_INCORRECT_AND_UNCHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
+        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
       });
 
-      it('QCM, Au moins l\'une des réponse correcte n\'est pas cochée', function() {
+      it('QCM, Au moins l\'une des réponses correctes n\'est pas cochée', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -103,14 +83,14 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect(charCount($(LABEL_CORRECT_AND_UNCHECKED).text())).to.be.above(0);
-        expect($(LABEL_CORRECT_AND_UNCHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('no');
+        expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-goodness')).to.equal('good');
       });
 
-      it('QCM, au moins l\'une des réponse incorrecte est cochée', function() {
+      it('QCM, au moins l\'une des réponses incorrectes est cochée', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -119,28 +99,26 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(CHECKBOX_CORRECT_AND_UNCHECKED).is(':checked')).to.equal(false);
-        expect(charCount($(LABEL_INCORRECT_AND_CHECKED).text())).to.be.above(0);
-        expect($(LABEL_INCORRECT_AND_CHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_ON);
-
+        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('yes');
+        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
       });
 
-      it('Aucune case à cocher n\'est cliquable', function() {
+      it('Aucune case à cocher n\'est cliquable', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        const size = $('.comparison-window .qcm-proposal-label__checkbox-picture').length;
+        const size = findAll('.comparison-window .qcm-proposal-label__checkbox-picture').length;
         _.times(size, function(index) {
-          expect($('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').is(':disabled')).to.equal(true);
+          expect(find('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
         });
       });
     });

--- a/mon-pix/tests/integration/components/qcu-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals-test.js
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCU proposals', function() {
 
-  setupComponentTest('qcu-proposals', {
-    integration: true
-  });
+  setupRenderingTest();
 
   /* Rendering
    ----------------------------------------------------- */
@@ -28,17 +27,17 @@ describe('Integration | Component | QCU proposals', function() {
     // - Ember-mocha: https://github.com/emberjs/ember-mocha#setup-component-tests
     // - Ember: https://guides.emberjs.com/v2.10.0/testing/testing-components
     // -        https://guides.emberjs.com/v2.10.0/tutorial/autocomplete-component/
-    it('should render as much radio buttons as proposals', function() {
+    it('should render as much radio buttons as proposals', async function() {
       // given
       this.set('proposals', proposals);
       this.set('answers', answers);
       this.set('answerChanged', answerChangedHandler);
 
       // when
-      this.render(hbs`{{qcu-proposals answers=answers proposals=proposals answerChanged='answerChanged'}}`);
+      await render(hbs`{{qcu-proposals answers=answers proposals=proposals answerChanged='answerChanged'}}`);
 
       // then
-      expect(this.$('.proposal-text')).to.have.lengthOf(3);
+      expect(findAll('.proposal-text')).to.have.lengthOf(3);
     });
 
   });

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -1,38 +1,18 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
-import $ from 'jquery';
-
-const RADIO_CORRECT_AND_CHECKED = '.picture-radio-proposal--qcu:eq(1)';
-const LABEL_CORRECT_AND_CHECKED = '.qcu-proposal-label__oracle:eq(1)';
-
-const LABEL_CORRECT_AND_UNCHECKED = '.qcu-proposal-label__oracle:eq(1)';
-
-const RADIO_INCORRECT_AND_CHECKED = '.picture-radio-proposal--qcu:eq(2)';
-const LABEL_INCORRECT_AND_CHECKED = '.qcu-proposal-label__oracle:eq(2)';
-
-const RADIO_INCORRECT_AND_UNCHECKED = '.picture-radio-proposal--qcu:eq(0)';
-const LABEL_INCORRECT_AND_UNCHECKED = '.qcu-proposal-label__oracle:eq(0)';
-
-const CSS_LINETHROUGH_ON = 'line-through';
-const CSS_LINETHROUGH_OFF = 'none';
 
 const assessment = {};
 let challenge = null;
 let answer = null;
 let solution = null;
 
-function charCount(str) {
-  return str.match(/[a-zA-Z]/g).length;
-}
-
 describe('Integration | Component | qcu-solution-panel.js', function() {
-  setupComponentTest('qcu-solution-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   const correctAnswer = {
     id: 'answer_id', assessment, challenge, value: '2'
@@ -44,10 +24,10 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
 
   describe('#Component should renders: ', function() {
 
-    it('Should renders', function() {
-      this.render(hbs`{{qcu-solution-panel}}`);
-      expect(this.$()).to.have.lengthOf(1);
-      expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(0);
+    it('Should renders', async function() {
+      await render(hbs`{{qcu-solution-panel}}`);
+      expect(find('.qcu-solution-panel')).to.exist;
+      expect(findAll('.qcu-proposal-label__oracle')).to.have.lengthOf(0);
     });
 
     describe('Radio state', function() {
@@ -64,24 +44,21 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         answer = EmberObject.create(correctAnswer);
       });
 
-      it('QCU,la réponse correcte est cochée', function() {
+      it('QCU,la réponse correcte est cochée', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
         // When
-        this.render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(LABEL_CORRECT_AND_CHECKED)).to.have.lengthOf(1);
-        expect($(RADIO_CORRECT_AND_CHECKED)).to.have.lengthOf(1);
-
-        expect($(RADIO_CORRECT_AND_CHECKED).hasClass('radio-on')).to.equal(true);
-        expect(charCount($(LABEL_CORRECT_AND_CHECKED).text())).to.be.above(0);
-        expect($(LABEL_CORRECT_AND_CHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
+        expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-goodness')).to.equal('good');
+        expect(findAll('.picture-radio-proposal--qcu')[1].classList.contains('radio-on')).to.equal(true);
       });
 
-      it('QCU, la réponse correcte n\'est pas cochée', function() {
+      it('QCU, la réponse correcte n\'est pas cochée', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -90,31 +67,30 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(RADIO_CORRECT_AND_CHECKED).hasClass('radio-off')).to.equal(true);
-
-        expect(charCount($(LABEL_CORRECT_AND_UNCHECKED).text())).to.be.above(0);
-        expect($(LABEL_CORRECT_AND_UNCHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('no');
+        expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-goodness')).to.equal('good');
+        expect(findAll('.picture-radio-proposal--qcu')[1].classList.contains('radio-off')).to.equal(true);
       });
 
-      it('QCU, la réponse incorrecte n\'est pas cochée', function() {
+      it('QCU, la réponse incorrecte n\'est pas cochée', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(RADIO_INCORRECT_AND_UNCHECKED).hasClass('radio-off')).to.equal(true);
-        expect(charCount($(LABEL_INCORRECT_AND_UNCHECKED).text())).to.be.above(0);
-        expect($(LABEL_INCORRECT_AND_UNCHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_OFF);
+        expect(findAll('.qcu-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
+        expect(findAll('.qcu-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
+        expect(findAll('.picture-radio-proposal--qcu')[0].classList.contains('radio-off')).to.equal(true);
       });
 
-      it('QCU,la réponse incorrecte est cochée', function() {
+      it('QCU,la réponse incorrecte est cochée', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -123,27 +99,26 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        expect($(RADIO_INCORRECT_AND_CHECKED).hasClass('radio-on')).to.equal(true);
-        expect(charCount($(LABEL_INCORRECT_AND_CHECKED).text())).to.be.above(0);
-        expect($(LABEL_INCORRECT_AND_CHECKED).css('text-decoration')).to.contain(CSS_LINETHROUGH_ON);
+        expect(findAll('.qcu-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('yes');
+        expect(findAll('.qcu-proposal-label__oracle')[2].getAttribute('data-goodness')).to.equal('bad');
+        expect(findAll('.picture-radio-proposal--qcu')[2].classList.contains('radio-on')).to.equal(true);
       });
 
-      it('Aucune case à cocher n\'est cliquable', function() {
+      it('Aucune case à cocher n\'est cliquable', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
         this.set('challenge', challenge);
 
         // When
-        this.render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        const size = $('.comparison-window .qcu-panel__proposal-radio').length;
-        _.times(size, function(index) {
-          expect($('.comparison-window .qcu-panel__proposal-radio:eq(' + index + ')').is(':disabled')).to.equal(true);
+        _.times(findAll('.comparison-window .qcu-panel__proposal-radio').length, function(index) {
+          expect(find('.comparison-window .qcu-panel__proposal-radio:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
         });
       });
     });

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -1,48 +1,45 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROC proposal', function() {
 
-  setupComponentTest('qroc-proposal', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{qroc-proposal}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{qroc-proposal}}`);
+    expect(find('.qroc-proposal')).to.exist;
   });
 
   describe('Component behavior when the user clicks on the input:', function() {
 
-    it('should not display autocompletion answers', function() {
+    it('should not display autocompletion answers', async function() {
       // given
       const proposals = '${myInput}';
       this.set('proposals', proposals);
       this.set('answerValue', '');
       // when
-      this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+      await render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
       // then
-      expect(this.$('.challenge-response__proposal-input').attr('autocomplete')).to.equal('off');
+      expect(find('.challenge-response__proposal-input').getAttribute('autocomplete')).to.equal('off');
     });
   });
 
   describe('Component behavior when user fill input of challenge:', function() {
 
-    it('should display a value when a non-empty value is providing by user', function() {
+    it('should display a value when a non-empty value is providing by user', async function() {
       // given
       const proposals = '${myInput}';
       this.set('proposals', proposals);
       this.set('answerValue', 'myValue');
       // when
-      this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+      await render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
       // then
-      expect(this.$('.challenge-response__proposal-input').val()).to.equal('myValue');
+      expect(find('.challenge-response__proposal-input').value).to.equal('myValue');
     });
   });
-
-  //     block.push(Ember.Object.create({name: 'myInput', input: 'mylabel'}));
 
   describe('Component behavior when user skip challenge:', function() {
 
@@ -57,14 +54,14 @@ describe('Integration | Component | QROC proposal', function() {
       { input: '', output: '' }
     ].forEach(({ input, output }) => {
 
-      it(`should display '' value ${input} is providing to component`, function() {
+      it(`should display '' value ${input} is providing to component`, async function() {
         // given
         this.set('proposals', '${myLabel}');
         this.set('answerValue', input);
         // when
-        this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+        await render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
         // then
-        expect(this.$('.challenge-response__proposal-input').val()).to.be.equal(output);
+        expect(find('.challenge-response__proposal-input').value).to.be.equal(output);
       });
 
     });

--- a/mon-pix/tests/integration/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel-test.js
@@ -1,7 +1,8 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const ANSWER_BLOCK = '.correction-qroc-box__answer';
@@ -10,13 +11,11 @@ const SOLUTION_BLOCK = '.correction-qroc-box__solution';
 
 describe('Integration | Component | qroc solution panel', function() {
 
-  setupComponentTest('qroc-solution-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('should disabled all inputs', function() {
+  it('should disabled all inputs', async function() {
     // given
-    this.render(hbs`{{qroc-solution-panel}}`);
+    await render(hbs`{{qroc-solution-panel}}`);
 
     // then
     expect(document.querySelector('input')).to.have.attr('disabled');
@@ -28,10 +27,10 @@ describe('Integration | Component | qroc solution panel', function() {
     const challenge = EmberObject.create({ id: 'challenge_id' });
     const answer = EmberObject.create({ id: 'answer_id', result: 'ok', assessment, challenge });
 
-    it('should diplay the answer in bold green and not the solution', function() {
+    it('should diplay the answer in bold green and not the solution', async function() {
       // given
       this.set('answer', answer);
-      this.render(hbs`{{qroc-solution-panel answer=answer}}`);
+      await render(hbs`{{qroc-solution-panel answer=answer}}`);
 
       // when
       const answerInput = document.querySelector(ANSWER_INPUT);
@@ -50,13 +49,13 @@ describe('Integration | Component | qroc solution panel', function() {
 
   describe('comparison when the answer is false', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       const assessment = EmberObject.create({ id: 'assessment_id' });
       const challenge = EmberObject.create({ id: 'challenge_id' });
       const answer = EmberObject.create({ id: 'answer_id', result: 'ko', assessment, challenge });
 
       this.set('answer', answer);
-      this.render(hbs`{{qroc-solution-panel answer=answer}}`);
+      await render(hbs`{{qroc-solution-panel answer=answer}}`);
     });
 
     it('should display the false answer line-through', function() {
@@ -82,14 +81,14 @@ describe('Integration | Component | qroc solution panel', function() {
 
     describe('comparison when the answer was not given', function() {
 
-      beforeEach(function() {
+      beforeEach(async function() {
         const assessment = EmberObject.create({ id: 'assessment_id' });
         const challenge = EmberObject.create({ id: 'challenge_id' });
         const answer = EmberObject.create({ id: 'answer_id', result: 'aband', assessment, challenge });
 
         this.set('answer', answer);
         this.set('isResultWithoutAnswer', true);
-        this.render(hbs`{{qroc-solution-panel answer=answer}}`);
+        await render(hbs`{{qroc-solution-panel answer=answer}}`);
       });
 
       it('should display PAS DE REPONSE in italic', function() {

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -1,7 +1,8 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 function getLabels(panelElement) {
@@ -28,9 +29,7 @@ const SOLUTION_TEXT = '.correction-qrocm__solution-text';
 
 describe('Integration | Component | qrocm solution panel', function() {
 
-  setupComponentTest('qrocm-ind-solution-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({
@@ -54,17 +53,17 @@ describe('Integration | Component | qrocm solution panel', function() {
     this.set('challenge', challenge);
   });
 
-  it('should disabled all inputs', function() {
+  it('should disabled all inputs', async function() {
     // when
-    this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
+    await render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
 
     // then
     expect(document.querySelector('input')).to.have.attr('disabled');
   });
 
-  it('should contains three labels', function() {
+  it('should contains three labels', async function() {
     // when
-    this.render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
+    await render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
 
     const panelElement = document.querySelector(PANEL);
     const labels = getLabels(panelElement);
@@ -77,9 +76,9 @@ describe('Integration | Component | qrocm solution panel', function() {
 
     describe('right answer display', function() {
 
-      it('should display the right answer in green bold', function() {
+      it('should display the right answer in green bold', async function() {
         // when
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const panelElement = document.querySelector(PANEL);
@@ -93,9 +92,9 @@ describe('Integration | Component | qrocm solution panel', function() {
         expect(answerInputStyles.getPropertyValue('text-decoration')).to.include('none');
       });
 
-      it('should not display the solution', function() {
+      it('should not display the solution', async function() {
         // when
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK);
@@ -106,9 +105,9 @@ describe('Integration | Component | qrocm solution panel', function() {
 
     describe('wrong answer display', function() {
 
-      it('should display the wrong answer in the second div line-throughed bold', function() {
+      it('should display the wrong answer in the second div line-throughed bold', async function() {
         // when
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const panelElement = document.querySelector(PANEL);
@@ -122,9 +121,9 @@ describe('Integration | Component | qrocm solution panel', function() {
         expect(answerInputStyles.getPropertyValue('text-decoration')).to.include('line-through');
       });
 
-      it('should display one solution in bold green below the input', function() {
+      it('should display one solution in bold green below the input', async function() {
         // when
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK)[1];
@@ -140,9 +139,9 @@ describe('Integration | Component | qrocm solution panel', function() {
 
     describe('no answer display', function() {
 
-      it('should display the empty answer in the third div with "pas de réponse" in italic', function() {
+      it('should display the empty answer in the third div with "pas de réponse" in italic', async function() {
         // when
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const panelElement = document.querySelector(PANEL);
@@ -156,9 +155,9 @@ describe('Integration | Component | qrocm solution panel', function() {
         expect(answerInputStyles.getPropertyValue('text-decoration')).to.include('none');
       });
 
-      it('should display one solution in bold green below the input', function() {
+      it('should display one solution in bold green below the input', async function() {
         // given
-        this.render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // then
         const solutionBlock = document.querySelectorAll(SOLUTION_BLOCK)[1];

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -1,31 +1,30 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QrocmProposalComponent', function() {
 
-  setupComponentTest('qrocm-proposal', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{qrocm-proposal}}`);
+  it('renders', async function() {
+    await render(hbs`{{qrocm-proposal}}`);
 
-    expect(this.$()).to.have.lengthOf(1);
+    expect(find('.qrocm-proposal')).to.exist;
   });
 
   describe('Component behavior when the user clicks on the input:', function() {
 
-    it('should not display autocompletion answers', function() {
+    it('should not display autocompletion answers', async function() {
       // given
       const proposals = '${myInput}';
       this.set('proposals', proposals);
       this.set('answerValue', '');
       // when
-      this.render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
+      await render(hbs`{{qroc-proposal proposals=proposals answerValue=answerValue}}`);
       // then
-      expect(this.$('.challenge-response__proposal-input').attr('autocomplete')).to.equal('off');
+      expect(find('.challenge-response__proposal-input').getAttribute('autocomplete')).to.equal('off');
     });
   });
 

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -2,21 +2,20 @@ import EmberObject from '@ember/object';
 import { resolve, reject } from 'rsvp';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | reset password form', function() {
-  setupComponentTest('reset-password-form', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Component rendering', function() {
 
-    it('should be rendered', function() {
-      this.render(hbs`{{reset-password-form}}`);
-      expect(this.$()).to.have.length(1);
+    it('should be rendered', async function() {
+      await render(hbs`{{reset-password-form}}`);
+      expect(find('.sign-form__container')).to.exist;
     });
 
     describe('When component is rendered,', function() {
@@ -30,37 +29,37 @@ describe('Integration | Component | reset password form', function() {
         { item: '.form-textfield__input-field-container' },
         { item: '.button' }
       ].forEach(({ item }) => {
-        it(`should contains a item with class: ${item}`, function() {
+        it(`should contains a item with class: ${item}`, async function() {
           // when
-          this.render(hbs`{{reset-password-form}}`);
+          await render(hbs`{{reset-password-form}}`);
 
           // then
-          expect(this.$(item)).to.have.lengthOf(1);
+          expect(find(item)).to.exist;
         });
       });
 
-      it('should display user’s fullName', function() {
+      it('should display user’s fullName', async function() {
         // given
         const user = { fullName: 'toto riri' };
         this.set('user', user);
 
         // when
-        this.render(hbs`{{reset-password-form user=user}}`);
+        await render(hbs`{{reset-password-form user=user}}`);
 
         // then
-        expect(this.$('.sign-form-title').text().trim()).to.equal(user.fullName);
+        expect(find('.sign-form-title').textContent.trim()).to.equal(user.fullName);
       });
 
     });
 
     describe('A submit button', () => {
 
-      it('should be rendered', function() {
+      it('should be rendered', async function() {
         // when
-        this.render(hbs`{{reset-password-form}}`);
+        await render(hbs`{{reset-password-form}}`);
 
         // then
-        expect(this.$('.button')).to.have.lengthOf(1);
+        expect(find('.button')).to.exist;
       });
 
       describe('Saving behavior', function() {
@@ -87,19 +86,19 @@ describe('Integration | Component | reset password form', function() {
           this.set('user', user);
           const validPassword = 'Pix 1 2 3!';
 
-          this.render(hbs `{{reset-password-form user=user}}`);
+          await render(hbs `{{reset-password-form user=user}}`);
 
           // when
-          this.$(PASSWORD_INPUT_CLASS).val(validPassword);
-          this.$(PASSWORD_INPUT_CLASS).change();
+          await fillIn(PASSWORD_INPUT_CLASS, validPassword);
+          await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
 
-          await this.$('.button').click();
+          await click('.button');
 
           // then
           expect(isSaveMethodCalled).to.be.true;
           expect(this.get('user.password')).to.eql(null);
-          expect(this.$(PASSWORD_INPUT_CLASS).val()).to.equal(undefined);
-          expect(this.$('.password-reset-demand-form__body')).to.have.lengthOf(1);
+          expect(find(PASSWORD_INPUT_CLASS)).to.not.exist;
+          expect(find('.password-reset-demand-form__body')).to.exist;
         });
 
         it('should get an error, when button is clicked and saving return error', async function() {
@@ -108,19 +107,19 @@ describe('Integration | Component | reset password form', function() {
           this.set('user', user);
           const validPassword = 'Pix 1 2 3!';
 
-          this.render(hbs `{{reset-password-form user=user}}`);
+          await render(hbs `{{reset-password-form user=user}}`);
 
           // when
-          this.$(PASSWORD_INPUT_CLASS).val(validPassword);
-          this.$(PASSWORD_INPUT_CLASS).change();
+          await fillIn(PASSWORD_INPUT_CLASS, validPassword);
+          await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
 
-          await this.$('.button').click();
+          await click('.button');
 
           // then
           expect(isSaveMethodCalled).to.be.true;
           expect(this.get('user.password')).to.eql(validPassword);
-          expect(this.$(PASSWORD_INPUT_CLASS).val()).to.equal(validPassword);
-          expect(this.$('.form-textfield__message--error')).to.have.lengthOf(1);
+          expect(find(PASSWORD_INPUT_CLASS).value).to.equal(validPassword);
+          expect(find('.form-textfield__message--error')).to.exist;
         });
 
       });

--- a/mon-pix/tests/integration/components/result-item-campaign-test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign-test.js
@@ -1,14 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | result item campaign', function() {
 
-  setupComponentTest('result-item-campaign-campaign', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Component rendering', function() {
 
@@ -35,96 +34,96 @@ describe('Integration | Component | result item campaign', function() {
 
     beforeEach(function() {
       this.set('index', 0);
-      return this.on('openComparisonWindow', () => {});
+      return this.set('openComparisonWindow', () => {});
     });
 
-    it('should exist', function() {
+    it('should exist', async function() {
       // given
       this.set('answer', '');
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer}}`);
+      await render(hbs`{{result-item-campaign answer=answer}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.result-item-campaign')).to.exist;
     });
 
-    it('should render an instruction with no empty content', function() {
+    it('should render an instruction with no empty content', async function() {
       // given
       this.set('answer', '');
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer}}`);
+      await render(hbs`{{result-item-campaign answer=answer}}`);
 
       // then
-      expect(this.$('.result-item-campaign__instruction')).to.have.lengthOf(1);
-      expect(this.$('.result-item-campaign__instruction').text()).to.contain('\n');
+      expect(find('.result-item-campaign__instruction')).to.exist;
+      expect(find('.result-item-campaign__instruction').textContent).to.contain('\n');
     });
 
-    it('should render the challenge instruction', function() {
+    it('should render the challenge instruction', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // then
       const expectedChallengeInstruction = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs';
-      expect(this.$('.result-item-campaign__instruction').text().trim()).to.equal(expectedChallengeInstruction);
+      expect(find('.result-item-campaign__instruction').textContent.trim()).to.equal(expectedChallengeInstruction);
     });
 
-    it('should render an button when QCM', function() {
+    it('should render an button when QCM', async function() {
       // given
       this.set('answer', answer);
 
-      this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
       // Then
-      expect(this.$('.result-item-campaign__correction-button').text().trim()).to.deep.equal('Réponses et tutos');
+      expect(find('.result-item-campaign__correction-button').textContent.trim()).to.deep.equal('Réponses et tutos');
     });
 
-    it('should render tooltip for the answer', function() {
+    it('should render tooltip for the answer', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
     });
 
-    it('should not render a tooltip when the answer is being retrieved', function() {
+    it('should not render a tooltip when the answer is being retrieved', async function() {
       // given
       this.set('answer', null);
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer}}`);
+      await render(hbs`{{result-item-campaign answer=answer}}`);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title')).to.equal(undefined);
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title')).to.not.exist;
     });
 
-    it('should update the tooltip when the answer is eventually retrieved', function() {
+    it('should update the tooltip when the answer is eventually retrieved', async function() {
       // given
       this.set('answer', null);
-      this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // when
       this.set('answer', answer);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
     });
 
-    it('should render tooltip with an image', function() {
+    it('should render tooltip with an image', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // Then
-      expect(this.$('result-item-campaign__icon-img'));
+      expect(find('result-item-campaign__icon-img'));
     });
 
     [
@@ -135,16 +134,16 @@ describe('Integration | Component | result item campaign', function() {
       { status: 'timedout', color:'red' },
     ].forEach(function(data) {
 
-      it(`should display the good result icon when answer's result is "${data.status}"`, function() {
+      it(`should display the good result icon when answer's result is "${data.status}"`, async function() {
         // given
         answer.set('result', data.status);
         this.set('answer', answer);
 
         // when
-        this.render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+        await render(hbs`{{result-item-campaign answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
         // then
-        expect(this.$(`.result-item-campaign__icon--${data.color}`)).to.have.lengthOf(1);
+        expect(find(`.result-item-campaign__icon--${data.color}`)).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/result-item-test.js
+++ b/mon-pix/tests/integration/components/result-item-test.js
@@ -1,17 +1,16 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | result item', function() {
 
-  setupComponentTest('result-item', {
-    integration: true
-  });
+  setupRenderingTest();
 
   beforeEach(function() {
-    return this.on('openComparisonWindow', () => {});
+    return this.set('openComparisonWindow', () => {});
   });
 
   describe('Component rendering ', function() {
@@ -37,93 +36,93 @@ describe('Integration | Component | result item', function() {
       }
     });
 
-    it('should exist', function() {
+    it('should exist', async function() {
       // given
       this.set('answer', '');
 
       // when
-      this.render(hbs`{{result-item answer=answer}}`);
+      await render(hbs`{{result-item answer=answer}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.result-item')).to.exist;
     });
 
-    it('should render an instruction with no empty content', function() {
+    it('should render an instruction with no empty content', async function() {
       // given
       this.set('answer', '');
 
       // when
-      this.render(hbs`{{result-item answer=answer}}`);
+      await render(hbs`{{result-item answer=answer}}`);
 
       // then
-      expect(this.$('.result-item__instruction')).to.have.lengthOf(1);
-      expect(this.$('.result-item__instruction').text()).to.contain('\n');
+      expect(find('.result-item__instruction')).to.exist;
+      expect(find('.result-item__instruction').textContent).to.contain('\n');
     });
 
-    it('should render the challenge instruction', function() {
+    it('should render the challenge instruction', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // then
       const expectedChallengeInstruction = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir...';
-      expect(this.$('.result-item__instruction').text().trim()).to.equal(expectedChallengeInstruction);
+      expect(find('.result-item__instruction').textContent.trim()).to.equal(expectedChallengeInstruction);
     });
 
-    it('should render an button when QCM', function() {
+    it('should render an button when QCM', async function() {
       // given
       this.set('answer', answer);
 
-      this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
       // Then
-      expect(this.$('.result-item__correction__button').text().trim()).to.deep.equal('Réponses et tutos');
+      expect(find('.result-item__correction__button').textContent.trim()).to.deep.equal('Réponses et tutos');
     });
 
-    it('should render tooltip for the answer', function() {
+    it('should render tooltip for the answer', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
     });
 
-    it('should not render a tooltip when the answer is being retrieved', function() {
+    it('should not render a tooltip when the answer is being retrieved', async function() {
       // given
       this.set('answer', null);
 
       // when
-      this.render(hbs`{{result-item answer=answer}}`);
+      await render(hbs`{{result-item answer=answer}}`);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title')).to.equal(undefined);
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title')).to.not.exist;
     });
 
-    it('should update the tooltip when the answer is eventually retrieved', function() {
+    it('should update the tooltip when the answer is eventually retrieved', async function() {
       // given
       this.set('answer', null);
-      this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // when
       this.set('answer', answer);
 
       // then
-      expect(this.$('div[data-toggle="tooltip"]').attr('data-original-title').trim()).to.equal('Réponse incorrecte');
+      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
     });
 
-    it('should render tooltip with an image', function() {
+    it('should render tooltip with an image', async function() {
       // given
       this.set('answer', answer);
 
       // when
-      this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
       // Then
-      expect(this.$('result-item__icon-img'));
+      expect(find('result-item__icon-img'));
     });
 
     [
@@ -135,18 +134,17 @@ describe('Integration | Component | result item', function() {
       { status: 'default' },
     ].forEach(function(data) {
 
-      it(`should display the good result icon when answer's result is "${data.status}"`, function() {
+      it(`should display the good result icon when answer's result is "${data.status}"`, async function() {
         // given
         answer.set('result', data.status);
         this.set('answer', answer);
 
         // when
-        this.render(hbs`{{result-item answer=answer openAnswerDetails=(action 'openComparisonWindow')}}`);
+        await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
 
         // then
-        const $icon = this.$('.result-item__icon-img');
-        expect(this.$(`.result-item__icon-img--${data.status}`)).to.have.lengthOf(1);
-        expect($icon.attr('src')).to.equal(`/images/answer-validation/icon-${data.status}.svg`);
+        expect(find(`.result-item__icon-img--${data.status}`)).to.exist;
+        expect(find('.result-item__icon-img').getAttribute('src')).to.equal(`/images/answer-validation/icon-${data.status}.svg`);
       });
     });
 

--- a/mon-pix/tests/integration/components/results-warning-test.js
+++ b/mon-pix/tests/integration/components/results-warning-test.js
@@ -1,34 +1,33 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | results-warning', function() {
 
-  setupComponentTest('results-warning', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Warning message display', function() {
     const campaignParticipationToResume = EmberObject.create({});
 
-    it('should display the warning message when user has began a campaign', function() {
+    it('should display the warning message when user has began a campaign', async function() {
       // given
       this.set('campaignParticipations', [campaignParticipationToResume]);
       // when
-      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      await render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
       // then
-      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(1);
+      expect(find('.results-warning__warning-message')).to.exist;
     });
 
-    it('should not display the warning message when user has not began any campaign', function() {
+    it('should not display the warning message when user has not began any campaign', async function() {
       // given
       this.set('campaignParticipations', []);
       // when
-      this.render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
+      await render(hbs`{{results-warning campaignParticipations=campaignParticipations}}`);
       // then
-      expect(this.$('.results-warning__warning-message')).to.have.lengthOf(0);
+      expect(find('.results-warning__warning-message')).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -1,16 +1,15 @@
 import { alias } from '@ember/object/computed';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import LinkComponent from '@ember/routing/link-component';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | resume-campaign-banner', function() {
 
-  setupComponentTest('resume-campaign-banner', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Banner display', function() {
     const campaignToResume = EmberObject.create({
@@ -43,53 +42,53 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
     context('when campaign is not finished and not shared', function() {
 
-      it('should display the resume campaign banner', function() {
+      it('should display the resume campaign banner', async function() {
         // given
         this.set('campaignParticipations', [campaignToResume, oldCampaignNotFinished, campaignFinished]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__container')).to.have.lengthOf(1);
+        expect(find('.resume-campaign-banner__container')).to.exist;
       });
 
-      it('should display a link to resume the campaign', function() {
+      it('should display a link to resume the campaign', async function() {
         // given
         this.set('campaignParticipations', [campaignToResume]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__button')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__button').text()).to.equal('Reprendre');
-        expect(this.$('.resume-campaign-banner__button').attr('href')).to.contains('campaigns.start-or-resume');
+        expect(find('.resume-campaign-banner__button')).to.exist;
+        expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+        expect(find('.resume-campaign-banner__button').getAttribute('href')).to.contains('campaigns.start-or-resume');
       });
 
-      it('should display a sentence to ask user to resume with the title of campaign', function() {
+      it('should display a sentence to ask user to resume with the title of campaign', async function() {
         // given
         this.set('campaignParticipations', [campaignToResume]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__title')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__title').text()).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
+        expect(find('.resume-campaign-banner__title')).to.exist;
+        expect(find('.resume-campaign-banner__title').textContent).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
       });
 
-      it('should display a simple sentence to ask user to resume when campaign has no title', function() {
+      it('should display a simple sentence to ask user to resume when campaign has no title', async function() {
         // given
         campaignToResume.campaign.set('title', null);
         this.set('campaignParticipations', [campaignToResume]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__title')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__title').text()).to.equal('Vous n\'avez pas terminé votre parcours');
+        expect(find('.resume-campaign-banner__title')).to.exist;
+        expect(find('.resume-campaign-banner__title').textContent).to.equal('Vous n\'avez pas terminé votre parcours');
       });
 
     });
@@ -107,75 +106,75 @@ describe('Integration | Component | resume-campaign-banner', function() {
         }),
       });
 
-      it('should display the resume campaign banner', function() {
+      it('should display the resume campaign banner', async function() {
         // given
         this.set('campaignParticipations', [oldCampaignNotFinished, campaignFinished, campaignFinishedButNotShared]);
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
         // then
-        expect(this.$('.resume-campaign-banner__container')).to.have.lengthOf(1);
+        expect(find('.resume-campaign-banner__container')).to.exist;
       });
 
-      it('should display a link to shared the results', function() {
+      it('should display a link to shared the results', async function() {
         // given
         this.set('campaignParticipations', [campaignFinishedButNotShared]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__button')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__button').text()).to.equal('Continuer');
-        expect(this.$('.resume-campaign-banner__button').attr('href')).to.contains('campaigns.start-or-resume');
+        expect(find('.resume-campaign-banner__button')).to.exist;
+        expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+        expect(find('.resume-campaign-banner__button').getAttribute('href')).to.contains('campaigns.start-or-resume');
       });
 
-      it('should display a sentence to ask user to share his results with the title of campaign', function() {
+      it('should display a sentence to ask user to share his results with the title of campaign', async function() {
         // given
         this.set('campaignParticipations', [campaignFinishedButNotShared]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__title')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__title').text()).to.equal(`Parcours "${campaignFinishedButNotShared.campaign.title}" terminé ! Envoyez vos résultats.`);
+        expect(find('.resume-campaign-banner__title')).to.exist;
+        expect(find('.resume-campaign-banner__title').textContent).to.equal(`Parcours "${campaignFinishedButNotShared.campaign.title}" terminé ! Envoyez vos résultats.`);
       });
 
-      it('should display a simple sentence to ask user to share his results when campaign has no title', function() {
+      it('should display a simple sentence to ask user to share his results when campaign has no title', async function() {
         // given
         campaignFinishedButNotShared.campaign.set('title', null);
         this.set('campaignParticipations', [campaignFinishedButNotShared]);
 
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
 
         // then
-        expect(this.$('.resume-campaign-banner__title')).to.have.lengthOf(1);
-        expect(this.$('.resume-campaign-banner__title').text()).to.equal('Parcours terminé ! Envoyez vos résultats.');
+        expect(find('.resume-campaign-banner__title')).to.exist;
+        expect(find('.resume-campaign-banner__title').textContent).to.equal('Parcours terminé ! Envoyez vos résultats.');
       });
     });
 
     context('when campaign is finished and shared', function() {
 
-      it('should not display the resume campaign banner when the list of campaigns contains only finished campaign', function() {
+      it('should not display the resume campaign banner when the list of campaigns contains only finished campaign', async function() {
         // given
         this.set('campaignParticipations', [campaignFinished]);
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
         // then
-        expect(this.$('.resume-campaign-banner__container')).to.have.lengthOf(0);
+        expect(find('.resume-campaign-banner__container')).to.not.exist;
       });
     });
 
     context('when campaign is not started yet', function() {
 
-      it('should not display the resume campaign banner when the list of campaigns is empty', function() {
+      it('should not display the resume campaign banner when the list of campaigns is empty', async function() {
         // given
         this.set('campaignParticipations', []);
         // when
-        this.render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
         // then
-        expect(this.$('.resume-campaign-banner__container')).to.have.lengthOf(0);
+        expect(find('.resume-campaign-banner__container')).to.not.exist;
       });
     });
 

--- a/mon-pix/tests/integration/components/routes/board-page-test.js
+++ b/mon-pix/tests/integration/components/routes/board-page-test.js
@@ -1,30 +1,28 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 
 describe('Integration | Component | Board page', function() {
-  setupComponentTest('board-page', {
-    integration: true
-  });
+  setupRenderingTest();
 
   context('On component rendering', function() {
     const organization = { id: 1 };
 
     beforeEach(function() {
       this.set('organization', organization);
-      this.register('service:session', Service.extend({
+      this.owner.register('service:session', Service.extend({
         data: {
           authenticated: {
             token: 'VALID-TOKEN',
           }
         },
       }));
-      this.inject.service('session', { as: 'session' });
     });
 
-    it('should render component container', function() {
+    it('should render component container', async function() {
       // given
       const snapshots = {
         data: [],
@@ -33,16 +31,16 @@ describe('Integration | Component | Board page', function() {
       this.set('snapshots', snapshots);
 
       // when
-      this.render(hbs`{{routes/board-page organization=organization snapshots=snapshots}}`);
+      await render(hbs`{{routes/board-page organization=organization snapshots=snapshots}}`);
 
       // then
-      expect(this.$('.too-many-snapshots')).to.have.lengthOf(0);
-      expect(this.$('.profiles-title__export-csv').attr('href')).to.equal(
+      expect(find('.too-many-snapshots')).to.not.exist;
+      expect(find('.profiles-title__export-csv').getAttribute('href')).to.equal(
         'http://localhost:3000/api/organizations/1/snapshots/export?userToken=VALID-TOKEN'
       );
     });
 
-    it('should render component with tooManySnapshots', function() {
+    it('should render component with tooManySnapshots', async function() {
       // given
       const snapshots = {
         data: [],
@@ -51,10 +49,10 @@ describe('Integration | Component | Board page', function() {
       this.set('snapshots', snapshots);
 
       // when
-      this.render(hbs`{{routes/board-page organization=organization snapshots=snapshots}}`);
+      await render(hbs`{{routes/board-page organization=organization snapshots=snapshots}}`);
 
       // then
-      expect(this.$('.too-many-snapshots')).to.have.lengthOf(1);
+      expect(find('.too-many-snapshots')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/score-pastille-test.js
+++ b/mon-pix/tests/integration/components/score-pastille-test.js
@@ -1,42 +1,41 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | score pastille', function() {
-  setupComponentTest('score-pastille', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('Component rendering', function() {
 
-    it('should render component', function() {
+    it('should render component', async function() {
       // when
-      this.render(hbs`{{score-pastille}}`);
+      await render(hbs`{{score-pastille}}`);
 
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.score-pastille')).to.exist;
     });
 
     describe('Component dashes rendering instead of zero cases:', function() {
 
-      it('should display two dashes, when no pixScore provided', function() {
+      it('should display two dashes, when no pixScore provided', async function() {
         // when
-        this.render(hbs`{{score-pastille}}`);
+        await render(hbs`{{score-pastille}}`);
         // then
-        expect(this.$('.score-pastille__pix-score').text().trim()).to.equal('–');
+        expect(find('.score-pastille__pix-score').textContent.trim()).to.equal('–');
       });
 
     });
 
-    it('should display provided score in pastille', function() {
+    it('should display provided score in pastille', async function() {
       // given
       const pixScore = '777';
       this.set('pixScore', pixScore);
       // when
-      this.render(hbs`{{score-pastille pixScore=pixScore}}`);
+      await render(hbs`{{score-pastille pixScore=pixScore}}`);
       // then
-      expect(this.$('.score-pastille__pix-score').text().trim()).to.equal(pixScore);
+      expect(find('.score-pastille__pix-score').textContent.trim()).to.equal(pixScore);
     });
   });
 });

--- a/mon-pix/tests/integration/components/scoring-panel-tantpix-test.js
+++ b/mon-pix/tests/integration/components/scoring-panel-tantpix-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const COMPONENT_WRAPPER = '.scoring-panel-tantpix';
@@ -22,18 +23,16 @@ const BUTTON_NEXT_CLASS = '.tantpix-panel__button';
 const BUTTON_NEXT_CONTENT = 'revenir à l\'accueil';
 
 describe('Integration | Component | scoring panel tantpix', function() {
-  setupComponentTest('scoring-panel-tantpix', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('On Component rendering:', function() {
-    beforeEach(function() {
-      this.render(hbs`{{scoring-panel-tantpix}}`);
+    beforeEach(async function() {
+      await render(hbs`{{scoring-panel-tantpix}}`);
     });
 
     it('should render successfully component wrapper', function() {
-      expect(this.$()).to.have.lengthOf(1);
-      expect(this.$(COMPONENT_WRAPPER)).to.lengthOf(1);
+      expect(find('.scoring-panel-tantpix')).to.exist;
+      expect(find(COMPONENT_WRAPPER)).to.exist;
     });
 
     describe('wrappers rendering', function() {
@@ -68,9 +67,8 @@ describe('Integration | Component | scoring panel tantpix', function() {
 
       ].forEach(({ wrapperDescription, wrapperClass, wrapperTagName, wrapperLength }) => {
         it(`should contain: ${wrapperDescription} in scoring panel`, function() {
-          const wrapperRendered = this.$(wrapperClass);
-          expect(wrapperRendered.prop('tagName').toLowerCase()).to.equal(wrapperTagName);
-          expect(wrapperRendered).to.lengthOf(wrapperLength);
+          expect(find(wrapperClass).tagName.toLowerCase()).to.equal(wrapperTagName);
+          expect(findAll(wrapperClass)).to.lengthOf(wrapperLength);
         });
       });
 
@@ -104,18 +102,18 @@ describe('Integration | Component | scoring panel tantpix', function() {
         },
       ].forEach(({ itemDescription, itemClass, itemTagName, itemContent }) => {
         it(`should be ${itemDescription} in scoring panel`, function() {
-          const itemRendered = this.$(itemClass);
-          expect(itemRendered.prop('tagName').toLowerCase()).to.equal(itemTagName);
-          expect(itemRendered.text().trim()).to.be.equal(itemContent);
+          const itemRendered = find(itemClass);
+          expect(itemRendered.tagName.toLowerCase()).to.equal(itemTagName);
+          expect(itemRendered.textContent.trim()).to.be.equal(itemContent);
         });
       });
 
       it('should return a smiley illustration which satisfy minimals accessibilities conditions', function() {
-        const smiley = this.$(HEADING_ILLUSTRATION_CLASS);
-        expect(smiley.attr('src')).to.includes('/images/smiley.png');
-        expect(smiley.attr('srcset')).to.includes('/images/smiley@2x.png');
-        expect(smiley.attr('srcset')).to.includes('/images/smiley@3x.png');
-        expect(smiley.attr('alt')).to.includes('smiley');
+        const smiley = find(HEADING_ILLUSTRATION_CLASS);
+        expect(smiley.getAttribute('src')).to.includes('/images/smiley.png');
+        expect(smiley.getAttribute('srcset')).to.includes('/images/smiley@2x.png');
+        expect(smiley.getAttribute('srcset')).to.includes('/images/smiley@3x.png');
+        expect(smiley.getAttribute('alt')).to.includes('smiley');
       });
     });
 

--- a/mon-pix/tests/integration/components/scoring-panel-test.js
+++ b/mon-pix/tests/integration/components/scoring-panel-test.js
@@ -1,16 +1,15 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const TANTPIX_CONTAINER_CLASS = '.scoring-panel-tantpix';
 
 describe('Integration | Component | scoring panel', function() {
 
-  setupComponentTest('scoring-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   const assessmentWithTrophy = EmberObject.create({ estimatedLevel: 1, pixScore: 67, course: { isAdaptive: true } });
   const assessmentWithNoTrophyAndSomePix = EmberObject.create({
@@ -24,76 +23,76 @@ describe('Integration | Component | scoring panel', function() {
     course: { isAdaptive: true }
   });
 
-  it('renders', function() {
-    this.render(hbs`{{scoring-panel}}`);
-    expect(this.$()).to.have.lengthOf(1);
+  it('renders', async function() {
+    await render(hbs`{{scoring-panel}}`);
+    expect(find('.scoring-panel')).to.exist;
   });
 
   describe('Default display', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('assessment', assessmentWithNoTrophyAndNoPix);
-      this.render(hbs`{{scoring-panel assessment=assessment}}`);
+      await render(hbs`{{scoring-panel assessment=assessment}}`);
     });
 
     it('it should not display trophy panel', function() {
       // then
-      expect(this.$('.scoring-panel__trophy')).to.have.lengthOf(0);
-      expect(this.$('.scoring-panel__text')).to.have.lengthOf(0);
+      expect(find('.scoring-panel__trophy')).to.not.exist;
+      expect(find('.scoring-panel__text')).to.not.exist;
     });
 
     it('should display tantpix result, when user has no reward', function() {
       // then
-      expect(this.$(TANTPIX_CONTAINER_CLASS)).to.lengthOf(1);
+      expect(find(TANTPIX_CONTAINER_CLASS)).to.exist;
     });
   });
 
   describe('Display a trophy when the user won a trophy', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('assessment', assessmentWithTrophy);
-      this.render(hbs`{{scoring-panel assessment=assessment}}`);
+      await render(hbs`{{scoring-panel assessment=assessment}}`);
     });
 
     it('should display the won trophy', function() {
       // then
-      expect(this.$('.scoring-panel__reward')).to.have.lengthOf(1);
-      expect(this.$('.trophy-item')).to.have.lengthOf(1);
+      expect(find('.scoring-panel__reward')).to.exist;
+      expect(find('.trophy-item')).to.exist;
     });
 
     it('should display the congratulations', function() {
       // then
-      expect(this.$('.scoring-panel__congrats-course-name')).to.have.lengthOf(1);
-      expect(this.$('.scoring-panel__congrats-felicitations')).to.have.lengthOf(1);
-      expect(this.$('.scoring-panel__congrats-scoring')).to.have.lengthOf(1);
+      expect(find('.scoring-panel__congrats-course-name')).to.exist;
+      expect(find('.scoring-panel__congrats-felicitations')).to.exist;
+      expect(find('.scoring-panel__congrats-scoring')).to.exist;
     });
 
     it('should display the "back to home" button', function() {
       // then
-      expect(this.$('.scoring-panel__index-link')).to.have.lengthOf(1);
-      expect(this.$('.scoring-panel__index-link-back').text()).to.be.equal('REVENIR À L\'ACCUEIL');
+      expect(find('.scoring-panel__index-link')).to.exist;
+      expect(find('.scoring-panel__index-link-back').textContent).to.be.equal('REVENIR À L\'ACCUEIL');
     });
   });
 
   describe('Display a medal when the user won some pix but not a trophy', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       this.set('assessment', assessmentWithNoTrophyAndSomePix);
-      this.render(hbs`{{scoring-panel assessment=assessment}}`);
+      await render(hbs`{{scoring-panel assessment=assessment}}`);
     });
 
     it('should display the won medal', function() {
       // then
       // then
-      expect(this.$('.scoring-panel__reward')).to.have.lengthOf(1);
-      expect(this.$('.medal-item')).to.have.lengthOf(1);
+      expect(find('.scoring-panel__reward')).to.exist;
+      expect(find('.medal-item')).to.exist;
     });
 
     it('should display the congratulations', function() {
       // then
-      expect(this.$('.scoring-panel__congrats-course-name')).to.have.lengthOf(1);
-      expect(this.$('.scoring-panel__congrats-pas-mal')).to.have.lengthOf(1);
-      expect(this.$('.scoring-panel__congrats-scoring')).to.have.lengthOf(1);
+      expect(find('.scoring-panel__congrats-course-name')).to.exist;
+      expect(find('.scoring-panel__congrats-pas-mal')).to.exist;
+      expect(find('.scoring-panel__congrats-scoring')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/share-profile-test.js
+++ b/mon-pix/tests/integration/components/share-profile-test.js
@@ -1,87 +1,85 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import RSVP from 'rsvp';
-import $ from 'jquery';
 
 describe('Integration | Component | share profile', function() {
 
-  setupComponentTest('share-profile', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   function expectToBeOnOrganizationCodeEntryView() {
-    expect($('.share-profile__section--organization-code-entry')).to.have.lengthOf(1);
-    expect($('.share-profile__section--sharing-confirmation')).to.have.lengthOf(0);
-    expect($('.share-profile__section--success-notification')).to.have.lengthOf(0);
+    expect(find('.share-profile__section--organization-code-entry')).to.exist;
+    expect(find('.share-profile__section--sharing-confirmation')).to.not.exist;
+    expect(find('.share-profile__section--success-notification')).to.not.exist;
   }
 
   function expectToBeSharingConfirmationView() {
-    expect($('.share-profile__section--organization-code-entry')).to.have.lengthOf(0);
-    expect($('.share-profile__section--sharing-confirmation')).to.have.lengthOf(1);
-    expect($('.share-profile__section--success-notification')).to.have.lengthOf(0);
+    expect(find('.share-profile__section--organization-code-entry')).to.not.exist;
+    expect(find('.share-profile__section--sharing-confirmation')).to.exist;
+    expect(find('.share-profile__section--success-notification')).to.not.exist;
   }
 
   function expectToBeOnSuccessNotificationView() {
-    expect($('.share-profile__section--organization-code-entry')).to.have.lengthOf(0);
-    expect($('.share-profile__section--sharing-confirmation')).to.have.lengthOf(0);
-    expect($('.share-profile__section--success-notification')).to.have.lengthOf(1);
+    expect(find('.share-profile__section--organization-code-entry')).to.not.exist;
+    expect(find('.share-profile__section--sharing-confirmation')).to.not.exist;
+    expect(find('.share-profile__section--success-notification')).to.exist;
   }
 
   function expectModalToBeClosed() {
-    expect($('.pix-modal')).to.have.lengthOf(0);
+    expect(find('.pix-modal')).to.not.exist;
   }
 
   describe('Step 0 - "Share" button on modal wrapper', function() {
 
     it('should open profile sharing modal on "organization code entry" view', async function() {
       // given
-      this.render(hbs`{{share-profile}}`);
-      expect(document.querySelectorAll('.pix-modal-dialog')).to.have.lengthOf(0);
+      await render(hbs`{{share-profile}}`);
+      expect(document.querySelectorAll('.pix-modal-dialog')).to.not.exist;
 
       // when
-      await document.querySelector(('.share-profile__share-button')).click();
+      await click('.share-profile__share-button');
 
       // then
-      expect(document.querySelectorAll('.pix-modal-dialog')).to.have.lengthOf(1);
-      expect(document.querySelectorAll('.share-profile__section--organization-code-entry')).to.have.lengthOf(1);
+      expect(document.querySelectorAll('.pix-modal-dialog')).to.exist;
+      expect(document.querySelectorAll('.share-profile__section--organization-code-entry')).to.exist;
     });
   });
 
   describe('Step 1 - "Organization code entry" view', function() {
 
-    it('should be the modal default view', function() {
+    it('should be the modal default view', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true}}`);
+      await render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
       expectToBeOnOrganizationCodeEntryView();
     });
 
-    it('should contain a text input for the organization code', function() {
+    it('should contain a text input for the organization code', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true}}`);
+      await render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect($('.share-profile__organization-code-input')).to.have.lengthOf(1);
+      expect(find('.share-profile__organization-code-input')).to.exist;
     });
 
-    it('should contain a "Continue" button to find the organization', function() {
+    it('should contain a "Continue" button to find the organization', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true}}`);
+      await render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect($('.share-profile__continue-button')).to.have.lengthOf(1);
+      expect(find('.share-profile__continue-button')).to.exist;
     });
 
-    it('should contain a "Cancel" button to cancel the profile sharing', function() {
+    it('should contain a "Cancel" button to cancel the profile sharing', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true}}`);
+      await render(hbs`{{share-profile _showingModal=true}}`);
 
       // then
-      expect($('.share-profile__cancel-button')).to.have.lengthOf(1);
+      expect(find('.share-profile__cancel-button')).to.exist;
     });
 
     it('should redirect to "sharing confirmation" view when clicking on "Continue" button', async function() {
@@ -90,10 +88,10 @@ describe('Integration | Component | share profile', function() {
         const organization = EmberObject.create({ name: 'Pix' });
         return RSVP.resolve(organization);
       });
-      this.render(hbs`{{share-profile _showingModal=true _code="ABCD01" searchForOrganization=searchForOrganization}}`);
+      await render(hbs`{{share-profile _showingModal=true _code="ABCD01" searchForOrganization=searchForOrganization}}`);
 
       // when
-      await document.querySelector('.share-profile__continue-button').click();
+      await click('.share-profile__continue-button');
 
       // then
       expectToBeSharingConfirmationView();
@@ -104,22 +102,22 @@ describe('Integration | Component | share profile', function() {
       this.set('searchForOrganization', function() {
         return RSVP.resolve(null);
       });
-      this.render(hbs`{{share-profile _showingModal=true searchForOrganization=searchForOrganization}}`);
+      await render(hbs`{{share-profile _showingModal=true searchForOrganization=searchForOrganization}}`);
 
       // when
-      await document.querySelector('.share-profile__continue-button').click();
+      await click('.share-profile__continue-button');
 
       // then
-      expect($('.share-profile__form-error')).to.have.lengthOf(1);
+      expect(find('.share-profile__form-error')).to.exist;
       expectToBeOnOrganizationCodeEntryView();
     });
 
     it('should close the modal when clicking on "Cancel" button', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true}}`);
+      await render(hbs`{{share-profile _showingModal=true}}`);
 
       // when
-      await document.querySelector('.share-profile__cancel-button').click();
+      await click('.share-profile__cancel-button');
 
       // then
       expectModalToBeClosed();
@@ -129,25 +127,25 @@ describe('Integration | Component | share profile', function() {
 
   describe('Step 2 - "Sharing confirmation" view', function() {
 
-    it('should display the name of the found organization', function() {
+    it('should display the name of the found organization', async function() {
       // given
       this.set('organization', EmberObject.create({ name: 'Pix' }));
 
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
 
       // then
-      expect($('.share-profile__organization-name').text().trim()).to.equal('Pix');
+      expect(find('.share-profile__organization-name').textContent.trim()).to.equal('Pix');
     });
 
     describe('when organization\'s type is SUP', function() {
 
-      beforeEach(function() {
+      beforeEach(async function() {
         // given
         this.set('organization', EmberObject.create({ name: 'Pix', type: 'SUP' }));
 
         // when
-        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+        await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
       });
 
       it('should ask for student code (required)', function() {
@@ -164,12 +162,12 @@ describe('Integration | Component | share profile', function() {
 
     describe('when organization\'s type is SCO', function() {
 
-      beforeEach(function() {
+      beforeEach(async function() {
         // given
         this.set('organization', EmberObject.create({ name: 'Pix', type: 'SCO' }));
 
         // when
-        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+        await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
       });
 
       it('should not ask for student code', function() {
@@ -186,12 +184,12 @@ describe('Integration | Component | share profile', function() {
 
     describe('when organization\'s type is PRO', function() {
 
-      beforeEach(function() {
+      beforeEach(async function() {
         // given
         this.set('organization', EmberObject.create({ name: 'Pix', type: 'PRO' }));
 
         // when
-        this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+        await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
       });
 
       it('should ask for ID-Pix (optional)', function() {
@@ -206,28 +204,28 @@ describe('Integration | Component | share profile', function() {
 
     });
 
-    it('should contain a "Confirm" button to valid the profile sharing', function() {
+    it('should contain a "Confirm" button to valid the profile sharing', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
 
       // then
-      expect($('.share-profile__confirm-button')).to.have.lengthOf(1);
+      expect(find('.share-profile__confirm-button')).to.exist;
     });
 
-    it('should contain a "Cancel" button to cancel the profile sharing for the given organization', function() {
+    it('should contain a "Cancel" button to cancel the profile sharing for the given organization', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
 
       // then
-      expect($('.share-profile__cancel-button')).to.have.lengthOf(1);
+      expect(find('.share-profile__cancel-button')).to.exist;
     });
 
     it('should return back to "organization code entry" view when clicking on "Cancel" button', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
 
       // when
-      await document.querySelector('.share-profile__cancel-button').click();
+      await click('.share-profile__cancel-button');
 
       // then
       expectToBeOnOrganizationCodeEntryView();
@@ -239,33 +237,33 @@ describe('Integration | Component | share profile', function() {
       this.set('shareProfileSnapshot', () => {
         return RSVP.resolve(null);
       });
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization shareProfileSnapshot=shareProfileSnapshot}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization shareProfileSnapshot=shareProfileSnapshot}}`);
 
       // when
-      await document.querySelector('.share-profile__confirm-button').click();
+      await click('.share-profile__confirm-button');
 
       // then
       expectToBeOnSuccessNotificationView();
     });
 
-    it('should limit the lenght of the campainCode to 255 characters', function() {
+    it('should limit the lenght of the campainCode to 255 characters', async function() {
       // given
       this.set('organization', EmberObject.create({ name: 'Pix' }));
 
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
 
       // then
       expect(document.querySelector('.share-profile__campaign-code-input').getAttribute('maxlength')).to.equal('255');
 
     });
 
-    it('should limit the lenght of the studentCode to 255 characters', function() {
+    it('should limit the lenght of the studentCode to 255 characters', async function() {
       // given
       this.set('organization', EmberObject.create({ name: 'Pix', type: 'SUP' }));
 
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation" _organization=organization}}`);
 
       // then
       expect(document.querySelector('.share-profile__student-code-input').getAttribute('maxlength')).to.equal('255');
@@ -276,23 +274,23 @@ describe('Integration | Component | share profile', function() {
 
   describe('Step 3 - "Success notification" view', function() {
 
-    it('should contain a "Close" button that hide the modal', function() {
+    it('should contain a "Close" button that hide the modal', async function() {
       // when
-      this.render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
 
       // then
-      expect($('.share-profile__close-button')).to.have.lengthOf(1);
+      expect(find('.share-profile__close-button')).to.exist;
     });
 
     it('should close the modal when clicking on "Cancel" button', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
+      await render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
 
       // when
-      await document.querySelector('.share-profile__close-button').click();
+      await click('.share-profile__close-button');
 
       // then
-      expect($('.pix-modal')).to.have.lengthOf(0);
+      expect(find('.pix-modal')).to.not.exist;
     });
   });
 
@@ -300,11 +298,11 @@ describe('Integration | Component | share profile', function() {
 
     it('should open the modal on default "organization code entry" view even if modal was previously closed on "sharing confirmation" view', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
-      await document.querySelector('.pix-modal__close-link > a').click();
+      await render(hbs`{{share-profile _showingModal=true _view="sharing-confirmation"}}`);
+      await click('.pix-modal__close-link > a');
 
       // when
-      await document.querySelector('.share-profile__share-button').click();
+      await click('.share-profile__share-button');
 
       // then
       expectToBeOnOrganizationCodeEntryView();
@@ -312,11 +310,11 @@ describe('Integration | Component | share profile', function() {
 
     it('should open the modal on default "organization code entry" view even if modal was previously closed on "success notification" view', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
-      await document.querySelector('.pix-modal__close-link > a').click();
+      await render(hbs`{{share-profile _showingModal=true _view="success-notification"}}`);
+      await click('.pix-modal__close-link > a');
 
       // when
-      await document.querySelector('.share-profile__share-button').click();
+      await click('.share-profile__share-button');
 
       // then
       expectToBeOnOrganizationCodeEntryView();
@@ -324,20 +322,20 @@ describe('Integration | Component | share profile', function() {
 
     it('should display the code input filled with the previously set organization code even after canceling sharing (step 2)', async function() {
       // given
-      this.render(hbs`{{share-profile _showingModal=true _code="ORGA00" _view="sharing-confirmation"}}`);
+      await render(hbs`{{share-profile _showingModal=true _code="ORGA00" _view="sharing-confirmation"}}`);
 
       // when
-      await document.querySelector('.share-profile__cancel-button').click();
+      await click('.share-profile__cancel-button');
 
       // then
-      expect($('.share-profile__organization-code-input').val()).to.equal('ORGA00');
+      expect(find('.share-profile__organization-code-input').value).to.equal('ORGA00');
     });
 
   });
 
   describe('Actions', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       this.set('showingModal', true);
       this.set('view', 'sharing-confirmation');
@@ -347,7 +345,7 @@ describe('Integration | Component | share profile', function() {
       this.set('studentCode', 'student_code');
       this.set('campaignCode', 'campaign_code');
 
-      this.render(hbs`{{share-profile
+      await render(hbs`{{share-profile
       _showingModal=showingModal
       _view=view
       _code=code
@@ -361,7 +359,7 @@ describe('Integration | Component | share profile', function() {
 
       it('should remove all input information when modal is closed', async function() {
         // when
-        await document.querySelector('.pix-modal__close-link > a').click();
+        await click('.pix-modal__close-link > a');
 
         // then
         expect(this.get('showingModal')).to.be.false;
@@ -379,7 +377,7 @@ describe('Integration | Component | share profile', function() {
 
       it('should remove all input information but organization code when sharing confirmation is canceled', async function() {
         // when
-        await document.querySelector('.share-profile__cancel-button').click();
+        await click('.share-profile__cancel-button');
 
         // then
         expect(this.get('showingModal')).to.be.true;

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -1,63 +1,61 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { run } from '@ember/runloop';
 
 describe('Integration | Component | signin form', function() {
 
-  setupComponentTest('signin-form', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  describe('Rendering', function() {
+  describe('Rendering', async function() {
 
-    it('should display an input for email field', function() {
+    it('should display an input for email field', async function() {
       // when
-      this.render(hbs`{{signin-form}}`);
+      await render(hbs`{{signin-form}}`);
 
       // then
       expect(document.querySelector('input#email')).to.exist;
     });
 
-    it('should display an input for password field', function() {
+    it('should display an input for password field', async function() {
       // when
-      this.render(hbs`{{signin-form}}`);
+      await render(hbs`{{signin-form}}`);
 
       // then
       expect(document.querySelector('input#password')).to.exist;
     });
 
-    it('should display a submit button to authenticate', function() {
+    it('should display a submit button to authenticate', async function() {
       // when
-      this.render(hbs`{{signin-form}}`);
+      await render(hbs`{{signin-form}}`);
 
       // then
       expect(document.querySelector('button.button')).to.exist;
     });
 
-    it('should display a link to password reset view', function() {
+    it('should display a link to password reset view', async function() {
       // when
-      this.render(hbs`{{signin-form}}`);
+      await render(hbs`{{signin-form}}`);
 
       // then
       expect(document.querySelector('a.sign-form-body__forgotten-password-link')).to.exist;
     });
 
-    it('should not display any error by default', function() {
+    it('should not display any error by default', async function() {
       // when
-      this.render(hbs`{{signin-form}}`);
+      await render(hbs`{{signin-form}}`);
 
       // then
       expect(document.querySelector('div.sign-form__notification-message')).to.not.exist;
     });
 
-    it('should display an error if authentication failed', function() {
+    it('should display an error if authentication failed', async function() {
       // given
       this.set('displayErrorMessage', true);
 
       // when
-      this.render(hbs`{{signin-form displayErrorMessage=displayErrorMessage}}`);
+      await render(hbs`{{signin-form displayErrorMessage=displayErrorMessage}}`);
 
       // then
       expect(document.querySelector('div.sign-form__notification-message--error')).to.exist;
@@ -66,27 +64,27 @@ describe('Integration | Component | signin form', function() {
 
   describe('Behaviours', function() {
 
-    it('should authenticate user when she submitted sign-in form', function() {
+    it('should authenticate user when she submitted sign-in form', async function() {
       // given
       const expectedEmail = 'email@example.fr';
       const expectedPassword = 'azerty';
 
-      this.on('onSubmitAction', function(email, password) {
+      this.set('onSubmitAction', function(email, password) {
         // then
         expect(email).to.equal(expectedEmail);
         expect(password).to.equal(expectedPassword);
         return Promise.resolve();
       });
 
-      this.render(hbs`{{signin-form authenticateUser=(action 'onSubmitAction')}}`);
+      await render(hbs`{{signin-form authenticateUser=(action onSubmitAction)}}`);
 
-      this.$('input#email').val(expectedEmail);
-      this.$('input#email').change();
-      this.$('input#password').val(expectedPassword);
-      this.$('input#password').change();
+      await fillIn('input#email', expectedEmail);
+      await triggerEvent('input#email', 'change');
+      await fillIn('input#password', expectedPassword);
+      await triggerEvent('input#password', 'change');
 
       // when
-      run(() => document.querySelector('button.button').click());
+      await click('button.button');
     });
 
   });

--- a/mon-pix/tests/integration/components/snapshot-list-test.js
+++ b/mon-pix/tests/integration/components/snapshot-list-test.js
@@ -2,53 +2,52 @@ import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | snapshot list', function() {
-  setupComponentTest('snapshot-list', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
+  it('renders', async function() {
     const organization = EmberObject.create({ id: 1, snapshots: resolve([]) });
     this.set('organization', organization);
 
-    this.render(hbs`{{snapshot-list organization=organization}}`);
-    expect(this.$()).to.have.lengthOf(1);
+    await render(hbs`{{snapshot-list organization=organization}}`);
+    expect(find('.snapshot-list')).to.exist;
   });
 
-  it('should inform the user when no profile', function() {
+  it('should inform the user when no profile', async function() {
     // Given
     const organization = EmberObject.create({ id: 1, snapshots: resolve([]) });
     this.set('organization', organization);
 
     // When
-    this.render(hbs`{{snapshot-list organization=organization}}`);
+    await render(hbs`{{snapshot-list organization=organization}}`);
 
     // Then
-    expect(this.$('.snapshot-list__no-profile')).to.have.lengthOf(1);
-    expect(this.$('.snapshot-list__no-profile').text()).to.equal('Aucun profil partagé pour le moment');
+    expect(find('.snapshot-list__no-profile')).to.exist;
+    expect(find('.snapshot-list__no-profile').textContent).to.equal('Aucun profil partagé pour le moment');
   });
 
-  it('it should display as many snapshot items as shared', function() {
+  it('it should display as many snapshot items as shared', async function() {
     // Given
     const snapshot1 = EmberObject.create({ id: 1 });
     const snapshot2 = EmberObject.create({ id: 2 });
     this.set('snapshots', [snapshot1, snapshot2]);
 
     // When
-    this.render(hbs`{{snapshot-list snapshots=snapshots}}`);
+    await render(hbs`{{snapshot-list snapshots=snapshots}}`);
 
     // Then
     return wait().then(function() {
-      expect(this.$('.snapshot-list__no-profile')).to.have.lengthOf(0);
-      expect(this.$('.snapshot-list__snapshot-item')).to.have.lengthOf(2);
-    }.bind(this));
+      expect(find('.snapshot-list__no-profile')).to.not.exist;
+      expect(findAll('.snapshot-list__snapshot-item')).to.have.lengthOf(2);
+    });
   });
 
-  it('should display snapshot informations', function() {
+  it('should display snapshot informations', async function() {
     // Given
     const user = EmberObject.create({ id: 1, firstName: 'Werner', lastName: 'Heisenberg' });
     const snapshot = EmberObject.create({
@@ -61,16 +60,16 @@ describe('Integration | Component | snapshot list', function() {
     this.set('snapshots', [snapshot]);
 
     // When
-    this.render(hbs`{{snapshot-list snapshots=snapshots}}`);
+    await render(hbs`{{snapshot-list snapshots=snapshots}}`);
 
     // Then
     return wait().then(function() {
-      expect(this.$('.snapshot-list__snapshot-item')).to.have.lengthOf(1);
-      expect(this.$('.snapshot-list__snapshot-item td:eq(0)').text().trim()).to.equal(user.get('lastName'));
-      expect(this.$('.snapshot-list__snapshot-item td:eq(1)').text().trim()).to.equal(user.get('firstName'));
-      expect(this.$('.snapshot-list__snapshot-item td:eq(2)').text().trim()).to.equal('25/09/2017');
-      expect(this.$('.snapshot-list__snapshot-item td:eq(3)').text().trim()).to.equal(snapshot.get('score').toString());
-      expect(this.$('.snapshot-list__snapshot-item td:eq(4)').text().trim()).to.equal(snapshot.get('numberOfTestsFinished') + '/16');
-    }.bind(this));
+      expect(find('.snapshot-list__snapshot-item')).to.exist;
+      expect(findAll('.snapshot-list__snapshot-item td')[0].textContent.trim()).to.equal(user.get('lastName'));
+      expect(findAll('.snapshot-list__snapshot-item td')[1].textContent.trim()).to.equal(user.get('firstName'));
+      expect(findAll('.snapshot-list__snapshot-item td')[2].textContent.trim()).to.equal('25/09/2017');
+      expect(findAll('.snapshot-list__snapshot-item td')[3].textContent.trim()).to.equal(snapshot.get('score').toString());
+      expect(findAll('.snapshot-list__snapshot-item td')[4].textContent.trim()).to.equal(snapshot.get('numberOfTestsFinished') + '/16');
+    });
   });
 });

--- a/mon-pix/tests/integration/components/timeout-jauge-test.js
+++ b/mon-pix/tests/integration/components/timeout-jauge-test.js
@@ -1,41 +1,40 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | TimeoutJauge', function() {
 
-  setupComponentTest('timeout-jauge', {
-    integration: true
-  });
+  setupRenderingTest();
 
   /* Rendering
   ----------------------------------------------------- */
   describe('Rendering', function() {
-    it('It renders', function() {
+    it('It renders', async function() {
       // when
-      this.render(hbs`{{timeout-jauge }}`);
+      await render(hbs`{{timeout-jauge }}`);
 
       // then
-      expect(this.$('.timeout-jauge')).to.have.lengthOf(1);
+      expect(find('.timeout-jauge')).to.exist;
     });
 
-    it('It renders a red clock if time is over', function() {
+    it('It renders a red clock if time is over', async function() {
       // when
-      this.render(hbs`{{timeout-jauge allotedTime=0}}`);
+      await render(hbs`{{timeout-jauge allotedTime=0}}`);
 
       // then
-      expect(this.$('.svg-timeout-clock-black')).to.have.lengthOf(0);
-      expect(this.$('.svg-timeout-clock-red')).to.have.lengthOf(1);
+      expect(find('.svg-timeout-clock-black')).to.not.exist;
+      expect(find('.svg-timeout-clock-red')).to.exist;
     });
 
-    it('It renders a black clock if time is not over', function() {
+    it('It renders a black clock if time is not over', async function() {
       // when
-      this.render(hbs`{{timeout-jauge allotedTime=1}}`);
+      await render(hbs`{{timeout-jauge allotedTime=1}}`);
 
       // then
-      expect(this.$('.svg-timeout-clock-red')).to.have.lengthOf(0);
-      expect(this.$('.svg-timeout-clock-black')).to.have.lengthOf(1);
+      expect(find('.svg-timeout-clock-red')).to.not.exist;
+      expect(find('.svg-timeout-clock-black')).to.exist;
     });
 
   });

--- a/mon-pix/tests/integration/components/trophy-item-test.js
+++ b/mon-pix/tests/integration/components/trophy-item-test.js
@@ -1,36 +1,35 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | trophy item', function() {
-  setupComponentTest('trophy-item', {
-    integration: true
+  setupRenderingTest();
+
+  it('renders', async function() {
+    await render(hbs`{{trophy-item}}`);
+    expect(find('.trophy-item')).to.exist;
   });
 
-  it('renders', function() {
-    this.render(hbs`{{trophy-item}}`);
-    expect(this.$()).to.have.lengthOf(1);
-  });
-
-  it('should contain the level passed in the component', function() {
+  it('should contain the level passed in the component', async function() {
     // given
     const level = 3;
     this.set('level', level);
 
     // when
-    this.render(hbs`{{trophy-item level=level}}`);
+    await render(hbs`{{trophy-item level=level}}`);
 
     // then
-    expect(this.$('.trophy-item__level').text()).to.contain(level.toString());
+    expect(find('.trophy-item__level').textContent).to.contain(level.toString());
   });
 
-  it('should contain an image of a trophy with the text "NIVEAU"', function() {
+  it('should contain an image of a trophy with the text "NIVEAU"', async function() {
     // when
-    this.render(hbs`{{trophy-item}}`);
+    await render(hbs`{{trophy-item}}`);
 
     // then
-    expect(this.$('.trophy-item__img').length).to.equal(1);
-    expect(this.$('.trophy-item__level').text()).to.contain('NIVEAU');
+    expect(findAll('.trophy-item__img').length).to.equal(1);
+    expect(find('.trophy-item__level').textContent).to.contain('NIVEAU');
   });
 });

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | tutorial panel', function() {
-  setupComponentTest('tutorial-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
   context('when the result is not ok', function() {
     beforeEach(function() {
@@ -19,20 +18,20 @@ describe('Integration | Component | tutorial panel', function() {
         this.set('tutorials', []);
       });
 
-      it('should render the hint', function() {
+      it('should render the hint', async function() {
         // when
-        this.render(hbs`{{tutorial-panel hint=hint resultItemStatus=resultItemStatus tutorials=tutorials}}`);
+        await render(hbs`{{tutorial-panel hint=hint resultItemStatus=resultItemStatus tutorials=tutorials}}`);
 
         // then
-        expect(this.$('.tutorial-panel')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__hint-container')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__hint-title')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__hint-picto-container')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__hint-picto')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__hint-content')).to.have.lengthOf(1);
+        expect(find('.tutorial-panel')).to.exist;
+        expect(find('.tutorial-panel__hint-container')).to.exist;
+        expect(find('.tutorial-panel__hint-title')).to.exist;
+        expect(find('.tutorial-panel__hint-picto-container')).to.exist;
+        expect(find('.tutorial-panel__hint-picto')).to.exist;
+        expect(find('.tutorial-panel__hint-content')).to.exist;
 
-        const $contentElement = this.$('.tutorial-panel__hint-content');
-        expect($contentElement.text().trim()).to.equal('Ceci est un indice.');
+        const $contentElement = find('.tutorial-panel__hint-content');
+        expect($contentElement.textContent.trim()).to.equal('Ceci est un indice.');
       });
     });
     context('when a tutorial is present', function() {
@@ -40,15 +39,15 @@ describe('Integration | Component | tutorial panel', function() {
         this.set('hint', 'Ceci est un indice');
         this.set('tutorials', [{ titre: 'Ceci est un tuto', duration: '20:00:00' }]);
       });
-      it('should render the tutorial', function() {
+      it('should render the tutorial', async function() {
         // when
-        this.render(hbs`{{tutorial-panel hint=hint resultItemStatus=resultItemStatus tutorials=tutorials}}`);
+        await render(hbs`{{tutorial-panel hint=hint resultItemStatus=resultItemStatus tutorials=tutorials}}`);
 
         // then
-        expect(this.$('.tutorial-panel')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-panel__tutorials-container')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-item__tutorial-title')).to.have.lengthOf(1);
-        expect(this.$('.tutorial-item__tutorial-details')).to.have.lengthOf(1);
+        expect(find('.tutorial-panel')).to.exist;
+        expect(find('.tutorial-panel__tutorials-container')).to.exist;
+        expect(find('.tutorial-item__tutorial-title')).to.exist;
+        expect(find('.tutorial-item__tutorial-details')).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/user-certifications-detail-area-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-area-test.js
@@ -1,15 +1,13 @@
 import EmberObject from '@ember/object';
 import { A as EmberArray } from '@ember/array';
-
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user certifications detail area', function() {
-  setupComponentTest('user-certifications-detail-area', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   let area;
 
@@ -43,16 +41,16 @@ describe('Integration | Component | user certifications detail area', function()
     this.set('area', area);
   });
 
-  it('renders', function() {
-    this.render(hbs`{{user-certifications-detail-area area=area}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{user-certifications-detail-area area=area}}`);
+    expect(find('.user-certifications-detail-area')).to.exist;
   });
 
   context('when has a list of competences', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // when
-      this.render(hbs`{{user-certifications-detail-area area=area}}`);
+      await render(hbs`{{user-certifications-detail-area area=area}}`);
     });
 
     // then
@@ -61,7 +59,7 @@ describe('Integration | Component | user certifications detail area', function()
       const divOfName = '.user-certifications-detail-area__box-name';
 
       // then
-      expect(this.$(divOfName).text()).to.include(area.get('title'));
+      expect(find(divOfName).textContent).to.include(area.get('title'));
     });
 
     it('should include one competences detail per competence', function() {
@@ -69,7 +67,7 @@ describe('Integration | Component | user certifications detail area', function()
       const divOfCompetence = '.user-certifications-detail-competence';
 
       // then
-      expect(this.$(divOfCompetence)).to.have.lengthOf(area.get('resultCompetences.length'));
+      expect(findAll(divOfCompetence)).to.have.lengthOf(area.get('resultCompetences.length'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
@@ -1,13 +1,12 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user certifications detail competence', function() {
-  setupComponentTest('user-certifications-detail-competence', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   let competence;
 
@@ -20,21 +19,21 @@ describe('Integration | Component | user certifications detail competence', func
     });
   });
 
-  it('renders', function() {
+  it('renders', async function() {
     this.set('competence', competence);
 
-    this.render(hbs`{{user-certifications-detail-competence competence=competence}}`);
-    expect(this.$()).to.have.length(1);
+    await render(hbs`{{user-certifications-detail-competence competence=competence}}`);
+    expect(find('.user-certifications-detail-competence')).to.exist;
   });
 
   context('when competence has level -1', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{user-certifications-detail-competence competence=competence}}`);
+      await render(hbs`{{user-certifications-detail-competence competence=competence}}`);
     });
 
     // then
@@ -43,7 +42,7 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfName = '.user-certifications-detail-competence__box-name';
 
       // then
-      expect(this.$(divOfName).text()).to.include(competence.name);
+      expect(find(divOfName).textContent).to.include(competence.name);
     });
 
     it('should not show the level of competence', function() {
@@ -51,7 +50,7 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfLevel = '.user-certifications-detail-competence__box-level';
 
       // then
-      expect(this.$(divOfLevel)).to.have.lengthOf(0);
+      expect(find(divOfLevel)).to.not.exist;
     });
 
     it('should show all level bar in grey', function() {
@@ -59,13 +58,13 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfBarUnvalidatedLevel = '.user-certifications-detail-competence__not-validate-level';
 
       // then
-      expect(this.$(divOfBarUnvalidatedLevel)).to.have.lengthOf(8);
+      expect(findAll(divOfBarUnvalidatedLevel)).to.have.lengthOf(8);
     });
   });
 
   context('when competence has level 0', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       competence = EmberObject.create({
         'index': 1.2,
@@ -76,7 +75,7 @@ describe('Integration | Component | user certifications detail competence', func
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{user-certifications-detail-competence competence=competence}}`);
+      await render(hbs`{{user-certifications-detail-competence competence=competence}}`);
     });
 
     // then
@@ -85,7 +84,7 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfName = '.user-certifications-detail-competence__box-name';
 
       // then
-      expect(this.$(divOfName).text()).to.include(competence.name);
+      expect(find(divOfName).textContent).to.include(competence.name);
     });
 
     it('should not show the level of competence', function() {
@@ -93,7 +92,7 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfLevel = '.user-certifications-detail-competence__box-level';
 
       // then
-      expect(this.$(divOfLevel)).to.have.lengthOf(0);
+      expect(find(divOfLevel)).to.not.exist;
     });
 
     it('should show all level bar in grey', function() {
@@ -101,13 +100,13 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfBarUnvalidatedLevel = '.user-certifications-detail-competence__not-validate-level';
 
       // then
-      expect(this.$(divOfBarUnvalidatedLevel)).to.have.lengthOf(8);
+      expect(findAll(divOfBarUnvalidatedLevel)).to.have.lengthOf(8);
     });
   });
 
   context('when competence has level 5', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       competence = EmberObject.create({
         'index': 1.2,
@@ -118,7 +117,7 @@ describe('Integration | Component | user certifications detail competence', func
       this.set('competence', competence);
 
       // when
-      this.render(hbs`{{user-certifications-detail-competence competence=competence}}`);
+      await render(hbs`{{user-certifications-detail-competence competence=competence}}`);
     });
 
     // then
@@ -127,7 +126,7 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfName = '.user-certifications-detail-competence__box-name';
 
       // then
-      expect(this.$(divOfName).text()).to.include(competence.name);
+      expect(find(divOfName).textContent).to.include(competence.name);
     });
 
     it('should show the level of competence', function() {
@@ -135,8 +134,8 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfLevel = '.user-certifications-detail-competence__box-level';
 
       // then
-      expect(this.$(divOfLevel)).to.have.lengthOf(1);
-      expect(this.$(divOfLevel).text()).to.include(competence.level);
+      expect(find(divOfLevel)).to.exist;
+      expect(find(divOfLevel).textContent).to.include(competence.level);
 
     });
 
@@ -146,8 +145,8 @@ describe('Integration | Component | user certifications detail competence', func
       const divOfBarUnvalidatedLevel = '.user-certifications-detail-competence__not-validate-level';
 
       // then
-      expect(this.$(divOfBarValidatedLevel)).to.have.lengthOf(5);
-      expect(this.$(divOfBarUnvalidatedLevel)).to.have.lengthOf(3);
+      expect(findAll(divOfBarValidatedLevel)).to.have.lengthOf(5);
+      expect(findAll(divOfBarUnvalidatedLevel)).to.have.lengthOf(3);
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -1,24 +1,23 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications detail header', function() {
-  setupComponentTest('user-certifications-detail-header', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   let certification;
 
-  it('renders', function() {
-    this.render(hbs`{{user-certifications-detail-header certification=certification}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{user-certifications-detail-header certification=certification}}`);
+    expect(find('.user-certifications-detail-header')).to.exist;
   });
 
   context('when certification is complete', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -36,41 +35,41 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{user-certifications-detail-header certification=certification}}`);
+      await render(hbs`{{user-certifications-detail-header certification=certification}}`);
     });
 
     // then
     it('should show the certification icon', function() {
-      expect(this.$('.user-certifications-detail-header__icon')).to.have.lengthOf(1);
+      expect(find('.user-certifications-detail-header__icon')).to.exist;
     });
 
     it('should show the certification date', function() {
-      expect(this.$('.user-certifications-detail-header__data-box')).to.have.lengthOf(1);
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.include('15 février 2018');
+      expect(find('.user-certifications-detail-header__data-box')).to.exist;
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('15 février 2018');
     });
 
     it('should show the certification user full name', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.include('Nom : Jean Bon');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Nom : Jean Bon');
     });
 
     it('should show the certification user birthdate', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.include('Date de naissance : 22' +
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Date de naissance : 22' +
         ' janvier 2000');
     });
 
     it('should show the certification user birthplace', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.include('Lieu de naissance : Paris');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Lieu de naissance : Paris');
     });
 
     it('should show the certification center', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.include('Centre de' +
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Centre de' +
         ' certification : Université de Lyon');
     });
   });
 
   context('when certification is not complete', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -88,28 +87,28 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{user-certifications-detail-header certification=certification}}`);
+      await render(hbs`{{user-certifications-detail-header certification=certification}}`);
     });
 
     // then
     it('should not show the certification date', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.not.include('obtenue le');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('obtenue le');
     });
 
     it('should not show the certification user full name', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.not.include('Nom :');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Nom :');
     });
 
     it('should not show the certification user birthdate', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.not.include('Date de naissance :');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Date de naissance :');
     });
 
     it('should not show the certification user birthplace', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.not.include('Lieu de naissance :');
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Lieu de naissance :');
     });
 
     it('should not show the certification center', function() {
-      expect(this.$('.user-certifications-detail-header__data-box').text()).to.not.include('Centre de' +
+      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Centre de' +
         ' certification :');
     });
   });

--- a/mon-pix/tests/integration/components/user-certifications-detail-profile-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-profile-test.js
@@ -1,15 +1,13 @@
 import EmberObject from '@ember/object';
 import { A } from '@ember/array';
-
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user certifications detail profile', function() {
-  setupComponentTest('user-certifications-detail-profile', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   const resultCompetenceTree = EmberObject.create({
     areas: A([
@@ -37,21 +35,21 @@ describe('Integration | Component | user certifications detail profile', functio
     ]),
   });
 
-  it('renders', function() {
+  it('renders', async function() {
     this.set('resultCompetenceTree', resultCompetenceTree);
 
-    this.render(hbs`{{user-certifications-detail-profile  resultCompetenceTree=resultCompetenceTree}}`);
-    expect(this.$()).to.have.length(1);
+    await render(hbs`{{user-certifications-detail-profile resultCompetenceTree=resultCompetenceTree}}`);
+    expect(find('.user-certifications-detail-profile')).to.exist;
   });
 
   context('when are has a list of competences', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       this.set('resultCompetenceTree', resultCompetenceTree);
 
       // when
-      this.render(hbs`{{user-certifications-detail-profile resultCompetenceTree=resultCompetenceTree}}`);
+      await render(hbs`{{user-certifications-detail-profile resultCompetenceTree=resultCompetenceTree}}`);
     });
 
     it('should include one area detail per area', function() {
@@ -59,7 +57,7 @@ describe('Integration | Component | user certifications detail profile', functio
       const divOfArea = '.user-certifications-detail-area';
 
       // then
-      expect(this.$(divOfArea)).to.have.lengthOf(resultCompetenceTree.areas.length);
+      expect(findAll(divOfArea)).to.have.lengthOf(resultCompetenceTree.areas.length);
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
@@ -1,24 +1,23 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications detail result', function() {
-  setupComponentTest('user-certifications-detail-result', {
-    integration: true,
-  });
+  setupRenderingTest();
 
   let certification;
 
-  it('renders', function() {
-    this.render(hbs`{{user-certifications-detail-result certification=certification}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{user-certifications-detail-result certification=certification}}`);
+    expect(find('.user-certifications-detail-result')).to.exist;
   });
 
   context('when certification is complete', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -35,24 +34,24 @@ describe('Integration | Component | user certifications detail result', function
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{user-certifications-detail-result certification=certification}}`);
+      await render(hbs`{{user-certifications-detail-result certification=certification}}`);
     });
 
     // then
     it('should show the pix score', function() {
-      expect(this.$('.user-certifications-detail-result__pix-score')).to.have.lengthOf(1);
-      expect(this.$('.user-certifications-detail-result__pix-score').text()).to.include('654');
+      expect(find('.user-certifications-detail-result__pix-score')).to.exist;
+      expect(find('.user-certifications-detail-result__pix-score').textContent).to.include('654');
     });
 
     it('should show the comment for candidate', function() {
-      expect(this.$('.user-certifications-detail-result__comment-jury')).to.have.lengthOf(1);
-      expect(this.$('.user-certifications-detail-result__comment-jury').text()).to.include('Comment for candidate');
+      expect(find('.user-certifications-detail-result__comment-jury')).to.exist;
+      expect(find('.user-certifications-detail-result__comment-jury').textContent).to.include('Comment for candidate');
     });
   });
 
   context('when certification has no comment for user', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -69,17 +68,17 @@ describe('Integration | Component | user certifications detail result', function
       this.set('certification', certification);
 
       // when
-      this.render(hbs`{{user-certifications-detail-result certification=certification}}`);
+      await render(hbs`{{user-certifications-detail-result certification=certification}}`);
     });
 
     // then
     it('should show the pix score', function() {
-      expect(this.$('.user-certifications-detail-result__pix-score')).to.have.lengthOf(1);
-      expect(this.$('.user-certifications-detail-result__pix-score').text()).to.include('654');
+      expect(find('.user-certifications-detail-result__pix-score')).to.exist;
+      expect(find('.user-certifications-detail-result__pix-score').textContent).to.include('654');
     });
 
     it('should not show the comment for candidate', function() {
-      expect(this.$('.user-certifications-detail-result__comment-jury')).to.have.lengthOf(0);
+      expect(find('.user-certifications-detail-result__comment-jury')).to.not.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/user-certifications-panel-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-panel-test.js
@@ -1,33 +1,32 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications panel', function() {
-  setupComponentTest('user-certifications-panel', {
-    integration: true
-  });
+  setupRenderingTest();
 
-  it('renders', function() {
-    this.render(hbs`{{user-certifications-panel}}`);
-    expect(this.$()).to.have.length(1);
+  it('renders', async function() {
+    await render(hbs`{{user-certifications-panel}}`);
+    expect(find('.user-certifications-panel')).to.exist;
   });
 
   context('when there is no certifications', function() {
 
-    it('should render a panel which indicate there is no certifications', function() {
+    it('should render a panel which indicate there is no certifications', async function() {
       // when
-      this.render(hbs`{{user-certifications-panel}}`);
+      await render(hbs`{{user-certifications-panel}}`);
 
       // then
-      expect(this.$('.user-certifications-panel__no-certification-panel')).to.have.length(1);
+      expect(find('.user-certifications-panel__no-certification-panel')).to.exist;
     });
   });
 
   context('when there is some certifications to show', function() {
 
-    it('should render a certifications list', function() {
+    it('should render a certifications list', async function() {
       // given
       const certification1 = EmberObject.create({
         id: 1,
@@ -45,10 +44,10 @@ describe('Integration | Component | user certifications panel', function() {
       this.set('certifications', certifications);
 
       // when
-      this.render(hbs`{{user-certifications-panel certifications=certifications}}`);
+      await render(hbs`{{user-certifications-panel certifications=certifications}}`);
 
       // then
-      expect(this.$('.user-certifications-panel__certifications-list')).to.have.length(1);
+      expect(find('.user-certifications-panel__certifications-list')).to.exist;
     });
 
   });

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -1,22 +1,20 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { click, find, findAll, triggerKeyEvent, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
-import $ from 'jquery';
 
 describe('Integration | Component | user logged menu', function() {
 
-  setupComponentTest('user-logged-menu', {
-    integration: true
-  });
+  setupRenderingTest();
 
   describe('when rendering for logged user', function() {
 
-    beforeEach(function() {
+    beforeEach(async function() {
       // given
-      this.register('service:currentUser', Service.extend({
+      this.owner.register('service:currentUser', Service.extend({
         user: {
           firstName: 'FHI',
           email: 'FHI@4EVER.fr',
@@ -24,152 +22,146 @@ describe('Integration | Component | user logged menu', function() {
         }
       }));
 
-      this.inject.service('currentUser', { as: 'currentUser' });
-
       // when
-      this.render(hbs`{{user-logged-menu}}`);
+      await render(hbs`{{user-logged-menu}}`);
     });
 
     it('should render component', function() {
       // then
-      expect(this.$()).to.have.lengthOf(1);
+      expect(find('.logged-user-details')).to.exist;
     });
 
     it('should display logged user name ', function() {
       // then
-      expect(this.$('.logged-user-name')).to.have.lengthOf(1);
-      expect(this.$('.logged-user-name__link')).to.have.lengthOf(1);
-      expect(this.$('.logged-user-name__link').text().trim()).to.be.equal('FHI 4EVER');
+      expect(find('.logged-user-name')).to.exist;
+      expect(find('.logged-user-name__link')).to.exist;
+      expect(find('.logged-user-name__link').textContent.trim()).to.be.equal('FHI 4EVER');
     });
 
-    it('should hide user menu, when no action on user-name', function() {
+    it('should hide user menu, when no action on user-name', async function() {
       // when
-      this.render(hbs`{{user-logged-menu}}`);
+      await render(hbs`{{user-logged-menu}}`);
 
       // then
-      expect(this.$('.logged-user-menu')).to.have.lengthOf(0);
+      expect(find('.logged-user-menu')).to.not.exist;
     });
 
-    it('should display a user menu, when user-name is clicked', function() {
+    it('should display a user menu, when user-name is clicked', async function() {
       // given
-      this.render(hbs`{{user-logged-menu}}`);
+      await render(hbs`{{user-logged-menu}}`);
 
       // when
-      this.$('.logged-user-name__link').click();
+      await click('.logged-user-name__link');
 
       return wait().then(() => {
         // then
-        expect(this.$('.logged-user-menu')).to.have.lengthOf(1);
-        expect(this.$('.user-menu-item__details-firstname').text().trim()).to.equal('FHI');
-        expect(this.$('.user-menu-item__details-email').text().trim()).to.equal('FHI@4EVER.fr');
+        expect(find('.logged-user-menu')).to.exist;
+        expect(find('.user-menu-item__details-firstname').textContent.trim()).to.equal('FHI');
+        expect(find('.user-menu-item__details-email').textContent.trim()).to.equal('FHI@4EVER.fr');
       });
     });
 
-    it('should display link to user certifications and help', function() {
+    it('should display link to user certifications and help', async function() {
       // when
-      this.render(hbs`{{user-logged-menu _canDisplayMenu=true}}`);
+      await render(hbs`{{user-logged-menu _canDisplayMenu=true}}`);
 
       return wait().then(() => {
         // then
-        expect(this.$('.logged-user-menu')).to.have.lengthOf(1);
-        expect(this.$('.user-menu-item__link')).to.have.lengthOf(2);
-        expect(this.$('.user-menu-item__link').text()).to.contains('MES CERTIFICATIONS');
-        expect(this.$('.user-menu-item__link').text()).to.contains('AIDE');
+        expect(find('.logged-user-menu')).to.exist;
+        expect(findAll('.user-menu-item__link')).to.have.lengthOf(2);
+        expect(findAll('.user-menu-item__link')[0].textContent.trim()).to.equal('MES CERTIFICATIONS');
+        expect(findAll('.user-menu-item__link')[1].textContent.trim()).to.equal('AIDE');
       });
     });
 
-    it('should hide user menu, when it was previously open and user-name is clicked one more time', function() {
+    it('should hide user menu, when it was previously open and user-name is clicked one more time', async function() {
       // when
-      this.render(hbs`{{user-logged-menu}}`);
-      this.$('.logged-user-name').click();
-      this.$('.logged-user-name').click();
+      await render(hbs`{{user-logged-menu}}`);
+      await click('.logged-user-name');
+      await click('.logged-user-name');
 
       return wait().then(() => {
         // then
-        expect(this.$('.logged-user-menu')).to.have.lengthOf(0);
+        expect(find('.logged-user-menu')).to.not.exist;
       });
     });
 
-    it('should hide user menu, when it was previously open and user press key escape', function() {
+    it('should hide user menu, when it was previously open and user press key escape', async function() {
       // when
-      this.$('.logged-user-name').click();
-      this.$('.logged-user-name').trigger($.Event('keydown', { keyCode: 27 }));
+      await click('.logged-user-name');
+      await triggerKeyEvent('.logged-user-name', 'keydown', 27);
 
       return wait().then(() => {
         // then
-        expect(this.$('.logged-user-menu')).to.have.lengthOf(0);
+        expect(find('.logged-user-menu')).to.not.exist;
       });
     });
 
-    it('should hide user menu, when the menu is opened then closed', function() {
+    it('should hide user menu, when the menu is opened then closed', async function() {
       // when
-      this.$('.logged-user-name').click();
-      this.$('.logged-user-name').click();
+      await click('.logged-user-name');
+      await click('.logged-user-name');
 
       return wait().then(() => {
         // then
-        expect(this.$('.logged-user-menu')).to.have.lengthOf(0);
+        expect(find('.logged-user-menu')).to.not.exist;
       });
     });
 
     describe('button rendering', function() {
 
       context('when the user is on compte page', function() {
-        it('should not render a button link to the "profile" page', function() {
-          this.register('service:-routing', Service.extend({
+        it('should not render a button link to the "profile" page', async function() {
+          this.owner.register('service:-routing', Service.extend({
             currentRouteName: 'compte',
             generateURL: function() {
               return '/compte';
             }
           }));
-          this.inject.service('-routing', { as: '-routing' });
-
           // when
-          this.render(hbs`{{user-logged-menu}}`);
-          this.$('.logged-user-name').click();
+          await render(hbs`{{user-logged-menu}}`);
+          await click('.logged-user-name');
 
           return wait().then(() => {
             // then
-            expect(this.$('.user-menu-item__account-link').length).to.equal(0);
+            expect(findAll('.user-menu-item__account-link').length).to.equal(0);
           });
         });
 
-        it('should not render a button link to the "board" page', function() {
-          this.register('service:-routing', Service.extend({
+        it('should not render a button link to the "board" page', async function() {
+          this.owner.register('service:-routing', Service.extend({
             currentRouteName: 'board',
             generateURL: function() {
               return '/board';
             }
           }));
-          this.inject.service('-routing', { as: '-routing' });
 
           // when
-          this.render(hbs`{{user-logged-menu}}`);
-          this.$('.logged-user-name').click();
+          await render(hbs`{{user-logged-menu}}`);
+          await click('.logged-user-name');
 
           return wait().then(() => {
             // then
-            expect(this.$('.user-menu-item__account-link').length).to.equal(0);
+            expect(findAll('.user-menu-item__account-link').length).to.equal(0);
           });
         });
       });
 
-      it('should render a button link to the profile when the user is not on compte page', function() {
-        this.register('service:-routing', Service.extend({
+      it('should render a button link to the profile when the user is not on compte page', async function() {
+        this.owner.register('service:-routing', Service.extend({
           generateURL: function() {
             return '/autreRoute';
           }
         }));
-        this.inject.service('-routing', { as: '-routing' });
 
         // when
-        this.render(hbs`{{user-logged-menu}}`);
-        this.$('.logged-user-name__link').click();
+        await render(hbs`{{user-logged-menu}}`);
+        await click('.logged-user-name__link');
 
         return wait().then(() => {
           // then
-          expect(this.$('.user-menu-item__details-account-link').text().trim()).to.equal('Mon compte');
-          expect(this.$('.user-menu-item__details-account-link').length).to.equal(1);
+          expect(find('.user-menu-item__details-account-link').textContent.trim()).to.equal('Mon compte');
+          expect(findAll('.user-menu-item__details-account-link').length).to.equal(1);
         });
       });
 
@@ -179,18 +171,16 @@ describe('Integration | Component | user logged menu', function() {
 
   describe('when user is unlogged or not found', function() {
     beforeEach(function() {
-      this.register('service:currentUser', Service.extend({ user: null }));
-
-      this.inject.service('currentUser', { as: 'currentUser' });
+      this.owner.register('service:currentUser', Service.extend({ user: null }));
     });
 
-    it('should not display user information, for unlogged', function() {
+    it('should not display user information, for unlogged', async function() {
       // when
-      this.render(hbs`{{user-logged-menu}}`);
+      await render(hbs`{{user-logged-menu}}`);
 
       // then
       return wait().then(() => {
-        expect(this.$('.logged-user-name')).to.have.lengthOf(0);
+        expect(find('.logged-user-name')).to.not.exist;
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
En vue d'une mise à jour de ember-mocha, il est nécessaire de supprimer les usages dépréciés de ce dernier.

## :robot: Solution

- Utiliser `setupRenderingTest()` à la place de `setupComponentTest()`
-Utiliser `render()` helper de `@ember/test-helpers`à la place de `this.render()`
- `render()`est maintenant asynchrone
- Utiliser `this.element` pour accéder au DOM
- Remplacer `this.on` par `this.set` pour tester l'invocation, et transformer `action 'actionName'` en `action actionName`
- Ne plus utiliser jQuery pour les interaction du DOM, utiliser `@ember/test-helpers` à la place
