### PR TITLE
[BUGFIX] Une migration de mise à jour de la table answers n'était pas bloquante

### DIFF
--- a/api/db/migrations/20170306151003_update_answers.js
+++ b/api/db/migrations/20170306151003_update_answers.js
@@ -2,14 +2,14 @@ const TABLE_NAME = 'answers';
 
 exports.up = (knex) => {
 
-  knex.schema.alterTable(TABLE_NAME, (t) => {
+  return knex.schema.alterTable(TABLE_NAME, (t) => {
     t.text('value').alter();
   });
 };
 
-exports.down = function(knex) {
+exports.down = (knex) => {
 
-  knex.schema.alterTable(TABLE_NAME, (t) => {
+  return knex.schema.alterTable(TABLE_NAME, (t) => {
     t.text('string').alter();
   });
 };


### PR DESCRIPTION
## :unicorn: Problème
Un fichier de migration concernant la table `answers` contenait des opérations qui ne retournaient pas de promesses.

## :robot: Solution
Retourner des promesses aux endroits nécessaires.

## :rainbow: Remarques
- Cela peut ou pas résoudre un problème ponctuel lors de lancement de la commande npm t (drop -> create -> migrate -> test). En effet, à de rares occasions, beaucoup de tests liés aux answers plantaient. Peut-être était-ce dû à la correction de la présente PR, ou pas !!
- Aucun impact sur intégration ou la prod, ou même sur les PR courantes
