### PR TITLE
[FEATURE] Limiter la taille des messages de feedbacks (PF-864).

### DIFF
--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -72,10 +72,6 @@
   }
 }
 
-.feedback-panel__field--content {
-  resize: none;
-}
-
 .feedback-panel__quick-help {
   font-size: 1.8rem;
   margin: 20px 0;

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -42,7 +42,8 @@
           </div>
           {{#if displayTextBox}}
             <div class="feedback-panel__group">
-              {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Précisez" rows=3}}
+              <p>Votre message est limité à 10 000 caractères.</p>
+              {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Précisez" maxlength="10000" rows=3}}
             </div>
             {{#if _error}}
               <div class="alert alert-danger" role="alert">

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -43,7 +43,7 @@
           {{#if displayTextBox}}
             <div class="feedback-panel__group">
               <p>Votre message est limité à 10 000 caractères.</p>
-              {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Précisez" maxlength="10000" rows=3}}
+              {{textarea class="feedback-panel__field feedback-panel__field--content" value=_content placeholder="Précisez" maxlength="10000" rows=5}}
             </div>
             {{#if _error}}
               <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
## :unicorn: Problème
Certains utilisateurs utilisent le text-area des signalements pour mettre des messages trop longs.

## :robot: Solution
Limiter la taille du message à 10000 caractères.

## :rainbow: Remarques
Le ticket de base PF-855 correspondait à cette demande, mais remontait en faite un bug réglé par la pr #752 