### PR TITLE
[FEATURE] Ajout d'une modale pour prévenir un utilisateur nouvellement migré V2. (PF-634)

### DIFF
--- a/api/db/migrations/20190620160455_add_isMigratedToV2_to_user.js
+++ b/api/db/migrations/20190620160455_add_isMigratedToV2_to_user.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'isMigratedToV2';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).nullable().defaultTo(null);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20190620160456_add_hasSeenMigration_to_user.js
+++ b/api/db/migrations/20190620160456_add_hasSeenMigration_to_user.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'hasSeenMigration';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).nullable().defaultTo(null);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -135,13 +135,15 @@ exports.register = async function(server) {
           payload: {
             data: {
               attributes: {
-                password: Joi.string().regex(XRegExp(passwordValidationPattern)),
+                password: Joi.string().regex(XRegExp(passwordValidationPattern)).allow(null),
                 'pix-orga-terms-of-service-accepted': Joi.boolean(),
-                'pix-certif-terms-of-service-accepted': Joi.boolean()
-              }
+                'pix-certif-terms-of-service-accepted': Joi.boolean(),
+                'has-seen-migration': Joi.boolean(),
+              },
             }
           }
-        }, tags: ['api']
+        },
+        tags: ['api'],
       }
     },
     {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -80,6 +80,11 @@ module.exports = {
             userId
           });
         }
+        if (user.hasSeenMigration) {
+          return usecases.updateUserHasSeenMigration({
+            userId
+          });
+        }
         return Promise.reject(new BadRequestError());
       })
       .then(() => null);

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -14,6 +14,8 @@ class User {
     lastName,
     password,
     samlId,
+    isMigratedToV2,
+    hasSeenMigration,
     // includes
     memberships = [],
     certificationCenterMemberships = [],
@@ -34,7 +36,8 @@ class User {
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.samlId = samlId;
-    this.knowledgeElements = knowledgeElements;
+    this.isMigratedToV2 = isMigratedToV2;
+    this.hasSeenMigration = hasSeenMigration;
     // includes
     this.pixRoles = pixRoles;
     this.pixScore = pixScore;
@@ -43,6 +46,7 @@ class User {
     this.scorecards = scorecards;
     this.campaignParticipations = campaignParticipations;
     this.organizations = organizations;
+    this.knowledgeElements = knowledgeElements;
     // references
   }
 

--- a/api/lib/domain/usecases/get-current-user.js
+++ b/api/lib/domain/usecases/get-current-user.js
@@ -2,7 +2,7 @@ module.exports = async ({ authenticatedUserId, userRepository, assessmentReposit
   const user = await userRepository.get(authenticatedUserId);
   const usesProfileV2 = await assessmentRepository.hasCampaignOrCompetenceEvaluation(authenticatedUserId);
 
-  user.usesProfileV2 = usesProfileV2;
+  user.usesProfileV2 = (usesProfileV2 || user.isMigratedToV2) ? true : false;
 
   return user;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -120,6 +120,7 @@ module.exports = injectDependencies({
   updateCertification: require('./update-certification'),
   updateOrganizationInformation: require('./update-organization-information'),
   updateSession: require('./update-session'),
+  updateUserHasSeenMigration: require('./update-user-has-seen-migration'),
   updateUserPassword: require('./update-user-password'),
   writeOrganizationSharedProfilesAsCsvToStream: require('./write-organization-shared-profiles-as-csv-to-stream'),
 });

--- a/api/lib/domain/usecases/update-user-has-seen-migration.js
+++ b/api/lib/domain/usecases/update-user-has-seen-migration.js
@@ -1,0 +1,10 @@
+module.exports = async function updateUserHasSeenMigration({
+  userId,
+  userRepository
+}) {
+  const user = await userRepository.get(userId);
+
+  user.hasSeenMigration = true;
+
+  return userRepository.updateUser(user);
+};

--- a/api/lib/infrastructure/data/user.js
+++ b/api/lib/infrastructure/data/user.js
@@ -49,6 +49,8 @@ module.exports = Bookshelf.model('User', {
     model.cgu = Boolean(model.cgu);
     model.pixOrgaTermsOfServiceAccepted = Boolean(model.pixOrgaTermsOfServiceAccepted);
     model.pixCertifTermsOfServiceAccepted = Boolean(model.pixCertifTermsOfServiceAccepted);
+    model.isMigratedToV2 = Boolean(model.isMigratedToV2);
+    model.hasSeenMigration = Boolean(model.hasSeenMigration);
 
     return new User(model);
   }

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -62,6 +62,8 @@ function _toDomain(userBookshelf) {
     memberships: _toMembershipsDomain(userBookshelf.related('memberships')),
     certificationCenterMemberships: _toCertificationCenterMembershipsDomain(userBookshelf.related('certificationCenterMemberships')),
     pixRoles: _toPixRolesDomain(userBookshelf.related('pixRoles')),
+    isMigratedToV2: Boolean(userBookshelf.get('isMigratedToV2')),
+    hasSeenMigration: Boolean(userBookshelf.get('hasSeenMigration')),
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
         'firstName', 'lastName', 'email', 'cgu', 'pixOrgaTermsOfServiceAccepted',
         'pixCertifTermsOfServiceAccepted', 'usesProfileV2', 'memberships',
         'certificationCenterMemberships', 'pixScore', 'scorecards',
-        'campaignParticipations', 'organizations',
+        'campaignParticipations', 'organizations', 'isMigratedToV2', 'hasSeenMigration'
       ],
       memberships: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -74,6 +74,7 @@ module.exports = {
       cgu: json.data.attributes.cgu,
       pixOrgaTermsOfServiceAccepted: json.data.attributes['pix-orga-terms-of-service-accepted'],
       pixCertifTermsOfServiceAccepted: json.data.attributes['pix-certif-terms-of-service-accepted'],
+      hasSeenMigration: json.data.attributes['has-seen-migration'],
     });
   }
 

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -42,6 +42,8 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false,
             'uses-profile-v2': false,
+            'is-migrated-to-v2': false,
+            'has-seen-migration': false,
           },
           relationships: {
             memberships: {

--- a/api/tests/acceptance/application/users/users-controller-get-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user_test.js
@@ -50,7 +50,9 @@ describe('Acceptance | Controller | users-controller-get-user', () => {
             'email': userToInsert.email.toLowerCase(),
             'cgu': true,
             'pix-orga-terms-of-service-accepted': false,
-            'pix-certif-terms-of-service-accepted': false
+            'pix-certif-terms-of-service-accepted': false,
+            'has-seen-migration': false,
+            'is-migrated-to-v2': false,
           },
           relationships: {
             'memberships': {

--- a/api/tests/acceptance/application/users/users-controller-update_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update_test.js
@@ -109,6 +109,31 @@ describe('Acceptance | Controller | users-controller', () => {
         });
       });
     });
+
+    context('with hasSeenMigration field', () => {
+
+      it('should reply 204 status code', async () => {
+        // given
+        options = {
+          method: 'PATCH',
+          url: `/api/users/${userId}`,
+          payload: {
+            data: {
+              attributes: {
+                'has-seen-migration': true
+              }
+            }
+          }
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
   });
 });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -222,6 +222,33 @@ describe('Unit | Controller | user-controller', () => {
         });
       });
     });
