### PR TITLE
[BUGFIX] Polir le titre des checkpoints (PF-823).

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -112,4 +112,8 @@
   font-size: 3.2rem;
   line-height: 4.5rem;
   margin-bottom: 26px;
+
+  &--all-small-caps {
+    font-variant-caps: all-small-caps;
+  }
 }

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -27,7 +27,7 @@
     <div class="rounded-panel rounded-panel--strong checkpoint__content">
       {{#if shouldDisplayAnswers}}
         <div class="rounded-panel-one-line-header">
-          <h1 class="rounded-panel-header-text__content rounded-panel-title">
+          <h1 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-title--all-small-caps">
             vos réponses
           </h1>
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, on voit ça 
<img width="1017" alt="Screenshot 2019-10-02 at 15 55 59" src="https://user-images.githubusercontent.com/46371288/66050462-8d64e700-e52d-11e9-9d34-576648b85265.png">

On s'attend à voir ça 
<img width="1008" alt="Screenshot 2019-10-02 at 15 55 42" src="https://user-images.githubusercontent.com/46371288/66050523-a5d50180-e52d-11e9-920a-11d65fc7953a.png">


## :robot: Solution
On ajoute un modifier css pour conserver le visuel des autres `rounded-panel-title`
<img width="947" alt="Screenshot 2019-10-02 at 15 54 03" src="https://user-images.githubusercontent.com/46371288/66050672-e7fe4300-e52d-11e9-9a20-923320b09a23.png">

## 🌈 Remarques
Idéalement, il faudrait s'aligner complètement au InVision et faire une classe css `rounded-panel-headtitle` pour les checkpoints. Dans l'attente, on part sur la philosophie YAGNI.

[Pour en savoir plus sur `font-variant-caps`](https://developer.mozilla.org/fr/docs/Web/CSS/font-variant-caps)