### PR TITLE
[TECH] Fermer proprement les connexions à PostgreSQL lors de l'arrêt (PF-923)

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -1,2 +1,2 @@
 background: npm run scalingo-background-job
-web: npm run scalingo-start
+web: npm run db:migrate && exec node bin/www

--- a/api/bin/www
+++ b/api/bin/www
@@ -4,6 +4,7 @@ const heapProfile = require('heap-profile');
 const createServer = require('../server');
 const logger = require('../lib/infrastructure/logger');
 const { system } = require('../lib/config');
+const { disconnect } = require('../db/knex-database-connection');
 
 const start = async () => {
   try {
@@ -20,5 +21,15 @@ const start = async () => {
     process.exit(1);
   }
 };
+
+function exitOnSignal(signal) {
+  logger.info(`Received signal ${signal}. Closing DB connections before exiting.`);
+  disconnect().then(() => {
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
 
 start();

--- a/api/bin/www
+++ b/api/bin/www
@@ -26,6 +26,9 @@ function exitOnSignal(signal) {
   logger.info(`Received signal ${signal}. Closing DB connections before exiting.`);
   disconnect().then(() => {
     process.exit(0);
+  }).catch((err) => {
+    logger.error(err);
+    process.exit(1);
   });
 }
 

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -48,8 +48,13 @@ async function emptyAllTables() {
   }
 }
 
+async function disconnect() {
+  return knex.destroy();
+}
+
 module.exports = {
   knex,
+  disconnect,
   listAllTableNames,
   emptyAllTables,
 };

--- a/api/package.json
+++ b/api/package.json
@@ -108,7 +108,6 @@
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",
     "scalingo-postbuild": "echo 'nothing to do'",
     "scalingo-post-ra-creation": "npm run db:seed",
-    "scalingo-start": "npm run db:migrate && npm start",
     "start": "node bin/www",
     "start:watch": "nodemon --signal SIGTERM bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",


### PR DESCRIPTION
## :unicorn: Problème
On a des messages d'avertissement dans les logs du serveur PostgreSQL chez Scalingo du type :

```
2019-10-29 15:42:34.049640680 +0100 CET [postgresql-1] 2019-10-29 14:42:34 UTC LOG:  could not receive data from client: Connection reset by peer
```

Après investigation, il s'avère que ce message est écrit par le serveur quand un client ferme sa connexion sans l'avoir fait proprement.
On constate effectivement qu'une série de messages de ce type est écrit à chaque arrêt d'un conteneur de l'application.

## :robot: Solution
On intercepte le signal envoyé par Scalingo demandant l'arrêt du conteneur et on utilise la fonction `destroy` de `knex` pour fermer proprement les connexions ouvertes.

Noter qu'il faut se débarrasser du processus `npm` pendant l'exécution afin que le signal `SIGTERM` soit correctement reçu par notre processus `node` (cf. https://github.com/npm/npm/issues/4603), donc on supprime le script `npm` nommé `scalingo-start` et dans le `Procfile` on écrit directement la commande `node` qui démarre l'application (on n'utilise plus non plus `npm start`).

## 🔬 Comment vérifier que ça marche
À faire sur la _review app_ :
 * Solliciter l'API pour que l'application ouvre des connexions à la base de données, par exemple avec :
```
siege -b https://api-pr796.review.pix.fr/api/healthcheck/db
```
(laisser tourner ce processus pendant le reste du test pour s'assurer que les connexions restent ouvertes)
 * Observer sur le _dashboard_ PostgreSQL de Scalingo associé, que l'application a ouvert plusieurs connexions ;
 * Dans le _dashboard_ Scalingo, réduire le nombre de conteneurs de l'application de 1 à 0 ;
 * Observer les logs dans le _dashboard_ PostgreSQL et constater que le message `Connection reset by peer` n'apparaît pas.

(reproduire le même test sur une _review app_ n'ayant pas cette PR pour voir la différence).

## :rainbow: Remarques
On espère que ça pourrait réduire les occurrences d'épuisement de connexions disponibles à PostgreSQL, même si l'avertissement est en principe bénin.