### PR TITLE
[BUGFIX] Supprime le style par défaut sur les invalid input (PF-812).

### DIFF
--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -36,3 +36,7 @@
 @import 'components/certification-select';
 @import 'components/certification-list';
 @import 'components/confirm-popup';
+
+input:invalid {
+  box-shadow: none;
+}

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -32,3 +32,7 @@ body, html{
 body > .ember-view {
   height: 100%;
 }
+
+input:invalid {
+  box-shadow: none;
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -102,3 +102,7 @@ body {
 input[type='radio'] {
   margin: 0 5px 0 0;
 }
+
+input:invalid {
+  box-shadow: none;
+}

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -75,7 +75,9 @@
   color: $caribbean-green;
 }
 
-.form-textfield__message--error.form-textfield__message-password, .form-textfield__message--error.form-textfield__message-email, .form-textfield__message--error.form-textfield__message-text {
+.form-textfield__message--error.form-textfield__message-password,
+.form-textfield__message--error.form-textfield__message-email,
+.form-textfield__message--error.form-textfield__message-text {
   position: relative;
   text-align: right;
   margin-top: -5px;

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -2,7 +2,6 @@
 
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";
-
 @import "globals/breakpoints";
 @import "globals/colors";
 @import "globals/fonts";
@@ -14,7 +13,6 @@
 @import "globals/tables";
 @import "globals/texts";
 @import "globals/titles";
-
 @import "components/login-form";
 @import "components/campaign-list";
 @import "components/campaign-item";
@@ -23,7 +21,6 @@
 @import "components/pagination-control";
 @import "components/progression-gauge";
 @import "components/sidebar-menu";
-
 @import "pages/login";
 @import "pages/authenticated";
 @import "pages/authenticated/campaigns";
@@ -52,4 +49,8 @@ body, html {
 
 body > .ember-view {
   height: 100%;
+}
+
+input:invalid {
+  box-shadow: none;
 }


### PR DESCRIPTION
## :unicorn: Problème
On gère déjà les erreurs dans les formulaires, et le comportement par défaut des navigateurs faisait doublons. 

## :robot: Solution
Désactiver le style par défaut des navigateurs.
