### PR TITLE
[BUGFIX] Nettoyage des données dans la DB. Puis plus de doublon dans Campaign-participation. (PF-702)

### DIFF
--- a/api/db/migrations/20190626111900_add_campaign_participation_unique_constraint_on_user_and_campaign.js
+++ b/api/db/migrations/20190626111900_add_campaign_participation_unique_constraint_on_user_and_campaign.js
@@ -1,0 +1,27 @@
+const TABLE_NAME = 'campaign-participations';
+
+exports.up = async function(knex) {
+  await knex.raw(`
+    DELETE FROM "campaign-participations"
+    WHERE id IN (
+      SELECT cp.id
+      FROM "campaign-participations" AS cp
+      INNER JOIN "campaign-participations" AS cpbis
+      ON cp."campaignId" = cpbis."campaignId" AND cp."userId" = cpbis."userId"
+      WHERE cp.id != cpbis.id
+      AND cp."createdAt" < cpbis."createdAt"
+    );
+  `);
+
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(['campaignId', 'userId']);
+  });
+};
+
+exports.down = function(knex) {
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique(['campaignId', 'userId']);
+  });
+};
+


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans notre DB il est possible d'avoir plusieurs Campaign-Participation pour un même User. 
Nous avons donc plusieurs lignes dans la DB qui posent des soucis à l'affichage, au résultat calculé ...

## :robot: Solution
Nous avons pris le parti de mettre une contrainte dans notre table "Campaign-participation"
- Utilisation d'une Unique sur les colonnes "UserId" et "campaignId".
- Utilisation du Delete sur les doublons déjà présents en base.

## :rainbow: Remarques

