### PR TITLE
[DOC] Supprime Test.md et déplace `transitionTo` dans Ember.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,39 +56,6 @@ server.route([
 );
 ```
 
-## Utilisation de transitionTo
-
-Éviter les `transistionTo` dans le hook `model()`. Privilégier leur utilisation dans l’`afterModel()`, une fois que le modèle est chargé.
-
-```javascript
-// BAD
-export default Route.extend({
-  model() {
-    const store = this.get('store');
-    return store.findRecord('user', this.get('session.data.authenticated.userId'))
-      .then((user) => {
-        if (user.get('organizations.length') > 0) {
-          return this.transitionTo('board');
-        }
-        return user;
-      });
-  },
-});
-
-// GOOD
-export default Route.extend({
-  model() {
-    return this.store.findRecord('user', this.get('session.data.authenticated.userId'));
-  },
-  
-  afterModel(model) {
-    if (model.get('organizations.length') > 0) {
-      return this.transitionTo('board');
-    }
-  }
-});
-```
-
 ## Configuration
 
 ### Options d'environnement
@@ -230,6 +197,14 @@ const config = {
   },
 };
 ```
+
+
+## Tests
+
+### ♻️ Tests unitaires
+
+Un test unitaire doit passer sans base de données.
+
 
 ## Feature Toggles
 

--- a/docs/Ember.md
+++ b/docs/Ember.md
@@ -1,0 +1,34 @@
+## Utilisation de transitionTo
+
+Éviter les `transistionTo` dans le hook `model()`. Privilégier leur utilisation dans l’`afterModel()`, une fois que le modèle est chargé.
+
+```javascript
+// BAD
+export default Route.extend({
+  model() {
+    const store = this.get('store');
+    return store.findRecord('user', this.get('session.data.authenticated.userId'))
+      .then((user) => {
+        if (user.get('organizations.length') > 0) {
+          return this.transitionTo('board');
+        }
+        return user;
+      });
+  },
+});
+
+// GOOD
+export default Route.extend({
+  model() {
+    return this.store.findRecord('user', this.get('session.data.authenticated.userId'));
+  },
+
+  afterModel(model) {
+    if (model.get('organizations.length') > 0) {
+      return this.transitionTo('board');
+    }
+  }
+});
+```
+
+

--- a/docs/Tests.md
+++ b/docs/Tests.md
@@ -1,5 +1,0 @@
-# Tests
-
-## Tests unitaires
-
-Un test unitaire doit passer sans base de données.


### PR DESCRIPTION
## :unicorn: Problème

- Le fichier Test.md ne contenait qu'une seule information qui concerne l'API
- Dans API.md, il y avait une section sur transitionTo qui concerne Ember

## :robot: Solution

- Supprimer Test.md et déplacer l'info dans API.md
- Créer Ember.md et y déplacer l'info sur `transitionTo
