### PR TITLE
[BUGFIX] Vider et replier le feedback_panel après avoir envoyé le commentaire. (PF-708)

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -13,11 +13,11 @@ export default Component.extend({
   assessment: null,
   challenge: null,
 
+  isFormOpened: false,
+
   _content: null,
   _error: null,
-
-  isFormOpened: false,
-  isSubmitted: false,
+  _isSubmitted: false,
 
   _scrollToPanel: function() {
     $('html,body').animate({
@@ -25,13 +25,23 @@ export default Component.extend({
     }, config.APP.SCROLL_DURATION);
   },
 
+  _resetPanel: function() {
+    this.set('_isSubmitted', false);
+    this.set('_error', null);
+  },
+
+  didReceiveAttrs: function() {
+    this._super();
+    this._resetPanel();
+    this.set('_content', null);
+  },
+
   actions: {
 
     toggleFeedbackForm() {
       if (this.isFormOpened) {
         this.set('isFormOpened', false);
-        this.set('isSubmitted', false);
-        this.set('_error', null);
+        this._resetPanel();
       } else {
         this.set('isFormOpened', true);
         this._scrollToPanel();
@@ -54,7 +64,8 @@ export default Component.extend({
 
       await feedback.save();
 
-      this.set('isSubmitted', true);
+      this.set('_content', null);
+      this.set('_isSubmitted', true);
     }
   }
 });

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -44,6 +44,6 @@
 
 {{#if canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    {{feedback-panel assessment=assessment challenge=challenge}}
+    {{feedback-panel assessment=assessment challenge=challenge isFormOpened=false}}
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -44,6 +44,6 @@
 
 {{#if canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    {{feedback-panel assessment=assessment challenge=challenge}}
+    {{feedback-panel assessment=assessment challenge=challenge isFormOpened=false}}
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -44,6 +44,6 @@
 
 {{#if canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    {{feedback-panel assessment=assessment challenge=challenge}}
+    {{feedback-panel assessment=assessment challenge=challenge isFormOpened=false}}
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -44,6 +44,6 @@
 
 {{#if canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    {{feedback-panel assessment=assessment challenge=challenge}}
+    {{feedback-panel assessment=assessment challenge=challenge isFormOpened=false}}
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -3,7 +3,7 @@
 </div>
 
 {{#if isFormOpened}}
-  {{#if isSubmitted}}
+  {{#if _isSubmitted}}
     <div class="feedback-panel__view feedback-panel__view--mercix">
       <p>Votre commentaire a bien été transmis à l’équipe du projet Pix.</p>
       <p>Mercix !</p>

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -36,7 +36,7 @@ describe('Integration | Component | feedback-panel', function() {
   describe('Default rendering', function() {
 
     beforeEach(async function() {
-      await render(hbs`{{feedback-panel}}`);
+      await render(hbs`{{feedback-panel isFormOpened=false}}`);
     });
 
     it('should display the feedback panel', function() {
@@ -119,8 +119,8 @@ describe('Integration | Component | feedback-panel', function() {
         expect(saveMethodBody.assessment).to.exist;
         expect(saveMethodBody.challenge).to.exist;
         expect(saveMethodBody.content).to.equal(CONTENT_VALUE);
-        expectMercixViewToBeVisible(this);
         expectFormViewToNotBeVisible(this);
+        expectMercixViewToBeVisible(this);
       });
     });
   });
@@ -163,5 +163,25 @@ describe('Integration | Component | feedback-panel', function() {
       // then
       expect(find('.alert')).to.not.exist;
     });
+  });
+
+  it('should be reseted when challenge is changed', async function() {
+    // given
+    this.set('challenge', 1);
+    await render(hbs`{{feedback-panel challenge=challenge isFormOpened=false}}`);
+    await click(TOGGLE_LINK);
+    await setContent('TEST_CONTENT');
+
+    // when
+    this.set('challenge', 2);
+
+    // then
+    expect(find('.feedback-panel__field--content')).to.not.exist;
+
+    // when
+    await click(TOGGLE_LINK);
+
+    // then
+    expect(find('.feedback-panel__field--content').value).to.equal('');
   });
 });

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -25,14 +25,14 @@ describe('Unit | Component | feedback-panel', function() {
       const component = this.owner.lookup('component:feedback-panel');
       component.set('isFormOpened', true);
       component.set('_error', '10, 9, 8, ...');
-      component.set('isSubmitted', true);
+      component.set('_isSubmitted', true);
 
       // when
       component.send('toggleFeedbackForm');
 
       // then
       expect(component.isFormOpened).to.be.false;
-      expect(component.isSubmitted).to.be.false;
+      expect(component._isSubmitted).to.be.false;
       expect(component._error).to.be.null;
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Le formulaire de feedback restait déroulé après avoir submit ou changé de question.

## :robot: Solution
Utiliser le hook `didUpdateAttrs` pour re-render correctement le composant.