### PR TITLE
[BUGFIX] Optimise le chargement de la bannière de reprise de campagne (PF-840).

### DIFF
--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -1,6 +1,6 @@
-import _orderBy from 'lodash/orderBy';
-import _filter from 'lodash/filter';
+import _maxBy from 'lodash/maxBy';
 import { computed } from '@ember/object';
+import { filterBy } from '@ember/object/computed';
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -8,21 +8,18 @@ export default Component.extend({
   classNames: ['resume-campaign-banner'],
   campaignParticipations: [],
 
-  campaignToResumeOrShare: computed('campaignParticipations', function() {
-    const campaignParticipations = this.campaignParticipations.toArray();
+  unsharedCampaignParticipations: filterBy('campaignParticipations', 'isShared', false),
 
-    const campaignParticipationsNotShared = _filter(campaignParticipations,
-      (campaignParticipation) => campaignParticipation.isShared === false);
+  lastUnsharedCampaignParticipation: computed('unsharedCampaignParticipations.@each.createdAt', function() {
+    return _maxBy(this.unsharedCampaignParticipations, 'createdAt');
+  }),
 
-    const campaignParticipationOrdered = _orderBy(campaignParticipationsNotShared, 'createdAt', 'desc');
-
-    const lastCampaignParticipationStarted = campaignParticipationOrdered[0];
-
-    if (lastCampaignParticipationStarted) {
+  campaignToResumeOrShare: computed('lastUnsharedCampaignParticipation.campaign.{title,code},lastUnsharedCampaignParticipation.assessment.isCompleted', function() {
+    if (this.lastUnsharedCampaignParticipation) {
       return {
-        title: lastCampaignParticipationStarted.campaign.get('title'),
-        code: lastCampaignParticipationStarted.campaign.get('code'),
-        assessment: lastCampaignParticipationStarted.assessment
+        title: this.lastUnsharedCampaignParticipation.campaign.get('title'),
+        code: this.lastUnsharedCampaignParticipation.campaign.get('code'),
+        assessment: this.lastUnsharedCampaignParticipation.assessment
       };
     }
 

--- a/mon-pix/tests/acceptance/profile-test.js
+++ b/mon-pix/tests/acceptance/profile-test.js
@@ -125,6 +125,7 @@ describe('Acceptance | Profile', function() {
           campaignId: 1,
           assessmentId: 2,
           userId: 1,
+          createdAt: '2019-09-30T14:30:00Z',
         });
 
         // when
@@ -149,6 +150,7 @@ describe('Acceptance | Profile', function() {
           campaignId: 3,
           assessmentId: 2,
           userId: 1,
+          createdAt: '2019-09-30T14:30:00Z',
         });
 
         // when
@@ -176,6 +178,7 @@ describe('Acceptance | Profile', function() {
           campaignId: 1,
           assessmentId: 2,
           userId: 1,
+          createdAt: '2019-09-30T14:30:00Z',
         });
 
         // when
@@ -200,6 +203,7 @@ describe('Acceptance | Profile', function() {
           campaignId: 3,
           assessmentId: 2,
           userId: 1,
+          createdAt: '2019-09-30T14:30:00Z',
         });
 
         // when

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -14,6 +14,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
   describe('Banner display', function() {
     const campaignToResume = EmberObject.create({
       isShared: false,
+      createdAt: '2019-09-30T12:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
         title: 'Parcours Pix'
@@ -21,12 +22,14 @@ describe('Integration | Component | resume-campaign-banner', function() {
     });
     const oldCampaignNotFinished = EmberObject.create({
       isShared: false,
+      createdAt: '2019-09-30T10:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
       })
     });
     const campaignFinished = EmberObject.create({
       isShared: true,
+      createdAt: '2019-09-30T14:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
       }),
@@ -97,6 +100,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
       const campaignFinishedButNotShared = EmberObject.create({
         isShared: false,
+        createdAt: '2019-09-30T10:30:00Z',
         campaign: EmberObject.create({
           code: 'AZERTY',
           title: 'Parcours Pix'

--- a/mon-pix/tests/unit/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/unit/components/resume-campaign-banner-test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
+import { A } from '@ember/array';
 
 describe('Unit | Component | resume-campaign-banner-component ', function() {
 
@@ -49,7 +50,6 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
   });
 
   describe('#campaignToResumeOrShare', function() {
-
     it('should return the most recent campaign among campaigns not finished and not shared', function() {
       // given
       const listCampaignParticipations = [oldCampaignNotFinished, campaignNotFinished];
@@ -66,6 +66,33 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
 
       // then
       expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+    });
+
+    it('should return the most recent campaign among campaigns not finished and not shared dynamically', function() {
+      // given
+      const participations = A([]);
+      component.set('campaignParticipations', participations);
+
+      // then
+      expect(component.get('campaignToResumeOrShare')).to.equal(null);
+
+      // when
+      const updatableCampaignNotFinished = EmberObject.create({
+        isShared: false,
+        createdAt: '2018-01-01',
+        campaign: EmberObject.create({
+          code: 'AZERTY0',
+        })
+      });
+      participations.addObject(oldCampaignNotFinished);
+      participations.addObject(updatableCampaignNotFinished);
+
+      // then
+      expect(component.get('campaignToResumeOrShare').code).to.equal('AZERTY0');
+
+      updatableCampaignNotFinished.set('createdAt', '2000-05-13');
+
+      expect(component.get('campaignToResumeOrShare').code).to.equal(oldCampaignNotFinished.campaign.code);
     });
 
     it('should return the most recent campaign among campaigns not shared', function() {


### PR DESCRIPTION
## :unicorn: Problème
On a vu que 
* Se rendre sur un profil n'ayant pas de campagne en cours
* Lancer une campagne
* La quitter au bout de la 1ere question
* Le bandeau jaune "reprendre" n'apparaît pas
* Il faut reload sa page pour  voir le bandeau apparaître

## :robot: Solution
On refactorise le composant pour se servir des propriétés d'observation des attributs offerts par Ember. 

## :rainbow: Remarques
Dans `/routes/profile.js`, on aurait pu faire :
```js
await user.hasMany('campaignParticipations').reload();
```
Toutefois, le problème sous-jacent n'aurait pas été résolu et aurait ralenti la page de chargement du profil