### PR TITLE
[BUGFIX] Initialiser les UserCompetences sans skills ni challenges 

### DIFF
--- a/api/lib/domain/models/UserCompetence.js
+++ b/api/lib/domain/models/UserCompetence.js
@@ -17,8 +17,6 @@ class UserCompetence {
     pixScore,
     estimatedLevel,
     // includes
-    skills = [],
-    challenges = [],
     // references
   } = {}) {
     this.id = id;
@@ -29,8 +27,8 @@ class UserCompetence {
     this.pixScore = pixScore;
     this.estimatedLevel = estimatedLevel;
     // includes
-    this.skills = skills;
-    this.challenges = challenges;
+    this.skills = [];
+    this.challenges = [];
     // references
   }
 

--- a/api/tests/unit/domain/models/UserCompetence_test.js
+++ b/api/tests/unit/domain/models/UserCompetence_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Models | UserCompetence', () => {
 
   describe('#constructor', () => {
 
-    it('should construct a model UserCompetence from attributes', () => {
+    it('should construct a model UserCompetence from attributes and set skills and challenges to an empty array', () => {
       // given
       const userCompetenceRawData = {
         id: 1,
@@ -14,8 +14,8 @@ describe('Unit | Domain | Models | UserCompetence', () => {
         area: 'area',
         pixScore: 10,
         estimatedLevel: 5,
-        skills: [],
-        challenges: [],
+        skills: ['some skills'],
+        challenges: ['some challenges'],
       };
 
       // when
@@ -23,7 +23,14 @@ describe('Unit | Domain | Models | UserCompetence', () => {
 
       // then
       expect(actualUserCompetence).to.be.an.instanceof(UserCompetence);
-      expect(actualUserCompetence).to.deep.equal(userCompetenceRawData);
+      expect(actualUserCompetence.id).to.deep.equal(userCompetenceRawData.id);
+      expect(actualUserCompetence.index).to.deep.equal(userCompetenceRawData.index);
+      expect(actualUserCompetence.name).to.deep.equal(userCompetenceRawData.name);
+      expect(actualUserCompetence.area).to.deep.equal(userCompetenceRawData.area);
+      expect(actualUserCompetence.pixScore).to.deep.equal(userCompetenceRawData.pixScore);
+      expect(actualUserCompetence.estimatedLevel).to.deep.equal(userCompetenceRawData.estimatedLevel);
+      expect(actualUserCompetence.skills).to.be.empty;
+      expect(actualUserCompetence.challenges).to.be.empty;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un refactoring sur une PR précédente, un commit (https://github.com/1024pix/pix/pull/750/commits/9d69948a54321611bcc4aa9ffbb9cf8953fe53eb) a modifié l'initialisation des `UserCompetence` en replaçant `this.skills = []` par `this.skills = skills` étant donné que les skills étaient passés en paramètre en tant que propriété de l'objet `competence`. 

L'initialisation avec des array vide était néanmoins intentionnelle.

## :robot: Solution
Réinitialiser les `UserCompetence` sans y mettre tout le référentiel pix.
