### PR TITLE
[FEATURE] Création de la page /campagnes permettant de rentrer un code Campagne (PF-639).

### DIFF
--- a/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
@@ -1,0 +1,44 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+
+  store: service(),
+
+  campaignCode: null,
+  errorMessage: null,
+
+  actions: {
+
+    async startCampaign() {
+      this.set('errorMessage', null);
+
+      if (!this.get('campaignCode')) {
+        this.set('errorMessage', 'Merci de renseigner le code du parcours.');
+
+      } else {
+        const campaignCode = this.get('campaignCode').toUpperCase();
+
+        const campaignCodeExists = await this.store.query('campaign', { filter: { code: campaignCode } })
+          .then(() => true,
+            (error) => {
+              if (error.errors[0].status === '404') {
+                return false;
+              } else {
+                throw (error);
+              }
+            });
+
+        if (campaignCodeExists) {
+          return this.transitionToRoute('campaigns.start-or-resume', campaignCode);
+        } else {
+          this.set('errorMessage', 'Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+        }
+      }
+    },
+
+    clearErrorMessage() {
+      this.set('errorMessage', null);
+    }
+  }
+});

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -47,6 +47,7 @@ export default Router.map(function() {
   });
 
   this.route('campaigns', { path: '/campagnes' }, function() {
+    this.route('fill-in-campaign-code', { path: '/' });
     this.route('start-or-resume', { path: '/:campaign_code' });
     this.route('campaign-landing-page', { path: '/:campaign_code/presentation' });
     this.route('fill-in-id-pix', { path: '/:campaign_code/identifiant' });

--- a/mon-pix/app/routes/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/routes/campaigns/fill-in-campaign-code.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+
+});

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -96,6 +96,7 @@
 @import 'pages/compte';
 @import 'pages/course-preview';
 @import 'pages/error';
+@import 'pages/fill-in-campaign-code';
 @import 'pages/fill-in-id-pix';
 @import 'pages/not-connected';
 @import 'pages/profile';

--- a/mon-pix/app/styles/globals/_fonts.scss
+++ b/mon-pix/app/styles/globals/_fonts.scss
@@ -3,6 +3,7 @@ $font-open-sans: 'Open Sans', Arial, sans-serif;
 $font-raleway: 'Raleway', Arial, sans-serif;
 $font-overpass: 'Overpass', Arial, sans-serif;
 $font-roboto: 'Roboto', Arial, sans-serif;
