### PR TITLE
[FEATURE] Retouche de la fenêtre pour signaler un problème. (PF-612)

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,51 +1,23 @@
 import { isEmpty } from '@ember/utils';
 import $ from 'jquery';
-import { equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import config from 'mon-pix/config/environment';
 
-const FORM_CLOSED = 'FORM_CLOSED';
-const FORM_OPENED = 'FORM_OPENED';
-const FORM_SUBMITTED = 'FORM_SUBMITTED';
-
 export default Component.extend({
-
-  store: service(),
 
   classNames: ['feedback-panel'],
 
+  store: service(),
+
   assessment: null,
   challenge: null,
-  collapsible: true,
 
-  _status: FORM_CLOSED,
   _content: null,
   _error: null,
 
-  isFormClosed: equal('_status', FORM_CLOSED),
-  isFormOpened: equal('_status', FORM_OPENED),
-  isFormSubmitted: equal('_status', FORM_SUBMITTED),
-
-  didReceiveAttrs() {
-    this._super(...arguments);
-    this._reset();
-  },
-
-  _reset() {
-    this.set('_content', null);
-    this.set('_error', null);
-    this.set('_status', this._getDefaultStatus());
-  },
-
-  _closeForm() {
-    this.set('_status', FORM_CLOSED);
-    this.set('_error', null);
-  },
-
-  _getDefaultStatus() {
-    return this.collapsible ? FORM_CLOSED : FORM_OPENED;
-  },
+  isFormOpened: false,
+  isSubmitted: false,
 
   _scrollToPanel: function() {
     $('html,body').animate({
@@ -55,33 +27,34 @@ export default Component.extend({
 
   actions: {
 
-    openFeedbackForm() {
-      this.set('_status', FORM_OPENED);
-      this._scrollToPanel();
+    toggleFeedbackForm() {
+      if (this.isFormOpened) {
+        this.set('isFormOpened', false);
+        this.set('isSubmitted', false);
+        this.set('_error', null);
+      } else {
+        this.set('isFormOpened', true);
+        this._scrollToPanel();
+      }
     },
 
-    cancelFeedback() {
-      this._closeForm();
-    },
-
-    sendFeedback() {
+    async sendFeedback() {
       const content = this._content;
+
       if (isEmpty(content) || isEmpty(content.trim())) {
         this.set('_error', 'Vous devez saisir un message.');
         return;
       }
 
-      const store = this.store;
-      const assessment = this.assessment;
-      const challenge = this.challenge;
-
-      const feedback = store.createRecord('feedback', {
-        content: this._content,
-        assessment,
-        challenge
+      const feedback = this.store.createRecord('feedback', {
+        content,
+        assessment: this.assessment,
+        challenge: this.challenge,
       });
-      feedback.save()
-        .then(() => this.set('_status', FORM_SUBMITTED));
+
+      await feedback.save();
+
+      this.set('isSubmitted', true);
     }
   }
 });

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -6,6 +6,10 @@
 /* "Link" view
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
+.feedback-panel__view--link {
+  margin-bottom: 10px;
+}
+
 .feedback-panel__open-link {
   cursor: pointer;
   color: inherit;
@@ -22,13 +26,6 @@
 
 /* "Form" view
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-
-.feedback-panel__form-title {
-  font-size: 15px;
-  font-weight: $font-heavy;
-  margin: 0 0 20px;
-  line-height: 20px;
-}
 
 .feedback-panel__form-description {
   margin-bottom: 20px;

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -78,7 +78,7 @@
 
       <div class="pix-modal-footer">
         <div class="comparison-window__feedback-panel">
-          {{feedback-panel assessment=answer.assessment challenge=answer.challenge collapsible=false}}
+          {{feedback-panel assessment=answer.assessment challenge=answer.challenge isFormOpened=true}}
         </div>
       </div>
     </div>

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -1,52 +1,44 @@
-{{#if isFormClosed}}
-  <div class="feedback-panel__view feedback-panel__view--link">
-    <a class="feedback-panel__open-link" {{action "openFeedbackForm"}} href="#">Signaler un problème</a>
-  </div>
-{{/if}}
+<div class="feedback-panel__view feedback-panel__view--link">
+  <a class="feedback-panel__open-link" {{action "toggleFeedbackForm"}} href="#">Signaler un problème</a>
+</div>
 
 {{#if isFormOpened}}
-  <div class="feedback-panel__view feedback-panel__view--form">
-    <h3 class="feedback-panel__form-title">Signaler un problème</h3>
-
-    <div class="feedback-panel__form-description">
-      <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*</p>
+  {{#if isSubmitted}}
+    <div class="feedback-panel__view feedback-panel__view--mercix">
+      <p>Votre commentaire a bien été transmis à l’équipe du projet Pix.</p>
+      <p>Mercix !</p>
     </div>
+  {{else}}
+    <div class="feedback-panel__view feedback-panel__view--form">
+      <div class="feedback-panel__form-description">
+        <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*</p>
+      </div>
 
-    <div class="feedback-panel__form-wrapper">
-      <form class="feedback-panel__form">
-        <div class="feedback-panel__group">
-          {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
-        </div>
-
-        {{#if _error}}
-          <div class="alert alert-danger" role="alert">
-            {{_error}}
+      <div class="feedback-panel__form-wrapper">
+        <form class="feedback-panel__form">
+          <div class="feedback-panel__group">
+            {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Votre message" rows=6}}
           </div>
-        {{/if}}
-        <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
-        {{#if collapsible}}
-          <button class="feedback-panel__button feedback-panel__button--cancel" {{action "cancelFeedback"}}>Annuler
-          </button>
-        {{/if}}
-      </form>
+
+          {{#if _error}}
+            <div class="alert alert-danger" role="alert">
+              {{_error}}
+            </div>
+          {{/if}}
+          <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
+        </form>
+      </div>
+
+      <div class="feedback-panel__form-description">
+        <p>* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
+        <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
+      </div>
+
+      <div class="feedback-panel__form-description">
+        <p>Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de <a href="mailto:dpo@pix.fr" class="link">dpo@pix.fr</a>.</p>
+        <p><a href="https://pix.fr/dp-formulaire-signalement-epreuve" target="_blank" class="link">Pour en savoir plus sur la protection de vos données et sur vos droits.</a></p>
+      </div>
+
     </div>
-
-    <div class="feedback-panel__form-description">
-      <p>* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
-      <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
-    </div>
-
-    <div class="feedback-panel__form-description">
-      <p>Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de <a href="mailto:dpo@pix.fr" class="link">dpo@pix.fr</a>.</p>
-      <p><a href="https://pix.fr/dp-formulaire-signalement-epreuve" target="_blank" class="link">Pour en savoir plus sur la protection de vos données et sur vos droits.</a></p>
-    </div>
-
-  </div>
-{{/if}}
-
-{{#if isFormSubmitted}}
-  <div class="feedback-panel__view feedback-panel__view--mercix">
-    <p>Votre commentaire a bien été transmis à l’équipe du projet Pix.</p>
-    <p>Mercix !</p>
-  </div>
+  {{/if}}
 {{/if}}

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -9,9 +9,7 @@
     <h3 class="feedback-panel__form-title">Signaler un problème</h3>
 
     <div class="feedback-panel__form-description">
-      <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !</p>
-      <p>Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
-      <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
+      <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*</p>
     </div>
 
     <div class="feedback-panel__form-wrapper">
@@ -31,7 +29,11 @@
           </button>
         {{/if}}
       </form>
+    </div>
 
+    <div class="feedback-panel__form-description">
+      <p>* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
+      <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
     </div>
 
     <div class="feedback-panel__form-description">

--- a/mon-pix/tests/acceptance/challenge-feedback-test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback-test.js
@@ -3,8 +3,6 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const FEEDBACK_FORM = '.feedback-panel__form';
-
 describe('Acceptance | Giving feedback about a challenge', function() {
 
   let application;
@@ -14,13 +12,11 @@ describe('Acceptance | Giving feedback about a challenge', function() {
   }
 
   function assertThatFeedbackFormIsClosed() {
-    expect(find('.feedback-panel__open-link')).to.have.lengthOf(1);
-    expect(find(FEEDBACK_FORM)).to.have.lengthOf(0);
+    expect(find('.feedback-panel__form')).to.have.lengthOf(0);
   }
 
   function assertThatFeedbackFormIsOpen() {
-    expect(find('.feedback-panel__open-link')).to.have.lengthOf(0);
-    expect(find(FEEDBACK_FORM)).to.have.lengthOf(1);
+    expect(find('.feedback-panel__form')).to.have.lengthOf(1);
   }
 
   beforeEach(function() {

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -5,9 +5,6 @@ import { setupRenderingTest } from 'ember-mocha';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-const FEEDBACK_FORM = '.feedback-panel__view--form';
-const LINK_OPEN_FORM = '.feedback-panel__view--link';
-
 describe('Integration | Component | comparison-window', function() {
 
   setupRenderingTest();
@@ -110,8 +107,7 @@ describe('Integration | Component | comparison-window', function() {
       await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
       //then
       expect(find('.comparison-window__feedback-panel')).to.exist;
-      expect(find(FEEDBACK_FORM)).to.exist;
-      expect(find(LINK_OPEN_FORM)).to.not.exist;
+      expect(find('.feedback-panel__form')).to.exist;
     });
 
     [

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -9,29 +9,19 @@ import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
 
-const LINK_VIEW = '.feedback-panel__view--link';
-const FORM_VIEW = '.feedback-panel__view--form';
-const MERCIX_VIEW = '.feedback-panel__view--mercix';
-const OPEN_LINK = '.feedback-panel__open-link';
+const TOGGLE_LINK = '.feedback-panel__open-link';
 const BUTTON_SEND = '.feedback-panel__button--send';
-const BUTTON_CANCEL = '.feedback-panel__button--cancel';
-
-function expectLinkViewToBeVisible() {
-  expect(find(LINK_VIEW)).to.exist;
-  expect(find(FORM_VIEW)).to.not.exist;
-  expect(find(MERCIX_VIEW)).to.not.exist;
-}
 
 function expectFormViewToBeVisible() {
-  expect(find(LINK_VIEW)).to.not.exist;
-  expect(find(FORM_VIEW)).to.exist;
-  expect(find(MERCIX_VIEW)).to.not.exist;
+  expect(find('.feedback-panel__view--form')).to.exist;
+}
+
+function expectFormViewToNotBeVisible() {
+  expect(find('.feedback-panel__view--form')).to.not.exist;
 }
 
 function expectMercixViewToBeVisible() {
-  expect(find(LINK_VIEW)).to.not.exist;
-  expect(find(FORM_VIEW)).to.not.exist;
-  expect(find(MERCIX_VIEW)).to.exist;
+  expect(find('.feedback-panel__view--mercix')).to.exist;
 }
 
 async function setContent(content) {
@@ -45,40 +35,34 @@ describe('Integration | Component | feedback-panel', function() {
 
   describe('Default rendering', function() {
 
-    it('should display the feedback Panel', async function() {
-      // when
-      await render(hbs`{{feedback-panel}}`);
-      // then
-      expect(find('.feedback-panel')).to.exist;
-      expectLinkViewToBeVisible();
-    });
-
-  });
-
-  describe('Link view (available only when form is closed by default)', function() {
-
     beforeEach(async function() {
       await render(hbs`{{feedback-panel}}`);
     });
 
-    it('should display only the "link" view', function() {
-      expectLinkViewToBeVisible();
+    it('should display the feedback panel', function() {
+      expect(find('.feedback-panel__view--link')).to.exist;
     });
 
-    it('the link label should be "Signaler un problème"', function() {
-      expect(find(OPEN_LINK).textContent).to.contain('Signaler un problème');
-    });
-
-    it('clicking on the open link should hide the "link" view and display the "form" view', async function() {
+    it('should toggle the form view when clicking on the toggle link', async function() {
       // when
-      await click(OPEN_LINK);
-      // then
-      expectFormViewToBeVisible();
-    });
+      await click(TOGGLE_LINK);
 
+      // then
+      expectFormViewToBeVisible(this);
+
+      // then when
+      await click(TOGGLE_LINK);
+
+      // then
+      expectFormViewToNotBeVisible(this);
+    });
   });
 
   describe('Form view', function() {
+
+    let isSaveMethodCalled;
+    let saveMethodBody;
+    let saveMethodUrl;
 
     const storeStub = Service.extend({
       createRecord() {
@@ -93,10 +77,6 @@ describe('Integration | Component | feedback-panel', function() {
         });
       }
     });
-
-    let isSaveMethodCalled;
-    let saveMethodBody;
-    let saveMethodUrl;
 
     beforeEach(async function() {
       // configure answer & cie. model object
@@ -114,21 +94,13 @@ describe('Integration | Component | feedback-panel', function() {
       // stub store service
       this.owner.register('service:store', storeStub);
 
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=false}}`);
+      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge isFormOpened=true}}`);
     });
 
-    it('should display only the "form" view', function() {
-      expectFormViewToBeVisible();
-    });
-
-    it('should contain content textarea field', function() {
+    it('should display the "form" view', function() {
+      expectFormViewToBeVisible(this);
       expect(find('textarea.feedback-panel__field--content')).to.exist;
-      expect(find('textarea.feedback-panel__field--content').getAttribute('placeholder')).to.equal('Votre message');
-    });
-
-    it('should contain "send" button with label "Envoyer"', function() {
       expect(find(BUTTON_SEND)).to.exist;
-      expect(find(BUTTON_SEND).textContent).to.equal('Envoyer');
     });
 
     it('clicking on "send" button should save the feedback into the store / API and display the "mercix" view', async function() {
@@ -147,98 +119,28 @@ describe('Integration | Component | feedback-panel', function() {
         expect(saveMethodBody.assessment).to.exist;
         expect(saveMethodBody.challenge).to.exist;
         expect(saveMethodBody.content).to.equal(CONTENT_VALUE);
-        expectMercixViewToBeVisible();
+        expectMercixViewToBeVisible(this);
+        expectFormViewToNotBeVisible(this);
       });
     });
-
-    it('should not contain "cancel" button if the feedback form is opened by default', function() {
-      // then
-      expect(find(BUTTON_CANCEL)).to.not.exist;
-    });
-  });
-
-  describe('#Cancel Button management', function() {
-
-    beforeEach(function() {
-      // configure answer & cie. model object
-      const assessment = EmberObject.extend({ id: 'assessment_id' }).create();
-      const challenge = EmberObject.extend({ id: 'challenge_id' }).create();
-
-      // render component
-      this.set('assessment', assessment);
-      this.set('challenge', challenge);
-    });
-
-    it('should not be visible if feedback-panel is not collapsible', async function() {
-      // when
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=false}}`);
-
-      // then
-      expect(find(BUTTON_CANCEL)).to.not.exist;
-    });
-
-    it('should not be visible if status is not FORM_OPENED', async function() {
-      // when
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge collapsible=true _status="FORM_CLOSED"}}`);
-
-      // then
-      expect(find(BUTTON_CANCEL)).to.not.exist;
-    });
-
-    it('should be visible only if component is collapsible and form is opened', async function() {
-      // given
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
-
-      // when
-      await click(OPEN_LINK);
-
-      // then
-      expect(find(BUTTON_CANCEL)).to.exist;
-    });
-
-    it('should contain "cancel" button with label "Annuler" and placeholder "Votre message"', async function() {
-      // given
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
-
-      //when
-      await click(OPEN_LINK);
-
-      //then
-      expect(find(BUTTON_CANCEL)).to.exist;
-      expect(find(BUTTON_CANCEL).textContent.trim()).to.equal('Annuler');
-    });
-
-    it('clicking on "cancel" button should close the "form" view and display the "link" view', async function() {
-      // given
-      await render(hbs`{{feedback-panel assessment=assessment challenge=challenge}}`);
-
-      // when
-      await click(OPEN_LINK);
-      await click(BUTTON_CANCEL);
-
-      // then
-      expectLinkViewToBeVisible();
-    });
-
   });
 
   describe('Error management', function() {
 
     it('should display error if "content" is empty', async function() {
       // given
-      await render(hbs`{{feedback-panel collapsible=false}}`);
+      await render(hbs`{{feedback-panel isFormOpened=true}}`);
 
       // when
       await click(BUTTON_SEND);
 
       // then
       expect(find('.alert')).to.exist;
-      expectFormViewToBeVisible();
     });
 
     it('should display error if "content" is blank', async function() {
       // given
-      await render(hbs`{{feedback-panel collapsible=false}}`);
+      await render(hbs`{{feedback-panel isFormOpened=true}}`);
       await setContent('');
 
       // when
@@ -246,36 +148,20 @@ describe('Integration | Component | feedback-panel', function() {
 
       // then
       expect(find('.alert')).to.exist;
-      expectFormViewToBeVisible();
     });
 
     it('should not display error if "form" view (with error) was closed and re-opened', async function() {
       // given
-      await render(hbs`{{feedback-panel}}`);
-
-      await click(OPEN_LINK);
+      await render(hbs`{{feedback-panel isFormOpened=true}}`);
       await setContent('   ');
-
       await click(BUTTON_SEND);
-      expect(find('.alert')).to.exist;
 
       // when
-      await click(BUTTON_CANCEL);
-      await click(OPEN_LINK);
+      await click(TOGGLE_LINK);
+      await click(TOGGLE_LINK);
 
       // then
       expect(find('.alert')).to.not.exist;
-    });
-
-    it('should display an error even if the user did not focus on content', async function() {
-      // given
-      await render(hbs`{{feedback-panel collapsible=false}}`);
-
-      // when
-      await click(BUTTON_SEND);
-
-      // then
-      expect(find('.alert')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -6,133 +6,34 @@ describe('Unit | Component | feedback-panel', function() {
 
   setupTest();
 
-  describe('#isFormClosed', function() {
+  describe('#toggleFeedbackForm', function() {
 
-    it('should return true by default', function() {
+    it('should open form', function() {
       // given
       const component = this.owner.lookup('component:feedback-panel');
+      component.set('_scrollToPanel', () => {});
 
       // when
-      const isFormClosed = component.get('isFormClosed');
+      component.send('toggleFeedbackForm');
 
       // then
-      expect(isFormClosed).to.be.true;
+      expect(component.isFormOpened).to.be.true;
     });
 
-    it('should return true if status equals "FORM_CLOSED"', function() {
+    it('should close and reset form', function() {
       // given
       const component = this.owner.lookup('component:feedback-panel');
-      component.set('_status', 'FORM_CLOSED');
+      component.set('isFormOpened', true);
+      component.set('_error', '10, 9, 8, ...');
+      component.set('isSubmitted', true);
 
       // when
-      const isFormClosed = component.get('isFormClosed');
+      component.send('toggleFeedbackForm');
 
       // then
-      expect(isFormClosed).to.be.true;
-    });
-
-    it('should return false if status is not equal to "FORM_CLOSED"', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('_status', 'FORM_OPENED');
-
-      // when
-      const isFormClosed = component.get('isFormClosed');
-
-      // then
-      expect(isFormClosed).to.be.false;
-    });
-  });
-
-  describe('#isFormOpened', function() {
-
-    it('should return true if status equals "FORM_OPENED"', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('_status', 'FORM_OPENED');
-
-      // when
-      const isFormClosed = component.get('isFormOpened');
-
-      // then
-      expect(isFormClosed).to.be.true;
-    });
-
-    it('should return false if status is not equal to "FORM_OPENED"', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('_status', 'FORM_CLOSED');
-
-      // when
-      const isFormClosed = component.get('isFormOpened');
-
-      // then
-      expect(isFormClosed).to.be.false;
-    });
-
-  });
-
-  describe('#_reset', function() {
-
-    it('should return empty text, error and back to the default status', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('collapsible', false);
-      component.set('_content', 'un contenu');
-      component.set('_error', 'une erreur');
-      component.set('_status', 'FORM_CLOSED');
-
-      // when
-      component._reset();
-
-      // then
-      expect(component.get('_content')).to.be.null;
-      expect(component.get('_error')).to.be.null;
-      expect(component.get('_status')).to.be.equal('FORM_OPENED');
-    });
-  });
-
-  describe('#_closeForm', function() {
-
-    it('should set status to CLOSED and set errors to null', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('_error', 'une erreur');
-      component.set('_status', 'FORM_OPENED');
-
-      // when
-      component._closeForm();
-
-      // then
-      expect(component.get('_error')).to.be.null;
-      expect(component.get('_status')).to.be.equal('FORM_CLOSED');
-    });
-  });
-
-  describe('#_getDefaultStatus', function() {
-
-    it('should return FORM_CLOSED if has property collapsible at "true"', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('collapsible', true);
-
-      // when
-      const defaultStatus = component._getDefaultStatus();
-
-      // then
-      expect(defaultStatus).to.equal('FORM_CLOSED');
-    });
-
-    it('should return FORM_OPENED if has property collapsible at "false"', function() {
-      // given
-      const component = this.owner.lookup('component:feedback-panel');
-      component.set('collapsible', false);
-
-      // when
-      const defaultStatus = component._getDefaultStatus();
-
-      // then
-      expect(defaultStatus).to.equal('FORM_OPENED');
+      expect(component.isFormOpened).to.be.false;
+      expect(component.isSubmitted).to.be.false;
+      expect(component._error).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'UX de la fenêtre pour signaler un problème n'est pas très clair :
- infos rgpd mises trop en avant
- bouton annuler non-intuitif

## :robot: Solution
- déplacement du texte rgpd après la textarea
- suppression du bouton annuler
- lien d'ouverture maintenant un toggle