### PR TITLE
[BUG] Erreur lors de la Remise à Zéro impactant plusieurs fois la même campagne (PF-717).

### DIFF
--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -100,10 +100,13 @@ async function _resetSmartPlacementAssessments({ userId, resetSkills, assessment
 }
 
 async function _resetSmartPlacementAssessment({ assessment, resetSkills, assessmentRepository, campaignParticipationRepository }) {
+  if (assessment.isAborted()) {
+    return null;
+  }
   const campaignParticipation = await campaignParticipationRepository.findOneByAssessmentId(assessment.id);
 
   const resetSkillsNotIncludedInTargetProfile = _computeResetSkillsNotIncludedInTargetProfile({
-    targetObjectSkills: campaignParticipation.campaign.targetProfile.skills,
+    targetObjectSkills: _.get(campaignParticipation, 'campaign.targetProfile.skills'),
     resetSkills
   });
 

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -82,7 +82,7 @@ function _resetCompetenceEvaluation({ userId, competenceId, competenceEvaluation
 }
 
 async function _resetSmartPlacementAssessments({ userId, resetSkills, assessmentRepository, campaignParticipationRepository }) {
-  const smartPlacementAssessments = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+  const smartPlacementAssessments = await assessmentRepository.findNotAbortedSmartPlacementAssessmentsByUserId(userId);
 
   if (!smartPlacementAssessments) {
     return null;
@@ -100,9 +100,6 @@ async function _resetSmartPlacementAssessments({ userId, resetSkills, assessment
 }
 
 async function _resetSmartPlacementAssessment({ assessment, resetSkills, assessmentRepository, campaignParticipationRepository }) {
-  if (assessment.isAborted()) {
-    return null;
-  }
   const campaignParticipation = await campaignParticipationRepository.findOneByAssessmentId(assessment.id);
 
   const resetSkillsNotIncludedInTargetProfile = _computeResetSkillsNotIncludedInTargetProfile({

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -132,9 +132,10 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
-  findSmartPlacementAssessmentsByUserId(userId) {
+  findNotAbortedSmartPlacementAssessmentsByUserId(userId) {
     return BookshelfAssessment
       .where({ userId, type: 'SMART_PLACEMENT' })
+      .where('state', '!=', 'aborted')
       .fetchAll()
       .then((assessments) => bookshelfToDomainConverter.buildDomainObjects(BookshelfAssessment, assessments));
   },

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -685,12 +685,17 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
   });
 
-  describe('#findSmartPlacementAssessmentsByUserId', () => {
+  describe('#findNotAbortedSmartPlacementAssessmentsByUserId', () => {
     let assessmentId;
     let userId;
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAssessment({
+        userId,
+        type: Assessment.types.SMARTPLACEMENT,
+        state: Assessment.states.ABORTED
+      });
 
       assessmentId = databaseBuilder.factory.buildAssessment({
         userId,
@@ -715,9 +720,10 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
     it('should returns the assessment with campaign when it matches with userId', async () => {
       // when
-      const assessmentsReturned = await assessmentRepository.findSmartPlacementAssessmentsByUserId(userId);
+      const assessmentsReturned = await assessmentRepository.findNotAbortedSmartPlacementAssessmentsByUserId(userId);
 
       // then
+      expect(assessmentsReturned.length).to.equal(1);
       expect(assessmentsReturned[0]).to.be.an.instanceOf(Assessment);
       expect(assessmentsReturned[0].id).to.equal(assessmentId);
     });

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -179,6 +179,7 @@ describe('Unit | Service | ScorecardService', function() {
 
       let oldAssessment1;
       let oldAssessment2;
+      let oldAssessment3;
       let oldAssessment1Aborted;
       let oldAssessment2Aborted;
       let newAssessment1Saved;
@@ -188,6 +189,7 @@ describe('Unit | Service | ScorecardService', function() {
       let campaign;
       const assessmentId1 = 12345;
       const assessmentId2 = 56789;
+      const assessmentId3 = 492377;
       const skillId = 'recmoustache';
       const campaignParticipation1Updated = Symbol('campaign participation 1 updated');
       const campaignParticipation2Updated = Symbol('campaign participation 2 updated');
@@ -201,6 +203,7 @@ describe('Unit | Service | ScorecardService', function() {
         campaignParticipation2 = domainBuilder.buildCampaignParticipation({ assessmentId: assessmentId2, campaign, campaignId: campaign.id, isShared: false });
         oldAssessment1 = domainBuilder.buildAssessment({ id: assessmentId1 });
         oldAssessment2 = domainBuilder.buildAssessment({ id: assessmentId2 });
+        oldAssessment3 = domainBuilder.buildAssessment({ id: assessmentId3, state: Assessment.states.ABORTED });
         oldAssessment1Aborted = domainBuilder.buildAssessment({ ...oldAssessment1, state: Assessment.states.ABORTED });
         oldAssessment2Aborted = domainBuilder.buildAssessment({ ...oldAssessment2, state: Assessment.states.ABORTED });
         newAssessment1Saved = domainBuilder.buildAssessment({ id: 67890 });
@@ -223,7 +226,7 @@ describe('Unit | Service | ScorecardService', function() {
           updateAssessmentIdByOldAssessmentId: sinon.stub(),
         };
 
-        assessmentRepository.findSmartPlacementAssessmentsByUserId.withArgs(userId).resolves([oldAssessment1, oldAssessment2]);
+        assessmentRepository.findSmartPlacementAssessmentsByUserId.withArgs(userId).resolves([oldAssessment1, oldAssessment2, oldAssessment3]);
 
         assessmentRepository.updateStateById.withArgs({ id: oldAssessment1.id, state: Assessment.states.ABORTED }).resolves(oldAssessment1Aborted);
         assessmentRepository.updateStateById.withArgs({ id: oldAssessment2.id, state: Assessment.states.ABORTED }).resolves(oldAssessment2Aborted);
@@ -234,6 +237,7 @@ describe('Unit | Service | ScorecardService', function() {
 
         campaignParticipationRepository.findOneByAssessmentId.withArgs(oldAssessment1.id).resolves(campaignParticipation1);
         campaignParticipationRepository.findOneByAssessmentId.withArgs(oldAssessment2.id).resolves(campaignParticipation2);
+        campaignParticipationRepository.findOneByAssessmentId.withArgs(oldAssessment3.id).resolves(null);
 
         campaignParticipationRepository.updateAssessmentIdByOldAssessmentId
           .withArgs({ oldAssessmentId: oldAssessment1.id, newAssessmentId: newAssessment1Saved.id })
@@ -262,13 +266,13 @@ describe('Unit | Service | ScorecardService', function() {
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
 
-      it('should update old assessment and save another assessment', async () => {
+      it('should update old assessment and save another assessment, and ignore old assessment already aborted', async () => {
 
         [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
           userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
         });
 
-        expect(resetCampaignParticipation).to.deep.equal([campaignParticipation1Updated, campaignParticipation2Updated]);
+        expect(resetCampaignParticipation).to.deep.equal([campaignParticipation1Updated, campaignParticipation2Updated, null]);
       });
 
       context('when campaign is already shared', function() {
@@ -285,7 +289,7 @@ describe('Unit | Service | ScorecardService', function() {
             userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
           });
           //then
-          expect(resetCampaignParticipation).to.deep.equal([null, null]);
+          expect(resetCampaignParticipation).to.deep.equal([null, null, null]);
         });
       });
 
@@ -306,7 +310,7 @@ describe('Unit | Service | ScorecardService', function() {
           });
 
           //then
-          expect(resetCampaignParticipation).to.deep.equal([null, null]);
+          expect(resetCampaignParticipation).to.deep.equal([null, null, null]);
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on faisait une Remise à Zéro plusieurs fois sur la même compétence, et affectant la même campagne, on avait une erreur 500, suite à un `Cannot read property 'campaign' of null`
Ce bug était lié au fait qu'on retentait de reset un assessment de campagne qui avait déjà été reset.

## :robot: Solution
On ne récupère pas les assessments  `aborted`

## :rainbow: Remarques
Ajout de l'utilisation de _.get() pour récupérer les informations sur la campagne, pour éviter une erreur de type `Cannot read property 'campaign' of null`
