### PR TITLE
[BUGFIX] Remise en place des previews.

### DIFF
--- a/mon-pix/app/routes/challenge-preview.js
+++ b/mon-pix/app/routes/challenge-preview.js
@@ -9,7 +9,6 @@ export default Route.extend({
 
   afterModel(challenge) {
     const store = this.store;
-    const that = this;
 
     const assessment = store.createRecord('assessment', { type: 'PREVIEW' });
 
@@ -17,7 +16,7 @@ export default Route.extend({
 
     correctionAdapter.refreshRecord('correction', { challengeId: challenge.get('id') });
     return assessment.save().then(() => {
-      return that.transitionTo('assessments.challenge', { assessment, challenge });
+      return this.replaceWith('assessments.challenge', assessment.id, challenge.id);
     });
   }
 });


### PR DESCRIPTION
## :unicorn: Problème
Les previews ne s'affichaient plus

## :robot: Solution
Les previews envoyaient encore les objets plutot que les id quand on transitait vers la route assessments.challenge, ce qui posait problème.
La transition a donc été réécrite
