### PR TITLE
[TECH] S'assurer que les ids sont toujours traités en tant qu'entier

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -16,7 +16,7 @@ module.exports = {
 
   async get(request) {
     const userId = requestUtils.extractUserIdFromRequest(request);
-    const answerId = request.params.id;
+    const answerId = parseInt(request.params.id);
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);
@@ -24,7 +24,7 @@ module.exports = {
 
   async update(request) {
     const userId = requestUtils.extractUserIdFromRequest(request);
-    const answerId = request.params.id;
+    const answerId = parseInt(request.params.id);
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);
@@ -43,7 +43,7 @@ module.exports = {
     const userId = requestUtils.extractUserIdFromRequest(request);
 
     const correction = await usecases.getCorrectionForAnswer({
-      answerId: request.params.id,
+      answerId: parseInt(request.params.id),
       userId
     });
 

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -36,7 +36,7 @@ module.exports = {
   },
 
   async get(request) {
-    const assessmentId = request.params.id;
+    const assessmentId = parseInt(request.params.id);
 
     const assessment = await usecases.getAssessment({ assessmentId });
 
@@ -65,12 +65,12 @@ module.exports = {
     const logContext = {
       zone: 'assessmentController.getNextChallenge',
       type: 'controller',
-      assessmentId: request.params.id,
+      assessmentId: parseInt(request.params.id),
     };
     logger.trace(logContext, 'tracing assessmentController.getNextChallenge()');
 
     return assessmentRepository
-      .get(request.params.id)
+      .get(parseInt(request.params.id))
       .then((assessment) => {
 
         logContext.assessmentType = assessment.type;
@@ -123,7 +123,7 @@ module.exports = {
   },
 
   async completeAssessment(request) {
-    const assessmentId = request.params.id;
+    const assessmentId = parseInt(request.params.id);
     const userId = requestUtils.extractUserIdFromRequest(request);
 
     const completedAssessment = await usecases.completeAssessment({ userId, assessmentId });

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -7,7 +7,7 @@ const serializer = require('../../infrastructure/serializers/jsonapi/campaign-pa
 module.exports = {
 
   async getById(request) {
-    const campaignParticipationId = request.params.id;
+    const campaignParticipationId = parseInt(request.params.id);
     const userId = request.auth.credentials.userId;
     const options = queryParamsUtils.extractParameters(request.query);
 

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   getById(request) {
-    const campaignId = request.params.id;
+    const campaignId = parseInt(request.params.id);
     const options = queryParamsUtils.extractParameters(request.query);
     const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
     return usecases.getCampaign({ campaignId, options })
@@ -59,7 +59,7 @@ module.exports = {
 
   update(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = request.params.id;
+    const campaignId = parseInt(request.params.id);
     const { title, 'custom-landing-page-text': customLandingPageText } = request.payload.data.attributes;
 
     return usecases.updateCampaign({ userId, campaignId, title, customLandingPageText })
@@ -76,7 +76,7 @@ module.exports = {
 
   async getCollectiveResult(request) {
     const { userId } = request.auth.credentials;
-    const campaignId = request.params.id;
+    const campaignId = parseInt(request.params.id);
 
     const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId });
     return campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   getById(request) {
-    const certificationCenterId = request.params.id;
+    const certificationCenterId = parseInt(request.params.id);
     return usecases.getCertificationCenter({ id: certificationCenterId })
       .then(certificationCenterSerializer.serialize);
   },

--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -19,7 +19,7 @@ module.exports = {
 
   getCertification(request) {
     const userId = request.auth.credentials.userId;
-    const certificationId = request.params.id;
+    const certificationId = parseInt(request.params.id);
 
     return usecases.getUserCertificationWithResultTree({
       userId,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -15,7 +15,7 @@ const EXPORT_CSV_FILE_NAME = 'Pix - Export donnees partagees.csv';
 module.exports = {
 
   getOrganizationDetails: (request) => {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
 
     return usecases.getOrganizationDetails({ organizationId })
       .then(organizationSerializer.serialize);
@@ -60,14 +60,14 @@ module.exports = {
   },
 
   getCampaigns(request) {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
 
     return usecases.getOrganizationCampaigns({ organizationId })
       .then((campaigns) => campaignSerializer.serialize(campaigns, { ignoreCampaignReportRelationshipData : false }));
   },
 
   getMemberships(request) {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
 
     return usecases.getOrganizationMemberships({ organizationId })
       .then(membershipSerializer.serialize);
@@ -81,7 +81,7 @@ module.exports = {
   },
 
   exportSharedSnapshotsAsCsv: async (request) => {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
 
     const stream = new PassThrough();
 
@@ -99,14 +99,14 @@ module.exports = {
   },
 
   findStudents: async (request) => {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
 
     return usecases.findOrganizationStudents({ organizationId })
       .then(studentSerializer.serialize);
   },
 
   importStudentsFromSIECLE(request) {
-    const organizationId = request.params.id;
+    const organizationId = parseInt(request.params.id);
     const buffer = request.payload;
 
     return usecases.importStudentsFromSIECLE({ organizationId, buffer })

--- a/api/lib/application/preHandlers/assessment-authorization.js
+++ b/api/lib/application/preHandlers/assessment-authorization.js
@@ -5,7 +5,7 @@ const { extractUserIdFromRequest } = require('../../infrastructure/utils/request
 module.exports = {
   verify(request, h) {
     const userId = extractUserIdFromRequest(request);
-    const assessmentId = request.params.id;
+    const assessmentId = parseInt(request.params.id);
 
     return assessmentRepository
       .getByAssessmentIdAndUserId(assessmentId, userId)

--- a/api/lib/application/preHandlers/snapshot-authorization.js
+++ b/api/lib/application/preHandlers/snapshot-authorization.js
@@ -7,7 +7,7 @@ module.exports = {
   verify(request, h) {
     const token = request.query.userToken || tokenService.extractTokenFromAuthChain(request.headers.authorization);
     const userId = tokenService.extractUserId(token);
-    const organizationId = request.params.id || extractParameters(request.query).filter.organizationId;
+    const organizationId = parseInt(request.params.id) || parseInt(extractParameters(request.query).filter.organizationId);
 
     return organizationRepository
       .findByUserId(userId)

--- a/api/lib/application/preHandlers/snapshot-authorization.js
+++ b/api/lib/application/preHandlers/snapshot-authorization.js
@@ -11,7 +11,7 @@ module.exports = {
 
     return organizationRepository
       .findByUserId(userId)
-      .then((organizations) => organizations.some((organization) => organization.id == organizationId))
+      .then((organizations) => organizations.some((organization) => organization.id === organizationId))
       .then((organizationFound) => organizationFound ? null : Promise.reject())
       .catch(() => {
         const buildedError = _dataAuthorizationPayload('Vous n’êtes pas autorisé à accéder à ces profils partagés');

--- a/api/lib/application/preHandlers/user-existence-verification.js
+++ b/api/lib/application/preHandlers/user-existence-verification.js
@@ -6,7 +6,7 @@ const { UserNotFoundError } = require('../../domain/errors');
 module.exports = {
   verifyById(request, h) {
     return userRepository
-      .get(request.params.id)
+      .get(parseInt(request.params.id))
       .catch((err) => {
         if (err instanceof User.NotFoundError) {
           const serializedError = errorSerializer.serialize(new UserNotFoundError().getErrorMessage());

--- a/api/lib/application/scorecards/scorecard-controller.js
+++ b/api/lib/application/scorecards/scorecard-controller.js
@@ -4,7 +4,7 @@ const usecases = require('../../domain/usecases');
 module.exports = {
 
   getScorecard(request) {
-    const authenticatedUserId = request.auth.credentials.userId.toString();
+    const authenticatedUserId = request.auth.credentials.userId;
     const scorecardId = request.params.id;
 
     return usecases.getScorecard({ authenticatedUserId, scorecardId })

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   async get(request) {
-    const sessionId = request.params.id;
+    const sessionId = parseInt(request.params.id);
     const session = await sessionService.get(sessionId);
 
     return sessionSerializer.serialize(session);
@@ -31,7 +31,7 @@ module.exports = {
   async update(request) {
     const userId = request.auth.credentials.userId;
     const session = sessionSerializer.deserialize(request.payload);
-    session.id = request.params.id;
+    session.id = parseInt(request.params.id);
 
     const updatedSession = await usecases.updateSession({ userId, session });
 
@@ -39,7 +39,7 @@ module.exports = {
   },
 
   async getAttendanceSheet(request, h) {
-    const sessionId = request.params.id;
+    const sessionId = parseInt(request.params.id);
     const token = request.query.accessToken;
     const userId = tokenService.extractUserId(token);
     const attendanceSheet = await usecases.getAttendanceSheet({ sessionId, userId });

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -34,7 +34,7 @@ module.exports = async function completeAssessment({
     throw new NotFoundError();
   }
 
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to complete this assessment.');
   }
 

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -24,7 +24,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
 
   const assessment = await assessmentRepository.get(answer.assessmentId);
 
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to add an answer for this assessment.');
   }
 

--- a/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
@@ -11,7 +11,7 @@ module.exports = async function findAnswerByChallengeAndAssessment(
     assessmentRepository,
   } = {}) {
   const assessment = await assessmentRepository.get(assessmentId);
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to see this assessment.');
   }
 

--- a/api/lib/domain/usecases/get-answer.js
+++ b/api/lib/domain/usecases/get-answer.js
@@ -12,7 +12,7 @@ module.exports = async function getAnswer(
 
   const answer = await answerRepository.get(answerId);
   const assessment = await assessmentRepository.get(answer.assessmentId);
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to get this answer.');
   }
   return answer;

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -16,7 +16,7 @@ module.exports = async function getCorrectionForAnswer({
 };
 
 function _validateCorrectionIsAccessible(assessment, userId) {
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new ForbiddenAccess('User is not allowed to see correction of this assessment.');
   }
   if (!assessment.isCompleted() && !assessment.isSmartPlacement() && !assessment.isCompetenceEvaluation()) {

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -28,7 +28,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
 };
 
 function _checkIfAssessmentBelongsToUser(assessment, userId) {
-  if (assessment.userId != userId) {
+  if (assessment.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntity();
   }
 }

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -5,7 +5,7 @@ module.exports = async function getScorecard({ authenticatedUserId, scorecardId,
 
   const { userId, competenceId } = Scorecard.parseId(scorecardId);
 
-  if (parseInt(authenticatedUserId) !== parseInt(userId)) {
+  if (authenticatedUserId !== userId) {
     throw new UserNotAuthorizedToAccessEntity();
   }
 

--- a/api/lib/domain/usecases/get-user-certification-with-result-tree.js
+++ b/api/lib/domain/usecases/get-user-certification-with-result-tree.js
@@ -24,7 +24,7 @@ module.exports = function getUserCertificationWithResultTree({
 }) {
   return certificationRepository.getByCertificationCourseId({ id: certificationId })
     .then((certification) => {
-      if (certification.userId !== parseInt(userId, 10)) {
+      if (certification.userId !== userId) {
         throw new UserNotAuthorizedToAccessEntity();
       }
 

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -82,8 +82,8 @@ function checkRequestedUserIsAuthenticatedUser(request, h) {
     return _replyWithAuthorizationError(h);
   }
 
-  const authenticatedUserId = request.auth.credentials.userId.toString();
-  const requestedUserId = request.params.userId || request.params.id;
+  const authenticatedUserId = request.auth.credentials.userId;
+  const requestedUserId = parseInt(request.params.userId) || parseInt(request.params.id);
 
   return authenticatedUserId === requestedUserId ? h.response(true) : _replyWithAuthorizationError(h);
 }
@@ -94,7 +94,7 @@ function checkUserIsOwnerInOrganization(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = parseInt(request.params.id);
 
   return checkUserIsOwnerInOrganizationUseCase.execute(userId, organizationId)
     .then((isOwnerInOrganization) => {
@@ -115,7 +115,7 @@ async function checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = parseInt(request.params.id);
 
   const isOwnerInOrganization = await checkUserIsOwnerInOrganizationUseCase.execute(userId, organizationId);
   if (isOwnerInOrganization) {
@@ -136,7 +136,7 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = parseInt(request.params.id);
 
   let belongsToScoOrganizationAndManageStudents;
   try {
@@ -159,7 +159,7 @@ async function checkUserIsOwnerInScoOrganizationAndManagesStudents(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = parseInt(request.params.id);
 
   const belongsToScoOrganizationAndManageStudents = await checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
   if (belongsToScoOrganizationAndManageStudents) {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -393,7 +393,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
   describe('#findStudents', () => {
 
     const connectedUserId = 1;
-    const organizationId = '145';
+    const organizationId = 145;
 
     let student;
     let serializedStudents;
@@ -401,7 +401,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     beforeEach(() => {
       request = {
         auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId }
+        params: { id: organizationId.toString() }
       };
 
       sinon.stub(usecases, 'findOrganizationStudents');
@@ -444,13 +444,13 @@ describe('Unit | Application | Organizations | organization-controller', () => {
   describe('#importStudentsFromSIECLE', () => {
 
     const connectedUserId = 1;
-    const organizationId = '145';
+    const organizationId = 145;
     const buffer = null;
 
     beforeEach(() => {
       request = {
         auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
+        params: { id: organizationId.toString() },
         payload: buffer
       };
 

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -92,13 +92,14 @@ describe('Unit | Controller | sessionController', () => {
   });
 
   describe('#get', function() {
+    const sessionId = 123;
 
     beforeEach(() => {
       sinon.stub(sessionService, 'get');
       sinon.stub(sessionSerializer, 'serialize');
       request = {
         params: {
-          id: 'sessionId'
+          id: sessionId.toString(),
         }
       };
     });
@@ -113,7 +114,7 @@ describe('Unit | Controller | sessionController', () => {
         await sessionController.get(request, hFake);
 
         // then
-        expect(sessionService.get).to.have.been.calledWith('sessionId');
+        expect(sessionService.get).to.have.been.calledWith(sessionId);
       });
 
       it('should serialize session informations', async function() {

--- a/api/tests/unit/domain/usecases/get-user-certification-with-result-tree_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-with-result-tree_test.js
@@ -5,7 +5,7 @@ const ResultCompetenceTree = require('../../../../lib/domain/models/ResultCompet
 
 describe('Unit | UseCase | getUserCertificationWithResultTree', () => {
 
-  const userId = '2';
+  const userId = 2;
   const certificationId = '23';
 
   const assessmentRepository = {
@@ -76,7 +76,7 @@ describe('Unit | UseCase | getUserCertificationWithResultTree', () => {
       assessment = domainBuilder.buildAssessment();
       assessmentRepository.getByCertificationCourseId.resolves(assessment);
 
-      certification = domainBuilder.buildCertification({ userId: parseInt(userId, 10) });
+      certification = domainBuilder.buildCertification({ userId });
       certificationRepository.getByCertificationCourseId.resolves(certification);
 
       competenceMarks = [domainBuilder.buildCompetenceMark()];


### PR DESCRIPTION
## :unicorn: Problème
Il existe des ids traités parfois en entier, d'autres fois en chaîne, et comparés de manière non stricte `==` `!=` au lieu de `===` `!==`

## :robot: Solution
Depuis le changement de type des colonnes en base de données de BIGINT vers INTEGER, ce traitement en tant que chaîne n'est plus nécessaire. Tous les casts et les comparaisons en tant que chaîne ont été remplacés par des comparaisons entre entiers (comme il se doit d'ailleurs lorsqu'on traite avec des ids entiers).

## :rainbow: Remarques
