### PR TITLE
[FEATURE] Ajout d'une page pour voir la liste des participants à une session. (PC-49)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -65,7 +65,20 @@ exports.register = async (server) => {
         ],
         tags: ['api', 'session']
       }
-    }
+    },
+    {
+      method: 'GET',
+      path: '/api/sessions/{id}/certification-courses',
+      config: {
+        handler: sessionController.getCertificationCourses,
+        tags: ['api'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération de la liste des participants d\'une session\n' +
+          '- L‘utilisateur doit avoir les droits d‘accès à l‘organisation liée à la session à modifier',
+        ],
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const sessionService = require('../../domain/services/session-service');
-const serializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
+const sessionSerializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
+const certificationCourseSerializer = require('../../infrastructure/serializers/jsonapi/certification-course-serializer');
 const tokenService = require('../../../lib/domain/services/token-service');
 
 module.exports = {
@@ -8,33 +9,33 @@ module.exports = {
   async find() {
     const session = await sessionService.find();
 
-    return serializer.serialize(session);
+    return sessionSerializer.serialize(session);
   },
 
   async get(request) {
     const sessionId = request.params.id;
     const session = await sessionService.get(sessionId);
 
-    return serializer.serialize(session);
+    return sessionSerializer.serialize(session);
   },
 
   async save(request) {
     const userId = request.auth.credentials.userId;
-    const session = serializer.deserialize(request.payload);
+    const session = sessionSerializer.deserialize(request.payload);
 
     const newSession = await usecases.createSession({ userId, session });
 
-    return serializer.serialize(newSession);
+    return sessionSerializer.serialize(newSession);
   },
 
   async update(request) {
     const userId = request.auth.credentials.userId;
-    const session = serializer.deserialize(request.payload);
+    const session = sessionSerializer.deserialize(request.payload);
     session.id = request.params.id;
 
     const updatedSession = await usecases.updateSession({ userId, session });
 
-    return serializer.serialize(updatedSession);
+    return sessionSerializer.serialize(updatedSession);
   },
 
   async getAttendanceSheet(request, h) {
@@ -46,5 +47,13 @@ module.exports = {
     return h.response(attendanceSheet)
       .header('Content-Type', 'application/vnd.oasis.opendocument.spreadsheet')
       .header('Content-Disposition', 'attachment; filename=pv-session-' + sessionId + '.ods');
-  }
+  },
+
+  async getCertificationCourses(request) {
+    const userId = request.auth.credentials.userId;
+    const sessionId = request.params.id;
+    const certificationCourses = await usecases.findCertificationCourses({ userId, sessionId });
+
+    return certificationCourseSerializer.serialize(certificationCourses);
+  },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -46,6 +46,12 @@ class UserNotAuthorizedToGetCampaignResultsError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToGetSessionCertificationCoursesError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 class CampaignWithoutOrganizationError extends DomainError {
   constructor(message) {
     super(message);
@@ -312,6 +318,7 @@ module.exports = {
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToGetCampaignResultsError,
+  UserNotAuthorizedToGetSessionCertificationCoursesError,
   UserNotAuthorizedToUpdateResourceError,
   UserNotFoundError,
   WrongDateFormatError,

--- a/api/lib/domain/services/session-service.js
+++ b/api/lib/domain/services/session-service.js
@@ -5,7 +5,7 @@ const sessionRepository = require('../../infrastructure/repositories/session-rep
 module.exports = {
 
   get(sessionId) {
-    return sessionRepository.get(sessionId);
+    return sessionRepository.getWithCertificationCourses(sessionId);
   },
 
   find() {

--- a/api/lib/domain/usecases/find-certification-courses.js
+++ b/api/lib/domain/usecases/find-certification-courses.js
@@ -1,0 +1,12 @@
+const { UserNotAuthorizedToGetSessionCertificationCoursesError } = require('../errors');
+
+module.exports = async function findCertificationCourses({ userId, sessionId, certificationCourseRepository, sessionRepository, userRepository }) {
+  const [ user, session ] = await Promise.all([
+    userRepository.getWithCertificationCenterMemberships(userId),
+    sessionRepository.get(sessionId)
+  ]);
+  if (!user.hasAccessToCertificationCenter(session.certificationCenterId)) {
+    throw new UserNotAuthorizedToGetSessionCertificationCoursesError('Cet utilisateur n\'a pas accès à la liste des participants de cette session');
+  }
+  return certificationCourseRepository.find(sessionId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -64,6 +64,7 @@ module.exports = injectDependencies({
   createUser: require('./create-user'),
   findCertificationAssessments: require('./find-certification-assessments'),
   findCertificationCenters: require('./find-certification-centers'),
+  findCertificationCourses: require('./find-certification-courses'),
   findCompetenceEvaluations: require('./find-competence-evaluations'),
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findOrganizations: require('./find-organizations'),

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -56,6 +56,13 @@ module.exports = {
       });
   },
 
+  find(sessionId) {
+    return CertificationCourseBookshelf
+      .where({ sessionId })
+      .fetchAll()
+      .then((certificationCourses) => certificationCourses.map(_toDomain));
+  },
+
   findLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
     return CertificationCourseBookshelf
       .where({ userId, sessionId })

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -42,13 +42,26 @@ module.exports = {
   get(idSession) {
     return BookshelfSession
       .where({ id: idSession })
+      .fetch({ require: true })
+      .then(_toDomain)
+      .catch((error) => {
+        if (error instanceof BookshelfSession.NotFoundError) {
+          throw new NotFoundError();
+        }
+        throw error;
+      });
+  },
+
+  getWithCertificationCourses(idSession) {
+    return BookshelfSession
+      .where({ id: idSession })
       .fetch({ require: true, withRelated: ['certificationCourses'] })
       .then(_toDomain)
       .catch((error) => {
         if (error instanceof BookshelfSession.NotFoundError) {
-          return Promise.reject(new NotFoundError());
+          throw new NotFoundError();
         }
-        return Promise.reject(error);
+        throw error;
       });
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -9,14 +9,14 @@ module.exports = {
   serialize(certificationCourse) {
 
     return new Serializer('course', {
-      attributes: ['userId', 'assessment', 'type', 'nbChallenges'],
-      assessment: {
-        ref: 'id',
-      },
       transform(record) {
         record.userId = record.userId.toString();
         record.type = 'CERTIFICATION';
         return record;
+      },
+      attributes: ['userId', 'assessment', 'type', 'nbChallenges', 'birthplace', 'birthdate', 'firstName', 'lastName', 'externalId'],
+      assessment: {
+        ref: 'id',
       },
     }).serialize(certificationCourse);
   },

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -77,6 +77,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToGetCampaignResultsError) {
     return new InfraErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToGetSessionCertificationCoursesError) {
+    return new InfraErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.UserNotFoundError) {
     return new InfraErrors.NotFoundError(error.message);
   }

--- a/api/tests/acceptance/application/session-controller_test.js
+++ b/api/tests/acceptance/application/session-controller_test.js
@@ -422,4 +422,80 @@ describe('Acceptance | Controller | session-controller', () => {
     });
   });
 
+  describe('GET /sessions/{id}/certification-courses', function() {
+    let request;
+    let certificationCourses;
+
+    beforeEach(async () => {
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+      const user = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCenterMembership({ certificationCenterId: certificationCenter.id, userId: user.id });
+      const session = databaseBuilder.factory.buildSession({ certificationCenterId: certificationCenter.id });
+      certificationCourses = [
+        databaseBuilder.factory.buildCertificationCourse({
+          sessionId: session.id }),
+        databaseBuilder.factory.buildCertificationCourse({
+          sessionId: session.id }),
+      ];
+      request = {
+        method: 'GET',
+        url: '/api/sessions/' + session.id + '/certification-courses',
+        headers: { authorization: generateValidRequestAuhorizationHeader(user.id) },
+      };
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => await databaseBuilder.clean());
+
+    it('should return all certification courses linked to the given session', async () => {
+      // given
+      const expectedResult = {
+        data: [{
+          type: 'courses',
+          id: certificationCourses[0].id.toString(),
+          attributes: {
+            birthplace: certificationCourses[0].birthplace,
+            birthdate: certificationCourses[0].birthdate,
+            'external-id': certificationCourses[0].externalId,
+            'first-name': certificationCourses[0].firstName,
+            'last-name': certificationCourses[0].lastName,
+            type: 'CERTIFICATION',
+            'user-id': certificationCourses[0].userId.toString(),
+            'nb-challenges': undefined,
+          },
+          relationships: {
+            assessment: {
+              data: null
+            }
+          }
+        }, {
+          type: 'courses',
+          id: certificationCourses[1].id.toString(),
+          attributes: {
+            birthplace: certificationCourses[1].birthplace,
+            birthdate: certificationCourses[1].birthdate,
+            'external-id': certificationCourses[1].externalId,
+            'first-name': certificationCourses[1].firstName,
+            'last-name': certificationCourses[1].lastName,
+            type: 'CERTIFICATION',
+            'user-id': certificationCourses[1].userId.toString(),
+            'nb-challenges': undefined,
+          },
+          relationships: {
+            assessment: {
+              data: null
+            }
+          }
+        }]
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedResult);
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -176,6 +176,36 @@ describe('Integration | Repository | Certification Course', function() {
     });
   });
 
+  describe('#find', function() {
+
+    let sessionId;
+
+    beforeEach(() => {
+      const userId = 1;
+      sessionId = 'ABCD12';
+      databaseBuilder.factory.buildCertificationCourse({ id: 1, userId: 2, sessionId, completedAt: null, createdAt: new Date('2018-12-21T01:02:03Z') });
+      databaseBuilder.factory.buildCertificationCourse({ id: 2, userId, sessionId: 'ABCD21', completedAt: null, createdAt: new Date('2018-12-21T01:02:03Z') });
+      databaseBuilder.factory.buildCertificationCourse({ id: 3, userId, sessionId, createdAt: new Date('2018-12-11T01:02:03Z') });
+      databaseBuilder.factory.buildCertificationCourse({ id: 4, userId, sessionId, completedAt: null, createdAt: new Date('2018-11-11T01:02:03Z') });
+      databaseBuilder.factory.buildCertificationCourse({ id: 5, userId, sessionId, completedAt: null, createdAt: new Date('2018-12-12T01:02:03Z') });
+      return databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      return databaseBuilder.clean();
+    });
+
+    it('should retrieve certification course with given sessionId', async function() {
+      // when
+      const result = await certificationCourseRepository.find(sessionId);
+
+      // then
+      expect(result).to.have.lengthOf(4);
+      expect(result[0]).to.be.instanceOf(CertificationCourse);
+      expect(result[0].id).to.equal(1);
+    });
+  });
+
   describe('#update', function() {
 
     const certificationCourse = {

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -151,19 +151,11 @@ describe('Integration | Repository | Session', function() {
     });
   });
 
-  describe('#get', () => {
+  describe('#getWithCertificationCourses', () => {
 
     beforeEach(() => {
       databaseBuilder.factory.buildSession({
         id: 1,
-        certificationCenter: 'Tour Gamma',
-        address: 'rue de Bercy',
-        room: 'Salle A',
-        examiner: 'Monsieur Examinateur',
-        date: '2018-02-23',
-        time: '12:00',
-        description: 'CertificationPix pour les jeunes',
-        accessCode: 'NJR10'
       });
 
       databaseBuilder.factory.buildCertificationCourse({
@@ -180,6 +172,47 @@ describe('Integration | Repository | Session', function() {
         id: 3,
         userId: 3,
         sessionId: 2
+      });
+      return databaseBuilder.commit();
+    });
+
+    it('should return associated certifications', function() {
+      // when
+      const promise = sessionRepository.getWithCertificationCourses(1);
+
+      // then
+      return promise.then((session) => {
+        expect(session.certifications).to.be.instanceOf(Array);
+        expect(session.certifications.length).to.be.equal(2);
+        expect(session.certifications[0].attributes.id).to.be.equal(1);
+        expect(session.certifications[0].attributes.userId).to.be.equal(1);
+        expect(session.certifications[1].attributes.id).to.be.equal(2);
+        expect(session.certifications[1].attributes.userId).to.be.equal(2);
+      });
+    });
+
+    it('should return a Not found error when no session was found', function() {
+      // when
+      const promise = sessionRepository.getWithCertificationCourses(2);
+
+      // then
+      return expect(promise).to.be.rejectedWith(NotFoundError);
+    });
+  });
+
+  describe('#get', () => {
+
+    beforeEach(() => {
+      databaseBuilder.factory.buildSession({
+        id: 1,
+        certificationCenter: 'Tour Gamma',
+        address: 'rue de Bercy',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        date: '2018-02-23',
+        time: '12:00',
+        description: 'CertificationPix pour les jeunes',
+        accessCode: 'NJR10'
       });
       return databaseBuilder.commit();
     });
@@ -202,21 +235,6 @@ describe('Integration | Repository | Session', function() {
         expect(session.time).to.be.equal('12:00');
         expect(session.description).to.be.equal('CertificationPix pour les jeunes');
         expect(session.accessCode).to.be.equal('NJR10');
-      });
-    });
-
-    it('should return associated certifications', function() {
-      // when
-      const promise = sessionRepository.get(1);
-
-      // then
-      return promise.then((session) => {
-        expect(session.certifications).to.be.instanceOf(Array);
-        expect(session.certifications.length).to.be.equal(2);
-        expect(session.certifications[0].attributes.id).to.be.equal(1);
-        expect(session.certifications[0].attributes.userId).to.be.equal(1);
-        expect(session.certifications[1].attributes.id).to.be.equal(2);
-        expect(session.certifications[1].attributes.userId).to.be.equal(2);
       });
     });
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -64,4 +64,17 @@ describe('Unit | Application | Sessions | Routes', () => {
       expect(res.statusCode).to.equal(200);
     });
   });
+
+  describe('GET /api/sessions/{id}/certification-courses', () => {
+
+    beforeEach(() => {
+      sinon.stub(sessionController, 'getCertificationCourses').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/certification-courses' });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -8,6 +8,7 @@ const sessionService = require('../../../../lib/domain/services/session-service'
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 
 const sessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
+const certificationCourseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-course-serializer');
 
 describe('Unit | Controller | sessionController', () => {
 
@@ -152,7 +153,7 @@ describe('Unit | Controller | sessionController', () => {
     });
   });
 
-  describe('#update ', () => {
+  describe('#update', () => {
     let request, updatedSession, updateSessionArgs;
 
     beforeEach(() => {
@@ -177,16 +178,42 @@ describe('Unit | Controller | sessionController', () => {
       sessionSerializer.deserialize.withArgs(request.payload).returns({});
     });
 
-    it('should returns the updated session', async () => {
+    it('should return the updated session', async () => {
       // given
       usecases.updateSession.withArgs(updateSessionArgs).resolves(updatedSession);
       sessionSerializer.serialize.withArgs(updatedSession).returns(updatedSession);
 
       // when
-      const response = await sessionController.update(request, hFake);
+      const response = await sessionController.update(request);
 
       // then
       expect(response).to.deep.equal(updatedSession);
+    });
+  });
+
+  describe('#getCertificationCourses', () => {
+    let request;
+
+    beforeEach(() => {
+      request = {
+        auth: { credentials: { userId: 1 } },
+        params: { id : 1 }
+      };
+
+      sinon.stub(usecases, 'findCertificationCourses');
+      sinon.stub(certificationCourseSerializer, 'serialize');
+    });
+
+    it('should return the certification courses related to a given session', async() => {
+      // given
+      usecases.findCertificationCourses.withArgs({ userId: 1, sessionId: 1 }).resolves([]);
+      certificationCourseSerializer.serialize.withArgs([]).returns('json');
+
+      // when
+      const response = await sessionController.getCertificationCourses(request);
+
+      // then
+      expect(response).to.be.equal('json');
     });
   });
 });

--- a/api/tests/unit/domain/services/session-service_test.js
+++ b/api/tests/unit/domain/services/session-service_test.js
@@ -63,14 +63,14 @@ describe('Unit | Service | session', () => {
     it('should get session informations with related certifications', () => {
       // given
       const sessionId = 'sessionId';
-      sinon.stub(sessionRepository, 'get').resolves();
+      sinon.stub(sessionRepository, 'getWithCertificationCourses').resolves();
 
       // when
       const promise = sessionService.get(sessionId);
 
       // then
       return promise.then(() => {
-        expect(sessionRepository.get).to.have.been.calledWith('sessionId');
+        expect(sessionRepository.getWithCertificationCourses).to.have.been.calledWith('sessionId');
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-certification-courses_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-courses_test.js
@@ -1,0 +1,58 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const findCertificationCourses = require('../../../../lib/domain/usecases/find-certification-courses');
+const { UserNotAuthorizedToGetSessionCertificationCoursesError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | find-certification-courses', () => {
+
+  const sessionId = 1;
+  const certificationCenterId = 2;
+  const userId = 3;
+  let userRepository;
+  let sessionRepository;
+  let certificationCourseRepository;
+  let user;
+
+  beforeEach(() => {
+    userRepository = {
+      getWithCertificationCenterMemberships: sinon.stub(),
+    };
+    sessionRepository = {
+      get: sinon.stub(),
+    };
+    certificationCourseRepository = {
+      find: sinon.stub(),
+    };
+    user = {
+      id: 1,
+      hasAccessToCertificationCenter: sinon.stub(),
+    };
+  });
+
+  it('should throw an unauthorized error', async () => {
+    // given
+    userRepository.getWithCertificationCenterMemberships.withArgs(userId).resolves(user);
+    sessionRepository.get.withArgs(sessionId).resolves({ certificationCenterId });
+    user.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
+
+    // when
+    const error = await catchErr(findCertificationCourses)({ userId, sessionId, sessionRepository, certificationCourseRepository, userRepository });
+
+    // then
+    expect(error).to.be.instanceOf(UserNotAuthorizedToGetSessionCertificationCoursesError);
+  });
+
+  it('should find the certification courses of the given session', async () => {
+    // given
+    userRepository.getWithCertificationCenterMemberships.withArgs(userId).resolves(user);
+    sessionRepository.get.withArgs(sessionId).resolves({ certificationCenterId });
+    user.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
+    certificationCourseRepository.find.withArgs(sessionId).resolves([{ id: 1 }, { id: 2 }]);
+
+    // when
+    const result = await findCertificationCourses({ userId, sessionId, sessionRepository, certificationCourseRepository, userRepository });
+
+    // then
+    expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -18,6 +18,11 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
         userId: 2,
         assessment: assessment,
         nbChallenges: 3,
+        birthdate: '14 Jan 2005',
+        birthplace: 'Guantanamo',
+        firstName: 'José',
+        lastName: 'Ock',
+        externalId: 5,
       });
 
       const jsonCertificationCourseWithAssessment = {
@@ -26,8 +31,13 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
           id: 'certification_id',
           attributes: {
             'user-id': '2',
-            'type': 'CERTIFICATION',
+            type: 'CERTIFICATION',
             'nb-challenges': 3,
+            birthdate: '14 Jan 2005',
+            birthplace: 'Guantanamo',
+            'first-name': 'José',
+            'last-name': 'Ock',
+            'external-id': 5,
           },
           relationships: {
             assessment: {


### PR DESCRIPTION
## :unicorn: Problème
User PixCertif ne peut pas voir la liste des participants à une session

## :robot: Solution
Ajouter un endpoint côté API afin de récupérer la liste des participants à une session, et côté App Certif ajouter un onglet à côté du détail de la session qui va contenir la liste des participants.

## :rainbow: Remarques
-
