### PR TITLE
[TECH] Correction du crash de Chrome 76 sur Mac pendant les tests front.

### DIFF
--- a/admin/testem.js
+++ b/admin/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/certif/testem.js
+++ b/certif/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/mon-pix/testem.js
+++ b/mon-pix/testem.js
@@ -13,7 +13,6 @@ module.exports = {
       ci: [        // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/orga/testem.js
+++ b/orga/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
## :unicorn: Problème
Depuis Chrome 76, il est impossible de lancer `npm test` sur mac.

## :robot: Solution
En s'appuyant sur : https://github.com/ember-cli/ember-cli/pull/8774, on enlève `--disable-gpu` dans les différents `testem`.

