### PR TITLE
[BUGFIX] Empêcher la création de plus d'un certification-course pour un même utilisateur dans une session (PF-814)

### DIFF
--- a/api/lib/domain/services/session-service.js
+++ b/api/lib/domain/services/session-service.js
@@ -12,7 +12,7 @@ module.exports = {
     return sessionRepository.find();
   },
 
-  sessionExists(accessCode) {
+  getSessionIdByAccessCode(accessCode) {
     return sessionCodeService.getSessionByAccessCode(accessCode)
       .then((session) => {
         if (session) {

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -13,7 +13,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   certificationCourseRepository,
   assessmentRepository,
 }) {
-  const sessionId = await sessionService.sessionExists(accessCode);
+  const sessionId = await sessionService.getSessionIdByAccessCode(accessCode);
   const certificationCourses = await certificationCourseRepository.findLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
 
   if (_.size(certificationCourses) > 0) {

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -57,15 +57,6 @@ module.exports = {
       });
   },
 
-  findLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
-    return CertificationCourseBookshelf
-      .where({ userId, sessionId })
-      .orderBy('createdAt', 'desc')
-      .query((qb) => qb.limit(1))
-      .fetchAll()
-      .then((certificationCourses) => certificationCourses.map(_toDomain));
-  },
-
   getLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
     return CertificationCourseBookshelf
       .where({ userId, sessionId })

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -66,6 +66,21 @@ module.exports = {
       .then((certificationCourses) => certificationCourses.map(_toDomain));
   },
 
+  getLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
+    return CertificationCourseBookshelf
+      .where({ userId, sessionId })
+      .orderBy('createdAt', 'desc')
+      .query((qb) => qb.limit(1))
+      .fetch({ require: true })
+      .then(_toDomain)
+      .catch((error) => {
+        if (error instanceof CertificationCourseBookshelf.NotFoundError) {
+          throw new NotFoundError();
+        }
+        throw error;
+      });
+  },
+
   update(certificationCourse) {
     const certificationCourseData = _adaptModelToDb(certificationCourse);
     const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourseData);

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -106,62 +106,6 @@ describe('Integration | Repository | Certification Course', function() {
 
   });
 
-  describe('#findLastCertificationCourseByUserIdAndSessionId', function() {
-
-    let userId, yetAnotherUserId;
-    let sessionId, yetAnotherSessionId;
-    let expectedCertificationCourse;
-
-    beforeEach(async () => {
-      // given
-      userId = databaseBuilder.factory.buildUser({}).id;
-      const anotherUserId = databaseBuilder.factory.buildUser({}).id;
-      yetAnotherUserId = databaseBuilder.factory.buildUser({}).id;
-      sessionId = databaseBuilder.factory.buildSession({}).id;
-      const anotherSessionId = databaseBuilder.factory.buildSession({}).id;
-      yetAnotherSessionId = databaseBuilder.factory.buildSession({}).id;
-      _.each([
-        { userId: anotherUserId, sessionId, completedAt: null, createdAt: new Date('2018-12-21T01:02:03Z') },
-        { userId, sessionId: anotherSessionId, completedAt: null, createdAt: new Date('2018-12-21T01:02:03Z') },
-        { userId, sessionId, createdAt: new Date('2018-12-11T01:02:03Z') },
-        { userId, sessionId, completedAt: null, createdAt: new Date('2018-11-11T01:02:03Z') },
-      ], (certificationCourse) => {
-        databaseBuilder.factory.buildCertificationCourse(certificationCourse);
-      });
-      expectedCertificationCourse = databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, completedAt: null, createdAt: new Date('2018-12-12T01:02:03Z') });
-      await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
-    it('should retrieve certification course with given userId, sessionId and with value null as completedAt', async () => {
-      // when
-      const certificationCourses = await certificationCourseRepository.findLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
-      // then
-      expect(certificationCourses).to.have.lengthOf(1);
-      expect(_.omit(certificationCourses[0], [
-        'assessment',
-        'challenges',
-        'type',
-        'nbChallenges',
-        // TODO : Handle date type correctly
-        'birthdate',
-        'updatedAt'
-      ])).to.deep.equal(_.omit(expectedCertificationCourse, ['birthdate', 'updatedAt']));
-      expect(certificationCourses[0]['birthdate'].toLocaleDateString()).to.equal(expectedCertificationCourse['birthdate'].toLocaleDateString());
-    });
-
-    it('should retrieve empty array when none of certification courses matches', async () => {
-      // when
-      const certificationCourses = await certificationCourseRepository.findLastCertificationCourseByUserIdAndSessionId(yetAnotherUserId, yetAnotherSessionId);
-
-      // then
-      expect(certificationCourses).to.deep.equal([]);
-    });
-  });
-
   describe('#getLastCertificationCourseByUserIdAndSessionId', function() {
 
     const createdAt = new Date('2018-12-11T01:02:03Z');

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const BookshelfCertificationCourse = require('../../../../lib/infrastructure/data/certification-course');
 const { NotFoundError } = require('../../../../lib/domain/errors');
@@ -159,6 +159,46 @@ describe('Integration | Repository | Certification Course', function() {
 
       // then
       expect(certificationCourses).to.deep.equal([]);
+    });
+  });
+
+  describe('#getLastCertificationCourseByUserIdAndSessionId', function() {
+
+    const createdAt = new Date('2018-12-11T01:02:03Z');
+    const createdAtLater = new Date('2018-12-12T01:02:03Z');
+    let userId;
+    let sessionId;
+
+    beforeEach(async () => {
+      // given
+      await databaseBuilder.clean();
+      userId = databaseBuilder.factory.buildUser({}).id;
+      sessionId = databaseBuilder.factory.buildSession({}).id;
+      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt });
+      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt: createdAtLater });
+
+      databaseBuilder.factory.buildCertificationCourse({ sessionId });
+      databaseBuilder.factory.buildCertificationCourse({ userId });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(() => databaseBuilder.clean());
+
+    it('should retrieve the last certification course with given userId, sessionId', async () => {
+      // when
+      const certificationCourse = await certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
+
+      // then
+      expect(certificationCourse.createdAt).to.deep.equal(createdAtLater);
+    });
+
+    it('should throw not found error when no certification course found', async () => {
+      // when
+      const result = await catchErr(certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId)(userId + 1, sessionId + 1);
+
+      // then
+      expect(result).to.be.instanceOf(NotFoundError);
     });
   });
 

