### PR TITLE
[BUGFIX] Télécharger les résultats CSV de grosses campagne (PO-257).

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -108,7 +108,7 @@ module.exports = injectDependencies({
   getOrganizationInvitation: require('./get-organization-invitation'),
   getOrganizationMemberships: require('./get-organization-memberships'),
   getProgression: require('./get-progression'),
-  getResultsCampaignInCSVFormat: require('./get-results-campaign-in-csv-format'),
+  startWritingCampaignResultsToStream: require('./start-writing-campaign-results-to-stream'),
   getScorecard: require('./get-scorecard'),
   getSession: require('./get-session'),
   getSessionCertificationCandidates: require('./get-session-certification-candidates'),

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -68,7 +68,7 @@ describe('Unit | Application | Controller | Campaign', () => {
     const userId = 1;
 
     beforeEach(() => {
-      sinon.stub(usecases, 'getResultsCampaignInCSVFormat');
+      sinon.stub(usecases, 'startWritingCampaignResultsToStream');
       sinon.stub(tokenService, 'extractUserIdForCampaignResults').resolves(userId);
     });
 
@@ -83,19 +83,19 @@ describe('Unit | Application | Controller | Campaign', () => {
           id: campaignId
         }
       };
-      usecases.getResultsCampaignInCSVFormat.resolves('csv;result');
+      usecases.startWritingCampaignResultsToStream.resolves({ fileName: 'any file name' });
 
       // when
-      await campaignController.getCsvResults(request, hFake);
+      await campaignController.getCsvResults(request);
 
       // then
-      expect(usecases.getResultsCampaignInCSVFormat).to.have.been.calledOnce;
-      const getResultsCampaignArgs = usecases.getResultsCampaignInCSVFormat.firstCall.args[0];
+      expect(usecases.startWritingCampaignResultsToStream).to.have.been.calledOnce;
+      const getResultsCampaignArgs = usecases.startWritingCampaignResultsToStream.firstCall.args[0];
       expect(getResultsCampaignArgs).to.have.property('userId');
       expect(getResultsCampaignArgs).to.have.property('campaignId');
     });
 
-    it('should return a serialized campaign when the campaign has been successfully created', async () => {
+    it('should return a response with correct headers', async () => {
       // given
       const campaignId = 2;
       const request = {
@@ -106,14 +106,16 @@ describe('Unit | Application | Controller | Campaign', () => {
           id: campaignId
         }
       };
-      usecases.getResultsCampaignInCSVFormat.resolves({ csvData: 'csv;result', campaignName: 'Campagne' });
+
+      usecases.startWritingCampaignResultsToStream.resolves({ fileName: 'expected file name' });
 
       // when
-      const response = await campaignController.getCsvResults(request, hFake);
+      const response = await campaignController.getCsvResults(request);
 
       // then
-      expect(response.source).to.deep.equal('csv;result');
-    });
+      expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
+      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected file name"');
+      expect(response.headers['content-encoding']).to.equal('identity'); });
   });
 
   describe('#getByCode ', () => {


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible de télécharger les résultats CSV des campagnes qui ont 3000 participations.

C'est dû :
- à un temps de traitement supérieur à 30 secondes (donc timeout de Scalingo même si la requête réussit)

## :robot: Solution

Utiliser un stream comme pour les snapshots (voir 9fab661cf8cc532468fc5594fb5f97b0b9022a2b)

## :rainbow: Remarques

Il faut faire mieux, permettre de résister à une combinatoire de 6000 participations x 700 acquis (profil cible).

Aussi, on a mesuré l'occupation mémoire, dans nos mesures elle était du même ordre de grandeur (environ 200 Mo max) pour un export csv seul que pour deux exports en même temps.

Un seul export :

![UnExport](https://user-images.githubusercontent.com/7529/67690884-f6f5db00-f99d-11e9-8566-3e40b384a764.png)

Deux exports (les 0 sont des faux, ce sont des marqueurs de démarrage et de fin) :

![DeuxExportsCSV](https://user-images.githubusercontent.com/7529/67690963-168d0380-f99e-11e9-97ad-cd40827c8b37.png)
