### PR TITLE
[BUGFIX] Fix de la disparition de la barre de progression en démo et en certification

### DIFF
--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -7,20 +7,19 @@ import ENV from 'mon-pix/config/environment';
 export default Component.extend({
 
   classNames: ['progress'],
-
-  progression: AssessmentProgression.create(),
+  progression: null,
 
   setProgression() {
-    let nbChallenges;
+    let challengesToAnswerCount;
     if (this.get('assessment.hasCheckpoints')) {
-      nbChallenges = ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
+      challengesToAnswerCount = ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     } else {
-      nbChallenges = this.get('assessment.course.nbChallenges');
+      challengesToAnswerCount = this.get('assessment.course.nbChallenges');
     }
     this.set('progression', AssessmentProgression.create({
       assessmentType: this.get('assessment.type'),
-      nbAnswers: this.get('assessment.answers.length'),
-      nbChallenges
+      challengesAnsweredCount: this.get('assessment.answers.length'),
+      challengesToAnswerCount,
     }));
   },
 

--- a/mon-pix/app/models/assessment-progression.js
+++ b/mon-pix/app/models/assessment-progression.js
@@ -11,25 +11,25 @@ export default EmberObject.extend({
 
   // Data props
   assessmentType: null,
-  nbAnswers: null,
-  nbChallenges: null,
+  challengesAnsweredCount: null,
+  challengesToAnswerCount: null,
 
   // CPs
-  _currentStep: computed('assessmentType', 'nbAnswers', 'nbChallenges', function() {
+  _currentStep: computed('assessmentType', 'challengesAnsweredCount', 'challengesToAnswerCount', function() {
     const assessmentType = this.assessmentType;
-    const nbAnswers = this.nbAnswers;
+    const challengesAnsweredCount = this.challengesAnsweredCount;
     if (assessmentType === 'COMPETENCE_EVALUATION' || assessmentType === 'SMART_PLACEMENT') {
-      return FIRST_STEP_VALUE + nbAnswers % CHECKPOINTS_MAX_STEPS;
+      return FIRST_STEP_VALUE + challengesAnsweredCount % CHECKPOINTS_MAX_STEPS;
     }
-    return Math.min(FIRST_STEP_VALUE + nbAnswers, this.nbChallenges);
+    return Math.min(FIRST_STEP_VALUE + challengesAnsweredCount, this.challengesToAnswerCount);
   }),
 
-  _maxSteps: computed('assessmentType', 'nbChallenges', function() {
+  _maxSteps: computed('assessmentType', 'challengesToAnswerCount', function() {
     const assessmentType = this.assessmentType;
     if (assessmentType === 'COMPETENCE_EVALUATION' || assessmentType === 'SMART_PLACEMENT') {
       return CHECKPOINTS_MAX_STEPS;
     }
-    return this.nbChallenges;
+    return this.challengesToAnswerCount;
   }),
 
   valueNow: computed('_currentStep', '_maxSteps', function() {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -8,7 +8,6 @@ export default Route.extend({
 
     const assessment = this.modelFor('assessments');
     const challengeId = params.challenge_id;
-
     return RSVP.hash({
       assessment,
       challenge: store.findRecord('challenge', challengeId),
@@ -26,6 +25,9 @@ export default Route.extend({
       const campaignCode = modelResult.assessment.codeCampaign;
       const campaigns = await this._findCampaigns({ campaignCode });
       modelResult.campaign = campaigns.get('firstObject');
+    }
+    if (modelResult.assessment.get('isDemo') || modelResult.assessment.get('isCertification')) {
+      await modelResult.assessment.belongsTo('course').reload();
     }
   },
 

--- a/mon-pix/tests/unit/components/progress-bar-test.js
+++ b/mon-pix/tests/unit/components/progress-bar-test.js
@@ -28,8 +28,8 @@ describe('Unit | Component | progress-bar', function() {
 
       // then
       expect(progression.get('assessmentType')).to.equal('DEMO');
-      expect(progression.get('nbAnswers')).to.equal(3);
-      expect(progression.get('nbChallenges')).to.equal(10);
+      expect(progression.get('challengesAnsweredCount')).to.equal(3);
+      expect(progression.get('challengesToAnswerCount')).to.equal(10);
     });
   });
 

--- a/mon-pix/tests/unit/models/assessment-progress-test.js
+++ b/mon-pix/tests/unit/models/assessment-progress-test.js
@@ -12,8 +12,8 @@ describe('Unit | Model | assessment progress', function() {
         // given
         const model = AssessmentProgression.create({
           assessmentType: 'DEMO',
-          nbAnswers: 8,
-          nbChallenges: 10,
+          challengesAnsweredCount: 8,
+          challengesToAnswerCount: 10,
         });
 
         // when
@@ -27,8 +27,8 @@ describe('Unit | Model | assessment progress', function() {
         // given
         const model = AssessmentProgression.create({
           assessmentType: 'DEMO',
-          nbAnswers: 10,
-          nbChallenges: 10,
+          challengesAnsweredCount: 10,
+          challengesToAnswerCount: 10,
         });
         // when
         const _currentStep = model.get('_currentStep');
@@ -51,7 +51,7 @@ describe('Unit | Model | assessment progress', function() {
 
       it('should return 3 if number of answers is 2 (less than 5)', () => {
         // given
-        model.set('nbAnswers', 2);
+        model.set('challengesAnsweredCount', 2);
 
         // when
         const _currentStep = model.get('_currentStep');
@@ -62,7 +62,7 @@ describe('Unit | Model | assessment progress', function() {
 
       it('should return 4 (a modulo of 5) if number of answers is 8 (more than 5)', () => {
         // given
-        model.set('nbAnswers', 8);
+        model.set('challengesAnsweredCount', 8);
 
         // when
         const _currentStep = model.get('_currentStep');
@@ -81,7 +81,7 @@ describe('Unit | Model | assessment progress', function() {
         // given
         const model = AssessmentProgression.create({
           assessmentType: 'DEMO',
-          nbChallenges: 10
+          challengesToAnswerCount: 10
         });
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Lors des DEMO et des CERTIFICATIONS, la barre de progression disparaissait lorsqu'on effectuait un refresh. 

## :robot: Solution
Il convient de s'assurer que le model reload bien les relationships avant de rendre la vue, quelque soit le point d'entrée.

## :rainbow: Remarques
J'ai essayé de mettre des test cypress mais il faut fixturer un profil certifiable ce que je ne parvenais pas à faire de la bonne façon et rapidement. Je laisse ça pour un autre ticket, où l'on écrira une batterie de test cypress.