### PR TITLE
[FEATURE] Affichage de la moyenne des résultats d'une campagne. (PO-197)

### DIFF
--- a/orga/app/components/routes/authenticated/campaigns/details/collective-results-tab.js
+++ b/orga/app/components/routes/authenticated/campaigns/details/collective-results-tab.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  averageValidatedSkills: computed('campaignCollectiveResults', function() {
+    const campaignCompetenceCollectiveResults = this.get('campaignCollectiveResults.campaignCompetenceCollectiveResults');
+
+    return campaignCompetenceCollectiveResults;
+  }),
+});

--- a/orga/app/models/campaign-collective-result.js
+++ b/orga/app/models/campaign-collective-result.js
@@ -3,23 +3,24 @@ import { computed } from '@ember/object';
 import _ from 'lodash';
 
 export default DS.Model.extend({
-  campaignCollectiveResult: DS.belongsTo('campaign-collective-result'),
-  totalValidatedSkills: computed.mapBy('campaignCompetenceCollectiveResults', 'totalValidatedSkills'),
 
   campaignCompetenceCollectiveResults: DS.hasMany('campaignCompetenceCollectiveResult'),
 
-  totalSkillsCounts: computed.mapBy('campaignCompetenceCollectiveResults', 'totalSkillsCount'),
-  maxTotalSkillsCountInCompetences: computed.max('totalSkillsCounts'),
+  // -- Computed properties --
 
-  averageValidatedSkills: computed('campaignCompetenceCollectiveResults', function() {
-
-    const campaignCompetenceCollectiveResults =  this.campaignCompetenceCollectiveResults;
-    return  _.sumBy(campaignCompetenceCollectiveResults.toArray(), 'roundedAverageValidatedSkills');
+  maxTotalSkillsCountInCompetences: computed('campaignCompetenceCollectiveResults.@each.totalSkillsCount', function() {
+    return _.maxBy(this.campaignCompetenceCollectiveResults.toArray(), 'totalSkillsCount').totalSkillsCount;
   }),
 
-  totalSkills: computed.sum('totalSkillsCounts'),
+  averageValidatedSkillsSum: computed('campaignCompetenceCollectiveResults.@each.averageValidatedSkills', function() {
+    return  _.sumBy(this.campaignCompetenceCollectiveResults.toArray(), 'averageValidatedSkills');
+  }),
 
-  averageResult: computed('averageValidatedSkills', 'totalSkills', function() {
-    return Math.round(this.averageValidatedSkills * 100 / this.totalSkills);
+  totalSkills: computed('campaignCompetenceCollectiveResults.@each.totalSkillsCount', function() {
+    return _.sumBy(this.campaignCompetenceCollectiveResults.toArray(), 'totalSkillsCount');
+  }),
+
+  averageResult: computed('averageValidatedSkillsSum', 'totalSkills', function() {
+    return Math.round(this.averageValidatedSkillsSum * 100 / this.totalSkills);
   }),
 });

--- a/orga/app/models/campaign-collective-result.js
+++ b/orga/app/models/campaign-collective-result.js
@@ -13,7 +13,10 @@ export default DS.Model.extend({
   }),
 
   averageValidatedSkillsSum: computed('campaignCompetenceCollectiveResults.@each.averageValidatedSkills', function() {
-    return  _.sumBy(this.campaignCompetenceCollectiveResults.toArray(), 'averageValidatedSkills');
+    const roundedAverageResults = this.campaignCompetenceCollectiveResults.map((campaignCompetenceCollectiveResult) => {
+      return Math.round(campaignCompetenceCollectiveResult.averageValidatedSkills * 10) / 10;
+    });
+    return Math.round(_.sum(roundedAverageResults) * 10) / 10;
   }),
 
   totalSkills: computed('campaignCompetenceCollectiveResults.@each.totalSkillsCount', function() {

--- a/orga/app/models/campaign-collective-result.js
+++ b/orga/app/models/campaign-collective-result.js
@@ -1,9 +1,25 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import _ from 'lodash';
 
 export default DS.Model.extend({
+  campaignCollectiveResult: DS.belongsTo('campaign-collective-result'),
+  totalValidatedSkills: computed.mapBy('campaignCompetenceCollectiveResults', 'totalValidatedSkills'),
+
   campaignCompetenceCollectiveResults: DS.hasMany('campaignCompetenceCollectiveResult'),
 
   totalSkillsCounts: computed.mapBy('campaignCompetenceCollectiveResults', 'totalSkillsCount'),
   maxTotalSkillsCountInCompetences: computed.max('totalSkillsCounts'),
+
+  averageValidatedSkills: computed('campaignCompetenceCollectiveResults', function() {
+
+    const campaignCompetenceCollectiveResults =  this.campaignCompetenceCollectiveResults;
+    return  _.sumBy(campaignCompetenceCollectiveResults.toArray(), 'roundedAverageValidatedSkills');
+  }),
+
+  totalSkills: computed.sum('totalSkillsCounts'),
+
+  averageResult: computed('averageValidatedSkills', 'totalSkills', function() {
+    return Math.round(this.averageValidatedSkills * 100 / this.totalSkills);
+  }),
 });

--- a/orga/app/routes/authenticated/campaigns/details/collective-results.js
+++ b/orga/app/routes/authenticated/campaigns/details/collective-results.js
@@ -2,12 +2,11 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
 
-  model() {
-    return this.modelFor('authenticated.campaigns.details');
-  },
+  async model() {
+    const details = await this.modelFor('authenticated.campaigns.details');
+    await details.belongsTo('campaignCollectiveResult').reload();
 
-  afterModel(model) {
-    model.belongsTo('campaignCollectiveResult').reload();
+    return details;
   }
 
 });

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant-results.scss
@@ -20,6 +20,10 @@
   &__details {
     margin-bottom: 30px;
   }
+
+  &-row {
+    margin-bottom: 1em;
+  }
 }
 
 .participant-results-header {

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
@@ -1,47 +1,43 @@
-<div class="panel panel--light-shadow participant-results__details content-text content-text--small">
-  <div class="participant-results-row">
-    <div class="participant-results-content__summary">
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Compétences testées</div>
-        <div class="content-text content-text--big">
-          {{ campaignCollectiveResult.campaignCompetenceCollectiveResults.length }}
-        </div>
-      </div>
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Acquis validés</div>
-        <div class="content-text content-text--big">
-          {{ campaignCollectiveResult.averageValidatedSkillsSum }}
-        </div>
-      </div>
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Acquis évalués</div>
-        <div class="content-text content-text--big">
-          {{ campaignCollectiveResult.totalSkills }}
-        </div>
+<div class="panel participant-results-row">
+
+  <div class="participant-results-content__summary">
+    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+      <div class="label-text participant-results-content__label-text">Acquis validés</div>
+      <div class="content-text content-text--big">
+        {{ campaignCollectiveResult.averageValidatedSkillsSum }}
       </div>
     </div>
-
-    <div class="participant-results-content">
-      <div class="participant-results-content__score">
-        <div class="content-text content-text--big content-text--bold">Résultat</div>
-        <div class="participant-results-content__circle-chart">
-          {{#circle-chart value=campaignCollectiveResult.averageResult}}
-            <span class="participant-results-content__circle-chart-value">
-              {{campaignCollectiveResult.averageResult}}%
-            </span>
-          {{/circle-chart}}
-        </div>
+    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+      <div class="label-text participant-results-content__label-text">Acquis évalués</div>
+      <div class="content-text content-text--big">
+        {{ campaignCollectiveResult.totalSkills }}
       </div>
     </div>
   </div>
+
+  <div class="participant-results-content">
+    <div class="participant-results-content__score">
+      <div class="content-text content-text--big content-text--bold">Résultat</div>
+      <div class="participant-results-content__circle-chart">
+        {{#circle-chart value=campaignCollectiveResult.averageResult}}
+          <span class="participant-results-content__circle-chart-value">
+            {{campaignCollectiveResult.averageResult}}%
+          </span>
+        {{/circle-chart}}
+      </div>
+    </div>
+  </div>
+
+</div>
+<div class="panel panel--light-shadow participant-results__details content-text content-text--small">
 
 
   <table>
     <thead>
     <tr>
-      <th class="table__column--wide">Compétences</th>
-      <th class="table__column--wide">Résultats (moyenne)</th>
-      <th class="table__column--small">Acquis validés (moyenne)</th>
+      <th class="table__column--wide">Compétences ({{ campaignCollectiveResult.campaignCompetenceCollectiveResults.length }})</th>
+      <th class="table__column--wide">Résultats</th>
+      <th class="table__column--small">Acquis validés</th>
       <th class="table__column--small">Acquis évalués</th>
     </tr>
     </thead>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
@@ -10,13 +10,13 @@
       <div class="participant-results-content participant-results-content--large participant-results-content--wide">
         <div class="label-text participant-results-content__label-text">Acquis validés</div>
         <div class="content-text content-text--big">
-          {{ campaignCollectiveResult.averageValidatedSkills }}
+          {{ campaignCollectiveResult.averageValidatedSkillsSum }}
         </div>
       </div>
       <div class="participant-results-content participant-results-content--large participant-results-content--wide">
         <div class="label-text participant-results-content__label-text">Acquis évalués</div>
         <div class="content-text content-text--big">
-          {{ campaignCollectiveResult.totalSkillsCounts }}
+          {{ campaignCollectiveResult.totalSkills }}
         </div>
       </div>
     </div>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
@@ -1,4 +1,40 @@
 <div class="panel panel--light-shadow participant-results__details content-text content-text--small">
+  <div class="participant-results-row">
+    <div class="participant-results-content__summary">
+      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+        <div class="label-text participant-results-content__label-text">Compétences testées</div>
+        <div class="content-text content-text--big">
+          {{ campaignCollectiveResult.campaignCompetenceCollectiveResults.length }}
+        </div>
+      </div>
+      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+        <div class="label-text participant-results-content__label-text">Acquis validés</div>
+        <div class="content-text content-text--big">
+          {{ campaignCollectiveResult.averageValidatedSkills }}
+        </div>
+      </div>
+      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+        <div class="label-text participant-results-content__label-text">Acquis évalués</div>
+        <div class="content-text content-text--big">
+          {{ campaignCollectiveResult.totalSkillsCounts }}
+        </div>
+      </div>
+    </div>
+
+    <div class="participant-results-content">
+      <div class="participant-results-content__score">
+        <div class="content-text content-text--big content-text--bold">Résultat</div>
+        <div class="participant-results-content__circle-chart">
+          {{#circle-chart value=campaignCollectiveResult.averageResult}}
+            <span class="participant-results-content__circle-chart-value">
+              {{campaignCollectiveResult.averageResult}}%
+            </span>
+          {{/circle-chart}}
+        </div>
+      </div>
+    </div>
+  </div>
+
 
   <table>
     <thead>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
@@ -84,7 +84,7 @@
 
     <div class="participant-results-content">
       <div class="participant-results-content__score">
-        <div class="content-text content-text--big content-text--bold">Score</div>
+        <div class="content-text content-text--big content-text--bold">Résultats</div>
         <div class="participant-results-content__circle-chart">
           {{#circle-chart value=campaignParticipation.campaignParticipationResult.masteryPercentage
                           isDisabled=(not campaignParticipation.isShared) }}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
@@ -56,50 +56,44 @@
 
   </div>
 </div>
-<div class="panel panel--light-shadow participant-results__details content-text content-text--small">
-  <div class="participant-results-row">
-    <div class="participant-results-content__summary">
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Compétences testées</div>
-        <div class="content-text content-text--big">
-          {{if campaignParticipation.isShared
-               campaignParticipation.campaignParticipationResult.competenceResults.length '-' }}
-        </div>
-      </div>
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Acquis validés</div>
-        <div class="content-text content-text--big">
-          {{if campaignParticipation.isShared
-               campaignParticipation.campaignParticipationResult.validatedSkillsCount '-' }}
-        </div>
-      </div>
-      <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-        <div class="label-text participant-results-content__label-text">Acquis évalués</div>
-        <div class="content-text content-text--big">
-          {{if campaignParticipation.isShared
-               campaignParticipation.campaignParticipationResult.totalSkillsCount '-' }}
-        </div>
+<div class="panel participant-results-row">
+  <div class="participant-results-content__summary">
+    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+      <div class="label-text participant-results-content__label-text">Acquis validés</div>
+      <div class="content-text content-text--big">
+        {{if campaignParticipation.isShared
+             campaignParticipation.campaignParticipationResult.validatedSkillsCount '-' }}
       </div>
     </div>
-
-    <div class="participant-results-content">
-      <div class="participant-results-content__score">
-        <div class="content-text content-text--big content-text--bold">Résultats</div>
-        <div class="participant-results-content__circle-chart">
-          {{#circle-chart value=campaignParticipation.campaignParticipationResult.masteryPercentage
-                          isDisabled=(not campaignParticipation.isShared) }}
-            <span class="participant-results-content__circle-chart-value">
-              {{campaignParticipation.campaignParticipationResult.masteryPercentage}}%
-            </span>
-          {{/circle-chart}}
-        </div>
+    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
+      <div class="label-text participant-results-content__label-text">Acquis évalués</div>
+      <div class="content-text content-text--big">
+        {{if campaignParticipation.isShared
+             campaignParticipation.campaignParticipationResult.totalSkillsCount '-' }}
       </div>
     </div>
   </div>
+
+  <div class="participant-results-content">
+    <div class="participant-results-content__score">
+      <div class="content-text content-text--big content-text--bold">Résultat</div>
+      <div class="participant-results-content__circle-chart">
+        {{#circle-chart value=campaignParticipation.campaignParticipationResult.masteryPercentage
+                        isDisabled=(not campaignParticipation.isShared) }}
+          <span class="participant-results-content__circle-chart-value">
+            {{campaignParticipation.campaignParticipationResult.masteryPercentage}}%
+          </span>
+        {{/circle-chart}}
+      </div>
+    </div>
+  </div>
+</div>
+<div class="panel panel--light-shadow participant-results__details content-text content-text--small">
   <table>
     <thead>
     <tr>
-      <th class="table__column--wide">Compétences</th>
+      <th class="table__column--wide">Compétences ({{if campaignParticipation.isShared
+                                                            campaignParticipation.campaignParticipationResult.competenceResults.length '-' }})</th>
       <th class="table__column--wide">Résultats</th>
       <th class="table__column--small">Acquis validés</th>
       <th class="table__column--small">Acquis évalués</th>

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
@@ -88,9 +88,8 @@ module('Integration | Component | routes/authenticated/campaign/details/particip
     await render(hbs`{{routes/authenticated/campaigns/details/participants/results-item campaignParticipation=campaignParticipation}}`);
 
     // then
-    assert.dom('.participant-results-content__summary .participant-results-content .content-text--big').hasText('1');
-    assert.dom('.participant-results-content__summary .participant-results-content:nth-child(2) .content-text--big').hasText('15');
-    assert.dom('.participant-results-content__summary .participant-results-content:nth-child(3) .content-text--big').hasText('30');
+    assert.dom('.participant-results-content__summary .participant-results-content:nth-child(1) .content-text--big').hasText('15');
+    assert.dom('.participant-results-content__summary .participant-results-content:nth-child(2) .content-text--big').hasText('30');
     assert.dom('.participant-results-content__circle-chart-value').hasText('50%');
 
     assert.dom('table tbody tr').exists({ count: 1 });

--- a/orga/tests/unit/models/campaign-collective-results-test.js
+++ b/orga/tests/unit/models/campaign-collective-results-test.js
@@ -36,4 +36,38 @@ module('Unit | Model | campaign-collective-results', function(hooks) {
       }
     ]);
   });
+
+  module('averageResult', function() {
+
+    test('it should return averge result', function(assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const competenceCollectiveResults1 = store.createRecord('campaign-competence-collective-result', {
+        roundedAverageValidatedSkills: 12,
+        totalSkillsCount: 20
+      });
+      const competenceCollectiveResults2 = store.createRecord('campaign-competence-collective-result', {
+        roundedAverageValidatedSkills: 45,
+        totalSkillsCount: 66
+      });
+      const competenceCollectiveResults3 = store.createRecord('campaign-competence-collective-result', {
+        roundedAverageValidatedSkills: 2,
+        totalSkillsCount: 5
+      });
+
+      const model = run(()=> store.createRecord('campaign-collective-result', {}));
+      model.set(
+        'campaignCompetenceCollectiveResults',
+        [competenceCollectiveResults1, competenceCollectiveResults2, competenceCollectiveResults3]
+      );
+
+      //when
+      const averageResult = model.get('averageResult');
+
+      //then
+      assert.equal(averageResult, 65);
+    });
+
+  });
 });

--- a/orga/tests/unit/models/campaign-collective-results-test.js
+++ b/orga/tests/unit/models/campaign-collective-results-test.js
@@ -5,55 +5,53 @@ import { run } from '@ember/runloop';
 module('Unit | Model | campaign-collective-results', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign-collective-result', {}));
-    assert.ok(model);
-  });
+  module('averageValidatedSkillsSum', function() {
 
-  test('it should return the right data in the campaign-collective-result model', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign-collective-result', {
-      id: '123',
-      collectiveResultsByCompetence: [
-        {
-          'area-code': '1',
-          'competence-id': 'rec1',
-          'competence-name': 'Pocher les gambas',
-          'average-validated-skills': 2,
-          'total-skills-count': 3
-        }
-      ]
-    }));
-    assert.equal(model.id, '123');
-    assert.deepEqual(model.collectiveResultsByCompetence, [
-      {
-        'area-code': '1',
-        'competence-id': 'rec1',
-        'competence-name': 'Pocher les gambas',
-        'average-validated-skills': 2,
-        'total-skills-count': 3
-      }
-    ]);
-  });
-
-  module('averageResult', function() {
-
-    test('it should return averge result', function(assert) {
+    test('it should return the sum of competences average validated skills', function(assert) {
       //given
       const store = this.owner.lookup('service:store');
 
       const competenceCollectiveResults1 = store.createRecord('campaign-competence-collective-result', {
-        roundedAverageValidatedSkills: 12,
-        totalSkillsCount: 20
+        averageValidatedSkills: 12
       });
       const competenceCollectiveResults2 = store.createRecord('campaign-competence-collective-result', {
-        roundedAverageValidatedSkills: 45,
-        totalSkillsCount: 66
+        averageValidatedSkills: 45
       });
       const competenceCollectiveResults3 = store.createRecord('campaign-competence-collective-result', {
-        roundedAverageValidatedSkills: 2,
-        totalSkillsCount: 5
+        averageValidatedSkills: 3
+      });
+
+      const model = run(() => store.createRecord('campaign-collective-result', {}));
+      model.set(
+        'campaignCompetenceCollectiveResults',
+        [competenceCollectiveResults1, competenceCollectiveResults2, competenceCollectiveResults3]
+      );
+
+      //when
+      const averageValidatedSkillsSum = model.get('averageValidatedSkillsSum');
+
+      //then
+      assert.equal(averageValidatedSkillsSum, 60);
+    });
+  });
+
+  module('averageResult', function() {
+
+    test('it should return average result', function(assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const competenceCollectiveResults1 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 10,
+        totalSkillsCount: 20,
+      });
+      const competenceCollectiveResults2 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 20,
+        totalSkillsCount: 40,
+      });
+      const competenceCollectiveResults3 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 30,
+        totalSkillsCount: 60,
       });
 
       const model = run(()=> store.createRecord('campaign-collective-result', {}));
@@ -66,8 +64,72 @@ module('Unit | Model | campaign-collective-results', function(hooks) {
       const averageResult = model.get('averageResult');
 
       //then
-      assert.equal(averageResult, 65);
+      assert.equal(averageResult, (10 + 20 + 30) / (20 + 40 + 60) * 100);
+    });
+  });
+
+  module('totalSkills', function() {
+
+    test('it should return total skills', function(assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const competenceCollectiveResults1 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 10,
+        totalSkillsCount: 20,
+      });
+      const competenceCollectiveResults2 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 20,
+        totalSkillsCount: 40,
+      });
+      const competenceCollectiveResults3 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 30,
+        totalSkillsCount: 60,
+      });
+
+      const model = run(()=> store.createRecord('campaign-collective-result', {}));
+      model.set(
+        'campaignCompetenceCollectiveResults',
+        [competenceCollectiveResults1, competenceCollectiveResults2, competenceCollectiveResults3]
+      );
+
+      //when
+      const totalSkills = model.get('totalSkills');
+
+      //then
+      assert.equal(totalSkills, 20 + 40 + 60);
     });
 
