### PR TITLE
[FEATURE] Mise à jour des organisations en ajoutant un identifiant externe et le département à l'aide d'un script (PF-778).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -28,9 +28,9 @@ module.exports = {
 
   updateOrganizationInformation: (request) => {
     const id = request.payload.data.id;
-    const { name, type, 'logo-url': logoUrl } = request.payload.data.attributes;
+    const { name, type, 'logo-url': logoUrl, 'external-id': externalId, 'province-code': provinceCode } = request.payload.data.attributes;
 
-    return usecases.updateOrganizationInformation({ id, name, type, logoUrl })
+    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -1,17 +1,19 @@
-module.exports = async function updateOrganizationInformation(
-  {
-    id,
-    name,
-    type,
-    logoUrl,
-    organizationRepository
-  }) {
-
+module.exports = async function updateOrganizationInformation({
+  id,
+  name,
+  type,
+  logoUrl,
+  externalId,
+  provinceCode,
+  organizationRepository
+}) {
   const organization = await organizationRepository.get(id);
 
   if (name) organization.name = name;
   if (type) organization.type = type;
   if (logoUrl) organization.logoUrl = logoUrl;
+  if (externalId) organization.externalId = externalId;
+  if (provinceCode) organization.provinceCode = provinceCode;
 
   await organizationRepository.update(organization);
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -63,7 +63,7 @@ module.exports = {
 
   update(organization) {
 
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl']);
+    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode']);
 
     return new BookshelfOrganization({ id: organization.id })
       .save(organizationRawData, { patch: true })

--- a/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
+++ b/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
@@ -1,0 +1,154 @@
+"use strict";
+require('dotenv').config();
+const path = require('path');
+const fs = require('fs');
+const request = require('request-promise-native');
+const papa = require('papaparse');
+
+const CSV_HEADERS = {
+  ID: 'Orga_ID',
+  EXTERNAL_ID: 'Code établissement (code UAI)',
+};
+
+function assertFileValidity(filePath) {
+  const fileExists = fs.existsSync(filePath);
+  if (!fileExists) {
+    const errorMessage = `File not found ${filePath}`;
+    throw new Error(errorMessage);
+  }
+  const fileExtension = path.extname(filePath);
+  if (fileExtension !== '.csv') {
+    const errorMessage = `File extension not supported ${fileExtension}`;
+    throw new Error(errorMessage);
+  }
+  return true;
+}
+
+function convertCSVDataIntoOrganizations(csvParsingResult) {
+  const dataRows = csvParsingResult.data;
+  return dataRows.reduce((organizations, dataRow) => {
+    const externalId = dataRow[CSV_HEADERS.EXTERNAL_ID].toUpperCase();
+    const organization = {
+      id: parseInt(dataRow[CSV_HEADERS.ID]),
+      externalId,
+      provinceCode: externalId.substring(0, 3)
+    };
+    organizations.push(organization);
+    return organizations;
+  }, []);
+}
+
+function _buildRequestObject(accessToken, organization) {
+  return {
+    method: 'PATCH',
+    headers: { authorization: `Bearer ${accessToken}` },
+    baseUrl: process.env.BASE_URL,
+    url: `/api/organizations/${organization.id}`,
+    json: true,
+    body: {
+      data: {
+        type: 'organizations',
+        id: organization.id,
+        attributes: {
+          'external-id': organization.externalId,
+          'province-code': organization.provinceCode
+        }
+      }
+    }
+  };
+}
+
+function _buildTokenRequestObject() {
+  return {
+    method: 'POST',
+    baseUrl: process.env.BASE_URL,
+    url: '/api/token',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    form: {
+      grant_type: 'password',
+      username: process.env.PIXMASTER_EMAIL,
+      password: process.env.PIXMASTER_PASSWORD
+    },
+    json: true
+  };
+}
+
+/**
+ * @param options
+ * - accessToken: String
+ * - organizations: Array[Object]
+ */
+function saveOrganizations(options) {
+  const errorObjects = [];
+
+  const promises = options.organizations.map((organization) => {
+    const requestConfig = _buildRequestObject(options.accessToken, organization);
+    return request(requestConfig)
+      .catch((err) => {
+        errorObjects.push({
+          errorMessage: err.message,
+          organization
+        });
+      });
+  });
+  return Promise.all(promises).then(() => {
+    return errorObjects;
+  });
+}
+
+function _logErrorObjects(errorObjects) {
+  console.log('Mise à jour des organisations : OK');
+  console.log(`\nIl y a eu ${errorObjects.length} erreurs`);
+  errorObjects.forEach((errorObject) => {
+    console.log(`  > id de l\'organization : ${errorObject.organization.id} - erreur : ${errorObject.errorMessage}`);
+  });
+}
+
+/**
+ * Usage: BASE_URL='url' (...) node update-sco-organizations-with-province-code-and-external-id.js my_file.csv
+ */
+async function main() {
+  console.log('Début du script de mise à jour des Organisations avec l\'ID externe et le département');
+  try {
+    const filePath = process.argv[2];
+
+    const response = await request(_buildTokenRequestObject());
+    const accessToken = response.access_token;
+
+    console.log('\nTest de validité du fichier...');
+    assertFileValidity(filePath);
+    console.log('Test de validité du fichier : OK');
+
+    fs.readFile(filePath, 'utf8', async function(err, data) {
+      console.log('\nMise à jour des organizations...');
+
+      // We delete the BOM UTF8 at the beginning of the CSV,
+      // otherwise the first element is wrongly parsed.
+      const csvRawData = data.toString('utf8').replace(/^\uFEFF/, '');
+
+      const parsedCSVData = papa.parse(csvRawData, { header: true });
+
+      const organizations = convertCSVDataIntoOrganizations(parsedCSVData);
+      const options = { accessToken, organizations };
+
+      const errorObjects = await saveOrganizations(options);
+      _logErrorObjects(errorObjects);
+
+      console.log('\nFin du script');
+    });
+
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  assertFileValidity,
+  convertCSVDataIntoOrganizations,
+  saveOrganizations
+};

--- a/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
+++ b/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
@@ -1,0 +1,400 @@
+const { expect, sinon, nock } = require('../../test-helper');
+const script = require('../../../scripts/update-sco-organizations-with-province-code-and-external-id');
+
+describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and-external-id.js', () => {
+
+  describe('#assertFileValidity', () => {
+
+    it('should throw an error when file does not exist', () => {
+      // given
+      const filePath = 'inexistant.file';
+
+      try {
+        // when
+        script.assertFileValidity(filePath);
+
+        // then
+        expect.fail('Expected error to have been thrown');
+      } catch (err) {
+        expect(err.message).to.equal('File not found inexistant.file');
+      }
+    });
+
+    it('should throw an error when file extension is not ".csv"', () => {
+      // given
+      const filePath = `${__dirname}/file_with_bad_extension.html`;
+
+      try {
+        // when
+        script.assertFileValidity(filePath);
+
+        // then
+        expect.fail('Expected error to have been thrown');
+      } catch (err) {
+        expect(err.message).to.equal('File extension not supported .html');
+      }
+    });
+
+    it('should return true if file is valid', () => {
+      // given
+      const filePath = `${__dirname}/valid-organizations-test-file.csv`;
+
+      // when
+      const result = script.assertFileValidity(filePath);
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#convertCSVDataIntoOrganizations', () => {
+
+    it('should return an array of organizations (JSON) object', () => {
+      // given
+      const csvParsingResult = {
+        data: [{
+          'Orga_ID': '1',
+          'Code établissement (code UAI)' : ''
+        }, {
+          'Orga_ID': '2',
+          'Code établissement (code UAI)' : '9752145V'
+        }, {
+          'Orga_ID': '3',
+          'Code établissement (code UAI)' : '01A4556S'
+        }]
+      };
+      const expectedOrganizations = [{
+        id: 1,
+        externalId : '',
+        provinceCode : ''
+      }, {
+        id: 2,
+        externalId : '9752145V',
+        provinceCode : '975'
+      }, {
+        id: 3,
+        externalId : '01A4556S',
+        provinceCode : '01A'
+      }];
+
+      // when
+      const organizations = script.convertCSVDataIntoOrganizations(csvParsingResult);
+
+      // then
+      expect(organizations).to.deep.equal(expectedOrganizations);
+    });
+  });
+
+  describe('#saveOrganizations', () => {
+
+    let options;
+
+    beforeEach(() => {
+      process.env.BASE_URL = 'http://localhost:3000';
+      options = {
+        accessToken: 'token-token',
+        organizations: []
+      };
+    });
+
+    it('should not do any http request, when there is no organization', () => {
+      // given
+      options.organizations = [];
+
+      // when
+      const promise = script.saveOrganizations(options);
+
+      // then
+      promise.catch(() => {
+        sinon.assert.fail('Should not fail');
+      });
+    });
+
+    it('should call PATCH /api/organizations/:id once, when there is an organization', async () => {
+      // given
+      const expectedBody = {
+        data: {
+          type: 'organizations',
+          id: 1,
+          attributes: {
+            'external-id': '9752145V',
+            'province-code': '975'
+          }
+        }
+      };
+
+      options.organizations = [{
+        id: 1,
+        externalId: '9752145V',
+        provinceCode: '975'
+      }];
+
+      const nockStub = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/1', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody);
+        })
+        .reply(200, {});
+
+      // when
+      await script.saveOrganizations(options);
+
+      // then
+      expect(nockStub.isDone()).to.equal(true);
+    });
+
+    it('should call PATCH /api/organizations/:id three times, when there are three organizations', async () => {
+      // given
+      const expectedBody1 = {
+        data: {
+          type: 'organizations',
+          id: 1,
+          attributes: {
+            'external-id': '9752145V',
+            'province-code': '975'
+          }
+        }
+      };
+      const expectedBody2 = {
+        data: {
+          type: 'organizations',
+          id: 2,
+          attributes: {
+            'external-id': '',
+            'province-code': ''
+          }
+        }
+      };
+      const expectedBody3 = {
+        data: {
+          type: 'organizations',
+          id: 3,
+          attributes: {
+            'external-id': '02A2145V',
+            'province-code': '02A'
+          }
+        }
+      };
+
+      options.organizations = [{
+        id: 1,
+        externalId: '9752145V',
+        provinceCode: '975'
+      }, {
+        id: 2,
+        externalId: '',
+        provinceCode: ''
+      }, {
+        id: 3,
+        externalId: '02A2145V',
+        provinceCode: '02A'
+      }];
+
+      const nockStub1 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/1', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody1);
+        })
+        .reply(200, {});
+      const nockStub2 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/2', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody2);
+        })
+        .reply(200, {});
+      const nockStub3 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/3', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody3);
+        })
+        .reply(200, {});
+
+      // when
+      await script.saveOrganizations(options);
+
+      // then
+      expect(nockStub1.isDone()).to.equal(true);
+      expect(nockStub2.isDone()).to.equal(true);
+      expect(nockStub3.isDone()).to.equal(true);
+    });
+
+    it('should call PATCH /api/organizations/:id three times, even when an error occur on an organization', async () => {
+      // given
+      const expectedBody1 = {
+        data: {
+          type: 'organizations',
+          id: 1,
+          attributes: {
+            'external-id': '9752145V',
+            'province-code': '975'
+          }
+        }
+      };
+      const expectedBody2 = {
+        data: {
+          type: 'organizations',
+          id: 2,
+          attributes: {
+            'external-id': '',
+            'province-code': ''
+          }
+        }
+      };
+      const expectedBody3 = {
+        data: {
+          type: 'organizations',
+          id: 3,
+          attributes: {
+            'external-id': '02A2145V',
+            'province-code': '02A'
+          }
+        }
+      };
+
+      options.organizations = [{
+        id: 1,
+        externalId: '9752145V',
+        provinceCode: '975'
+      }, {
+        id: 2,
+        externalId: '',
+        provinceCode: ''
+      }, {
+        id: 3,
+        externalId: '02A2145V',
+        provinceCode: '02A'
+      }];
+
+      const nockStub1 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/1', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody1);
+        })
+        .replyWithError('Error');
+
+      const nockStub2 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/2', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody2);
+        })
+        .reply(200, {});
+
+      const nockStub3 = nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/3', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody3);
+        })
+        .reply(200, {});
+
+      // when
+      await script.saveOrganizations(options);
+
+      // then
+      expect(nockStub1.isDone()).to.equal(true);
+      expect(nockStub2.isDone()).to.equal(true);
+      expect(nockStub3.isDone()).to.equal(true);
+    });
+
+    it('should return a promise resolving to an array of objects ' +
+      'containing the API error and relevant informations to find the csv row', async () => {
+      // given
+      const expectedBody1 = {
+        data: {
+          type: 'organizations',
+          id: 1,
+          attributes: {
+            'external-id': '9752145V',
+            'province-code': '975'
+          }
+        }
+      };
+      const expectedBody2 = {
+        data: {
+          type: 'organizations',
+          id: 2,
+          attributes: {
+            'external-id': '',
+            'province-code': ''
+          }
+        }
+      };
+      const expectedBody3 = {
+        data: {
+          type: 'organizations',
+          id: 3,
+          attributes: {
+            'external-id': '02A2145V',
+            'province-code': '02A'
+          }
+        }
+      };
+      const expectedErrorObjects = [{
+        errorMessage: 'Error: Error 1',
+        organization: {
+          id: 1,
+          externalId: '9752145V',
+          provinceCode: '975'
+        }
+      }, {
+        errorMessage: 'Error: Error 2',
+        organization: {
+          id: 2,
+          externalId: '',
+          provinceCode: ''
+        }
+      }];
+
+      options.organizations = [{
+        id: 1,
+        externalId: '9752145V',
+        provinceCode: '975'
+      }, {
+        id: 2,
+        externalId: '',
+        provinceCode: ''
+      }, {
+        id: 3,
+        externalId: '02A2145V',
+        provinceCode: '02A'
+      }];
+
+      nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/1', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody1);
+        })
+        .replyWithError('Error 1');
+
+      nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/2', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody2);
+        })
+        .replyWithError('Error 2');
+
+      nock('http://localhost:3000', {
+        reqheaders: { authorization: 'Bearer token-token' }
+      })
+        .patch('/api/organizations/3', function(body) {
+          return JSON.stringify(body) === JSON.stringify(expectedBody3);
+        })
+        .reply(200, {});
+
+      // when
+      const errorObjects = await script.saveOrganizations(options);
+
+      // then
+      expect(errorObjects).to.deep.equal(expectedErrorObjects);
+    });
+  });
+
+});

