### PR TITLE
[BUGFIX] La remise à zéro plante lors de la 2e raz (PF-740).

### DIFF
--- a/api/lib/application/competence-evaluations/competence-evaluation-controller.js
+++ b/api/lib/application/competence-evaluations/competence-evaluation-controller.js
@@ -5,14 +5,14 @@ const { BadRequestError } = require('../../infrastructure/errors');
 
 module.exports = {
 
-  start(request, h) {
+  async startOrResume(request, h) {
     const userId = request.auth.credentials.userId;
-    const competenceId = request.payload.data.attributes['competence-id'];
-    return usecases.startOrResumeCompetenceEvaluation({ competenceId, userId })
-      .then(({ created, competenceEvaluation }) => {
-        const serialized = serializer.serialize(competenceEvaluation);
-        return created ? h.response(serialized).created() : serialized;
-      });
+    const competenceId = request.payload.competenceId;
+
+    const { competenceEvaluation, created } = await usecases.startOrResumeCompetenceEvaluation({ competenceId, userId });
+    const serializedCompetenceEvaluation = serializer.serialize(competenceEvaluation);
+
+    return created ? h.response(serializedCompetenceEvaluation).created() : serializedCompetenceEvaluation;
   },
 
   async find(request) {
@@ -24,7 +24,7 @@ module.exports = {
     }
 
     const { models: competenceEvaluations } = await usecases.findCompetenceEvaluations({ userId, options });
-    
+
     return serializer.serialize(competenceEvaluations);
   },
 };

--- a/api/lib/application/competence-evaluations/index.js
+++ b/api/lib/application/competence-evaluations/index.js
@@ -4,9 +4,9 @@ exports.register = async function(server) {
   server.route([
     {
       method: 'POST',
-      path: '/api/competence-evaluations',
+      path: '/api/competence-evaluations/start-or-resume',
       config: {
-        handler: competenceEvaluationController.start,
+        handler: competenceEvaluationController.startOrResume,
         notes: [
           '- **Route nécessitant une authentification**\n' +
           '- S\'il existe déjà une évaluation de competences pour l\'utilisateur courant, alors cette route renvoie l\'évaluation de competences existante avec un code 200\n' +

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -171,7 +171,7 @@ exports.register = async function(server) {
       }
     },
     {
-      method: 'PATCH',
+      method: 'POST',
       path: '/api/users/{userId}/competences/{competenceId}/reset',
       config: {
         handler: userController.resetScorecard,

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -29,19 +29,15 @@ async function _resumeCompetenceEvaluation({ userId, competenceId, assessmentRep
   if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
     return _restartCompetenceEvaluation({ userId, competenceEvaluation, assessmentRepository, competenceEvaluationRepository });
   }
-  return {
-    created: false,
-    competenceEvaluation,
-  };
+
+  return { competenceEvaluation, created: false };
 }
 
 async function _startCompetenceEvaluation({ userId, competenceId, assessmentRepository, competenceEvaluationRepository }) {
   const assessment = await _createAssessment({ userId, competenceId, assessmentRepository });
   const competenceEvaluation = await _createCompetenceEvaluation(competenceId, assessment.id, userId, competenceEvaluationRepository);
-  return {
-    created: true,
-    competenceEvaluation,
-  };
+
+  return { competenceEvaluation, created: true };
 }
 
 function _createAssessment({ userId, competenceId, assessmentRepository }) {
@@ -71,8 +67,5 @@ async function _restartCompetenceEvaluation({ userId, competenceEvaluation, asse
   await competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId({ userId, competenceId: competenceEvaluation.competenceId, status: CompetenceEvaluation.statuses.STARTED });
   const updatedCompetenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({ userId, competenceId: competenceEvaluation.competenceId });
 
-  return {
-    created: true,
-    competenceEvaluation: updatedCompetenceEvaluation,
-  };
+  return { competenceEvaluation: updatedCompetenceEvaluation, created: false };
 }

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -11,23 +11,16 @@ describe('Acceptance | API | Competence Evaluations', () => {
     server = await createServer();
   });
 
-  describe('POST /api/competence-evaluations', () => {
+  describe('POST /api/competence-evaluations/start-or-resume', () => {
     const competenceId = 'recABCD123';
 
     const options = {
       method: 'POST',
-      url: '/api/competence-evaluations',
+      url: '/api/competence-evaluations/start-or-resume',
       headers: {
         authorization: generateValidRequestAuhorizationHeader(userId)
       },
-      payload: {
-        data: {
-          type: 'competence-evaluations',
-          attributes: {
-            'competence-id': competenceId,
-          },
-        }
-      }
+      payload: { competenceId },
     };
 
     context('When user is authenticated', () => {
@@ -69,7 +62,6 @@ describe('Acceptance | API | Competence Evaluations', () => {
           await databaseBuilder.commit();
           // when
           const response = await server.inject(options);
-
           // then
           expect(response.statusCode).to.equal(200);
           expect(response.result.data.id).to.exist;
@@ -79,7 +71,7 @@ describe('Acceptance | API | Competence Evaluations', () => {
       context('and competence does not exists', () => {
         it('should return 404 error', () => {
           // given
-          options.payload.data.attributes['competence-id'] = null;
+          options.payload.competenceId = 'WRONG_ID';
 
           // when
           const promise = server.inject(options);

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
   beforeEach(async () => {
 
     options = {
-      method: 'PATCH',
+      method: 'POST',
       url: `/api/users/${userId}/competences/${competenceId}/reset`,
       payload: {},
       headers: {},
@@ -41,7 +41,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
     server = await createServer();
   });
 
-  describe('PATCH /users/{id}/competences/{id}/reset', () => {
+  describe('POST /users/{id}/competences/{id}/reset', () => {
 
     describe('Resource access management', () => {
 

--- a/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -19,14 +19,7 @@ describe('Unit | Application | Controller | Competence-Evaluation', () => {
       request = {
         headers: { authorization: 'token' },
         auth: { credentials: { userId } },
-        payload: {
-          data: {
-            type: 'competence-evaluations',
-            attributes: {
-              'competence-id': competenceId,
-            }
-          }
-        }
+        payload: { competenceId },
       };
     });
 
@@ -35,7 +28,7 @@ describe('Unit | Application | Controller | Competence-Evaluation', () => {
       usecases.startOrResumeCompetenceEvaluation.resolves({});
 
       // when
-      await competenceEvaluationController.start(request, hFake);
+      await competenceEvaluationController.startOrResume(request, hFake);
 
       // then
       expect(usecases.startOrResumeCompetenceEvaluation).to.have.been.calledOnce;
@@ -49,7 +42,7 @@ describe('Unit | Application | Controller | Competence-Evaluation', () => {
     it('should return the serialized competence evaluation when it has been successfully created', async () => {
       // given
       const competenceEvaluation = domainBuilder.buildCompetenceEvaluation({ competenceId });
-      usecases.startOrResumeCompetenceEvaluation.resolves({ created: true, competenceEvaluation });
+      usecases.startOrResumeCompetenceEvaluation.resolves({ competenceEvaluation, created: true });
 
       const serializedCompetenceEvaluation = {
         id: 1,
@@ -60,10 +53,10 @@ describe('Unit | Application | Controller | Competence-Evaluation', () => {
       serializer.serialize.returns(serializedCompetenceEvaluation);
 
       // when
-      const response = await competenceEvaluationController.start(request, hFake);
+      const response = await competenceEvaluationController.startOrResume(request, hFake);
 
       // then
-      expect(serializer.serialize).to.have.been.calledWith();
+      expect(serializer.serialize).to.have.been.calledWith(competenceEvaluation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCompetenceEvaluation);
     });

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -5,7 +5,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const _ = require('lodash');
 
-describe  ('Unit | UseCase | start-or-resume-competence-evaluation', () => {
+describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
 
   const userId = 123;
   const assessmentId = 456;
@@ -80,11 +80,11 @@ describe  ('Unit | UseCase | start-or-resume-competence-evaluation', () => {
           userId,
         })).resolves(competenceEvaluation);
       });
-      it('should return the created competence evaluation with created flag set to true', async () => {
+      it('should return the created competence evaluation', async () => {
         const res = await usecases.startOrResumeCompetenceEvaluation({
           competenceId, userId, competenceEvaluationRepository, assessmentRepository, competenceRepository
         });
-        expect(res).to.deep.equal({ created: true, competenceEvaluation });
+        expect(res).to.deep.equal({ competenceEvaluation, created: true });
       });
     });
 
@@ -97,7 +97,7 @@ describe  ('Unit | UseCase | start-or-resume-competence-evaluation', () => {
         const res = await usecases.startOrResumeCompetenceEvaluation({
           competenceId, userId, competenceEvaluationRepository, assessmentRepository, competenceRepository
         });
-        expect(res).to.deep.equal({ created: false, competenceEvaluation });
+        expect(res).to.deep.equal({ competenceEvaluation, created: false });
       });
     });
 
@@ -124,7 +124,7 @@ describe  ('Unit | UseCase | start-or-resume-competence-evaluation', () => {
         });
       });
       it('should return the updated competenceEvaluation', () => {
-        expect(res).to.deep.equal({ created: true, competenceEvaluation: updatedCompetenceEvaluation });
+        expect(res).to.deep.equal({ competenceEvaluation: updatedCompetenceEvaluation, created: false });
       });
       it('should have updated the status', () => {
         expect(competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId).to.have.been

--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -1,0 +1,24 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  urlForQueryRecord(query) {
+    if (query.startOrResume) {
+      delete query.startOrResume;
+      return `${this._super(...arguments)}/start-or-resume`;
+    }
+
+    return this._super(...arguments);
+  },
+
+  queryRecord(store, type, query) {
+    if (query.startOrResume) {
+      const url = this.buildURL(type.modelName, null, null, 'queryRecord', query);
+
+      return this.ajax(url, 'POST', { data: { competenceId: query.competenceId } });
+    }
+
+    return this._super(...arguments);
+  },
+
+});

--- a/mon-pix/app/adapters/scorecard.js
+++ b/mon-pix/app/adapters/scorecard.js
@@ -9,5 +9,15 @@ export default ApplicationAdapter.extend({
     }
 
     return this._super(...arguments);
-  }
+  },
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions.resetCompetence) {
+      const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+
+      return this.ajax(url, 'POST');
+    }
+
+    return this._super(...arguments);
+  },
 });

--- a/mon-pix/app/routes/competences/resume.js
+++ b/mon-pix/app/routes/competences/resume.js
@@ -9,15 +9,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   competenceId: null,
 
   model(params) {
-    const competenceId = params.competence_id;
-
-    const competenceEvaluation = this.store.peekAll('competenceEvaluation')
-      .find((competenceEvaluation) => competenceEvaluation.get('competenceId') === competenceId);
-    if (competenceEvaluation) {
-      return competenceEvaluation;
-    }
-    return this.store.createRecord('competenceEvaluation', { competenceId }).save();
-
+    return this.store.queryRecord('competenceEvaluation', { competenceId: params.competence_id, startOrResume: true });
   },
 
   afterModel(competenceEvaluation) {

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -56,7 +56,13 @@
         {{/if}}
       {{/link-to}}
     {{/unless}}
-
+    {{#if displayResetButton}}
+      <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
+        Remettre à zéro <div class="sr-only">la compétence "{{scorecard.name}}"</div>
+      </button>
+    {{else if displayWaitSentence}}
+      <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
+    {{/if}}
   </div>
 
 </div>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -73,7 +73,7 @@ export default function() {
   this.get('/users/:id/pixscore', getPixScore);
   this.get('/users/:id/scorecards', getScorecards);
   this.get('/users/:id/campaign-participations', getUserCampaignParticipations);
-  this.patch('/users/:userId/competences/:competenceId/reset', resetScorecard);
+  this.post('/users/:userId/competences/:competenceId/reset', resetScorecard);
   this.get('/scorecards/:id', getScorecard);
   this.get('/competences/:id');
   this.get('/areas/:id');

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -117,5 +117,5 @@ export default function() {
   this.get('/campaign-participations/:id/campaign-participation-result', getCampaignParticipationResult);
 
   this.get('/competence-evaluations');
-  this.post('/competence-evaluations', postCompetenceEvaluation);
+  this.post('/competence-evaluations/start-or-resume', postCompetenceEvaluation);
 }

--- a/mon-pix/mirage/routes/post-competence-evaluation.js
+++ b/mon-pix/mirage/routes/post-competence-evaluation.js
@@ -1,7 +1,7 @@
 export default function(schema, request) {
   const params = JSON.parse(request.requestBody);
 
-  const competenceId = params.data.attributes['competence-id'];
+  const competenceId = params.competenceId;
 
   if (competenceId === 'wrongId') {
     return schema.competenceEvaluations.find(null);

--- a/mon-pix/tests/acceptance/competence-details-test.js
+++ b/mon-pix/tests/acceptance/competence-details-test.js
@@ -187,7 +187,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
         expect(find('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
       });
 
-      context.skip('when it is remaining some days before reset', () => {
+      context('when it is remaining some days before reset', () => {
 
         beforeEach(() => {
           remainingDaysBeforeReset = 5;
@@ -211,12 +211,12 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           await visit(`/competences/${scorecard.id}`);
 
           // then
-          //expect(find('.scorecard-details-content-right__reset-message').text()).to.contain(`Remise à zéro disponible dans ${remainingDaysBeforeReset} jours`);
+          expect(find('.scorecard-details-content-right__reset-message').text()).to.contain(`Remise à zéro disponible dans ${remainingDaysBeforeReset} jours`);
           expect(find('.scorecard-details__reset-button')).to.have.lengthOf(0);
         });
       });
 
-      context.skip('when it is not remaining days before reset', () => {
+      context('when it is not remaining days before reset', () => {
 
         beforeEach(() => {
           remainingDaysBeforeReset = 0;

--- a/mon-pix/tests/unit/adapters/competence-evaluation-test.js
+++ b/mon-pix/tests/unit/adapters/competence-evaluation-test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapters | competence-evaluation', function() {
+  setupTest();
+
+  describe('#queryRecord', () => {
+
+    let adapter;
+
+    beforeEach(function() {
+      adapter = this.owner.lookup('adapter:competence-evaluation');
+      adapter.ajax = sinon.stub().resolves();
+    });
+
+    it('should build /startOrResume url', async function() {
+      // when
+      const url = await adapter.urlForQueryRecord({ startOrResume: true }, 'competenceEvaluation');
+
+      // then
+      expect(url).to.equal('http://localhost:3000/api/competence-evaluations/start-or-resume');
+    });
+
+    it('should build classic url', async function() {
+      // when
+      const url = await adapter.urlForQueryRecord({}, 'competenceEvaluation');
+
+      // then
+      expect(url).to.equal('http://localhost:3000/api/competence-evaluations');
+    });
+
+  });
+
+});

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Route | subscribers', function() {
+describe('Unit | Adapters | user', function() {
   setupTest();
 
   describe('#queryRecord', () => {

--- a/mon-pix/tests/unit/routes/competences/resume-test.js
+++ b/mon-pix/tests/unit/routes/competences/resume-test.js
@@ -10,23 +10,17 @@ describe('Unit | Route | Competence | Resume', function() {
 
   let route;
   const competenceId = 'competenceId';
-  let competenceEvaluationFromStore, competenceEvaluationCreated, competenceEvaluationFromAnotherCompetence;
   let storeStub;
-  let peekAllStub;
-  let createRecordStub;
+  let queryRecordStub;
+  let competenceEvaluation;
 
   beforeEach(function() {
-    competenceEvaluationFromStore = EmberObject.create({ id: 123, competenceId });
-    competenceEvaluationCreated = EmberObject.create({ id: 456, competenceId });
-    competenceEvaluationFromAnotherCompetence = EmberObject.create({ id: 789, competenceId: 'other' });
 
-    peekAllStub = sinon.stub();
-    createRecordStub = sinon.stub().returns({
-      save: sinon.stub().resolves(competenceEvaluationCreated),
-    });
+    competenceEvaluation = EmberObject.create({ id: 123, competenceId });
+
+    queryRecordStub = sinon.stub().resolves(competenceEvaluation);
     storeStub = Service.extend({
-      peekAll: peekAllStub,
-      createRecord: createRecordStub
+      queryRecord: queryRecordStub
     });
 
     // manage dependency injection context
@@ -40,32 +34,15 @@ describe('Unit | Route | Competence | Resume', function() {
 
   describe('#model', function() {
 
-    it('should create the CompetenceEvaluation if it not exits', function() {
+    it('should returns the competenceEvaluation', async function() {
       // given
-      peekAllStub.returns([competenceEvaluationFromAnotherCompetence]);
-
       const params = { competence_id: competenceId };
 
       // when
-      const promise = route.model(params);
+      const model = await route.model(params);
 
       // then
-      promise.then((resultModel) => {
-        expect(resultModel).to.equal(competenceEvaluationCreated);
-      });
-
-    });
-
-    it('should return the CompetenceEvaluation in store if it exists', function() {
-      // given
-      peekAllStub.returns([competenceEvaluationFromStore]);
-      const params = { competence_id: competenceId };
-
-      // when
-      const resultModel = route.model(params);
-
-      // then
-      expect(resultModel).to.equal(competenceEvaluationFromStore);
+      expect(model).to.equal(competenceEvaluation);
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Quand on commence un parcours par competence, qu'on le reset et qu'on recommence, le parcours reprend là où il en était au lieu de repartir à zéro.

## :robot: Solution
Le problème vient de l'enchaînement du `peekAll` suivi d'un `createRecord` qui ne gère pas le cas où la competenceEvaluation est `reset`, il a été donc été décidé de :
- Remplacer cette logique par un `queryRecord` spécifique pour appeler le endpoint dédié. 
- Remplacer le POST /competence-evaluations en POST /competence-evaluations/start-or-resume.