### PR TITLE
[TECH] Variabiliser le routage des apps front pour le changement de région Scalingo

### DIFF
--- a/admin/nginx.conf.erb
+++ b/admin/nginx.conf.erb
@@ -40,7 +40,7 @@ location /api/ {
   #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
   #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
   proxy_redirect default;
 }
 

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -40,7 +40,7 @@ location /api/ {
   #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
   #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
   proxy_redirect default;
 }
 

--- a/docs/Glossaire-Variables-Env.md
+++ b/docs/Glossaire-Variables-Env.md
@@ -46,3 +46,9 @@ Une explication est associée à chaque variable ainsi que leur utilisation (OUI
 | SENTRY_DSN                            | Adresse pour la collecte d'erreurs sur Sentry                                                                                                | OUI      | OUI      | OUI         |
 | TEST_DATABASE_URL                     | Définit l'adresse, le port et le nom de la BDD PostgreSQL à utiliser pour les tests automatiques                                             | OUI      | NON      | NON         |
 | TOKEN_LIFE_SPAN                       | Durée de vie du token de connexion. Exemple : `7d` pour 7 jours.                                                                             | OUI      | OUI      | OUI         |
+
+### PIX FRONT (app, orga, certif, admin)
+
+| Variable                              | Description                                                                                                                                  | DEV      | INT      | PROD        | Si absente                                                      |
+| ---                                   | ---                                                                                                                                          | ---      | ---      | ---         | ---                                                             |
+| API_HOST_SUFFIX                       | Utilisée pour déterminer le nom de domaine où router les requêtes API                                                                        |          |          |             | scalingo.io                                                     |

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -40,7 +40,7 @@ location /api/ {
   #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
   #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
   proxy_redirect default;
 }
 

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -40,7 +40,7 @@ location /api/ {
   #   pix-orga-integration-pr123 -> pix-api-integration-pr123.scalingo.io
   #   pix-orga-production        -> pix-api-production.scalingo.io
   %>
-  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.scalingo.io;
+  proxy_pass https://<%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
   proxy_redirect default;
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui dans notre routage des applications front vers leur api, on ne peut pas spécifier de région particulière pour Scalingo. Ces applications front ne peuvent référencer que des APIs référencées par la région agora, vouée à disparaitre.

## :robot: Solution
On ajoute une nouvelle variable d'environnement pour adapter le suffixe du host API en fonction de nos besoins.

## :rainbow: Remarques
On prévoit le cas par défaut ``scalingo.io`` qui fait référence à agora, et qui correspond à notre cas d'usage jusque ici.
