### PR TITLE
[FEATURE] Ajouter des identifiants externes aux Organisations. (PA-83)

### DIFF
--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -4,6 +4,7 @@ import BootstrapTheme from 'ember-models-table/themes/bootstrap4';
 const columns = [
   {
     propertyName: 'id',
+    title: 'Numéro du membre',
     disableFiltering: true,
   },
   {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -9,6 +9,7 @@ export default DS.Model.extend({
   type: attr(),
   code: attr(),
   logoUrl: attr(),
+  externalId: attr(),
 
   // Relationships
   memberships: hasMany('membership'),

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -44,10 +44,6 @@
         font-weight: 600;
         margin-bottom: 20px;
       }
-
-      .organization__type {
-
-      }
     }
   }
 

--- a/admin/app/templates/components/organization-information-section.hbs
+++ b/admin/app/templates/components/organization-information-section.hbs
@@ -19,6 +19,9 @@
       <p>
         Type : <span class="organization__type">{{organization.type}}</span><br>
         Code : <span class="organization__code">{{organization.code}}</span><br>
+        {{#if organization.externalId}}
+          Identifiant externe : <span class="organization__externalId">{{organization.externalId}}</span><br>
+        {{/if}}
       </p>
     </div>
   </div>

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -59,7 +59,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       // then
       assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 5);
 
-      assert.dom('div.member-list table > thead').includesText('Id');
+      assert.dom('div.member-list table > thead').includesText('Numéro du membre');
       assert.dom('div.member-list table > thead').includesText('Prénom');
       assert.dom('div.member-list table > thead').includesText('Nom');
       assert.dom('div.member-list table > thead').includesText('Courriel');

--- a/api/db/migrations/20190719152419_add_column_externalId_to_organizations.js
+++ b/api/db/migrations/20190719152419_add_column_externalId_to_organizations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'externalId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).index();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -7,6 +7,7 @@ class Organization {
     name,
     type,
     logoUrl,
+    externalId,
     // includes
     user,
     memberships = [],
@@ -19,6 +20,7 @@ class Organization {
     this.name = name;
     this.type = type;
     this.logoUrl = logoUrl;
+    this.externalId = externalId;
     // includes
     this.user = user;
     this.memberships = memberships;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -14,6 +14,7 @@ function _toDomain(bookshelfOrganization) {
     name: rawOrganization.name,
     type: rawOrganization.type,
     logoUrl: rawOrganization.logoUrl,
+    externalId: rawOrganization.externalId,
   });
 
   let members = [];

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      attributes: ['name', 'type', 'code', 'logoUrl', 'user', 'memberships'],
+      attributes: ['name', 'type', 'code', 'logoUrl', 'externalId', 'user', 'memberships'],
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName', 'email'],

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -514,6 +514,7 @@ describe('Acceptance | Application | organization-controller', () => {
               'name': organization.name,
               'type': organization.type,
               'logo-url': organization.logoUrl,
+              'external-id': organization.externalId,
             },
             'id': organization.id.toString(),
             'relationships': {

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -9,11 +9,12 @@ const buildOrganization = function buildOrganization({
   name = faker.company.companyName(),
   code = 'ABCD12',
   logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+  externalId = faker.lorem.word(),
   userId = null,
   createdAt = faker.date.recent()
 } = {}) {
 
-  const values = { id, type, name, code, logoUrl, createdAt, userId };
+  const values = { id, type, name, code, logoUrl, externalId, createdAt, userId };
   return databaseBuffer.pushInsertable({
     tableName: 'organizations',
     values,
@@ -26,13 +27,14 @@ buildOrganization.withUser = function buildOrganizationWithUser({
   name = faker.company.companyName(),
   code = 'ABCD12',
   logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+  externalId = faker.lorem.word(),
   userId,
   createdAt = faker.date.recent()
 } = {}) {
 
   userId = _.isNil(userId) ? buildUser().id : userId;
 
-  const values = { id, type, name, code, logoUrl, createdAt, userId };
+  const values = { id, type, name, code, logoUrl, externalId, createdAt, userId };
   return databaseBuffer.pushInsertable({
     tableName: 'organizations',
     values,

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -20,12 +20,13 @@ function buildOrganization(
     name = 'Lycée Luke Skywalker',
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+    externalId = 'OrganizationIdLinksToExternalSource',
     createdAt = new Date('2018-01-12T01:02:03Z'),
     user = null,
     memberships = [],
     targetProfileShares = []
   } = {}) {
-  return new Organization({ id, code, name, type, logoUrl, createdAt, user, memberships, targetProfileShares });
+  return new Organization({ id, code, name, type, logoUrl, externalId, createdAt, user, memberships, targetProfileShares });
 }
 
 buildOrganization.withUser = function(
@@ -35,11 +36,12 @@ buildOrganization.withUser = function(
     name = 'Lycée Luke Skywalker',
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+    externalId = 'OrganizationIdLinksToExternalSource',
     createdAt = new Date('2018-01-12T01:02:03Z'),
     user = _buildMember()
   } = {}
 ) {
-  return new Organization({ id, code, name, type, logoUrl, createdAt, user });
+  return new Organization({ id, code, name, type, logoUrl, externalId, createdAt, user });
 };
 
 buildOrganization.withMembers = function(
@@ -49,6 +51,7 @@ buildOrganization.withMembers = function(
     name = 'Lycée Luke Skywalker',
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+    externalId = 'OrganizationIdLinksToExternalSource',
     createdAt = new Date('2018-01-12T01:02:03Z'),
     members = [
       _buildMember({ id: 1, firstName: 'John', lastName: 'Doe', email: 'john.doe@example.com' }),
@@ -56,7 +59,7 @@ buildOrganization.withMembers = function(
     ]
   } = {}
 ) {
-  return new Organization({ id, code, name, type, logoUrl, createdAt, members });
+  return new Organization({ id, code, name, type, logoUrl, externalId, createdAt, members });
 };
 
 module.exports = buildOrganization;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -22,6 +22,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'type': organization.type,
             'code': organization.code,
             'logo-url': organization.logoUrl,
+            'external-id': organization.externalId,
           },
           relationships: {
             user: { data: null },


### PR DESCRIPTION
## :unicorn: Problème
On veut pouvoir préciser un identifiant externe à une *Organisation*.
(paramètre optionnel d'une orga)
Ce champs sera renseigné lors de l'import open-data des établissements. 

## :robot: Solution
Ajout d'une colonne `externalId` dans la table `organizations`.
Ajout de l'affichage de ce paramètre sur la page de détail d'un organisation dans Pix admin.
