### PR TITLE
[FEATURE] Annule le téléch. des résultats longs d'une campagne (PO-255)

### DIFF
--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -123,9 +123,9 @@ function _insertSnapshot(organizationId, userId) {
   return knex('snapshots').insert(snapshotRaw).returning('id');
 }
 
-function _createToken(user) {
+function _createTokenWithUserId(userId) {
   return jwt.sign({
-    user_id: user,
+    user_id: userId,
   }, settings.authentication.secret, { expiresIn: settings.authentication.tokenLifespan });
 }
 
@@ -427,7 +427,7 @@ describe('Acceptance | Application | organization-controller', () => {
     beforeEach(() => {
       return _insertUser()
         .then(({ id }) => userId = id)
-        .then(() => userToken = _createToken(userId))
+        .then(() => userToken = _createTokenWithUserId(userId))
         .then(() => _insertOrganization(userId))
         .then(({ id }) => organizationId = id)
         .then(() => _insertSnapshot(organizationId, userId));


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible de télécharger les résultats CSV des campagnes qui ont 3000 participations.

C'est dû :
- à une multiplication de promesses qui se lancent en même temps
- à un temps de traitement supérieur à 30 secondes (donc timeout de Scalingo même si la requête réussit)

## :robot: Solution

Ce n'est pas une solution dans le sens où elle ne permet pas de télécharger les résultats, mais au moins :
- les promesses sont maintenant séquentielles
- au bout de 30 secondes, le traitement qui génère le CSV est annulé, ce qui libère l'instance API utilisée

## :rainbow: Remarques

Il faut faire mieux, par exemple en utilisant les streams comme pour les snapshots (voir 9fab661cf8cc532468fc5594fb5f97b0b9022a2b)