### PR TITLE
[BUGFIX] Problème d'affichage de l'oeil lorsque l'utilisateur souhaite continuer d'écrire (PF-807).

### DIFF
--- a/certif/tests/integration/components/login-form-test.js
+++ b/certif/tests/integration/components/login-form-test.js
@@ -71,14 +71,39 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message').hasText('L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
   });
 
-  test('it should display password when user click', async function(assert) {
-    // given
-    await render(hbs`{{login-form}});`);
+  module('when password is hidden', function(hooks) {
 
-    // when
-    assert.dom('#login-password').hasAttribute('type','password');
-    await click('.login-form__icon');
-    assert.dom('#login-password').hasAttribute('type', 'text');
+    hooks.beforeEach(async function() {
+      // given
+      await render(hbs`{{login-form}});`);
+    });
+
+    test('it should display password when user click', async function(assert) {
+      // when
+      await click('.login-form__icon');
+
+      // then
+      assert.dom('#login-password').hasAttribute('type', 'text');
+    });
+
+    test('it should change icon when user click on it', async function(assert) {
+      // when
+      await click('.login-form__icon');
+
+      // then
+      assert.dom('.fa-eye').exists();
+    });
+
+    test('it should not change icon when user keeps typing his password', async function(assert) {
+      // given
+      await fillIn('#login-password', 'début du mot de passe');
+
+      // when
+      await click('.login-form__icon');
+      await fillIn('#login-password', 'fin du mot de passe');
+
+      // then
+      assert.dom('.fa-eye').exists();
+    });
   });
-
 });

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -36,9 +36,9 @@ export default Component.extend({
 
   onValidate: () => {},
 
-  textfieldType: computed('textfieldName', function() {
+  textfieldType: computed('textfieldName', 'isPasswordVisible',  function() {
     if (this.textfieldName === 'password') {
-      return 'password';
+      return this.isPasswordVisible ? 'text' : 'password';
     }
     if (this.textfieldName === 'email') {
       return 'email';
@@ -77,7 +77,6 @@ export default Component.extend({
   actions: {
     togglePasswordVisibility() {
       this.toggleProperty('isPasswordVisible');
-      this.set('textfieldType', this.textfieldType === 'password' ? 'text' : 'password');
     }
   }
 });

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -94,6 +94,7 @@
   height: 20px;
   margin: 6px 8px;
   border: none;
+  background: none;
 
   &:focus {
     border-radius: 10px;

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -33,7 +33,6 @@
       {{form-textfield
         label="Mot de passe"
         textfieldName="password"
-        textfieldType="password"
         validationStatus="default"
         inputBindingValue=password
         autocomplete="current-password"}}

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -57,7 +57,6 @@
       {{form-textfield
         label="Mot de passe"
         textfieldName="password"
-        textfieldType="password"
         validationStatus=validation.password.status
         onValidate=(action "validateInputPassword")
         inputBindingValue=user.password
@@ -100,7 +99,7 @@
       Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix
       pour permettre l'accès au service offert par Pix.
       Elles sont conservées pendant une durée de 5 ans maximum à compter du dernier accès au compte utilisateur,
-      et archivées selon les délais de prescription légale (5 ans). 
+      et archivées selon les délais de prescription légale (5 ans).
       Elles sont destinées à Pix et à ses prestataires techniques exclusivement.
       Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à dpd@pix.fr.
     </div>

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -180,22 +180,45 @@ describe('Integration | Component | form textfield', function() {
     });
   });
 
-  describe('#When type is password it\'s possible to show this', function() {
+  describe('#When password is hidden', function() {
     this.beforeEach(async function() {
       this.set('label', 'Mot de passe');
       this.set('validationStatus', 'default');
       this.set('validationMessage', '');
       this.set('textfieldName', 'password');
 
-      // When
+      // given
       await render(hbs`{{form-textfield label=label validationStatus=validationStatus validationMessage=validationMessage textfieldName=textfieldName value=inputValue}}`);
     });
 
     it('should change type when user click on eye icon', async function() {
-      //then
-      expect(find('input').getAttribute('type')).to.equal('password');
+      // when
       await click('.form-textfield__icon');
+
+      // then
       expect(find('input').getAttribute('type')).to.equal('text');
+    });
+
+    it('should change icon when user click on it', async function() {
+      // when
+      expect(find('.fa-eye-slash')).to.exist;
+      await click('.form-textfield__icon');
+
+      // then
+      expect(find('.fa-eye')).to.exist;
+    });
+
+    it('should not change icon when user keeps typing his password', async function() {
+      // given
+      await fillIn(INPUT, 'test');
+
+      // when
+      expect(find('.fa-eye-slash')).to.exist;
+      await click('.form-textfield__icon');
+      await fillIn(INPUT, 'test');
+
+      // then
+      expect(find('.fa-eye')).to.exist;
     });
   });
 });

--- a/orga/tests/integration/components/login-form-test.js
+++ b/orga/tests/integration/components/login-form-test.js
@@ -71,14 +71,39 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message').hasText('L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
   });
 
-  test('it should display password when user click', async function(assert) {
-    // given
-    await render(hbs`{{login-form}});`);
+  module('when password is hidden', function(hooks) {
 
-    // when
-    assert.dom('#login-password').hasAttribute('type','password');
-    await click('.login-form__icon');
-    assert.dom('#login-password').hasAttribute('type', 'text');
+    hooks.beforeEach(async function() {
+      // given
+      await render(hbs`{{login-form}});`);
+    });
+
+    test('it should display password when user click', async function(assert) {
+      // when
+      await click('.login-form__icon');
+
+      // then
+      assert.dom('#login-password').hasAttribute('type', 'text');
+    });
+
+    test('it should change icon when user click on it', async function(assert) {
+      // when
+      await click('.login-form__icon');
+
+      // then
+      assert.dom('.fa-eye').exists();
+    });
+
+    test('it should not change icon when user keeps typing his password', async function(assert) {
+      // given
+      await fillIn('#login-password', 'début du mot de passe');
+
+      // when
+      await click('.login-form__icon');
+      await fillIn('#login-password', 'fin du mot de passe');
+
+      // then
+      assert.dom('.fa-eye').exists();
+    });
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur tape son mot de passe, appuie sur l'oeil puis continue de taper, l'icône de l'oeil n'était pas le bon.

## :robot: Solution
Résoudre le problème de surcharge de la computed de `textfieldType`.

