### PR TITLE
[BUGFIX] Correction de l'apparition de bordures rouges pour les champs de saisie du formulaire de connexion pour Pix Orga et Pix Certif.

### DIFF
--- a/certif/app/templates/components/login-form.hbs
+++ b/certif/app/templates/components/login-form.hbs
@@ -26,7 +26,6 @@
           @id="login-email"
           @name="email"
           @type="email"
-          @required="true"
           @class="input"
           @value={{email}}
           @autocomplete="username"
@@ -40,7 +39,6 @@
             @id="login-password"
             @name="password"
             @type={{passwordInputType}}
-            @required="true"
             @class="input"
             @value={{password}}
             @autocomplete="current-password"

--- a/orga/app/templates/components/login-form.hbs
+++ b/orga/app/templates/components/login-form.hbs
@@ -28,7 +28,6 @@
           @id="login-email"
           @name="email"
           @type="email"
-          @required="true"
           @class="input"
           @value={{email}}
           @autocomplete="username"
@@ -42,7 +41,6 @@
             @id="login-password"
             @name="password"
             @type={{passwordInputType}}
-            @required="true"
             @class="input"
             @value={{password}}
             @autocomplete="current-password"

--- a/orga/app/templates/components/routes/authenticated/team/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/team/new-item.hbs
@@ -3,7 +3,6 @@
   <div class="form__field">
     <label for="email" class="label">Email</label>
     <Input
-      @required="true"
       @type="email"
       @id="email"
       @name="email"


### PR DESCRIPTION
Lors des montées de version des dépendances, une correction a été apportée dans les templates `.hbs`, lors du passage de la déclaration de champs input du style Mustache à AngleBracket, au niveau de l'attribut `required`. Il s'avère que par le passé, ce champs n'était pas correctement déclaré `{{input required}}` plutôt que `{{input required=true}}`. Par conséquence, Firefox n'appliquait pas son comportement par défaut consistant à mettre des bordures rouge sur les "champs requis". 
 
La solution retenue pour fixer le problème est de se dire qu'on va être iso-prod et donc de supprimer (peut-être temporairement) l'attribut `required`.