### PR TITLE
[BUGFIX] Un utilisateur doit pouvoir accéder à son profil Pix via le GAR et ne pas être bloqué (PF-774).

### DIFF
--- a/api/lib/application/saml/saml-controller.js
+++ b/api/lib/application/saml/saml-controller.js
@@ -27,7 +27,7 @@ module.exports = {
 
       const token = tokenService.createTokenFromUser(user, 'external');
 
-      return h.redirect(`/connexion?token=${encodeURIComponent(token)}&user-id=${user.id}`);
+      return h.redirect(`/?token=${encodeURIComponent(token)}&user-id=${user.id}`);
     } catch (e) {
       logger.error(e);
       return h.response(e.toString()).code(500);

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -207,7 +207,7 @@ describe('Acceptance | Controller | saml-controller', () => {
       it('should consume valid SAML assertion and create user', () => {
         // then
         expect(firstVisitResponse.statusCode).to.equal(302);
-        expect(firstVisitResponse.headers.location).to.match(/^\/connexion\?token=[-_a-zA-Z0-9.]+&user-id=[0-9]+$/);
+        expect(firstVisitResponse.headers.location).to.match(/^\/\?token=[-_a-zA-Z0-9.]+&user-id=[0-9]+$/);
       });
 
       it('should retrieve the user on a second visit', async () => {

--- a/api/tests/unit/application/saml/saml-controller_test.js
+++ b/api/tests/unit/application/saml/saml-controller_test.js
@@ -34,7 +34,7 @@ describe('Unit | Application | Controller | Saml', () => {
 
       // then
       expect(usecases.getOrCreateSamlUser).to.have.been.calledWith({ userAttributes });
-      expect(response.location).to.match(/^\/connexion\?token=dummy-token&user-id=12$/);
+      expect(response.location).to.match(/^\/\?token=dummy-token&user-id=12$/);
     });
   });
 });

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -14,5 +14,13 @@
     "email": "samwell.tarly@pix.fr",
     "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
     "cgu": true
+  },
+  {
+    "id": 3,
+    "firstName": "John",
+    "lastName": "Snow",
+    "email": "john.snow@pix.fr",
+    "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
+    "cgu": true
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/campaign.feature
+++ b/high-level-tests/e2e/cypress/integration/campaign.feature
@@ -5,7 +5,7 @@ Feature: Campagne
 
   Scenario: Je commence mon parcours prescrit
     Given je vais sur Pix
-    And je suis connecté à Pix
+    And je suis connecté à Pix en tant que "Daenerys Targaryen"
     When je vais sur la campagne "NERA"
     Then je vois la page de "presentation" de la campagne
     When je clique sur "Je commence"

--- a/high-level-tests/e2e/cypress/integration/login.feature
+++ b/high-level-tests/e2e/cypress/integration/login.feature
@@ -1,9 +1,15 @@
 Feature: Connexion
 
   Background:
-    Given le compte de "Daenerys Targaryen" est créé
+    Given tous les comptes sont créés
 
   Scenario: Je me connecte
     Given je vais sur Pix
     When je me connecte avec le compte "daenerys.targaryen@pix.fr"
     Then je suis redirigé vers le compte de "Daenerys Targaryen"
+
+
+   Scenario: Je me connecte via un organisme externe
+     Given je suis connecté à Pix en tant que "John Snow"
+     When je vais sur Pix via un organisme externe
+     Then je suis redirigé vers le compte de "Daenerys Targaryen"

--- a/high-level-tests/e2e/cypress/integration/profile.feature
+++ b/high-level-tests/e2e/cypress/integration/profile.feature
@@ -5,7 +5,7 @@ Feature: Profil
 
   Scenario: J'accède à la page de détails d'une compétence
     Given je vais sur Pix
-    And je suis connecté à Pix
+    And je suis connecté à Pix en tant que "Daenerys Targaryen"
     When j'accède à mon profil
     And je clique sur le rond de niveau de la compétence "Traiter des données"
     Then je vois la page de détails de la compétence "Traiter des données"

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -69,3 +69,20 @@ Cypress.Commands.add('loginAdmin', (username, password) => {
   });
   cy.wait(['@getCurrentUser']);
 });