+$font-roboto-mono: 'Roboto Mono', monospace;
 
 // Standards from Mozilla Foundation
 // https://developer.mozilla.org/fr/docs/Web/CSS/font-weight

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -1,0 +1,110 @@
+.fill-in-campaign-code {
+  &__gradient {
+    z-index: -1;
+    height: 240px;
+    width: 100%;
+    background: $pix-blue-to-purple-gradient;
+    box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  &__container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    max-width: 960px;
+    margin: -230px 10px;
+    padding-bottom: 30px;
+
+    @include device-is('tablet') {
+      margin: -200px auto;
+      padding: 40px;
+    }
+  }
+
+  &__title {
+    text-align: center;
+    color: $nero;
+
+    @include device-is('tablet') {
+      font-size: 4.2rem;
+    }
+  }
+
+  &__instruction {
+    color: $nero;
+    font-family: $font-open-sans;
+    font-size: 2rem;
+    text-align: center;
+    font-weight: $font-light;
+    margin-bottom: 16px;
+  }
+
+  &__form-field {
+    display: inline-block;
+    text-align: left;
+
+    & input {
+      box-sizing: content-box;
+      border: solid 2px $alto-grey;
+      border-radius: 3px;
+      outline: none;
+      height: 50px;
+      padding: 0 1px 1px .5ch;
+      text-transform: uppercase;
+      width: 13.6ch;
+      background: repeating-linear-gradient(90deg,
+        $silver-grey 0,
+        $silver-grey 1ch,
+        transparent 0,
+        transparent 1.5ch) 0 96%/98% 2px no-repeat;
+      background-origin: content-box;
+      color: $tundora-grey;
+      font-size: 3rem;
+      font-family: $font-roboto-mono;
+      letter-spacing: .5ch;
+
+      @media all and (-ms-high-contrast: none) {
+        //display differently for IE because 1 character (ch) is equal to 1.162
+        line-height: 0.7;
+        width: 15.6ch;
+        letter-spacing: .4ch;
+        background: repeating-linear-gradient(90deg,
+          $silver-grey 0,
+          $silver-grey 1.33ch,
+          transparent 0,
+          transparent 1.733ch) 0 96%/98% 2px no-repeat;
+        background-origin: content-box;
+      }
+
+      &::-ms-clear {
+        // not display cross that allow to clear field
+        display: none;
+      }
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    height: 160px;
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  &__error {
+    color: $pure-orange;
+    font-size: 1.5rem;
+    padding: 4px 10px;
+
+    @include device-is('tablet') {
+      padding: 0;
+    }
+  }
+}

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -1,0 +1,30 @@
+<div>
+  {{navbar-header class="navbar-header--white"}}
+</div>
+<div class="fill-in-campaign-code__gradient"></div>
+
+<div class="fill-in-campaign-code__container rounded-panel rounded-panel--strong">
+  <h1 class="fill-in-campaign-code__title rounded-panel-title">
+    Vous souhaitez participer<br>à un parcours de test
+  </h1>
+
+  <div class="fill-in-campaign-code__instruction">Saisissez le code du parcours</div>
+  <form class="fill-in-campaign-code__form" autocomplete="off">
+
+    <div class="fill-in-campaign-code__form-field">
+      {{input required type="text" id="campaign-code" value=campaignCode maxlength="9" key-down=(action 'clearErrorMessage')}}
+    </div>
+
+    {{#if errorMessage}}
+      <div class="fill-in-campaign-code__error" aria-live="polite">
+        {{ errorMessage }}
+      </div>
+    {{/if}}
+
+    <div class="fill-in-campaign-code__actions">
+      <button type="submit" class="button button--extra-big fill-in-campaign-code__start-button" {{action 'startCampaign'}}>
+        Commencer mon parcours
+      </button>
+    </div>
+  </form>
+</div>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -40,7 +40,8 @@ module.exports = function(environment) {
       'Open+Sans:300,400,600', // used for ex. on buttons
       'Raleway:100,300,400,600,700,800', // used for index page titles
       'Roboto:300,400,500', // used for campaign
-      'Overpass' //used on the trophy
+      'Overpass', //used on the trophy
+      'Roboto+Mono' //used for monospaced needs
     ],
 
     fontawesome: {

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -27,10 +27,71 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
 
     context('When user is not logged in', function() {
 
+      context('When user has not given any campaign code', function() {
+
+        it('should access campaign form page', async function() {
+          // when
+          await visit('/campagnes');
+
+          // then
+          expect(find('.button').text()).to.contains('Commencer mon parcours');
+        });
+      });
+
+      context('When user want to access a campaign with only its code', function() {
+
+        it('should access presentation page', async function() {
+          // given
+          const campaignCode = 'AZERTY1';
+          await visit('/campagnes');
+
+          // when
+          await fillIn('#campaign-code', campaignCode);
+          await click('.button');
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+        });
+
+        context('When campaign code does not exist', function() {
+
+          it('should display an error message on fill-in-campaign-code page', async function() {
+            // given
+            const campaignCode = 'AZERTY123';
+            await visit('/campagnes');
+
+            // when
+            await fillIn('#campaign-code', campaignCode);
+            await click('.button');
+
+            // then
+            expect(currentURL()).to.equal('/campagnes');
+            expect(find('.fill-in-campaign-code__error').text())
+              .to.contains('Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+          });
+        });
+
+        context('When user validates with empty campaign code', function() {
+
+          it('should display an error', async function() {
+            // given
+            await visit('/campagnes');
+
+            // when
+            await click('.button');
+
+            // then
+            expect(currentURL()).to.equal('/campagnes');
+            expect(find('.fill-in-campaign-code__error').text()).to.contains('Merci de renseigner le code du parcours.');
+          });
+        });
+      });
+
       context('When the user has already seen the landing page', function() {
         beforeEach(async function() {
           await startCampaignByCode('AZERTY1');
         });
+
         it('should redirect to signin page', async function() {
           // then
           return andThen(() => {

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
+
+  setupTest();
+
+  let controller;
+  let storeStub;
+
+  beforeEach(function() {
+    controller = this.owner.lookup('controller:campaigns/fill-in-campaign-code');
+    storeStub = { query: sinon.stub() };
+    controller.transitionToRoute = sinon.stub();
+    controller.set('store', storeStub);
+    controller.set('errorMessage', null);
+    controller.set('campaignCode', null);
+  });
+
+  describe('#startCampaign', () => {
+
+    it('should call start-or-resume', async () => {
+      // given
+      const campaignCode = 'azerty1';
+      controller.set('campaignCode', campaignCode);
+      storeStub.query.resolves();
+
+      // when
+      await controller.actions.startCampaign.call(controller);
+
+      // then
+      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume', campaignCode.toUpperCase());
+    });
+
+    it('should set error when campaign code is empty', async () => {
+      // given
+      controller.set('campaignCode', '');
+
+      // when
+      await controller.actions.startCampaign.call(controller);
+
+      // then
+      expect(controller.get('errorMessage')).to.equal('Merci de renseigner le code du parcours.');
+    });
+
+    it('should set error when campaign code is wrong', async () => {
+      // given
+      controller.set('campaignCode', 'SOMECODE');
+      storeStub.query.rejects({ errors: [{ status: '404' }] });
+
+      // when
+      await controller.actions.startCampaign.call(controller);
+
+      // then
+      expect(controller.get('errorMessage')).to.equal('Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les utilisateurs de Pix doivent copier-coller l'url d'une campagne pour y accéder. Avec la nouvelle page `/campagnes` ils pourront rentrer le code Campagne et commencer leur parcours.

## :robot: Solution
- Création de la page `/campagnes` ;
- Gestion des erreurs (code vide, code erroné).

## :rainbow: Remarques
On souhaiterait rajouter un bouton annuler, mais les faire naviguer vers où ? Puisqu'il viennent de différents endroits, et qu'ils sont connectés ou non.