### PR TITLE
[FEATURE] Modifier le format des mots de passe (PF-748).

### DIFF
--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -45,7 +45,7 @@ const userValidationJoiSchema = Joi.object().keys({
     if (error.type === 'any.empty') {
       return { message: 'Votre mot de passe n’est pas renseigné.' };
     }
-    return { message: 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.' };
+    return { message: 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.' };
   }),
 
   cgu: Joi.boolean().required().valid(true).error(() => {

--- a/api/lib/settings.js
+++ b/api/lib/settings.js
@@ -70,7 +70,7 @@ module.exports = (function() {
       payload: 'PixResetPassword'
     },
 
-    passwordValidationPattern: '^(?=.*\\p{L})(?=.*\\d).{8,}$',
+    passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',
 
     redisUrl: process.env.REDIS_URL,
     redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | users-controller', () => {
               'first-name': 'John',
               'last-name': 'DoDoe',
               'email': 'john.dodoe@example.net',
-              'password': 'A124B2C3#!',
+              'password': 'Ab124B2C3#!',
               'cgu': true,
               'recaptcha-token': 'reCAPTCHAToken',
             },

--- a/api/tests/unit/domain/validations/user-validator_test.js
+++ b/api/tests/unit/domain/validations/user-validator_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Validators | user-validator', function() {
       firstName: 'John',
       lastName: 'Doe',
       email: 'john.doe@example.net',
-      password: 'password1234',
+      password: 'Password1234',
       cgu: true,
     });
   });
@@ -95,7 +95,7 @@ describe('Unit | Domain | Validators | user-validator', function() {
         // given
         const expectedError = {
           attribute: 'password',
-          message: 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.'
+          message: 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.'
         };
         user.password = 'invalid';
 

--- a/api/tests/unit/infrastructure/validators/password-validator_test.js
+++ b/api/tests/unit/infrastructure/validators/password-validator_test.js
@@ -1,23 +1,28 @@
 const { expect } = require('../../../test-helper');
-const isPasswordvalid = require('../../../../lib/infrastructure/validators/password-validator');
+const isPasswordValid = require('../../../../lib/infrastructure/validators/password-validator');
 
 describe('Unit | Validator | password-validator', function() {
 
   describe('Validation rules', function() {
 
     it('should contain at least 8 characters:', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
-      expect(isPasswordvalid('A1')).to.be.false;
-    });
-
-    it('should contain at least one letter ', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
-      expect(isPasswordvalid('12345678')).to.be.false;
+      expect(isPasswordValid('Ab123456')).to.be.true;
+      expect(isPasswordValid('Ab1')).to.be.false;
     });
 
     it('should contain at least one digit', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
-      expect(isPasswordvalid('ABCDEFGH')).to.be.false;
+      expect(isPasswordValid('Ab123456')).to.be.true;
+      expect(isPasswordValid('AbCDEFGH')).to.be.false;
+    });
+
+    it('should contain at least one uppercase letter', function() {
+      expect(isPasswordValid('Ab123456')).to.be.true;
+      expect(isPasswordValid('ab123456')).to.be.false;
+    });
+
+    it('should contain at least one lowercase letter', function() {
+      expect(isPasswordValid('Ab123456')).to.be.true;
+      expect(isPasswordValid('AB123456')).to.be.false;
     });
 
   });
@@ -33,33 +38,35 @@ describe('Unit | Validator | password-validator', function() {
       'password',
       '12345678&',
       '+!@)-=`"#&',
-      '+!@)-=`"#&1'
+      '+!@)-=`"#&1',
+      '+!@)-=`"#&1A',
+      '+!@)-=`"#&1a'
     ].forEach(function(badPassword) {
       it(`should return false when password is invalid: ${badPassword}`, function() {
-        expect(isPasswordvalid(badPassword)).to.be.false;
+        expect(isPasswordValid(badPassword)).to.be.false;
       });
     });
   });
 
   describe('Valid password', function() {
     [
-      'PIXBETA1',
-      'PIXBETA12',
-      'NULLNULL1',
-      '12345678a',
-      '12345678ab',
-      '12345678ab+',
-      '12345678ab+!',
-      '12345678ab+!@',
-      '12345678ab+!@)-=`',
-      '12345678ab+!@)-=`"',
-      '12345678ab+!@)-=`"#&',
+      'PIXBETa1',
+      'PIXBETa12',
+      'NULLNuLL1',
+      '1234567Aa',
+      '12345678Ab',
+      '12345678Ab+',
+      '12345678Ab+!',
+      '12345678Ab+!@',
+      '12345678Ab+!@)-=`',
+      '12345678Ab+!@)-=`"',
+      '12345678Ab+!@)-=`"#&',
       '1234Password avec espace',
-      '1A      A1',
-      'à1      '
+      '1A      a1',
+      'Aà1      '
     ].forEach(function(validPassword) {
       it(`should return true if provided password is valid: ${validPassword}`, function() {
-        expect(isPasswordvalid(validPassword)).to.be.true;
+        expect(isPasswordValid(validPassword)).to.be.true;
       });
     });
   });

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -2,7 +2,8 @@ import Component from '@ember/component';
 import isPasswordValid from '../utils/password-validator';
 import ENV from 'mon-pix/config/environment';
 
