### PR TITLE
[BUGFIX] Mise à jour via campagnes des scorecards remises à zéro (PF-841).

### DIFF
--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -73,11 +73,8 @@ class Scorecard {
 }
 
 function _getScorecardStatus(competenceEvaluation, knowledgeElements) {
-  if (!competenceEvaluation) {
+  if (!competenceEvaluation || competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
     return _.isEmpty(knowledgeElements) ? statuses.NOT_STARTED : statuses.STARTED;
-  }
-  if (competenceEvaluation.status === CompetenceEvaluation.statuses.RESET) {
-    return statuses.NOT_STARTED;
   }
   const stateOfAssessment = _.get(competenceEvaluation, 'assessment.state');
   if (stateOfAssessment === Assessment.states.COMPLETED) {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -99,7 +99,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
 
-    context('when the competence evaluation has been reset', () => {
+    context('when the competence evaluation has been reset but no knowledgeElements exist', () => {
       beforeEach(() => {
         // given
         const knowledgeElements = [];
@@ -111,6 +111,22 @@ describe('Unit | Domain | Models | Scorecard', () => {
       // then
       it('should have set the scorecard status based on the competence evaluation status', () => {
         expect(actualScorecard.status).to.equal('NOT_STARTED');
+      });
+    });
+
+    context('when the competence evaluation has been reset and some knowledgeElements exist', () => {
+      beforeEach(() => {
+        // given
+        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, { earnedPix: 3.6, createdAt: new Date() }];
+        computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
+        competenceEvaluation = { status: 'reset' };
+
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+      });
+      // then
+      it('should have set the scorecard status STARTED', () => {
+        expect(actualScorecard.status).to.equal(Scorecard.statuses.STARTED);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
La constatation suivante a été faite : 
> Parcours autonomie sur 1.1 => répondre tout faux
> Remettre à zéro sa comp 1.1
> Lancer la campagne de test KKPUTW913 sur la 1.1 et la 2.3
> Répondre tout faux et terminer la campagne
> Envoyer ses résult et revenir à son profil
> La compétence 1.1 est toujours au statut "commencer" et la 2.3 et "reprendre
> — la 1.1 devrait aussi être en "reprendre"

## :robot: Solution
Les `knowledge-elements` acquis en campagne sont bien associés à la compétence remise à zéro.  

Pour établir le statut d'une `Scorecard`, on utilise maintenant les `knowledge-elements` 
- soit en l'absence de `competenceEvaluation` 
- soit quand le statut de la `competenceEvaluation` est à l'état de `CompetenceEvaluation.statuses.RESET`.