### PR TITLE
[FEATURE] Assigner le rôle MEMBER aux membres d'une organization. (PA-95) 

### DIFF
--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -17,6 +17,10 @@ const columns = [
   {
     propertyName: 'user.email',
     title: 'Courriel',
+  },
+  {
+    propertyName: 'organizationRole.displayName',
+    title: 'Rôle',
   }
 ];
 

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -9,5 +9,5 @@ export default DS.Model.extend({
   // Relationships
   organization: belongsTo('organization'),
   user: belongsTo('user'),
-
+  organizationRole: belongsTo('organization-role'),
 });

--- a/admin/app/models/organization-role.js
+++ b/admin/app/models/organization-role.js
@@ -1,13 +1,23 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 
-const { attr, belongsTo } = DS;
+const { attr, hasMany } = DS;
+
+const nameToDisplayName = {
+  ADMIN: 'Administrateur',
+  MEMBER: 'Membre',
+};
 
 export default DS.Model.extend({
 
   // Attributes
   name: attr(),
 
+  displayName: computed('name', function() {
+    return nameToDisplayName[this.name];
+  }),
+
   // Relationships
-  membership: belongsTo('membership'),
+  membership: hasMany('membership'),
 
 });

--- a/admin/mirage/serializers/membership.js
+++ b/admin/mirage/serializers/membership.js
@@ -1,9 +1,8 @@
 import ApplicationSerializer from './application';
 
-const _includes = ['organization', 'user'];
+const _includes = ['organization', 'user', 'organizationRole'];
 
 export default ApplicationSerializer.extend({
 
   include: _includes
 });
-

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -47,28 +47,46 @@ module('Acceptance | organization memberships management', function(hooks) {
       assert.dom('div.member-list').includesText('Charlie');
     });
 
-    test('should display the correct user data', async function(assert) {
+    test('should display the correct user data for an ADMIN', async function(assert) {
       // given
       const organization = this.server.create('organization');
       const user = this.server.create('user', { firstName: 'Denise', lastName: 'Ter Hegg', email: 'denise@example.com' });
-      this.server.create('membership', { user, organization });
+      const organizationRole = this.server.create('organization-role', { name: 'ADMIN' });
+
+      this.server.create('membership', { user, organization, organizationRole });
 
       // when
       await visit(`/organizations/${organization.id}`);
 
       // then
-      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 4);
+      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th').length, 5);
 
       assert.dom('div.member-list table > thead').includesText('Id');
       assert.dom('div.member-list table > thead').includesText('Prénom');
       assert.dom('div.member-list table > thead').includesText('Nom');
       assert.dom('div.member-list table > thead').includesText('Courriel');
+      assert.dom('div.member-list table > thead').includesText('Rôle');
 
       assert.dom('div.member-list table > tbody').includesText(user.id);
       assert.dom('div.member-list table > tbody').includesText('Denise');
       assert.dom('div.member-list table > tbody').includesText('Ter Hegg');
       assert.dom('div.member-list table > tbody').includesText('denise@example.com');
+      assert.dom('div.member-list table > tbody').includesText('Administrateur');
+    });
 
+    test('should display the correct user data for a MEMBER', async function(assert) {
+      // given
+      const organization = this.server.create('organization');
+      const user = this.server.create('user', { firstName: 'Louis', lastName: 'Ter Hegg', email: 'louis@example.com' });
+      const organizationRole = this.server.create('organization-role', { name: 'MEMBER' });
+
+      this.server.create('membership', { user, organization, organizationRole });
+
+      // when
+      await visit(`/organizations/${organization.id}`);
+
+      // then
+      assert.dom('div.member-list table > tbody').includesText('Membre');
     });
   });
 

--- a/api/db/migrations/20190621155332_create_member_organization_role.js
+++ b/api/db/migrations/20190621155332_create_member_organization_role.js
@@ -1,0 +1,11 @@
+const TABLE_NAME = 'organization-roles';
+
+exports.up = function(knex) {
+  return knex(TABLE_NAME).insert({ id: 2, name: 'MEMBER' });
+};
+
+exports.down = function(knex) {
+  return knex(TABLE_NAME)
+    .where('name', 'MEMBER')
+    .delete();
+};

