### PR TITLE
[BUGFIX] Permettre de nouveau l'export des snapshots - profil v1 (PF-844).

### DIFF
--- a/mon-pix/app/components/routes/board-page.js
+++ b/mon-pix/app/components/routes/board-page.js
@@ -12,7 +12,7 @@ export default Component.extend({
 
   snapshotsExportUrl: computed('organization', function() {
     const organizationId = this.get('organization.id');
-    const userToken = this.get('session.data.authenticated.token');
-    return `${ENV.APP.API_HOST}/api/organizations/${organizationId}/snapshots/export?userToken=${userToken}`;
+    const { access_token } = this.get('session.data.authenticated');
+    return `${ENV.APP.API_HOST}/api/organizations/${organizationId}/snapshots/export?userToken=${access_token}`;
   }),
 });

--- a/mon-pix/tests/acceptance/board-organization-test.js
+++ b/mon-pix/tests/acceptance/board-organization-test.js
@@ -70,6 +70,9 @@ describe('Acceptance | Board organization', function() {
 
     // then
     expect(find('.profiles-title__export-csv').textContent).to.contains('Exporter (.csv)');
+    expect(find('.profiles-title__export-csv').getAttribute('href')).to.equal(
+      `http://localhost:3000/api/organizations/1/snapshots/export?userToken=aaa.${btoa('{"user_id":2,"source":"mon-pix","iat":1545321469}')}.bbb`
+    );
   });
 
 });

--- a/mon-pix/tests/integration/components/routes/board-page-test.js
+++ b/mon-pix/tests/integration/components/routes/board-page-test.js
@@ -16,7 +16,7 @@ describe('Integration | Component | Board page', function() {
       this.owner.register('service:session', Service.extend({
         data: {
           authenticated: {
-            token: 'VALID-TOKEN',
+            access_token: 'VALID-TOKEN',
           }
         },
       }));


### PR DESCRIPTION
## :unicorn: Problème
En changeant la méthode d'authentification de mon-pix, l'export des snapshots a été oublié, il utilisait toujours l'ancienne manière qui n'existait plus. En conséquence, les utilisateurs de Pix Board ne pouvaient plus exporter les anciens snapshots issus des profils v1 de leurs élèves.

## :robot: Solution
Corriger la méthode de récupération du token d'authentification.

## :rainbow: Remarques
Rajout d'un test d'acceptance pour vérifier le bon fonctionnement global.
