### PR TITLE
[FEATURE] Changement du hover du bouton pour fermer la bandeau d'information nouveau profil (PF-785).

### DIFF
--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -118,7 +118,7 @@
   background-color: transparent;
   cursor: pointer;
   outline: none;
-  transition: background-color 0.2s ease;
+  transition: 0.2s ease;
   border-radius: 50%;
 
   &:hover, &:active {

--- a/mon-pix/app/styles/pages/_profile.scss
+++ b/mon-pix/app/styles/pages/_profile.scss
@@ -40,13 +40,11 @@
     align-self: flex-end;
     margin: 5px;
     padding: 4px 10px;
+    opacity: .5;
 
     &:hover, &:active {
-      background-color: $white;
-    }
-
-    svg {
-      font-size: 1.5 rem;
+      background-color: transparent;
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Le hover du bouton fermeture du bandeau d'information nouveau profil ne correspond pas aux attentes de Manu car il n'est pas en accord avec ceux de Pix-site. 

## :robot: Solution
Faire correspondre le hover à ceux de Pix-site.

## :sparkles: Review App 
https://app-pr641.review.pix.fr/profil
