### PR TITLE
[BUGFIX] Affichage des résultats collectifs sous IE (PO-212)

### DIFF
--- a/orga/app/routes/authenticated/campaigns/details/collective-results.js
+++ b/orga/app/routes/authenticated/campaigns/details/collective-results.js
@@ -2,11 +2,10 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
 
-  async model() {
-    const details = await this.modelFor('authenticated.campaigns.details');
-    await details.belongsTo('campaignCollectiveResult').reload();
-
-    return details;
+  model() {
+    const details = this.modelFor('authenticated.campaigns.details');
+    return details.belongsTo('campaignCollectiveResult').reload()
+      .then(() => details);
   }
 
 });


### PR DESCRIPTION
## 🐛 Problème
> Sous IE, l'onglet des résultats collectifs ne s'affiche plus

## :smile:  Solution
> Lors de la récupération du model, supprimer les async/await