### PR TITLE
[TECH] Rendre les identifiants de templates Mailjet configurables

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,11 +1,10 @@
 const mailJet = require('../../infrastructure/mailjet');
-const ACCOUNT_CREATION_EMAIL_TEMPLATE_ID = '143620';
-const RESET_PASSWORD_DEMAND_EMAIL_TEMPLATE_ID = '232827';
+const settings = require('../../settings');
 
 function sendAccountCreationEmail(email) {
   return mailJet.sendEmail({
     to: email,
-    template: ACCOUNT_CREATION_EMAIL_TEMPLATE_ID,
+    template: settings.mailing.mailjetAccountCreationTemplateId,
     from: 'ne-pas-repondre@pix.fr',
     fromName: 'PIX - Ne pas répondre',
     subject: 'Création de votre compte PIX'
@@ -15,7 +14,7 @@ function sendAccountCreationEmail(email) {
 function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
   return mailJet.sendEmail({
     to: email,
-    template: RESET_PASSWORD_DEMAND_EMAIL_TEMPLATE_ID,
+    template: settings.mailing.mailjetPasswordResetTemplateId,
     from: 'ne-pas-repondre@pix.fr',
     fromName: 'PIX - Ne pas répondre',
     subject: 'Demande de réinitialisation de mot de passe PIX',

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -38,7 +38,9 @@ module.exports = (function() {
     mailing: {
       enabled: !!process.env.MAILJET_KEY,
       mailjetApiKey: process.env.MAILJET_KEY,
-      mailjetApiSecret: process.env.MAILJET_SECRET
+      mailjetApiSecret: process.env.MAILJET_SECRET,
+      mailjetAccountCreationTemplateId: process.env.MAILJET_ACCOUNT_CREATION_TEMPLATE_ID,
+      mailjetPasswordResetTemplateId: process.env.MAILJET_PASSWORD_RESET_TEMPLATE_ID,
     },
 
     captcha: {
@@ -96,7 +98,9 @@ module.exports = (function() {
     config.mailing = {
       enabled: false,
       mailjetApiKey: 'test-api-ket',
-      mailjetApiSecret: 'test-api-secret'
+      mailjetApiSecret: 'test-api-secret',
+      mailjetAccountCreationTemplateId: 'test-account-creation-template-id',
+      mailjetPasswordResetTemplateId: 'test-password-reset-template-id',
     };
 
     config.captcha = {

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -95,7 +95,7 @@ describe('Acceptance | Controller | users-controller', () => {
           from: 'ne-pas-repondre@pix.fr',
           fromName: 'PIX - Ne pas répondre',
           subject: 'Création de votre compte PIX',
-          template: '143620',
+          template: 'test-account-creation-template-id',
           to: 'john.dodoe@example.net',
         };
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | MailService', () => {
       return promise.then(() => {
         sinon.assert.calledWith(sendEmailStub, {
           to: email,
-          template: '143620',
+          template: 'test-account-creation-template-id',
           from: 'ne-pas-repondre@pix.fr',
           fromName: 'PIX - Ne pas répondre',
           subject: 'Création de votre compte PIX'
@@ -59,7 +59,7 @@ describe('Unit | Service | MailService', () => {
         return promise.then(() => {
           sinon.assert.calledWith(sendEmailStub, {
             to: email,
-            template: '232827',
+            template: 'test-password-reset-template-id',
             from: 'ne-pas-repondre@pix.fr',
             fromName: 'PIX - Ne pas répondre',
             subject: 'Demande de réinitialisation de mot de passe PIX',


### PR DESCRIPTION
## :unicorn: Problème

Actuellement les identifiants de templates Mailjet utilisés pour l'envoi des emails de création de compte et de réinitialisation de mot de passe sont codés en dur, ce qui rend impossible d'utiliser un compte Mailjet différent pour les applications de test et d'intégration.

## :robot: Solution

On introduit deux nouvelles variables d'environnement, `MAILJET_ACCOUNT_CREATION_TEMPLATE_ID` et `MAILJET_PASSWORD_RESET_TEMPLATE_ID` pour paramétrer ces identifiants de templates.

## :rainbow: Remarques

En production, il faudra bien ajouter ces variables avec les valeurs actuelles :

```
scalingo -a pix-api-production env-set MAILJET_ACCOUNT_CREATION_TEMPLATE_ID=143620
scalingo -a pix-api-production env-set MAILJET_PASSWORD_RESET_TEMPLATE_ID=232827
```

On peut tout à fait ajouter ces variables bien avant le déploiement de cette PR.

Penser à mettre à jour le glossaire des variables d'environnement !