### PR TITLE
[BUGFIX] Lancer consécutivement deux campagnes avec demande ID (PF-825).

### DIFF
--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -8,6 +8,11 @@ export default Route.extend({
 
   session: service(),
 
+  deactivate: function() {
+    this.controller.set('participantExternalId', null);
+    this.controller.set('loading', false);
+  },
+
   async beforeModel(transition) {
     const campaignCode = transition.to.params.campaign_code;
 


### PR DESCRIPTION
## :unicorn: Problème
On pouvait être bloqué lors de la saisie du `participantExternalId` si on avait déjà saisi un  `participantExternalId` lors d'une précédente campagne au cours d'une même session continue et sans rechargement.

## :robot: Solution
On reset les variables utilisées sur la page à la sortie complète de la route afin de se prémunir de toute sauvegarde de données de la part d'Ember.js