+
+Cypress.Commands.add('loginToken', (username, password) => {
+  cy.server();
+  cy.route('/api/users/me').as('getCurrentUser');
+  cy.request({
+    url: `${Cypress.env('API_URL')}/api/token`,
+    method: 'POST',
+    form: true,
+    body: {
+      username,
+      password,
+    }
+  }).then((response) => {
+    cy.visit(`/?token=${response.body.access_token}`)
+  });
+  cy.wait(['@getCurrentUser']);
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -8,7 +8,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'users_pix_roles');
 });
 
-given('le compte de "Daenerys Targaryen" est créé', () => {
+given('tous les comptes sont créés', () => {
   cy.task('db:fixture', 'users');
 });
 
@@ -20,8 +20,12 @@ given('j\'accède à mon profil', () => {
   cy.visit('/profil');
 });
 
-given('je suis connecté à Pix', () => {
-  cy.login('daenerys.targaryen@pix.fr', 'pix123');
+given('je suis connecté à Pix en tant que {string}', (user) => {
+  if(user === 'John Snow') {
+    cy.login('john.snow@pix.fr', 'pix123');
+  } else {
+    cy.login('daenerys.targaryen@pix.fr', 'pix123');
+  }
 });
 
 given('je suis connecté à Pix en tant qu\'administrateur', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/login.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login.js
@@ -4,6 +4,10 @@ given(`je me connecte avec le compte {string}`, (email) => {
   cy.get('button[type=submit]').click();
 });
 
+when('je vais sur Pix via un organisme externe', () => {
+  cy.loginToken('daenerys.targaryen@pix.fr', 'pix123');
+});
+
 then(`je suis redirigé vers le compte de {string}`, (fullName) => {
   cy.url().should('include', '/compte');
   cy.get('.logged-user-name').should((userName) => {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -11,9 +11,9 @@
   },
   "scripts": {
     "cy:open": "npm run db:initialize && cypress open",
-    "cy:open:pg": "DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5433/pix_test npm run cy:open",
+    "cy:open:pg": "DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:6432/pix_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
-    "cy:run:pg": "DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5433/pix_test npm run cy:run",
+    "cy:run:pg": "DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:6432/pix_test npm run cy:run",
     "cy:test": "run-p start:api start:mon-pix cy:run",
     "cy:test:open": "run-p start:api start:mon-pix cy:open",
     "cy:test:pg": "run-p start:api:pg start:mon-pix cy:run:pg",
@@ -21,7 +21,7 @@
     "db:empty": "cd ../../api && npm run db:pg:empty",
     "db:initialize": "cd ../../api && npm run db:pg:prepare",
     "start:api": "cd ../../api && npm run start:watch",
-    "start:api:pg": "cd ../../api && DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5433/pix_test npm run start:watch",
+    "start:api:pg": "cd ../../api && DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:6432/pix_test npm run start:watch",
     "start:mon-pix": "cd ../../mon-pix && npx ember serve --proxy"
   },
   "devDependencies": {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -6,12 +6,22 @@ export default Route.extend(ApplicationRouteMixin, {
 
   splash: service(),
   currentUser: service(),
+  session: service(),
 
   activate() {
     this.splash.hide();
   },
 
-  beforeModel() {
+  _checkForURLAuthentication(transition) {
+    if (transition.to.queryParams && transition.to.queryParams.token) {
+      return this.session.authenticate(
+        'authenticator:simple', { token: transition.to.queryParams.token }
+      );
+    }
+  },
+
+  async beforeModel(transition) {
+    await this._checkForURLAuthentication(transition);
     return this._loadCurrentUser();
   },
 

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -6,16 +6,6 @@ export default Route.extend(UnauthenticatedRouteMixin, {
 
   session: service(),
 
-  beforeModel(transition) {
-    if (transition.to.queryParams && transition.to.queryParams.token) {
-      return this.session.authenticate(
-        'authenticator:simple', { token: transition.to.queryParams.token }
-      );
-    } else {
-      return this._super(...arguments);
-    }
-  },
-
   actions: {
     signin(email, password) {
       return this.session.authenticate('authenticator:simple', { email, password });

--- a/mon-pix/tests/helpers/testing.js
+++ b/mon-pix/tests/helpers/testing.js
@@ -13,7 +13,7 @@ export async function authenticateAsSimpleProfileV2User() {
 }
 
 export async function authenticateAsSimpleExternalUser() {
-  await visit('/connexion?token=aaa.' + btoa('{"user_id":3,"source":"external","iat":1545321469,"exp":4702193958}') + '.bbb');
+  await visit('/?token=aaa.' + btoa('{"user_id":3,"source":"external","iat":1545321469,"exp":4702193958}') + '.bbb');
 }
 
 export async function authenticateAsPrescriber() {

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -10,7 +10,7 @@ const SplashServiceStub = EmberObject.extend({
   }
 });
 
-describe('Unit | Route | application splash', function() {
+describe('Unit | Route | application', function() {
 
   setupTest();
 
@@ -44,5 +44,4 @@ describe('Unit | Route | application splash', function() {
     // then
     expect(currentUserStub.called).to.be.true;
   });
-
 });

--- a/mon-pix/tests/unit/routes/login-test.js
+++ b/mon-pix/tests/unit/routes/login-test.js
@@ -45,19 +45,5 @@ describe('Unit | Route | login page', function() {
         password: expectedPassword
       });
     });
-
-    it('should authenticate the user given token in URL', async function() {
-      // Given
-      authenticateStub.resolves();
-
-      const route = this.owner.lookup('route:login');
-      sinon.stub(route, 'transitionTo');
-
-      // When
-      await route.beforeModel({ to: { queryParams: { token: 'aaa.eyJ1c2VyX2lkIjoxLCJzb3VyY2UiOiJwaXgiLCJpYXQiOjE1NDUxMjg3NzcsImV4cCI6MTU0NTczMzU3N30.bbbb' } } });
-
-      // Then
-      sinon.assert.calledWith(authenticateStub, 'authenticator:simple', { token: 'aaa.eyJ1c2VyX2lkIjoxLCJzb3VyY2UiOiJwaXgiLCJpYXQiOjE1NDUxMjg3NzcsImV4cCI6MTU0NTczMzU3N30.bbbb' });
-    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs provenant du GAR sont bloqués sur la page de login lorsqu'un autre utilisateur (ou le même) est déjà loggué. Ils veulent pouvoir accéder à leur profil Pix sans être bloqué.

De plus, lorsqu'il s'agit d'un utilisateur différent de celui déjà connecté, Pix devrait authentifier celui qui cherche à accéder à sa page profil, et non accéder au profil de l'ancien utilisateur.

Problèmes techniques 🤖 : 
Un `transitionTo('/compte')` après `session.authenticate` a été supprimé dans un refacto précédent, ayant pour conséquence que l'utilisateur n'était pas redirigé.

De plus, on a rencontré un autre problème, qui est que l'implémentation ci-dessous ne fonctionnait pas, puisque le `this._super` n'a plus la même référence (idem en asynchrone) : 
```
return this.session.authenticate('authenticator:simple', { token: transition.to.queryParams.token })
.then(() => this._super(...arguments))
```
L'objectif ici était de rediriger sur la page profil via le comportement par défaut du `beforeModel`.

Autre problème : lorsque un utilisateur était connecté, puis un autre se connectait via le GAR, on chargait 2 fois `/users/me`, mais 2 `me` différents, un pour l'ancien (dans le `beforeModel` de `application.js` avec `_loadCurrentUser()`), et un pour le nouveau (dans le `beforeModel` de `login.js`).

## :robot: Solution
Nous avons déplacé cette logique qui était dans `login.js` dans `application.js` juste avant le chargement du `currentUser` et extrait dans une méthode `checkForURLAuthentication` pour plus de lisibilité.

## :rainbow: Remarques
🍰 fonc : Nous n'avons plus de page de login en mode flash pendant la connexion au GAR. De plus, la connexion est plus rapide car nous récupérons qu'une fois le `/users/me` (et le bon !) au chargement du profil.

🍰 tech : On redirige les utilisateurs connectés via GAR directement vers `/` et non plus vers `/connexion`. Le front gère la redirection comme un grand ! 😀

## 🔧 : Comment reproduire en Review App ?
- Aller sur https://app-pr632.review.pix.fr
- Se connecter en tant que userpix1
- Ouvrir `development tools`> `Application` > `Local Storage` > `https://app-pr632.review.pix.fr`
- Copier le token
- Se déconnecter de Pix
- Se connecter avec un autre utilisateur
- Aller à l'url 'https://app-pr632.review.pix.fr/?token=${token}' et remplacer ${token} par votre token
- Vérifier qu'on accède bien à Pix en tant que userpix1