### PR TITLE
[FEATURE] Obliger le code campagne à s'afficher sur une seule ligne (PO-222).

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -30,6 +30,8 @@
     display: flex;
     align-items: center;
     padding-right: 10px;
+    padding-left: 10px;
+    min-width: 345px;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, lorsque le nom de la campagne est long, le code campagne s'affiche sur plusieurs lignes. 

## :robot: Solution
Ajouter un `min-width` pour laisser l'affichage du code campagne sur une seule ligne. 

