### PR TITLE
[TECH] Mise à jour de la dépendance Joi dans l'API

### DIFF
--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -1,4 +1,4 @@
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const { ObjectValidationError } = require('../errors');
 
 const schemaValidateCompetenceMark = Joi.object().keys({
@@ -34,8 +34,8 @@ class CompetenceMark {
   }
 
   validate() {
-    const result = Joi.validate(this, schemaValidateCompetenceMark);
-    if (result.error === null) {
+    const result = schemaValidateCompetenceMark.validate(this);
+    if (result.error === undefined) {
       return Promise.resolve();
     } else {
       return Promise.reject(new ObjectValidationError(result.error));

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -258,6 +258,11 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hoek": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
@@ -280,26 +285,43 @@
           "version": "8.2.2",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
           "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+        },
+        "@hapi/joi": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+          "requires": {
+            "@hapi/address": "2.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/topo": "3.x.x"
+          }
         }
       }
     },
     "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.0.tgz",
+      "integrity": "sha512-OYWoI/uqs40IdRvPmgn5ame35esBnPR4qhzrE03o+Pb8NnlXIBJZWMXgAlwp43781Ybm0R1iEEMDx0H2lP8mJQ==",
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
+        "@hapi/formula": "1.x.x",
         "@hapi/hoek": "8.x.x",
+        "@hapi/pinpoint": "1.x.x",
         "@hapi/topo": "3.x.x"
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
-          "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+          "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
         }
       }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
     },
     "@hapi/topo": {
       "version": "3.1.3",
@@ -310,9 +332,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
-          "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+          "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
         }
       }
     },
@@ -891,6 +913,24 @@
         "easy-table": "1.x.x"
       },
       "dependencies": {
+        "@hapi/joi": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+          "requires": {
+            "@hapi/address": "2.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/topo": "3.x.x"
+          },
+          "dependencies": {
+            "@hapi/hoek": {
+              "version": "8.2.4",
+              "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+              "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
+            }
+          }
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -4233,6 +4273,17 @@
           "version": "8.2.2",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
           "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+        },
+        "@hapi/joi": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+          "requires": {
+            "@hapi/address": "2.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/topo": "3.x.x"
+          }
         }
       }
     },
@@ -7110,7 +7161,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
     "@hapi/inert": "^5.2.1",
+    "@hapi/joi": "^16.0.0",
     "airtable": "^0.7.1",
     "bcrypt": "^3.0.6",
     "blipp": "^4.0.0",
@@ -43,7 +44,6 @@
     "hapi-swagger": "^9.3.1",
     "heap-profile": "^0.3.2",
     "heapdump": "^0.3.14",
-    "joi": "^14.3.1",
     "json2csv": "^4.5.2",
     "jsonapi-serializer": "^3.6.5",
     "jsonwebtoken": "^8.5.1",
@@ -66,11 +66,11 @@
     "request-promise-native": "^1.0.7",
     "samlify": "github:1024pix/samlify#no-xml-validation",
     "vision": "^5.4.4",
+    "xml-buffer-tostring": "^0.2.0",
     "xml-crypto": "~1.0.2",
     "xmldom": "0.1.27",
     "xregexp": "^4.2.4",
-    "yamljs": "^0.3.0",
-    "xml-buffer-tostring": "^0.2.0"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -213,7 +213,7 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
             expect(response.statusCode).to.equal(422);
             expect(response.result.errors[0]).to.deep.equal({
               'title': 'Unprocessable entity',
-              'detail': 'ValidationError: child "score" fails because ["score" must be less than or equal to 64]',
+              'detail': 'ValidationError: "score" must be less than or equal to 64',
               'status': '422'
             });
           });

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -56,8 +56,7 @@ describe('Integration | Repository | CompetenceMark', () => {
     context('when competenceMark is not validated', () => {
       it('should return an error', () => {
         // given
-        const expectedValidationErrorMessage = 'ValidationError: child "level" fails because' +
-                                               ' ["level" must be less than or equal to 8]';
+        const expectedValidationErrorMessage = 'ValidationError: "level" must be less than or equal to 8';
         const markWithLevelGreaterThanEight = domainBuilder.buildCompetenceMark({
           score: 13,
           level: 10,

--- a/api/tests/unit/domain/models/CompetenceMark_test.js
+++ b/api/tests/unit/domain/models/CompetenceMark_test.js
@@ -49,7 +49,7 @@ describe('Unit | Domain | Models | Competence Mark', () => {
       // then
       return promise
         .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be less than or equal to 8]');
+          expect(error.message).to.be.equal('ValidationError: "level" must be less than or equal to 8');
         });
     });
 
@@ -63,7 +63,7 @@ describe('Unit | Domain | Models | Competence Mark', () => {
       // then
       return promise
         .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: child "level" fails because ["level" must be larger than or equal to -1]');
+          expect(error.message).to.be.equal('ValidationError: "level" must be larger than or equal to -1');
         });
     });
 
@@ -77,7 +77,7 @@ describe('Unit | Domain | Models | Competence Mark', () => {
       // then
       return promise
         .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: child "score" fails because ["score" must be less than or equal to 64]');
+          expect(error.message).to.be.equal('ValidationError: "score" must be less than or equal to 64');
           expect(error).to.be.instanceOf(ObjectValidationError);
         });
     });


### PR DESCRIPTION
## :unicorn: Problème
La version de la dépendance de **Joi** incluse dans l'API est dépréciée. De plus, la dépendance a été déplacée vers **@hapi/joi**.

## :robot: Solution
Modification de la dépendance de **joi** vers **@hapi/joi**
Mise à jour de 14.3.1 vers 16.0.0
Adaptation de la validation des **competence-marks** pour fonctionner avec la nouvelle version.

## :rainbow: Remarques
Changelog : 
de 14.3.1 vers 16.0.0 : https://github.com/hapijs/joi/issues/2037