--- a/api/tests/unit/domain/services/session-service_test.js
+++ b/api/tests/unit/domain/services/session-service_test.js
@@ -6,7 +6,7 @@ const sessionRepository = require('../../../../lib/infrastructure/repositories/s
 
 describe('Unit | Service | session', () => {
 
-  describe('#sessionExists', () => {
+  describe('#getSessionIdByAccessCode', () => {
 
     beforeEach(() => {
       sinon.stub(sessionCodeService, 'getSessionByAccessCode');
@@ -18,7 +18,7 @@ describe('Unit | Service | session', () => {
         sessionCodeService.getSessionByAccessCode.resolves(null);
 
         // when
-        const promise = sessionService.sessionExists(null);
+        const promise = sessionService.getSessionIdByAccessCode(null);
 
         // then
         return promise.catch((result) => {
@@ -33,7 +33,7 @@ describe('Unit | Service | session', () => {
         sessionCodeService.getSessionByAccessCode.resolves(null);
 
         // when
-        const promise = sessionService.sessionExists('1234');
+        const promise = sessionService.getSessionIdByAccessCode('1234');
 
         // then
         return promise.catch((result) => {
@@ -48,7 +48,7 @@ describe('Unit | Service | session', () => {
         sessionCodeService.getSessionByAccessCode.resolves({ id: 12 });
 
         // when
-        const promise = sessionService.sessionExists('ABCD12');
+        const promise = sessionService.getSessionIdByAccessCode('ABCD12');
 
         // then
         return promise.then((result) => {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -27,7 +27,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         certificationCourse = domainBuilder.buildCertificationCourse({ id: 'newlyCreatedCertificationCourse', sessionId, userId, createdAt: new Date('2018-12-12T01:02:03Z') });
         oldCertificationCourse = domainBuilder.buildCertificationCourse({ id: 'oldCertificationCourse', sessionId, userId, createdAt: new Date('2018-11-11T01:02:03Z') });
 
-        sinon.stub(sessionService, 'sessionExists').resolves(sessionId);
+        sinon.stub(sessionService, 'getSessionIdByAccessCode').resolves(sessionId);
         sinon.stub(certificationCourseRepository, 'findLastCertificationCourseByUserIdAndSessionId').resolves([certificationCourse, oldCertificationCourse]);
         sinon.stub(certificationCourseRepository, 'save').resolves();
       });
@@ -64,7 +64,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         accessCode = 'ABCD12';
         certificationCourse = domainBuilder.buildCertificationCourse({ id: 'newlyCreatedCertificationCourse', sessionId, userId, createdAt: new Date('2018-12-12T01:02:03Z') });
 
-        sinon.stub(sessionService, 'sessionExists').rejects(new NotFoundError());
+        sinon.stub(sessionService, 'getSessionIdByAccessCode').rejects(new NotFoundError());
         sinon.stub(certificationCourseRepository, 'findLastCertificationCourseByUserIdAndSessionId').resolves(certificationCourse);
         sinon.stub(certificationCourseRepository, 'save').resolves();
       });
@@ -136,7 +136,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           nbChallenges: 3
         });
 
-        sinon.stub(sessionService, 'sessionExists').resolves(sessionId);
+        sinon.stub(sessionService, 'getSessionIdByAccessCode').resolves(sessionId);
         sinon.stub(certificationCourseRepository, 'findLastCertificationCourseByUserIdAndSessionId').resolves([]);
 
         clock = sinon.useFakeTimers(now);


### PR DESCRIPTION
## :unicorn: Problème
Dans des cas dont la liste précise est difficile à évaluer (ouverture de deux navigateurs et lancement de session de certification presque en simultané + léger lag côté API), on peut se retrouver avec deux certification-courses créés pour un même utilisateur sur une session donnée.
Il existait pourtant une vérification côté API pour s'assurer de ne pas créer deux fois le certification-course. Mais la création du certification-course ne suit pas directement la vérification : avant, le profil de l'utilisateur est compute de sorte à générer la liste des challenges pour la certification. Cette opération peut parfois prendre un peu de temps, et donc la vérification peut être obsolète entre temps.

## :robot: Solution
Ajout d'une deuxième vérification après le computing des challenges

## :rainbow: Remarques
Je suis ouverte à toutes les remarques, car je ne trouve pas ma solution très élégante mais au moins elle lance la discussion
