### PR TITLE
[FEATURE] Ajouter le details des erreurs sur la page "Oups" (PF-882).

### DIFF
--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -13,6 +13,18 @@ export default Route.extend({
 
   setupController(controller, error) {
     this._super(...arguments);
+    controller.set('errorMessage', error);
+
+    if (error.errors && error.errors[0]) {
+      const apiError = error.errors[0];
+      controller.setProperties({
+        'errorDetail': apiError.detail,
+        'errorStatus': apiError.status,
+        'errorTitle': apiError.title
+      });
+    } else {
+      controller.setProperties({ 'errorDetail': null, 'errorStatus': null, 'errorTitle': null });
+    }
 
     if (this.hasUnauthorizedError(error)) {
       return this.session.invalidate()

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -3,6 +3,18 @@
   flex-direction: column;
   align-items: center;
   margin-top: 5%;
+
+  &__error {
+    margin: 20px;
+    padding: 20px;
+    background: $mercury-grey;
+    color: $boulder-grey;
+  }
+
+  &__error-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
 }
 
 .error-page__body-section {
@@ -18,6 +30,8 @@
   flex-direction: column;
   align-items: center;
   padding: 40px;
+  border-bottom: 1px dashed $slate-grey;
+  margin: 0 20px;
 
   @include device-is('desktop') {
     padding: 80px 0;

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -15,6 +15,13 @@
           {{#link-to 'login' class="button button--extra-big button--link error-page__index-link"}}
             Revenir à la page d'accueil{{/link-to}}
         </div>
+        <div>
+          hey les erreurs sont ici :
+          Message -> {{this.errorMessage}}
+          Title -> {{this.errorTitle}}
+          Detail -> {{this.errorDetail}}
+          Status -> {{this.errorStatus}}
+        </div>
       </div>
     </div>
 

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -15,12 +15,11 @@
           {{#link-to 'login' class="button button--extra-big button--link error-page__index-link"}}
             Revenir à la page d'accueil{{/link-to}}
         </div>
-        <div>
-          hey les erreurs sont ici :
-          Message -> {{this.errorMessage}}
-          Title -> {{this.errorTitle}}
-          Detail -> {{this.errorDetail}}
-          Status -> {{this.errorStatus}}
+        <div class="error-page__error">
+          <p class="error-page__error-title">{{this.errorTitle}}</p>
+          <p class="error-page__error-status">{{this.errorStatus}}</p>
+          <p class="error-page__error-message">{{this.errorMessage}}</p>
+          <p class="error-page__error-detail">{{this.errorDetail}}</p>
         </div>
       </div>
     </div>

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -7,12 +7,12 @@
       <div class="rounded-panel rounded-panel--strong error-page__body-section">
         <div class="error-page__main-content">
           <h1 class="error-page-main-content__title">Oups, une erreur est survenue !</h1>
-          <p>Nous vous invitons à recharger cette page ou {{#link-to 'index'}}revenir à la page d’accueil{{/link-to}}.</p>
+          <p>Nous vous invitons à recharger cette page ou {{#link-to 'login'}}revenir à la page d’accueil{{/link-to}}.</p>
           <p>Vous pouvez aussi nous contacter par courriel à l’adresse <a href="mailto:support@pix.fr">support@pix.fr</a>.
           </p>
           <p>Nous vous prions de nous excuser pour la gêne occasionnée.</p>
           <p>L'équipe Pix.</p>
-          {{#link-to 'index' class="button button--extra-big button--link error-page__index-link"}}
+          {{#link-to 'login' class="button button--extra-big button--link error-page__index-link"}}
             Revenir à la page d'accueil{{/link-to}}
         </div>
       </div>


### PR DESCRIPTION
## :unicorn: Problème
On ne sait pour quelles erreurs l'utilisateur tombe sur la page "Oups".

## :robot: Solution
On affiche le message et le détail de l'erreur directement sur la page "Oups"

## :rainbow: Remarques
Les erreurs front n'ont pas de détail.
Il faudra peut-être améliorer le style (voir Quentin).
