### PR TITLE
[BUGFIX] Correction du champ de saisie du mot de passe à la connexion pour Pix Orga et Pix Certif.

### DIFF
--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -44,7 +44,7 @@
     background-color: white;
     border: 2px solid $alto;
 
-    &:hover {
+    &:focus-within {
       border: 2px solid $dodger-blue;
     }
 
@@ -58,7 +58,8 @@
       font-size: 1rem;
 
       &:focus {
-        outline: none;
+        outline: 0;
+        border: none;
       }
 
       &::-ms-clear, &::-ms-reveal {

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -45,7 +45,7 @@
     background-color: white;
     border: 2px solid $alto;
 
-    &:hover {
+    &:focus-within {
       border: 2px solid $dodger-blue;
     }
 
@@ -59,7 +59,8 @@
       font-size: 1rem;
 
       &:focus {
-        outline: none;
+        outline: 0;
+        border: none;
       }
 
       &::-ms-clear, &::-ms-reveal {


### PR DESCRIPTION
Suite à la montée de version et à la conversion `{{input}}` vers `<Input />`, il y a un souci de rendu au survol du champ "mot de passe" pour le formulaire de login de Pix Orga et Pix Certif.

**Avant**

![image](https://user-images.githubusercontent.com/265963/65332908-d88f0980-dbbf-11e9-8908-665f0149b213.png)

**Après**

![image](https://user-images.githubusercontent.com/265963/65332979-f5c3d800-dbbf-11e9-9c01-7da29567d526.png)
