### PR TITLE
[BUGFIX] Sortir les résultats collectifs avec les bonnes statistiques (PO-214).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -66,13 +66,13 @@ function _extractParticipantsKEs(sharedParticipations, targetedSkillIds) {
     const filteredKEs = participation
       .related('user')
       .related('knowledgeElements')
-      .filter((ke) => ke.isValidated()
-        && ke.isCoveredByTargetProfile(targetedSkillIds)
+      .filter((ke) => ke.isCoveredByTargetProfile(targetedSkillIds)
         && ke.wasCreatedBefore(participation.get('sharedAt'))
       );
 
     const sortedByDateKEs = _.orderBy(filteredKEs, ((ke) => ke.get('createdAt')), 'desc');
-    return _.uniqBy(sortedByDateKEs, ((ke) => ke.get('skillId')));
+    const uniqueBySkillIdKEs = _.uniqBy(sortedByDateKEs, ((ke) => ke.get('skillId')));
+    return _.filter(uniqueBySkillIdKEs, ((ke) => ke.isValidated()));
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
1 - Un utilisateur a remis à zéro une compétence
2 - Un utilisateur est le seul à passer une campagne portant sur cette compétence
3 - il la termine et envoie ses résultats

Observé : Dans Pix Orga, les résultats individuels ne sont pas les même que les résultats individuels alors qu'il n'y a qu'une seule personne.
Attendu : Dans Pix Orga les résultats collectifs doivent être les même que les résultats individuels.

## :robot: Solution
Lors de la récupération des résultats collectifs, l'enchaînement des actions de filtres et tris ne se faisait pas dans le bon ordre.
Pour les knowledge elements validés, on doit : 
1 - trier par date
2 - faire un unique par skillId pour avoir le dernier
3 - trier par knowledge elements validés

Avant : 
1 - trier par knowledge elements validés
2 - trier par date
3 - faire un unique par skillId pour avoir le dernier

## :rainbow: Remarques
Impacts de la remise à Zéro que l'on a pas vu ☮️ ❤️ 🦄
