### PR TITLE
[TECH] Supprime la bascule FT_USE_ONLY_V1_CERTIFICATION

### DIFF
--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -10,49 +10,45 @@ function _canStartACertification(userCompetences) {
   return _.size(competencesWithEstimatedLevelHigherThan0) >= 5;
 }
 
-function _selectProfileToCertify(userCompetencesProfilV1, userCompetencesProfilV2) {
-  const canStartACertificationOnProfileV2 = _canStartACertification(userCompetencesProfilV2);
-  const canStartACertificationOnProfileV1 = _canStartACertification(userCompetencesProfilV1);
+function _selectProfileToCertify(userCompetencesProfileV1, userCompetencesProfileV2) {
+  const canStartACertificationOnProfileV2 = _canStartACertification(userCompetencesProfileV2);
+  const canStartACertificationOnProfileV1 = _canStartACertification(userCompetencesProfileV1);
 
   if (!canStartACertificationOnProfileV1 && !canStartACertificationOnProfileV2) {
     return null;
   }
 
   else if (canStartACertificationOnProfileV1 && !canStartACertificationOnProfileV2) {
-    return userCompetencesProfilV1;
+    return userCompetencesProfileV1;
   }
 
   else if (!canStartACertificationOnProfileV1 && canStartACertificationOnProfileV2) {
-    return userCompetencesProfilV2;
+    return userCompetencesProfileV2;
   }
 
   else {
-    const pixScoreProfilV1 = _.sumBy(userCompetencesProfilV1, 'pixScore');
-    const pixScoreProfilV2 = _.sumBy(userCompetencesProfilV2, 'pixScore');
+    const pixScoreProfileV1 = _.sumBy(userCompetencesProfileV1, 'pixScore');
+    const pixScoreProfileV2 = _.sumBy(userCompetencesProfileV2, 'pixScore');
 
-    if (pixScoreProfilV1 >= pixScoreProfilV2) return userCompetencesProfilV1;
+    if (pixScoreProfileV1 >= pixScoreProfileV2) return userCompetencesProfileV1;
 
-    return userCompetencesProfilV2;
+    return userCompetencesProfileV2;
   }
 }
 
 async function _startNewCertification({
   userId,
   sessionId,
-  isCertificationV2Active,
   userService,
   certificationChallengesService,
   certificationCourseRepository
 }) {
-  const userCompetencesProfileV1 = await userService.getProfileToCertifyV1({ userId, limitDate: new Date() });
 
-  let userCompetencesProfileV2;
-  if (isCertificationV2Active) {
-    userCompetencesProfileV2 = await userService.getProfileToCertifyV2({ userId, limitDate: new Date() });
-  }
-  else {
-    userCompetencesProfileV2 = [];
-  }
+  const now = new Date();
+  const [userCompetencesProfileV1, userCompetencesProfileV2] = await Promise.all([
+    userService.getProfileToCertifyV1({ userId, now }),
+    userService.getProfileToCertifyV2({ userId, now }),
+  ]);
 
   const userCompetencesToCertify = _selectProfileToCertify(userCompetencesProfileV1, userCompetencesProfileV2);
   if (!userCompetencesToCertify) {
@@ -69,7 +65,6 @@ async function _startNewCertification({
 module.exports = async function retrieveLastOrCreateCertificationCourse({
   accessCode,
   userId,
-  settings,
   sessionService,
   userService,
   certificationChallengesService,
@@ -81,11 +76,9 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   if (_.size(certificationCourses) > 0) {
     return { created: false, certificationCourse: certificationCourses[0] };
   } else {
-    const isCertificationV2Active = settings.features.isCertificationV2Active;
     const certificationCourse = await _startNewCertification({
       userId,
       sessionId,
-      isCertificationV2Active,
       userService,
       certificationChallengesService,
       certificationCourseRepository

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -79,9 +79,8 @@ module.exports = (function() {
     },
 
     features: {
-      isCertificationV2Active: process.env.FT_USE_ONLY_V1_CERTIFICATION !== 'true',
       dayBeforeCompetenceResetV2: process.env.DAY_BEFORE_COMPETENCE_RESET_V2
-    }
+    },
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -11,12 +11,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
   describe('#retrieveLastOrCreateCertificationCourse', () => {
 
-    const settings = {
-      features: {
-        isCertificationV2Active: true
-      }
-    };
-
     context('when a certification course already exists for given sessionId and userId', function() {
 
       let userId;
@@ -42,7 +36,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         const result = await retrieveLastOrCreateCertificationCourse({
           accessCode,
           userId,
-          settings,
           sessionService,
           userService,
           certificationChallengesService,
@@ -163,7 +156,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           const createNewCertificationPromise = retrieveLastOrCreateCertificationCourse({
             accessCode,
             userId,
-            settings,
             sessionService,
             userService,
             certificationChallengesService,
@@ -189,7 +181,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         const newCertification = await retrieveLastOrCreateCertificationCourse({
           accessCode,
           userId,
-          settings,
           sessionService,
           userService,
           certificationChallengesService,
@@ -219,7 +210,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           await retrieveLastOrCreateCertificationCourse({
             accessCode,
             userId,
-            settings,
             sessionService,
             userService,
             certificationChallengesService,
@@ -243,7 +233,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           await retrieveLastOrCreateCertificationCourse({
             accessCode,
             userId,
-            settings,
             sessionService,
             userService,
             certificationChallengesService,
@@ -267,7 +256,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           await retrieveLastOrCreateCertificationCourse({
             accessCode,
             userId,
-            settings,
             sessionService,
             userService,
             certificationChallengesService,
@@ -291,7 +279,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           await retrieveLastOrCreateCertificationCourse({
             accessCode,
             userId,
-            settings,
             sessionService,
             userService,
             certificationChallengesService,
@@ -303,56 +290,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0WithHigherScore, sinon.match.any);
           expect(certificationCourseRepository.save)
             .to.have.been.calledWithMatch({ isV2Certification: true });
-        });
-      });
-
-      describe('certification v2 activation', () => {
-        beforeEach(() => {
-          sinon.stub(userService, 'getProfileToCertifyV1').resolves(fiveCompetencesWithLevelHigherThan0);
-          sinon.stub(userService, 'getProfileToCertifyV2').resolves(fiveCompetencesWithLevelHigherThan0WithHigherScore);
-          sinon.stub(certificationChallengesService, 'saveChallenges').resolves();
-          sinon.stub(certificationCourseRepository, 'save').resolves();
-        });
-
-        it('should choose profile v2 when certification v2 is active', async () => {
-          // when
-          await retrieveLastOrCreateCertificationCourse({
-            accessCode,
-            userId,
-            settings,
-            sessionService,
-            userService,
-            certificationChallengesService,
-            certificationCourseRepository
-          });
-
-          // then
-          expect(certificationChallengesService.saveChallenges)
-            .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0WithHigherScore, sinon.match.any);
-        });
-
-        it('should not choose profile v2 when certification v2 is inactive', async () => {
-          // given
-          const settings = {
-            features: {
-              isCertificationV2Active: false
-            }
-          };
-
-          // when
-          await retrieveLastOrCreateCertificationCourse({
-            accessCode,
-            userId,
-            settings,
-            sessionService,
-            userService,
-            certificationChallengesService,
-            certificationCourseRepository
-          });
-
-          // then
-          expect(certificationChallengesService.saveChallenges)
-            .to.have.been.calledWith(fiveCompetencesWithLevelHigherThan0, sinon.match.any);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Les certifications v2 sont en production depuis le 7 juin, on n'a plus besoin de pouvoir revenir sur un fonctionnement "certifs v1 uniquement".

De plus, conserver des bascules trop longtemps revient à du code mort et conduit à une combinatoire complexe.

## :robot: Solution

Supprimer la bascule FT_USE_ONLY_V1_CERTIFICATION.

## :rainbow: Remarques

Plus d'infos sur la gestion des bascules en #543.