### PR TITLE
[TECH] Rétablir le fonctionnement mode watch des tests auto (PF-924)

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -38,7 +38,8 @@ async function emptyAllTables() {
   const tableNames = await listAllTableNames();
   const tablesToDelete = _.without(tableNames,
     'knex_migrations',
-    'knex_migrations_lock'
+    'knex_migrations_lock',
+    'pix_roles'
   );
 
   const query = _dbSpecificQueries[_clientName].truncateTableQuery;

--- a/api/db/migrations/20180731102046_create_target_profiles_table.js
+++ b/api/db/migrations/20180731102046_create_target_profiles_table.js
@@ -2,40 +2,6 @@ const TABLE_NAME_TARGET_PROFILES = 'target-profiles';
 const TABLE_NAME_TARGET_PROFILES_SKILLS = 'target-profiles_skills';
 const TABLE_NAME_CAMPAIGNS = 'campaigns';
 
-const targetProfile = {
-  name: 'PIC - Diagnostic Initial',
-  isPublic: true,
-  organizationId: null
-};
-
-const associatedSkills = [
-  { skillId: 'rectL2ZZeWPc7yezp' },
-  { skillId: 'recndXqXiv4pv2Ukp' },
-  { skillId: 'recMOy4S8XnaWblYI' },
-  { skillId: 'recagUd44RPEWti0X' },
-  { skillId: 'recrvTvLTUXEcUIV1' },
-  { skillId: 'recX7RyCsdNV2p168' },
-  { skillId: 'recxtb5aLs6OAAKIg' },
-  { skillId: 'receRbbt9Lb661wFB' },
-  { skillId: 'rec71e3PSct2zLEMj' },
-  { skillId: 'recFwJlpllhWzuLom' },
-  { skillId: 'rec0J9OXaAj5v7w3r' },
-  { skillId: 'reclY3njuk6EySJuU' },
-  { skillId: 'rec5V9gp65a58nnco' },
-  { skillId: 'recPrXhP0X07OdHXe' },
-  { skillId: 'recPG9ftlGZLiF0O6' },
-  { skillId: 'rectLj7NPg5JcSIqN' },
-  { skillId: 'rec9qal2FLjWysrfu' },
-  { skillId: 'rechRPFlSryfY3UnG' },
-  { skillId: 'recL0AotZshb9quhR' },
-  { skillId: 'recrOwaV2PTt1N0i5' },
-  { skillId: 'recpdpemRXuzV9r10' },
-  { skillId: 'recWXtN5cNP1JQUVx' },
-  { skillId: 'recTIddrkopID28Ep' },
-  { skillId: 'recBrDIfDDW2IPpZV' },
-  { skillId: 'recgOc2OreHCosoRp' },
-];
-
 exports.up = function(knex) {
   return knex.schema
     .createTable(TABLE_NAME_TARGET_PROFILES, (t) => {
@@ -58,22 +24,6 @@ exports.up = function(knex) {
     })
     .then(() => {
       console.log(`${TABLE_NAME_TARGET_PROFILES_SKILLS} table is created!`);
-    })
-    .then(() => {
-      return knex(TABLE_NAME_TARGET_PROFILES)
-        .insert(targetProfile)
-        .returning('id');
-    })
-    .then((insertedTargetProfileId) => {
-      const associatedSkillsWithTargetProfileId = associatedSkills.map((associatedSkill) => {
-        associatedSkill.targetProfileId = insertedTargetProfileId[0];
-        return associatedSkill;
-      });
-      return associatedSkillsWithTargetProfileId;
-    })
-    .then((associatedSkillsWithTargetProfileId) => {
-      return knex(TABLE_NAME_TARGET_PROFILES_SKILLS)
-        .insert(associatedSkillsWithTargetProfileId);
     })
     .then(() => {
       return knex.schema.table(TABLE_NAME_CAMPAIGNS, function(table) {

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -1,0 +1,39 @@
+module.exports = function targetProfilesBuilder({ databaseBuilder }) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile({
+    id:1,
+    name: 'PIC - Diagnostic Initial',
+    isPublic: true,
+    organizationId: null,
+  }).id;
+  [ 'rectL2ZZeWPc7yezp',
+    'recndXqXiv4pv2Ukp',
+    'recMOy4S8XnaWblYI',
+    'recagUd44RPEWti0X',
+    'recrvTvLTUXEcUIV1',
+    'recX7RyCsdNV2p168',
+    'recxtb5aLs6OAAKIg',
+    'receRbbt9Lb661wFB',
+    'rec71e3PSct2zLEMj',
+    'recFwJlpllhWzuLom',
+    'rec0J9OXaAj5v7w3r',
+    'reclY3njuk6EySJuU',
+    'rec5V9gp65a58nnco',
+    'recPrXhP0X07OdHXe',
+    'recPG9ftlGZLiF0O6',
+    'rectLj7NPg5JcSIqN',
+    'rec9qal2FLjWysrfu',
+    'rechRPFlSryfY3UnG',
+    'recL0AotZshb9quhR',
+    'recrOwaV2PTt1N0i5',
+    'recpdpemRXuzV9r10',
+    'recWXtN5cNP1JQUVx',
+    'recTIddrkopID28Ep',
+    'recBrDIfDDW2IPpZV',
+    'recgOc2OreHCosoRp',
+  ].forEach((skillId) => {
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId,
+      skillId,
+    });
+  });
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -18,7 +18,7 @@ const pixAileBuilder = require('./data/pix-aile-builder');
 const buildPixAileProfile = require('./data/pix-aile-profile-builder');
 const sessionsBuilder = require('./data/sessions-builder');
 const snapshotsBuilder = require('./data/snapshots-builder');
-const targetProfileBuilder = require('./data/target-profile-builder');
+const targetProfilesBuilder = require('./data/target-profiles-builder');
 const usersBuilder = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 
@@ -36,7 +36,7 @@ exports.seed = (knex) => {
   dragonAndCoBuilder({ databaseBuilder });
   organizationsBuilder({ databaseBuilder });
   snapshotsBuilder({ databaseBuilder });
-  targetProfileBuilder({ databaseBuilder });
+  targetProfilesBuilder({ databaseBuilder });
   campaignsBuilder({ databaseBuilder });
   campaignParticipationsBuilder({ databaseBuilder });
   certificationCentersBuilder({ databaseBuilder });

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -25,10 +25,6 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return 200 HTTP status code', () => {
         // when
         const promise = server.inject(options);
@@ -80,10 +76,6 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return 403 HTTP status code', () => {
         // when
         const promise = server.inject(options);
@@ -105,10 +97,6 @@ describe('Acceptance | Controller | answer-controller', () => {
           method: 'GET',
           url: `/api/answers?challenge=${challengeId}&assessment=${assessment.id}`,
         };
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return 200 HTTP status code', () => {

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -69,10 +69,6 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async() => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the answer correction', async () => {
       // given
       const options = {

--- a/api/tests/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get_test.js
@@ -24,10 +24,6 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return 200 HTTP status code', () => {
         // when
         const promise = server.inject(options);
@@ -79,10 +75,6 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return 403 HTTP status code', () => {
         // when
         const promise = server.inject(options);
@@ -104,10 +96,6 @@ describe('Acceptance | Controller | answer-controller', () => {
           method: 'GET',
           url: `/api/answers/${answer.id}`,
         };
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return 200 HTTP status code', () => {

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -26,12 +26,11 @@ describe('Acceptance | Controller | answer-controller-save', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       nock.cleanAll();
       airtableBuilder.cleanAll();
 
-      await knex('answers').delete();
-      await databaseBuilder.clean();
+      return knex('answers').delete();
     });
 
     context('when the user is linked to the assessment', () => {

--- a/api/tests/acceptance/application/answers/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-update_test.js
@@ -22,10 +22,6 @@ describe('Acceptance | Controller | answer-controller', () => {
       };
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-    
     it('should return 200 HTTP status code', () => {
       // when
       const promise = server.inject(options);

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, knex, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, cleanupUsersAndPixRolesTables } = require('../../../test-helper');
+const { expect, knex, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
@@ -54,10 +54,9 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
       return insertUserWithRolePixMaster();
     });
 
-    afterEach(() => {
-      return knex('competence-marks').delete()
-        .then(() => knex('assessment-results').delete())
-        .then(() => cleanupUsersAndPixRolesTables());
+    afterEach(async () => {
+      await knex('competence-marks').delete();
+      return knex('assessment-results').delete();
     });
 
     before(() => { return knex('certification-courses').delete()

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -27,9 +27,8 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     };
   });
 
-  afterEach(async () => {
-    await knex('assessment-results').delete();
-    return databaseBuilder.clean();
+  afterEach(() => {
+    return knex('assessment-results').delete();
   });
 
   describe('PATCH /assessments/{id}/complete-assessment', () => {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -150,10 +150,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the second challenge if the first answer is correct', () => {
         // given
         const options = {
@@ -205,10 +201,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-compet
           competenceId
         });
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should finish the test if there is no next challenge', () => {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-nonadaptive_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-nonadaptive_test.js
@@ -95,10 +95,6 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
         return databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
-      });
-
       it('should return 200 HTTP status code', () => {
         // given
         const options = {
@@ -153,10 +149,6 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
         return databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
-      });
-
       it('should return the second challenge', async () => {
         // given
         const options = {
@@ -180,10 +172,6 @@ describe('Acceptance | API | assessment-controller-get-nonadaptive', function() 
         databaseBuilder.factory.buildAnswer({ challengeId: 'first_challenge', assessmentId });
         databaseBuilder.factory.buildAnswer({ challengeId: 'second_challenge', assessmentId });
         return databaseBuilder.commit();
-      });
-
-      afterEach(() => {
-        return databaseBuilder.clean();
       });
 
       it('should finish the test', async () => {

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -119,9 +119,8 @@ describe('Acceptance | API | assessment-controller-get', () => {
     await databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    airtableBuilder.cleanAll();
-    await databaseBuilder.clean();
+  afterEach(() => {
+    return airtableBuilder.cleanAll();
   });
 
   after(() => {
@@ -142,10 +141,6 @@ describe('Acceptance | API | assessment-controller-get', () => {
         url: `/api/assessments/${assessmentId}`,
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return 200 HTTP status code', () => {
@@ -220,10 +215,6 @@ describe('Acceptance | API | assessment-controller-get', () => {
       };
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return 200 HTTP status code, when userId provided is linked to assessment', () => {
       // when
       const promise = server.inject(options);
@@ -253,10 +244,6 @@ describe('Acceptance | API | assessment-controller-get', () => {
       answer2 = databaseBuilder.factory.buildAnswer({ assessmentId });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return 200 HTTP status code', () => {
@@ -354,10 +341,6 @@ describe('Acceptance | API | assessment-controller-get', () => {
         }).id;
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return 200 HTTP status code', () => {

--- a/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-post_test.js
@@ -1,4 +1,4 @@
-const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithStandardRole } = require('../../../test-helper');
+const { expect, knex, generateValidRequestAuthorizationHeader, insertUserWithStandardRole } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const BookshelfAssessment = require('../../../../lib/infrastructure/data/assessment');
 
@@ -14,8 +14,7 @@ describe('Acceptance | API | Assessments POST', () => {
 
     afterEach(async () => {
       await knex('assessments').delete();
-      await knex('users').delete();
-      await databaseBuilder.clean();
+      return knex('users').delete();
     });
 
     let options;

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -25,20 +25,12 @@ describe('Acceptance | Controller | authentication-controller', () => {
     await databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('POST /api/token', () => {
 
     beforeEach(async () => {
       const organizationId = databaseBuilder.factory.buildOrganization({}).id;
       databaseBuilder.factory.buildMembership({ userId, organizationId, organizationRoleId: orgaRoleInDB.id });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return an 200 with accessToken when authentication is ok', () => {

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -14,17 +14,12 @@ describe('Acceptance | API | Campaign Controller', () => {
   let server;
 
   beforeEach(async () => {
-    await databaseBuilder.clean();
     server = await createServer();
     organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
     targetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: organization.id });
     campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id, targetProfileId: targetProfile.id });
     campaignWithoutOrga = databaseBuilder.factory.buildCampaign({ organizationId: null });
     await databaseBuilder.commit();
-  });
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
   });
 
   describe('GET /api/campaign', () => {

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -39,10 +39,6 @@ describe('Acceptance | API | Campaign Participations', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the campaign-participation', async () => {
       // given
       options = {
@@ -107,10 +103,6 @@ describe('Acceptance | API | Campaign Participations', () => {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('when the user own the campaign participation', () => {
@@ -268,8 +260,7 @@ describe('Acceptance | API | Campaign Participations', () => {
 
     afterEach(async () => {
       await cache.flushAll();
-      await databaseBuilder.clean();
-      await airtableBuilder.cleanAll();
+      return airtableBuilder.cleanAll();
     });
 
     it('should return the campaign participation of a given campaign with each campaign participation result', () => {
@@ -463,10 +454,6 @@ describe('Acceptance | API | Campaign Participations', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should allow the user to share his campaign participation', async () => {
         // when
         const response = await server.inject(options);
@@ -499,10 +486,6 @@ describe('Acceptance | API | Campaign Participations', () => {
         });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should disallow the user to share his campaign participation', async () => {
@@ -549,8 +532,7 @@ describe('Acceptance | API | Campaign Participations', () => {
 
     afterEach(async () => {
       await knex('assessments').delete();
-      await knex('campaign-participations').delete();
-      await databaseBuilder.clean();
+      return knex('campaign-participations').delete();
     });
 
     it('should return 201 and the campaign participation when it has been successfully created', async () => {
@@ -589,9 +571,8 @@ describe('Acceptance | API | Campaign Participations', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('assessments').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('assessments').delete();
     });
 
     context('when user is connected', () => {

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -116,8 +116,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
 
   afterEach(async () => {
     await cache.flushAll();
-    await databaseBuilder.clean();
-    await airtableBuilder.cleanAll();
+    return airtableBuilder.cleanAll();
   });
 
   describe('GET /api/campaign-participations/{id}/campaign-participation-result', () => {

--- a/api/tests/acceptance/application/campaign-report_test.js
+++ b/api/tests/acceptance/application/campaign-report_test.js
@@ -31,10 +31,6 @@ describe('Acceptance | API | Campaign Report', () => {
     await databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('GET /api/campaign/{id}/campaign-report', () => {
     let options;
 

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const {
-  expect, generateValidRequestAuthorizationHeader, cleanupUsersAndPixRolesTables,
+  expect, generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster, databaseBuilder, knex
 } = require('../../test-helper');
 const createServer = require('../../../server');
@@ -10,12 +10,8 @@ describe('Acceptance | API | Certification Center', () => {
   let server, options;
 
   beforeEach(async () => {
-    await cleanupUsersAndPixRolesTables();
     server = await createServer();
     await insertUserWithRolePixMaster();
-  });
-  afterEach(() => {
-    return cleanupUsersAndPixRolesTables();
   });
 
   describe('GET /api/certification-centers', () => {
@@ -27,10 +23,6 @@ describe('Acceptance | API | Certification Center', () => {
 
       _.times(5, databaseBuilder.factory.buildCertificationCenter);
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('when user is Pix Master', () => {
@@ -178,10 +170,6 @@ describe('Acceptance | API | Certification Center', () => {
       };
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     context('when user is Pix Master', () => {
       beforeEach(() => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader() };
@@ -274,10 +262,6 @@ describe('Acceptance | API | Certification Center', () => {
         method: 'GET',
         url: '/api/certification-centers/' + certificationCenter.id + '/sessions',
       };
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('when user is linked to the certification center', () => {

--- a/api/tests/acceptance/application/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-membership-controller_test.js
@@ -1,5 +1,5 @@
 const {
-  expect, generateValidRequestAuthorizationHeader, cleanupUsersAndPixRolesTables,
+  expect, generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster, databaseBuilder, knex
 } = require('../../test-helper');
 const createServer = require('../../../server');
@@ -9,12 +9,8 @@ describe('Acceptance | API | Certification Center Membership', () => {
   let server, options;
 
   beforeEach(async () => {
-    await cleanupUsersAndPixRolesTables();
     server = await createServer();
     await insertUserWithRolePixMaster();
-  });
-  afterEach(() => {
-    return cleanupUsersAndPixRolesTables();
   });
 
   describe('POST /api/certification-center-memberships', () => {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -77,10 +77,6 @@ describe('Acceptance | API | Certification Course', () => {
         return databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
-      });
-
       it('should return 200 HTTP status code', () => {
         // when
         const promise = server.inject(options);
@@ -163,10 +159,6 @@ describe('Acceptance | API | Certification Course', () => {
           }
         };
         return databaseBuilder.commit();
-      });
-
-      afterEach(() => {
-        return databaseBuilder.clean();
       });
 
       it('should return 200 HTTP status code', () => {
@@ -301,10 +293,6 @@ describe('Acceptance | API | Certification Course', () => {
       };
 
       return databaseBuilder.commit();
-    });
-
-    afterEach(() => {
-      return databaseBuilder.clean();
     });
 
     it('should update the certification course', () => {

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -1,5 +1,5 @@
 const {
-  expect, generateValidRequestAuthorizationHeader, cleanupUsersAndPixRolesTables,
+  expect, generateValidRequestAuthorizationHeader,
   insertUserWithRolePixMaster, insertUserWithStandardRole, knex, nock, databaseBuilder,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
@@ -70,12 +70,11 @@ describe('Acceptance | API | Certifications', () => {
         .then(() => knex('assessment-results').insert(assessmentResult));
     });
 
-    afterEach(() => {
-      return knex('assessment-results').delete()
-        .then(() => knex('assessments').delete())
-        .then(() => knex('certification-courses').delete())
-        .then(() => knex('sessions').delete())
-        .then(cleanupUsersAndPixRolesTables);
+    afterEach(async () => {
+      await knex('assessment-results').delete();
+      await knex('assessments').delete();
+      await knex('certification-courses').delete();
+      return knex('sessions').delete();
     });
 
     it('should return 200 HTTP status code', () => {
@@ -402,13 +401,12 @@ describe('Acceptance | API | Certifications', () => {
         .then(() => knex('competence-marks').insert(competenceMark));
     });
 
-    afterEach(() => {
-      return knex('competence-marks').delete()
-        .then(() => knex('assessment-results').delete())
-        .then(() => knex('assessments').delete())
-        .then(() => knex('certification-courses').delete())
-        .then(() => knex('sessions').delete())
-        .then(cleanupUsersAndPixRolesTables);
+    afterEach(async () => {
+      await knex('competence-marks').delete();
+      await knex('assessment-results').delete();
+      await knex('assessments').delete();
+      await knex('certification-courses').delete();
+      return knex('sessions').delete();
     });
 
     it('should return 200 HTTP status code and the certification with the result competence tree included', () => {
@@ -602,12 +600,11 @@ describe('Acceptance | API | Certifications', () => {
         .then(() => knex('assessment-results').insert(assessmentResult));
     });
 
-    afterEach(() => {
-      return knex('assessment-results').delete()
-        .then(() => knex('assessments').delete())
-        .then(() => knex('certification-courses').delete())
-        .then(() => knex('sessions').delete())
-        .then(cleanupUsersAndPixRolesTables);
+    afterEach(async () => {
+      await knex('assessment-results').delete();
+      await knex('assessments').delete();
+      await knex('certification-courses').delete();
+      return knex('sessions').delete();
     });
 
     it('should return 200 HTTP status code and the updated certification', () => {
@@ -690,10 +687,6 @@ describe('Acceptance | API | Certifications', () => {
     const odsFileName = 'files/parse-from-attendance-sheet-test-ok.ods';
     const odsFilePath = `${__dirname}/${odsFileName}`;
     let options;
-
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
 
     context('User does not have the role PIX MASTER', () => {
 

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -13,8 +13,6 @@ describe('Acceptance | API | Competence Evaluations', () => {
     server = await createServer();
   });
 
-  afterEach(() => databaseBuilder.clean());
-
   describe('POST /api/competence-evaluations/start-or-resume', () => {
 
     const competenceId = 'recABCD123';
@@ -47,8 +45,7 @@ describe('Acceptance | API | Competence Evaluations', () => {
           airtableBuilder.cleanAll();
           await cache.flushAll();
           await knex('competence-evaluations').delete();
-          await knex('assessments').delete();
-          await databaseBuilder.clean();
+          return knex('assessments').delete();
         });
 
         it('should return 201 and the competence evaluation when it has been successfully created', async () => {
@@ -130,10 +127,6 @@ describe('Acceptance | API | Competence Evaluations', () => {
         url: `/api/competence-evaluations?filter[assessmentId]=${assessment.id}`,
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the competence-evaluation of the given assessmentId', async () => {

--- a/api/tests/acceptance/application/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedback-controller_test.js
@@ -46,9 +46,8 @@ describe('Acceptance | Controller | feedback-controller', () => {
       };
     });
 
-    afterEach(async () => {
-      await knex('feedbacks').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('feedbacks').delete();
     });
 
     it('should return 201 HTTP status code', () => {

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -4,7 +4,7 @@ const iconv = require('iconv-lite');
 
 const {
   expect, knex, nock, databaseBuilder,
-  generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, cleanupUsersAndPixRolesTables
+  generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster,
 } = require('../../test-helper');
 
 const createServer = require('../../../server');
@@ -173,10 +173,6 @@ describe('Acceptance | Application | organization-controller', () => {
     await insertUserWithRolePixMaster();
   });
 
-  afterEach(async () => {
-    await cleanupUsersAndPixRolesTables();
-  });
-
   describe('POST /api/organizations', () => {
     let payload;
     let options;
@@ -314,8 +310,6 @@ describe('Acceptance | Application | organization-controller', () => {
       };
     });
 
-    afterEach(() => databaseBuilder.clean());
-
     it('should return 200 HTTP status code', async () => {
       // when
       const response = await server.inject(options);
@@ -376,10 +370,6 @@ describe('Acceptance | Application | organization-controller', () => {
         .then(() => _insertOrganization(userId));
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     it('should return 200 HTTP status code', () => {
       // when
       const promise = server.inject(options);
@@ -433,9 +423,8 @@ describe('Acceptance | Application | organization-controller', () => {
         .then(() => _insertSnapshot(organizationId, userId));
     });
 
-    afterEach(async () => {
-      await knex('snapshots').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('snapshots').delete();
     });
 
     it('should return 200 HTTP status code', async () => {
@@ -482,10 +471,6 @@ describe('Acceptance | Application | organization-controller', () => {
         });
         databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[2].id, isShared: true });
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return the organization campaigns', () => {
@@ -554,10 +539,6 @@ describe('Acceptance | Application | organization-controller', () => {
           headers: { authorization: generateValidRequestAuthorizationHeader(userPixMaster.id) },
         };
 
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return the matching organization as JSON API', async () => {
@@ -682,10 +663,6 @@ describe('Acceptance | Application | organization-controller', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the matching organization as JSON API', async () => {
         // given
         const expectedResult = {
@@ -784,10 +761,6 @@ describe('Acceptance | Application | organization-controller', () => {
         url: `/api/organizations/${organization.id}/students`,
         headers: { authorization: generateValidRequestAuthorizationHeader(connectedUser.id) },
       };
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('Expected output', () => {
@@ -958,9 +931,8 @@ describe('Acceptance | Application | organization-controller', () => {
       };
     });
 
-    afterEach(async () => {
-      await knex('students').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('students').delete();
     });
 
     context('Expected output', () => {
@@ -1295,9 +1267,8 @@ describe('Acceptance | Application | organization-controller', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await knex('organization-invitations').delete();
-        await databaseBuilder.clean();
+      afterEach(() => {
+        return knex('organization-invitations').delete();
       });
 
       it('should return the matching organization-invitations as JSON API', async () => {
@@ -1352,9 +1323,8 @@ describe('Acceptance | Application | organization-controller', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await knex('organization-invitations').delete();
-        await databaseBuilder.clean();
+      afterEach(() => {
+        return knex('organization-invitations').delete();
       });
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
@@ -1464,8 +1434,7 @@ describe('Acceptance | Application | organization-controller', () => {
 
     afterEach(async () => {
       await knex('memberships').delete();
-      await knex('organization-invitations').delete();
-      await databaseBuilder.clean();
+      return knex('organization-invitations').delete();
     });
 
     context('Expected output', () => {

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -55,9 +55,8 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await knex('memberships').delete();
-        await databaseBuilder.clean();
+      afterEach(() => {
+        return knex('memberships').delete();
       });
 
       it('should return 204 HTTP status code', async () => {
@@ -95,10 +94,6 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         };
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should respond with a 404 if organization-invitation does not exist with id and code', async () => {
@@ -200,10 +195,6 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return 200 HTTP status code', async () => {
         // when
         const response = await server.inject(options);
@@ -232,10 +223,6 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         };
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should respond with a 400 - missing parameters if organization-invitation is requested without code', async () => {

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -17,14 +17,13 @@ describe('Acceptance | Controller | password-controller', () => {
   describe('POST /api/password-reset-demands', () => {
     let options;
 
-    before(async () => {
+    beforeEach(() => {
       databaseBuilder.factory.buildUser({ email: fakeUserEmail });
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
-    after(async () => {
-      await knex('reset-password-demands').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('reset-password-demands').delete();
     });
 
     describe('when email provided is unknown', () => {
@@ -209,9 +208,8 @@ describe('Acceptance | Controller | password-controller', () => {
         await _insertPasswordResetDemand(temporaryKey, fakeUserEmail);
       });
 
-      afterEach(async () => {
-        await knex('reset-password-demands').delete();
-        await databaseBuilder.clean();
+      afterEach(() => {
+        return knex('reset-password-demands').delete();
       });
 
       it('should reply with 200 status code', () => {

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -47,9 +47,8 @@ describe('Acceptance | API | Progressions', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       nock.cleanAll();
-      await databaseBuilder.clean();
     });
 
     context('without authorization token', () => {

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -38,7 +38,6 @@ describe('Acceptance | API | Progressions', () => {
       const campaignId = databaseBuilder.factory.buildCampaign(
         {
           name: 'Campaign',
-          targetProfileId: 1
         }).id;
       databaseBuilder.factory.buildCampaignParticipation(
         {

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -23,14 +23,12 @@ describe('Acceptance | Controller | scorecard-controller', () => {
   });
 
   afterEach(async () => {
+    airtableBuilder.cleanAll();
     await knex('knowledge-elements').delete();
     await knex('answers').delete();
     await knex('competence-evaluations').delete();
     await knex('assessments').delete();
-    await knex('campaign-participations').delete();
-
-    airtableBuilder.cleanAll();
-    return databaseBuilder.clean();
+    return knex('campaign-participations').delete();
   });
 
   after(() => {

--- a/api/tests/acceptance/application/session-controller_test.js
+++ b/api/tests/acceptance/application/session-controller_test.js
@@ -32,10 +32,6 @@ describe('Acceptance | Controller | sessions-controller', () => {
     };
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('PUT /sessions/{id}/finalization', () => {
 
     describe('Resource access management', () => {

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -10,10 +10,6 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
     server = await createServer();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('#createCandidateParticipation', () => {
     let options;
     let payload;

--- a/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
@@ -26,7 +26,6 @@ describe('Acceptance | Controller | session-controller-get-attendance-sheet', ()
 
       await databaseBuilder.commit();
     });
-    afterEach(() => databaseBuilder.clean());
 
     it('should respond with a 200 when session can be found', async () => {
       // when

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -21,8 +21,6 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
       return databaseBuilder.commit();
     });
 
-    afterEach(() => databaseBuilder.clean());
-
     context('when user has no access to session resources', () => {
 
       beforeEach(() => {

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -34,8 +34,6 @@ describe('Acceptance | Controller | session-controller-get', () => {
       return databaseBuilder.commit();
     });
 
-    afterEach(() => databaseBuilder.clean());
-
     it('should return 200 HTTP status code', () => {
       // when
       const promise = server.inject({
@@ -134,8 +132,6 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       return databaseBuilder.commit();
     });
-
-    afterEach(() => databaseBuilder.clean());
 
     it('should return 200 HTTP status code', () => {
       // when

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
@@ -31,9 +31,8 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('certification-candidates').delete();
-      return databaseBuilder.clean();
+    afterEach(() => {
+      return knex('certification-candidates').delete();
     });
 
     context('The user can access the session', () => {

--- a/api/tests/acceptance/application/session/session-controller-patch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch_test.js
@@ -54,10 +54,6 @@ describe('Acceptance | Controller | session-controller-patch', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     it('should respond with a 200 and update the session', function() {
       const options = {
         method: 'PATCH',

--- a/api/tests/acceptance/application/session/session-controller-post_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post_test.js
@@ -39,8 +39,7 @@ describe('Acceptance | Controller | session-controller-post', () => {
       return databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
+    afterEach(() => {
       return knex('sessions').delete();
     });
 

--- a/api/tests/acceptance/application/student-user-association-controller_test.js
+++ b/api/tests/acceptance/application/student-user-association-controller_test.js
@@ -33,10 +33,6 @@ describe('Acceptance | Controller | Student-user-associations', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      return databaseBuilder.clean();
-    });
-
     it('should return an 204 status after having successfully associated user to student', async () => {
       // given
       options.headers.authorization = generateValidRequestAuthorizationHeader(user.id);

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -32,9 +32,8 @@ describe('Acceptance | Controller | target-profile-controller', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
+      afterEach(() => {
         nock.cleanAll();
-        await databaseBuilder.clean();
       });
 
       it('should return 200', async () => {

--- a/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
@@ -21,10 +21,6 @@ describe('Acceptance | Controller | users-controller-accept-pix-certif-terms-of-
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('Resource access management', () => {
 
     it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/acceptance/application/users/accept-pix-orga-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-orga-terms-of-service_test.js
@@ -21,10 +21,6 @@ describe('Acceptance | Controller | users-controller-accept-pix-orga-terms-of-se
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('Resource access management', () => {
 
     it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
+++ b/api/tests/acceptance/application/users/remember-user-has-seen-assessment-instructions_test.js
@@ -21,10 +21,6 @@ describe('Acceptance | Controller | users-controller-remember-user-has-seen-asse
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('Resource access management', () => {
 
     it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/acceptance/application/users/update-password_test.js
+++ b/api/tests/acceptance/application/users/update-password_test.js
@@ -17,9 +17,8 @@ describe('Acceptance | Controller | users-controller-update-password', () => {
     await _insertPasswordResetDemand(temporaryKey, user.email);
   });
 
-  afterEach(async () => {
-    await knex('reset-password-demands').delete();
-    await databaseBuilder.clean();
+  afterEach(() => {
+    return knex('reset-password-demands').delete();
   });
 
   describe('Error case', () => {

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -27,10 +27,6 @@ describe('Acceptance | users-controller-find-users', () => {
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('GET /users', () => {
 
     describe('Resource access management', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
@@ -29,10 +29,6 @@ describe('Acceptance | Controller | users-controller-get-certification-center-me
       return databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     describe('Resource access management', () => {
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/acceptance/application/users/users-controller-get-certification-profile_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-certification-profile_test.js
@@ -41,8 +41,7 @@ describe('Acceptance | users-controller-get-certification-profile', () => {
   });
 
   afterEach(() => {
-    airtableBuilder.cleanAll();
-    return databaseBuilder.clean();
+    return airtableBuilder.cleanAll();
   });
 
   after(() => {

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -22,10 +22,6 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('GET /users/me', () => {
 
     it('should return found user with 200 HTTP status code', async () => {

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -31,10 +31,6 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
       };
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     describe('Resource access management', () => {
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-pix-score_test.js
@@ -26,10 +26,6 @@ describe('Acceptance | users-controller-get-pix-score', () => {
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('GET /users/:id/pixscore', () => {
 
     describe('Resource access management', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-student_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-student_test.js
@@ -27,10 +27,6 @@ describe('Acceptance | Controller | users-controller-get-user-student', () => {
     };
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('GET /users/:id/student', () => {
 
     describe('Resource access management', () => {

--- a/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
@@ -21,9 +21,8 @@ describe('Acceptance | Controller | users-controller-get-user-scorecards', () =>
     server = await createServer();
   });
 
-  afterEach(async () => {
-    airtableBuilder.cleanAll();
-    await databaseBuilder.clean();
+  afterEach(() => {
+    return airtableBuilder.cleanAll();
   });
 
   after(() => {

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -44,8 +44,10 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
   });
 
   afterEach(async () => {
-    await knex('assessments').delete();
-    await databaseBuilder.clean();
+    await knex('competence-evaluations').delete();
+    await knex('knowledge-elements').delete();
+    await knex('answers').delete();
+    return knex('assessments').delete();
   });
 
   describe('POST /users/{id}/competences/{id}/reset', () => {
@@ -96,10 +98,6 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
         });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should respond with a 421 - precondition failed - if last knowledge element date is not old enough', async () => {
@@ -183,9 +181,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
         await knex('competence-evaluations').delete();
         await knex('assessments').delete();
         await knex('campaign-participations').delete();
-
-        await databaseBuilder.clean();
-        airtableBuilder.cleanAll();
+        return airtableBuilder.cleanAll();
       });
 
       it('should return 200 and the updated scorecard', async () => {

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -51,10 +51,6 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
       return databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     describe('Resource access management', () => {
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -18,10 +18,6 @@ describe('Integration | Services | extractCertificationCandidatesFromAttendanceS
     await databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   context('When attendance sheet is of version 1.0', () => {
 
     it('should throw a InvalidCertificationCandidate if any of the candidate data is missing a mandatory field', async () => {

--- a/api/tests/integration/domain/services/certifications-ods-service/certifications-ods-service_test.js
+++ b/api/tests/integration/domain/services/certifications-ods-service/certifications-ods-service_test.js
@@ -1,12 +1,8 @@
-const { expect, databaseBuilder } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const certificationsOdsService = require('../../../../../lib/domain/services/certifications-ods-service');
 const fs = require('fs');
 
 describe('Integration | Services | extractCertificationsDataFromAttendanceSheet', () => {
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
 
   context('When attendance sheet is of version 1.0', () => {
 

--- a/api/tests/integration/domain/services/smart-random/solution-service-function-revalidate_test.js
+++ b/api/tests/integration/domain/services/smart-random/solution-service-function-revalidate_test.js
@@ -11,7 +11,7 @@ describe('Integration | Service | SolutionService', function() {
 
     let ko_answer, ok_answer, unimplemented_answer;
 
-    before(async () => {
+    beforeEach(() => {
       const assessmentId = databaseBuilder.factory.buildAssessment().id;
       ko_answer = domainBuilder.buildAnswer(
         { id: 1,
@@ -35,12 +35,10 @@ describe('Integration | Service | SolutionService', function() {
         assessmentId,
       });
       _.each([ ko_answer, ok_answer, unimplemented_answer], (answer) => (databaseBuilder.factory.buildAnswer(answer)));
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
-    after(() => databaseBuilder.clean());
-
-    it('If the answer is ko, resolve to the answer itself, with result corresponding to the matching', function(done) {
+    it('If the answer is ko, resolve to the answer itself, with result corresponding to the matching', async () => {
 
       // given
       const MATCHING_RETURNS = { result: '#ANY_RESULT#', resultDetails: null };
@@ -50,20 +48,17 @@ describe('Integration | Service | SolutionService', function() {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(ko_answer)).then(function(foundAnswer) {
+      const foundAnswer = await service.revalidate(new Answer(ko_answer));
 
-        // then
-        expect(solutionRepository.getByChallengeId.callOnce);
-        expect(service.validate.callOnce);
-        expect(foundAnswer.id).equals(ko_answer.id);
-        expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
-
-        done();
-      });
+      // then
+      expect(solutionRepository.getByChallengeId.callOnce);
+      expect(service.validate.callOnce);
+      expect(foundAnswer.id).equals(ko_answer.id);
+      expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
 
     });
 
-    it('If the answer is ok, resolve to the answer itself, with result corresponding to the matching', function(done) {
+    it('If the answer is ok, resolve to the answer itself, with result corresponding to the matching', async () => {
 
       // given
       const MATCHING_RETURNS = { result: '#ANY_RESULT#', resultDetails: null };
@@ -74,20 +69,16 @@ describe('Integration | Service | SolutionService', function() {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(ok_answer)).then(function(foundAnswer) {
+      const foundAnswer = await service.revalidate(new Answer(ok_answer));
 
-        // then
-        expect(solutionRepository.getByChallengeId.callOnce);
-        expect(service.validate.callOnce);
-        expect(foundAnswer.id).equals(ok_answer.id);
-        expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
-
-        done();
-      });
-
+      // then
+      expect(solutionRepository.getByChallengeId.callOnce);
+      expect(service.validate.callOnce);
+      expect(foundAnswer.id).equals(ok_answer.id);
+      expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
     });
 
-    it('If the answer is unimplemented, resolve to the answer itself, with result corresponding to the matching', function(done) {
+    it('If the answer is unimplemented, resolve to the answer itself, with result corresponding to the matching', async() => {
 
       // given
       const MATCHING_RETURNS = { result: '#ANY_RESULT#', resultDetails: null };
@@ -98,17 +89,13 @@ describe('Integration | Service | SolutionService', function() {
       expect(service.revalidate).to.exist;
 
       // when
-      service.revalidate(new Answer(unimplemented_answer)).then(function(foundAnswer) {
+      const foundAnswer = await service.revalidate(new Answer(unimplemented_answer));
 
-        // then
-        expect(solutionRepository.getByChallengeId.callOnce);
-        expect(service.validate.callOnce);
-        expect(foundAnswer.id).equals(unimplemented_answer.id);
-        expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
-
-        done();
-      });
-
+      // then
+      expect(solutionRepository.getByChallengeId.callOnce);
+      expect(service.validate.callOnce);
+      expect(foundAnswer.id).equals(unimplemented_answer.id);
+      expect(foundAnswer.attributes.result).equals(MATCHING_RETURNS.result);
     });
 
   });

--- a/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
+++ b/api/tests/integration/domain/usecases/get-attendance-sheet/get-attendance-sheet_test.js
@@ -11,8 +11,7 @@ describe('Integration | UseCases | getAttendanceSheet', () => {
   const expectedOdsFilePath = `${__dirname}/attendance_sheet_template_target.ods`;
   const actualOdsFilePath = `${__dirname}/attendance_sheet_template_actual.tmp.ods`;
 
-  beforeEach(async () => {
-    await databaseBuilder.clean();
+  beforeEach(() => {
     const certificationCenterName = 'Centre de certification';
     userId = databaseBuilder.factory.buildUser().id;
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ name: certificationCenterName }).id;
@@ -38,11 +37,10 @@ describe('Integration | UseCases | getAttendanceSheet', () => {
       databaseBuilder.factory.buildCertificationCandidate(candidate);
     });
 
-    await databaseBuilder.commit();
+    return databaseBuilder.commit();
   });
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
+  afterEach(() => {
     fs.unlinkSync(actualOdsFilePath);
   });
 

--- a/api/tests/integration/infrastructure/knex-database-connection_test.js
+++ b/api/tests/integration/infrastructure/knex-database-connection_test.js
@@ -1,9 +1,9 @@
-const { expect/*, databaseBuilder*/ } = require('../../test-helper');
+const { expect, databaseBuilder } = require('../../test-helper');
 
 const knexDatabaseConnection = require('../../../db/knex-database-connection');
 
-// const { UserNotFoundError } = require('../../../lib/domain/errors');
-// const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
+const { UserNotFoundError } = require('../../../lib/domain/errors');
+const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
 
 describe('Integration | Infrastructure | knex-database-connection', () => {
 
@@ -21,9 +21,7 @@ describe('Integration | Infrastructure | knex-database-connection', () => {
     expect(tableNames).to.include('users');
   });
 
-  // Waiting for a better option, since testing this have consequences on following tests...
-  // Force migrations?
-/*  it('should empty all tables', async () => {
+  it('should empty all tables', async () => {
     // given
     const { id } = databaseBuilder.factory.buildUser();
     await databaseBuilder.commit();
@@ -33,5 +31,5 @@ describe('Integration | Infrastructure | knex-database-connection', () => {
 
     // then
     await expect(userRepository.get(id)).to.be.rejectedWith(UserNotFoundError);
-  });*/
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -17,10 +17,6 @@ describe('Integration | Repository | AnswerRepository', () => {
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('#get', () => {
 
     context('when there are no answers', () => {

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -39,10 +39,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the assessment with the answers sorted by creation date ', async () => {
         // when
         const assessment = await assessmentRepository.get(assessmentId);
@@ -87,10 +83,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         await databaseBuilder.commit();
       });
 
-      after(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should fetch relative assessment ', async () => {
         // when
         const assessment = await assessmentRepository.getByAssessmentIdAndUserId(assessmentId, userId);
@@ -113,10 +105,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
             courseId: 'courseId',
           }).id;
         await databaseBuilder.commit();
-      });
-
-      after(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should fetch relative assessment', async () => {
@@ -260,10 +248,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
     });
 
-    after(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should correctly query Assessment conditions', async () => {
       // given
       const expectedAssessments = [
@@ -312,7 +296,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     let assessmentToBeSaved;
     let assessmentReturned;
 
-    before(async () => {
+    beforeEach(() => {
       userId = databaseBuilder.factory.buildUser().id;
 
       assessmentToBeSaved = new Assessment({
@@ -322,12 +306,11 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         state: Assessment.states.COMPLETED,
       });
 
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
-    after(async () => {
-      await knex('assessments').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('assessments').delete();
     });
 
     it('should save new assessment if not already existing', async () => {
@@ -341,10 +324,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
   });
 
   describe('#getByCertificationCourseId', async () => {
-
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
 
     context('When several assessments exist for a given certification course id', () => {
 
@@ -458,10 +437,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       return databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     context('When several assessments exist for a given certification course id', () => {
 
       context('When one of those assessment is completed', () => {
@@ -563,10 +538,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       await databaseBuilder.commit();
     });
 
-    after(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return assessment with campaignParticipation when it matches with campaignParticipationId', async () => {
       // when
       const assessmentsReturned = await assessmentRepository.getByCampaignParticipationId(campaignParticipationId);
@@ -606,10 +577,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       });
 
       await databaseBuilder.commit();
-    });
-
-    after(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the assessment with campaign when it matches with userId and ignore aborted assessments', async () => {
@@ -654,10 +621,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
         await databaseBuilder.commit();
       });
 
-      after(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the assessment with campaign when asked', async () => {
         // when
         const assessmentReturned = await assessmentRepository.findLastSmartPlacementAssessmentByUserIdAndCampaignCode({ userId, campaignCode: campaign.code, includeCampaign: true });
@@ -696,10 +659,6 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       userId = databaseBuilder.factory.buildUser().id;
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('when user does not have campaign or competenceEvaluation', () => {

--- a/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-result-repository_test.js
@@ -11,9 +11,8 @@ describe('Integration | Repository | AssessmentResult', function() {
     let assessmentResultToSave;
     let assessmentResult;
 
-    afterEach(async () => {
-      await knex('assessment-results').where('id', assessmentResult.id).delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('assessment-results').where('id', assessmentResult.id).delete();
     });
 
     beforeEach(async () => {
@@ -59,10 +58,6 @@ describe('Integration | Repository | AssessmentResult', function() {
       competenceMarks2 = databaseBuilder.factory.buildCompetenceMark({ id: 2, assessmentResultId: assessmentResult.id });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the assessmentResult', async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository-test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository-test.js
@@ -57,8 +57,7 @@ describe('Integration | Repository | Service | Campaign collective result reposi
 
   afterEach(async () => {
     await cache.flushAll();
-    await airtableBuilder.cleanAll();
-    await databaseBuilder.clean();
+    return airtableBuilder.cleanAll();
   });
 
   describe('#getCampaignCollectiveResults', () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -43,10 +43,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return a campaign participation object', async () => {
       // when
       const foundCampaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
@@ -84,9 +80,8 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('campaign-participations').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('campaign-participations').delete();
     });
 
     it('should return the given campaign participation', async () => {
@@ -156,10 +151,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should count all campaignParticipations', async () => {
       // when
       const count = await campaignParticipationRepository.count();
@@ -218,10 +209,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return all the campaign-participation links to the given campaign', () => {
       // given
       const campaignId = campaign1.id;
@@ -254,10 +241,6 @@ describe('Integration | Repository | Campaign Participation', () => {
         databaseBuilder.factory.buildCampaignParticipation({});
       });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return all the campaign-participation links to the given user', async () => {
@@ -293,10 +276,6 @@ describe('Integration | Repository | Campaign Participation', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the campaign-participation linked to the given assessment with skills', async () => {
         // when
         const campaignParticipationFound = await campaignParticipationRepository.findOneByAssessmentIdWithSkillIds(assessmentId);
@@ -318,10 +297,6 @@ describe('Integration | Repository | Campaign Participation', () => {
         databaseBuilder.factory.buildCampaignParticipation({ assessmentId: 67890 });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return null', async () => {
@@ -347,10 +322,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       databaseBuilder.factory.buildAssessment({ campaignParticipationId: otherCampaignParticipation.id });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return campaign participation that match given assessmentId', async function() {
@@ -413,10 +384,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       pixMembers.forEach(insertPixMember);
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return paginated campaign participations including users sorted by name, lastname, their assessment and uniq knowledge elements', async () => {
@@ -486,10 +453,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       sinon.useFakeTimers(frozenTime);
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the shared campaign-participation', () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -8,18 +8,13 @@ const _ = require('lodash');
 
 describe('Integration | Repository | Campaign', () => {
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('#isCodeAvailable', () => {
 
     beforeEach(async () => {
-      await databaseBuilder.clean();
       databaseBuilder.factory.buildCampaign({ code: 'BADOIT710' });
       await databaseBuilder.commit();
     });
-    
+
     it('should resolve true if the code is available', async () => {
       // when
       const isCodeAvailable = await campaignRepository.isCodeAvailable('FRANCE998');
@@ -103,9 +98,8 @@ describe('Integration | Repository | Campaign', () => {
       savedCampaign = await campaignRepository.save(campaignToSave);
     });
 
-    afterEach(async () => {
-      await knex('campaigns').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('campaigns').delete();
     });
 
     it('should save the given campaign', async () => {
@@ -123,10 +117,6 @@ describe('Integration | Repository | Campaign', () => {
   });
 
   describe('#findByOrganizationIdWithCampaignReports', () => {
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
 
     context('when campaigns have campaignReports', async () => {
 

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -15,8 +15,7 @@ describe('Integration | Repository | CertificationCandidate', function() {
     let sessionId;
     let userId;
 
-    beforeEach(async () => {
-      await databaseBuilder.clean();
+    beforeEach(() => {
       // given
       sessionId = databaseBuilder.factory.buildSession().id;
       userId = databaseBuilder.factory.buildUser().id;
@@ -24,9 +23,8 @@ describe('Integration | Repository | CertificationCandidate', function() {
       return databaseBuilder.commit();
     });
 
-    afterEach(async() => {
-      await knex('certification-candidates').delete();
-      return databaseBuilder.clean();
+    afterEach(() => {
+      return knex('certification-candidates').delete();
     });
 
     context('when a proper candidate is being saved', () => {
@@ -145,8 +143,6 @@ describe('Integration | Repository | CertificationCandidate', function() {
         await databaseBuilder.commit();
       });
 
-      afterEach(() => databaseBuilder.clean());
-
       it('should return the deleted certification candidate with all its attributes undefined', async () => {
         // when
         const certificationCandidateDeleted = await certificationCandidateRepository.delete(certificationCandidateToDeleteId);
@@ -204,8 +200,6 @@ describe('Integration | Repository | CertificationCandidate', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(() => databaseBuilder.clean());
-
     context('when there are some certification candidates with the given session id', function() {
 
       it('should fetch, alphabetically sorted, the certification candidates with a specific session ID', async () => {
@@ -244,8 +238,6 @@ describe('Integration | Repository | CertificationCandidate', function() {
       sessionId = databaseBuilder.factory.buildSession().id;
       return databaseBuilder.commit();
     });
-
-    afterEach(() => databaseBuilder.clean());
 
     context('when there is one certification candidate with the given info in the session', function() {
 
@@ -364,9 +356,8 @@ describe('Integration | Repository | CertificationCandidate', function() {
       return databaseBuilder.commit();
     });
 
-    afterEach(async() => {
-      await knex('certification-candidates').delete();
-      return databaseBuilder.clean();
+    afterEach(() => {
+      return knex('certification-candidates').delete();
     });
 
     context('when there are some certification candidates to delete', function() {
@@ -428,8 +419,6 @@ describe('Integration | Repository | CertificationCandidate', function() {
       databaseBuilder.factory.buildCertificationCandidate({ sessionId: sessionId, userId: userId });
       return databaseBuilder.commit();
     });
-
-    afterEach(() => databaseBuilder.clean());
 
     context('when there is one certification candidate with the given session id and user id', function() {
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -6,10 +6,6 @@ const CertificationCenter = require('../../../../lib/domain/models/Certification
 
 describe('Integration | Repository | Certification Center Membership', () => {
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('#create', () => {
     let userId, certificationCenterId;
     beforeEach(async () => {
@@ -18,9 +14,8 @@ describe('Integration | Repository | Certification Center Membership', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('certification-center-memberships').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('certification-center-memberships').delete();
     });
 
     it('should add a new membership in database', async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -6,14 +6,6 @@ const _ = require('lodash');
 
 describe('Integration | Repository | Certification Center', () => {
 
-  beforeEach(async () => {
-    await databaseBuilder.clean();
-  });
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('#get', () => {
     context('the certification is found', () => {
       beforeEach(async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -19,9 +19,8 @@ describe('Integration | Repository | Certification Challenge', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('certification-challenges').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('certification-challenges').delete();
     });
 
     it('should return certification challenge object', () => {
@@ -60,10 +59,6 @@ describe('Integration | Repository | Certification Challenge', function() {
         });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should find all challenges related to a given certification courseId', async () => {
@@ -114,10 +109,6 @@ describe('Integration | Repository | Certification Challenge', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should find all challenges related to a given certification course id', async () => {
       // when
       const certificationChallenges = await certificationChallengeRepository.findChallengesByCertificationCourseId(certificationCourseId);
@@ -165,10 +156,6 @@ describe('Integration | Repository | Certification Challenge', function() {
         await databaseBuilder.commit();
       });
 
-      after(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should reject the promise if no non answered challenge is found', function() {
         // when
         const promise = certificationChallengeRepository.getNonAnsweredChallengeByCourseId(
@@ -213,10 +200,6 @@ describe('Integration | Repository | Certification Challenge', function() {
           });
 
         await databaseBuilder.commit();
-      });
-
-      after(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return one challenge which has no answer associated', async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -17,10 +17,6 @@ describe('Integration | Repository | Certification Course', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should update completedAt of the certificationCourse if one date is passed', async () => {
       // when
       const completionDate = new Date('2018-01-01T06:07:08Z');
@@ -61,10 +57,6 @@ describe('Integration | Repository | Certification Course', function() {
         databaseBuilder.factory.buildCertificationChallenge(certificationChallenge);
       });
       return databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     context('When the certification course exists', () => {
@@ -176,9 +168,8 @@ describe('Integration | Repository | Certification Course', function() {
     let userId;
     let sessionId;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       // given
-      await databaseBuilder.clean();
       userId = databaseBuilder.factory.buildUser({}).id;
       sessionId = databaseBuilder.factory.buildSession({}).id;
       databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt });
@@ -187,10 +178,8 @@ describe('Integration | Repository | Certification Course', function() {
       databaseBuilder.factory.buildCertificationCourse({ sessionId });
       databaseBuilder.factory.buildCertificationCourse({ userId });
 
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
-
-    afterEach(() => databaseBuilder.clean());
 
     it('should retrieve the last certification course with given userId, sessionId', async () => {
       // when
@@ -218,10 +207,6 @@ describe('Integration | Repository | Certification Course', function() {
       const bookshelfCertificationCourse = databaseBuilder.factory.buildCertificationCourse({ userId });
       certificationCourse = domainBuilder.buildCertificationCourse(bookshelfCertificationCourse);
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return a certification course domain object', async () => {

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -105,8 +105,6 @@ describe('Integration | Repository | Certification ', () => {
     await databaseBuilder.commit();
   });
 
-  afterEach(() => databaseBuilder.clean());
-
   describe('#getByCertificationCourseId', () => {
 
     it('should return a certification with needed informations', async () => {

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -15,9 +15,8 @@ describe('Integration | Repository | Competence Evaluation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('competence-evaluations').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('competence-evaluations').delete();
     });
 
     it('should return the given competence evaluation', () => {
@@ -94,10 +93,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the competence evaluation linked to the assessment', () => {
       // when
       const promise = competenceEvaluationRepository.getByAssessmentId(assessmentForExpectedCompetenceEvaluation.id);
@@ -147,10 +142,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the competence evaluation linked to the competence id', () => {
@@ -214,10 +205,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the competence evaluation linked to the competence id', () => {
       // when
       const promise = competenceEvaluationRepository.findByUserId(user.id);
@@ -241,10 +228,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should update the competence status', async () => {
       // when
       const updatedCompetenceEvaluation = await competenceEvaluationRepository.updateStatusByAssessmentId({ assessmentId: assessment.id, status: 'new_status' });
@@ -264,10 +247,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       newAssessmentId = databaseBuilder.factory.buildAssessment({}).id;
       databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId: currentAssessmentId });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should update the assessment id', async () => {
@@ -291,10 +270,6 @@ describe('Integration | Repository | Competence Evaluation', () => {
       databaseBuilder.factory.buildCompetenceEvaluation({ userId, competenceId, status: 'current_status' });
       databaseBuilder.factory.buildCompetenceEvaluation({ userId: otherUserId, competenceId, status: 'current_status' });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should update the competence status', async () => {

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -108,10 +108,6 @@ describe('Integration | Repository | CompetenceMark', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return all competence-marks for one assessmentResult', () => {
       // when
       const promise = CompetenceMarkRepository.findByAssessmentResultId(assessmentResultId);

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -6,9 +6,8 @@ const moment = require('moment');
 
 describe('Integration | Repository | KnowledgeElementRepository', () => {
 
-  afterEach(async () => {
-    await knex('knowledge-elements').delete();
-    await databaseBuilder.clean();
+  afterEach(() => {
+    return knex('knowledge-elements').delete();
   });
 
   describe('#save', () => {
@@ -99,10 +98,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should find the knowledge elements associated with a given assessment', async () => {
       // when
       const knowledgeElementsFound = await KnowledgeElementRepository.findByAssessmentId(assessmentId);
@@ -145,10 +140,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     context('when there is no limit date', () => {
       it('should find the knowledge elements for smart placement assessment associated with a user id', async () => {
         // when
@@ -189,10 +180,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should find the knowledge elements grouped by competence id', async () => {
       // when
       const actualKnowledgeElementsGroupedByCompetenceId = await KnowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
@@ -211,7 +198,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     const today = new Date('2018-08-01T12:34:56Z');
     const yesterday = moment(today).subtract(1, 'days').toDate();
 
-    beforeEach(async () => {
+    beforeEach(() => {
       // given
       userId = databaseBuilder.factory.buildUser().id;
       const userId_tmp = databaseBuilder.factory.buildUser().id;
@@ -227,11 +214,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
         { skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated' },
       ], (ke) => databaseBuilder.factory.buildKnowledgeElement(ke));
 
-      await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
+      return databaseBuilder.commit();
     });
 
     it('should return the right sum of Pix from user knowledge elements', async () => {
@@ -272,10 +255,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should find only the knowledge elements matching both userId and competenceId', async () => {

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -8,13 +8,8 @@ const User = require('../../../../lib/domain/models/User');
 
 describe('Integration | Infrastructure | Repository | membership-repository', () => {
 
-  beforeEach(async () => {
-    await databaseBuilder.clean();
-  });
-
-  afterEach(async () => {
-    await knex('memberships').delete();
-    await databaseBuilder.clean();
+  afterEach(() => {
+    return knex('memberships').delete();
   });
 
   describe('#create', () => {

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -15,9 +15,8 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('organization-invitations').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('organization-invitations').delete();
     });
 
     it('should save the organization invitation in db', async () => {
@@ -45,10 +44,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
     beforeEach(async () => {
       insertedOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation();
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should get the organization-invitation from db', async () => {
@@ -82,10 +77,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
     beforeEach(async () => {
       insertedOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation();
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should get the organization-invitation by id and code', async () => {
@@ -128,10 +119,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return an Organization-invitation domain object', async () => {
       // when
       const organizationInvitationSaved = await organizationInvitationRepository.markAsAccepted(organizationInvitation.id);
@@ -170,10 +157,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
 
   describe('#findOneByOrganizationIdAndEmail', () => {
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should retrieve organization-invitation with given organizationId and email', async () => {
       // given
       const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation();
@@ -209,10 +192,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
         status: OrganizationInvitation.StatusType.ACCEPTED,
       });
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should find two of the three organization-invitations from db by organizationId', async () => {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -6,14 +6,6 @@ const _ = require('lodash');
 
 describe('Integration | Repository | Organization', function() {
 
-  beforeEach(async () => {
-    await databaseBuilder.clean();
-  });
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('#create', () => {
 
     afterEach(async () => {
@@ -71,10 +63,6 @@ describe('Integration | Repository | Organization', function() {
       const bookshelfOrganization = databaseBuilder.factory.buildOrganization({ id: 1, code: organizationCode });
       organization = domainBuilder.buildOrganization(bookshelfOrganization);
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return an Organization domain object', async () => {
@@ -144,10 +132,6 @@ describe('Integration | Repository | Organization', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the code when the code is not already used', async () => {
       // when
       const code = await organizationRepository.isCodeAvailable('ABCD02');
@@ -174,10 +158,6 @@ describe('Integration | Repository | Organization', function() {
       beforeEach(async () => {
         insertedOrganization = databaseBuilder.factory.buildOrganization();
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return a organization by provided id', async () => {
@@ -227,10 +207,6 @@ describe('Integration | Repository | Organization', function() {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return an list of profile containing the shared profile', async () => {
         // when
         const organization = await organizationRepository.get(insertedOrganization.id);
@@ -262,10 +238,6 @@ describe('Integration | Repository | Organization', function() {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     describe('success management', function() {
@@ -318,10 +290,6 @@ describe('Integration | Repository | Organization', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the organizations that matches the filters', async () => {
       // given
       const filters = { type: 'PRO' };
@@ -339,15 +307,12 @@ describe('Integration | Repository | Organization', function() {
   });
 
   describe('#find', () => {
-    after(async () => {
-      await databaseBuilder.clean();
-    });
 
     context('when there are Organizations in the database', () => {
 
-      beforeEach(async () => {
+      beforeEach(() => {
         _.times(3, databaseBuilder.factory.buildOrganization);
-        await databaseBuilder.commit();
+        return databaseBuilder.commit();
       });
 
       it('should return an Array of Organizations', async () => {

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -7,14 +7,6 @@ const sessionRepository = require('../../../../lib/infrastructure/repositories/s
 
 describe('Integration | Repository | Session', function() {
 
-  beforeEach(async () => {
-    await databaseBuilder.clean();
-  });
-
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('#save', () => {
     let session, certificationCenter;
 
@@ -34,9 +26,8 @@ describe('Integration | Repository | Session', function() {
       await databaseBuilder.commit();
     });
 
-    afterEach(async() => {
-      await knex('sessions').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('sessions').delete();
     });
 
     it('should persist the session in db', async () => {
@@ -179,8 +170,6 @@ describe('Integration | Repository | Session', function() {
       _.times(3, () => databaseBuilder.factory.buildCertificationCourse());
       await databaseBuilder.commit();
     });
-
-    afterEach(() => databaseBuilder.clean());
 
     it('should return session informations in a session Object', async () => {
       // when

--- a/api/tests/integration/infrastructure/repositories/smart-placement-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/smart-placement-assessment-repository_test.js
@@ -167,9 +167,8 @@ describe('Integration | Repository | SmartPlacementAssessmentRepository', () => 
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      airtableBuilder.cleanAll();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return airtableBuilder.cleanAll();
     });
 
     it('should get the smart placement assessment', () => {
@@ -221,10 +220,6 @@ describe('Integration | Repository | SmartPlacementAssessmentRepository', () => 
       });
       userWithNoAssessment = databaseBuilder.factory.buildUser();
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should resolve if the given assessmentId belongs to the user', () => {

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -5,14 +5,6 @@ const Student = require('../../../../lib/domain/models/Student');
 
 describe('Integration | Infrastructure | Repository | student-repository', () => {
 
-  beforeEach(() => {
-    return databaseBuilder.clean();
-  });
-
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('#findByOrganizationId', () => {
 
     it('should return instances of Student', async () => {
@@ -139,9 +131,8 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
 
   describe('#batchSave', () => {
 
-    afterEach(async () => {
-      await knex('students').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('students').delete();
     });
 
     it('should save all students', async function() {
@@ -175,9 +166,8 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
 
   describe('#findByOrganizationIdAndUserInformation', () => {
 
-    afterEach(async () => {
-      await knex('students').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('students').delete();
     });
 
     context('User is part of the studentList', async () => {
@@ -391,9 +381,8 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
 
   describe('#associateUserAndStudent', () => {
 
-    afterEach(async () => {
-      await knex('students').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('students').delete();
     });
 
     let organization;

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -92,10 +92,9 @@ describe('Integration | Repository | Target-profile', () => {
 
       // then
       return promise.then((targetProfiles) => {
-        expect(targetProfiles).to.have.lengthOf(2); // There is one public target profile in database migrations already
+        expect(targetProfiles).to.have.lengthOf(1);
         expect(targetProfiles[0]).to.be.an.instanceOf(TargetProfile);
         expect(targetProfiles[0].isPublic).to.be.true;
-        expect(targetProfiles[1].isPublic).to.be.true;
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -25,10 +25,6 @@ describe('Integration | Repository | Target-profile', () => {
       sinon.stub(skillDatasource, 'findByRecordIds').resolves([skillAssociatedToTargetProfile]);
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the target profile with its associated skills and the list of organizations which could access it', () => {
       // when
       const promise = targetProfileRepository.get(targetProfile.id);
@@ -70,10 +66,6 @@ describe('Integration | Repository | Target-profile', () => {
 
       targetProfileSkill = new SkillDataObject({ id: publicProfileSkillAssociation.skillId, name: '@Acquis1' });
       sinon.stub(skillDatasource, 'findByRecordIds').resolves([targetProfileSkill]);
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return an Array', () => {
@@ -135,10 +127,6 @@ describe('Integration | Repository | Target-profile', () => {
 
       targetProfileSkill = new SkillDataObject({ id: targetProfileSkillAssociation.skillId, name: '@Acquis2' });
       sinon.stub(skillDatasource, 'findByRecordIds').resolves([targetProfileSkill]);
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return an Array', () => {
@@ -209,10 +197,6 @@ describe('Integration | Repository | Target-profile', () => {
       sinon.stub(skillDatasource, 'findByRecordIds').resolves([targetProfileSkill]);
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return an Array', async () => {
       // when
       const foundTargetProfiles = await targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
@@ -221,17 +205,16 @@ describe('Integration | Repository | Target-profile', () => {
       expect(foundTargetProfiles).to.be.an('array');
     });
 
-    it('should return all the target profile the organization can access (owned + public) but not outdated', async () => {
+    it('should return all the target profile the organization can access but not outdated', async () => {
       // when
       const foundTargetProfiles = await targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
 
       // then
       expect(foundTargetProfiles[0]).to.be.an.instanceOf(TargetProfile);
-      expect(foundTargetProfiles).to.have.lengthOf(4);
-      expect(foundTargetProfiles[0].name).to.equal('PIC - Diagnostic Initial');
-      expect(foundTargetProfiles[1].name).to.equal(organizationTargetProfile.name);
-      expect(foundTargetProfiles[2].name).to.equal(organizationTargetProfilePublic.name);
-      expect(foundTargetProfiles[3].name).to.equal(publicTargetProfile.name);
+      expect(foundTargetProfiles).to.have.lengthOf(3);
+      expect(foundTargetProfiles[0].name).to.equal(organizationTargetProfile.name);
+      expect(foundTargetProfiles[1].name).to.equal(organizationTargetProfilePublic.name);
+      expect(foundTargetProfiles[2].name).to.equal(publicTargetProfile.name);
     });
 
     it('should contain skills linked to every target profiles', () => {
@@ -266,10 +249,6 @@ describe('Integration | Repository | Target-profile', () => {
       sinon.stub(skillDatasource, 'findByRecordIds').resolves([skillAssociatedToTargetProfile]);
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should return the target profile matching the campaign id', async () => {

--- a/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
@@ -11,18 +11,16 @@ describe('Integration | Repository | Target-profile-sahre', () => {
     let targetProfileB;
     let targetProfileC;
 
-    afterEach(async () => {
-      await knex('target-profile-shares').delete();
-      await databaseBuilder.clean();
+    afterEach(() => {
+      return knex('target-profile-shares').delete();
     });
 
-    beforeEach(async () => {
-      await databaseBuilder.clean();
+    beforeEach(() => {
       organization = databaseBuilder.factory.buildOrganization();
       targetProfileA = databaseBuilder.factory.buildTargetProfile();
       targetProfileB = databaseBuilder.factory.buildTargetProfile();
       targetProfileC = databaseBuilder.factory.buildTargetProfile();
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
     it('should save all the target profile shares for the organization', async function() {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -64,10 +64,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should be a function', () => {
         // then
         expect(userRepository.findByEmail).to.be.a('function');
@@ -95,12 +91,8 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     describe('#findByEmailWithRoles', () => {
 
-      beforeEach(async () => {
-        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
+      beforeEach(() => {
+        return _insertUserWithOrganizationsAndCertificationCenterAccesses();
       });
 
       it('should return user informations for the given email', async () => {
@@ -176,10 +168,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return user informations for the given SAML ID', async () => {
         // when
         const user = await userRepository.getBySamlId('some-saml-id');
@@ -213,10 +201,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return the found user', async () => {
         // when
         const user = await userRepository.get(userInDb.id);
@@ -247,10 +231,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       beforeEach(async () => {
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return user for the given id', async () => {
@@ -308,10 +288,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       beforeEach(async () => {
         await _insertUserWithOrganizationsAndCertificationCenterAccesses();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return user for the given id', async () => {
@@ -420,10 +396,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should return the email when the email is not registered', async () => {
       // when
       const email = await userRepository.isEmailAvailable('email@example.net');
@@ -450,10 +422,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await databaseBuilder.clean();
-    });
-
     it('should save the user', async () => {
       // given
       const newPassword = '1235Pix!';
@@ -478,10 +446,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
     });
 
     it('should update pixOrgaTermsOfServiceAccepted field', async () => {
@@ -517,14 +481,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
   describe('#isUserExistingByEmail', () => {
     const email = 'shi@fu.fr';
-    beforeEach(async () => {
+
+    beforeEach(() => {
       databaseBuilder.factory.buildUser({ email });
       databaseBuilder.factory.buildUser();
-      await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await databaseBuilder.clean();
+      return databaseBuilder.commit();
     });
 
     it('should return true when the user exists by email', async () => {
@@ -542,14 +503,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     context('when there are users in the database', () => {
 
-      beforeEach(async () => {
+      beforeEach(() => {
         _.times(3, databaseBuilder.factory.buildUser);
 
-        await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
+        return databaseBuilder.commit();
       });
 
       it('should return an Array of Users', async () => {
@@ -571,14 +528,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     context('when there are lots of users (> 10) in the database', () => {
 
-      beforeEach(async () => {
+      beforeEach(() => {
         _.times(12, databaseBuilder.factory.buildUser);
 
-        await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
+        return databaseBuilder.commit();
       });
 
       it('should return paginated matching users', async () => {
@@ -605,10 +558,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         databaseBuilder.factory.buildUser({ firstName: 'Vegeta' });
         databaseBuilder.factory.buildUser({ firstName: 'Piccolo' });
         return databaseBuilder.commit();
-      });
-
-      afterEach(() => {
-        return databaseBuilder.clean();
       });
 
       it('should return only users matching "first name" if given in filters', async () => {
@@ -642,10 +591,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return only users matching "last name" if given in filters', async () => {
         // given
         const filters = { lastName: 'walk' };
@@ -675,10 +620,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         });
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should return only users matching "email" if given in filters', async () => {
@@ -716,10 +657,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         await databaseBuilder.commit();
       });
 
-      afterEach(async () => {
-        await databaseBuilder.clean();
-      });
-
       it('should return only users matching "first name" AND "last name" AND "email" if given in filters', async () => {
         // given
         const filters = { firstName: 'fn_ok', lastName: 'ln_ok', email: 'email_ok' };
@@ -747,10 +684,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         secondUserId = databaseBuilder.factory.buildUser().id;
 
         await databaseBuilder.commit();
-      });
-
-      afterEach(async () => {
-        await databaseBuilder.clean();
       });
 
       it('should ignore the filters and retrieve all users', async () => {

--- a/api/tests/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
+++ b/api/tests/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
@@ -12,10 +12,6 @@ const BookshelfCampaignParticipation = require('../../../../lib/infrastructure/d
 
 describe('Integration | Infrastructure | Utils | Bookshelf to domain converter', function() {
 
-  afterEach(async () => {
-    await databaseBuilder.clean();
-  });
-
   describe('buildDomainObject', () => {
     it('should convert a Bookshelf object into a domain object', async () => {
       // given

--- a/api/tests/integration/infrastructure/utils/query-builder_test.js
+++ b/api/tests/integration/infrastructure/utils/query-builder_test.js
@@ -15,10 +15,6 @@ describe('Integration | Infrastructure | Utils | Query Builder', function() {
     return databaseBuilder.commit();
   });
 
-  afterEach(() => {
-    return databaseBuilder.clean();
-  });
-
   describe('find', function() {
     it('should return all snapshots', async function() {
       // when

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -13,6 +13,7 @@ const _ = require('lodash');
 
 afterEach(function() {
   sinon.restore();
+  return databaseBuilder.clean();
 });
 
 // Knex
@@ -87,10 +88,6 @@ async function insertUserWithStandardRole() {
   return user;
 }
 
-function cleanupUsersAndPixRolesTables() {
-  return databaseBuilder.clean();
-}
-
 // Hapi
 const hFake = {
   response(source) {
@@ -160,7 +157,6 @@ function catchErr(promiseFn, ctx) {
 
 module.exports = {
   airtableBuilder,
-  cleanupUsersAndPixRolesTables,
   expect,
   domainBuilder: require('./tooling/domain-builder/factory'),
   databaseBuilder,

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -1,14 +1,20 @@
 const databaseBuffer = require('./database-buffer');
 const factory = require('./factory/index');
+const knexDatabaseConnection = require('../../../db/knex-database-connection');
 
 module.exports = class DatabaseBuilder {
   constructor({ knex }) {
     this.knex = knex;
     this.databaseBuffer = databaseBuffer;
     this.factory = factory;
+    this.isFirstCommit = true;
   }
 
   async commit() {
+    if (this.isFirstCommit) {
+      await knexDatabaseConnection.emptyAllTables();
+      this.isFirstCommit = false;
+    }
     for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
       await this.knex(objectToInsert.tableName).insert(objectToInsert.values);
       this.databaseBuffer.objectsToDelete.unshift(objectToInsert);

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -23,9 +23,11 @@ module.exports = class DatabaseBuilder {
   }
 
   async clean() {
-    for (const objectToDelete of this.databaseBuffer.objectsToDelete) {
-      await this.knex(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete();
+    if (this.databaseBuffer.objectsToDelete.length > 0) {
+      for (const objectToDelete of this.databaseBuffer.objectsToDelete) {
+        await this.knex(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete();
+      }
+      this.databaseBuffer.purge();
     }
-    this.databaseBuffer.purge();
   }
 };

--- a/high-level-tests/e2e/cypress/fixtures/pix_roles.json
+++ b/high-level-tests/e2e/cypress/fixtures/pix_roles.json
@@ -1,6 +1,0 @@
-[
-  {
-    "id": 1,
-    "name": "PIX_MASTER"
-  }
-]

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -5,7 +5,6 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'target-profiles');
   cy.task('db:fixture', 'target-profiles_skills');
   cy.task('db:fixture', 'campaigns');
-  cy.task('db:fixture', 'pix_roles');
   cy.task('db:fixture', 'users_pix_roles');
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Les tests auto n'étaient pas au vert lorsqu'on ils était déclenchés en boucle en mode _watch_. Plusieurs causes à cela:
- Des _seeds_ étaient insidieusement placés dans un fichier de migration (`target-profile`)
- Certains tests (faire une passe dessus à l'occasion) laissent parfois derrière eux des données dans la base, et cela a pour conséquence de faire échouer des tests lors du relancement auto en _watch_
Hormis ces causes-là, l'état de la base de tests ne pouvait pas être garanti. En effet, malgré les hooks `after/before` qui se chargent de nettoyer les données pendant les tests, le fait de relancer en mode _watch_ ne garantissait pas qu'on passe obligatoirement par ces hooks.

## :robot: Solution
- Déplacement de seeds depuis un fichier de migration vers un fichier de seed
- Ajout de la table PIX_ROLES dans la liste des exceptions de suppression lors de la vidange de la base
- Ajout d'un flag de premier passage dans le singleton du databaseBuilder afin de faire la vidange de la base avant le tout premier commit (= premier usage).
- Suppression de TOUS les afterEach de databaseBuilder.clean(), car maintenant clean auto à chaque fin de test !
- Réduction du temps d'exécution des tests API

## :rainbow: Remarques