### PR TITLE
[TECH] Remaniement des tests d'intégration de user-repository

### DIFF
--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -15,10 +15,11 @@ const buildUser = function buildUser({
   email = faker.internet.exampleEmail().toLowerCase(),
   password = encrypt.hashPasswordSync(faker.internet.password()),
   cgu = true,
+  samlId = `saml-id-${faker.random.uuid()}`,
 } = {}) {
 
   const values = {
-    id, firstName, lastName, email, password, cgu,
+    id, firstName, lastName, email, password, cgu, samlId,
   };
 
   return databaseBuffer.pushInsertable({
@@ -34,12 +35,13 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   email = faker.internet.email(),
   rawPassword = faker.internet.password(),
   cgu = true,
+  samlId = `saml-id-${faker.random.uuid()}`,
 }) {
 
   const password = encrypt.hashPasswordSync(rawPassword);
 
   const values = {
-    id, firstName, lastName, email, password, cgu,
+    id, firstName, lastName, email, password, cgu, samlId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -15,7 +15,7 @@ const buildUser = function buildUser({
   email = faker.internet.exampleEmail().toLowerCase(),
   password = encrypt.hashPasswordSync(faker.internet.password()),
   cgu = true,
-  samlId = `saml-id-${faker.random.uuid()}`,
+  samlId,
 } = {}) {
 
   const values = {
@@ -35,7 +35,7 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   email = faker.internet.email(),
   rawPassword = faker.internet.password(),
   cgu = true,
-  samlId = `saml-id-${faker.random.uuid()}`,
+  samlId,
 }) {
 
   const password = encrypt.hashPasswordSync(rawPassword);


### PR DESCRIPTION
## :unicorn: Problème
> Dans l'objectif de faire passer tous les tests sous PostgreSQL, des modifications doivent être faites dans les tests d'intégration de user-repository.

## :robot: Solution
> Utilisation du helper Database-factory-builUser
