### PR TITLE
[TECH] Retrait de la fonctionnalité plus utilisée d'import CSV dans PixAdmin (PA-111)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import Papa from 'papaparse';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
@@ -25,33 +24,6 @@ export default Controller.extend({
   },
 
   actions: {
-
-    async importAndLinkCandidatesToTheSessionCertifications(file) {
-      const csvAsText = await file.readAsText();
-      // XXX We delete the BOM UTF8 at the beginning of the CSV, otherwise the first element is wrongly parsed.
-      const csvRawData = csvAsText.toString('utf8').replace(/^\uFEFF/, '');
-      const fileHeaders = {
-        'ID de certification': 'certificationId',
-        'Prenom du candidat': 'firstName',
-        'Nom du candidat': 'lastName',
-        'Date de naissance du candidat': 'birthdate',
-        'Lieu de naissance du candidat': 'birthplace',
-        'Identifiant Externe': 'externalId',
-      };
-      const candidatesData = Papa.parse(csvRawData, {
-        header: true,
-        skipEmptyLines: true,
-        transformHeader: ((header) => {
-          return fileHeaders[header];
-        })
-      }).data;
-      try {
-        await this.sessionInfoService.updateCertificationsFromCandidatesData(this.model.certifications, candidatesData);
-        this.notifications.success(`${candidatesData.length} lignes correctement importé(e)s.`);
-      } catch (error) {
-        this.notifications.error(error);
-      }
-    },
 
     async onSaveReportData(candidatesData) {
       try {

--- a/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
@@ -5,13 +5,6 @@
     <div class="btn-group certification-list-page__actions" role="group">
 
       <button class="btn btn-outline-default btn--check-session-record" type="button">
-        {{#file-upload name="session-certifications-candidates" onfileadd=(action "importAndLinkCandidatesToTheSessionCertifications") accept="text/csv"}}
-          {{fa-icon "users"}}
-        {{/file-upload}}
-        {{#bs-tooltip}}Importer les données des candidats de la session pour compléter les données de certifications correspondantes (.csv){{/bs-tooltip}}
-      </button>
-
-      <button class="btn btn-outline-default btn--check-session-record" type="button">
         {{#file-upload name="session-record-report" onfileadd=(action "displayCertificationSessionReportModal") accept="application/vnd.oasis.opendocument.spreadsheet"}}
           {{fa-icon "clipboard-list"}}
         {{/file-upload}}

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -20009,12 +20009,6 @@
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
       "dev": true
     },
-    "papaparse": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.1.0.tgz",
-      "integrity": "sha512-3jEYMiCc8qN7V5ffi2BTS2mRauKxCu5AIED6DxbjnHhIm7OY7fzKYkndfPlHWaaKUDCTml5XTU6V+hiuxGlZuw==",
-      "dev": true
-    },
     "parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",

--- a/admin/package.json
+++ b/admin/package.json
@@ -82,7 +82,6 @@
     "json2csv": "^4.5.3",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
-    "papaparse": "^5.1.0",
     "popper.js": "^1.15.0",
     "qunit-dom": "^0.9.0",
     "sass": "^1.22.12",


### PR DESCRIPTION
## :unicorn: Situation
Deux méthodes d'import de PV de session coexistent dans PixAdmin :
- l'import du PV de session en format ODS
- l'import d'un csv issu d'un calcul réalisé par une macro sur un document custom qui rassemble plusieurs PVs de session.
Cette dernière méthode n'est désormais plus du tout utilisée.

## :robot: Solution
Retirer le bouton et l'ensemble du code liés à cette méthode d'import.

## :rainbow: Remarques
