### PR TITLE
Supprimer la clé étrangère lié à OrganizationRoleId

### DIFF
--- a/api/db/migrations/20190701102247_remove_organizationRoleId_column.js
+++ b/api/db/migrations/20190701102247_remove_organizationRoleId_column.js
@@ -4,6 +4,7 @@ exports.up = async function(knex) {
   const info = await knex(TABLE_NAME).columnInfo();
   if (info.organisationRoleId) {
     await knex.schema.alterTable(TABLE_NAME, (table) => {
+      table.dropForeign('organizationRoleId');
       table.dropColumn('organizationRoleId');
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
Knex.js ne peut pas supprimer de colonne si celle-ci à 1 clé étrangère.
[Référence: Issue Knex.js](https://github.com/tgriesser/knex/issues/214)

## :robot: Solution
Supprimer la clé étrangère avant de supprimer la colonne.
[Référence: Issue Knex.js](https://github.com/tgriesser/knex/issues/157#issuecomment-47876027)

## :rainbow: Remarques
Vive les arc-en-ciels !
