### PR TITLE
[FEATURE] Ajout d'un bouton de navigation sur Pix Orga (PO-252).

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
 export default Component.extend({
-
+  tagName: '',
   currentUser: service(),
 
 });

--- a/orga/app/styles/components/sidebar-menu.scss
+++ b/orga/app/styles/components/sidebar-menu.scss
@@ -1,4 +1,5 @@
 .sidebar-menu {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   padding-top: 30px;

--- a/orga/app/styles/components/sidebar-menu.scss
+++ b/orga/app/styles/components/sidebar-menu.scss
@@ -3,6 +3,13 @@
   display: flex;
   flex-direction: column;
   padding-top: 30px;
+
+  &__documentation-item {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
 }
 
 .sidebar-menu__item {
@@ -22,5 +29,35 @@
   &.active {
     border-left: 3px solid $amber;
     background-color: $chambray;
+  }
+}
+
+.sidebar-menu-documentation-item {
+  &__bar {
+    width: 157px;
+    border: 1px solid $white;
+    opacity: .25;
+    margin: 0 auto;
+    transition: .5s;
+  }
+
+  &__button {
+    height: 44px;
+    color: $white;
+    font-family: $roboto;
+    font-size: 0.875rem;
+    line-height: 2.75rem;
+    text-decoration: none;
+    text-align: center;
+    border-top: 1px black;
+    border-top-width: 157px;
+
+    &:hover {
+      background-color: $curious-blue;
+    }
+
+    &:hover .sidebar-menu-documentation-item__bar {
+      width: 100%;
+    }
   }
 }

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -7,6 +7,7 @@ $astronaut: #213371;
 $chambray: #325792;
 $mariner: #355BD1;
 $denim: #0D7DC4;
+$curious-blue: #2b89c8;
 $aqua: #388AFF;
 $dodger-blue: #3D68FF;
 $comet: #585F75;

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -12,9 +12,7 @@
 
     </div>
 
-    <div class="">
-      {{sidebar-menu}}
-    </div>
+    {{sidebar-menu}}
   </aside>
 
   <div class="app__main-content main-content">

--- a/orga/app/templates/components/sidebar-menu.hbs
+++ b/orga/app/templates/components/sidebar-menu.hbs
@@ -12,4 +12,14 @@
       Élèves
     {{/link-to}}
   {{/if}}
+  {{#if currentUser.canAccessStudentsPage}}
+    <div class="sidebar-menu__documentation-item">
+      <a class="sidebar-menu-documentation-item__button" href="https://bit.ly/ressourcespixorga"
+         target="_blank">
+        <div class="sidebar-menu-documentation-item__bar"></div>
+        {{fa-icon 'book' class="sidebar--padding-right"}}
+        Documentation
+      </a>
+    </div>
+  {{/if}}
 </nav>

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -218,7 +218,7 @@ module('Acceptance | authentication', function(hooks) {
           await visit('/');
 
           // then
-          assert.dom('.sidebar-menu a').exists({ count: 3 });
+          assert.dom('.sidebar-menu a').exists({ count: 4 });
           assert.dom('.sidebar-menu a:first-child').hasText('Campagnes');
           assert.dom('.sidebar-menu a:nth-child(2)').hasText('Équipe');
           assert.dom('.sidebar-menu a:nth-child(3)').hasText('Élèves');
@@ -237,6 +237,14 @@ module('Acceptance | authentication', function(hooks) {
           assert.dom('.sidebar-menu a:nth-child(3)').hasText('Élèves');
           assert.dom('.sidebar-menu a:nth-child(3)').hasClass('active');
           assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
+        });
+
+        test('should have resources link', async function(assert) {
+          // given
+          await visit('/');
+
+          // then
+          assert.dom('.sidebar-menu-documentation-item__button').hasText('Documentation');
         });
       });
     });
@@ -281,7 +289,7 @@ module('Acceptance | authentication', function(hooks) {
           await visit('/');
 
           // then
-          assert.dom('.sidebar-menu a').exists({ count: 2 });
+          assert.dom('.sidebar-menu a').exists({ count: 3 });
           assert.dom('.sidebar-menu a:first-child').hasText('Campagnes');
           assert.dom('.sidebar-menu a:nth-child(2)').hasText('Élèves');
           assert.dom('.sidebar-menu a:first-child ').hasClass('active');


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur SCO de Pix Orga se pose une question, il ne sait pas quoi faire.

## :robot: Solution
Ajouter un bouton en bas du menu, afin de rediriger les SCO sur le guide d'utilisation de Pix. 
