### PR TITLE
[FEATURE] Recalculer le score des certifications V2 dans un état inconsistent (PF-646).

### DIFF
--- a/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
+++ b/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
@@ -84,17 +84,19 @@ function _saveAssessmentResult({
     assessmentScore.competenceMarks,
     assessmentRepository.updateStateById({ id: assessment.id, state: Assessment.states.COMPLETED }),
   ])
-    .then(([assessmentResult, competenceMarks]) => {
-      const assessmentResultId = assessmentResult.id;
+    .then(([assessmentResult, competenceMarks]) => _saveCompetenceMarks({ assessmentResult, competenceMarks, assessment, competenceMarkRepository }))
+    .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository, updateCertificationCompletionDate));
+}
 
-      const saveMarksPromises = competenceMarks
-        .map((mark) => _setAssessmentResultIdOnMark(mark, assessmentResultId))
-        .map((mark) => _ceilCompetenceMarkLevelForCertification(mark, assessment))
-        .map(competenceMarkRepository.save);
+function _saveCompetenceMarks({ assessmentResult, competenceMarks, assessment, competenceMarkRepository }) {
+  const assessmentResultId = assessmentResult.id;
 
-      return Promise.all(saveMarksPromises);
-    })
-    .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository));
+  const saveMarksPromises = competenceMarks
+    .map((mark) => _setAssessmentResultIdOnMark(mark, assessmentResultId))
+    .map((mark) => _ceilCompetenceMarkLevelForCertification(mark, assessment))
+    .map(competenceMarkRepository.save);
+
+  return Promise.all(saveMarksPromises);
 }
 
 function _getAssessmentStatus(assessment, assessmentScore) {

--- a/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
+++ b/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
@@ -14,6 +14,7 @@ module.exports = function createAssessmentResultForCompletedAssessment({
   // Parameters
   assessmentId,
   forceRecomputeResult = false,
+  updateCertificationCompletionDate = true,
   // Repositories
   answerRepository,
   assessmentRepository,
@@ -50,6 +51,7 @@ module.exports = function createAssessmentResultForCompletedAssessment({
     .then((assessmentScore) => _saveAssessmentResult({
       assessment,
       assessmentScore,
+      updateCertificationCompletionDate,
       assessmentRepository,
       assessmentResultRepository,
       certificationCourseRepository,
@@ -58,6 +60,7 @@ module.exports = function createAssessmentResultForCompletedAssessment({
     .catch((error) => _saveResultAfterComputingError({
       assessment,
       assessmentId,
+      updateCertificationCompletionDate,
       assessmentRepository,
       assessmentResultRepository,
       certificationCourseRepository,
@@ -69,6 +72,7 @@ function _saveAssessmentResult({
   // Parameters
   assessment,
   assessmentScore,
+  updateCertificationCompletionDate,
   // Repositories
   assessmentRepository,
   assessmentResultRepository,
@@ -125,8 +129,8 @@ function _ceilCompetenceMarkLevelForCertification(mark, assessment) {
   return mark;
 }
 
-function _updateCompletedDateOfCertification(assessment, certificationCourseRepository) {
-  if (assessment.isCertification()) {
+function _updateCompletedDateOfCertification(assessment, certificationCourseRepository, updateCertificationCompletionDate) {
+  if (assessment.isCertification() && updateCertificationCompletionDate) {
     return certificationCourseRepository.changeCompletionDate(
       assessment.courseId,
       new Date(),
@@ -139,6 +143,7 @@ function _updateCompletedDateOfCertification(assessment, certificationCourseRepo
 function _saveResultAfterComputingError({
   assessment,
   assessmentId,
+  updateCertificationCompletionDate,
   assessmentRepository,
   assessmentResultRepository,
   certificationCourseRepository,
@@ -154,5 +159,5 @@ function _saveResultAfterComputingError({
     assessmentResultRepository.save(assessmentResult),
     assessmentRepository.updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }),
   ])
-    .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository));
+    .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository, updateCertificationCompletionDate));
 }

--- a/api/scripts/compute-missing-certifv2-scores/bin.js
+++ b/api/scripts/compute-missing-certifv2-scores/bin.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-console, no-unused-vars */
+require('dotenv').config();
+
+const answerRepository = require('../../lib/infrastructure/repositories/answer-repository');
+const assessmentRepository = require('../../lib/infrastructure/repositories/assessment-repository');
+const assessmentResultRepository = require('../../lib/infrastructure/repositories/assessment-result-repository');
+const certificationCourseRepository = require('../../lib/infrastructure/repositories/certification-course-repository');
+const challengeRepository = require('../../lib/infrastructure/repositories/challenge-repository');
+const competenceRepository = require('../../lib/infrastructure/repositories/competence-repository');
+const competenceMarkRepository = require('../../lib/infrastructure/repositories/competence-mark-repository');
+const courseRepository = require('../../lib/infrastructure/repositories/course-repository');
+const skillRepository = require('../../lib/infrastructure/repositories/skill-repository');
+const scoringService = require('../../lib/domain/services/scoring/scoring-service');
+
+const recomputeCertificationCoursesV2 = require('./compute-missing-certifv2-scores');
+
+function run() {
+  return recomputeCertificationCoursesV2({
+    // Repositories
+    answerRepository,
+    assessmentRepository,
+    assessmentResultRepository,
+    certificationCourseRepository,
+    challengeRepository,
+    competenceRepository,
+    competenceMarkRepository,
+    courseRepository,
+    skillRepository,
+    // Services
+    scoringService,
+    // Options
+    logger: console,
+  });
+}
+
+run()
+  .then(() => {
+    console.log('The script executed successfully');
+    process.exit(0);
+  })
+  .catch((err) =>{
+    console.error(err);
+    process.exit(1);
+  });
+

--- a/api/scripts/compute-missing-certifv2-scores/compute-missing-certifv2-scores.js
+++ b/api/scripts/compute-missing-certifv2-scores/compute-missing-certifv2-scores.js
@@ -1,0 +1,45 @@
+'use strict';
+require('dotenv').config();
+const _ = require('lodash');
+const bluebird = require('bluebird');
+
+const { knex } = require('../../db/knex-database-connection');
+
+const createAssessmentResultForCompletedAssessment = require('../../lib/domain/usecases/create-assessment-result-for-completed-assessment');
+
+async function recomputeCertificationCoursesV2({ logger, ...dependencies }) {
+  let updatedCount = 0;
+  const assessmentIds = await _getAssessmentIdsToRecompute(logger);
+  await bluebird.map(assessmentIds, async (assessmentId) => {
+    const progress = `(${++updatedCount}/${assessmentIds.length})`;
+    try {
+      await createAssessmentResultForCompletedAssessment({
+        ...dependencies,
+        ...{ assessmentId, forceRecomputeResult: true, updateCertificationCompletionDate: false }
+      });
+      logger.log(`The assessment ${assessmentId} was successfully updated ${progress}`);
+    } catch (err) {
+      logger.log(`Unable to recompute assessment result for assessmentId : ${assessmentId} ${progress}`);
+      logger.error(err);
+    }
+  }, { concurrency: (~~process.env.CONCURRENCY || 1) });
+}
+
+async function _getAssessmentIdsToRecompute(logger) {
+  try {
+    const queryResults = await knex
+      .select('assessments.id as assessmentId')
+      .from('assessments')
+      .join('certification-courses', 'assessments.courseId', '=', knex.raw('cast("certification-courses".id as varchar)'))
+      .where('certification-courses.isV2Certification', true)
+      .where('assessments.state', 'completed');
+
+    return _.map(queryResults, 'assessmentId');
+
+  } catch (err) {
+    logger.log('Unable to compute assessment ids');
+    logger.log(err);
+  }
+}
+
+module.exports = recomputeCertificationCoursesV2;

--- a/api/tests/unit/scripts/compute-missing-certifv2-scores/compute-missing-certifv2-scores_test.js
+++ b/api/tests/unit/scripts/compute-missing-certifv2-scores/compute-missing-certifv2-scores_test.js
@@ -1,0 +1,160 @@
+const { expect, sinon, databaseBuilder, domainBuilder, knex } = require('../../../test-helper');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
+const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
+const competenceMarkRepository = require('../../../../lib/infrastructure/repositories/competence-mark-repository');
+const recomputeCertificationCoursesV2 = require('../../../../scripts/compute-missing-certifv2-scores/compute-missing-certifv2-scores');
+const _ = require('lodash');
+
+const {
+  buildUser,
+  buildCompetenceMark,
+  buildCertificationCourse,
+  buildAssessment,
+  buildAssessmentResult
+} = databaseBuilder.factory;
+
+describe('Compute missing certification v2 scores', () => {
+
+  const createdAt = new Date('2019-04-22');
+  const type = 'CERTIFICATION';
+  const state = 'completed';
+  const emitter = 'PIX-ALGO';
+  const isV2Certification = true;
+
+  const score = {
+    nbPix: 42,
+    competenceMarks: [
+      domainBuilder.buildCompetenceMark({ area_code: '42' }),
+      domainBuilder.buildCompetenceMark({ area_code: '42' }),
+    ],
+  };
+  
+  function testRecomputeCertificationCoursesV2() {
+    return recomputeCertificationCoursesV2({
+      assessmentRepository,
+      assessmentResultRepository,
+      certificationCourseRepository,
+      competenceMarkRepository,
+      scoringService: { calculateAssessmentScore: () => score },
+      logger: { log: () => {} },
+    });
+  }
+
+  let candidatId;
+  let juryId;
+  
+  beforeEach(async () => {
+    await databaseBuilder.clean();
+
+    candidatId = buildUser().id;
+    juryId = buildUser().id;
+
+    sinon.spy(assessmentResultRepository, 'save');
+    sinon.spy(certificationCourseRepository, 'changeCompletionDate');
+
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('competence-marks').delete();
+    await knex('assessment-results').delete();
+    await databaseBuilder.clean();
+  });
+
+  it('should not create a new assessment-result if the certification-course is V1', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification: false, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state, type, courseId: certificationCourseId }).id;
+    buildAssessmentResult({ assessmentId, status: 'error', juryId }).id;
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    expect(assessmentResultRepository.save).not.to.have.been.called;
+  });
+
+  it('should not update the assessment if not completed', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state: 'started', type, courseId: certificationCourseId }).id;
+    buildAssessmentResult({ assessmentId, status: 'error', juryId, emitter });
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    const { state } = await assessmentRepository.get(assessmentId);
+    expect(state).to.equal('started');
+  });
+
+  it('should create a validated assessment result when the assessment does not have any', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification: true, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state, type, courseId: certificationCourseId }).id;
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    const { status, pixScore } = (await knex('assessment-results').where({ assessmentId }))[0];
+    expect(status).to.equal('validated');
+    expect(pixScore).to.equal(score.nbPix);
+  });
+
+  it('should create a new assessment result as validated when the assessment already has one', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification: true, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state, type, courseId: certificationCourseId }).id;
+    const assessmentResultId = buildAssessmentResult({ assessmentId, status: 'error', juryId, emitter }).id;
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    const assessmentResults = (await knex('assessment-results').where({ assessmentId }));
+    expect(assessmentResults).to.have.lengthOf(2);
+    expect(assessmentResults[0].id).to.equal(assessmentResultId);
+    expect(assessmentResults[0].status).to.equal('error');
+    expect(assessmentResults[1].id).not.to.equal(assessmentResultId);
+    expect(assessmentResults[1].status).to.equal('validated');
+  });
+
+  it('should create the expected competence-marks without deleting the old ones if any', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification: true, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state, type, courseId: certificationCourseId }).id;
+    const assessmentResultId = buildAssessmentResult({ assessmentId, status: 'error', juryId, emitter }).id;
+    _.times(10, () => buildCompetenceMark({ assessmentResultId }));
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    const competenceMarks = await knex('competence-marks');
+    expect(competenceMarks).to.have.lengthOf(12);
+    expect(competenceMarks[9].area_code).not.to.equal('42');
+    expect(competenceMarks[10].area_code).to.equal('42');
+    expect(competenceMarks[11].area_code).to.equal('42');
+  });
+
+  it('should not update the certification course completion date', async () => {
+    // given
+    const certificationCourseId = buildCertificationCourse({ candidatId, isV2Certification: true, createdAt }).id;
+    const assessmentId = buildAssessment({ candidatId, state, type, courseId: certificationCourseId }).id;
+    buildAssessmentResult({ assessmentId, status: 'error', juryId, emitter });
+    await databaseBuilder.commit();
+
+    // when
+    await testRecomputeCertificationCoursesV2();
+
+    // then
+    expect(certificationCourseRepository.changeCompletionDate).not.to.have.been.called;
+  });
+});


### PR DESCRIPTION
## 🌊 Problème
La certification Pix regroupe un ensemble de briques fonctionnelles dont le bon fonctionnement repose sur deux hypothèses quand aux données utilisées, qui donne lieu à deux algorithmes différents : c'est ce que l'on nomme souvent V1 (basé sur les `answers`) et V2 (basé sur les `knowledgeElements`). Pour permettre au plus tôt de se certifier en V2, il a été décidé déployer une partie de la certification V2, sans que le scoring V2 soit déployé, ce qui a engendré des scoring incohérents en base de donnée, bloquant ainsi l'annonce des résultats. Cette PR propose un script permettant de rattraper ainsi le scoring afin de remettre les données dans un bon état.

## :robot: Solution

Le script (`api/scripts/compute-missing-v2-certification-score/bin.js`) énumère les certifications V2 terminées et ré-exécute le _usecase_ `createAssessmentResultForCompletedAssessment` sur chacune, afin de générer un nouvel `assessment-result` pour chaque certification. L'ancien `assessment-result` n'est pas modifié : le système était déjà prévu pour prendre en compte uniquement le dernier en date.

De plus, on a détecté un problème dans le choix des questions de certification à partir d'un profil V2. Les certifications V2 qui ont eu lieu ont inclus des questions appartenant à des compétences pour lesquelles l'utilisateur n'avait pas le niveau 1, et donc non certifiables. L'algorithme de sélection de questions sera corrigé dans une PR séparée ; dans celle-ci on a modifié l'algorithme de calcul des scores de certification pour ignorer les questions portant sur des compétences non certifiables.

## :gear: Comment exécuter le script

```CONCURRENCY=4 node api/scripts/compute-missing-v2-certification-score/bin.js```
Vous pouvez remplacer la valeur de CONCURRENCY par celle de votre choix pour paralléliser.

## :rainbow: Remarques

Des cas pathologiques ont été détectés, où le calcul du scoring en V1 n'a pas forcément toujours généré une erreur, si l'utilisateur avait un profil certifiable en V1 et en V2 à la fois, rendant la compréhension des possibles assez difficile à bien évaluer.
