### PR TITLE
[BUGFIX] Problème de taille des icônes d'œil pour les champs mot de passe.

### DIFF
--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -54,7 +54,7 @@
       border: none;
       border-radius: 3px;
       outline: none;
-      padding: 1px 10px;
+      padding: 0 10px;
       font-size: 1rem;
 
       &:focus {
@@ -69,11 +69,15 @@
 
   &__icon {
     height: 20px;
-    margin: 6px 10px;
+    width: 38px;
+    display: flex;
     border: none;
     background: none;
+    padding: 0;
+  }
 
-    &-eye {
+  &-icon {
+    &__eye {
       color: $dove-gray;
       transition: .5s;
       font-size: 1.1rem;

--- a/certif/app/templates/components/login-form.hbs
+++ b/certif/app/templates/components/login-form.hbs
@@ -32,9 +32,9 @@
                   value=password}}
           <button type="button" aria-label="rendre le mot de passe lisible" class="login-form__icon" {{action 'togglePasswordVisibility'}} >
             {{#if isPasswordVisible}}
-              <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="login-form__icon-eye"}}</div>
+              <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw login-form-icon__eye"}}</div>
             {{else}}
-              <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="login-form__icon-eye"}}</div>
+              <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="fa-fw login-form-icon__eye"}}</div>
             {{/if}}
           </button>
         </div>

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -82,26 +82,45 @@
   margin-bottom: 5px;
 }
 
-.form-textfield__icons {
-  height: 20px;
-  margin: 6px 8px;
-  border: none;
-  background: none;
-
-  &:focus {
-    outline: 1px solid $pix-blue;
-    box-shadow: 0 0 5px 0 rgba(61, 104, 255, 0.5);
-  }
-}
-
 .form-textfield__icon {
-  color: $dove-gray;
-  transition: .5s;
-  font-size: 1.8rem;
-  margin-top: 1px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2px;
 
-  &:hover {
-    color: $nero;
-    cursor: pointer;
+
+}
+
+.form-textfield-icon {
+  &__button {
+    display: flex;
+    border: none;
+    padding: 0;
+    background: none;
+    margin-right: 10px;
+
+    &:focus {
+      outline: 1px solid $pix-blue;
+      box-shadow: 0 0 5px 0 rgba(61, 104, 255, 0.5);
+    }
+  }
+
+  &__state {
+    margin-right: 10px;
   }
 }
+
+.form-textfield-icon-button {
+  &__eye {
+    color: $dove-gray;
+    transition: .5s;
+    font-size: 1.8rem;
+    margin-top: 1px;
+
+    &:hover {
+      color: $nero;
+      cursor: pointer;
+    }
+  }
+}
+

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -11,21 +11,22 @@
           class= 'form-textfield__input'
           classBinding="inputValidationStatus"
           autocomplete=autocomplete}}
