### PR TITLE
[FEATURE] Possibilité d'afficher le mot de passe dans les formulaires (PF-116).

### DIFF
--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { inject } from '@ember/service';
 
 export default Component.extend({
@@ -7,6 +8,10 @@ export default Component.extend({
 
   email: null,
   password: null,
+  isPasswordVisible: false,
+  passwordInputType: computed('isPasswordVisible', function() {
+    return this.isPasswordVisible ? 'text' : 'password';
+  }),
 
   isErrorMessagePresent: false,
 
@@ -20,6 +25,10 @@ export default Component.extend({
         .catch(() => {
           this.set('isErrorMessagePresent', true);
         });
+    },
+
+    togglePasswordVisibility() {
+      this.toggleProperty('isPasswordVisible');
     }
 
   }

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -17,7 +17,7 @@
     margin-bottom: 10px;
   }
 
-  &__input-field {
+  &__input-container {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -32,6 +32,55 @@
 
       &:hover, &:active, &:focus {
         text-decoration: underline;
+      }
+    }
+  }
+
+  &__input-field {
+    display: flex;
+    height: 42px;
+    border-radius: 3px;
+    align-items: center;
+    background-color: white;
+    border: 2px solid $alto;
+
+    &:hover {
+      border: 2px solid $dodger-blue;
+    }
+
+    input {
+      height: 40px;
+      flex-grow: 1;
+      border: none;
+      border-radius: 3px;
+      outline: none;
+      padding: 1px 10px;
+      font-size: 1rem;
+
+      &:focus {
+        outline: none;
+      }
+
+      &::-ms-clear, &::-ms-reveal {
+        display: none;
+      }
+    }
+  }
+
+  &__icon {
+    height: 20px;
+    margin: 6px 10px;
+    border: none;
+
+    &-eye {
+      color: $dove-gray;
+      transition: .5s;
+      font-size: 1.1rem;
+      margin-top: 2px;
+
+      &:hover {
+        color: $nero;
+        cursor: pointer;
       }
     }
   }

--- a/certif/app/templates/components/login-form.hbs
+++ b/certif/app/templates/components/login-form.hbs
@@ -20,17 +20,27 @@
 
     <form {{action 'authenticate' on='submit'}}>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <label for="login-email" class="label">E-mail</label>
         {{input required id='login-email' class="input" name='email' type='email' value=email }}
       </div>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <label for="login-password" class="label">Mot de passe</label>
-        {{input required id='login-password' class="input" name='password' type='password' value=password}}
+        <div class="login-form__input-field">
+          {{input required id='login-password' name='password' type=passwordInputType
+                  value=password}}
+          <button aria-label="rendre le mot de passe lisible" class="login-form__icon" {{action 'togglePasswordVisibility'}}>
+            {{#if isPasswordVisible}}
+              {{fa-icon 'eye' class="login-form__icon-eye"}}
+            {{else}}
+              {{fa-icon 'eye-slash' class="login-form__icon-eye"}}
+            {{/if}}
+          </button>
+        </div>
       </div>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <button type="submit" class="button">Je me connecte</button>
       </div>
 

--- a/certif/tests/integration/components/login-form-test.js
+++ b/certif/tests/integration/components/login-form-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | login-form', function(hooks) {
     await fillIn('#login-password', 'JeMeLoggue1024');
 
     //  when
-    await click('button');
+    await click('.button');
 
     // then
     assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
@@ -64,11 +64,21 @@ module('Integration | Component | login-form', function(hooks) {
     await fillIn('#login-password', 'Mauvais mot de passe');
 
     //  when
-    await click('button');
+    await click('.button');
 
     // then
     assert.dom('#login-form-error-message').exists();
     assert.dom('#login-form-error-message').hasText('L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
+  });
+
+  test('it should display password when user click', async function(assert) {
+    // given
+    await render(hbs`{{login-form}});`);
+
+    // when
+    assert.dom('#login-password').hasAttribute('type','password');
+    await click('.login-form__icon');
+    assert.dom('#login-password').hasAttribute('type', 'text');
   });
 
 });

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -31,6 +31,8 @@ export default Component.extend({
   label: '',
   textfieldName: '',
   validationMessage: '',
+  isPassword: computed.equal('textfieldName','password'),
+  isPasswordVisible: false,
 
   onValidate: () => {},
 
@@ -71,4 +73,11 @@ export default Component.extend({
     const inputValidationStatus = this.validationStatus;
     return MESSAGE_VALIDATION_STATUS_MAP[inputValidationStatus] || '';
   }),
+
+  actions: {
+    togglePasswordVisibility() {
+      this.toggleProperty('isPasswordVisible');
+      this.set('textfieldType', this.textfieldType === 'password' ? 'text' : 'password');
+    }
+  }
 });

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -53,7 +53,20 @@
   @include device-is('desktop') {
     height: 48px;
   }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &::-ms-clear, &::-ms-reveal {
+    display: none;
+  }
 }
+
 
 .form-textfield__message {
   position: absolute;
@@ -70,15 +83,31 @@
   color: $caribbean-green;
 }
 
-.form-textfield__message--error.form-textfield__message-password, .form-textfield__message--error.form-textfield__message-email {
+.form-textfield__message--error.form-textfield__message-password, .form-textfield__message--error.form-textfield__message-email, .form-textfield__message--error.form-textfield__message-text {
   position: relative;
   text-align: right;
   margin-top: -5px;
   margin-bottom: 5px;
 }
 
-.form-textfield__icon {
-  width: 20px;
+.form-textfield__icons {
   height: 20px;
   margin: 6px 8px;
+  border: none;
+
+  &:focus {
+    border-radius: 10px;
+  }
+}
+
+.form-textfield__icon {
+  color: $dove-gray;
+  transition: .5s;
+  font-size: 1.8rem;
+  margin-top: 1px;
+
+  &:hover {
+    color: $nero;
+    cursor: pointer;
+  }
 }

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -11,13 +11,21 @@
           class= 'form-textfield__input'
           classBinding="inputValidationStatus"
           autocomplete=autocomplete}}
-
+  {{#if isPassword}}
+    <button aria-label="rendre le mot de passe lisible" class="form-textfield__icons" {{action 'togglePasswordVisibility'}}>
+      {{#if isPasswordVisible}}
+        {{fa-icon 'eye' class="form-textfield__icon"}}
+      {{else}}
+        {{fa-icon 'eye-slash' class="form-textfield__icon"}}
+      {{/if}}
+    </button>
+  {{/if}}
   {{#if hasIcon}}
     {{#if (eq validationStatus 'error') }}
-      <img src="/images/icons/icon-error.svg" class="form-textfield__icon form-textfield__icon--error">
+      <img src="/images/icons/icon-error.svg" class="form-textfield__icons form-textfield__icon--error">
     {{else}}
       <img src="/images/icons/icon-success.svg"
-           class="form-textfield__icon form-textfield__icon--success validation-icon-success">
+           class="form-textfield__icons form-textfield__icon--success validation-icon-success">
     {{/if}}
   {{/if}}
 </div>

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
-import { find, findAll, fillIn, triggerEvent, render } from '@ember/test-helpers';
+import { click, find, findAll, fillIn, triggerEvent, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
@@ -177,6 +177,25 @@ describe('Integration | Component | form textfield', function() {
         // then
         expect(find(itemSelector).getAttribute('class')).to.contain(expectedClass);
       });
+    });
+  });
+
+  describe('#When type is password it\'s possible to show this', function() {
+    this.beforeEach(async function() {
+      this.set('label', 'Mot de passe');
+      this.set('validationStatus', 'default');
+      this.set('validationMessage', '');
+      this.set('textfieldName', 'password');
+
+      // When
+      await render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName value=inputValue}}`);
+    });
+
+    it('should change type when user click on eye icon', async function() {
+      //then
+      expect(find('input').getAttribute('type')).to.equal('password');
+      await click('.form-textfield__icon');
+      expect(find('input').getAttribute('type')).to.equal('text');
     });
   });
 });

--- a/orga/app/components/login-form.js
+++ b/orga/app/components/login-form.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { inject } from '@ember/service';
 
 export default Component.extend({
@@ -7,6 +8,10 @@ export default Component.extend({
 
   email: null,
   password: null,
+  isPasswordVisible: false,
+  passwordInputType: computed('isPasswordVisible', function() {
+    return this.isPasswordVisible ? 'text' : 'password';
+  }),
 
   isErrorMessagePresent: false,
 
@@ -20,6 +25,10 @@ export default Component.extend({
         .catch(() => {
           this.set('isErrorMessagePresent', true);
         });
+    },
+
+    togglePasswordVisibility() {
+      this.toggleProperty('isPasswordVisible');
     }
 
   }

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -17,7 +17,7 @@
     margin-bottom: 10px;
   }
 
-  &__input-field {
+  &__input-container {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -35,4 +35,56 @@
       }
     }
   }
+
+
+  &__input-field {
+    display: flex;
+    height: 42px;
+    border-radius: 3px;
+    align-items: center;
+    background-color: white;
+    border: 2px solid $alto;
+
+    &:hover {
+      border: 2px solid $dodger-blue;
+    }
+
+    input {
+      height: 40px;
+      flex-grow: 1;
+      border: none;
+      border-radius: 3px;
+      outline: none;
+      padding: 1px 10px;
+      font-size: 1rem;
+
+      &:focus {
+        outline: none;
+      }
+
+      &::-ms-clear, &::-ms-reveal {
+        display: none;
+      }
+    }
+  }
+
+  &__icon {
+    height: 20px;
+    margin: 6px 10px;
+    border: none;
+
+    &-eye {
+      color: $dove-gray;
+      transition: .5s;
+      font-size: 1.1rem;
+      margin-top: 2px;
+
+      &:hover {
+        color: $nero;
+        cursor: pointer;
+      }
+    }
+  }
 }
+
+

--- a/orga/app/templates/components/login-form.hbs
+++ b/orga/app/templates/components/login-form.hbs
@@ -22,18 +22,27 @@
 
     <form {{action 'authenticate' on='submit'}}>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <label for="login-email" class="label">E-mail</label>
         {{input required id='login-email' class="input" name='email' type='email' value=email }}
       </div>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <label for="login-password" class="label">Mot de passe</label>
-        {{input required id='login-password' class="input" name='password' type='password'
+        <div class="login-form__input-field">
+          {{input required id='login-password' name='password' type=passwordInputType
                 value=password}}
+          <button aria-label="rendre le mot de passe lisible" class="login-form__icon" {{action 'togglePasswordVisibility'}}>
+             {{#if isPasswordVisible}}
+                {{fa-icon 'eye' class="login-form__icon-eye"}}
+             {{else}}
+                {{fa-icon 'eye-slash' class="login-form__icon-eye"}}
+            {{/if}}
+          </button>
+        </div>
       </div>
 
-      <div class="login-form__input-field">
+      <div class="login-form__input-container">
         <button type="submit" class="button">Je me connecte</button>
       </div>
 

--- a/orga/tests/integration/components/login-form-test.js
+++ b/orga/tests/integration/components/login-form-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | login-form', function(hooks) {
     await fillIn('#login-password', 'JeMeLoggue1024');
 
     //  when
-    await click('button');
+    await click('.button');
 
     // then
     assert.equal(sessionServiceObserver.authenticator, 'authenticator:oauth2');
@@ -64,11 +64,21 @@ module('Integration | Component | login-form', function(hooks) {
     await fillIn('#login-password', 'Mauvais mot de passe');
 
     //  when
-    await click('button');
+    await click('.button');
 
     // then
     assert.dom('#login-form-error-message').exists();
     assert.dom('#login-form-error-message').hasText('L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
+  });
+
+  test('it should display password when user click', async function(assert) {
+    // given
+    await render(hbs`{{login-form}});`);
+
+    // when
+    assert.dom('#login-password').hasAttribute('type','password');
+    await click('.login-form__icon');
+    assert.dom('#login-password').hasAttribute('type', 'text');
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur veut se créer un compte ou se connecter, celui-ci ne peut pas voir le mot de passe qu'il a tapé.

## :robot: Solution
Ajout d'une icône oeil sur les champs mot de passe, permettant d'afficher ou non le mot de passe.

## :rainbow: Remarque 
Un problème existe lorsque l'on souhaite se créer un compte, une fois le mot de passe entré (focus dans le input) et que l'on souhaite afficher son mot de passe en cliquant sur l'oeil, on perd l'action du clique à cause de la vérification du champs. 