### PR TITLE
[BUGFIX] parsing des externalId dans l'export des résultats d'une certif (PA-97).

### DIFF
--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -63,17 +63,26 @@ export default Service.extend({
     const updateRequests = candidatesCertifications.map((certification) => {
 
       function _updateCertificationFieldFromCandidateData(fieldName) {
-        if (!_.isEmpty(candidateData[fieldName])) {
-          certification.set(fieldName, candidateData[fieldName]);
+        const candidateValue = _.trim(candidateData[fieldName]);
+        if (_.isNil(candidateValue) || _.isEmpty(candidateValue)) {
+          return;
         }
+        certification.set(fieldName, candidateValue);
       }
 
       const candidateData = _.find(candidatesData, ['certificationId', certification.id]);
-      _updateCertificationFieldFromCandidateData('firstName');
-      _updateCertificationFieldFromCandidateData('lastName');
-      _updateCertificationFieldFromCandidateData('birthdate');
-      _updateCertificationFieldFromCandidateData('birthplace');
-      _updateCertificationFieldFromCandidateData('externalId');
+
+      _.each([
+        'firstName',
+        'lastName',
+        'birthdate',
+        'birthplace',
+        'externalId',
+
+      ], (candidateProperty) => {
+        _updateCertificationFieldFromCandidateData(candidateProperty);
+      });
+
       return certification.save({ adapterOptions: { updateMarks: false } });
     });
     await Promise.all(updateRequests);

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -155,7 +155,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '1',
           firstName: 'Prénom 1',
           lastName: 'Nom 1',
-          row: 1
+          row: '1'
         },
         {
           birthdate: '10/01/2018',
@@ -163,7 +163,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '2',
           firstName: 'Prénom 2',
           lastName: 'Nom 2',
-          row: 2
+          row: '2'
         },
         {
           birthdate: '10/01/2018',
@@ -171,7 +171,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '3',
           firstName: 'Prénom 3',
           lastName: 'Nom 3',
-          row: 3
+          row: '3'
         }
       ];
 
@@ -220,7 +220,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '1',
           firstName: 'Prénom 1',
           lastName: 'Nom 1',
-          row: 1
+          row: '1'
         },
         {
           birthdate: '10/01/2018',
@@ -228,7 +228,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '2',
           firstName: 'Prénom 2',
           lastName: 'Nom 2',
-          row: 2
+          row: '2'
         }
       ];
 
@@ -278,7 +278,7 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '1',
           firstName: 'Prénom 1',
           lastName: 'Nom 1',
-          row: 1
+          row: '1'
         },
         {
           birthdate: '10/01/2018',
@@ -286,15 +286,15 @@ module('Unit | Service | session-info-service', function(hooks) {
           certificationId: '2',
           firstName: 'Prénom 2',
           lastName: 'Nom 2',
-          row: 2
+          row: '2'
         },
         {
-          birthdate: null,
+          birthdate: '',
           birthplace: 'Gonesse',
           certificationId: '3',
           firstName: 'Prénom 3',
           lastName: 'Nom 3',
-          row: 3
+          row: '3'
         }
       ];
 


### PR DESCRIPTION
## :unicorn: Problème
Pour une session de certification dans Pix Admin, lors d'un export de résultats après jury, le fichier .ods généré ne met pas à jour le contenu de la colonne "Identifiant Externe"

## :robot: Solution
Le problème venait du fait que notre parser ne traduisait pas toutes les valeurs des cellules en string. Si la cellule parsée ne contient qu'un nombre, par exemple 42, on obtenait `42` et non `'42'`. Notre condition de mise-à-jour de fonctionnait alors pas comme attendu.
On a rajouté une conversion en String en amont, et modifié la condition de non-mise à jour d'un champ.

## :rainbow: Remarques et Infos
Info : `_.isEmpty(42)` renverra true.
En appliquant un `_.trim` sur chaque valeur parsée, on effectue en même temps une conversion en string. `_.isEmpty('42')` renverra false

On en a profité pour refacto une suite d'appels à `_updateCertificationFieldFromCandidateData`