--- a/api/db/seeds/data/dragon-and-co-builder.js
+++ b/api/db/seeds/data/dragon-and-co-builder.js
@@ -9,6 +9,15 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     cgu: true,
   });
 
+  const proUserGreyWorm = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    id: 8,
+    firstName: 'Thorgo',
+    lastName: 'Nudo',
+    email: 'greyworm@example.net',
+    rawPassword: 'pix123',
+    cgu: true,
+  });
+
   const dragonAndCoCompany = databaseBuilder.factory.buildOrganization({
     id: 1,
     type: 'PRO',
@@ -22,6 +31,12 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     userId: proUserDaenerys.id,
     organizationId: dragonAndCoCompany.id,
     organizationRoleId: 1,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: proUserGreyWorm.id,
+    organizationId: dragonAndCoCompany.id,
+    organizationRoleId: 2,
   });
 
   const privateTargetProfile = databaseBuilder.factory.buildTargetProfile({

--- a/api/lib/domain/models/Membership.js
+++ b/api/lib/domain/models/Membership.js
@@ -1,3 +1,8 @@
+const roles = {
+  ADMIN: 1,
+  MEMBER: 2,
+};
+
 class Membership {
 
   constructor({
@@ -18,5 +23,7 @@ class Membership {
     // references
   }
 }
+
+Membership.roles = roles;
 
 module.exports = Membership;

--- a/api/lib/domain/usecases/create-membership.js
+++ b/api/lib/domain/usecases/create-membership.js
@@ -1,3 +1,8 @@
-module.exports = function createMembership({ membershipRepository, userId, organizationId, organizationRoleId = 1 }) {
+const { roles } = require('../models/Membership');
+
+module.exports = async function createMembership({ membershipRepository, userId, organizationId }) {
+  const memberships = await membershipRepository.findByOrganizationId(organizationId);
+  const organizationRoleId =  memberships.length ? roles.MEMBER : roles.ADMIN;
+
   return membershipRepository.create(userId, organizationId, organizationRoleId);
 };

--- a/api/tests/unit/domain/usecases/create-membership_test.js
+++ b/api/tests/unit/domain/usecases/create-membership_test.js
@@ -1,19 +1,41 @@
 const { expect, sinon } = require('../../../test-helper');
 const createMembership = require('../../../../lib/domain/usecases/create-membership');
+const { roles } = require('../../../../lib/domain/models/Membership');
 
 describe('Unit | UseCase | create-membership', () => {
 
-  it('should insert a new membership', async () => {
+  it('should insert the first membership as an ADMIN', async () => {
     // given
-    const membershipRepository = { create: sinon.stub() };
+    const membershipRepository = {
+      create: sinon.stub(),
+      findByOrganizationId: sinon.stub().resolves([]),
+    };
+
     const userId = 1;
     const organizationId = 2;
-    const DEFAULT_ORGANIZATION_ROLE_ADMIN_ID = 1;
 
     // when
     await createMembership({ membershipRepository, userId, organizationId });
 
     // then
-    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organizationId, DEFAULT_ORGANIZATION_ROLE_ADMIN_ID);
+    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organizationId, roles.ADMIN);
   });
+
+  it('should insert the second membership as a MEMBER', async () => {
+    // given
+    const membershipRepository = {
+      create: sinon.stub(),
+      findByOrganizationId: sinon.stub().resolves([{}]),
+    };
+
+    const userId = 1;
+    const organizationId = 2;
+
+    // when
+    await createMembership({ membershipRepository, userId, organizationId });
+
+    // then
+    expect(membershipRepository.create).to.has.been.calledWithExactly(userId, organizationId, roles.MEMBER);
+  });
+
 });


### PR DESCRIPTION
## 🌶  Problème
Tous les utilisateurs (memberships) d'une organization ont un rôle ADMIN.

## 🥛  Solution
Donner le rôle ADMIN au premier et le rôle MEMBER au suivants.

## :bee:  Remarques
Seulement ce commit https://github.com/1024pix/pix/pull/569/commits/8a014df7d23f109e990dec863ec6ae104c7f01ec est à review.
