### PR TITLE
[FEATURE] Ne pas afficher les profils cibles archivés (PO-254).

### DIFF
--- a/api/db/migrations/20191017151624_add_columns_outdated_to_target_profiles_table.js
+++ b/api/db/migrations/20191017151624_add_columns_outdated_to_target_profiles_table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'target-profiles';
+const OUTDATED_COLUMN_NAME = 'outdated';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(OUTDATED_COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(OUTDATED_COLUMN_NAME);
+  });
+};

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -73,11 +73,11 @@ module.exports = {
       .then(membershipSerializer.serialize);
   },
 
-  findTargetProfiles(request) {
+  async findTargetProfiles(request) {
     const requestedOrganizationId = parseInt(request.params.id);
 
-    return organizationService.findAllTargetProfilesAvailableForOrganization(requestedOrganizationId)
-      .then(targetProfileSerializer.serialize);
+    const targetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(requestedOrganizationId);
+    return targetProfileSerializer.serialize(targetProfiles);
   },
 
   exportSharedSnapshotsAsCsv: async (request) => {

--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -4,6 +4,7 @@ class TargetProfile {
     // attributes
     name,
     isPublic,
+    outdated,
     // includes
     skills = [],
     // references
@@ -14,6 +15,7 @@ class TargetProfile {
     // attributes
     this.name = name;
     this.isPublic = isPublic;
+    this.outdated = outdated;
     // includes
     this.skills = skills;
     // references

--- a/api/lib/domain/services/organization-service.js
+++ b/api/lib/domain/services/organization-service.js
@@ -8,12 +8,12 @@ function _randomLetters(count) {
 }
 
 function _extractProfilesSharedWithOrganization(organization) {
-  const targetProfileSharesNonOutdated = organization.targetProfileShares.filter((targetProfileShare) => {
-    return !targetProfileShare.targetProfile.outdated;
+  const targetProfilesSharedNonOutdated = organization.targetProfileShares.filter((targetProfileShared) => {
+    return !targetProfileShared.targetProfile.outdated;
   });
 
-  return targetProfileSharesNonOutdated.map((targetProfileShareNonOutdated) => {
-    return targetProfileShareNonOutdated.targetProfile;
+  return targetProfilesSharedNonOutdated.map((targetProfileSharedNonOutdated) => {
+    return targetProfileSharedNonOutdated.targetProfile;
   });
 }
 
@@ -34,9 +34,9 @@ module.exports = {
 
   async findAllTargetProfilesAvailableForOrganization(organizationId) {
     const organization = await organizationRepository.get(organizationId);
-    const targetProfilesOrganizationCanUse = await targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
-    const targetProfileSharesWithOrganization = _extractProfilesSharedWithOrganization(organization);
-    const allAvailableTargetProfiles = orderBy(concat(targetProfilesOrganizationCanUse, targetProfileSharesWithOrganization), ['isPublic', 'name']);
+    const targetProfilesOrganizationCanUse = await targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
+    const targetProfilesSharedWithOrganization = _extractProfilesSharedWithOrganization(organization);
+    const allAvailableTargetProfiles = orderBy(concat(targetProfilesOrganizationCanUse, targetProfilesSharedWithOrganization), ['isPublic', 'name']);
     return uniqBy(allAvailableTargetProfiles, 'id');
   },
 

--- a/api/lib/domain/services/organization-service.js
+++ b/api/lib/domain/services/organization-service.js
@@ -28,21 +28,15 @@ module.exports = {
       .catch(() => this.generateUniqueOrganizationCode({ organizationRepository }));
   },
 
-  findAllTargetProfilesAvailableForOrganization(organizationId) {
-    return organizationRepository.get(organizationId)
-      .then((organization) => {
-        return Promise.all([
-          targetProfileRepository.findTargetProfilesOwnedByOrganizationId(organizationId),
-          _extractProfilesSharedWithOrganization(organization),
-          targetProfileRepository.findPublicTargetProfiles(),
-        ]);
-      })
-      .then(([targetProfilesOwnedByOrganization, targetProfileSharesWithOrganization, publicTargetProfiles]) => {
-        const orderedPrivateProfile = orderBy(concat(targetProfilesOwnedByOrganization, targetProfileSharesWithOrganization), 'name');
-        const orderedPublicProfile = orderBy(publicTargetProfiles, 'name');
-        const allAvailableTargetProfiles = concat(orderedPrivateProfile, orderedPublicProfile);
-        return uniqBy(allAvailableTargetProfiles, 'id');
-      });
+  async findAllTargetProfilesAvailableForOrganization(organizationId) {
+    const organization = await organizationRepository.get(organizationId);
+    const targetProfilesOwnedByOrganization = await targetProfileRepository.findTargetProfilesOwnedByOrganizationId(organizationId);
+    const targetProfileSharesWithOrganization = _extractProfilesSharedWithOrganization(organization);
+    const publicTargetProfiles = await targetProfileRepository.findPublicTargetProfiles();
+    const orderedPrivateProfile = orderBy(concat(targetProfilesOwnedByOrganization, targetProfileSharesWithOrganization), 'name');
+    const orderedPublicProfile = orderBy(publicTargetProfiles, 'name');
+    const allAvailableTargetProfiles = concat(orderedPrivateProfile, orderedPublicProfile);
+    return uniqBy(allAvailableTargetProfiles, 'id');
   },
 
 };

--- a/api/lib/domain/services/organization-service.js
+++ b/api/lib/domain/services/organization-service.js
@@ -8,8 +8,12 @@ function _randomLetters(count) {
 }
 
 function _extractProfilesSharedWithOrganization(organization) {
-  return organization.targetProfileShares.map((targetProfileShare) => {
-    return targetProfileShare.targetProfile;
+  const targetProfileSharesNonOutdated = organization.targetProfileShares.filter((targetProfileShare) => {
+    return !targetProfileShare.targetProfile.outdated;
+  });
+
+  return targetProfileSharesNonOutdated.map((targetProfileShareNonOutdated) => {
+    return targetProfileShareNonOutdated.targetProfile;
   });
 }
 

--- a/api/lib/domain/services/organization-service.js
+++ b/api/lib/domain/services/organization-service.js
@@ -30,12 +30,9 @@ module.exports = {
 
   async findAllTargetProfilesAvailableForOrganization(organizationId) {
     const organization = await organizationRepository.get(organizationId);
-    const targetProfilesOwnedByOrganization = await targetProfileRepository.findTargetProfilesOwnedByOrganizationId(organizationId);
+    const targetProfilesOrganizationCanUse = await targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
     const targetProfileSharesWithOrganization = _extractProfilesSharedWithOrganization(organization);
-    const publicTargetProfiles = await targetProfileRepository.findPublicTargetProfiles();
-    const orderedPrivateProfile = orderBy(concat(targetProfilesOwnedByOrganization, targetProfileSharesWithOrganization), 'name');
-    const orderedPublicProfile = orderBy(publicTargetProfiles, 'name');
-    const allAvailableTargetProfiles = concat(orderedPrivateProfile, orderedPublicProfile);
+    const allAvailableTargetProfiles = orderBy(concat(targetProfilesOrganizationCanUse, targetProfileSharesWithOrganization), ['isPublic', 'name']);
     return uniqBy(allAvailableTargetProfiles, 'id');
   },
 

--- a/api/lib/infrastructure/adapters/target-profile-adapter.js
+++ b/api/lib/infrastructure/adapters/target-profile-adapter.js
@@ -17,6 +17,7 @@ module.exports = {
       name: bookshelfTargetProfile.get('name'),
       isPublic: Boolean(bookshelfTargetProfile.get('isPublic')),
       organizationId: bookshelfTargetProfile.get('organizationId'),
+      outdated: bookshelfTargetProfile.get('outdated'),
       skills,
       sharedWithOrganizationIds,
     });

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -37,8 +37,8 @@ module.exports = {
   findAllTargetProfileOrganizationCanUse(organizationId) {
     return BookshelfTargetProfile
       .query((qb) => {
-        qb.where('organizationId', organizationId);
-        qb.orWhere('isPublic', true);
+        qb.where({ 'organizationId': organizationId, 'outdated': false });
+        qb.orWhere({ 'isPublic': true, 'outdated': false });
       })
       .fetchAll({ withRelated: ['skillIds'] })
       .then((bookshelfTargetProfiles) => Promise.all(bookshelfTargetProfiles.map(_getWithAirtableSkills)));

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -34,7 +34,7 @@ module.exports = {
       .then((bookshelfTargetProfiles) => Promise.all(bookshelfTargetProfiles.map(_getWithAirtableSkills)));
   },
 
-  findAllTargetProfileOrganizationCanUse(organizationId) {
+  findAllTargetProfilesOrganizationCanUse(organizationId) {
     return BookshelfTargetProfile
       .query((qb) => {
         qb.where({ 'organizationId': organizationId, 'outdated': false });

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -33,6 +33,16 @@ module.exports = {
       .fetchAll({ withRelated: ['skillIds'] })
       .then((bookshelfTargetProfiles) => Promise.all(bookshelfTargetProfiles.map(_getWithAirtableSkills)));
   },
+
+  findAllTargetProfileOrganizationCanUse(organizationId) {
+    return BookshelfTargetProfile
+      .query((qb) => {
+        qb.where('organizationId', organizationId);
+        qb.orWhere('isPublic', true);
+      })
+      .fetchAll({ withRelated: ['skillIds'] })
+      .then((bookshelfTargetProfiles) => Promise.all(bookshelfTargetProfiles.map(_getWithAirtableSkills)));
+  },
 };
 
 function _getWithAirtableSkills(targetProfile) {

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -182,7 +182,7 @@ describe('Integration | Repository | Target-profile', () => {
     });
   });
 
-  describe('#findAllTargetProfileOrganizationCanUse', () => {
+  describe('#findAllTargetProfilesOrganizationCanUse', () => {
 
     let organizationId;
     let otherOrganizationId;
@@ -216,7 +216,7 @@ describe('Integration | Repository | Target-profile', () => {
 
     it('should return an Array', async () => {
       // when
-      const foundTargetProfiles = await targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
+      const foundTargetProfiles = await targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
 
       // then
       expect(foundTargetProfiles).to.be.an('array');
@@ -224,7 +224,7 @@ describe('Integration | Repository | Target-profile', () => {
 
     it('should return all the target profile the organization can access (owned + public) but not outdated', async () => {
       // when
-      const foundTargetProfiles = await targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
+      const foundTargetProfiles = await targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
 
       // then
       expect(foundTargetProfiles[0]).to.be.an.instanceOf(TargetProfile);
@@ -237,7 +237,7 @@ describe('Integration | Repository | Target-profile', () => {
 
     it('should contain skills linked to every target profiles', () => {
       // when
-      const promise = targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
+      const promise = targetProfileRepository.findAllTargetProfilesOrganizationCanUse(organizationId);
 
       // then
       return promise.then((targetProfiles) => {

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -200,6 +200,8 @@ describe('Integration | Repository | Target-profile', () => {
       organizationTargetProfilePublic = databaseBuilder.factory.buildTargetProfile({ organizationId, isPublic: true });
       publicTargetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: null, isPublic: true });
       databaseBuilder.factory.buildTargetProfile({ organizationId: otherOrganizationId, isPublic: false });
+      databaseBuilder.factory.buildTargetProfile({ organizationId: null, isPublic: true, outdated: true });
+      databaseBuilder.factory.buildTargetProfile({ organizationId, isPublic: false, outdated: true });
 
       const targetProfileSkillAssociation = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: organizationTargetProfile.id });
       await databaseBuilder.commit();
@@ -220,7 +222,7 @@ describe('Integration | Repository | Target-profile', () => {
       expect(foundTargetProfiles).to.be.an('array');
     });
 
-    it('should return all the target profile the organization can access (owned + public)', async () => {
+    it('should return all the target profile the organization can access (owned + public) but not outdated', async () => {
       // when
       const foundTargetProfiles = await targetProfileRepository.findAllTargetProfileOrganizationCanUse(organizationId);
 

--- a/api/tests/tooling/database-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/database-builder/factory/build-target-profile.js
@@ -9,6 +9,7 @@ module.exports = function buildTargetProfile({
   isPublic = faker.random.boolean(),
   organizationId,
   createdAt = faker.date.recent(),
+  outdated = false,
 } = {}) {
 
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
@@ -19,6 +20,7 @@ module.exports = function buildTargetProfile({
     isPublic,
     organizationId,
     createdAt,
+    outdated,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'target-profiles',

--- a/api/tests/tooling/domain-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile.js
@@ -9,6 +9,7 @@ module.exports = function buildTargetProfile({
   skills = [buildSkill()],
   organizationId = faker.random.number(),
   organizationsSharedId = [],
+  outdated = false,
 } = {}) {
   return new TargetProfile({
     id,
@@ -17,5 +18,6 @@ module.exports = function buildTargetProfile({
     skills,
     organizationId,
     organizationsSharedId,
+    outdated,
   });
 };

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -67,11 +67,11 @@ describe('Unit | Service | OrganizationService', () => {
       const organization = domainBuilder.buildOrganization({ id: organizationId, targetProfileShares });
       targetProfileOrganizationCanUse = concat(publicTargetProfiles, targetProfilesOwnedByOrganization);
 
-      sinon.stub(targetProfileRepository, 'findAllTargetProfileOrganizationCanUse').resolves(targetProfileOrganizationCanUse);
+      sinon.stub(targetProfileRepository, 'findAllTargetProfilesOrganizationCanUse').resolves(targetProfileOrganizationCanUse);
       sinon.stub(organizationRepository, 'get').resolves(organization);
     });
 
-    it('should return an array of target profiles', async () => {
+    it('should return an array of type target profile', async () => {
       // when
       const availableTargetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
 
@@ -93,7 +93,7 @@ describe('Unit | Service | OrganizationService', () => {
 
     it('should not have duplicate in targetProfiles', async () => {
       // given
-      targetProfileRepository.findAllTargetProfileOrganizationCanUse.resolves(targetProfilesOwnedByOrganization);
+      targetProfileRepository.findAllTargetProfilesOrganizationCanUse.resolves(targetProfilesOwnedByOrganization);
 
       // when
       const availableTargetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
@@ -123,7 +123,7 @@ describe('Unit | Service | OrganizationService', () => {
 
       targetProfileOrganizationCanUse = concat(targetProfilesOwnedByOrganization, publicTargetProfiles);
 
-      targetProfileRepository.findAllTargetProfileOrganizationCanUse.resolves(targetProfileOrganizationCanUse);
+      targetProfileRepository.findAllTargetProfilesOrganizationCanUse.resolves(targetProfileOrganizationCanUse);
       organizationRepository.get.resolves(organization);
       // when
       const availableTargetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
@@ -152,7 +152,7 @@ describe('Unit | Service | OrganizationService', () => {
       }];
       const organization = domainBuilder.buildOrganization({ id: organizationId, targetProfileShares });
 
-      targetProfileRepository.findAllTargetProfileOrganizationCanUse.resolves(targetProfiles);
+      targetProfileRepository.findAllTargetProfilesOrganizationCanUse.resolves(targetProfiles);
       organizationRepository.get.resolves(organization);
 
       // when

--- a/api/tests/unit/domain/services/organization-service_test.js
+++ b/api/tests/unit/domain/services/organization-service_test.js
@@ -136,5 +136,36 @@ describe('Unit | Service | OrganizationService', () => {
       expect(availableTargetProfiles[3].name).equal('A Public profile');
       expect(availableTargetProfiles[4].name).equal('B Public profile');
     });
+
+    it('should return a list of not outdated target profile', async () => {
+      // given
+      targetProfilesOwnedByOrganization = [
+        domainBuilder.buildTargetProfile({ organizationId, isPublic: false }),
+      ];
+      targetProfileSharesWithOrganization = [
+        domainBuilder.buildTargetProfile({ isPublic: false }),
+      ];
+      publicTargetProfiles = [
+        domainBuilder.buildTargetProfile({ isPublic: true }),
+      ];
+      const targetProfileShares = [{
+        targetProfile: targetProfileSharesWithOrganization
+      }];
+      const organization = domainBuilder.buildOrganization({ id: organizationId, targetProfileShares });
+
+      targetProfileOrganizationCanUse = concat(targetProfilesOwnedByOrganization, targetProfileSharesWithOrganization, publicTargetProfiles);
+
+      targetProfileRepository.findAllTargetProfileOrganizationCanUse.resolves(targetProfileOrganizationCanUse);
+      organizationRepository.get.resolves(organization);
+      // when
+      const availableTargetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
+
+      // then
+      expect(availableTargetProfiles.length).to.equal(4);
+      expect(availableTargetProfiles[0].outdated).to.be.false;
+      expect(availableTargetProfiles[1].outdated).to.be.false;
+      expect(availableTargetProfiles[2].outdated).to.be.false;
+      expect(availableTargetProfiles[3].shift().outdated).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## 🤖 Problème
Aujourd'hui les profils cibles (ceux qui portent sur les compétences de Pix) qui ne sont plus à jour, sont proposé lors de la selection du profil-cible à la création d'une campagne.

## 🚀 Solution
Ajouter un attribut `outdated` sur les profils-cibles, pour préciser si il sont archivé/périmé/plus à jour.
 
## 🌔 Remarques
C'est un premier pas pour gérer l'obsolescence des profils-cibles.
