### PR TITLE
[BUGFIX]  Corrige l'affichage des certifications d'une session (PA-109)

### DIFF
--- a/api/db/seeds/data/certification-courses-builder.js
+++ b/api/db/seeds/data/certification-courses-builder.js
@@ -42,4 +42,19 @@ module.exports = function certificationCoursesBuilder({ databaseBuilder }) {
     externalId: 'L\'élève',
     isPublished: false
   });
+
+  databaseBuilder.factory.buildCertificationCourse({
+    id: 4,
+    userId: 1,
+    completedAt: new Date('2018-02-15T15:15:52Z'),
+    createdAt: new Date('2018-02-15T15:14:46Z'),
+    firstName: 'Pix',
+    lastName: 'Aile',
+    birthdate: '1960-12-12',
+    birthplace: 'Paris',
+    sessionId: 1,
+    externalId: 'Certification course without assessment',
+    isPublished: true
+  });
+
 };

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -48,7 +48,7 @@ module.exports = {
       ...certification,
       ...lastAssessmentResultFull,
       ...{
-        assessmentId: assessment.id,
+        assessmentId: assessment ? assessment.id : null,
         certificationId: certification.id,
         createdAt: certification.createdAt,
         resultCreatedAt: lastAssessmentResultFull.createdAt,


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin, la page qui liste les certifications d'une session était cassée.

<img width="1392" alt="Capture d’écran 2019-09-13 à 18 08 48" src="https://user-images.githubusercontent.com/7529/64877403-a7f42080-d651-11e9-8043-9fc097498675.png">

C'est une régression suite à la PF-811.

Il y a 415 CertificationCourse sans Assessment. Quand on essaie d'afficher la liste des certifications d'une session qui contient l'un de ces CertificationCourse, l'API  essayait d'accéder à assessment.id d'un assessment undefined => erreur 500.

Voir [PA-109](https://1024pix.atlassian.net/browse/PA-109).

## :robot: Solution

1. Rétablir la vérification que l'assessment existe avant d'accéder à son id
2. Ajouter une seed qui permet de valider la correction en RA

<img width="1392" alt="Capture d’écran 2019-09-13 à 18 23 14" src="https://user-images.githubusercontent.com/7529/64878398-b93e2c80-d653-11e9-81bf-8a68bc95932a.png">

## :rainbow: Remarques

Cadeau, voici un nombre au hasard : 440906