### PR TITLE
[BUGFIX] La page de résultats d'un parcours par compétence n'affiche pas le nombre de Pix.

### DIFF
--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -11,4 +11,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
     });
     return competenceEvaluations.firstObject;
   },
+
+  afterModel(competenceEvaluation) {
+    return competenceEvaluation.belongsTo('scorecard').reload();
+  },
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans certains cas la page de résultats d'un parcours par compétence affiche "commencer" au lieu du nombre de Pix sur la compétence.

## :robot: Solution
Le score est calculé depuis l'objet `scorecard` qui peut être déjà présent dans le store et n'est donc pas à jour, on force son reload avant d'afficher les résultats.