### PR TITLE
[TECH] Retirer le bouton pour la remise à zéro.

### DIFF
--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -57,14 +57,6 @@
       {{/link-to}}
     {{/unless}}
 
-    {{#if displayResetButton}}
-      <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
-        Remettre à zéro <div class="sr-only">la compétence "{{scorecard.name}}"</div>
-      </button>
-    {{else if displayWaitSentence}}
-      <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
-    {{/if}}
-
   </div>
 
 </div>

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -187,7 +187,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
         expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
       });
 
-      context('when it is remaining some days before reset', () => {
+      context.skip('when it is remaining some days before reset', () => {
 
         beforeEach(() => {
           remainingDaysBeforeReset = 5;
@@ -211,12 +211,12 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           await visit(`/competences/${scorecard.id}`);
 
           // then
-          expect(find('.scorecard-details-content-right__reset-message').text()).to.contain(`Remise à zéro disponible dans ${remainingDaysBeforeReset} jours`);
+          //expect(find('.scorecard-details-content-right__reset-message').text()).to.contain(`Remise à zéro disponible dans ${remainingDaysBeforeReset} jours`);
           expect(find('.scorecard-details__reset-button')).to.have.lengthOf(0);
         });
       });
 
-      context('when it is not remaining days before reset', () => {
+      context.skip('when it is not remaining days before reset', () => {
 
         beforeEach(() => {
           remainingDaysBeforeReset = 0;


### PR DESCRIPTION
Pour la mise en prod : retirer le bouton remise à zéro.
A remettre après la mise à jour.