### PR TITLE
[TECH] Ajout du role MEMBER dans Pix Admin/Orga (PA-95)

### DIFF
--- a/api/db/migrations/20190621155332_create_member_organization_role.js
+++ b/api/db/migrations/20190621155332_create_member_organization_role.js
@@ -1,0 +1,11 @@
+const TABLE_NAME = 'organization-roles';
+
+exports.up = function(knex) {
+  return knex(TABLE_NAME).insert({ id: 2, name: 'MEMBER' });
+};
+
+exports.down = function(knex) {
+  return knex(TABLE_NAME)
+    .where('name', 'MEMBER')
+    .delete();
+};


### PR DESCRIPTION
## 🌶 Problème
Les prescripteurs ne pouvaient être que des administrateurs.

## 🥛 Solution
Maintenant ils peuvent être de simples membres sans droits d'administration. Via une migration.

## 🐝 Remarques
Le nommage MEMBER/Membre peut être discuté.