### PR TITLE
[TECH] Refactoring du contrôleur de `GET /api/users/me/profile`

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -47,15 +47,14 @@ module.exports = {
       .then(userSerializer.serialize);
   },
 
-  // FIXME: Pas de tests ?!
-  getAuthenticatedUserProfile(request) {
+  async getAuthenticatedUserProfile(request) {
     const token = tokenService.extractTokenFromAuthChain(request.headers.authorization);
     const userId = tokenService.extractUserId(token);
-    return userRepository.findUserById(userId)
-      .then((foundUser) => {
-        return profileService.getByUserId(foundUser.id);
-      })
-      .then((buildedProfile) => profileSerializer.serialize(buildedProfile));
+
+    const foundUser = await userRepository.findUserById(userId);
+    const profile = await profileService.getByUserId(foundUser.id);
+
+    return profileSerializer.serialize(profile);
   },
 
   updateUser(request) {

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -12,6 +12,8 @@ const encryptionService = require('../../../../lib/domain/services/encryption-se
 const mailService = require('../../../../lib/domain/services/mail-service');
 const passwordResetService = require('../../../../lib/domain/services/reset-password-service');
 const userService = require('../../../../lib/domain/services/user-service');
+const profileService = require('../../../../lib/domain/services/profile-service');
+const tokenService = require('../../../../lib/domain/services/token-service');
 
 const usecases = require('../../../../lib/domain/usecases');
 
@@ -19,6 +21,7 @@ const membershipSerializer = require('../../../../lib/infrastructure/serializers
 const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
+const profileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/profile-serializer');
 
 describe('Unit | Controller | user-controller', () => {
 
@@ -90,9 +93,28 @@ describe('Unit | Controller | user-controller', () => {
   });
 
   describe('#getAuthenticatedUserProfile', () => {
-    it('should be a function', () => {
+    const expectedSerializedProfile = Symbol('a serialized profile');
+    const userId = 1234;
+
+    beforeEach(() => {
+      sinon.stub(tokenService, 'extractUserId').returns(userId);
+
+      const aUser = new User({ id: userId });
+      sinon.stub(userRepository, 'findUserById').withArgs(userId).resolves(aUser);
+
+      const aProfile = Symbol('a profile');
+      sinon.stub(profileService, 'getByUserId').withArgs(userId).resolves(aProfile);
+
+      sinon.stub(profileSerializer, 'serialize').withArgs(aProfile).resolves(expectedSerializedProfile);
+    });
+
+    it('should return a serialized profile', async () => {
+      // given
+      const request = { headers: {} };
+      // when
+      const profile = await userController.getAuthenticatedUserProfile(request);
       // then
-      expect(userController.getAuthenticatedUserProfile).to.be.a('function');
+      expect(profile).to.equal(expectedSerializedProfile);
     });
   });
 


### PR DESCRIPTION
## 🔍 Problème

La fonction `userController.getAuthenticatedUserProfile()`, qui répond au  `GET /api/users/me/profile` :
- n'était pas testée ;
- était décorée d'un beau `// FIXME: pas de tests ?!` ;
- utilisait deux `.then()`, la version `await` serait plus lisible.

## ⚙️ Solution

- ajouter un test ;
- une fois le test ajouté, convertir les `.then()` en `await`.

## 📰  Remarques

J'avais envie de m'entrainer sur un refactoring, sur "Use Mocks for Commands; Stubs for Queries" et d'avoir des retours.

Refs :
- https://blog.ploeh.dk/2013/10/23/mocks-for-commands-stubs-for-queries/
- http://geepawhill.org/always-small-always-better-always-wrong/