### PR TITLE
[BUGFIX] PixOrga ne fonctionne plus sous IE11 (PO-221).

### DIFF
--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  width: 100%;
 
   &__header {
     display: flex;

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -12,8 +12,11 @@ module.exports = function(defaults) {
 
     'ember-cli-template-lint': {
       testGenerator: 'qunit' // or 'mocha', etc.
-    }
+    },
 
+    'ember-cli-babel': {
+      includePolyfill: true
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## :unicorn: Problème
Le site ne fonctionne plus sous IE11
Le message d'erreur est "Promise is undefined"

## :robot: Solution
Enlever *async/await* du service **current-user**.