### PR TITLE
[BUGFIX] Corrige une typo dans la vérification cgu de Pix Certif (PC-75)

### DIFF
--- a/certif/app/routes/authenticated/index.js
+++ b/certif/app/routes/authenticated/index.js
@@ -6,10 +6,16 @@ export default Route.extend({
   currentUser: service(),
 
   beforeModel() {
-    if (this.currentUser.user.pixOrgaTermsOfServiceAccepted) {
-      return this.transitionTo('authenticated.sessions.list');
-    } else {
-      return this.transitionTo('authenticated.terms-of-service');
+    const transition = this._selectTransition(this.currentUser);
+
+    return this.transitionTo(transition);
+  },
+
+  _selectTransition({ pixOrgaTermsOfServiceAccepted }) {
+    if (!pixOrgaTermsOfServiceAccepted) {
+      return 'authenticated.terms-of-service';
     }
+
+    return 'authenticated.sessions.list';
   }
 });

--- a/certif/app/routes/authenticated/index.js
+++ b/certif/app/routes/authenticated/index.js
@@ -11,8 +11,8 @@ export default Route.extend({
     return this.transitionTo(transition);
   },
 
-  _selectTransition({ pixOrgaTermsOfServiceAccepted }) {
-    if (!pixOrgaTermsOfServiceAccepted) {
+  _selectTransition({ pixCertifTermsOfServiceAccepted }) {
+    if (!pixCertifTermsOfServiceAccepted) {
       return 'authenticated.terms-of-service';
     }
 

--- a/certif/tests/unit/routes/authenticated-test.js
+++ b/certif/tests/unit/routes/authenticated-test.js
@@ -5,9 +5,15 @@ module('Unit | Route | authenticated', function(hooks) {
 
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:authenticated');
-    assert.ok(route);
-  });
+  test('it should redirect to sessions list if the current user has accepted terms of service', function(assert) {
+    // given
+    const route =  this.owner.lookup('route:authenticated.index');
+    const userWithAcceptedTermsOfService = { pixCertifTermsOfServiceAccepted: true };
 
+    // when
+    const redirection = route._selectTransition(userWithAcceptedTermsOfService);
+
+    // then
+    assert.equal('authenticated.sessions.list', redirection);
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

La route front `/` faisait une vérification sur `currentUser.pixOrgaTermsOfServiceAccepted` (au lieu de `pixCertifTermsOfServiceAccepted`) pour savoir si elle devait rediriger vers `/cgu` ou vers `sessions/list`.

Les tests passaient , et ça marchait quand même grâce à la redirection d’après : `/` -> `/cgu` -> `sessions/list` au lieu de `/` -> `sessions/list`.

## :robot: Solution

Ajouter un test qui échoue, et corriger la typo.

## :rainbow: Remarques

Il y a deux commit, un qui change la structure, puis un qui change le comportement.

J'ai suivi les idées de cette page de la doc Ember :
- https://guides.emberjs.com/v3.12.0/testing/testing-routes/