### PR TITLE
[FEATURE] Limiter visuellement le nombre de Pix maximum pouvant être gagnés actuellement (PF-767).

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -1,6 +1,8 @@
 const settings = require('../settings');
 module.exports = {
   MAX_REACHABLE_LEVEL: 5,
+  MAX_REACHABLE_PIX_BY_COMPETENCE: 40,
+  MAX_TOTAL_REACHABLE_PIX: 640,
   PIX_COUNT_BY_LEVEL: 8,
   MINIMUM_DELAY_IN_DAYS_FOR_RESET: settings.features.dayBeforeCompetenceResetV2 || 7,
 

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -2,7 +2,6 @@ const settings = require('../settings');
 module.exports = {
   MAX_REACHABLE_LEVEL: 5,
   MAX_REACHABLE_PIX_BY_COMPETENCE: 40,
-  MAX_TOTAL_REACHABLE_PIX: 640,
   PIX_COUNT_BY_LEVEL: 8,
   MINIMUM_DELAY_IN_DAYS_FOR_RESET: settings.features.dayBeforeCompetenceResetV2 || 7,
 

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -87,7 +87,8 @@ function _getScorecardStatus(competenceEvaluation, knowledgeElements) {
 }
 
 function _getTotalEarnedPix(knowledgeElements) {
-  return Math.min(_.floor(_(knowledgeElements).sumBy('earnedPix')), constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+  const userTotalEarnedPix = _.floor(_(knowledgeElements).sumBy('earnedPix'));
+  return Math.min(userTotalEarnedPix, constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
 }
 
 function _getCompetenceLevel(earnedPix) {

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -87,7 +87,7 @@ function _getScorecardStatus(competenceEvaluation, knowledgeElements) {
 }
 
 function _getTotalEarnedPix(knowledgeElements) {
-  return _.floor(_(knowledgeElements).sumBy('earnedPix'));
+  return Math.min(_.floor(_(knowledgeElements).sumBy('earnedPix')), constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
 }
 
 function _getCompetenceLevel(earnedPix) {

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -44,8 +44,8 @@ class Scorecard {
     return { userId: _.parseInt(userId), competenceId };
   }
 
-  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation }) {
-    const totalEarnedPix = _getTotalEarnedPix(knowledgeElements);
+  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation, blockReachablePixAndLevel }) {
+    const totalEarnedPix = _getTotalEarnedPix(knowledgeElements, blockReachablePixAndLevel);
 
     const remainingDaysBeforeReset = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 
@@ -86,9 +86,12 @@ function _getScorecardStatus(competenceEvaluation, knowledgeElements) {
   return statuses.STARTED;
 }
 
-function _getTotalEarnedPix(knowledgeElements) {
+function _getTotalEarnedPix(knowledgeElements, blockReachablePixAndLevel) {
   const userTotalEarnedPix = _.floor(_(knowledgeElements).sumBy('earnedPix'));
-  return Math.min(userTotalEarnedPix, constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+  if (blockReachablePixAndLevel) {
+    return Math.min(userTotalEarnedPix, constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+  }
+  return userTotalEarnedPix;
 }
 
 function _getCompetenceLevel(earnedPix) {

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -4,8 +4,7 @@ const KnowledgeElement = require('../models/KnowledgeElement');
 const Scorecard = require('../models/Scorecard');
 const _ = require('lodash');
 
-async function computeScorecard({ userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository }) {
-
+async function computeScorecard({ userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository, blockReachablePixAndLevel = false }) {
   const [knowledgeElements, competence, competenceEvaluations] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId }),
     competenceRepository.get(competenceId),
@@ -19,6 +18,7 @@ async function computeScorecard({ userId, competenceId, competenceRepository, co
     knowledgeElements,
     competenceEvaluation,
     competence,
+    blockReachablePixAndLevel
   });
 }
 

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -14,7 +14,8 @@ module.exports = async ({ authenticatedUserId, scorecardId, scorecardService, co
     competenceId,
     competenceRepository,
     competenceEvaluationRepository,
-    knowledgeElementRepository
+    knowledgeElementRepository,
+    blockReachablePixAndLevel: true,
   });
 };
 

--- a/api/lib/domain/usecases/get-user-scorecards.js
+++ b/api/lib/domain/usecases/get-user-scorecards.js
@@ -24,6 +24,7 @@ module.exports = async ({ authenticatedUserId, requestedUserId, knowledgeElement
       knowledgeElements: knowledgeElementsForCompetence,
       competence,
       competenceEvaluation,
+      blockReachablePixAndLevel: true
     });
   });
 };

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -258,12 +258,14 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const userId_tmp = databaseBuilder.factory.buildUser().id;
 
       _.each([
-        { id: 1, skillId: 'rec1', userId, earnedPix: 5 },
-        { id: 2, skillId: 'rec2', userId, earnedPix: 10, status: 'validated', createdAt: today },
-        { id: 3, skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
-        { id: 4, skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
-        { id: 5, skillId: 'rec3', userId, earnedPix: 3, status: 'validated' },
-        { id: 6, skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated' },
+        { skillId: 'rec1', userId, earnedPix: 5, competenceId: 1 },
+        { skillId: 'rec3', userId, earnedPix: 40, status: 'validated', competenceId: 1 },
+        { skillId: 'rec2', userId, earnedPix: 10, status: 'validated', createdAt: today, competenceId: 1 },
+        { skillId: 'rec4', userId, earnedPix: 10, status: 'validated', competenceId: 2 },
+        { skillId: 'rec5', userId, earnedPix: 10, status: 'validated', competenceId: 3 },
+        { skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
+        { skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
+        { skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated' },
       ], (ke) => databaseBuilder.factory.buildKnowledgeElement(ke));
 
       await databaseBuilder.commit();
@@ -278,7 +280,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const earnedPix = await KnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
 
       // then
-      expect(earnedPix).to.equal(18);
+      expect(earnedPix).to.equal(60);
     });
 
   });

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const moment = require('moment');
+const constants = require('../../../../lib/domain/constants');
 
 describe('Unit | Domain | Models | Scorecard', () => {
 
@@ -143,17 +144,31 @@ describe('Unit | Domain | Models | Scorecard', () => {
     });
 
     context('when the user pix score is higher than the max', () => {
+      let knowledgeElements;
       beforeEach(() => {
         // given
-        const knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+      });
+      it('should have the same number of pix if blockReachablePixAndLevel is not defined', () => {
         //when
         actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(120);
       });
-      // then
-      it('should have the competence level capped at the maximum value', () => {
-        expect(actualScorecard.earnedPix).to.equal(40);
+      it('should have the same number of pix if blockReachablePixAndLevel is false', () => {
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: false });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(120);
       });
+      it('should have the number of pix blocked if blockReachablePixAndLevel is true', () => {
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: true });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+      });
+
     });
 
     context('when there is no knowledge elements', () => {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -142,6 +142,20 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
 
+    context('when the user pix score is higher than the max', () => {
+      beforeEach(() => {
+        // given
+        const knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+      });
+      // then
+      it('should have the competence level capped at the maximum value', () => {
+        expect(actualScorecard.earnedPix).to.equal(40);
+      });
+    });
+
     context('when there is no knowledge elements', () => {
       it('should return null', () => {
         const knowledgeElements = [];

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -67,7 +67,8 @@ describe('Unit | Service | ScorecardService', function() {
           userId: authenticatedUserId,
           knowledgeElements: knowledgeElementList,
           competence,
-          competenceEvaluation
+          competenceEvaluation,
+          blockReachablePixAndLevel: false
         }).returns(expectedUserScorecard);
 
         // when

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -136,6 +136,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           knowledgeElements: knowledgeElementGroupedByCompetenceId[1],
           competence: competenceList[0],
           competenceEvaluation: competenceEvaluationOfCompetence1,
+          blockReachablePixAndLevel: true,
         }).returns(expectedUserScorecard[0]);
 
         Scorecard.buildFrom.withArgs({
@@ -143,6 +144,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           knowledgeElements: knowledgeElementGroupedByCompetenceId[2],
           competence: competenceList[1],
           competenceEvaluation: undefined,
+          blockReachablePixAndLevel: true,
         }).returns(expectedUserScorecard[1]);
 
         Scorecard.buildFrom.withArgs({
@@ -150,6 +152,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           knowledgeElements: undefined,
           competence: competenceList[2],
           competenceEvaluation: undefined,
+          blockReachablePixAndLevel: true,
         }).returns(expectedUserScorecard[2]);
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
- Actuellement sur Pix, les utilisateurs ne doivent pouvoir gagner que 40 pix par compétence, donc le niveau 5, et aussi 640 pix en tout.
- Suite à des dépassements possibles dans certains cas, nous souhaitons garder le nombre de pix gagnés en base, mais n'afficher que le nombre de pix pris en compte (voir les limitations ci-dessusà

## :robot: Solution
- Bloquer le nombre de pix renvoyé, notamment pour le nombre de total de Pix, qui doit être cohérent avec le nombre de pix par compétence.
