### PR TITLE
[TECH] Supprime la méthtode inutile mail-service#sendWelcomeEmail

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,6 +1,5 @@
 const mailJet = require('../../infrastructure/mailjet');
 const ACCOUNT_CREATION_EMAIL_TEMPLATE_ID = '143620';
-const WELCOME_EMAIL_TEMPLATE_ID = '129291';
 const RESET_PASSWORD_DEMAND_EMAIL_TEMPLATE_ID = '232827';
 
 function sendAccountCreationEmail(email) {
@@ -10,13 +9,6 @@ function sendAccountCreationEmail(email) {
     from: 'ne-pas-repondre@pix.fr',
     fromName: 'PIX - Ne pas répondre',
     subject: 'Création de votre compte PIX'
-  });
-}
-
-function sendWelcomeEmail(email) {
-  return mailJet.sendEmail({
-    to: email,
-    template: WELCOME_EMAIL_TEMPLATE_ID
   });
 }
 
@@ -33,6 +25,5 @@ function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
 
 module.exports = {
   sendAccountCreationEmail,
-  sendWelcomeEmail,
   sendResetPasswordDemandEmail
 };

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -32,32 +32,6 @@ describe('Unit | Service | MailService', () => {
     });
   });
 
-  describe('#sendWelcomeEmail', () => {
-
-    let sendEmailStub;
-
-    beforeEach(() => {
-      sendEmailStub = sinon.stub(mailJet, 'sendEmail').resolves();
-    });
-
-    it('should use mailJet to send an email', () => {
-      // given
-      const email = 'text@example.net';
-
-      // when
-      const promise = mailService.sendWelcomeEmail(email);
-
-      // then
-      return promise.then(() => {
-        sinon.assert.called(sendEmailStub);
-        expect(sendEmailStub.firstCall.args[0]).to.deep.equal({
-          to: email,
-          template: '129291'
-        });
-      });
-    });
-  });
-
   describe('#sendResetPasswordDemandEmail', () => {
 
     let sendEmailStub;


### PR DESCRIPTION
En regardant quels sont nos usages de MailJet d'un point de vue applicatif (i.e. hors Discourse & cie.), je me suis rendu compte qu'on a une méthode morte. #RGPD

L'objet de cette PR consiste à supprimer ce code mort.

> **Remarque** : le template - dont l'ID est `129291` - a été supprimé de MailJet.