### PR TITLE
[FEATURE] Afficher la version de la certification dans Pix Admin (PF-577).

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -32,6 +32,11 @@ export default DS.Model.extend({
     const value = this.isPublished;
     return value ? 'Oui' : 'Non';
   }),
+  isV2Certification: DS.attr('boolean', { defaultValue: false }),
+  isV2CertificationText: computed('isV2Certification', function() {
+    const value = this.isV2Certification;
+    return value ? 'Oui' : 'Non';
+  }),
   indexedCompetences: computed('competencesWithMark', function() {
     const competencesWithMarks = this.competencesWithMark;
     return competencesWithMarks.reduce((result, value) => {

--- a/admin/app/templates/authenticated/certifications/single/info.hbs
+++ b/admin/app/templates/authenticated/certifications/single/info.hbs
@@ -13,6 +13,7 @@
             {{certification-info-field value=certification.creationDate edition=false label="Créée le :"}}
             {{certification-info-field value=certification.completionDate edition=false label="Terminée le :"}}
             {{certification-info-field value=certification.publishedText edition=false label="Publiée :"}}
+            {{certification-info-field value=certification.isV2CertificationText edition=false label="Certification v2 :"}}
           </div>
         </div>
       </div>

--- a/api/db/migrations/20190606125500_add_is-v2-certification_column_in_certification-course.js
+++ b/api/db/migrations/20190606125500_add_is-v2-certification_column_in_certification-course.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'isV2Certification';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/certification-courses-builder.js
+++ b/api/db/seeds/data/certification-courses-builder.js
@@ -13,6 +13,7 @@ module.exports = function certificationCoursesBuilder({ databaseBuilder }) {
     externalId: 'NumeroEtudiantHubert',
     isPublished: true
   });
+
   databaseBuilder.factory.buildCertificationCourse({
     id: 2,
     userId: 1,
@@ -24,8 +25,10 @@ module.exports = function certificationCoursesBuilder({ databaseBuilder }) {
     birthplace: 'Bruxelles',
     sessionId: 2,
     externalId: 'L\'élève',
-    isPublished: true
+    isPublished: true,
+    isV2Certification: true
   });
+
   databaseBuilder.factory.buildCertificationCourse({
     id: 3,
     userId: 1,

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -12,6 +12,7 @@ class CertificationCourse {
       isPublished = false,
       lastName,
       nbChallenges,
+      isV2Certification = false,
       // includes
       // references
       userId,
@@ -28,6 +29,7 @@ class CertificationCourse {
     this.isPublished = isPublished;
     this.lastName = lastName;
     this.nbChallenges = nbChallenges;
+    this.isV2Certification = isV2Certification;
     // includes
     // references
     this.userId = userId;

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -287,6 +287,7 @@ module.exports = {
           sessionId: certification.sessionId,
           externalId: certification.externalId,
           isPublished: certification.isPublished,
+          isV2Certification: certification.isV2Certification,
         };
       });
   },

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -15,7 +15,7 @@ function _selectProfileToCertify(userCompetencesProfilV1, userCompetencesProfilV
   const canStartACertificationOnProfileV1 = _canStartACertification(userCompetencesProfilV1);
 
   if (!canStartACertificationOnProfileV1 && !canStartACertificationOnProfileV2) {
-    throw new UserNotAuthorizedToCertifyError();
+    return null;
   }
 
   else if (canStartACertificationOnProfileV1 && !canStartACertificationOnProfileV2) {
@@ -44,7 +44,6 @@ async function _startNewCertification({
   certificationChallengesService,
   certificationCourseRepository
 }) {
-  const newCertificationCourse = new CertificationCourse({ userId, sessionId });
 
   const userCompetencesProfileV1 = await userService.getProfileToCertifyV1(userId, new Date());
 
@@ -57,7 +56,11 @@ async function _startNewCertification({
   }
 
   const userCompetencesToCertify = _selectProfileToCertify(userCompetencesProfileV1, userCompetencesProfileV2);
+  if (!userCompetencesToCertify) {
+    throw new UserNotAuthorizedToCertifyError();
+  }
 
+  const newCertificationCourse = new CertificationCourse({ userId, sessionId });
   const savedCertificationCourse = await certificationCourseRepository.save(newCertificationCourse);
   return certificationChallengesService.saveChallenges(userCompetencesToCertify, savedCertificationCourse);
 }

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -60,7 +60,9 @@ async function _startNewCertification({
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  const newCertificationCourse = new CertificationCourse({ userId, sessionId });
+  const isV2Certification = userCompetencesToCertify === userCompetencesProfileV2;
+
+  const newCertificationCourse = new CertificationCourse({ userId, sessionId, isV2Certification });
   const savedCertificationCourse = await certificationCourseRepository.save(newCertificationCourse);
   return certificationChallengesService.saveChallenges(userCompetencesToCertify, savedCertificationCourse);
 }

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -22,6 +22,7 @@ function _toDomain(model) {
       sessionId: model.get('sessionId'),
       externalId: model.get('externalId'),
       isPublished: Boolean(model.get('isPublished')),
+      isV2Certification: Boolean(model.get('isV2Certification')),
     });
   }
   return null;

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -45,6 +45,7 @@ module.exports = {
         'sessionId',
         'externalId',
         'isPublished',
+        'isV2Certification',
       ],
     }).serialize(certificationCourseResult);
   },
@@ -64,6 +65,7 @@ module.exports = {
       lastName: json.data.attributes.lastName,
       birthdate: moment.utc(json.data.attributes.birthdate, 'DD/MM/YYYY').format('YYYY-MM-DD'),
       birthplace: json.data.attributes.birthplace,
+      isV2Certification: json.data.attributes.isV2Certification,
     });
   },
 };

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -208,6 +208,7 @@ describe('Integration | Repository | Certification Course', function() {
         birthdate: '24/10/1989',
         sessionId: null,
         isPublished: 0,
+        isV2Certification: 0,
         externalId: ''
       };
 

--- a/api/tests/tooling/database-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-course.js
@@ -15,6 +15,7 @@ module.exports = function buildCertificationCourse({
   sessionId,
   externalId = faker.random.uuid(),
   isPublished = faker.random.boolean(),
+  isV2Certification = false,
   createdAt = faker.date.past(),
 } = {}) {
 
@@ -33,6 +34,7 @@ module.exports = function buildCertificationCourse({
     lastName,
     sessionId,
     userId,
+    isV2Certification,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -15,6 +15,7 @@ module.exports = function buildCertificationCourse(
     isPublished = faker.random.boolean(),
     lastName = faker.name.lastName(),
     nbChallenges = faker.random.number(40),
+    isV2Certification = false,
     // includes
     // references
     userId = faker.random.number(),
@@ -32,6 +33,7 @@ module.exports = function buildCertificationCourse(
     isPublished,
     lastName,
     nbChallenges,
+    isV2Certification,
     sessionId,
     userId,
   });

--- a/api/tests/unit/domain/services/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification-service_test.js
@@ -7,6 +7,7 @@ const Competence = require('../../../../lib/domain/models/Competence');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const CompetenceMarks = require('../../../../lib/domain/models/CompetenceMark');
+const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
 
@@ -190,7 +191,7 @@ describe('Unit | Service | Certification Service', function() {
       state: 'completed',
     });
 
-    const certificationCourse = { id: 'course1', status: 'completed', completedAt: dateCreationCertif };
+    const certificationCourse = new CertificationCourse({ id: 'course1', status: 'completed', completedAt: dateCreationCertif });
 
     beforeEach(() => {
       sinon.stub(assessmentRepository, 'getByCertificationCourseId').resolves(certificationAssessment);
@@ -719,7 +720,7 @@ describe('Unit | Service | Certification Service', function() {
 
   describe('#calculateCertificationResultByAssessmentId', () => {
 
-    const certificationCourse = { id: 'course1', status: 'completed' };
+    const certificationCourse = new CertificationCourse({ id: 'course1', status: 'completed' });
     const dateCreationCertif = new Date('2018-02-02T01:02:03Z');
 
     const certificationAssessment = Assessment.fromAttributes({
@@ -1186,7 +1187,7 @@ describe('Unit | Service | Certification Service', function() {
             _buildAssessmentResult(20, 3),
           ],
         }));
-        sinon.stub(certificationCourseRepository, 'get').resolves({
+        sinon.stub(certificationCourseRepository, 'get').resolves(new CertificationCourse({
           createdAt: new Date('2017-12-23T15:23:12Z'),
           completedAt: new Date('2017-12-23T16:23:12Z'),
           firstName: 'Pumba',
@@ -1195,7 +1196,7 @@ describe('Unit | Service | Certification Service', function() {
           birthdate: '28/01/1992',
           sessionId: 'MoufMufassa',
           externalId: 'TimonsFriend',
-        });
+        }));
         assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1')];
         sinon.stub(assessmentResultRepository, 'get').resolves(
           assessmentResult,
@@ -1251,7 +1252,7 @@ describe('Unit | Service | Certification Service', function() {
         sinon.stub(assessmentRepository, 'getByCertificationCourseId').resolves(Assessment.fromAttributes({
           state: 'started',
         }));
-        sinon.stub(certificationCourseRepository, 'get').resolves({
+        sinon.stub(certificationCourseRepository, 'get').resolves(new CertificationCourse({
           createdAt: new Date('2017-12-23T15:23:12Z'),
           firstName: 'Pumba',
           lastName: 'De La Savane',
@@ -1259,7 +1260,7 @@ describe('Unit | Service | Certification Service', function() {
           birthdate: '28/01/1992',
           sessionId: 'MoufMufassa',
           externalId: 'TimonsFriend',
-        });
+        }));
         sinon.stub(assessmentResultRepository, 'get').resolves(null);
       });
 
@@ -1281,6 +1282,16 @@ describe('Unit | Service | Certification Service', function() {
         });
       });
 
+      it('should know certification version', async () => {
+        // given
+        const certificationCourseId = 1;
+
+        // when
+        const certificationResult = await certificationService.getCertificationResult(certificationCourseId);
+
+        // then
+        expect(certificationResult.isV2Certification).to.be.false;
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -229,6 +229,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           // then
           expect(certificationChallengesService.saveChallenges)
             .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0, sinon.match.any);
+          expect(certificationCourseRepository.save)
+            .to.have.been.calledWithMatch({ isV2Certification: false });
         });
 
         it('should use certifiable profil V2 even when V1 has higher score but is not certifiable', async () => {
@@ -251,6 +253,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           // then
           expect(certificationChallengesService.saveChallenges)
             .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0, sinon.match.any);
+          expect(certificationCourseRepository.save)
+            .to.have.been.calledWithMatch({ isV2Certification: true });
         });
 
         it('should use certification profile v1 when v1 pix score is greater than v2', async () => {
@@ -273,6 +277,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           // then
           expect(certificationChallengesService.saveChallenges)
             .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0WithHigherScore, sinon.match.any);
+          expect(certificationCourseRepository.save)
+            .to.have.been.calledWithMatch({ isV2Certification: false });
         });
 
         it('should use certification profile v2 when v2 pix score is greater than v1', async () => {
@@ -295,6 +301,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           // then
           expect(certificationChallengesService.saveChallenges)
             .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0WithHigherScore, sinon.match.any);
+          expect(certificationCourseRepository.save)
+            .to.have.been.calledWithMatch({ isV2Certification: true });
         });
       });
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -34,6 +34,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
         sinon.stub(sessionService, 'sessionExists').resolves(sessionId);
         sinon.stub(certificationCourseRepository, 'findLastCertificationCourseByUserIdAndSessionId').resolves([certificationCourse, oldCertificationCourse]);
+        sinon.stub(certificationCourseRepository, 'save').resolves();
       });
 
       it('should get last started certification course for given sessionId and userId', async function() {
@@ -70,6 +71,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
         sinon.stub(sessionService, 'sessionExists').rejects(new NotFoundError());
         sinon.stub(certificationCourseRepository, 'findLastCertificationCourseByUserIdAndSessionId').resolves(certificationCourse);
+        sinon.stub(certificationCourseRepository, 'save').resolves();
       });
 
       it('should rejects an error when the session does not exist',  function() {
@@ -178,10 +180,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
       it('should create the certification course with status "started", if at least 5 competences with level higher than 0', async function() {
         // given
-        sinon.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
         sinon.stub(userService, 'getProfileToCertifyV1').resolves(fiveCompetencesWithLevelHigherThan0);
         sinon.stub(userService, 'getProfileToCertifyV2').resolves([]);
         sinon.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
+        sinon.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
 
         // when
         const newCertification = await retrieveLastOrCreateCertificationCourse({
@@ -202,6 +204,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
       });
 
       describe('choice of certification profile v1 or v2', () => {
+
+        beforeEach(() => {
+          sinon.stub(certificationCourseRepository, 'save').resolves();
+        });
 
         it('should use certifiable profil V1 even when V2 has higher score but is not certifiable', async () => {
           // given
@@ -297,6 +303,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           sinon.stub(userService, 'getProfileToCertifyV1').resolves(fiveCompetencesWithLevelHigherThan0);
           sinon.stub(userService, 'getProfileToCertifyV2').resolves(fiveCompetencesWithLevelHigherThan0WithHigherScore);
           sinon.stub(certificationChallengesService, 'saveChallenges').resolves();
+          sinon.stub(certificationCourseRepository, 'save').resolves();
         });
 
         it('should choose profile v2 when certification v2 is active', async () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -63,7 +63,8 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         birthplace: 'Neuilly-Sur-Seine',
         sessionId: '#DaftPunk',
         externalId: 'Grammys2016',
-        isPublished: 'true',
+        isPublished: true,
+        isV2Certification: true,
       });
 
       // when
@@ -84,7 +85,8 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'birthplace': 'Neuilly-Sur-Seine',
             'session-id': '#DaftPunk',
             'external-id': 'Grammys2016',
-            'is-published': 'true',
+            'is-published': true,
+            'is-v2-certification': true,
           },
         },
       });


### PR DESCRIPTION
## :unicorn: Problème
Avant de lancer les certifications du profil v2, il est important de pouvoir se souvenir du type de certification passé par l'utilisateur. Ensuite le scoring de la certification pourra se baser sur cette donnée.

## :robot: Solution
Ajout d'une colonne `isV2Certification` dans la table `certificationCourse`.
Pour pouvoir valider ça, nous avons ajouté l'affichage du type de la certification dans Pix Admin.

## :rainbow: Remarques
Il faudra se souvenir de ré-initialiser les `assessment-results` des certifications V2 dès que le scoring V2 sera prêt.