-const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.';
+const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+
 const VALIDATION_MAP = {
   default: {
     status: 'default', message: null

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -9,7 +9,7 @@ const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'Votre prénom n’est pas renseigné.',
   lastName: 'Votre nom n’est pas renseigné.',
   email: 'Votre email n’est pas valide.',
-  password: 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.'
+  password: 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.'
 };
 const TEMPORARY_DIV_CLASS_MAP = {
   error: 'signup-form__temporary-msg--error',

--- a/mon-pix/app/utils/password-validator.js
+++ b/mon-pix/app/utils/password-validator.js
@@ -4,6 +4,6 @@ export default function isPasswordValid(password) {
   if (!password) {
     return false;
   }
-  const pattern = XRegExp('^(?=.*\\p{L})(?=.*\\d).{8,}$');
+  const pattern = XRegExp('^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$');
   return pattern.test(password);
 }

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -34,8 +34,7 @@ const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
 const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
-const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit comporter au moins une lettre, un chiffre et' +
-  ' 8 caractères.';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 const userEmpty = EmberObject.create({});
 const CAPTCHA_CONTAINER = '.signup-form__captcha-container';
@@ -397,7 +396,7 @@ describe('Integration | Component | signup form', function() {
         await render(hbs`{{signup-form user=user}}`);
 
         // when
-        await fillIn('#password', 'mypassword1');
+        await fillIn('#password', 'Mypassword1');
         await triggerEvent('#password', 'blur');
 
         // then

--- a/mon-pix/tests/unit/components/form-textfield-test.js
+++ b/mon-pix/tests/unit/components/form-textfield-test.js
@@ -4,8 +4,7 @@ import { setupTest } from 'ember-mocha';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
-const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit comporter au moins une lettre, un chiffre et' +
-  ' 8 caractères.';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 describe('Unit | Component | signupTextfieldComponent', function() {
 

--- a/mon-pix/tests/unit/components/reset-password-form-test.js
+++ b/mon-pix/tests/unit/components/reset-password-form-test.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit comporter au moins une lettre, un chiffre et 8 caractères.';
+const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 const VALIDATION_MAP = {
   default: {

--- a/mon-pix/tests/unit/utils/password-validator-test.js
+++ b/mon-pix/tests/unit/utils/password-validator-test.js
@@ -7,18 +7,23 @@ describe('Unit | Utility | password validator', function() {
   describe('Validation rules', function() {
 
     it('should contain at least 8 characters:', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
+      expect(isPasswordvalid('Ab123456')).to.be.true;
       expect(isPasswordvalid('A1')).to.be.false;
     });
 
-    it('should contain at least one letter ', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
-      expect(isPasswordvalid('12345678')).to.be.false;
+    it('should contain at least one digit', function() {
+      expect(isPasswordvalid('Ab123456')).to.be.true;
+      expect(isPasswordvalid('ABCDEFGH')).to.be.false;
     });
 
-    it('should contain at least one digit', function() {
-      expect(isPasswordvalid('ABCD1234')).to.be.true;
-      expect(isPasswordvalid('ABCDEFGH')).to.be.false;
+    it('should contain at least one uppercase letter', function() {
+      expect(isPasswordvalid('Ab123456')).to.be.true;
+      expect(isPasswordvalid('a1234567')).to.be.false;
+    });
+
+    it('should contain at least one lowercase letter', function() {
+      expect(isPasswordvalid('Ab123456')).to.be.true;
+      expect(isPasswordvalid('A1234567')).to.be.false;
     });
 
   });
@@ -34,7 +39,9 @@ describe('Unit | Utility | password validator', function() {
       'password',
       '12345678&',
       '+!@)-=`"#&',
-      '+!@)-=`"#&1'
+      '+!@)-=`"#&1',
+      '+!@)-=`"#&1A',
+      '+!@)-=`"#&1a'
     ].forEach(function(badPassword) {
       it(`should return false when password is invalid: ${badPassword}`, function() {
         expect(isPasswordvalid(badPassword)).to.be.false;
@@ -44,20 +51,20 @@ describe('Unit | Utility | password validator', function() {
 
   describe('Valid password', function() {
     [
-      'PIXBETA1',
-      'PIXBETA12',
-      'NULLNULL1',
-      '12345678a',
-      '12345678ab',
-      '12345678ab+',
-      '12345678ab+!',
-      '12345678ab+!@',
-      '12345678ab+!@)-=`',
-      '12345678ab+!@)-=`"',
-      '12345678ab+!@)-=`"#&',
+      'PIXBETa1',
+      'PIXBETa12',
+      'NULLNuLL1',
+      '1234567Aa',
+      '12345678Ab',
+      '12345678Ab+',
+      '12345678Ab+!',
+      '12345678Ab+!@',
+      '12345678Ab+!@)-=`',
+      '12345678Ab+!@)-=`"',
+      '12345678Ab+!@)-=`"#&',
       '1234Password avec espace',
-      '1A      A1',
-      'à1      ',
+      '1A      a1',
+      'Aà1      ',
     ].forEach(function(validPassword) {
       it(`should return true if provided password is valid: ${validPassword}`, function() {
         expect(isPasswordvalid(validPassword)).to.be.true;


### PR DESCRIPTION
## :unicorn: Problème
Afin de suivre les recommandations de la CNIL, le format des mots de passe doit être modifié.
Les nouvelles règles sont : 
- 8 caractères minimum, avec au moins un chiffre, une minuscule et une majuscule. 

## :robot: Solution
- Mise à jour du pattern regex
- Mise à jour les messages d’erreur de format de mot de passe
- Mise à jour l’email de reset password (template MAILJET en prod)