### PR TITLE
[TECH] Permettre de configurer API_HOST sur mon-pix en dev

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -93,7 +93,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
-    ENV.APP.API_HOST = 'http://localhost:3000';
+    ENV.APP.API_HOST = process.env.API_HOST || 'http://localhost:3000';
     ENV.APP.HOME_HOST = '/';
   }
 


### PR DESCRIPTION
## :unicorn: Problème

L'API du plugin pix-auto-answer démarre en local sur le port 3000. Quand on veut l'utiliser sur Pix en local, on doit donc démarrer l'API Pix sur un autre port.

Pb : on ne peut pas configurer l'API_HOST de mon-pix en environnement `development`.

## :robot: Solution

Permettre de configurer l'API_HOST de mon-pix en environnement `development`.
