### PR TITLE
[BUGFIX] Dysfonctionnement du nettoyage journalier des caches (PF-836)

### DIFF
--- a/api/scripts/reload-cache-everyday.js
+++ b/api/scripts/reload-cache-everyday.js
@@ -6,14 +6,12 @@ function authenticationTokenRequest() {
   return {
     method: 'POST',
     baseUrl: process.env.BASE_URL,
-    uri: '/api/authentications',
-    body: {
-      data: {
-        attributes: {
-          email: process.env.PIXMASTER_EMAIL,
-          password: process.env.PIXMASTER_PASSWORD
-        }
-      }
+    uri: '/api/token',
+    form: {
+      grant_type: 'password',
+      username: process.env.PIXMASTER_EMAIL,
+      password: process.env.PIXMASTER_PASSWORD,
+      scope: 'pix-cron'
     },
     json: true
   };
@@ -49,7 +47,7 @@ cron.schedule(process.env.CACHE_RELOAD_TIME, () => {
   console.log('Starting daily cache reload');
 
   return request(authenticationTokenRequest())
-    .then((response) => authToken = response.data.attributes.token)
+    .then((response) => authToken = response.access_token)
     .then(() => request(cacheFlushingRequest(authToken)))
     .then(() => request(cacheWarmupRequest(authToken)))
     .then(() => console.log('Daily cache reload done'))


### PR DESCRIPTION
## :unicorn: Problème
La tâche CRON permettant le nettoyage des caches ne fonctionne plus.

## :robot: Solution
La route d'authentification utilisée n'existe plus.
Utilisation du POST /api/token

## :rainbow: Remarques
TODO: Ecrite des tests unitaires pour effectuer les vérifications formelles des URLs utilisées par le script.

