### PR TITLE
[TECH] Amélioration de la conversion BookshelfUser en DomainUser dans le UserRepository.

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -47,7 +47,7 @@ function _toPixRolesDomain(pixRolesBookshelf) {
 }
 
 function _toDomain(userBookshelf) {
-  return new User({
+  const user = new User({
     id: userBookshelf.get('id'),
     firstName: userBookshelf.get('firstName'),
     lastName: userBookshelf.get('lastName'),
@@ -63,6 +63,8 @@ function _toDomain(userBookshelf) {
     hasSeenNewProfileInfo: Boolean(userBookshelf.get('hasSeenNewProfileInfo')),
     hasSeenAssessmentInstructions: Boolean(userBookshelf.get('hasSeenAssessmentInstructions')),
   });
+  user.memberships.forEach((membership) => membership.user = user);
+  return user;
 }
 
 function _setSearchFiltersForQueryBuilder(filters, qb) {

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -5,7 +5,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 
 describe('Acceptance | Controller | users-controller-get-memberships', () => {
 
-  let userId;
+  let user;
   let organization;
   let membershipId;
   let options;
@@ -15,19 +15,23 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
   beforeEach(async () => {
     server = await createServer();
   });
-  
+
   describe('GET /users/:id/memberships', () => {
 
     beforeEach(async () => {
-      userId = databaseBuilder.factory.buildUser().id;
+      user = databaseBuilder.factory.buildUser();
       organization = databaseBuilder.factory.buildOrganization();
-      membershipId = databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId, organizationRole }).id;
+      membershipId = databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: user.id,
+        organizationRole
+      }).id;
       await databaseBuilder.commit();
 
       options = {
         method: 'GET',
-        url: `/api/users/${userId}/memberships`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        url: `/api/users/${user.id}/memberships`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
     });
 
@@ -79,7 +83,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
               },
               relationships: {
                 'organization': { data: { type: 'organizations', id: organization.id.toString() }, },
-                'user': { data: null, },
+                'user': { data: { type: 'users', id: user.id.toString() }, },
               },
             },
           ],
@@ -104,16 +108,25 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
                     related: `/api/organizations/${organization.id.toString()}/memberships`
                   }
                 },
-                'target-profiles': {
-                  links: {
-                    related: `/api/organizations/${organization.id.toString()}/target-profiles`
-                  }
-                },
                 students: {
                   links: {
                     related: `/api/organizations/${organization.id.toString()}/students`
                   }
                 },
+                'target-profiles': {
+                  links: {
+                    related: `/api/organizations/${organization.id.toString()}/target-profiles`
+                  }
+                },
+              }
+            },
+            {
+              type: 'users',
+              id: user.id.toString(),
+              attributes: {
+                email: user.email,
+                'first-name': user.firstName,
+                'last-name': user.lastName,
               }
             },
           ],

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -330,6 +330,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         expect(associatedOrganization.type).to.equal(organizationInDB.type);
 
         expect(membership.organizationRole).to.equal(membershipInDB.organizationRole);
+        expect(membership.user).to.equal(user);
       });
 
       it('should reject with a UserNotFound error when no user was found with the given id', async () => {


### PR DESCRIPTION
### Problème

Ember Data n'aime pas les relations bidirectionnelles _impures_.

Dans notre cas, `/api/users/:id` retourne, au format JSON:API, un objet `User` avec des liens vers ses relations, dont ses `Membershsips`. 

Ceux-ci sont récupérés dans un second temps, grâce à la ressource `/api/users/:id/memberships`.

Le problème, c'est que dans la réponse, au format JSON:API, on a bien l'attribut / la relation `user` qui est remontée, mais la propriété vaut `null`. Ember-Data s'attend à trouver des informations sur l'utilisateur, ou à tout le moins, son ID, afin _d'équilibrer_ la relation.

En conséquence de quoi, Ember Data nous crie dessus très fortement dans les logs de la console. Et puis, en maître bienveillant, il fait quand même le nécessaire pour résoudre de lui-même la relation et vivre sa vie d'ORM.

### Solution

La correction consiste à renseigner le User associé à chaque Membership instancié lors de l'instanciation du premier : 

```
function _toDomain(userBookshelf) {
    const user = new User({
        // …
        memberships: _toMembershipsDomain(userBookshelf.related('memberships')),
        // …
    });
    user.memberships.forEach((membership) => membership.user = user);
})
```
