### PR TITLE
[BUGFIX] User connecté /index redirigé vers /campagnes (PO-264).

### DIFF
--- a/orga/app/routes/login.js
+++ b/orga/app/routes/login.js
@@ -2,4 +2,5 @@ import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 export default Route.extend(UnauthenticatedRouteMixin, {
+  routeIfAlreadyAuthenticated: 'authenticated'
 });

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -31,6 +31,27 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
+  module('When user is already logged in', function() {
+
+    test('it should redirect user to campaign list page', async function(assert) {
+      // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      await authenticateSession({
+        user_id: user.id,
+        access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+        expires_in: 3600,
+        token_type: 'Bearer token type',
+      });
+
+      // when
+      await visit('/connexion');
+
+      // then
+      assert.equal(currentURL(), '/campagnes');
+      assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+    });
+  });
+
   module('When user is logging in but has not accepted terms of service yet', function(hooks) {
 
     let user;


### PR DESCRIPTION
## :unicorn: Problème
- se connecter à PixOrga et voir la liste des campagnes
- taper l'URL : `/connexion`
- se retrouver nez à nez avec une page blanche

## :robot: Solution
Pix Orga est tout perdu car il essaie de rediriger vers `/index`, page n'existant pas. Il faut spécifier à la route `login` que `routeIfAlreadyAuthenticated` est à `authenticated` (par défaut `index`), et ainsi être redirigé vers la page par défaut, qui se trouve être la page `/campagnes`.
