### PR TITLE
[BUGFIX] Des réponses trop longues envoyées dans les signalements (PF-865).

### DIFF
--- a/api/db/migrations/20191008142311_alter_feedback_answer_column_to_text.js
+++ b/api/db/migrations/20191008142311_alter_feedback_answer_column_to_text.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'feedbacks';
+
+exports.up = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.text('answer').alter();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('answer').alter();
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Dans les signalements actuelles (table `feedbacks`), on remonte la réponse de l'utilisateur. Cette réponse est enregistrée dans la table `answers` via un champ `text`, mais via un champ `varchar(255)` dans la table `feedbacks`.
Si un utilisateur enregistrait une réponse trop longue et faisait un signalement, alors le signalement plantait car la taille de la réponse dépassait 255.

## :robot: Solution
Changer le type de la colonne `answer` de `feedbacks` pour la passer en `text`, comme dans la table `answers`

## :rainbow: Remarques
-