### PR TITLE
[BUGFIX] Ajustements sur le CSS pour imprimer la page de résultats d'une campagne (PF-583).

### DIFF
--- a/mon-pix/app/styles/globals/_palette.scss
+++ b/mon-pix/app/styles/globals/_palette.scss
@@ -21,6 +21,7 @@ $charcoal-grey: #3e4149;
 $grayish-grey: #39393A;
 $nero: #222222;
 $black: #000000;
+$orange-peel: #FF9400;
 
 $periwinkle-blue: #c3d0ff;
 $jordy-blue: #8D9EF7;

--- a/mon-pix/app/styles/globals/_palette.scss
+++ b/mon-pix/app/styles/globals/_palette.scss
@@ -21,7 +21,6 @@ $charcoal-grey: #3e4149;
 $grayish-grey: #39393A;
 $nero: #222222;
 $black: #000000;
-$orange-peel: #FF9400;
 
 $periwinkle-blue: #c3d0ff;
 $jordy-blue: #8D9EF7;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -159,3 +159,30 @@
   font-family: $font-roboto;
   font-size: 3.1rem;
 }
+
+@media print {
+  a[href]:after {
+    content: none;
+  }
+
+  .progression-gauge {
+    border-bottom: 4px solid $alto-grey;
+  }
+
+  .progression-gauge__marker {
+    border-bottom: 4px solid $orange-peel;
+  }
+
+  .default-table thead {
+    display: table-header-group;
+  }
+
+  .default-table tr {
+    display: table-row;
+    height: 60px;
+  }
+
+  .skill-review-results__header {
+    flex-direction: row;
+  }
+}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -170,7 +170,7 @@
   }
 
   .progression-gauge__marker {
-    border-bottom: 4px solid $orange-peel;
+    border-bottom: 4px solid $dark-orange;
   }
 
   .default-table thead {


### PR DESCRIPTION
## :unicorn: Problème
La page de résultats d'une campagne ne s'imprime pas correctement.

## :robot: Solution
Ajout d'une media query `print` pour afficher correctement le contenu lors d'une impression.
Le `background-color` ne s'imprime pas par défaut, il a été remplacé par des `border-color`.

## :rainbow: Remarques
La media query a été rajoutée à la fin du fichier CSS correspondant. Si d'autres pages doivent être modifiées, envisager la création d'un fichier `print.scss` spécifique ?
