### PR TITLE
[BUGFIX] Ajout d'une campaignParticipationId dans le cas d'une remise à zéro durant une campagne

### DIFF
--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -115,6 +115,7 @@ async function _resetSmartPlacementAssessment({ assessment, resetSkills, assessm
     userId: assessment.userId,
     state: Assessment.states.STARTED,
     type: Assessment.types.SMARTPLACEMENT,
+    campaignParticipationId: assessment.campaignParticipationId,
     courseId: 'Smart Placement Tests CourseId Not Used'
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment.js
@@ -1,4 +1,5 @@
 const faker = require('faker');
+const _ = require('lodash');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const SmartPlacementAssessment = require('../../../../lib/domain/models/SmartPlacementAssessment');
 
@@ -36,7 +37,6 @@ function buildAssessment({
     state,
     isImproving,
     competenceId,
-
     // relationships
     answers,
     assessmentResults,
@@ -61,8 +61,11 @@ buildAssessment.ofTypeSmartPlacement = function({
   targetProfile = buildTargetProfile(),
   knowledgeElements = [buildKnowledgeElement()],
   campaignParticipation = buildCampaignParticipation(),
+  campaignParticipationId = null,
   title = 'campaignTitle',
 } = {}) {
+  campaignParticipationId = _.isNil(campaignParticipationId) ? _.get(campaignParticipation, 'id') : campaignParticipationId;
+
   return new SmartPlacementAssessment({
     // attributes
     id,
@@ -74,6 +77,7 @@ buildAssessment.ofTypeSmartPlacement = function({
     type: Assessment.types.SMARTPLACEMENT,
     state,
     isImproving,
+    campaignParticipationId,
 
     // relationships
     answers,

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -198,14 +198,14 @@ describe('Unit | Service | ScorecardService', function() {
         const skill = domainBuilder.buildSkill({ id: skillId });
         const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
         campaign = domainBuilder.buildCampaign({ targetProfileId: targetProfile.id, targetProfile });
-        campaignParticipation1 = domainBuilder.buildCampaignParticipation({ campaign, campaignId: campaign.id, isShared: false });
-        campaignParticipation2 = domainBuilder.buildCampaignParticipation({ campaign, campaignId: campaign.id, isShared: false });
-        oldAssessment1 = domainBuilder.buildAssessment({ id: assessmentId1, campaignParticipationId: campaignParticipation1.id });
-        oldAssessment2 = domainBuilder.buildAssessment({ id: assessmentId2, campaignParticipationId: campaignParticipation2.id });
-        oldAssessment1Aborted = domainBuilder.buildAssessment({ ...oldAssessment1, state: Assessment.states.ABORTED });
-        oldAssessment2Aborted = domainBuilder.buildAssessment({ ...oldAssessment2, state: Assessment.states.ABORTED });
-        newAssessment1Saved = domainBuilder.buildAssessment({ id: 67890 });
-        newAssessment2Saved = domainBuilder.buildAssessment({ id: 98760 });
+        campaignParticipation1 = domainBuilder.buildCampaignParticipation({ id: 1, campaign, campaignId: campaign.id, isShared: false });
+        campaignParticipation2 = domainBuilder.buildCampaignParticipation({ id: 2, campaign, campaignId: campaign.id, isShared: false });
+        oldAssessment1 = domainBuilder.buildAssessment.ofTypeSmartPlacement({ id: assessmentId1, state: 'started', campaignParticipationId: campaignParticipation1.id, userId });
+        oldAssessment2 = domainBuilder.buildAssessment.ofTypeSmartPlacement({ id: assessmentId2, state: 'started', campaignParticipationId: campaignParticipation2.id, userId });
+        oldAssessment1Aborted = domainBuilder.buildAssessment({ ...oldAssessment1, state: Assessment.states.ABORTED, campaignParticipationId: campaignParticipation1.id });
+        oldAssessment2Aborted = domainBuilder.buildAssessment({ ...oldAssessment2, state: Assessment.states.ABORTED, campaignParticipationId: campaignParticipation2.id });
+        newAssessment1Saved = domainBuilder.buildAssessment({ id: 67890, campaignParticipationId: campaignParticipation1.id });
+        newAssessment2Saved = domainBuilder.buildAssessment({ id: 98760, campaignParticipationId: campaignParticipation2.id });
         resetKnowledgeElement1 = domainBuilder.buildKnowledgeElement({ skillId });
         resetKnowledgeElement2 = domainBuilder.buildKnowledgeElement({ skillId });
 
@@ -261,6 +261,17 @@ describe('Unit | Service | ScorecardService', function() {
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
         expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
+      });
+
+      it('should save a new Assessment', async () => {
+
+        // when
+        await scorecardService.resetScorecard({
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
+        });
+        // given
+        expect(assessmentRepository.save.args[0][0]).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 1 });
+        expect(assessmentRepository.save.args[1][0]).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 2 });
       });
 
       context('when campaign is already shared', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur remet à zéro une compétence alors qu'il passe une campagne, on recrée un assessment et l'ancien devient `aborted` pour la campagne. Suite à l'ajout de la colonne "campaignParticipationId", celle-ci était vide dans ce cas là.

## :robot: Solution
Lorsqu'on crée le nouvel Assessment, on met bien le campaignParticipationId
