### PR TITLE
[FEATURE] Ajout du département (code) aux Organisations et affichage dans Pix Admin (PA-105).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -10,6 +10,7 @@ export default DS.Model.extend({
   code: attr(),
   logoUrl: attr(),
   externalId: attr(),
+  provinceCode: attr(),
 
   // Relationships
   memberships: hasMany('membership'),

--- a/admin/app/templates/components/organization-information-section.hbs
+++ b/admin/app/templates/components/organization-information-section.hbs
@@ -22,6 +22,9 @@
         {{#if organization.externalId}}
           Identifiant externe : <span class="organization__externalId">{{organization.externalId}}</span><br>
         {{/if}}
+        {{#if organization.provinceCode}}
+          Département : <span class="organization__provinceCode">{{organization.provinceCode}}</span><br>
+        {{/if}}
       </p>
     </div>
   </div>

--- a/api/db/migrations/20190918105231_add_column_provinceCode_to_organizations.js
+++ b/api/db/migrations/20190918105231_add_column_provinceCode_to_organizations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'provinceCode';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).index();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -8,6 +8,7 @@ class Organization {
     type,
     logoUrl,
     externalId,
+    provinceCode,
     isManagingStudents,
     // includes
     user,
@@ -23,6 +24,7 @@ class Organization {
     this.type = type;
     this.logoUrl = logoUrl;
     this.externalId = externalId;
+    this.provinceCode = provinceCode;
     this.isManagingStudents = isManagingStudents;
     // includes
     this.user = user;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -15,6 +15,7 @@ function _toDomain(bookshelfOrganization) {
     type: rawOrganization.type,
     logoUrl: rawOrganization.logoUrl,
     externalId: rawOrganization.externalId,
+    provinceCode: rawOrganization.provinceCode,
     isManagingStudents: Boolean(rawOrganization.isManagingStudents),
   });
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      attributes: ['name', 'type', 'code', 'logoUrl', 'externalId', 'isManagingStudents', 'user', 'memberships', 'students'],
+      attributes: ['name', 'type', 'code', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'user', 'memberships', 'students'],
       user: {
         ref: 'id',
         attributes: ['firstName', 'lastName', 'email'],

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -496,6 +496,7 @@ describe('Acceptance | Application | organization-controller', () => {
               'type': organization.type,
               'logo-url': organization.logoUrl,
               'external-id': organization.externalId,
+              'province-code': organization.provinceCode,
               'is-managing-students': organization.isManagingStudents,
             },
             'id': organization.id.toString(),

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -10,6 +10,7 @@ const buildOrganization = function buildOrganization({
   code = faker.random.alphaNumeric(6),
   logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
   externalId = faker.lorem.word(),
+  provinceCode = faker.random.alphaNumeric(3),
   isManagingStudents = false,
   userId = null,
   createdAt = faker.date.recent(),
@@ -24,6 +25,7 @@ const buildOrganization = function buildOrganization({
     logoUrl,
     createdAt,
     externalId,
+    provinceCode,
     isManagingStudents,
     userId,
     updatedAt
@@ -42,6 +44,7 @@ buildOrganization.withUser = function buildOrganizationWithUser({
   code = 'ABCD12',
   logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
   externalId = faker.lorem.word(),
+  provinceCode = faker.random.alphaNumeric(3),
   isManagingStudents = false,
   userId,
   createdAt = faker.date.recent()
@@ -49,7 +52,7 @@ buildOrganization.withUser = function buildOrganizationWithUser({
 
   userId = _.isNil(userId) ? buildUser().id : userId;
 
-  const values = { id, type, name, code, logoUrl, externalId, isManagingStudents, createdAt, userId };
+  const values = { id, type, name, code, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, userId };
   return databaseBuffer.pushInsertable({
     tableName: 'organizations',
     values,

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -34,13 +34,14 @@ function buildOrganization(
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
     externalId = 'OrganizationIdLinksToExternalSource',
+    provinceCode = '2A',
     isManagingStudents = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     user = null,
     memberships = [],
     targetProfileShares = []
   } = {}) {
-  return new Organization({ id, code, name, type, logoUrl, externalId, isManagingStudents, createdAt, user, memberships, targetProfileShares });
+  return new Organization({ id, code, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, user, memberships, targetProfileShares });
 }
 
 buildOrganization.withUser = function(
@@ -51,12 +52,13 @@ buildOrganization.withUser = function(
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
     externalId = 'OrganizationIdLinksToExternalSource',
+    provinceCode = '2A',
     isManagingStudents = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     user = _buildMember()
   } = {}
 ) {
-  return new Organization({ id, code, name, type, logoUrl, externalId, isManagingStudents, createdAt, user });
+  return new Organization({ id, code, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, user });
 };
 
 buildOrganization.withMembers = function(
@@ -67,6 +69,7 @@ buildOrganization.withMembers = function(
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
     externalId = 'OrganizationIdLinksToExternalSource',
+    provinceCode = '2A',
     isManagingStudents = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     members = [
@@ -75,7 +78,7 @@ buildOrganization.withMembers = function(
     ]
   } = {}
 ) {
-  return new Organization({ id, code, name, type, logoUrl, externalId, isManagingStudents, createdAt, members });
+  return new Organization({ id, code, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, members });
 };
 
 buildOrganization.withStudents = function(
@@ -86,12 +89,13 @@ buildOrganization.withStudents = function(
     type = 'SCO',
     logoUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
     externalId = 'OrganizationIdLinksToExternalSource',
+    provinceCode = '2A',
     isManagingStudents = true,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     students = []
   } = {}
 ) {
-  const organization = new Organization({ id, code, name, type, logoUrl, externalId, isManagingStudents, createdAt, students });
+  const organization = new Organization({ id, code, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, students });
 
   organization.students = [
     _buildStudent({ id: 1, lastName: 'Doe', firstName: 'John', organization }),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -23,6 +23,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'code': organization.code,
             'logo-url': organization.logoUrl,
             'external-id': organization.externalId,
+            'province-code': organization.provinceCode,
             'is-managing-students': organization.isManagingStudents,
           },
           relationships: {


### PR DESCRIPTION
## :unicorn: Problème
L'information du département (code) des Organisations n'est actuellement pas stockée. On souhaite pouvoir la stocker dans le cadre de l'import en masse des Organisations.

## :robot: Solution
Ajout d'une colonne `provinceCode` dans la table `Organization` et affichage de ce champ dans Pix Admin.
