### PR TITLE
[FEATURE] Plafonner le score et le niveau lors d'une certification (PF-773).

### DIFF
--- a/api/lib/domain/models/UserCompetence.js
+++ b/api/lib/domain/models/UserCompetence.js
@@ -14,6 +14,7 @@ class UserCompetence {
     // attributes
     index,
     name,
+    area,
     // includes
     // references
   } = {}) {
@@ -21,6 +22,7 @@ class UserCompetence {
     // attributes
     this.index = index;
     this.name = name;
+    this.area = area;
     // includes
     this.skills = [];
     this.challenges = [];

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -101,10 +101,10 @@ function _getSumScoreFromCertifiedCompetences(listCompetences) {
 function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, reproductibilityRate, certificationChallenges, continueOnError) {
   return listCompetences.map((competence) => {
     const numberOfCorrectAnswers = _numberOfCorrectAnswersPerCompetence(answers, competence, certificationChallenges, continueOnError);
-    // TODO: Convertir ça en Mark ?
     return {
       name: competence.name,
       index: competence.index,
+      area_code: competence.area.code,
       id: competence.id,
       positionedLevel: competence.estimatedLevel,
       positionedScore: competence.pixScore,
@@ -117,10 +117,10 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
 
 function _getCompetenceWithFailedLevel(listCompetences) {
   return listCompetences.map((competence) => {
-    // TODO: Convertir ça en Mark ?
     return {
       name: competence.name,
       index: competence.index,
+      area_code: competence.area.code,
       id: competence.id,
       positionedLevel: competence.estimatedLevel,
       positionedScore: competence.pixScore,
@@ -183,7 +183,7 @@ async function _getTestedCompetences({ userId, limitDate, isV2Certification }) {
   }
   return _(userCompetences)
     .filter((uc) => uc.estimatedLevel > 0)
-    .map((uc) => _.pick(uc, ['id', 'index', 'name', 'estimatedLevel', 'pixScore']))
+    .map((uc) => _.pick(uc, ['id', 'area', 'index', 'name', 'estimatedLevel', 'pixScore']))
     .value();
 }
 

--- a/api/lib/domain/services/scoring/scoring-certification.js
+++ b/api/lib/domain/services/scoring/scoring-certification.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const AssessmentScore = require('../../models/AssessmentScore');
 const CompetenceMark = require('../../models/CompetenceMark');
+const { MAX_REACHABLE_LEVEL } = require('../../constants');
 const certificationService = require('../../services/certification-service');
 
 async function calculate(assessment) {
@@ -9,7 +10,7 @@ async function calculate(assessment) {
 
   const competenceMarks = competencesWithMark.map((certifiedCompetence) => {
     return new CompetenceMark({
-      level: certifiedCompetence.obtainedLevel,
+      level: Math.min(certifiedCompetence.obtainedLevel, MAX_REACHABLE_LEVEL),
       score: certifiedCompetence.obtainedScore,
       area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,

--- a/api/lib/domain/services/scoring/scoring-certification.js
+++ b/api/lib/domain/services/scoring/scoring-certification.js
@@ -24,12 +24,8 @@ async function calculate({ competenceRepository }, assessment) {
     });
   });
 
-  const competencesPixScore = competenceMarks.map((competenceMark) => competenceMark.score);
-
-  const nbPix = _.sum(competencesPixScore);
-
   return new AssessmentScore({
-    nbPix,
+    nbPix: _.sumBy(competenceMarks, 'score'),
     competenceMarks,
   });
 }

--- a/api/lib/domain/services/scoring/scoring-certification.js
+++ b/api/lib/domain/services/scoring/scoring-certification.js
@@ -1,8 +1,12 @@
-const _ = require('lodash');
+const {
+  MAX_REACHABLE_LEVEL,
+  MAX_REACHABLE_PIX_BY_COMPETENCE,
+} = require('../../constants');
+
 const AssessmentScore = require('../../models/AssessmentScore');
 const CompetenceMark = require('../../models/CompetenceMark');
-const { MAX_REACHABLE_LEVEL } = require('../../constants');
 const certificationService = require('../../services/certification-service');
+const _ = require('lodash');
 
 async function calculate(assessment) {
 
@@ -11,7 +15,7 @@ async function calculate(assessment) {
   const competenceMarks = competencesWithMark.map((certifiedCompetence) => {
     return new CompetenceMark({
       level: Math.min(certifiedCompetence.obtainedLevel, MAX_REACHABLE_LEVEL),
-      score: certifiedCompetence.obtainedScore,
+      score: Math.min(certifiedCompetence.obtainedScore, MAX_REACHABLE_PIX_BY_COMPETENCE),
       area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,
     });

--- a/api/lib/domain/services/scoring/scoring-certification.js
+++ b/api/lib/domain/services/scoring/scoring-certification.js
@@ -3,23 +3,15 @@ const AssessmentScore = require('../../models/AssessmentScore');
 const CompetenceMark = require('../../models/CompetenceMark');
 const certificationService = require('../../services/certification-service');
 
-async function calculate({ competenceRepository }, assessment) {
+async function calculate(assessment) {
 
-  const [competences, { competencesWithMark }] = await Promise.all([
-    competenceRepository.list(),
-    certificationService.calculateCertificationResultByAssessmentId(assessment.id)
-  ]);
+  const { competencesWithMark } = await certificationService.calculateCertificationResultByAssessmentId(assessment.id);
 
   const competenceMarks = competencesWithMark.map((certifiedCompetence) => {
-
-    const area_code = competences.find((competence) => {
-      return competence.index === certifiedCompetence.index;
-    }).area.code;
-
     return new CompetenceMark({
       level: certifiedCompetence.obtainedLevel,
       score: certifiedCompetence.obtainedScore,
-      area_code,
+      area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,
     });
   });

--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -13,7 +13,7 @@ async function calculateAssessmentScore(dependencies, assessment) {
   }
 
   if (assessment.isCertification()) {
-    return scoringCertification.calculate(dependencies, assessment);
+    return scoringCertification.calculate(assessment);
   }
 }
 

--- a/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
+++ b/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
@@ -118,11 +118,6 @@ function _setAssessmentResultIdOnMark(mark, assessmentResultId) {
 }
 
 function _ceilCompetenceMarkLevelForCertification(mark, assessment) {
-  /*
-   * XXX une certification ne peut pas avoir une compétence en base au dessus de niveau 5;
-   * par contre le reste de l'algorithme peut avoir des niveaux au-dessus, et l'on ne plafonnera pas pour les
-   * autres Assessments (par exemple Placements).
-   */
   if (assessment.type === Assessment.types.CERTIFICATION) {
     mark.level = Math.min(mark.level, COMPETENCE_MAX_LEVEL_FOR_CERTIFICATION);
   }

--- a/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
+++ b/api/lib/domain/usecases/create-assessment-result-for-completed-assessment.js
@@ -82,14 +82,9 @@ async function _saveAssessmentResult({
   // Services
 }) {
   const assessmentResult = await _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository });
+  await assessmentRepository.completeByAssessmentId(assessment.id);
+  await _saveCompetenceMarks({ assessmentResult, competenceMarks: assessmentScore.competenceMarks, assessment, competenceMarkRepository });
 
-  const [savedAssessmentResult, competenceMarks] = await Promise.all([
-    assessmentResultRepository.save(assessmentResult),
-    assessmentScore.competenceMarks,
-    assessmentRepository.updateStateById({ id: assessment.id, state: Assessment.states.COMPLETED }),
-  ]);
-
-  await _saveCompetenceMarks({ assessmentResult: savedAssessmentResult, competenceMarks, assessment, competenceMarkRepository });
   return _updateCompletedDateOfCertification(assessment, certificationCourseRepository, updateCertificationCompletionDate);
 }
 
@@ -160,7 +155,7 @@ function _saveResultAfterComputingError({
 
   return Promise.all([
     assessmentResultRepository.save(assessmentResult),
-    assessmentRepository.updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }),
+    assessmentRepository.completeByAssessmentId(assessmentId),
   ])
     .then(() => _updateCompletedDateOfCertification(assessment, certificationCourseRepository, updateCertificationCompletionDate));
 }

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -131,6 +131,10 @@ module.exports = {
       .then((bookshelfAssessmentCollection) => bookshelfAssessmentCollection.length > 0);
   },
 
+  completeByAssessmentId(assessmentId) {
+    return this.updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED });
+  },
+
   updateStateById({ id, state }) {
     return BookshelfAssessment
       .where({ id })

--- a/api/tests/integration/domain/services/scoring/scoring-certification_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-certification_test.js
@@ -1,37 +1,22 @@
 const { expect, domainBuilder, sinon } = require('../../../../test-helper');
 const Assessment = require('../../../../../lib/domain/models/Assessment');
 const certificationService = require('../../../../../lib/domain/services/certification-service');
-const competenceRepository = require('../../../../../lib/infrastructure/repositories/competence-repository');
 const scoringCertification = require('../../../../../lib/domain/services/scoring/scoring-certification');
 
 describe('Integration | Domain | services | scoring | scoring-certification', () => {
 
   describe('#calculate', () => {
 
-    const COURSE_ID = 123;
-    const COMPETENCE_ID_1_1 = 'competence_id_1_1';
-    const COMPETENCE_ID_1_2 = 'competence_id_1_2';
-    const ASSESSMENT_ID = 836;
+    const courseId = 123;
+    const assessmentId = 836;
 
-    const skill_web1 = domainBuilder.buildSkill({ id: 'web1', name: '@web1' });
-    const skill_web2 = domainBuilder.buildSkill({ id: 'web2', name: '@web2' });
-    const skill_url1 = domainBuilder.buildSkill({ id: 'url1', name: '@url1' });
-    const skill_url4 = domainBuilder.buildSkill({ id: 'url4', name: '@url4' });
-
-    const competence_1_1 = domainBuilder.buildCompetence({ id: COMPETENCE_ID_1_1, index: '1.1', area: { code: 'area_1' }, skills: [skill_web1, skill_web2] });
-    const competence_1_2 = domainBuilder.buildCompetence({ id: COMPETENCE_ID_1_2, index: '1.2', area: { code: 'area_1' }, skills: [skill_url1, skill_url4] });
-    const competences = [competence_1_1, competence_1_2];
-
-    const competenceWithMark_1_1 = { index: competence_1_1.index, obtainedLevel: 0, obtainedScore: 4 };
-    const competenceWithMark_1_2 = { index: competence_1_2.index, obtainedLevel: 1, obtainedScore: 8 };
+    const competenceWithMark_1_1 = { index: '1.1', obtainedLevel: 0, obtainedScore: 4, area_code: '1', };
+    const competenceWithMark_1_2 = { index: '1.2', obtainedLevel: 1, obtainedScore: 8, area_code: '2', };
     const competencesWithMark = [competenceWithMark_1_1, competenceWithMark_1_2];
 
-    const assessment = domainBuilder.buildAssessment({ id: ASSESSMENT_ID, type: Assessment.types.PLACEMENT, courseId: COURSE_ID });
-
-    const dependencies = { competenceRepository };
+    const assessment = domainBuilder.buildAssessment({ id: assessmentId, type: Assessment.types.PLACEMENT, courseId });
 
     beforeEach(() => {
-      sinon.stub(competenceRepository, 'list').resolves(competences);
       sinon.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves({ competencesWithMark });
     });
 
@@ -42,7 +27,7 @@ describe('Integration | Domain | services | scoring | scoring-certification', ()
         certificationService.calculateCertificationResultByAssessmentId.rejects(new Error('Error from certificationService'));
 
         // when
-        const promise = scoringCertification.calculate(dependencies, assessment);
+        const promise = scoringCertification.calculate(assessment);
 
         // then
         return expect(promise).to.have.been.rejectedWith(Error, 'Error from certificationService');
@@ -59,14 +44,14 @@ describe('Integration | Domain | services | scoring | scoring-certification', ()
         competenceMarks: [{
           id: undefined,
           assessmentResultId: undefined,
-          'area_code': 'area_1',
+          'area_code': '1',
           'competence_code': '1.1',
           level: 0,
           score: 4
         }, {
           id: undefined,
           assessmentResultId: undefined,
-          'area_code': 'area_1',
+          'area_code': '2',
           'competence_code': '1.2',
           level: 1,
           score: 8
@@ -74,7 +59,7 @@ describe('Integration | Domain | services | scoring | scoring-certification', ()
       };
 
       // when
-      const assessmentScore = await scoringCertification.calculate(dependencies, assessment);
+      const assessmentScore = await scoringCertification.calculate(assessment);
 
       // then
       expect(assessmentScore).to.deep.equal(expectedAssessmentScore);

--- a/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
+++ b/api/tests/integration/domain/services/user-service_get-profile-to-certify_test.js
@@ -23,11 +23,12 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
 
   const answerCollectionWithEmptyData = [];
 
-  function _createCompetence(id, index, name) {
+  function _createCompetence(id, index, name, areaCode) {
     const competence = new Competence();
     competence.id = id;
     competence.index = index;
     competence.name = name;
+    competence.area = { code: areaCode };
 
     return competence;
   }
@@ -53,8 +54,8 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
   const skillSearch1 = new Skill({ id: 90, name: '@url1' });
   const skillWithoutChallenge = new Skill({ id: 100, name: '@oldSKill8' });
 
-  const competenceFlipper = _createCompetence('competenceRecordIdOne', '1.1', '1.1 Construire un flipper');
-  const competenceDauphin = _createCompetence('competenceRecordIdTwo', '1.2', '1.2 Adopter un dauphin');
+  const competenceFlipper = _createCompetence('competenceRecordIdOne', '1.1', '1.1 Construire un flipper', '1');
+  const competenceDauphin = _createCompetence('competenceRecordIdTwo', '1.2', '1.2 Adopter un dauphin', '1');
 
   const challengeForSkillCollaborer4 = _createChallenge('challengeRecordIdThree', 'competenceRecordIdThatDoesNotExistAnymore', [skillCollaborer4], '@collaborer4');
 
@@ -180,6 +181,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -189,6 +191,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir2],
               pixScore: 23,
@@ -232,6 +235,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [],
                   pixScore: 2,
@@ -263,6 +267,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
               expect(skillProfile).to.deep.equal([{
                 id: 'competenceRecordIdOne',
                 index: '1.1',
+                area: { code: '1' },
                 name: '1.1 Construire un flipper',
                 pixScore: 12,
                 estimatedLevel: 1,
@@ -271,6 +276,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
               }, {
                 id: 'competenceRecordIdTwo',
                 index: '1.2',
+                area: { code: '1' },
                 name: '1.2 Adopter un dauphin',
                 pixScore: 23,
                 estimatedLevel: 2,
@@ -300,6 +306,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [],
                   pixScore: 12,
@@ -309,6 +316,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [skillRemplir2],
                   pixScore: 23,
@@ -338,6 +346,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [skillCitation4],
                   pixScore: 12,
@@ -347,6 +356,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [],
                   pixScore: 23,
@@ -374,6 +384,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [skillCitation4, skillRecherche4, skillMoteur3],
                   pixScore: 12,
@@ -383,6 +394,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [],
                   pixScore: 23,
@@ -415,6 +427,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [skillRecherche4],
               pixScore: 12,
@@ -424,6 +437,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillUrl3, skillRemplir2],
               pixScore: 23,
@@ -452,6 +466,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -461,6 +476,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir4, skillUrl3, skillRemplir2],
               pixScore: 23,
@@ -491,6 +507,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -500,6 +517,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir4, skillUrl3, skillRemplir2],
               pixScore: 23,
@@ -527,6 +545,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -536,6 +555,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir2],
               pixScore: 23,
@@ -562,6 +582,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -571,6 +592,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [],
               pixScore: 23,
@@ -597,6 +619,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 12,
@@ -606,6 +629,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [],
               pixScore: 23,
@@ -696,6 +720,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
           {
             id: 'competenceRecordIdOne',
             index: '1.1',
+            area: { code: '1' },
             name: '1.1 Construire un flipper',
             skills: [],
             pixScore: 0,
@@ -705,6 +730,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
           {
             id: 'competenceRecordIdTwo',
             index: '1.2',
+            area: { code: '1' },
             name: '1.2 Adopter un dauphin',
             skills: [],
             pixScore: 0,
@@ -815,6 +841,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 4,
@@ -960,6 +987,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
               expect(skillProfile).to.deep.equal([{
                 id: 'competenceRecordIdOne',
                 index: '1.1',
+                area: { code: '1' },
                 name: '1.1 Construire un flipper',
                 pixScore: 0,
                 estimatedLevel: 0,
@@ -968,6 +996,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
               }, {
                 id: 'competenceRecordIdTwo',
                 index: '1.2',
+                area: { code: '1' },
                 name: '1.2 Adopter un dauphin',
                 pixScore: 23,
                 estimatedLevel: 2,
@@ -1006,6 +1035,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [],
                   pixScore: 0,
@@ -1015,6 +1045,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [skillRemplir2],
                   pixScore: 23,
@@ -1053,6 +1084,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [skillCitation4],
                   pixScore: 12,
@@ -1062,6 +1094,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [],
                   pixScore: 0,
@@ -1116,6 +1149,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdOne',
                   index: '1.1',
+                  area: { code: '1' },
                   name: '1.1 Construire un flipper',
                   skills: [skillCitation4, skillRecherche4, skillMoteur3],
                   pixScore: 12,
@@ -1125,6 +1159,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
                 {
                   id: 'competenceRecordIdTwo',
                   index: '1.2',
+                  area: { code: '1' },
                   name: '1.2 Adopter un dauphin',
                   skills: [],
                   pixScore: 0,
@@ -1183,6 +1218,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [skillRecherche4],
               pixScore: 12,
@@ -1192,6 +1228,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillUrl3, skillRemplir2],
               pixScore: 8,
@@ -1244,6 +1281,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 0,
@@ -1253,6 +1291,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir4, skillUrl3, skillRemplir2],
               pixScore: 23,
@@ -1314,6 +1353,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 0,
@@ -1323,6 +1363,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [skillRemplir4, skillUrl3, skillRemplir2],
               pixScore: 16,
@@ -1360,6 +1401,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 0,
@@ -1369,6 +1411,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [],
               pixScore: 4,
@@ -1408,6 +1451,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdOne',
               index: '1.1',
+              area: { code: '1' },
               name: '1.1 Construire un flipper',
               skills: [],
               pixScore: 0,
@@ -1417,6 +1461,7 @@ describe('Integration | Service | User Service | #getProfileToCertify', function
             {
               id: 'competenceRecordIdTwo',
               index: '1.2',
+              area: { code: '1' },
               name: '1.2 Adopter un dauphin',
               skills: [],
               pixScore: 0,

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -115,12 +115,12 @@ const challenges = _.map([
   { challengeId: 'challenge_L_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeL_4' },
 ], domainBuilder.buildCertificationChallenge);
 
-const competence_1 = domainBuilder.buildCompetence({ id: 'competence_1', index: '1.1', name: 'Mener une recherche', courseId: 'competence_1' });
-const competence_2 = domainBuilder.buildCompetence({ id: 'competence_2', index: '2.2', name: 'Partager', courseId: 'competence_2' });
-const competence_3 = domainBuilder.buildCompetence({ id: 'competence_3', index: '3.3', name: 'Adapter', courseId: 'competence_3' });
-const competence_4 = domainBuilder.buildCompetence({ id: 'competence_4', index: '4.4', name: 'Résoudre', courseId: 'competence_4' });
-const competence_5 = domainBuilder.buildCompetence({ id: 'competence_5', index: '5.5', name: 'Chercher', courseId: 'competence_5' });
-const competence_6 = domainBuilder.buildCompetence({ id: 'competence_6', index: '6.6', name: 'Trouver', courseId: 'competence_6' });
+const competence_1 = domainBuilder.buildCompetence({ id: 'competence_1', index: '1.1', area: { code: '1' }, name: 'Mener une recherche', courseId: 'competence_1' });
+const competence_2 = domainBuilder.buildCompetence({ id: 'competence_2', index: '2.2', area: { code: '2' }, name: 'Partager', courseId: 'competence_2' });
+const competence_3 = domainBuilder.buildCompetence({ id: 'competence_3', index: '3.3', area: { code: '3' }, name: 'Adapter', courseId: 'competence_3' });
+const competence_4 = domainBuilder.buildCompetence({ id: 'competence_4', index: '4.4', area: { code: '4' }, name: 'Résoudre', courseId: 'competence_4' });
+const competence_5 = domainBuilder.buildCompetence({ id: 'competence_5', index: '5.5', area: { code: '5' }, name: 'Chercher', courseId: 'competence_5' });
+const competence_6 = domainBuilder.buildCompetence({ id: 'competence_6', index: '6.6', area: { code: '6' }, name: 'Trouver', courseId: 'competence_6' });
 const competencesFromAirtable = [ competence_1, competence_2, competence_3, competence_4, competence_5, competence_6 ];
 
 const userCompetences = [
@@ -258,6 +258,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -266,6 +267,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -274,6 +276,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -282,6 +285,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -332,6 +336,7 @@ describe('Unit | Service | Certification Result Service', function() {
           const expectedCertifiedCompetences = [
             {
               index: '1.1',
+              area_code: '1',
               id: 'competence_1',
               name: 'Mener une recherche',
               obtainedLevel: 1,
@@ -340,6 +345,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence1,
             }, {
               index: '2.2',
+              area_code: '2',
               id: 'competence_2',
               name: 'Partager',
               obtainedLevel: 2,
@@ -348,6 +354,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence2,
             }, {
               index: '3.3',
+              area_code: '3',
               id: 'competence_3',
               name: 'Adapter',
               obtainedLevel: 3,
@@ -356,6 +363,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence3,
             }, {
               index: '4.4',
+              area_code: '4',
               id: 'competence_4',
               name: 'Résoudre',
               obtainedLevel: 4,
@@ -392,6 +400,7 @@ describe('Unit | Service | Certification Result Service', function() {
           answersRepository.findByAssessment.resolves(answersToHaveOnlyTheLastCompetenceFailed());
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: 1,
@@ -400,6 +409,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence1,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: 2,
@@ -408,6 +418,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: 3,
@@ -416,6 +427,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence3,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -459,6 +471,7 @@ describe('Unit | Service | Certification Result Service', function() {
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: 0,
@@ -467,6 +480,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence1 - malusForFalseAnswer,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: 2,
@@ -475,6 +489,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -484,6 +499,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: 3,
@@ -506,6 +522,7 @@ describe('Unit | Service | Certification Result Service', function() {
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: 0,
@@ -514,6 +531,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence1 - malusForFalseAnswer,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: 2,
@@ -522,6 +540,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             positionedLevel: 3,
@@ -531,6 +550,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: 3,
@@ -773,6 +793,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -782,6 +803,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -791,6 +813,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -800,6 +823,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -854,6 +878,7 @@ describe('Unit | Service | Certification Result Service', function() {
           const expectedCertifiedCompetences = [
             {
               index: '1.1',
+              area_code: '1',
               id: 'competence_1',
               name: 'Mener une recherche',
               obtainedLevel: 1,
@@ -862,6 +887,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence1,
             }, {
               index: '2.2',
+              area_code: '2',
               id: 'competence_2',
               name: 'Partager',
               obtainedLevel: 2,
@@ -870,6 +896,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence2,
             }, {
               index: '3.3',
+              area_code: '3',
               id: 'competence_3',
               name: 'Adapter',
               obtainedLevel: 3,
@@ -878,6 +905,7 @@ describe('Unit | Service | Certification Result Service', function() {
               obtainedScore: pixForCompetence3,
             }, {
               index: '4.4',
+              area_code: '4',
               id: 'competence_4',
               name: 'Résoudre',
               obtainedLevel: 4,
@@ -914,6 +942,7 @@ describe('Unit | Service | Certification Result Service', function() {
           answersRepository.findByAssessment.resolves(answersToHaveOnlyTheLastCompetenceFailed());
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: 1,
@@ -922,6 +951,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence1,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: 2,
@@ -930,6 +960,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: 3,
@@ -938,6 +969,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence3,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -981,6 +1013,7 @@ describe('Unit | Service | Certification Result Service', function() {
           const malusForFalseAnswer = 8;
           const expectedCertifiedCompetences = [{
             index: '1.1',
+            area_code: '1',
             id: 'competence_1',
             name: 'Mener une recherche',
             obtainedLevel: 0,
@@ -989,6 +1022,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence1 - malusForFalseAnswer,
           }, {
             index: '2.2',
+            area_code: '2',
             id: 'competence_2',
             name: 'Partager',
             obtainedLevel: 2,
@@ -997,6 +1031,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: pixForCompetence2,
           }, {
             index: '3.3',
+            area_code: '3',
             id: 'competence_3',
             name: 'Adapter',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -1005,6 +1040,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 0,
           }, {
             index: '4.4',
+            area_code: '4',
             id: 'competence_4',
             name: 'Résoudre',
             obtainedLevel: 3,
@@ -1070,6 +1106,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
           const expectedCertifiedCompetences = [{
             index: '5.5',
+            area_code: '5',
             id: 'competence_5',
             name: 'Chercher',
             obtainedLevel: 5,
@@ -1078,6 +1115,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 50,
           }, {
             index: '6.6',
+            area_code: '6',
             id: 'competence_6',
             name: 'Trouver',
             obtainedLevel: UNCERTIFIED_LEVEL,
@@ -1108,6 +1146,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
           const expectedCertifiedCompetences = [{
             index: '5.5',
+            area_code: '5',
             id: 'competence_5',
             name: 'Chercher',
             obtainedLevel: 4,
@@ -1116,6 +1155,7 @@ describe('Unit | Service | Certification Result Service', function() {
             obtainedScore: 42,
           }, {
             index: '6.6',
+            area_code: '6',
             id: 'competence_6',
             name: 'Trouver',
             obtainedLevel: 2,

--- a/api/tests/unit/domain/services/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring-service_test.js
@@ -67,7 +67,7 @@ describe('Unit | Service | scoring-service', () => {
         await scoringService.calculateAssessmentScore(dependencies, assessment);
 
         // then
-        expect(scoringCertification.calculate).to.have.been.calledWith(dependencies, assessment);
+        expect(scoringCertification.calculate).to.have.been.calledWith(assessment);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -101,8 +101,8 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
       domainBuilder.buildCompetenceMark({
         competence_code: '3.1',
         area_code: '3',
-        level: 6,
-        score: 52,
+        level: 5,
+        score: 42,
       }),
     ];
 
@@ -575,7 +575,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
             assessmentResultId: assessmentResultId,
             competence_code: '3.1',
             level: 5,
-            score: 52,
+            score: 42,
           });
         });
       });

--- a/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-result-for-completed-assessment_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
   };
   const assessmentRepository = {
     get: () => undefined,
-    updateStateById: () => undefined,
+    completeByAssessmentId: () => undefined,
   };
   const assessmentResultRepository = {
     save: () => undefined,
@@ -139,7 +139,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
     };
 
     sinon.stub(scoringService, 'calculateAssessmentScore').resolves(assessmentScore);
-    sinon.stub(assessmentRepository, 'updateStateById').resolves({ ...assessment, state: Assessment.states.COMPLETED });
+    sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves({ ...assessment, state: Assessment.states.COMPLETED });
     sinon.stub(assessmentResultRepository, 'save').resolves({ id: assessmentResultId });
     sinon.stub(assessmentRepository, 'get').resolves(assessment);
     sinon.stub(courseRepository, 'get').resolves(course);
@@ -257,7 +257,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
     // then
     return promise.then(() => {
-      expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
+      expect(assessmentRepository.completeByAssessmentId).to.have.been.calledWith(assessmentId);
     });
   });
 
@@ -625,7 +625,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
         // then
         return promise.then(() => {
-          expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
+          expect(assessmentRepository.completeByAssessmentId).to.have.been.calledWith(assessmentId);
         });
       });
 
@@ -716,7 +716,7 @@ describe('Unit | UseCase | create-assessment-result-for-completed-certification'
 
         // then
         return promise.then(() => {
-          expect(assessmentRepository.updateStateById).to.have.been.calledWith({ id: assessmentId, state: Assessment.states.COMPLETED });
+          expect(assessmentRepository.completeByAssessmentId).to.have.been.calledWith(assessmentId);
         });
       });
 


### PR DESCRIPTION
## 🐙 Problème
Le score et le niveau par compétence a récemment été plafonné, côté parcours d'évaluation. On souhaiterait avoir le même plafonnement pour les certifications futures, sans impacter les certifications existantes.

## 🔥 Solution
À l'heure actuelle, le résultat d'une certification est enregistré dans la table `competence-marks`, ainsi que `assessment-result`, en mode "append-only". On décide ainsi de stocker le score plafonné afin d'avoir un vrai _snapshot_ intemporel comme requis par le métier.

Cela signifie que pour l'instant, **on ne peut pas** obtenir l'information du scoring plafonné et non-plafonné. Si le besoin s'en fait sentir, cela pourra faire l'objet d'une autre PR.

## :rainbow: Remarques
Tous les premiers `commit` sont des `commits` de bsr. Les deux seuls `commits` fonctionnels sont : 
- https://github.com/1024pix/pix/commit/01d9a30fd753f1e67fb48aa5493db34edf10dcb4où on déplace la logique de plafonnement qui était déjà présente mais seulement sur le niveau, à un endroit plus proche d'où le calcul s'opère. 
- https://github.com/1024pix/pix/commit/f66bb85713a3b6d8e5841d7f19ac04958a9d810c Le plafonnement en question du nombre de pix
