### PR TITLE
[FEATURE] Afficher un warning lorsqu'une modification jury est illégale (PF-811).

### DIFF
--- a/admin/app/controllers/authenticated/certifications/single/details.js
+++ b/admin/app/controllers/authenticated/certifications/single/details.js
@@ -33,30 +33,10 @@ export default Controller.extend({
 
     onUpdateRate() {
       const competences = this.get('details.competences');
-      let jury = false;
-      const answersData = competences.reduce((data, competence) => {
-        if (competence.answers) {
-          competence.answers.forEach((answer) => {
-            if (answer.jury) {
-              if (answer.jury === 'ok') {
-                data.good++;
-              }
-              if (answer.jury !== 'skip') {
-                data.count++;
-              }
-              jury = true;
-            } else {
-              data.count++;
-              if (answer.result === 'ok') {
-                data.good++;
-              }
-            }
-          });
-        }
-        return data;
-      }, { count: 0, good: 0 });
+      const { good, count, jury } = _getCertificationResultsAfterJuryUpdate(competences);
+
       if (jury) {
-        this.set('juryRate', Math.round(answersData.good * 10000 / answersData.count) / 100);
+        this.set('juryRate', Math.round(good * 10000 / count) / 100);
       } else {
         this.set('juryRate', false);
       }
@@ -90,3 +70,27 @@ export default Controller.extend({
     }
   }
 });
+
+function _getCertificationResultsAfterJuryUpdate(competences) {
+  return competences.reduce((data, competence) => {
+    if (competence.answers) {
+      competence.answers.forEach((answer) => {
+        if (answer.jury) {
+          if (answer.jury === 'ok') {
+            data.good++;
+          }
+          if (answer.jury !== 'skip') {
+            data.count++;
+          }
+          data.jury = true;
+        } else {
+          data.count++;
+          if (answer.result === 'ok') {
+            data.good++;
+          }
+        }
+      });
+    }
+    return data;
+  }, { count: 0, good: 0, jury: false });
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -35,3 +35,4 @@
 @import 'components/certification-session-report';
 @import 'components/certification-select';
 @import 'components/certification-list';
+@import 'components/confirm-popup';

--- a/admin/app/styles/components/confirm-popup.scss
+++ b/admin/app/styles/components/confirm-popup.scss
@@ -1,0 +1,5 @@
+.confirm-popup__errors {
+  white-space: pre;
+  color: red;
+  font-weight: bold;
+}

--- a/admin/app/templates/authenticated/certifications/single/info.hbs
+++ b/admin/app/templates/authenticated/certifications/single/info.hbs
@@ -97,6 +97,11 @@
       </div>
     </div>
   {{/if}}
-  {{confirm-popup message=confirmMessage confirm=(action confirmAction) cancel=(action "onCancelConfirm")
-                  show=displayConfirm}}
+  {{confirm-popup
+    message=confirmMessage
+    error=confirmErrorMessage
+    confirm=(action confirmAction)
+    cancel=(action "onCancelConfirm")
+    show=displayConfirm
+  }}
 </div>

--- a/admin/app/templates/components/confirm-popup.hbs
+++ b/admin/app/templates/components/confirm-popup.hbs
@@ -8,5 +8,6 @@
   position="center"
   onSubmit=(action confirm)
   onHide=(action cancel)}}
-  {{message}}
+  <p>{{message}}</p>
+  <p class="confirm-popup__errors">{{error}}</p>
 {{/bs-modal-simple}}

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -42,29 +42,18 @@ module.exports = {
       lastAssessmentResultFull = await assessmentResultRepository.get(lastAssessmentResult.id);
     }
 
+    // TODO: Back this unnamed composite object with a real domain object
+    // TODO: model and do the necessary adjustements in PixAdmin.
     return {
-      level: lastAssessmentResultFull.level,
-      certificationId: certification.id,
-      assessmentId: assessment ? assessment.id : null,
-      emitter: lastAssessmentResultFull.emitter,
-      commentForJury: lastAssessmentResultFull.commentForJury,
-      commentForCandidate: lastAssessmentResultFull.commentForCandidate,
-      commentForOrganization: lastAssessmentResultFull.commentForOrganization,
-      status: lastAssessmentResultFull.status,
-      pixScore: lastAssessmentResultFull.pixScore,
-      createdAt: certification.createdAt,
-      juryId: lastAssessmentResultFull.juryId,
-      resultCreatedAt: lastAssessmentResultFull.createdAt,
-      completedAt: certification.completedAt,
-      competencesWithMark: lastAssessmentResultFull.competenceMarks,
-      firstName: certification.firstName,
-      lastName: certification.lastName,
-      birthdate: certification.birthdate,
-      birthplace: certification.birthplace,
-      sessionId: certification.sessionId,
-      externalId: certification.externalId,
-      isPublished: certification.isPublished,
-      isV2Certification: certification.isV2Certification,
+      ...certification,
+      ...lastAssessmentResultFull,
+      ...{
+        assessmentId: assessment.id,
+        certificationId: certification.id,
+        createdAt: certification.createdAt,
+        resultCreatedAt: lastAssessmentResultFull.createdAt,
+        competencesWithMark: lastAssessmentResultFull.competenceMarks,
+      },
     };
 
   },

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -31,54 +31,42 @@ module.exports = {
       .then((assessment) => certificationResultService.getCertificationResult(assessment, continueOnError));
   },
 
