### PR TITLE
[BUGFIX] Empêcher de poser des questions en trop en certification (PF-781)

### DIFF
--- a/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
+++ b/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
@@ -793,10 +793,62 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
 
       });
 
-      it('should exclude inferred KnowlegdeElements to select challenges', async () => {
+      context('when there are non-certifiable competences', async() => {
+        beforeEach(() => {
+          competenceRepository.list.resolves([
+            competenceFlipper,
+          ]);
+
+          const answerForNonCertifiableCompetence = new Answer({
+            id: 333,
+            challengeId: challengeForSkillCollaborer4.id,
+            result: 'ok'
+          });
+          const keForNonCertifiableCompetence = domainBuilder.buildKnowledgeElement({
+            userId,
+            answerId: answerForNonCertifiableCompetence.id,
+            competenceId: competenceFlipper.id,
+            skillId: skillCollaborer4.id,
+            earnedPix: 4,
+            source: KnowledgeElement.SourceType.DIRECT
+          });
+
+          answerRepository.findChallengeIdsFromAnswerIds
+            .withArgs([answerForNonCertifiableCompetence.id])
+            .resolves([answerForNonCertifiableCompetence.challengeId]);
+
+          sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
+            .withArgs({
+              userId,
+              limitDate: sinon.match.any
+            }).resolves({
+              'competenceRecordIdOne': [keForNonCertifiableCompetence],
+            });
+        });
+
+        it('should exclude challenges from non certifiable competences', async () => {
+          // when
+          const userCompetences = await userService.getProfileToCertifyV2({ userId, limitDate: 'date' });
+
+          // then
+          expect(userCompetences).to.deep.equal([
+            {
+              id: 'competenceRecordIdOne',
+              index: '1.1',
+              name: '1.1 Construire un flipper',
+              skills: [],
+              pixScore: 4,
+              estimatedLevel: 0,
+              challenges: []
+            }]
+          );
+        });
+      });
+
+      it('should exclude inferred KnowledgeElements to select challenges', async () => {
         // given
         const answer = new Answer({ id: 1, challengeId: challengeForSkillRemplir4.id, result: 'ok' });
-        answerRepositoryFindChallengeIds.withArgs([1]).resolves([answer.challengeId]);
+        answerRepositoryFindChallengeIds.withArgs([answer.id]).resolves([answer.challengeId]);
 
         const inferredKe = domainBuilder.buildKnowledgeElement({
           userId,
@@ -1480,34 +1532,30 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
 
           const ke = domainBuilder.buildKnowledgeElement({
             answerId: answer1.id,
-            competenceId: 'competenceRecordIdTwo',
             skillId: skillRecherche4.id,
             earnedPix: 4
           });
 
           const ke2 = domainBuilder.buildKnowledgeElement({
             answerId: answer2.id,
-            competenceId: 'competenceRecordIdTwo',
             skillId: skillCitation4.id,
             earnedPix: 4
           });
 
           const ke3 = domainBuilder.buildKnowledgeElement({
             answerId: answer2.id,
-            competenceId: 'competenceRecordIdTwo',
             skillId: skillMoteur3.id,
             earnedPix: 4
           });
 
           const ke4 = domainBuilder.buildKnowledgeElement({
             answerId: answer4.id,
-            competenceId: 'competenceRecordIdTwo',
             skillId: skillSearch1.id,
             earnedPix: 4
           });
 
           sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-            .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdTwo: [ke, ke2, ke3, ke4] });
+            .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdOne: [ke, ke2, ke3, ke4] });
 
           // when
           const promise = userService.getProfileToCertifyV2({ userId, limitDate: 'date' });

--- a/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
+++ b/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
@@ -220,6 +220,48 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
 
       context('when selecting challenges to validate the skills per competence', () => {
 
+        context('when competence level is less than 1', () => {
+
+          it('should select no challenge', () => {
+            // given
+            competenceRepository.list.resolves([
+              competenceFlipper,
+            ]);
+
+            const failedAssessment = Assessment.fromAttributes({
+              id: 'failed-assessment',
+              status: 'completed',
+              courseId: 'courseId1',
+              assessmentResults: [ new AssessmentResult({ level: 0, pixScore: 2 })]
+            });
+
+            answerRepository.findCorrectAnswersByAssessmentId.withArgs(failedAssessment.id).resolves([
+              new Answer({ challengeId: challengeForSkillCitation4.id, result: 'ok' })
+            ]);
+
+            assessmentRepository.findLastCompletedAssessmentsForEachCoursesByUser.resolves([
+              failedAssessment
+            ]);
+
+            // when
+            const promise = userService.getProfileToCertifyV1(userId);
+
+            // then
+            return promise.then((skillProfile) => {
+              expect(skillProfile).to.deep.equal([
+                {
+                  id: 'competenceRecordIdOne',
+                  index: '1.1',
+                  name: '1.1 Construire un flipper',
+                  skills: [],
+                  pixScore: 2,
+                  estimatedLevel: 0,
+                  challenges: []
+                }]);
+            });
+          });
+        });
+
         context('when no challenge validate the skill', () => {
 
           it('should not return the skill', () => {

--- a/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
+++ b/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
@@ -151,26 +151,6 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
       });
     });
 
-    it('should list right answers for every assessment fulfilled', () => {
-      // when
-      const promise = userService.getProfileToCertifyV1(userId);
-
-      // then
-      return promise.then(() => {
-        sinon.assert.calledTwice(answerRepository.findCorrectAnswersByAssessmentId);
-      });
-    });
-
-    it('should not list right answers for assessments that have an estimated level null or 0', () => {
-      // when
-      const promise = userService.getProfileToCertifyV1(userId);
-
-      // then
-      return promise.then(() => {
-        sinon.assert.neverCalledWith(answerRepository.findCorrectAnswersByAssessmentId, assessment3.id);
-      });
-    });
-
     it('should list available competences', () => {
       // when
       const promise = userService.getProfileToCertifyV1(userId);


### PR DESCRIPTION
## :unicorn: Problème
Pendant une certification V2, le candidat pouvait être interrogé sur des questions relatives à des compétences d'un niveau inférieur à 1, à partir du moment où il avait au moins une bonne réponse en positionnement sur celles-ci.

## :robot: Solution
Lorsqu'on récupère le profil du candidat (les fonctions getProfileToCertifyVX), et plus précisément au moment de sélectionner les questions à poser pour la certification (_pickChallengesForUserCompetences), on applique un filtre pour s'assurer que chaque compétence à certifier a bien un niveau supérieur ou égal à 1.

## :rainbow: Remarques
On notera que le développement de cette PR a commencé avant la migration V1 -> V2. Des tests V1 on été rajoutés/réécrits pour mieux comprendre les intentions. 