-  {{#if isPassword}}
-    <button type="button" aria-label="rendre le mot de passe lisible" class="form-textfield__icons"  {{action 'togglePasswordVisibility'}}>
-      {{#if isPasswordVisible}}
-        <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="form-textfield__icon"}}</div>
-      {{else}}
-        <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="form-textfield__icon"}}</div>
-      {{/if}}
-    </button>
-  {{/if}}
-  {{#if hasIcon}}
-    {{#if (eq validationStatus 'error') }}
-      <img src="/images/icons/icon-error.svg" class="form-textfield__icons form-textfield__icon--error">
-    {{else}}
-      <img src="/images/icons/icon-success.svg"
-           class="form-textfield__icons form-textfield__icon--success validation-icon-success">
+  <div class="form-textfield__icon">
+    {{#if isPassword}}
+      <button type="button" aria-label="rendre le mot de passe lisible" class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>
+        {{#if isPasswordVisible}}
+          <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw form-textfield-icon-button__eye"}}</div>
+        {{else}}
+          <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="fa-fw form-textfield-icon-button__eye"}}</div>
+        {{/if}}
+      </button>
     {{/if}}
-  {{/if}}
+    {{#if hasIcon}}
+      {{#if (eq validationStatus 'error') }}
+        <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
+      {{else}}
+        <img src="/images/icons/icon-success.svg" class="form-textfield-icon__state form-textfield-icon__state--success">
+      {{/if}}
+    {{/if}}
+  </div>
 </div>

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -133,7 +133,7 @@ describe('Integration | Component | form textfield', function() {
       // then
       return wait().then(() => {
         expect(findAll('img')).to.have.lengthOf(1);
-        expect(find('img').getAttribute('class')).to.contain('form-textfield__icon--error');
+        expect(find('img').getAttribute('class')).to.contain('form-textfield-icon__state--error');
       });
     });
 
@@ -165,7 +165,7 @@ describe('Integration | Component | form textfield', function() {
     it('return true if any img does exist', function() {
       // then
       expect(findAll('img')).to.have.lengthOf(1);
-      expect(find('img').getAttribute('class')).to.contain('form-textfield__icon--success');
+      expect(find('img').getAttribute('class')).to.contain('form-textfield-icon__state--success');
     });
 
     [
@@ -193,7 +193,7 @@ describe('Integration | Component | form textfield', function() {
 
     it('should change type when user click on eye icon', async function() {
       // when
-      await click('.form-textfield__icons');
+      await click('.form-textfield-icon__button');
 
       // then
       expect(find('input').getAttribute('type')).to.equal('text');
@@ -202,7 +202,7 @@ describe('Integration | Component | form textfield', function() {
     it('should change icon when user click on it', async function() {
       // when
       expect(find('.fa-eye-slash')).to.exist;
-      await click('.form-textfield__icons');
+      await click('.form-textfield-icon__button');
 
       // then
       expect(find('.fa-eye')).to.exist;
@@ -214,7 +214,7 @@ describe('Integration | Component | form textfield', function() {
 
       // when
       expect(find('.fa-eye-slash')).to.exist;
-      await click('.form-textfield__icon');
+      await click('.form-textfield-icon__button');
       await fillIn(INPUT, 'test');
     });
   });

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -186,7 +186,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-text').getAttribute('class')).to.contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(EMPTY_FIRSTNAME_ERROR_MESSAGE);
           expect(find('#firstName').getAttribute('class')).to.contain('form-textfield__input--error');
-          expect(find('.form-textfield__icon--error')).to.exist;
+          expect(find('.form-textfield-icon__state--error')).to.exist;
         });
       });
 
@@ -204,7 +204,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-text').getAttribute('class')).to.contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(EMPTY_LASTNAME_ERROR_MESSAGE);
           expect(find('#lastName').getAttribute('class')).to.contain('form-textfield__input--error');
-          expect(find('.form-textfield__icon--error')).to.exist;
+          expect(find('.form-textfield-icon__state--error')).to.exist;
         });
       });
 
@@ -222,7 +222,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-email').getAttribute('class')).to.contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(EMPTY_EMAIL_ERROR_MESSAGE);
           expect(find('#email').getAttribute('class')).to.contain('form-textfield__input--error');
-          expect(find('.form-textfield__icon--error')).to.exist;
+          expect(find('.form-textfield-icon__state--error')).to.exist;
         });
       });
 
@@ -240,7 +240,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-password').getAttribute('class')).to.contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
           expect(find('#password').getAttribute('class')).to.contain('form-textfield__input--error');
-          expect(find('.form-textfield__icon--error')).to.exist;
+          expect(find('.form-textfield-icon__state--error')).to.exist;
         });
       });
 
@@ -350,7 +350,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-text').getAttribute('class')).to.contain('form-textfield__message--success');
           expect(find('.form-textfield__message--error')).not.to.exist;
           expect(find('#firstName').getAttribute('class')).to.contain('form-textfield__input--success');
-          expect(find('.form-textfield__icon--success')).to.exist;
+          expect(find('.form-textfield-icon__state--success')).to.exist;
         });
       });
 
@@ -368,7 +368,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-text').getAttribute('class')).to.contain('form-textfield__message--success');
           expect(find('.form-textfield__message--error')).not.to.exist;
           expect(find('#lastName').getAttribute('class')).to.contain('form-textfield__input--success');
-          expect(find('.form-textfield__icon--success')).to.exist;
+          expect(find('.form-textfield-icon__state--success')).to.exist;
         });
       });
 
@@ -386,7 +386,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-email').getAttribute('class')).to.contain('form-textfield__message--success');
           expect(find('.form-textfield__message--error')).not.to.exist;
           expect(find('#email').getAttribute('class')).to.contain('form-textfield__input--success');
-          expect(find('.form-textfield__icon--success')).to.exist;
+          expect(find('.form-textfield-icon__state--success')).to.exist;
         });
       });
 
@@ -404,7 +404,7 @@ describe('Integration | Component | signup form', function() {
           expect(find('.form-textfield__message-password').getAttribute('class')).to.contain('form-textfield__message--success');
           expect(find('.form-textfield__message--error')).not.to.exist;
           expect(find('#password').getAttribute('class')).to.contain('form-textfield__input--success');
-          expect(find('.form-textfield__icon--success')).to.exist;
+          expect(find('.form-textfield-icon__state--success')).to.exist;
         });
       });
 

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -55,7 +55,7 @@
       border: none;
       border-radius: 3px;
       outline: none;
-      padding: 1px 10px;
+      padding: 0 10px;
       font-size: 1rem;
 
       &:focus {
@@ -70,11 +70,15 @@
 
   &__icon {
     height: 20px;
-    margin: 6px 10px;
+    width: 38px;
+    display: flex;
     border: none;
     background: none;
+    padding: 0;
+  }
 
-    &-eye {
+  &-icon {
+    &__eye {
       color: $dove-gray;
       transition: .5s;
       font-size: 1.1rem;

--- a/orga/app/templates/components/login-form.hbs
+++ b/orga/app/templates/components/login-form.hbs
@@ -34,9 +34,9 @@
                 value=password}}
           <button type="button" aria-label="rendre le mot de passe lisible" class="login-form__icon" {{action 'togglePasswordVisibility'}} >
              {{#if isPasswordVisible}}
-               <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="login-form__icon-eye"}}</div>
+               <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw login-form-icon__eye"}}</div>
              {{else}}
-               <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="login-form__icon-eye"}}</div>
+               <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="fa-fw login-form-icon__eye"}}</div>
             {{/if}}
           </button>
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Les deux icônes d'œil n'ont pas exactement la même taille et cela créé un décalage des icônes lors de l'appuie.

## :robot: Solution
Fixer la taille du `button` contenant les icônes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/1024pix/pix/679)
<!-- Reviewable:end -->