+  });
+
+  module('maxTotalSkillsCountInCompetences', function() {
+    test('it should return the highest value among the total skills counts', function(assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+
+      const competenceCollectiveResults1 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 10,
+        totalSkillsCount: 20,
+      });
+      const competenceCollectiveResults2 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 20,
+        totalSkillsCount: 40,
+      });
+      const competenceCollectiveResults3 = store.createRecord('campaign-competence-collective-result', {
+        averageValidatedSkills: 30,
+        totalSkillsCount: 60,
+      });
+
+      const model = run(() => store.createRecord('campaign-collective-result', {}));
+      model.set(
+        'campaignCompetenceCollectiveResults',
+        [competenceCollectiveResults1, competenceCollectiveResults2, competenceCollectiveResults3]
+      );
+      //when
+      const maxTotalSkillsCountInCompetences = model.get('maxTotalSkillsCountInCompetences');
+
+      //then
+      assert.equal(maxTotalSkillsCountInCompetences, 60);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Demande

Pour le Sup et Sco, on souhaite améliorer l'affichage des infos de résultat d'une campagne.

- Supprimer Compétences testées

Déplacement des éléments suivants:
- Acquis validés
- Acquis évalués
- Résultats partagés
- Résultat (en %)

## :rainbow: Remarques

Le visuel cible est encore en cours de réflexion.

- https://projects.invisionapp.com/share/GWP9OGTXFPK/#/screens/333006833
