### PR TITLE
[BUGFIX] Ajout d'une police par défault pour les fonts Roboto et Open-Sans sur Pix Orga (PO-258).

### DIFF
--- a/orga/app/styles/globals/fonts.scss
+++ b/orga/app/styles/globals/fonts.scss
@@ -1,2 +1,2 @@
-$roboto: 'Roboto';
-$open-sans: 'Open Sans';
+$roboto: 'Roboto', Arial, sans-serif;
+$open-sans: 'Open Sans', Arial, sans-serif;


### PR DESCRIPTION
## :unicorn: Problème
Sur certains écrans, certains libellés  et boutons s'affichent dans une mauvaise police (Times-New Roman plutôt que Roboto). 

## :robot: Solution
Rajouter des polices par défaut. 