### PR TITLE
[FEATURE] Afficher le rôle dans la liste des membres d'une organisation dans Pix Admin (PA-95)

### DIFF
--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -19,7 +19,7 @@ const columns = [
     title: 'Courriel',
   },
   {
-    propertyName: 'organizationRole.displayName',
+    propertyName: 'organizationRole.displayedName',
     title: 'Rôle',
   }
 ];

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -17,6 +17,10 @@ const columns = [
   {
     propertyName: 'user.email',
     title: 'Courriel',
+  },
+  {
+    propertyName: 'organizationRole.displayName',
+    title: 'Rôle',
   }
 ];
 

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -9,5 +9,5 @@ export default DS.Model.extend({
   // Relationships
   organization: belongsTo('organization'),
   user: belongsTo('user'),
-
+  organizationRole: belongsTo('organization-role'),
 });

--- a/admin/app/models/organization-role.js
+++ b/admin/app/models/organization-role.js
@@ -1,13 +1,23 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 
-const { attr, belongsTo } = DS;
+const { attr, hasMany } = DS;
+
+const nameToDisplayName = {
+  ADMIN: 'Administrateur',
+  MEMBER: 'Membre',
+};
 
 export default DS.Model.extend({
 
   // Attributes
   name: attr(),
 
+  displayName: computed('name', function() {
+    return nameToDisplayName[this.name];
+  }),
+
   // Relationships
-  membership: belongsTo('membership'),
+  membership: hasMany('membership'),
 
 });

--- a/admin/app/models/organization-role.js
+++ b/admin/app/models/organization-role.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 
 const { attr, hasMany } = DS;
 
-const nameToDisplayName = {
+const displayedNames = {
   ADMIN: 'Administrateur',
   MEMBER: 'Membre',
 };
@@ -13,8 +13,8 @@ export default DS.Model.extend({
   // Attributes
   name: attr(),
 
-  displayName: computed('name', function() {
-    return nameToDisplayName[this.name];
+  displayedName: computed('name', function() {
+    return displayedNames[this.name];
   }),
 
   // Relationships

--- a/admin/mirage/serializers/membership.js
+++ b/admin/mirage/serializers/membership.js
@@ -1,9 +1,8 @@
 import ApplicationSerializer from './application';
 
-const _includes = ['organization', 'user'];
+const _includes = ['organization', 'user', 'organizationRole'];
 
 export default ApplicationSerializer.extend({
 
   include: _includes
 });
-

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -47,28 +47,46 @@ module('Acceptance | organization memberships management', function(hooks) {
       assert.dom('div.member-list').includesText('Charlie');
     });
 
-    test('should display the correct user data', async function(assert) {
+    test('should display the correct user data for an ADMIN', async function(assert) {
       // given
       const organization = this.server.create('organization');
       const user = this.server.create('user', { firstName: 'Denise', lastName: 'Ter Hegg', email: 'denise@example.com' });
-      this.server.create('membership', { user, organization });
+      const organizationRole = this.server.create('organization-role', { name: 'ADMIN' });
+
+      this.server.create('membership', { user, organization, organizationRole });
 
       // when
       await visit(`/organizations/${organization.id}`);
 
       // then
-      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 4);
+      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th').length, 5);
 
       assert.dom('div.member-list table > thead').includesText('Id');
       assert.dom('div.member-list table > thead').includesText('Prénom');
       assert.dom('div.member-list table > thead').includesText('Nom');
       assert.dom('div.member-list table > thead').includesText('Courriel');
+      assert.dom('div.member-list table > thead').includesText('Rôle');
 
       assert.dom('div.member-list table > tbody').includesText(user.id);
       assert.dom('div.member-list table > tbody').includesText('Denise');
       assert.dom('div.member-list table > tbody').includesText('Ter Hegg');
       assert.dom('div.member-list table > tbody').includesText('denise@example.com');
+      assert.dom('div.member-list table > tbody').includesText('Administrateur');
+    });
 
+    test('should display the correct user data for a MEMBER', async function(assert) {
+      // given
+      const organization = this.server.create('organization');
+      const user = this.server.create('user', { firstName: 'Louis', lastName: 'Ter Hegg', email: 'louis@example.com' });
+      const organizationRole = this.server.create('organization-role', { name: 'MEMBER' });
+
+      this.server.create('membership', { user, organization, organizationRole });
+
+      // when
+      await visit(`/organizations/${organization.id}`);
+
+      // then
+      assert.dom('div.member-list table > tbody').includesText('Membre');
     });
   });
 


### PR DESCRIPTION
## 🌶 Problème
La liste des membre d'une organisation de Pix Admin n'affichait pas le rôle de chaque utilisateur.

## 🥛 Solution
Rajouter une colonne "Rôle" dans la liste:
![image](https://user-images.githubusercontent.com/4154003/59933778-59682900-944a-11e9-88ee-2a21312b50f8.png)

## 🌵 Remarques
Cette PR se base sur #565 
