### PR TITLE
[FEATURE] Ajout de l'antialiasing pour les polices d'écriture.

### DIFF
--- a/admin/app/styles/misc/global.scss
+++ b/admin/app/styles/misc/global.scss
@@ -7,6 +7,8 @@ html {
   font-family: 'Open Sans', Arial, sans-serif;
   font-size: 15px;
   color: #212529;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -26,6 +26,8 @@ body, html{
   height: 100%;
   font-family: $roboto;
   background-color: $porcelain;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body > .ember-view {

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -104,6 +104,11 @@
 @import 'pages/user-certifications';
 @import 'pages/user-certifications-get';
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 body {
   font-family: $font-lato;
   background-color: $porcelain-grey;

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -37,6 +37,8 @@ body, html {
   font-family: $roboto;
   font-size: 100%;
   background-color: $porcelain;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body > .ember-view {


### PR DESCRIPTION
## :unicorn: Problème
Avant:
![image](https://user-images.githubusercontent.com/4154003/60671668-e9a76480-9e73-11e9-81b3-63630e40dbd3.png)

## :robot: Solution
Après:
![image](https://user-images.githubusercontent.com/4154003/60671696-f3c96300-9e73-11e9-8d20-04c52b61dc2e.png)
La taille reste la même et les pixels en bordure sont antialiasés.

## :rainbow: Remarques
Supporté par:
- Firefox 25+ on OSX
- Webkits (Chrome, Safari, etc)

PS: A voir avec Manu!