### PR TITLE
[BUGFIX] Répare les routes de réponses.

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -26,7 +26,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
 
   const assessment = await assessmentRepository.get(answer.assessmentId);
 
-  if (assessment.userId !== userId) {
+  if (assessment.userId != userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
 

--- a/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
@@ -11,7 +11,7 @@ module.exports = async function findAnswerByChallengeAndAssessment(
     assessmentRepository,
   } = {}) {
   const assessment = await assessmentRepository.get(assessmentId);
-  if (assessment.userId !== userId) {
+  if (assessment.userId != userId) {
     throw new ForbiddenAccess('User is not allowed to see this assessment.');
   }
 

--- a/api/lib/domain/usecases/get-answer.js
+++ b/api/lib/domain/usecases/get-answer.js
@@ -12,7 +12,7 @@ module.exports = async function getAnswer(
 
   const answer = await answerRepository.get(answerId);
   const assessment = await assessmentRepository.get(answer.assessmentId);
-  if (assessment.userId !== userId) {
+  if (assessment.userId != userId) {
     throw new ForbiddenAccess('User is not allowed to get this answer.');
   }
   return answer;

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -16,7 +16,7 @@ module.exports = async function getCorrectionForAnswer({
 };
 
 function _validateCorrectionIsAccessible(assessment, userId) {
-  if (assessment.userId !== userId) {
+  if (assessment.userId != userId) {
     throw new ForbiddenAccess('User is not allowed to see correction of this assessment.');
   }
   if (!assessment.isCompleted() && !assessment.isSmartPlacement() && !assessment.isCompetenceEvaluation()) {


### PR DESCRIPTION
## :unicorn: Problème
Les routes de réponses ne marchent pas en stagging.

## :robot: Solution
PG et Sqlite ne renvoient pas la même chose pour les `bigint`. Changement des `!==` récemment ajoutés en `!=`

## :rainbow: Remarques
Cette solution est un patch pour débloquer l'environnement de stagging. 2 actions devront être mises en place pour éviter ce type de compromis :
- passer à PG partout
- uniformiser les id qui sont des fois en `integer` et des fois en `bigint`