--- a/api/tests/acceptance/scripts/valid-organizations-test-file.csv
+++ b/api/tests/acceptance/scripts/valid-organizations-test-file.csv
@@ -1,0 +1,4 @@
+Orga_ID,Code établissement (code UAI),Nom de l'établissement,Prénom de l'administrateur,Nom de l'administrateur,Email de l'administrateur (utilisé pour son compte Pix personnel),Académie
+1,0350151S,Collège Grégoire Bidule,Denise,Dapo,denise.dapo@ac-rennes.fr,RENNES
+2,01B0143S,Lycée Corsica,Charlotte,Sic,charlotte.sic@ac-bastia.fr,BASTIA
+3,,Lycée Vide,François,Frou,francois.frou@ac-bordeaux.fr,BORDEAUX

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -38,6 +38,8 @@ describe('Integration | Application | Organizations | organization-controller', 
           'type': 'PRO',
           'code': 'ABCD12',
           'logo-url': 'http://log.url',
+          'external-id': '02A2145V',
+          'province-code': '02A',
         }
       }
     };

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -100,6 +100,8 @@ describe('Integration | Repository | Organization', function() {
       organization.name = 'New name';
       organization.type = 'SCO';
       organization.logoUrl = 'http://new.logo.url';
+      organization.externalId = '999Z527F';
+      organization.provinceCode = '999';
 
       // when
       const organizationSaved = await organizationRepository.update(organization);
@@ -110,6 +112,8 @@ describe('Integration | Repository | Organization', function() {
       expect(organizationSaved.type).to.equal('SCO');
       expect(organizationSaved.logoUrl).to.equal('http://new.logo.url');
       expect(organizationSaved.code).to.equal(organization.code);
+      expect(organizationSaved.externalId).to.equal(organization.externalId);
+      expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
     });
 
     it('should not modify code property', async () => {
@@ -320,7 +324,7 @@ describe('Integration | Repository | Organization', function() {
 
       // when
       const actualOrganizations = await organizationRepository.findBy(filters);
-      
+
       // then
       expect(actualOrganizations).to.have.lengthOf(1);
       expect(actualOrganizations[0]).to.be.an.instanceof(Organization);

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -99,6 +99,70 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     });
   });
 
+  describe('#updateOrganizationInformation', () => {
+
+    let organization;
+
+    beforeEach(() => {
+      organization = domainBuilder.buildOrganization();
+      sinon.stub(usecases, 'updateOrganizationInformation');
+      sinon.stub(organizationSerializer, 'serialize');
+
+      request = {
+        payload: {
+          data: {
+            id: organization.id,
+            attributes: {
+              name: 'Acme',
+              type: 'PRO',
+              'logo-url': 'logo',
+              'external-id': '02A2145V',
+              'province-code': '02A'
+            }
+          }
+        }
+      };
+    });
+
+    context('successful case', () => {
+
+      let serializedOrganization;
+
+      beforeEach(() => {
+        serializedOrganization = { foo: 'bar' };
+
+        usecases.updateOrganizationInformation.resolves(organization);
+        organizationSerializer.serialize.withArgs(organization).returns(serializedOrganization);
+      });
+
+      it('should update an organization', async () => {
+        // when
+        await organizationController.updateOrganizationInformation(request, hFake);
+
+        // then
+        expect(usecases.updateOrganizationInformation).to.have.been.calledOnce;
+        expect(usecases.updateOrganizationInformation).to.have.been.calledWith({ id: organization.id, name: 'Acme', type: 'PRO', logoUrl: 'logo', externalId: '02A2145V', provinceCode: '02A' });
+      });
+
+      it('should serialized organization into JSON:API', async () => {
+        // when
+        await organizationController.updateOrganizationInformation(request, hFake);
+
+        // then
+        expect(organizationSerializer.serialize).to.have.been.calledOnce;
+        expect(organizationSerializer.serialize).to.have.been.calledWith(organization);
+      });
+
+      it('should return the serialized organization', async () => {
+        // when
+        const response = await organizationController.updateOrganizationInformation(request, hFake);
+
+        // then
+        expect(response).to.deep.equal(serializedOrganization);
+      });
+    });
+  });
+
   describe('#find', () => {
 
     beforeEach(() => {

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -12,6 +12,8 @@ describe('Unit | UseCase | update-organization-information', () => {
       name: 'Old name',
       type: 'SCO',
       logoUrl: 'http://old.logo.url',
+      externalId: 'extId',
+      provinceCode: '666'
     });
     organizationRepository = {
       get: sinon.stub().resolves(originalOrganization),
@@ -72,12 +74,48 @@ describe('Unit | UseCase | update-organization-information', () => {
 
       // then
       return promise.then((resultOrganization) => {
-        expect(resultOrganization.logoUrl).to.equal(newLogoUrl);
-
         expect(resultOrganization.name).to.equal(originalOrganization.name);
         expect(resultOrganization.type).to.equal(originalOrganization.type);
         expect(resultOrganization.logoUrl).to.equal(newLogoUrl);
       });
+    });
+
+    it('should allow to update the organization external id (only) if modified', async () => {
+      // given
+      const externalId = '9752145V';
+
+      // when
+      const resultOrganization = await updateOrganizationInformation({
+        id: originalOrganization.id,
+        externalId,
+        organizationRepository
+      });
+
+      // then
+      expect(resultOrganization.name).to.equal(originalOrganization.name);
+      expect(resultOrganization.type).to.equal(originalOrganization.type);
+      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
+      expect(resultOrganization.externalId).to.equal(externalId);
+      expect(resultOrganization.provinceCode).to.equal(originalOrganization.provinceCode);
+    });
+
+    it('should allow to update the organization province code (only) if modified', async () => {
+      // given
+      const provinceCode = '975';
+
+      // when
+      const resultOrganization = await updateOrganizationInformation({
+        id: originalOrganization.id,
+        provinceCode,
+        organizationRepository
+      });
+
+      // then
+      expect(resultOrganization.name).to.equal(originalOrganization.name);
+      expect(resultOrganization.type).to.equal(originalOrganization.type);
+      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
+      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
+      expect(resultOrganization.provinceCode).to.equal(provinceCode);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement aucune mise à jour de masse des organisations n'est possible. On veut pouvoir mettre à jour toutes les organisations déjà existantes en ajoutant un identifiant externe ainsi que le département.

## :robot: Solution
Ajout d'un script permettant cette action.
Le script fait appel à la route `PATCH /organizations/id`, il a donc été nécéssaire d'ajuster ce cas d'utilisation.
