### PR TITLE
[FEATURE] Création des nouveaux comptes en profil v2 (PF-741).

### DIFF
--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -14,6 +14,7 @@ class User {
     lastName,
     password,
     samlId,
+    isProfileV2 = true,
     // includes
     memberships = [],
     certificationCenterMemberships = [],
@@ -34,6 +35,7 @@ class User {
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.samlId = samlId;
+    this.isProfileV2 = isProfileV2;
     this.knowledgeElements = knowledgeElements;
     // includes
     this.pixRoles = pixRoles;

--- a/api/lib/domain/usecases/get-current-user.js
+++ b/api/lib/domain/usecases/get-current-user.js
@@ -2,7 +2,7 @@ module.exports = async ({ authenticatedUserId, userRepository, assessmentReposit
   const user = await userRepository.get(authenticatedUserId);
   const usesProfileV2 = await assessmentRepository.hasCampaignOrCompetenceEvaluation(authenticatedUserId);
 
-  user.usesProfileV2 = usesProfileV2;
+  user.usesProfileV2 = usesProfileV2 || user.isProfileV2;
 
   return user;
 };

--- a/api/lib/infrastructure/data/user.js
+++ b/api/lib/infrastructure/data/user.js
@@ -49,6 +49,7 @@ module.exports = Bookshelf.model('User', {
     model.cgu = Boolean(model.cgu);
     model.pixOrgaTermsOfServiceAccepted = Boolean(model.pixOrgaTermsOfServiceAccepted);
     model.pixCertifTermsOfServiceAccepted = Boolean(model.pixCertifTermsOfServiceAccepted);
+    model.isProfileV2 = Boolean(model.isProfileV2);
 
     return new User(model);
   }

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -58,6 +58,7 @@ function _toDomain(userBookshelf) {
     memberships: _toMembershipsDomain(userBookshelf.related('memberships')),
     certificationCenterMemberships: _toCertificationCenterMembershipsDomain(userBookshelf.related('certificationCenterMemberships')),
     pixRoles: _toPixRolesDomain(userBookshelf.related('pixRoles')),
+    isProfileV2: Boolean(userBookshelf.get('isProfileV2')),
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
         'firstName', 'lastName', 'email', 'cgu', 'pixOrgaTermsOfServiceAccepted',
         'pixCertifTermsOfServiceAccepted', 'usesProfileV2', 'memberships',
         'certificationCenterMemberships', 'pixScore', 'scorecards',
-        'campaignParticipations', 'organizations',
+        'campaignParticipations', 'organizations', 'isProfileV2'
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -39,6 +39,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             'last-name': user.lastName,
             email: user.email.toLowerCase(),
             cgu: true,
+            'is-profile-v2': false,
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false,
             'uses-profile-v2': false,

--- a/api/tests/acceptance/application/users/users-controller-get-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user_test.js
@@ -49,6 +49,7 @@ describe('Acceptance | Controller | users-controller-get-user', () => {
             'last-name': userToInsert.lastName,
             'email': userToInsert.email.toLowerCase(),
             'cgu': true,
+            'is-profile-v2': false,
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false
           },

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -85,6 +85,7 @@ describe('Acceptance | Controller | users-controller', () => {
             expect(users[0]).to.include(expectedUserWithNoPasswordNorId);
             expect(users[0].cgu).to.be.ok;
             expect(users[0].password).to.exist;
+            expect(users[0].isProfileV2).to.be.ok;
           });
       });
 

--- a/api/tests/unit/domain/usecases/get-current-user_test.js
+++ b/api/tests/unit/domain/usecases/get-current-user_test.js
@@ -25,4 +25,36 @@ describe('Unit | UseCase | get-current-user', () => {
     // then
     expect(result).to.deep.equal({ id: 1, usesProfileV2: true });
   });
+
+  it('should get a user with profile v2', async () => {
+    // given
+    userRepository.get.withArgs(1).resolves({ id: 1, isProfileV2: true });
+    assessmentRepository.hasCampaignOrCompetenceEvaluation.withArgs(1).resolves(false);
+
+    // when
+    const result = await getCurrentUser({
+      authenticatedUserId: 1,
+      userRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal({ id: 1, usesProfileV2: true, isProfileV2: true });
+  });
+
+  it('should get current user with correct attributes', async () => {
+    // given
+    userRepository.get.withArgs(1).resolves({ id: 1, isProfileV2: false });
+    assessmentRepository.hasCampaignOrCompetenceEvaluation.withArgs(1).resolves(false);
+
+    // when
+    const result = await getCurrentUser({
+      authenticatedUserId: 1,
+      userRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(result).to.deep.equal({ id: 1, usesProfileV2: false, isProfileV2: false });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -30,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
         lastName: 'Skywalker',
         email: 'lskywalker@deathstar.empire',
         cgu: true,
+        isProfileV2: false,
         pixOrgaTermsOfServiceAccepted: false,
         pixCertifTermsOfServiceAccepted: false,
         password: '',
@@ -47,6 +48,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'last-name': 'Skywalker',
             'email': 'lskywalker@deathstar.empire',
             'cgu': true,
+            'is-profile-v2': false,
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false
           },

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -8,6 +8,7 @@ export default Model.extend({
   lastName: attr('string'),
   email: attr('string'),
   usesProfileV2: attr('boolean'),
+  isProfileV2: attr('boolean'),
   password: attr('string'),
   cgu: attr('boolean'),
   recaptchaToken: attr('string'),

--- a/mon-pix/app/routes/compte.js
+++ b/mon-pix/app/routes/compte.js
@@ -6,6 +6,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   currentUser: service(),
 
+  beforeModel() {
+    this._super(...arguments);
+
+    if (this.currentUser.user.isProfileV2) {
+      return this.transitionTo('profilv2');
+    }
+  },
+
   async model() {
     const user = this.currentUser.user;
     const organizations = await user.organizations;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -46,7 +46,7 @@
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  padding-bottom: 18px;
+  height: 205px;
   border-bottom: 1px dashed $silver-grey;
 
   @include device-is('tablet') {

--- a/mon-pix/app/templates/profilv2.hbs
+++ b/mon-pix/app/templates/profilv2.hbs
@@ -11,14 +11,16 @@
           Vous avez 16 compétences à tester.<br>On se concentre et c'est partix !
         </h1>
 
-        <h2 class="rounded-panel-header-text__content profilv2-panel-header-information">
-          Le profil Pix évolue.
-          <a class="link"
-             href="https://pix.fr/actualites/votre-profil-evolue"
-             target="Actualité Pix">
-            Découvrez ce qui change.
-          </a>
-        </h2>
+        {{#unless model.isProfileV2}}
+          <h2 class="rounded-panel-header-text__content profilv2-panel-header-information">
+            Le profil Pix évolue.
+            <a class="link"
+               href="https://pix.fr/actualites/votre-profil-evolue"
+               target="Actualité Pix">
+              Découvrez ce qui change.
+            </a>
+          </h2>
+        {{/unless}}
       </div>
 
       <div class="rounded-panel-header__right-wrapper">
@@ -26,9 +28,11 @@
       </div>
     </div>
 
-    <div class="profilv2-panel__link-to-compte">
-      {{#link-to "compte" class="link link--grey rounded-panel__link"}}Accès à l'ancien profil{{/link-to}}
-    </div>
+    {{#unless model.isProfileV2}}
+      <div class="profilv2-panel__link-to-compte">
+        {{#link-to "compte" class="link link--grey rounded-panel__link"}}Accès à l'ancien profil{{/link-to}}
+      </div>
+    {{/unless}}
 
     <div class="rounded-panel-body">
       {{#each model.areasCode as |areaCode|}}

--- a/mon-pix/mirage/routes/post-authentications.js
+++ b/mon-pix/mirage/routes/post-authentications.js
@@ -8,6 +8,16 @@ const simpleUserAuthentication = {
     id: 1
   }
 };
+const simpleProfileV2UserAuthentication = {
+  data: {
+    type: 'authentication',
+    attributes: {
+      'user-id': 5,
+      token: 'aaa.' + btoa('{"user_id":5,"source":"pix","iat":1545321469,"exp":4702193958}') + '.bbb'
+    },
+    id: 5
+  }
+};
 const simpleExternalUserAuthentication = {
   data: {
     type: 'authentication',
@@ -42,6 +52,7 @@ export default function(schema, request) {
   const token = JSON.parse(request.requestBody).data.attributes.token;
 
   if (email === 'jane@acme.com') return simpleUserAuthentication;
+  if (email === 'jane-profilev2@acme.com') return simpleProfileV2UserAuthentication;
   if (email === 'john@acme.com') return prescriberAuthentication;
 
   const userId = JSON.parse(atob(token.split('.')[1])).user_id;

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -14,6 +14,20 @@ export default function(server) {
     email: 'jane@acme.com',
     password: 'Jane1234',
     cgu: true,
+    isProfileV2: false,
+    recaptchaToken: 'recaptcha-token-xxxxxx',
+    totalPixScore: 456,
+    competenceIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  });
+
+  server.create('user', {
+    id: 5,
+    firstName: 'Jane',
+    lastName: 'Doe v2',
+    email: 'jane-profilev2@acme.com',
+    password: 'Jane1234',
+    cgu: true,
+    isProfileV2: true,
     recaptchaToken: 'recaptcha-token-xxxxxx',
     totalPixScore: 456,
     competenceIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],

--- a/mon-pix/tests/acceptance/compte-authentication-and-profile-test.js
+++ b/mon-pix/tests/acceptance/compte-authentication-and-profile-test.js
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { authenticateAsPrescriber, authenticateAsSimpleUser } from '../helpers/testing';
+import { authenticateAsPrescriber, authenticateAsSimpleProfileV2User, authenticateAsSimpleUser } from '../helpers/testing';
 import defaultScenario from '../../mirage/scenarios/default';
 
 describe('Acceptance | Espace compte | Authentication', function() {
@@ -55,6 +55,23 @@ describe('Acceptance | Espace compte | Authentication', function() {
 
     });
 
+  });
+
+  describe('V2 Profile cases', function() {
+    describe('New v2 users', function() {
+      it('should be redirected to /profilv2 when they hit /compte', async function() {
+        // given
+        await authenticateAsSimpleProfileV2User();
+
+        // when
+        await visit('/compte');
+
+        // then
+        return andThen(function() {
+          expect(currentURL()).to.equal('/profilv2');
+        });
+      });
+    });
   });
 
   describe('Error case', function() {

--- a/mon-pix/tests/acceptance/profilv2-test.js
+++ b/mon-pix/tests/acceptance/profilv2-test.js
@@ -5,7 +5,7 @@ import {
   it
 } from 'mocha';
 import { expect } from 'chai';
-import { authenticateAsPrescriber, authenticateAsSimpleUser } from '../helpers/testing';
+import { authenticateAsPrescriber, authenticateAsSimpleUser, authenticateAsSimpleProfileV2User } from '../helpers/testing';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import defaultScenario from '../../mirage/scenarios/default';
@@ -206,6 +206,29 @@ describe('Acceptance | Profil v2 | Afficher profil v2', function() {
         expect(find('.resume-campaign-banner__container').text()).to.contain('Parcours "Le Titre de la campagne" terminé ! Envoyez vos résultats.');
         expect(find('.resume-campaign-banner__button').text()).to.equal('Continuer');
       });
+    });
+  });
+
+  describe('Authenticated cases as a new profile v2 user', function() {
+    beforeEach(async function() {
+      await authenticateAsSimpleProfileV2User();
+    });
+
+    it('can visit /profilv2', async function() {
+      // when
+      await visit('/profilv2');
+
+      // then
+      expect(currentURL()).to.equal('/profilv2');
+    });
+
+    it('should not display link /compte', async function() {
+      // given
+      await visit('/profilv2');
+
+      // then
+      expect(find('.rounded-panel__link')).to.have.lengthOf(0);
+
     });
   });
 

--- a/mon-pix/tests/helpers/testing.js
+++ b/mon-pix/tests/helpers/testing.js
@@ -5,6 +5,13 @@ export async function authenticateAsSimpleUser() {
   await click('.button');
 }
 
+export async function authenticateAsSimpleProfileV2User() {
+  await visit('/connexion');
+  await fillIn('#email', 'jane-profilev2@acme.com');
+  await fillIn('#password', 'Jane1234');
+  await click('.button');
+}
+
 export async function authenticateAsSimpleExternalUser() {
   await visit('/connexion?token=aaa.' + btoa('{"user_id":3,"source":"external","iat":1545321469,"exp":4702193958}') + '.bbb');
 }


### PR DESCRIPTION
## :unicorn: Problème
On veut créer les nouveaux users directement en profil v2

## :robot: Solution
Utiliser la colonne isProfileV2 le temps de la migration pour afficher le profil v2 aux nouveaux users

