### PR TITLE
[DOC] Supprimer la convention @exemplary

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,15 +33,3 @@ Pour aller plus loin :
 ## Node.js
 
 On ne commit le `package-lock.json` qu'en cas de modification du `package.json`
-
-## Flags du code à l'état de l'art
-
-Dans le code Pix, les bouts de code exemplaires, qui illustrent l’état de l’art actuel pour nous, sont signalés par le commentaire `// @exemplary`.
-
-Objectifs :
-
-- faciliter l’accès à l’information (`Ctrl-Shift-F` ou `grep` permet de lister ces bouts de code),
-- accélérer les choix d’implém,
-- et fluidifier la montée en compétence des nouveaux
-
-Pour mettre à jour ces flags, nous soumettons une PR qui suit la même validation que pour la mise à jour du `CONTRIBUTING.md`.


### PR DESCRIPTION
## :unicorn: Problème

En avril 2019, nous avions décidé de marquer des lignes de code exemplaires par le tag `@exemplary`.

Ce tag n'a pas été utilisé à ce jour.

## :robot: Solution

Je propose de le supprimer de la doc.

## :rainbow: Remarques

C'est peut-être le mot "exemplary" qui est intimidant, est-ce qu'un autre mot pourrait marcher, comme "inspirant" par exemple ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/1024pix/pix/683)
<!-- Reviewable:end -->
