### PR TITLE
[TECH] Découpler les review apps de l'application d'integration

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -61,7 +61,7 @@ const plugins = [
       }
     }
   },
-  ...(isProduction ? [
+  ...(isProduction && process.env.SENTRY_DSN ? [
     {
       plugin: require('hapi-sentry'),
       options: {

--- a/docs/Glossaire-Variables-Env.md
+++ b/docs/Glossaire-Variables-Env.md
@@ -8,41 +8,41 @@ Une explication est associée à chaque variable ainsi que leur utilisation (OUI
 
 ### PIX API
 
-| Variable  | Description | DEV | INT | PROD | Si absente |
-| --- | --- | --- | --- | --- | --- |
-| AIRTABLE_API_KEY |	Clef API / "Lien" de connexion pour Airtable | OUI	| OUI	| OUI | Pas de récupération du référentiel |
-| AIRTABLE_BASE	BDD | Airtable ciblée	| OUI	| OUI	| OUI | Pas de récupération du référentiel et des questions / réponses |
-| APPLICATION_NAME |	Nom de l'API	| OUI	| OUI	| OUI |
-| AUTH_SECRET |	Sécurité d'authentification	| OUI	| OUI	| OUI |
-| BASE_URL |	URL associée à la review app	| OUI	| OUI	| OUI |
-| BUILDPACK_SUBDIR |	Dossier de build ?	| OUI	| OUI	| OUI |
-| BUILDPACK_URL |	Adresse du dossier de build ?	| OUI	| OUI	| OUI |
-| CACHE_RELOAD_TIME |	Période de rechargement du cache au format cron	| OUI	| OUI	| OUI |
-| DATABASE_CONNECTION_POOL_MAX_SIZE |	Nombre de connexion simultanées à la base de données	| OUI	| OUI	| OUI |
-| DATABASE_SSL_ENABLED |	Sécurisation SSL de la base de données	| OUI	| OUI	| OUI |
-| DATABASE_URL |	Définit l'adresse, le port et le nom de la BDD PostgreSQL à utiliser. Sur Scalingo, l'hébergeur va lire la variable SCALINGO_POSTGRESQL_URL	| OUI	| OUI	| OUI | Application KO |
-| DAY_BEFORE_COMPETENCE_RESET_V2 |	Nombre de jours nécessaires avant la remise à zéro d'une compétence en profil v2	| OPT	| OUI	| OUI | On utilise une valeur par défaut |
-| INFLUXDB_SSL_CA_CERT |	Certificat SSL pour Influx DB	| OUI	| OUI	| OUI |
-| LOG_ENABLED |	Activation de l'affichage des logs	| OPT	| OPT	| true | Absence de logs |
-| LOG_LEVEL |	Niveau de détails affiché par les logs |	trace |	trace |	info |
-| MAILJET_KEY |	Clef API pour MailJet	| NON	| OUI	| OUI | Pas d'envoi de mails à l'inscription / reset password |
-| MAILJET_SECRET |	Secret de décryptage pour la clef API MailJet	| NON	| OUI	| OUI | Pas d'envoi de mails à l'inscription / reset password |
-| METRICS_DB_NAME |	Nom de la base de données pour les Metrics Grafana	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| METRICS_DB_PASSWORD |	Password de la base de données pour les Metrics Grafana	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| METRICS_DB_URL |	Adresse URL de la base de données pour les Metrics Grafana	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| METRICS_DB_USER |	Compte utilisateur de la base de données pour les Metrics Grafana	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| NODE_ENV |	Environnement Node reflétant l'environnement courant de l'API	| OUI	| OUI	| OUI |
-| NODE_OPTIONS | Options Node — utilisé ici pour définir son allocation mémoire autorisée |	staging |	staging |	production |
-| NPM_CONFIG_AUDIT |	Vérification NPM de la configuration |	false |	false |	false |
-| PAPERTRAIL_ENDPOINT |	URL de Papertrail	| OUI	| OUI	| OUI |
-| PGSSLMODE |	Mode SSL pour postgresql |	require	| require |	require |
-| PIXMASTER_EMAIL |	Compte Pix Master	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| PIXMASTER_PASSWORD |	Mot de passe Pix Master	| OUI	| OUI	| OUI | Potentiellement inutilisé |
-| PORT |	Port de connexion pour le développement sur localhost |	OPT.	| NON |	NON | Utilisation d'une valeur par défaut |
-| REDIS_CACHE_KEY_LOCK_TTL |	Délais de verrouillage du cache Redis	| OUI	| OUI	| OUI |
-| REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY |	Délais d'attente avant reconnexion au cache Redis	| OUI	| OUI	| OUI |
-| REDIS_URL |	Adresse URL du cache Redis. Sur Scalingo, l'hébergeur va lire SCALINGO_REDIS_URL	| OUI	| OUI	| OUI |
-| SAML_IDP_CONFIG |	En lien avec le GAR (???)	| OUI	| OUI	| OUI |
-| SENTRY_DSN |	Adresse pour la collecte d'erreurs sur Sentry	| OUI	| OUI	| OUI |
-| TEST_DATABASE_URL |	Définit l'adresse, le port et le nom de la BDD PostgreSQL à utiliser pour les tests automatiques	| OUI	| OUI	| NON |
-| TOKEN_LIFE_SPAN |	Durée de vie du token de connexion	| OUI	| OUI	| OUI |
+| Variable                              | Description                                                                                                                                  | DEV      | INT      | PROD        | Si absente                                                      |
+| ---                                   | ---                                                                                                                                          | ---      | ---      | ---         | ---                                                             |
+| AIRTABLE_API_KEY                      | Clé d'API (secret) de connexion pour Airtable                                                                                                | OUI      | OUI      | OUI         | Pas de récupération du référentiel                              |
+| AIRTABLE_BASE                         | Identifiant de la base Airtable ciblée                                                                                                       | OUI      | OUI      | OUI         | Pas de récupération du référentiel et des questions / réponses  |
+| APPLICATION_NAME                      |                                                                                                                                              | OUI      | OUI      | OUI         | Variable inutilisée                                             |
+| AUTH_SECRET                           | Sécurité d'authentification                                                                                                                  | OUI      | OUI      | OUI         |
+| BASE_URL                              | URL utilisée par le script de rechargement de cache                                                                                          | OUI      | OUI      | OUI         |
+| BUILDPACK_SUBDIR                      | Indique au `subdir-buildback` quel répertoire déployer                                                                                       | OUI      | OUI      | OUI         |
+| BUILDPACK_URL                         | Indique à Scalingo quel `buildpack` utiliser. En principe https://github.com/1024pix/subdir-buildpack                                        | OUI      | OUI      | OUI         |
+| CACHE_RELOAD_TIME                     | Période de rechargement du cache, utilisée par le script de rechargement de cache. Au format cron (ex. `5 8 * * *`)                          | OUI      | OUI      | OUI         |
+| DATABASE_CONNECTION_POOL_MAX_SIZE     | Nombre de connexion simultanées maximum à la base de données (par conteneur)                                                                 | OUI      | OUI      | OUI         |
+| DATABASE_SSL_ENABLED                  | Sécurisation SSL de la connexion à la base de données                                                                                        | OUI      | OUI      | OUI         |
+| DATABASE_URL                          | Définit l'adresse, le port et le nom de la BDD PostgreSQL à utiliser. Sur Scalingo, on met contient `$SCALINGO_POSTGRESQL_URL`               | OUI      | OUI      | OUI         | Application KO                                                  |
+| DAY_BEFORE_COMPETENCE_RESET_V2        | Nombre de jours nécessaires avant la remise à zéro d'une compétence en profil v2                                                             | OPT      | OUI      | OUI         | On utilise une valeur par défaut                                |
+| INFLUXDB_SSL_CA_CERT                  | Certificat SSL pour Influx DB                                                                                                                | OUI      | OUI      | OUI         | Potentiellement inutilisé                                       |
+| LOG_ENABLED                           | Activation de l'affichage des logs                                                                                                           | OPT      | OPT      | true        | Absence de logs                                                 |
+| LOG_LEVEL                             | Niveau de détails affiché par les logs                                                                                                       | trace    | trace    | info        |
+| MAILJET_KEY                           | Clef API pour MailJet                                                                                                                        | NON      | OUI      | OUI         | Pas d'envoi de mails à l'inscription / reset password           |
+| MAILJET_SECRET                        | Secret de décryptage pour la clef API MailJet                                                                                                | NON      | OUI      | OUI         | Pas d'envoi de mails à l'inscription / reset password           |
+| METRICS_DB_NAME                       | Nom de la base de données pour les Metrics Grafana                                                                                           | OUI      | OUI      | OUI         | Potentiellement inutilisé                                       |
+| METRICS_DB_PASSWORD                   | Password de la base de données pour les Metrics Grafana                                                                                      | OUI      | OUI      | OUI         | Potentiellement inutilisé                                       |
+| METRICS_DB_URL                        | Adresse URL de la base de données pour les Metrics Grafana                                                                                   | OUI      | OUI      | OUI         | Potentiellement inutilisé                                       |
+| METRICS_DB_USER                       | Compte utilisateur de la base de données pour les Metrics Grafana                                                                            | OUI      | OUI      | OUI         | Potentiellement inutilisé                                       |
+| NODE_ENV                              | Environnement Node reflétant l'environnement courant de l'API                                                                                | OUI      | OUI      | OUI         |
+| NODE_OPTIONS                          | Options Node — utilisé ici pour définir son allocation mémoire autorisée                                                                     |          | staging  | production  |
+| NPM_CONFIG_AUDIT                      | Peut être mis à `false` pour désactiver l'audit des packages NPM                                                                             |          | false    | false       |
+| PAPERTRAIL_ENDPOINT                   | URL de Papertrail                                                                                                                            | OUI      | OUI      | OUI         |
+| PGSSLMODE                             | Mode SSL pour PostgreSQL                                                                                                                     | require  | require  | require     |
+| PIXMASTER_EMAIL                       | Compte utilisé par le script de rechargement de cache                                                                                        | OUI      | OUI      | OUI         |                                                                 |
+| PIXMASTER_PASSWORD                    | Mot de passe du compte utilisé par le script de rechargement de cache                                                                        | OUI      | OUI      | OUI         |                                                                 |
+| PORT                                  | Port TCP sur lequel l'API doit écouter en HTTP. Alimenté par Scalingo au démarrage d'un conteneur.                                           | OPT.     | NON      | NON         | Utilisation d'une valeur par défaut                             |
+| REDIS_CACHE_KEY_LOCK_TTL              | Durée maximale de verrouillage du cache Redis                                                                                                | OUI      | OUI      | OUI         |
+| REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY  | Délai d'attente avant nouvelle tentative d'accès à une clé Redis verrouillée                                                                 | OUI      | OUI      | OUI         |
+| REDIS_URL                             | Adresse URL du cache Redis. Sur Scalingo, on met `$SCALINGO_REDIS_URL`                                                                       | OUI      | OUI      | OUI         |
+| SAML_IDP_CONFIG                       | Configuration de l'IdP SAML (voir `api/scripts/make-saml-env.js`)                                                                            | OUI      | OUI      | OUI         |
+| SENTRY_DSN                            | Adresse pour la collecte d'erreurs sur Sentry                                                                                                | OUI      | OUI      | OUI         |
+| TEST_DATABASE_URL                     | Définit l'adresse, le port et le nom de la BDD PostgreSQL à utiliser pour les tests automatiques                                             | OUI      | NON      | NON         |
+| TOKEN_LIFE_SPAN                       | Durée de vie du token de connexion. Exemple : `7d` pour 7 jours.                                                                             | OUI      | OUI      | OUI         |

--- a/scalingo.json
+++ b/scalingo.json
@@ -9,6 +9,10 @@
   "scripts": {
     "first-deploy": "npm run scalingo-post-ra-creation"
   },
+  "addons": [
+    "postgresql:postgresql-sandbox",
+    "redis:redis-sandbox"
+  ],
   "formation": {
     "web": {
       "amount": 1,

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -88,7 +88,7 @@ function extractIssueCodeFromBranchName(branchName) {
 }
 
 function extractPRNumberFromAppName(appName) {
-  const PRnumberRegex = new RegExp(/integration-pr(\d+)/);
+  const PRnumberRegex = new RegExp(/-pr(\d+)/);
   const regexMatches = appName.match(PRnumberRegex);
 
   if (regexMatches) {

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -28,7 +28,7 @@ async function main() {
   const raOrgaURL = `https://orga-pr${prNumber}.review.pix.fr`;
   const raCertifURL = `https://certif-pr${prNumber}.review.pix.fr`;
   const raAdminURL = `https://admin-pr${prNumber}.review.pix.fr`;
-  const raAPIURL = `https://pix-api-integration-pr${prNumber}.scalingo.io`;
+  const raAPIURL = `https://api-pr${prNumber}.review.pix.fr`;
 
   const scalingoCommentRegex = new RegExp(raAppURL, 'i');
 
@@ -52,7 +52,7 @@ async function main() {
   if (hasAlreadyScalingoComment) {
     console.log('Review apps urls already found in issue comments. No need to add it again');
   } else {
-    const text = `Je viens de déployer la Review App. Elle sera consultable sur les URL suivantes :\n` +
+    const text = 'Je viens de déployer la Review App. Elle sera consultable sur les URL suivantes :\n' +
       `- App : ${raAppURL}\n` +
       `- Orga : ${raOrgaURL}\n` +
       `- Certif : ${raCertifURL}\n` +

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -28,7 +28,7 @@ async function main() {
   const raOrgaURL = `https://orga-pr${prNumber}.review.pix.fr`;
   const raCertifURL = `https://certif-pr${prNumber}.review.pix.fr`;
   const raAdminURL = `https://admin-pr${prNumber}.review.pix.fr`;
-  const raAPIURL = `https://api-pr${prNumber}.review.pix.fr`;
+  const raAPIURL = `https://api-pr${prNumber}.review.pix.fr/api/`;
 
   const scalingoCommentRegex = new RegExp(raAppURL, 'i');
 

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -25,7 +25,7 @@ RA_APP_URL="https://app-pr$PR_NUMBER.review.pix.fr"
 RA_ORGA_URL="https://orga-pr$PR_NUMBER.review.pix.fr"
 RA_CERTIF_URL="https://certif-pr$PR_NUMBER.review.pix.fr"
 RA_ADMIN_URL="https://admin-pr$PR_NUMBER.review.pix.fr"
-RA_API_URL="https://api-pr$PR_NUMBER.review.pix.fr"
+RA_API_URL="https://api-pr$PR_NUMBER.review.pix.fr/api/"
 
 MESSAGE_PREFIX="I'm deploying this PR to these urls:"
 
@@ -37,5 +37,5 @@ if [[ $existing_comments == *"${MESSAGE_PREFIX}"* ]]; then
 else
 	curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
 		-X POST "https://api.github.com/repos/1024pix/pix/issues/${PR_NUMBER}/comments" \
-		--data "{\"body\":\"$MESSAGE_PREFIX\n\n- App: $RA_APP_URL\n- Orga: $RA_ORGA_URL\n- Certif: $RA_CERTIF_URL\n- Admin: $RA_ADMIN_URL\n- API: $RA_API_URL\n\n Please check it out\"}"
+		--data "{\"body\":\"$MESSAGE_PREFIX\n\n- App: $RA_APP_URL\n- Orga: $RA_ORGA_URL\n- Certif: $RA_CERTIF_URL\n- Admin: $RA_ADMIN_URL\n- API: $RA_API_URL\n\n Please check it out!\"}"
 fi

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -20,7 +20,7 @@
 	exit 1
 }
 
-PR_NUMBER=$(echo $APP | grep -Po '(?<=integration-pr)\d+')
+PR_NUMBER=$(echo $APP | grep -Po '(?<=-pr)\d+')
 RA_APP_URL="https://app-pr$PR_NUMBER.review.pix.fr"
 RA_ORGA_URL="https://orga-pr$PR_NUMBER.review.pix.fr"
 RA_CERTIF_URL="https://certif-pr$PR_NUMBER.review.pix.fr"

--- a/scripts/signal_deploy_to_pr.sh
+++ b/scripts/signal_deploy_to_pr.sh
@@ -25,7 +25,7 @@ RA_APP_URL="https://app-pr$PR_NUMBER.review.pix.fr"
 RA_ORGA_URL="https://orga-pr$PR_NUMBER.review.pix.fr"
 RA_CERTIF_URL="https://certif-pr$PR_NUMBER.review.pix.fr"
 RA_ADMIN_URL="https://admin-pr$PR_NUMBER.review.pix.fr"
-RA_API_URL="https://pix-api-integration-pr$PR_NUMBER.scalingo.io"
+RA_API_URL="https://api-pr$PR_NUMBER.review.pix.fr"
 
 MESSAGE_PREFIX="I'm deploying this PR to these urls:"
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les _review apps_ sont créées sur la base des applications Scalingo :
 * `pix-api-integration`
 * `pix-front-integration`

`pix-front-integration` est dédiée à ces créations de _review app_ mais `pix-api-integration` est également utilisée pour tester `dev`. Ceci présente plusieurs inconvénients :
 * tout paramétrage (variables d'environnement) fait sur `pix-api-integration` est hérité par les _review apps_ ;
 * à cause d'un bug Scalingo (qu'on vient de leur remonter), une _review app_ peut démarrer avant que son instance de PostgreSQL soit allouée, ce qui fait qu'elle se connecte à la base de `pix-api-integration`, avec des effets désastreux si la PR contient une migration.

## :robot: Solution
On va créer deux applications vouées à ne servir que de _template_ pour les _review apps_ :
 * `pix-api-review`
 * `pix-front-review`

Ces applications ne seront jamais déployées mais configurées pour engendrer des _review apps_ à la place de `pix-api-integration` et `pix-front-integration`.

Dans cette PR :
 * On assouplit la recherche de numéro de PR dans le nom de l'application Scalingo, pour ne pas exiger la présence du mot `integration-` dans le nom de la _review app_ ;
 * On évite d'initialiser `hapi-sentry` quand la variable d'environnement `SENTRY_DSN` n'est pas renseignée ;
 * On met à jour la documentation de quelques variables d'environnement ;
 * On précise dans le `scalingo.json` que `PostgreSQL` et `Redis` sont nécessaires pour la création de _review app_.

## :rainbow: Remarques
Les URL d'accès aux _review apps_ (https://app-prXXX.review.pix.fr) ne changent pas.

Le routeur des _review apps_ (https://github.com/1024pix/pix-review-router) sera simultanément mis à jour pour tenir compte des nouveaux noms d'application.