+
+    context('When payload has a hasSeenMigration field', () => {
+
+      it('should update hasSeenMigration', async () => {
+        // given
+        const userId = 7;
+        const request = {
+          params: {
+            id: userId,
+          },
+          payload: {
+            data: {
+              attributes: {
+                'has-seen-migration': true,
+              },
+            },
+          },
+        };
+        const usecaseStub = sinon.stub(usecases, 'updateUserHasSeenMigration');
+
+        // when
+        await userController.updateUser(request, hFake);
+
+        // then
+        expect(usecaseStub).to.have.been.calledWith({ userId });
+      });
+    });
   });
 
   describe('#getProfileToCertify', () => {

--- a/api/tests/unit/domain/usecases/get-current-user_test.js
+++ b/api/tests/unit/domain/usecases/get-current-user_test.js
@@ -10,7 +10,7 @@ describe('Unit | UseCase | get-current-user', () => {
     assessmentRepository = { hasCampaignOrCompetenceEvaluation: sinon.stub() };
   });
 
-  it('should get the current user', async () => {
+  it('should get the current user with usesProfileV2 if user has campaign or competence evaluation', async () => {
     // given
     userRepository.get.withArgs(1).resolves({ id: 1 });
     assessmentRepository.hasCampaignOrCompetenceEvaluation.withArgs(1).resolves(true);
@@ -24,5 +24,37 @@ describe('Unit | UseCase | get-current-user', () => {
 
     // then
     expect(result).to.deep.equal({ id: 1, usesProfileV2: true });
+  });
+
+  it('should get the current user with usesProfileV2 if user is migrated to V2', async () => {
+    // given
+    userRepository.get.withArgs(1).resolves({ id: 1, isMigratedToV2: true });
+    assessmentRepository.hasCampaignOrCompetenceEvaluation.withArgs(1).resolves(false);
+
+    // when
+    const result = await getCurrentUser({
+      authenticatedUserId: 1,
+      userRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal({ id: 1, isMigratedToV2: true, usesProfileV2: true });
+  });
+
+  it('should get the current user with falsy usesProfileV2', async () => {
+    // given
+    userRepository.get.withArgs(1).resolves({ id: 1 });
+    assessmentRepository.hasCampaignOrCompetenceEvaluation.withArgs(1).resolves(false);
+
+    // when
+    const result = await getCurrentUser({
+      authenticatedUserId: 1,
+      userRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal({ id: 1, usesProfileV2: false });
   });
 });

--- a/api/tests/unit/domain/usecases/update-user-has-seen-migration_test.js
+++ b/api/tests/unit/domain/usecases/update-user-has-seen-migration_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../../test-helper');
+const updateUserHasSeenMigration = require('../../../../lib/domain/usecases/update-user-has-seen-migration');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+describe('Unit | UseCase | accept-pix-orga-terms-of-service', () => {
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'get');
+    sinon.stub(userRepository, 'updateUser');
+  });
+
+  it('should update updateUserHasSeenMigration', async () => {
+    // given
+    const userId = 1;
+    userRepository.get.withArgs(userId).resolves({ id: 1 });
+    userRepository.updateUser.withArgs({ id: 1, hasSeenMigration: true }).resolves('ok');
+
+    // when
+    const result = await updateUserHasSeenMigration({ userId, userRepository });
+
+    // then
+    expect(result).to.be.equal('ok');
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -34,6 +34,8 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
         pixCertifTermsOfServiceAccepted: false,
         password: '',
         organizations: [],
+        hasSeenMigration: false,
+        isMigratedToV2: false,
       });
 
       // when
@@ -48,7 +50,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'email': 'lskywalker@deathstar.empire',
             'cgu': true,
             'pix-orga-terms-of-service-accepted': false,
-            'pix-certif-terms-of-service-accepted': false
+            'pix-certif-terms-of-service-accepted': false,
+            'has-seen-migration': false,
+            'is-migrated-to-v2': false,
           },
           id: '234567',
           type: 'users',

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -5,7 +5,8 @@
     "lastName": "Targaryen",
     "email": "daenerys.targaryen@pix.fr",
     "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
-    "cgu": true
+    "cgu": true,
+    "hasSeenMigration": true
   },
   {
     "id": 2,
@@ -13,6 +14,7 @@
     "lastName": "Tarly",
     "email": "samwell.tarly@pix.fr",
     "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
-    "cgu": true
+    "cgu": true,
+    "hasSeenMigration": true
   }
 ]

--- a/mon-pix/app/controllers/profilv2.js
+++ b/mon-pix/app/controllers/profilv2.js
@@ -1,0 +1,29 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+
+  currentUser: service(),
+
+  init() {
+    this._super(...arguments);
+
+    const user = this.currentUser.user;
+
+    if (user && !user.hasSeenMigration) {
+      this.set('showNewProfileModal', true);
+    }
+  },
+
+  actions: {
+    updateUserHasSeenMigration() {
+      this.set('showNewProfileModal', false);
+
+      const user = this.currentUser.user;
+
+      user.set('hasSeenMigration', true);
+
+      return user.save();
+    }
+  }
+});

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -10,6 +10,7 @@ export default Model.extend({
   usesProfileV2: attr('boolean'),
   password: attr('string'),
   cgu: attr('boolean'),
+  hasSeenMigration: attr('boolean'),
   recaptchaToken: attr('string'),
   totalPixScore: attr('number'),
   pixScore: belongsTo('pix-score'),

--- a/mon-pix/app/styles/pages/_profilv2.scss
+++ b/mon-pix/app/styles/pages/_profilv2.scss
@@ -27,3 +27,9 @@
   font-size: 1.8rem;
   line-height: 2.1rem;
 }
+
+.new-profile {
+  width: 100%;
+  padding: 40px;
+  text-align: center;
+}

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -46,3 +46,29 @@
 
   </div>
 </div>
+
+{{#if showNewProfileModal}}
+  {{#pix-modal onClose=(action "updateUserHasSeenMigration")}}
+    <div class="pix-modal__close-link">
+      <a href="#" {{action "updateUserHasSeenMigration"}}>Fermer
+        <img src="/images/icon-close-modal.svg" alt="Fermer la fenêtre modale" width="24" height="24">
+      </a>
+    </div>
+
+    <div class="pix-modal__container">
+      <div class="pix-modal-header">
+        <h1 class="pix-modal-header__title">Nouveau profil !</h1>
+      </div>
+
+      <div class="pix-modal-body">
+        <div class="new-profile">
+          <p>Vous avez été migré sur le tout nouveau profil de Pix.</p>
+        </div>
+      </div>
+
+      <div class="pix-modal-footer pix-modal-footer--with-centered--buttons">
+        <button class="button" {{action "updateUserHasSeenMigration"}}>Fermer</button>
+      </div>
+    </div>
+  {{/pix-modal}}
+{{/if}}

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -88,6 +88,7 @@ export default function() {
   this.get('/snapshots', getSnapshots);
 
   this.post('/users');
+  this.patch('/users/:id', getAuthenticatedUser);
   this.post('/assessment-results');
 
   this.del('/cache', () => null, 204);

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -46,6 +46,20 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
       expect(currentURL()).to.equal('/compte');
     });
 
+    it('should display a modal for migration', async function() {
+      // when
+      await visit('/profilv2');
+
+      // then
+      expect(find('.pix-modal')).to.exists;
+
+      // when
+      await click('.pix-modal-footer .button');
+
+      // then
+      expect(find('.pix-modal')).to.not.exists;
+    });
+
     it('should contains references to pix.fr/actualites/votre-profil-evolue', async function() {
       // when
       await visit('/profilv2');


### PR DESCRIPTION
## :unicorn: Problème
Avec la migration de V1 vers V2 on veut être capable de prévenir les utilisateurs concernés.

## :robot: Solution
- ajout d'une colonne isMigratedToV2 sur user
- ajout d'une colonne hasSeenMigration sur user
=> 2 colonnes car la deuxième va probablement rester plus longtemps présente dans le code que la première.
