### PR TITLE
[BUGFIX] La barre de progression pendant un test de certification était KO (PF-866)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -22,6 +22,9 @@ module.exports = {
             id: Progression.generateIdFromAssessmentId(currentAssessment.id),
           };
         }
+        if (currentAssessment.type === Assessment.types.CERTIFICATION) {
+          assessment.certificationCourse = { id: currentAssessment.courseId };
+        }
 
         if (currentAssessment.campaignParticipation && currentAssessment.campaignParticipation.campaign) {
           assessment.codeCampaign = currentAssessment.campaignParticipation.campaign.code;
@@ -45,6 +48,7 @@ module.exports = {
         'codeCampaign',
         'certificationNumber',
         'course',
+        'certificationCourse',
         'progression'
       ],
       answers: {
@@ -54,6 +58,15 @@ module.exports = {
         ref: 'id',
         included: _includeCourse(assessments),
         attributes: ['name', 'description', 'nbChallenges'],
+      },
+      certificationCourse: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current) {
+            return `/api/courses/${current.id}`;
+          }
+        }
       },
       progression: {
         ref: 'id',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -8,7 +8,9 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
 
     it('should convert an Assessment model object (of type CERTIFICATION) into JSON API data', function() {
       //given
-      const assessment = domainBuilder.buildAssessment();
+      const assessment = domainBuilder.buildAssessment({
+        type: Assessment.types.CERTIFICATION,
+      });
       const expectedJson = {
         data: {
           id: assessment.id.toString(),
@@ -33,7 +35,12 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
                 id: assessment.courseId.toString(),
                 type: 'courses'
               }
-            }
+            },
+            'certification-course': {
+              'links': {
+                'related': `/api/courses/${assessment.courseId}`,
+              }
+            },
           },
         },
         included: [{

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -14,7 +14,7 @@ export default Component.extend({
     if (this.get('assessment.hasCheckpoints')) {
       challengesToAnswerCount = ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     } else {
-      challengesToAnswerCount = this.get('assessment.course.nbChallenges');
+      challengesToAnswerCount = this.certificationCourseNbChallenges;
     }
     this.set('progression', AssessmentProgression.create({
       assessmentType: this.get('assessment.type'),

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -19,6 +19,7 @@ export default Model.extend({
 
   // includes
   answers: hasMany('answer'),
+  certificationCourse: belongsTo('certificationCourse', { inverse: null }),
   course: belongsTo('course', { inverse: null }),
   progression: belongsTo('progression', { inverse: null }),
   result: belongsTo('assessment-result'),

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default Model.extend({
+  name: attr('string'),
+  description: attr('string'),
+  duration: attr('number'),
+  imageUrl: attr('string'),
+  nbChallenges: attr('number'),
+  type: attr('string'),
+  accessCode : attr('string'),
+});

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -99,7 +99,7 @@ export default Route.extend({
 
   async _rateAssessment(assessment) {
     await assessment.save({ adapterOptions: { completeAssessment: true } });
-    
+
     return this._routeToResults(assessment);
   },
 

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -11,7 +11,7 @@
   <div class="assessment-challenge__content">
     {{#if model.assessment.showProgressBar}}
       <div class="assessment-challenge__progress-bar">
-        {{progress-bar assessment=model.assessment}}
+        {{progress-bar assessment=model.assessment certificationCourseNbChallenges=model.assessment.certificationCourse.nbChallenges }}
       </div>
     {{/if}}
 

--- a/mon-pix/tests/unit/components/progress-bar-test.js
+++ b/mon-pix/tests/unit/components/progress-bar-test.js
@@ -15,12 +15,10 @@ describe('Unit | Component | progress-bar', function() {
         type: 'DEMO',
         answers: [{}, {}, {}],
         hasCheckpoints: false,
-        course: {
-          nbChallenges: 10
-        }
       });
       const component = this.owner.lookup('component:progress-bar');
       component.set('assessment', assessment);
+      component.set('certificationCourseNbChallenges', 10);
       component.setProgression();
 
       // when
@@ -41,12 +39,10 @@ describe('Unit | Component | progress-bar', function() {
         type: 'DEMO',
         answers: [{}, {}, {}, {}, {}],
         hasCheckpoints: false,
-        course: {
-          nbChallenges: 10
-        }
       });
       const component = this.owner.lookup('component:progress-bar');
       component.set('assessment', assessment);
+      component.set('certificationCourseNbChallenges', 10);
       component.setProgression();
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Depuis https://github.com/1024pix/pix/pull/738 (du moins c'est ce qu'indique `git bisect` et ma propre vérification), la barre de progression pendant un test de certification était KO. Dans cette PR, un `reload()` forcé du certification course qui sous-tend la certification en cours a été enlevé, mais à juste titre !! (dans le lien de la PR, allez voir les modifs dans `mon-pix/app/routes/assessments/challenge.js`) : en effet, si l'on regarde le _serializer_ côté API de l'_assessment_, celui-ci semble nous promettre de nous renvoyer des données associées à son certification course, et notamment le nombre total de challenges qui est une donnée essentielle au rendu de la barre de progression.
Dans les faits, (dont l'origine d'ailleurs vient du fait que le champ _courseId_ dans la table `assessments` n'est pas une FK vers `certification-courses`, mais juste un varchar...), ces données n'ont jamais été envoyées correctement. Cette défaillance était justement camouflée par ce _reload_ forcé qui a été supprimée ; en d'autres termes, le _reload_ forcé avait pour **effet de bord** le bon fonctionnement de la barre de progression en test de certification.

## :robot: Solution
Le remaniement du concept (et surtout de la table) _CertificationCourse_ est un gros chantier, dont les différentes sous-tâches sont en cours de relevage dans l'issue Git correspondante. Cependant, cette PR est l'occasion de faire un (petit) pas vers une remise à plat de cet ensemble.
Le course associé à un _assessment_ via le champ _courseId_ n'est pas toujours un enregistrement de _certificationCourse_. Ce qui est dommage, car le mécanisme de _foreign-key_ (et donc de `withRelated` de bookshelf, etc) ne peut être exploité. On tâche donc, dans cette PR, de commencer à introduire la distinction entre course et certificationCourse.
La solution peut sembler contenir de la copie et de la redite, mais c'est un premier pas nécessaire pour bien distinguer les concepts.
1) Côté API, dans le _serializer_ d'assessment et dans le cas d'un assessment de type Certification, on envoie également une relationship nommé certification-course, laquelle contient un lien vers l'API permettant de récupérer les données du certification course correspondant
2) Côté MonPix, pareil, mise en place de la séparation course et certification course dans assessment. Désormais, le nombre de challenges est récupéré depuis la relation certificationCourse/assessment.

## :rainbow: Remarques
Pour le fonctionnel, je recommande :
- Tester rapidement Démo, positionnement et parcours (juste voir si la barre de prog s'affiche)
- Tester complètement un test de certification (de préférence le passer avec succès)
- Passer par PixAdmin pour vérifier que c'est ok et publier le certificat
- Vérifier que le certificat est bien publié et qu'on accède à ses détails avec succès
