### PR TITLE
[FEATURE] Lister les invitations sur la page équipe (PO-239)

### DIFF
--- a/api/db/seeds/data/dragon-and-co-builder.js
+++ b/api/db/seeds/data/dragon-and-co-builder.js
@@ -1,4 +1,5 @@
 const Membership = require('../../../lib/domain/models/Membership');
+const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
 
 module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
 
@@ -110,6 +111,18 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     userId: proUserSub2.id,
     organizationId: dragonAndCoSubsidiary2.id,
     organizationRole: Membership.roles.OWNER,
+  });
+
+  databaseBuilder.factory.buildOrganizationInvitation({
+    email: 'unsullied@example.net',
+    status: OrganizationInvitation.StatusType.ACCEPTED,
+    organizationId: dragonAndCoCompany.id,
+  });
+
+  databaseBuilder.factory.buildOrganizationInvitation({
+    email: 'khal@example.net',
+    status: OrganizationInvitation.StatusType.PENDING,
+    organizationId: dragonAndCoCompany.id,
   });
 
 };

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -169,7 +169,22 @@ exports.register = async (server) => {
         tags: ['api', 'invitations']
       }
     },
-
+    {
+      method: 'GET',
+      path: '/api/organizations/{id}/invitations',
+      config: {
+        pre: [{
+          method: securityController.checkUserIsOwnerInOrganization,
+          assign: 'isOwnerInOrganization'
+        }],
+        handler: organisationController.findPendingInvitations,
+        tags: ['api', 'invitations'],
+        notes: [
+          '- Cette route est restreinte aux utilisateurs authentifiés responsables de l\'organisation',
+          '- Elle permet de lister les invitations en attente d\'acceptation d\'une organisation',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -121,4 +121,10 @@ module.exports = {
     return h.response(organizationInvitationSerializer.serialize(organizationInvitation)).created();
   },
 
+  async findPendingInvitations(request) {
+    const organizationId = request.params.id;
+
+    return usecases.findPendingOrganizationInvitations({ organizationId })
+      .then((invitations) => organizationInvitationSerializer.serialize(invitations));
+  }
 };

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -15,6 +15,7 @@ class Organization {
     memberships = [],
     targetProfileShares = [],
     students = [],
+    organizationInvitations = [],
     // references
   } = {}) {
     this.id = id;
@@ -31,6 +32,7 @@ class Organization {
     this.memberships = memberships;
     this.targetProfileShares = targetProfileShares;
     this.students = students;
+    this.organizationInvitations = organizationInvitations;
     // references
   }
 }

--- a/api/lib/domain/usecases/find-pending-organization-invitations.js
+++ b/api/lib/domain/usecases/find-pending-organization-invitations.js
@@ -1,0 +1,3 @@
+module.exports = function findPendingOrganizationInvitations({ organizationId, organizationInvitationRepository }) {
+  return organizationInvitationRepository.findPendingByOrganizationId({ organizationId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -81,6 +81,7 @@ module.exports = injectDependencies({
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findOrganizationStudents: require('./find-organization-students'),
   findOrganizations: require('./find-organizations'),
+  findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
   findSessions: require('./find-sessions'),
   findSessionsForCertificationCenter: require('./find-sessions-for-certification-center'),
   findSmartPlacementAssessments: require('./find-smart-placement-assessments'),

--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -59,6 +59,13 @@ module.exports = {
       .catch((err) => _checkNotFoundError(err, id));
   },
 
+  findPendingByOrganizationId({ organizationId }) {
+    return BookshelfOrganizationInvitation
+      .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
+      .fetchAll()
+      .then((results) =>  bookshelfToDomainConverter.buildDomainObjects(BookshelfOrganizationInvitation, results));
+  },
+
   findOneByOrganizationIdAndEmail({ organizationId, email }) {
     return BookshelfOrganizationInvitation
       .where({ organizationId, email })

--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -12,6 +12,7 @@ module.exports = {
           record.organization.targetProfiles = [];
           record.organization.memberships = [];
           record.organization.students = [];
+          record.organization.organizationInvitations = [];
         }
         return record;
       },
@@ -19,7 +20,7 @@ module.exports = {
       organization: {
         ref: 'id',
         included: true,
-        attributes: ['code', 'name', 'type', 'isManagingStudents', 'campaigns', 'targetProfiles', 'memberships', 'students'],
+        attributes: ['code', 'name', 'type', 'isManagingStudents', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
         campaigns: {
           ref: 'id',
           ignoreRelationshipData: true,
@@ -55,7 +56,16 @@ module.exports = {
               return `/api/organizations/${parent.id}/students`;
             }
           }
-        }
+        },
+        organizationInvitations: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/invitations`;
+            }
+          }
+        },
       },
       user: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(invitations) {
     return new Serializer('organization-invitations', {
-      attributes: ['organizationId', 'email', 'status'],
+      attributes: ['organizationId', 'email', 'status', 'createdAt'],
     }).serialize(invitations);
   },
 

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -15,7 +15,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
   beforeEach(async () => {
     server = await createServer();
   });
-  
+
   describe('GET /users/:id/memberships', () => {
 
     beforeEach(async () => {
@@ -108,6 +108,11 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
                   links: {
                     related: `/api/organizations/${organization.id.toString()}/target-profiles`
                   }
+                },
+                'organization-invitations': {
+                  links: {
+                    related: `/api/organizations/${organization.id.toString()}/invitations`,
+                  },
                 },
                 students: {
                   links: {

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -114,4 +114,20 @@ describe('Integration | Application | Organizations | Routes', () => {
     });
   });
 
+  describe('GET /api/organizations/:id/invitations', () => {
+
+    beforeEach(() => {
+      sinon.stub(securityController, 'checkUserIsOwnerInOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(organisationController, 'findPendingInvitations').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const response = await server.inject({ method: 'GET', url: '/api/organizations/:id/invitations' });
+
+      expect(response.statusCode).to.equal(200);
+      expect(organisationController.findPendingInvitations).to.have.been.calledOnce;
+    });
+  });
+
 });

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -21,6 +21,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(usecases, 'findOrganizationStudents');
     sandbox.stub(usecases, 'createOrganizationInvitation');
     sandbox.stub(usecases, 'answerToOrganizationInvitation');
+    sandbox.stub(usecases, 'findPendingOrganizationInvitations');
 
     sandbox.stub(securityController, 'checkUserHasRolePixMaster');
     sandbox.stub(securityController, 'checkUserIsOwnerInOrganization');
@@ -243,7 +244,8 @@ describe('Integration | Application | Organizations | organization-controller', 
             attributes: {
               'organization-id': invitation.organizationId,
               email: invitation.email,
-              status
+              status,
+              'created-at': invitation.createdAt
             }
           }
         };
@@ -254,6 +256,32 @@ describe('Integration | Application | Organizations | organization-controller', 
 
         // then
         expect(_.omit(response.result, 'data.id')).to.deep.equal(expectedResult);
+      });
+    });
+  });
+
+  describe('#findPendingInvitations', () => {
+
+    context('Success cases', () => {
+
+      const invitation = domainBuilder.buildOrganizationInvitation({
+        organizationId: 1,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+
+      beforeEach(() => {
+        securityController.checkUserIsOwnerInOrganization.returns(true);
+      });
+
+      it('should return an HTTP response with status code 200', async () => {
+        // given
+        usecases.findPendingOrganizationInvitations.resolves([invitation]);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/organizations/1/invitations');
+
+        // then
+        expect(response.statusCode).to.equal(200);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -188,4 +188,53 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
     });
   });
 
+  describe('#findPendingByOrganizationId', () => {
+
+    let insertedOrganizationInvitation1;
+    let insertedOrganizationInvitation2;
+    const organizationId = 6789;
+
+    beforeEach(async () => {
+      databaseBuilder.factory.buildOrganization({
+        id: organizationId,
+      });
+      insertedOrganizationInvitation1 = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      insertedOrganizationInvitation2 = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: OrganizationInvitation.StatusType.ACCEPTED,
+      });
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await databaseBuilder.clean();
+    });
+
+    it('should find the organization-invitations from db by organizationId', async () => {
+      // when
+      const foundOrganizationInvitations = await organizationInvitationRepository.findPendingByOrganizationId({ organizationId });
+
+      // then
+      expect(foundOrganizationInvitations).to.deep.equal([
+        insertedOrganizationInvitation2,
+        insertedOrganizationInvitation1,
+      ]);
+    });
+
+    it('should return an empty array on no result', async () => {
+      // when
+      const foundOrganizationInvitations = await organizationInvitationRepository.findPendingByOrganizationId({ organizationId: 2978 });
+
+      // then
+      expect(foundOrganizationInvitations).to.deep.equal([]);
+    });
+  });
+
 });

--- a/api/tests/tooling/database-builder/factory/build-organization-invitation.js
+++ b/api/tests/tooling/database-builder/factory/build-organization-invitation.js
@@ -10,7 +10,7 @@ module.exports = function buildOrganizationInvitation(
     organizationId,
     email,
     status = OrganizationInvitation.StatusType.PENDING,
-    code = faker.random.alphaNumeric(10),
+    code = faker.random.alphaNumeric(10).toUpperCase(),
   } = {}) {
 
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
@@ -22,6 +22,8 @@ module.exports = function buildOrganizationInvitation(
     email,
     status,
     code,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   };
   return databaseBuffer.pushInsertable({
     tableName: 'organization-invitations',

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -56,4 +56,21 @@ describe('Unit | Router | organization-router', () => {
     });
   });
 
+  describe('GET /api/organizations/{id}/invitations', () => {
+
+    it('should exist', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/organizations/1/invitations'
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
 });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -12,6 +12,7 @@ const organizationSerializer = require('../../../../lib/infrastructure/serialize
 const campaignSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-serializer');
 const targetProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-serializer');
 const studentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-serializer');
+const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 
 describe('Unit | Application | Organizations | organization-controller', () => {
 
@@ -504,4 +505,36 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     });
   });
 
+  describe('#findPendingInvitations', () => {
+
+    const userId = 1;
+    const organization = domainBuilder.buildOrganization();
+
+    const resolvedOrganizationInvitations = 'organization invitations';
+    const serializedOrganizationInvitations = 'serialized organization invitations';
+
+    beforeEach(() => {
+      request = {
+        auth: { credentials: { userId } },
+        params: { id: organization.id },
+      };
+
+      sinon.stub(usecases, 'findPendingOrganizationInvitations');
+      sinon.stub(organizationInvitationSerializer, 'serialize');
+
+      usecases.findPendingOrganizationInvitations.resolves(resolvedOrganizationInvitations);
+      organizationInvitationSerializer.serialize.resolves(serializedOrganizationInvitations);
+    });
+
+    it('should call the usecase to find pending invitations with organizationId', async () => {
+      // when
+      const response = await organizationController.findPendingInvitations(request, hFake);
+
+      // then
+      expect(usecases.findPendingOrganizationInvitations).to.have.been.calledWith({ organizationId: organization.id });
+      expect(organizationInvitationSerializer.serialize).to.have.been.calledWith(resolvedOrganizationInvitations);
+      expect(response).to.deep.equal(serializedOrganizationInvitations);
+    });
+
+  });
 });

--- a/api/tests/unit/domain/usecases/find-pending-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/find-pending-organization-invitations_test.js
@@ -1,0 +1,41 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const findPendingOrganizationInvitations = require('../../../../lib/domain/usecases/find-pending-organization-invitations');
+const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
+
+describe('Unit | UseCase | find-pending-organization-invitations', () => {
+
+  it('should succeed', async () => {
+    // given
+    const organizationId = 1234;
+    const organizationInvitationRepositoryStub = { findPendingByOrganizationId: sinon.stub() };
+    organizationInvitationRepositoryStub.findPendingByOrganizationId.resolves();
+
+    // when
+    await findPendingOrganizationInvitations({
+      organizationId,
+      organizationInvitationRepository: organizationInvitationRepositoryStub,
+    });
+
+    // then
+    expect(organizationInvitationRepositoryStub.findPendingByOrganizationId).to.have.been.calledWith({ organizationId });
+  });
+
+  it('should return the OrganizationInvitations belonging to the given organization', async () => {
+    // given
+    const organizationId = 1234;
+    const foundOrganizationInvitations = [
+      domainBuilder.buildOrganizationInvitation({ organizationId, status: OrganizationInvitation.StatusType.PENDING }),
+      domainBuilder.buildOrganizationInvitation({ organizationId, status: OrganizationInvitation.StatusType.PENDING }),
+    ];
+    const organizationInvitationRepositoryStub = {
+      findPendingByOrganizationId: sinon.stub().resolves(foundOrganizationInvitations)
+    };
+
+    // when
+    const organizationInvitations = await findPendingOrganizationInvitations({ organizationId, organizationInvitationRepository: organizationInvitationRepositoryStub });
+
+    // then
+    expect(organizationInvitations).to.deep.equal(foundOrganizationInvitations);
+    expect(organizationInvitations[0]).to.be.an.instanceOf(OrganizationInvitation);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -66,7 +66,12 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
               links: {
                 related: '/api/organizations/10293/students'
               }
-            }
+            },
+            'organization-invitations': {
+              links: {
+                related: '/api/organizations/10293/invitations',
+              },
+            },
           }
         }]
       };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', () 
           'organization-id': invitationObject.organizationId,
           email: invitationObject.email,
           status: invitationObject.status,
+          'created-at': invitationObject.createdAt,
         },
       }
     };

--- a/orga/app/models/organization-invitation.js
+++ b/orga/app/models/organization-invitation.js
@@ -2,9 +2,11 @@ import DS from 'ember-data';
 import { equal } from '@ember/object/computed';
 
 export default DS.Model.extend({
-  organizationId: DS.attr('string'),
   email: DS.attr('string'),
   status: DS.attr('string'),
+  createdAt: DS.attr('date'),
+
+  organization: DS.belongsTo('organization'),
 
   isPending: equal('status', 'PENDING'),
   isAccepted: equal('status', 'ACCEPTED'),

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   campaigns: DS.hasMany('campaign'),
   targetProfiles: DS.hasMany('target-profile'),
   memberships: DS.hasMany('membership'),
+  organizationInvitations: DS.hasMany('organization-invitation'),
   students: DS.hasMany('student'),
   isManagingStudents: DS.attr('boolean'),
 

--- a/orga/app/routes/authenticated/team/list.js
+++ b/orga/app/routes/authenticated/team/list.js
@@ -10,6 +10,9 @@ export default Route.extend({
   },
 
   afterModel(model) {
-    return model.hasMany('memberships').reload();
+    return Promise.all([
+      model.hasMany('memberships').reload(),
+      model.hasMany('organizationInvitations').reload(),
+    ]);
   }
 });

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -9,6 +9,16 @@ table {
 thead {
   width: 100%;
   color: $mine-shaft;
+
+  caption {
+    text-align: left;
+    display: table-cell;
+    vertical-align: inherit;
+    height: 60px;
+    padding-left: 30px;
+    font-weight: bold;
+    font-size: 0.9rem;
+  }
 }
 
 tbody {
@@ -56,5 +66,3 @@ td, th {
   text-align: center;
   border-top: 2px solid $wild-sand;
 }
-
-

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -17,3 +17,7 @@
     margin-left: auto;
   }
 }
+
+.list-team-page-invitations {
+  margin-bottom: 35px;
+}

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -1,3 +1,3 @@
 <div class="list-team-page">
-  {{routes/authenticated/team/list-items memberships=model.memberships}}
+  {{routes/authenticated/team/list-items memberships=model.memberships organizationInvitations=model.organizationInvitations}}
 </div>

--- a/orga/app/templates/components/routes/authenticated/team/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/team/list-items.hbs
@@ -4,23 +4,44 @@
     {{#link-to 'authenticated.team.new' class="button button--link"}}Inviter un membre{{/link-to}}
   </div>
 </div>
+{{#if organizationInvitations}}
+  <div class="panel list-team-page-invitations">
+    <div class="table content-text content-text--small">
+      <table id="table-invitations">
+        <thead>
+          <caption>Invitations en attente ({{organizationInvitations.length}})</caption>
+        </thead>
+        <tbody>
+          {{#each organizationInvitations as |organizationInvitation|}}
+            <tr>
+              <td>{{organizationInvitation.email}}</td>
+              <td colspan="3">Invité le {{moment-format organizationInvitation.createdAt 'DD/MM/YYYY'}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{{/if}}
+
 <div class="panel">
   <div class="table content-text content-text--small">
-    <table>
+    <table id="table-members">
       <thead>
-      <tr>
-        <th>Nom</th>
-        <th>Prénom</th>
-      </tr>
+        <caption>Liste des membres ({{memberships.length}})</caption>
+        <tr>
+          <th>Nom</th>
+          <th>Prénom</th>
+        </tr>
       </thead>
       {{#if memberships}}
         <tbody>
-        {{#each memberships as |membership|}}
-          <tr>
-            <td>{{membership.user.lastName}}</td>
-            <td>{{membership.user.firstName}}</td>
-          </tr>
-        {{/each}}
+          {{#each memberships as |membership|}}
+            <tr>
+              <td>{{membership.user.lastName}}</td>
+              <td>{{membership.user.firstName}}</td>
+            </tr>
+          {{/each}}
         </tbody>
       {{/if}}
     </table>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -61,13 +61,21 @@ export default function() {
     return schema.memberships.where({ organizationId });
   });
 
+  this.get('/organizations/:id/invitations', (schema, request) => {
+    const organizationId = request.params.id;
+    return schema.organizationInvitations.where({ organizationId });
+  });
+
   this.post('/organizations/:id/invitations', (schema, request) => {
     const organizationId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);
     const email = requestBody.data.attributes.email;
     const code = 'ABCDEFGH01';
 
-    return schema.organizationInvitations.create({ organizationId, email: email, status: 'PENDING', code });
+    return schema.organizationInvitations.create({
+      organizationId, email: email, status: 'PENDING', code,
+      createdAt: new Date()
+    });
   });
 
   this.post('/organization-invitations/:id/response', (schema, request) => {

--- a/orga/mirage/factories/organization-invitation.js
+++ b/orga/mirage/factories/organization-invitation.js
@@ -1,0 +1,12 @@
+import { Factory, association } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+
+  email() {
+    return faker.internet.email();
+  },
+
+  organization: association(),
+
+});

--- a/orga/mirage/scenarios/default.js
+++ b/orga/mirage/scenarios/default.js
@@ -55,8 +55,32 @@ function _createStudents(server) {
   server.createList('students', 6, { organizationId: organization.id });
 }
 
+function _createOrganizationInvitations(server) {
+  const organization = server.create('organization', {
+    name: 'College Paul Verlaine',
+    type: 'SCO',
+    isManagingStudents: true,
+  });
+
+  const user = server.create('user', {
+    email: 'plane@example.net',
+  });
+
+  const userMembership = server.create('membership', {
+    organizationId: organization.id,
+    userId: user.id,
+    organizationRole: 'OWNER'
+  });
+
+  user.memberships = [userMembership];
+
+  server.create('organization-invitation', { email: 'car@example.net', organizationId: organization.id });
+  server.create('organization-invitation', { email: 'train@example.net', organizationId: organization.id });
+}
+
 export default function(server) {
   _createSignedUpUser(server);
   _createCampaigns(server);
   _createStudents(server);
+  _createOrganizationInvitations(server);
 }

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -3,18 +3,21 @@ import { JSONAPISerializer } from 'ember-cli-mirage';
 export default JSONAPISerializer.extend({
   links(organization) {
     return {
-      'campaigns': {
-        related: `/api/organizations/${organization.id}/campaigns`
+      campaigns: {
+        related: `/api/organizations/${organization.id}/campaigns`,
       },
-      'targetProfiles': {
-        related: `/api/organizations/${organization.id}/target-profiles`
+      targetProfiles: {
+        related: `/api/organizations/${organization.id}/target-profiles`,
       },
-      'memberships': {
-        related: `/api/organizations/${organization.id}/memberships`
+      memberships: {
+        related: `/api/organizations/${organization.id}/memberships`,
       },
-      'students': {
-        related: `/api/organizations/${organization.id}/students`
-      }
+      students: {
+        related: `/api/organizations/${organization.id}/students`,
+      },
+      organizationInvitations: {
+        related: `/api/organizations/${organization.id}/invitations`,
+      },
     };
   }
 });

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -73,6 +73,8 @@ module('Acceptance | Team Creation', function(hooks) {
         const email = 'gigi@labrochette.com';
         const code = 'ABCDEFGH01';
 
+        server.create('user', { firstName: 'Gigi', lastName: 'La Brochette', email, pixOrgaTermsOfServiceAccepted: true });
+
         await visit('/equipe/creation');
         await fillIn('#email', email);
 
@@ -80,12 +82,12 @@ module('Acceptance | Team Creation', function(hooks) {
         await click('button[type="submit"]');
 
         // then
-        const organizationInvitation = server.db.organizationInvitations[0];
+        const organizationInvitation = server.db.organizationInvitations[server.db.organizationInvitations.length - 1];
         assert.equal(organizationInvitation.email, email);
         assert.equal(organizationInvitation.status, 'PENDING');
         assert.equal(organizationInvitation.code, code);
         assert.equal(currentURL(), '/equipe');
-        assert.dom('.table tbody tr').exists({ count: 1 });
+        assert.dom('#table-members tbody tr').exists({ count: 1 });
       });
 
       test('should display an empty input field after cancel and before add a team member', async function(assert) {

--- a/orga/tests/acceptance/team-list-test.js
+++ b/orga/tests/acceptance/team-list-test.js
@@ -82,7 +82,22 @@ module('Acceptance | Team List', function(hooks) {
         await visit('/equipe');
 
         // then
-        assert.dom('.table tbody tr').exists({ count: 1 });
+        assert.dom('#table-members tbody tr').exists({ count: 1 });
+      });
+
+      test('it should list the pending team invitations', async function(assert) {
+        // given
+        const organizationId = server.db.organizations[0].id;
+        server.create('organization-invitation', {
+          organizationId,
+          createdAt: new Date()
+        });
+
+        // when
+        await visit('/equipe');
+
+        // then
+        assert.dom('#table-invitations tbody tr').exists({ count: 1 });
       });
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
@@ -6,37 +6,35 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | routes/authenticated/team | list-items', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display a list of members', async function(assert) {
+  test('it should display a list of members, their firstName and lastName', async function(assert) {
     // given
-    const memberships = [
+    this.set('memberships', [
       { user: { firstName: 'Gigi', lastName: 'La Terreur' } },
       { user: { firstName: 'Gogo', lastName: 'L\'asticot' } },
-    ];
-
-    this.set('memberships', memberships);
+    ]);
 
     // when
     await render(hbs`{{routes/authenticated/team/list-items memberships=memberships}}`);
 
     // then
-    assert.dom('.table tbody tr').exists();
-    assert.dom('.table tbody tr').exists({ count: 2 });
+    assert.dom('#table-members tbody tr').exists({ count: 2 });
+    assert.dom('#table-members tbody tr:first-child td:first-child').hasText('La Terreur');
+    assert.dom('#table-members tbody tr:first-child td:last-child').hasText('Gigi');
   });
 
-  test('it should display the firstName and lastName of member', async function(assert) {
+  test('it should display a list of invitations, their email and creation date', async function(assert) {
     // given
-    const memberships = [
-      { user: { firstName: 'Gigi', lastName: 'La Terreur' } },
-      { user: { firstName: 'Gogo', lastName: 'L\'asticot' } },
-    ];
-
-    this.set('memberships', memberships);
+    this.set('organizationInvitations', [
+      { email: 'gigi@pix.fr', createdAt: new Date('2019-10-08') },
+      { email: 'gogo@pix.fr', createdAt: new Date('2019-10-08') },
+    ]);
 
     // when
-    await render(hbs`{{routes/authenticated/team/list-items memberships=memberships}}`);
+    await render(hbs`{{routes/authenticated/team/list-items organizationInvitations=organizationInvitations}}`);
 
     // then
-    assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
-    assert.dom('.table tbody tr:first-child td:last-child').hasText('Gigi');
+    assert.dom('#table-invitations tbody tr').exists({ count: 2 });
+    assert.dom('#table-invitations tbody tr:last-child td:first-child').hasText('gogo@pix.fr');
+    assert.dom('#table-invitations tbody tr:last-child td:nth-child(2)').hasText('Invité le 08/10/2019');
   });
 });


### PR DESCRIPTION
## 🌧 : Problème
Les invitations sont invisible côté front sur Pix Orga.

## ☂️  Solution
Afficher une liste des invitations au status PENDING via une nouvelle route de l'API.

![image](https://user-images.githubusercontent.com/4154003/66507700-f8836000-eacf-11e9-85d4-189b49a0521b.png)
