### PR TITLE
[FEATURE] Afficher une information RGPD lors de la création d'une Campagne avec Identifiant externe (PO-223).

### DIFF
--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -25,6 +25,7 @@
 @import "pages/authenticated/campaigns";
 @import "pages/authenticated/campaigns/details";
 @import "pages/authenticated/campaigns/new";
+@import "pages/authenticated/campaigns/new-item";
 @import "pages/authenticated/campaigns/list";
 @import "pages/authenticated/campaigns/no-campaign-panel";
 @import "pages/authenticated/campaigns/details/parameters";

--- a/orga/app/styles/pages/authenticated/campaigns/new-item.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/new-item.scss
@@ -1,0 +1,6 @@
+.new-item-form {
+  &__gdpr-information {
+    margin-top: 50px;
+    text-align: justify;
+  }
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -68,7 +68,7 @@
           </div>
         {{/each}}
         <div class="form__information help-text">
-          Exemple: "Numéro de l'étudiant" ou "Adresse mail professionnelle"
+          Exemple: "Numéro de l'étudiant" ou "Adresse mail professionnelle" *
         </div>
 
       </div>
@@ -101,5 +101,11 @@
     <div class="button button--no-color" {{action cancel}}>Annuler</div>
     <button class="button" type="submit">Créer la campagne</button>
   </div>
+
+ {{#if wantIdPix}}
+   <div class="new-item-form__gdpr-information help-text">
+    * En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.
+   </div>
+ {{/if}}
 
 </form>

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -41,6 +41,26 @@ module('Acceptance | Campaign Creation', function(hooks) {
       assert.dom('.page__title').hasText('Création d\'une campagne');
     });
 
+    test('it should not display gdpr footnote', async function(assert) {
+      // when
+      await visit('/campagnes/creation');
+
+      // then
+      assert.dom('.new-item-form__gdpr-information').isNotVisible();
+    });
+
+    test('it should display gdpr footnote', async function(assert) {
+      // when
+      await visit('/campagnes/creation');
+      await click('#askLabelIdPix');
+
+      // then
+      assert.dom('.new-item-form__gdpr-information').isVisible();
+      assert.dom('.new-item-form__gdpr-information').hasText(
+        '* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.'
+      );
+    });
+
     test('it should allow to create a campaign and redirect to the newly created campaign', async function(assert) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;


### PR DESCRIPTION
## :unicorn: Problème
Rappel RGPD pour la création d'une campagne, si un identifiant externe sera demandé.

## :robot: Solution
Ajouter en bas de page le texte suivant : 
* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.