### PR TITLE
[BUGFIX] Correction du style pour la page compétence sous IE (PF-860).

### DIFF
--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -7,7 +7,6 @@
   margin-bottom: 50px;
   padding: 20px;
   text-rendering: optimizeLegibility;
-
   @include device-is('desktop') {
     padding: 50px 70px 40px;
   }
@@ -32,4 +31,9 @@
   font-size: 20px;
   line-height: 24px;
   margin-top: 58px;
+  
+  @include device-is('desktop') {
+    max-width: 850px;
+  }
+
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -62,12 +62,9 @@
     flex-grow: 1;
     padding: 0 30px 30px 30px;
     max-width: 100%;
-
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      max-width: 70%;
-    }
-
+    
     @include device-is('desktop') {
+      max-width: 68%;
       padding: 0 30px;
       border-right: 2px dashed $silver-grey;
     }
@@ -80,7 +77,12 @@
     align-items: center;
     padding: 0 30px;
     white-space: nowrap;
+    max-width: 100%;
+    @include device-is('desktop') {
+      max-width: 30%;
+    }
   }
+
 }
 
 .scorecard-details-content-left {


### PR DESCRIPTION
## :unicorn: Problème
Sous IE, la page compétence n'est pas lisible

## :robot: Solution
Pour IE, il y a besoin de préciser le max-width correctement, sinon le texte dépasse du bloc.

## :rainbow: Remarques
