### PR TITLE
[BUGFIX] Les utilisateurs étaient déconnectés intempestivement (PF-870).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -13,7 +13,6 @@ module.exports = {
       .then((accessToken) => {
         return h.response({
           token_type: 'bearer',
-          expires_in: 3600,
           access_token: accessToken,
           user_id: tokenService.extractUserId(accessToken),
         })

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -66,7 +66,6 @@ describe('Acceptance | Controller | authentication-controller', () => {
 
         const result = response.result;
         expect(result.token_type).to.equal('bearer');
-        expect(result.expires_in).to.equal(3600);
         expect(result.access_token).to.exist;
         expect(result.user_id).to.equal(userId);
       });

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -53,7 +53,6 @@ describe('Unit | Application | Controller | Authentication', () => {
       // then
       const expectedResponseResult = {
         token_type: 'bearer',
-        expires_in: 3600,
         access_token: 'jwt.access.token',
         user_id: 1
       };


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs se retrouvent déconnectés toutes les heures et tombent sur une page "Oups!".

## :robot: Solution
Supprimer l'attribut `expire_in` lors de la création de l'`access-token`.

## :rainbow: Remarques
Si l'attribut `expire_in` est présent le front (concrètement, `ember-simpl-auth`) tente de refresh le token, ce qui n'est pas encore implémenté dans l'API.
