### PR TITLE
[TECH] Éviter les plantages de Redis causés par une accumulation de requêtes

### DIFF
--- a/api/lib/infrastructure/caches/redis-client.js
+++ b/api/lib/infrastructure/caches/redis-client.js
@@ -4,10 +4,13 @@ const logger = require('../logger');
 const { promisify } = require('util');
 
 const REDIS_CLIENT_OPTIONS = {
-  // All commands that were unfulfilled while the connection is lost will be
-  // retried after the connection has been reestablished.
-  // Note that this is safe because all of our commands are idempotent.
-  retry_unfulfilled_commands: true
+  // To avoid a "thundering herd" effect on the Redis server when it comes back
+  // up after a crash or connection loss, which can cause Redis to use more
+  // memory (for client buffers) than the OS allows and get killed, causing
+  // more Redis queries to get backed up, do not store a backlog of Redis
+  // queries. Errors will be reported immediately if the Redis server is not
+  // available.
+  enable_offline_queue: false,
 };
 
 module.exports = class RedisClient {


### PR DESCRIPTION
## :unicorn: Problème

Parfois, le serveur Redis en production se met à redémarrer en boucle, jusqu'à ce qu'on redémarre les conteneurs de l'API.

Après analyse il s'avère que le serveur Redis consomme toute la mémoire qui lui est allouée pour préparer les réponses aux questions qui lui sont soumises.

Or, le client Redis pour Node accumule par défaut les requêtes Redis soumises quand le serveur Redis n'est pas disponible, pour les poser dès que le serveur redevient disponible (l'hypothèse étant que l'indisponibilité du serveur est transitoire, et qu'il vaut mieux faire patienter le client quelques secondes de plus, plutôt que de lui renvoyer une erreur). De plus, en 25802cf5cbb393e9e09db2e679933189e21724b9 nous avons activé une option supplémentaire qui conserve et retente les requêtes dont on attendait la réponse au moment où le serveur a été déconnecté.

Le résultat est que lorsque le serveur Redis devient même brièvement indisponible pendant une période de forte charge, un grand nombre de requêtes s'accumulent et lui sont soumises en bloc dès qu'il revient en ligne, causant une utilisation mémoire excessive côté serveur (pour chaque question posée, le serveur Redis doit allouer suffisamment de mémoire pour contenir la réponse, jusqu'à ce que le client ait fini de télécharger celle-ci), et donc un redémarrage, donc une nouvelle indisponibilité du serveur Redis, pendant laquelle d'autres questions s'accumulent… causant une indisponibilité de l'application qui durera jusqu'à redémarrage des conteneurs applicatifs.

## :robot: Solution

On retire l'option `retry_unfulfilled_commands` qui avait été activée explicitement, et on désactive l'option `enable_offline_queue` qui est activée par défaut.

En conséquence, en cas d'indisponibilité du serveur Redis les clients de l'API recevront une erreur 500. En pratique, la tentative de gérer de façon transparente les indisponibilités s'est plutôt avérée néfaste pour la stabilité de la plate-forme. Il serait de toute façon plus intéressant de gérer les erreurs proprement au niveau _front_.

## 😈  Remarques

Envie de planter un serveur Redis (avec la configuration par défaut) ?

```
yes info | redis-cli --pipe
```
