### PR TITLE
[DOC] Lien vers les teams Pix cassé dans le README du repo Pix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ npm run configure
 
 **3/ Configurer les variables d'environnement dans le fichier `pix/api/.env`**
 
-Pour récupérer les différents identifiants / clés de connexion, s'adresser à un membre de [l'équipe PIX](https://github.com/orgs/1024pix/teams/pix).
+Pour récupérer les différents identifiants / clés de connexion, s'adresser à un membre de [l'équipe PIX](https://github.com/orgs/1024pix/teams/everyone).
 
 
 **4/ Lancer l'application**


### PR DESCRIPTION
## :unicorn: Problème
Problème de validité de lien relevé par un visiteur dans l'issue https://github.com/1024pix/pix/issues/743
Le lien .../teams/pix n'existe pas (404)

## :robot: Solution
Remplacer par le lien .../teams/everyone

## :rainbow: Remarques
Ne connaissant pas les droits pour les "visiteurs", si quelqu'un pouvait prendre le temps de lui répondre concernant les accès. Car je ne sais pas si il a accès au nouveau lien tout de même !
