### PR TITLE
[TECH] Génération d'une importante quantité de candidats de certification dans les seeds

### DIFF
--- a/api/db/seeds/data/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification-candidates-builder.js
@@ -1,3 +1,7 @@
+const moment = require('moment');
+const faker = require('faker');
+const CANDIDATE_COUNT = 300;
+
 module.exports = function sessionsBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildCertificationCandidate({
@@ -21,25 +25,21 @@ module.exports = function sessionsBuilder({ databaseBuilder }) {
     extraTimePercentage: 0.3,
     sessionId: 1,
   });
-  databaseBuilder.factory.buildCertificationCandidate({
-    id: 3,
-    firstName: 'Octave',
-    lastName: 'Mouret',
-    birthplace: 'Céret',
-    birthdate: '1925-08-05',
-    externalId: 'OMOU789',
-    extraTimePercentage: null,
-    sessionId: 4,
-  });
 
-  databaseBuilder.factory.buildCertificationCandidate({
-    id: 4,
-    firstName: 'Jeanlin',
-    lastName: 'Maheu',
-    birthplace: 'Paris',
-    birthdate: '1958-04-01',
-    externalId: 'JMAH456',
-    extraTimePercentage: 1,
-    sessionId: 4,
-  });
+  const originLocale = faker.locale;
+  faker.locale = 'fr';
+  for (let i = 0; i < CANDIDATE_COUNT; ++i) {
+    const extraTimePercentage = i % 2 === 0 ? null : (faker.random.number(99) / 100);
+    databaseBuilder.factory.buildCertificationCandidate({
+      firstName: faker.name.firstName(),
+      lastName: faker.name.lastName(),
+      birthplace: faker.address.city(),
+      birthdate: moment(faker.date.past(90)).format('YYYY-MM-DD'),
+      externalId: faker.random.alphaNumeric(6),
+      extraTimePercentage,
+      sessionId: 4,
+    });
+  }
+
+  faker.locale = originLocale;
 };


### PR DESCRIPTION
## :unicorn: Problème
Afin d'alimenter la base de données, dans les environnements dév/RA, on utilise des seeds. Récemment a été introduit le concept de candidat de certification. Logiquement, quelques candidats de certification ont été créés via les seeds afin de pouvoir travailler. Pourtant, à l'usage, il est possible d'avoir des sessions de certification pour lesquelles sont inscrits plus d'une centaine de candidats.

## :robot: Solution
On souhaite pouvoir approcher davantage l'environnement de production et les environnements dév/RA en ajoutant une large quantité de seeds candidats.

- Génération de candidats à l'aide de faker
- Quantité : 300 pour la session d'id 4
- La locale de faker a été temporairement fixée à "fr" pour avoir un jeu de données francisé.

## :rainbow: Remarques
Chaque génération des seeds produira un jeu de données candidats différent. A priori cela ne pose pas de problème car la valeur des données en soi ne nous intéresse pas particulièrement, seulement la quantité.