-  getCertificationResult(certificationCourseId) {
-    let assessment = {};
-    let certification = {};
-    return assessmentRepository
-      .getByCertificationCourseId(certificationCourseId)
-      .then((foundAssessment) => {
-        assessment = foundAssessment;
-        return certificationCourseRepository.get(certificationCourseId);
-      })
-      .then((foundCertification) => {
-        certification = foundCertification;
+  async getCertificationResult(certificationCourseId) {
+    const assessment = await assessmentRepository.getByCertificationCourseId(certificationCourseId);
+    const certification = await certificationCourseRepository.get(certificationCourseId);
 
-        if (assessment) {
-          const lastAssessmentResult = assessment.getLastAssessmentResult();
+    let lastAssessmentResultFull = { competenceMarks: [], status: assessment ? assessment.state : 'missing-assessment' };
 
-          if (lastAssessmentResult) {
-            return assessmentResultRepository.get(lastAssessmentResult.id);
-          }
-        }
+    const lastAssessmentResult = assessment && assessment.getLastAssessmentResult();
+    if (lastAssessmentResult) {
+      lastAssessmentResultFull = await assessmentResultRepository.get(lastAssessmentResult.id);
+    }
 
-        return { competenceMarks: [], status: assessment ? assessment.state : 'missing-assessment' };
-      })
-      .then((lastAssessmentResultFull) => {
-        return {
-          level: lastAssessmentResultFull.level,
-          certificationId: certification.id,
-          assessmentId: assessment ? assessment.id : null,
-          emitter: lastAssessmentResultFull.emitter,
-          commentForJury: lastAssessmentResultFull.commentForJury,
-          commentForCandidate: lastAssessmentResultFull.commentForCandidate,
-          commentForOrganization: lastAssessmentResultFull.commentForOrganization,
-          status: lastAssessmentResultFull.status,
-          pixScore: lastAssessmentResultFull.pixScore,
-          createdAt: certification.createdAt,
-          juryId: lastAssessmentResultFull.juryId,
-          resultCreatedAt: lastAssessmentResultFull.createdAt,
-          completedAt: certification.completedAt,
-          competencesWithMark: lastAssessmentResultFull.competenceMarks,
-          firstName: certification.firstName,
-          lastName: certification.lastName,
-          birthdate: certification.birthdate,
-          birthplace: certification.birthplace,
-          sessionId: certification.sessionId,
-          externalId: certification.externalId,
-          isPublished: certification.isPublished,
-          isV2Certification: certification.isV2Certification,
-        };
-      });
+    return {
+      level: lastAssessmentResultFull.level,
+      certificationId: certification.id,
+      assessmentId: assessment ? assessment.id : null,
+      emitter: lastAssessmentResultFull.emitter,
+      commentForJury: lastAssessmentResultFull.commentForJury,
+      commentForCandidate: lastAssessmentResultFull.commentForCandidate,
+      commentForOrganization: lastAssessmentResultFull.commentForOrganization,
+      status: lastAssessmentResultFull.status,
+      pixScore: lastAssessmentResultFull.pixScore,
+      createdAt: certification.createdAt,
+      juryId: lastAssessmentResultFull.juryId,
+      resultCreatedAt: lastAssessmentResultFull.createdAt,
+      completedAt: certification.completedAt,
+      competencesWithMark: lastAssessmentResultFull.competenceMarks,
+      firstName: certification.firstName,
+      lastName: certification.lastName,
+      birthdate: certification.birthdate,
+      birthplace: certification.birthplace,
+      sessionId: certification.sessionId,
+      externalId: certification.externalId,
+      isPublished: certification.isPublished,
+      isV2Certification: certification.isV2Certification,
+    };
+
   },
 
   _computeAnswersSuccessRate,


### PR DESCRIPTION
## 😔 Problème
Le plafonnement d'une certification (https://github.com/1024pix/pix/pull/663) s'opère actuellement à un certain niveau, en sortie de calcul et juste avant d'enregistrer une liste de `CompetenceMarks` en base. Lors d'un jury, une nouvelle liste vient écraser la première. Or cette liste n'est pas plafonnée comme elle le devrait.

## 🍰 Solution
Les opérateurs de pix admin ont la main sur tout. Ils peuvent modifier une certification sans restrictions. Néanmoins pour les assister dans leurs modifications, on décide d'ajouter un message d'avertissement lorsque leur modifications sont contraires aux règles de la certification.

## 🌵 Remarques
Aucune remarque particulière.

## ⭕️ Autres remarques utiles
Saviez vous que le code de l'émoji 😔est _pensive_. 
Vous trouvez que ça a l'air de quelqu'un qui pense vous ? 🤔

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/1024pix/pix/677)
<!-- Reviewable:end -->
