### PR TITLE
[BUGFIX] Pouvoir passer une démo à nouveau

### DIFF
--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -2,12 +2,13 @@ const usecases = require('../../domain/usecases');
 const courseSerializer = require('../../infrastructure/serializers/jsonapi/course-serializer');
 const certificationCourseSerializer = require('../../infrastructure/serializers/jsonapi/certification-course-serializer');
 const courseService = require('../../../lib/domain/services/course-service');
+const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-utils');
 
 module.exports = {
 
   get(request) {
     const courseId = request.params.id;
-    const userId = parseInt(request.auth.credentials.userId);
+    const userId = extractUserIdFromRequest(request);
 
     return courseService
       .getCourse({ courseId, userId })

--- a/api/lib/application/courses/index.js
+++ b/api/lib/application/courses/index.js
@@ -6,6 +6,7 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/courses/{id}',
       config: {
+        auth: false,
         handler: courseController.get,
         tags: ['api']
       }

--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -24,7 +24,7 @@ module.exports = {
           }
         });
     } else {
-      let certificationCourse = await certificationCourseRepository.get(courseId);
+      const certificationCourse = await certificationCourseRepository.get(courseId);
       if (userId !== certificationCourse.userId) {
         throw new UserNotAuthorizedToGetCertificationCoursesError();
       }

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, sinon, hFake } = require('../../../test-helper');
+const { expect, sinon, hFake, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const Hapi = require('hapi');
 
 const courseController = require('../../../../lib/application/courses/course-controller');
@@ -39,7 +39,7 @@ describe('Unit | Controller | course-controller', () => {
       courseSerializer.serialize.callsFake(() => course);
       const request = {
         params: { id: 'course_id' },
-        auth: { credentials: { accessToken: 'jwt.access.token', userId } },
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         pre: { userId },
       };
 

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -24,10 +24,10 @@ describe('Unit | Service | Course Service', () => {
       it('should call the certification course repository  ', () => {
         // given
         const givenCourseId = 1;
-        certificationCourseRepository.get.resolves();
+        certificationCourseRepository.get.resolves(certificationCourse);
 
         // when
-        const promise = courseService.getCourse({ courseId: givenCourseId });
+        const promise = courseService.getCourse({ courseId: givenCourseId, userId });
 
         // then
         return promise.then(() => {


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un PR précédente, un control a été rajouté utilisant `auth: true` dans la configuration d'hapi, qui utilise un handler fait par nos sois dont l'implémentation ne permettait pas d'exécuter le code du controller si jamais le décodage du token n'était pas successful.

## :robot: Solution
La solution consiste à utiliser, comme c'est fait à d'autres endroit, le parsing directement à la main au niveau du controller grace au `tokenService`.

