### PR TITLE
[FEATURE] Page de reconciliation au lancement d'une campagne (PF-817).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -28,10 +28,9 @@ module.exports = {
 
   async getByCode(request) {
     const filters = queryParamsUtils.extractParameters(request.query).filter;
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
     await _validateFilters(filters);
 
-    const campaign = await usecases.retrieveCampaignInformation({ code: filters.code, userId });
+    const campaign = await usecases.retrieveCampaignInformation({ code: filters.code });
     return campaignSerializer.serialize([campaign]);
   },
 

--- a/api/lib/application/student-user-associations/index.js
+++ b/api/lib/application/student-user-associations/index.js
@@ -1,0 +1,20 @@
+const studentUserAssociationController = require('./student-user-association-controller');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/student-user-associations',
+      config: {
+        handler: studentUserAssociationController.associate,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Elle associe des données de l’utilisateur qui fait la requete, au student de l’organisation'
+        ],
+        tags: ['api', 'studentUserAssociation']
+      }
+    },
+  ]);
+};
+
+exports.name = 'student-user-associations-api';

--- a/api/lib/application/student-user-associations/student-user-association-controller.js
+++ b/api/lib/application/student-user-associations/student-user-association-controller.js
@@ -1,0 +1,19 @@
+const usecases = require('../../domain/usecases');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
+
+module.exports = {
+
+  async associate(request, h) {
+    const payload = request.payload.data.attributes;
+    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+    const user = {
+      id: userId,
+      firstName: payload['first-name'],
+      lastName: payload['last-name'],
+      birthdate: payload['birthdate'],
+    };
+
+    await usecases.linkUserToOrganizationStudentData({ campaignCode: payload['campaign-code'], user });
+    return h.response().code(204);
+  }
+};

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -249,6 +249,23 @@ exports.register = async function(server) {
         tags: ['api', 'user', 'scorecard']
       }
     },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/student',
+      config: {
+        pre: [{
+          method: securityController.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser'
+        }],
+        handler: userController.getStudent,
+        notes : [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération du student (au sein d’une organisation) lié au user\n' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'student']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -148,7 +148,7 @@ module.exports = {
   getStudent(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 
-    return usecases.getUserStudent({ userId: authenticatedUserId })
+    return usecases.getStudentLinkedToUser({ userId: authenticatedUserId })
       .then(studentSerializer.serialize);
   }
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -142,5 +142,7 @@ module.exports = {
 
     return usecases.resetScorecard({ userId: authenticatedUserId, competenceId })
       .then(scorecardSerializer.serialize);
-  }
+  },
+
+  getStudent() {}
 };

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -4,6 +4,7 @@ const certificationProfileSerializer = require('../../infrastructure/serializers
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
 const pixScoreSerializer = require('../../infrastructure/serializers/jsonapi/pix-score-serializer');
 const scorecardSerializer = require('../../infrastructure/serializers/jsonapi/scorecard-serializer');
+const studentSerializer = require('../../infrastructure/serializers/jsonapi/student-serializer');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 
 const usecases = require('../../domain/usecases');
@@ -144,5 +145,10 @@ module.exports = {
       .then(scorecardSerializer.serialize);
   },
 
-  getStudent() {}
+  getStudent(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+
+    return usecases.getUserStudent({ userId: authenticatedUserId })
+      .then(studentSerializer.serialize);
+  }
 };

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -10,6 +10,7 @@ class Campaign {
     createdAt,
     organizationLogoUrl,
     customLandingPageText,
+    isRestricted = false,
     // includes
     targetProfile,
     campaignReport,
@@ -28,6 +29,7 @@ class Campaign {
     this.createdAt = createdAt;
     this.organizationLogoUrl = organizationLogoUrl;
     this.customLandingPageText = customLandingPageText;
+    this.isRestricted = isRestricted;
     // includes
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;

--- a/api/lib/domain/models/Student.js
+++ b/api/lib/domain/models/Student.js
@@ -20,6 +20,7 @@ class Student {
     // includes
     organization,
     // references
+    userId,
   } = {}) {
     this.id = id;
     // attributes
@@ -40,6 +41,7 @@ class Student {
     // includes
     this.organization = organization;
     // references
+    this.userId = userId;
   }
 }
 

--- a/api/lib/domain/usecases/get-student-linked-to-user.js
+++ b/api/lib/domain/usecases/get-student-linked-to-user.js
@@ -1,0 +1,6 @@
+module.exports = async function getStudentLinkedToUser({
+  userId,
+  studentRepository,
+}) {
+  return await studentRepository.getByUserId({ userId });
+};

--- a/api/lib/domain/usecases/get-user-student.js
+++ b/api/lib/domain/usecases/get-user-student.js
@@ -1,6 +1,0 @@
-module.exports = async function linkUserToOrganizationStudentData({
-  userId,
-  studentRepository,
-}) {
-  return 0;
-};

--- a/api/lib/domain/usecases/get-user-student.js
+++ b/api/lib/domain/usecases/get-user-student.js
@@ -1,0 +1,6 @@
+module.exports = async function linkUserToOrganizationStudentData({
+  userId,
+  studentRepository,
+}) {
+  return 0;
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -121,6 +121,7 @@ module.exports = injectDependencies({
   getUserWithMemberships: require('./get-user-with-memberships'),
   importCertificationCandidatesFromAttendanceSheet: require('./import-certification-candidates-from-attendance-sheet'),
   importStudentsFromSIECLE: require('./import-students-from-siecle'),
+  linkUserToOrganizationStudentData: require('./link-user-to-organization-student-data'),
   parseCertificationsDataFromAttendanceSheet: require('./parse-certifications-data-from-attendance-sheet'),
   preloadCacheEntries: require('./preload-cache-entries'),
   reloadCacheEntry: require('./reload-cache-entry'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -118,7 +118,7 @@ module.exports = injectDependencies({
   getUserCurrentCertificationProfile: require('./get-user-current-certification-profile'),
   getUserPixScore: require('./get-user-pix-score'),
   getUserScorecards: require('./get-user-scorecards'),
-  getUserStudent: require('./get-user-student'),
+  getStudentLinkedToUser: require('./get-student-linked-to-user'),
   getUserWithMemberships: require('./get-user-with-memberships'),
   importCertificationCandidatesFromAttendanceSheet: require('./import-certification-candidates-from-attendance-sheet'),
   importStudentsFromSIECLE: require('./import-students-from-siecle'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -118,6 +118,7 @@ module.exports = injectDependencies({
   getUserCurrentCertificationProfile: require('./get-user-current-certification-profile'),
   getUserPixScore: require('./get-user-pix-score'),
   getUserScorecards: require('./get-user-scorecards'),
+  getUserStudent: require('./get-user-student'),
   getUserWithMemberships: require('./get-user-with-memberships'),
   importCertificationCandidatesFromAttendanceSheet: require('./import-certification-candidates-from-attendance-sheet'),
   importStudentsFromSIECLE: require('./import-students-from-siecle'),

--- a/api/lib/domain/usecases/link-user-to-organization-student-data.js
+++ b/api/lib/domain/usecases/link-user-to-organization-student-data.js
@@ -1,0 +1,31 @@
+const { NotFoundError, UserNotAuthorizedToAccessEntity } = require('../../domain/errors');
+
+module.exports = async function linkUserToOrganizationStudentData({
+  campaignCode,
+  user,
+  campaignRepository,
+  studentRepository,
+}) {
+  let student;
+  const campaign = await campaignRepository.getByCode(campaignCode);
+  const organizationId = campaign.organizationId;
+
+  if (user.id === null) {
+    throw new UserNotAuthorizedToAccessEntity('User is not part of the organization student list');
+  }
+
+  const students = await studentRepository.findByOrganizationIdAndUserInformation({
+    organizationId,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthdate: user.birthdate,
+  });
+
+  if (students.length === 1) {
+    student = students[0];
+  } else {
+    throw new NotFoundError('Not found only 1 student');
+  }
+
+  return await studentRepository.associateUserAndStudent({ userId: user.id, studentId: student.id });
+};

--- a/api/lib/domain/usecases/retrieve-campaign-information.js
+++ b/api/lib/domain/usecases/retrieve-campaign-information.js
@@ -1,12 +1,9 @@
-const { NotFoundError, UserNotAuthorizedToAccessEntity } = require('../../domain/errors');
+const { NotFoundError } = require('../../domain/errors');
 
 module.exports = async function retrieveCampaignInformation({
   code,
-  userId,
   campaignRepository,
   organizationRepository,
-  studentRepository,
-  userRepository,
 }) {
   const foundCampaign = await campaignRepository.getByCode(code);
   if (foundCampaign === null) {
@@ -17,18 +14,8 @@ module.exports = async function retrieveCampaignInformation({
   const foundOrganization = await organizationRepository.get(organizationId);
   foundCampaign.organizationLogoUrl = foundOrganization.logoUrl;
 
-  if (foundOrganization.isManagingStudents) {
-    if (userId === null) {
-      throw new UserNotAuthorizedToAccessEntity('User is not part of the organization student list');
-    }
-    const user = await userRepository.get(userId);
-    const userIsPartOfOrganizationStudentList = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-      user,
-      organizationId
-    });
-    if (!userIsPartOfOrganizationStudentList) {
-      throw new UserNotAuthorizedToAccessEntity('User is not part of the organization student list');
-    }
+  if (foundOrganization.isManagingStudents && foundOrganization.type === 'SCO') {
+    foundCampaign.isRestricted = true;
   }
 
   return foundCampaign;

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -76,7 +76,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult']);
+    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted']);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -28,12 +28,13 @@ module.exports = {
     return Bookshelf.knex.batchInsert('students', bookshelfStudents).then(() => undefined);
   },
 
-  findByOrganizationIdAndUserFirstNameLastName({ organizationId, firstName, lastName }) {
+  findByOrganizationIdAndUserInformation({ organizationId, firstName, lastName, birthdate }) {
     return BookshelfStudent
       .query((qb) => {
         qb.where('organizationId', organizationId);
         qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??), LOWER(??))', [firstName, 'firstName', 'middleName', 'thirdName']);
         qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??))', [lastName, 'lastName', 'preferredLastName']);
+        qb.where('birthdate', birthdate);
       })
       .fetchAll()
       .then((students) => bookshelfToDomainConverter.buildDomainObjects(BookshelfStudent, students));

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -50,6 +50,9 @@ module.exports = {
   },
 
   getByUserId({ userId }) {
-
+    return BookshelfStudent
+      .where({ userId })
+      .fetch()
+      .then((student) => bookshelfToDomainConverter.buildDomainObject(BookshelfStudent, student));
   }
 };

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -32,6 +32,7 @@ module.exports = {
     return BookshelfStudent
       .query((qb) => {
         qb.where('organizationId', organizationId);
+        qb.whereNull('userId');
         qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??), LOWER(??))', [firstName, 'firstName', 'middleName', 'thirdName']);
         qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??))', [lastName, 'lastName', 'preferredLastName']);
         qb.where('birthdate', birthdate);

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -48,4 +48,8 @@ module.exports = {
       })
       .then((student) => bookshelfToDomainConverter.buildDomainObject(BookshelfStudent, student));
   },
+
+  getByUserId({ userId }) {
+
+  }
 };

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -28,17 +28,14 @@ module.exports = {
     return Bookshelf.knex.batchInsert('students', bookshelfStudents).then(() => undefined);
   },
 
-  isThereAtLeastOneMatchForTheUserInStudentList({ user, organizationId }) {
+  findByOrganizationIdAndUserFirstNameLastName({ organizationId, firstName, lastName }) {
     return BookshelfStudent
       .query((qb) => {
         qb.where('organizationId', organizationId);
-        qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??), LOWER(??))', [user.firstName, 'firstName', 'middleName', 'thirdName']);
-        qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??))', [user.lastName, 'lastName', 'preferredLastName']);
-        qb.count();
+        qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??), LOWER(??))', [firstName, 'firstName', 'middleName', 'thirdName']);
+        qb.whereRaw('LOWER(?) in (LOWER(??), LOWER(??))', [lastName, 'lastName', 'preferredLastName']);
       })
-      .fetch()
-      .then((countStudents) => {
-        return parseInt(countStudents.attributes.count) === 1;
-      });
-  }
+      .fetchAll()
+      .then((students) => bookshelfToDomainConverter.buildDomainObjects(BookshelfStudent, students));
+  },
 };

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -38,4 +38,13 @@ module.exports = {
       .fetchAll()
       .then((students) => bookshelfToDomainConverter.buildDomainObjects(BookshelfStudent, students));
   },
+
+  associateUserAndStudent({ userId, studentId }) {
+    return BookshelfStudent
+      .where({ id: studentId })
+      .save({ userId }, {
+        patch: true,
+      })
+      .then((student) => bookshelfToDomainConverter.buildDomainObject(BookshelfStudent, student));
+  },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
   serialize(campaigns, { tokenForCampaignResults, ignoreCampaignReportRelationshipData = true } = {}) {
 
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult'],
+      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted'],
       transform: (record) => {
         const campaign = Object.assign({}, record);
         campaign.tokenForCampaignResults = tokenForCampaignResults;

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -27,6 +27,7 @@ module.exports = [
   require('./application/simulateErrors'),
   require('./application/progressions'),
   require('./application/snapshots'),
+  require('./application/student-user-associations'),
   require('./application/system'),
   require('./application/users'),
 ];

--- a/api/tests/acceptance/application/student-user-association-controller_test.js
+++ b/api/tests/acceptance/application/student-user-association-controller_test.js
@@ -1,0 +1,111 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const createServer = require('../../../server');
+
+describe('Acceptance | Controller | Student-user-associations', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('POST /api/student-user-associations', () => {
+    let organization;
+    let campaign;
+    let options;
+    let student;
+    let user;
+
+    beforeEach(async () => {
+      // given
+      options = {
+        method: 'POST',
+        url: '/api/student-user-associations',
+        headers: {},
+        payload: {}
+      };
+
+      user = databaseBuilder.factory.buildUser();
+      organization = databaseBuilder.factory.buildOrganization();
+      student = databaseBuilder.factory.buildStudent({ organizationId: organization.id, userId: null });
+      campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      return databaseBuilder.clean();
+    });
+
+    it('should return an 204 status after successfully associate user to student', async () => {
+      // given
+      options.headers.authorization = generateValidRequestAuthorizationHeader(user.id);
+      options.payload.data = {
+        attributes: {
+          'campaign-code': campaign.code,
+          'first-name': student.firstName,
+          'last-name': student.lastName,
+          'birthdate': student.birthdate
+        }
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return an 404 NotFoundError error if we don’t find a student to associate', async () => {
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/student-user-associations',
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        payload: {
+          data: {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': 'wrong fristName',
+              'last-name': 'wrong lastName',
+              'birthdate': '1990-03-01'
+            }
+          }
+        }
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+      expect(response.result.errors[0].detail).to.equal('Not found only 1 student');
+    });
+
+    it('should return an 403 UserNotAuthorizedToAccessEntity error if user is not connected', async () => {
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/student-user-associations',
+        headers: { authorization: generateValidRequestAuthorizationHeader(null) },
+        payload: {
+          data: {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': student.firstName,
+              'last-name': student.lastName,
+              'birthdate': student.birthdate
+            }
+          }
+        }
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result.errors[0].detail).to.equal('Utilisateur non autorisé à accéder à la ressource');
+    });
+  });
+});

--- a/api/tests/acceptance/application/student-user-association-controller_test.js
+++ b/api/tests/acceptance/application/student-user-association-controller_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | Controller | Student-user-associations', () => {
       return databaseBuilder.clean();
     });
 
-    it('should return an 204 status after successfully associate user to student', async () => {
+    it('should return an 204 status after having successfully associated user to student', async () => {
       // given
       options.headers.authorization = generateValidRequestAuthorizationHeader(user.id);
       options.payload.data = {

--- a/api/tests/acceptance/application/users/users-controller-get-student_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-student_test.js
@@ -7,7 +7,7 @@ describe('Acceptance | Controller | users-controller-get-user-student', () => {
   let options;
   let server;
   let user;
-  let userWithOutStudent;
+  let userWithoutStudent;
   let organization;
   let student;
 
@@ -16,7 +16,7 @@ describe('Acceptance | Controller | users-controller-get-user-student', () => {
 
     organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
     user = databaseBuilder.factory.buildUser();
-    userWithOutStudent = databaseBuilder.factory.buildUser();
+    userWithoutStudent = databaseBuilder.factory.buildUser();
     student = databaseBuilder.factory.buildStudent({ organizationId: organization.id, userId: user.id });
     await databaseBuilder.commit();
     options = {
@@ -79,9 +79,9 @@ describe('Acceptance | Controller | users-controller-get-user-student', () => {
         // given
         options = {
           method: 'GET',
-          url: '/api/users/' + userWithOutStudent.id + '/student',
+          url: '/api/users/' + userWithoutStudent.id + '/student',
           payload: {},
-          headers: { authorization: generateValidRequestAuthorizationHeader(userWithOutStudent.id) },
+          headers: { authorization: generateValidRequestAuthorizationHeader(userWithoutStudent.id) },
         };
 
         // when

--- a/api/tests/acceptance/application/users/users-controller-get-student_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-student_test.js
@@ -1,0 +1,95 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-get-user-student', () => {
+
+  let options;
+  let server;
+  let user;
+  let userWithOutStudent;
+  let organization;
+  let student;
+
+  beforeEach(async () => {
+    server = await createServer();
+
+    organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
+    user = databaseBuilder.factory.buildUser();
+    userWithOutStudent = databaseBuilder.factory.buildUser();
+    student = databaseBuilder.factory.buildStudent({ organizationId: organization.id, userId: user.id });
+    await databaseBuilder.commit();
+    options = {
+      method: 'GET',
+      url: '/api/users/' + user.id + '/student',
+      payload: {},
+      headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+    };
+  });
+
+  afterEach(async () => {
+    await databaseBuilder.clean();
+  });
+
+  describe('GET /users/:id/student', () => {
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should respond with a 403 - forbidden access - if requested user is not the same as authenticated user', async () => {
+        // given
+        const otherUserId = 9999;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('Success case', () => {
+
+      it('should return the student linked to the user and a 200 status code response ', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.attributes['first-name']).to.deep.equal(student.firstName);
+        expect(response.result.data.attributes['last-name']).to.deep.equal(student.lastName);
+        expect(response.result.data.attributes['birthdate']).to.deep.equal(student.birthdate);
+      });
+    });
+
+    describe('There is no student linked to the user', () => {
+
+      it('should return a data null', async () => {
+        // given
+        options = {
+          method: 'GET',
+          url: '/api/users/' + userWithOutStudent.id + '/student',
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(userWithOutStudent.id) },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.result.data).to.equal(null);
+      });
+    });
+  });
+});

--- a/api/tests/integration/application/student-user-associations/index_test.js
+++ b/api/tests/integration/application/student-user-associations/index_test.js
@@ -1,0 +1,35 @@
+const { expect, sinon } = require('../../../test-helper');
+const Hapi = require('hapi');
+const studentUserAssociationController = require('../../../../lib/application/student-user-associations/student-user-association-controller');
+
+describe('Integration | Application | Route | student-user-associations', () => {
+  let server;
+
+  beforeEach(() => {
+    sinon.stub(studentUserAssociationController, 'associate').callsFake((request, h) => h.response('ok').code(201));
+    server = Hapi.server();
+    return server.register(require('../../../../lib/application/student-user-associations'));
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  describe('POST /api/student-user-associations', () => {
+
+    it('should exist', () => {
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(201);
+      });
+
+    });
+
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -401,10 +401,45 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
       const fakeUserId = 1;
 
       // when
-      const error = await catchErr(studentRepository.associateUserAndStudent)({ userId: fakeUserId, studentId: student.id });
+      const error = await catchErr(studentRepository.associateUserAndStudent)({
+        userId: fakeUserId,
+        studentId: student.id
+      });
 
       // then
       expect(error.detail).to.be.equal(`Key (userId)=(${fakeUserId}) is not present in table "users".`);
+    });
+  });
+
+  describe('#getByUserId', () => {
+
+    it('should return instance of Student linked to the given userId', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildStudent({ organizationId: organization.id, userId, });
+
+      await databaseBuilder.commit();
+
+      // when
+      const student = await studentRepository.getByUserId({ userId });
+
+      // then
+      expect(student).to.be.an.instanceOf(Student);
+      expect(student.userId).to.equal(userId);
+    });
+
+    it('should return null if there is no student linked to the given userId', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await studentRepository.getByUserId({ userId });
+
+      // then
+      expect(result).to.equal(null);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -173,7 +173,7 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
     });
   });
 
-  describe('#findByOrganizationIdAndUserFirstNameLastName', () => {
+  describe('#findByOrganizationIdAndUserInformation', () => {
 
     afterEach(async () => {
       await knex('students').delete();
@@ -194,18 +194,19 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
           firstName: 'Stanley',
           middleName: 'Martin',
           thirdName: 'Stan',
+          birthdate: '2000-03-31',
         });
         await databaseBuilder.commit();
       });
 
       for (const [description, user] of [
-        ['should match on couple firstName and lastName and return the student', { firstName: 'Stanley', lastName: 'Lieber' }],
-        ['should match on couple firstName and preferredLastName and return the student', { firstName: 'Stanley', lastName: 'Lee' }],
-        ['should match on couple middleName and lastName and return the student', { firstName: 'Martin', lastName: 'Lieber' }],
-        ['should match on couple middleName and preferredLastName and return the student', { firstName: 'Martin', lastName: 'Lee' }],
-        ['should match on couple thirdName and lastName and return the student', { firstName: 'Stan', lastName: 'Lieber' }],
-        ['should match on couple thirdName and preferredLastName and return the student', { firstName: 'Stan', lastName: 'Lee' }],
-        ['should match indifferently of low/upper case and return the student', { firstName: 'STAN', lastName: 'LEE' }],
+        ['should match on couple firstName and lastName and return the student', { firstName: 'Stanley', lastName: 'Lieber', birthdate: '2000-03-31' }],
+        ['should match on couple firstName and preferredLastName and return the student', { firstName: 'Stanley', lastName: 'Lee', birthdate: '2000-03-31' }],
+        ['should match on couple middleName and lastName and return the student', { firstName: 'Martin', lastName: 'Lieber', birthdate: '2000-03-31' }],
+        ['should match on couple middleName and preferredLastName and return the student', { firstName: 'Martin', lastName: 'Lee', birthdate: '2000-03-31' }],
+        ['should match on couple thirdName and lastName and return the student', { firstName: 'Stan', lastName: 'Lieber', birthdate: '2000-03-31' }],
+        ['should match on couple thirdName and preferredLastName and return the student', { firstName: 'Stan', lastName: 'Lee', birthdate: '2000-03-31' }],
+        ['should match indifferently of low/upper case and return the student', { firstName: 'STAN', lastName: 'LEE', birthdate: '2000-03-31' }],
       ]) {
         it(description, async () => {
           // when
@@ -222,6 +223,20 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
       it('should return an empty list if there is one or more spelling mistake in user information', async () => {
         // given
         const user = { firstName: 'Sttan', lastName: 'Lees', birthdate: '2000-03-31' };
+
+        // when
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
+        });
+
+        // then
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(0);
+      });
+
+      it('should return an error if birthdate in user information does not match', async () => {
+        // given
+        const user = { firstName: 'Stan', lastName: 'Lee', birthdate: '2001-06-01' };
 
         // when
         const result = await studentRepository.findByOrganizationIdAndUserInformation({
@@ -250,6 +265,7 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
           firstName: 'Stanley',
           middleName: 'Martin',
           thirdName: 'Stan',
+          birthdate: '2000-03-31',
         });
         databaseBuilder.factory.buildStudent({
           organizationId: badOrganization.id,
@@ -259,6 +275,7 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
           firstName: 'Jacob',
           middleName: 'Jack',
           thirdName: 'The King of comic book',
+          birthdate: '2000-08-07',
         });
         await databaseBuilder.commit();
       });
@@ -305,6 +322,7 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
           firstName: 'Stanley',
           middleName: 'Martin',
           thirdName: 'Stan',
+          birthdate: '2000-03-31',
         });
         databaseBuilder.factory.buildStudent({
           organizationId: organization.id,
@@ -314,13 +332,14 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
           firstName: 'The second',
           middleName: 'Another one',
           thirdName: 'Stan',
+          birthdate: '2000-03-31',
         });
         await databaseBuilder.commit();
       });
 
       it('should return a list of all matching students', async () => {
         // given
-        const user = { firstName: 'Stan', lastName: 'Lee' };
+        const user = { firstName: 'Stan', lastName: 'Lee', birthdate: '2000-03-31' };
 
         // when
         const result = await studentRepository.findByOrganizationIdAndUserInformation({

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -173,7 +173,7 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
     });
   });
 
-  describe('#isThereAtLeastOneMatchForTheUserInStudentList', () => {
+  describe('#findByOrganizationIdAndUserFirstNameLastName', () => {
 
     afterEach(async () => {
       await knex('students').delete();
@@ -199,38 +199,38 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
       });
 
       for (const [description, user] of [
-        ['should match on couple firstName and lastName', { firstName: 'Stanley', lastName: 'Lieber' }],
-        ['should match on couple firstName and preferredLastName', { firstName: 'Stanley', lastName: 'Lee' }],
-        ['should match on couple middleName and lastName', { firstName: 'Martin', lastName: 'Lieber' }],
-        ['should match on couple middleName and preferredLastName', { firstName: 'Martin', lastName: 'Lee' }],
-        ['should match on couple thirdName and lastName', { firstName: 'Stan', lastName: 'Lieber' }],
-        ['should match on couple thirdName and preferredLastName', { firstName: 'Stan', lastName: 'Lee' }],
-        ['should match indifferently of low/upper case', { firstName: 'STAN', lastName: 'LEE' }],
+        ['should match on couple firstName and lastName and return the student', { firstName: 'Stanley', lastName: 'Lieber' }],
+        ['should match on couple firstName and preferredLastName and return the student', { firstName: 'Stanley', lastName: 'Lee' }],
+        ['should match on couple middleName and lastName and return the student', { firstName: 'Martin', lastName: 'Lieber' }],
+        ['should match on couple middleName and preferredLastName and return the student', { firstName: 'Martin', lastName: 'Lee' }],
+        ['should match on couple thirdName and lastName and return the student', { firstName: 'Stan', lastName: 'Lieber' }],
+        ['should match on couple thirdName and preferredLastName and return the student', { firstName: 'Stan', lastName: 'Lee' }],
+        ['should match indifferently of low/upper case and return the student', { firstName: 'STAN', lastName: 'LEE' }],
       ]) {
         it(description, async () => {
           // when
-          const result = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-            user,
-            organizationId: organization.id
+          const students = await studentRepository.findByOrganizationIdAndUserInformation({
+            organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
           });
 
           // then
-          expect(result).to.be.true;
+          expect(students.length).to.be.equal(1);
+          expect(students[0]).to.be.instanceof(Student);
         });
       }
 
-      it('should return false if there is one or more spelling mistake in user information', async () => {
+      it('should return an empty list if there is one or more spelling mistake in user information', async () => {
         // given
-        const user = { firstName: 'Sttan', lastName: 'Lees' };
+        const user = { firstName: 'Sttan', lastName: 'Lees', birthdate: '2000-03-31' };
 
         // when
-        const result = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-          user,
-          organizationId: organization.id
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
         });
 
         // then
-        expect(result).to.be.false;
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(0);
       });
     });
 
@@ -263,31 +263,31 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
         await databaseBuilder.commit();
       });
 
-      it('should return false, wrong user on right organization', async () => {
+      it('should return an empty list, wrong user on right organization', async () => {
         // given
-        const user = { firstName: 'Bob', lastName: 'Kane' };
+        const user = { firstName: 'Bob', lastName: 'Kane', birthdate: '2000-08-07' };
 
         // when
-        const result = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-          user,
-          organizationId: organization.id
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
         });
 
         // then
-        expect(result).to.be.false;
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(0);
       });
 
-      it('should return false, right user on wrong organization ', async () => {
-        const user = { firstName: 'Stan', lastName: 'Lee' };
+      it('should return an empty list, right user on wrong organization ', async () => {
+        const user = { firstName: 'Stan', lastName: 'Lee', birthdate: '2000-03-31' };
 
         // when
-        const result = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-          user,
-          organizationId: badOrganization.id
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: badOrganization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
         });
 
         // then
-        expect(result).to.be.false;
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(0);
       });
     });
 
@@ -318,18 +318,18 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
         await databaseBuilder.commit();
       });
 
-      it('should return false, even if user in part of the organization', async () => {
+      it('should return a list of all matching students', async () => {
         // given
         const user = { firstName: 'Stan', lastName: 'Lee' };
 
         // when
-        const result = await studentRepository.isThereAtLeastOneMatchForTheUserInStudentList({
-          user,
-          organizationId: organization.id
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
         });
 
         // then
-        expect(result).to.be.false;
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(2);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -351,6 +351,42 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
         expect(result.length).to.be.equal(2);
       });
     });
+
+    context('All the student are already associate', () => {
+
+      let organization;
+      let user;
+
+      beforeEach(async () => {
+        organization = databaseBuilder.factory.buildOrganization();
+        user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildStudent({
+          organizationId: organization.id,
+          userId: user.id,
+          preferredLastName: 'Lee',
+          lastName: 'Lieber',
+          firstName: 'Stanley',
+          middleName: 'Martin',
+          thirdName: 'Stan',
+          birthdate: '2000-03-31',
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('should return a list of all matching students', async () => {
+        // given
+        const user = { firstName: 'Stan', lastName: 'Lee', birthdate: '2000-03-31' };
+
+        // when
+        const result = await studentRepository.findByOrganizationIdAndUserInformation({
+          organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, birthdate: user.birthdate
+        });
+
+        // then
+        expect(result).to.be.an('array');
+        expect(result.length).to.be.equal(0);
+      });
+    });
   });
 
   describe('#associateUserAndStudent', () => {

--- a/api/tests/tooling/domain-builder/factory/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign.js
@@ -15,6 +15,7 @@ module.exports = function buildCampaign(
     organizationId = faker.random.number(2),
     targetProfileId = faker.random.number(2),
     targetProfile = buildTargetProfile({ id: targetProfileId }),
+    isRestricted = false,
     organizationLogoUrl
   } = {}) {
   return new Campaign({
@@ -29,6 +30,7 @@ module.exports = function buildCampaign(
     organizationId,
     targetProfileId,
     targetProfile,
+    isRestricted,
     organizationLogoUrl
   });
 };

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -10,7 +10,6 @@ const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Application | Controller | Campaign', () => {
 
@@ -124,14 +123,12 @@ describe('Unit | Application | Controller | Campaign', () => {
 
     let request;
     const campaignCode = 'AZERTY123';
-    const userId = 1;
     const createdCampaign = domainBuilder.buildCampaign();
 
     beforeEach(() => {
       request = {
         query: { 'filter[code]': campaignCode }
       };
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userId);
       sinon.stub(usecases, 'retrieveCampaignInformation');
       sinon.stub(campaignSerializer, 'serialize');
     });
@@ -147,7 +144,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       await campaignController.getByCode(request, hFake);
 
       // then
-      expect(usecases.retrieveCampaignInformation).to.have.been.calledWith({ code: campaignCode, userId });
+      expect(usecases.retrieveCampaignInformation).to.have.been.calledWith({ code: campaignCode });
     });
 
     it('should return the serialized campaign found by the use case', async () => {

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -255,4 +255,27 @@ describe('Unit | Router | user-router', () => {
       });
     });
   });
+
+  describe('GET /api/users/{id}/student', () => {
+    beforeEach(() => {
+      sinon.stub(userController, 'getStudent').returns('ok');
+      sinon.stub(securityController, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      startServer();
+    });
+
+    it('should exist', () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/users/42/student',
+      };
+
+      // when
+      return server.inject(options).then(() => {
+        // then
+        sinon.assert.calledOnce(userController.getStudent);
+      });
+
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -571,7 +571,7 @@ describe('Unit | Controller | user-controller', () => {
   describe('#getStudent', () => {
 
     beforeEach(() => {
-      sinon.stub(usecases, 'getUserStudent').resolves({ userId: 1 });
+      sinon.stub(usecases, 'getStudentLinkedToUser').resolves({ userId: 1 });
       sinon.stub(studentSerializer, 'serialize').resolves();
     });
 
@@ -594,7 +594,7 @@ describe('Unit | Controller | user-controller', () => {
       await userController.getStudent(request);
 
       // then
-      expect(usecases.getUserStudent).to.have.been.calledWith({ userId });
+      expect(usecases.getStudentLinkedToUser).to.have.been.calledWith({ userId });
     });
   });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -17,6 +17,7 @@ const campaignParticipationSerializer = require('../../../../lib/infrastructure/
 const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const membershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/membership-serializer');
 const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
+const studentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-serializer');
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 
@@ -120,7 +121,11 @@ describe('Unit | Controller | user-controller', () => {
     it('should update password', async () => {
       // given
       userSerializer.deserialize.withArgs(payload).returns({ password: userPassword, temporaryKey: userTemporaryKey });
-      usecases.updateUserPassword.withArgs({ userId, password: userPassword, temporaryKey: userTemporaryKey }).resolves({});
+      usecases.updateUserPassword.withArgs({
+        userId,
+        password: userPassword,
+        temporaryKey: userTemporaryKey
+      }).resolves({});
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
@@ -501,7 +506,7 @@ describe('Unit | Controller | user-controller', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'getUserScorecards').resolves({
-        name:'Comp1',
+        name: 'Comp1',
       });
       sinon.stub(scorecardSerializer, 'serialize').resolves();
     });
@@ -533,7 +538,7 @@ describe('Unit | Controller | user-controller', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'resetScorecard').resolves({
-        name:'Comp1',
+        name: 'Comp1',
       });
       sinon.stub(scorecardSerializer, 'serialize').resolves();
     });
@@ -560,6 +565,36 @@ describe('Unit | Controller | user-controller', () => {
 
       // then
       expect(usecases.resetScorecard).to.have.been.calledWith({ userId, competenceId });
+    });
+  });
+
+  describe('#getStudent', () => {
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getUserStudent').resolves({ userId: 1 });
+      sinon.stub(studentSerializer, 'serialize').resolves();
+    });
+
+    it('should call the expected usecase', async () => {
+      // given
+      const userId = 1;
+
+      const request = {
+        auth: {
+          credentials: {
+            userId
+          }
+        },
+        params: {
+          id: userId
+        }
+      };
+
+      // when
+      await userController.getStudent(request);
+
+      // then
+      expect(usecases.getUserStudent).to.have.been.calledWith({ userId });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-student-linked-to-user_test.js
+++ b/api/tests/unit/domain/usecases/get-student-linked-to-user_test.js
@@ -1,0 +1,62 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const Student = require('../../../../lib/domain/models/Student');
+const studentRepository = require('../../../../lib/infrastructure/repositories/student-repository');
+
+describe('Unit | UseCase | get-student-linked-to-user', () => {
+
+  const userId = 1;
+  let studentReceivedStub;
+  let student;
+  const organizationId = 1;
+
+  beforeEach(() => {
+    student = domainBuilder.buildStudent({ organizationId, userId });
+
+    studentReceivedStub = sinon.stub(studentRepository, 'getByUserId');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('There is a student linked to the given userId', () => {
+
+    it('should call getByUserId in student repositories', async () => {
+      // given
+      studentReceivedStub.resolves({});
+
+      // when
+      await usecases.getStudentLinkedToUser({ userId });
+
+      // then
+      expect(studentReceivedStub).have.been.calledOnce;
+    });
+
+    it('should return the student', async () => {
+      // given
+      studentReceivedStub.withArgs({ userId }).resolves(student);
+      
+      // when
+      const result = await usecases.getStudentLinkedToUser({ userId });
+
+      // then
+      expect(result).to.be.deep.equal(student);
+      expect(result).to.be.instanceof(Student);
+    });
+  });
+
+  describe('There is no student linked to the given userId', () => {
+
+    it('should return the repositories error', async () => {
+      // given
+      studentReceivedStub.withArgs({ userId }).resolves(null);
+
+      // when
+      const result = await usecases.getStudentLinkedToUser({ userId });
+
+      // then
+      expect(result).to.to.equal(null);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/link-user-to-organization-student-data_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-organization-student-data_test.js
@@ -29,11 +29,12 @@ describe('Unit | UseCase | link-user-to-organization-student-data', () => {
       .withArgs(campaignCode)
       .resolves({ organizationId });
 
-    findStudentStub = sinon.stub(studentRepository, 'findByOrganizationIdAndUserFirstNameLastName')
+    findStudentStub = sinon.stub(studentRepository, 'findByOrganizationIdAndUserInformation')
       .withArgs({
         organizationId,
         firstName: user.firstName,
-        lastName: user.lastName
+        lastName: user.lastName,
+        birthdate: user.birthdate
       }).resolves([student]);
 
     associateUserAndStudentStub = sinon.stub(studentRepository, 'associateUserAndStudent');

--- a/api/tests/unit/domain/usecases/link-user-to-organization-student-data_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-organization-student-data_test.js
@@ -1,0 +1,114 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const Student = require('../../../../lib/domain/models/Student');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+const studentRepository = require('../../../../lib/infrastructure/repositories/student-repository');
+const { UserNotAuthorizedToAccessEntity, NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | link-user-to-organization-student-data', () => {
+
+  let associateUserAndStudentStub;
+  let campaignCode;
+  let findStudentStub;
+  let student;
+  let user;
+  const organizationId = 1;
+  const studentId = 1;
+
+  beforeEach(() => {
+    campaignCode = 'ABCD12';
+    student = domainBuilder.buildStudent({ organizationId, id: studentId });
+    user = {
+      id: 1,
+      firstName: 'Joe',
+      lastName: 'Poe',
+      birthdate: '02/02/1992',
+    };
+
+    sinon.stub(campaignRepository, 'getByCode')
+      .withArgs(campaignCode)
+      .resolves({ organizationId });
+
+    findStudentStub = sinon.stub(studentRepository, 'findByOrganizationIdAndUserFirstNameLastName')
+      .withArgs({
+        organizationId,
+        firstName: user.firstName,
+        lastName: user.lastName
+      }).resolves([student]);
+
+    associateUserAndStudentStub = sinon.stub(studentRepository, 'associateUserAndStudent');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  context('User is not connected', () => {
+    it('should throw an error', async () => {
+      // given
+      user.id = null;
+
+      // when
+      try {
+        await usecases.linkUserToOrganizationStudentData({
+          user,
+          campaignCode,
+        });
+        throw new Error('expected error');
+      } catch (err) {
+        // then
+        expect(err).to.be.instanceof(UserNotAuthorizedToAccessEntity);
+      }
+    });
+  });
+
+  context('User is connected', () => {
+
+    it('should check if user is part of the student list and associate user and matching organization student', async () => {
+      // given
+      student.userId  = user.id;
+      associateUserAndStudentStub.withArgs({ userId: user.id, studentId }).resolves(student);
+
+      // when
+      await usecases.linkUserToOrganizationStudentData({
+        user,
+        campaignCode,
+      });
+
+      // then
+      expect(findStudentStub).have.been.calledOnce;
+      expect(associateUserAndStudentStub).have.been.calledOnce;
+    });
+
+    it('should resolve if student was patched', async () => {
+      // given
+      student.userId  = user.id;
+      associateUserAndStudentStub.withArgs({ userId: user.id, studentId }).resolves(student);
+
+      // when
+      const result = await usecases.linkUserToOrganizationStudentData({
+        user,
+        campaignCode,
+      });
+
+      // then
+      expect(result).to.be.instanceof(Student);
+      expect(result.userId).to.be.equal(user.id);
+    });
+
+    it('should throw an 401 error, when we don’t find student to associate in organization list', async () => {
+      // given
+      findStudentStub.rejects(new NotFoundError('test error'));
+
+      // when
+      const result = await catchErr(usecases.linkUserToOrganizationStudentData)({
+        user,
+        campaignCode,
+      });
+
+      // then
+      expect(result).to.be.instanceof(NotFoundError);
+      expect(result.message).to.equal('test error');
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/retrieve-campaign-information_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-campaign-information_test.js
@@ -1,29 +1,24 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
+const Campaign = require('../../../../lib/domain/models/Campaign');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
-const studentRepository = require('../../../../lib/infrastructure/repositories/student-repository');
-const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
-const { NotFoundError, UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | retrieve-campaign-information', () => {
 
+  let campaign;
   let campaignRepoStub;
   let orgaRepoStub;
-  let studentRepoStub;
-  let userRepoStub;
   const organizationId = 'organizationId';
-  const organization = { id: organizationId, logoUrl: 'a logo url' };
-  const campaign = { id: 'campaignId', organizationId };
+  const organization = { id: organizationId, logoUrl: 'a logo url', type: 'SCO' };
   const campaignCode = 'QWERTY123';
-  const augmentedCampaign = Object.assign({}, campaign, { organizationLogoUrl: organization.logoUrl });
   const user = { id: 1, firstName: 'John', lastName: 'Snow' };
 
   beforeEach(() => {
+    campaign = domainBuilder.buildCampaign({ id: 'campaignId', organizationId });
     campaignRepoStub = sinon.stub(campaignRepository, 'getByCode');
     orgaRepoStub = sinon.stub(organizationRepository, 'get').resolves(organization);
-    studentRepoStub = sinon.stub(studentRepository, 'isThereAtLeastOneMatchForTheUserInStudentList');
-    userRepoStub = sinon.stub(userRepository, 'get').withArgs(user.id).resolves(user);
   });
 
   afterEach(() => {
@@ -56,7 +51,7 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
 
     it('should return the campaign ', async () => {
       // when
-      const result = await usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
+      const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
       // then
       expect(campaignRepository.getByCode).to.have.been.calledWithExactly(campaignCode);
@@ -67,10 +62,11 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
 
       it('should return the same campaign with adding the organization logo url', async () => {
         // given
+        const augmentedCampaign = Object.assign({}, campaign, { organizationLogoUrl: organization.logoUrl });
         orgaRepoStub.resolves(organization);
 
         // when
-        const campaignRes = await usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
+        const campaignRes = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
         // then
         expect(campaignRes).to.be.deep.equal(augmentedCampaign);
@@ -82,56 +78,18 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
           orgaRepoStub.resolves(Object.assign(organization, { isManagingStudents: true }));
         });
 
-        it('should call isThereAtLeastOneMatchForTheUserInStudentList from student repository', async () => {
+        it('return a campaign with isRestricted equal true', async () => {
           // given
-          studentRepoStub.resolves(true);
 
           // when
-          await usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
+          const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
           // then
-          return expect(studentRepository.isThereAtLeastOneMatchForTheUserInStudentList).to.have.been.called;
+          expect(result).to.be.instanceof(Campaign);
+          expect(result.isRestricted).to.be.true;
+
         });
 
-        it('should resolve if user is part of the organization student list', async () => {
-          // given
-          studentRepoStub.resolves(true);
-
-          // when
-          const promise = usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
-
-          // then
-          return expect(promise).to.be.fulfilled;
-        });
-
-        it('should throw an error if user is not authorized to access ressource', () => {
-          // given
-          studentRepoStub.resolves(false);
-
-          // when
-          const promise = usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
-
-          // then
-          return expect(promise).to.be.rejected.then((error) => {
-            expect(error).to.be.an.instanceOf(UserNotAuthorizedToAccessEntity);
-          });
-        });
-
-        it('should throw an error if user is not connected', async () => {
-          // given
-          const userIdNull = null;
-          userRepoStub.withArgs(userIdNull).rejects(NotFoundError);
-
-          // when
-          try {
-            await usecases.retrieveCampaignInformation({ code: campaignCode, userId: userIdNull });
-          }
-
-          // then
-          catch (error) {
-            expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
-          }
-        });
       });
 
       context('Organization of the campaign is not managing student', () => {
@@ -140,20 +98,13 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
           orgaRepoStub.resolves(Object.assign(organization, { isManagingStudents: false }));
         });
 
-        it('should not called isThereAtLeastOneMatchForTheUserInStudentList method', async () => {
+        it('should resolve and return a campaign', async () => {
           // when
-          await usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
+          const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
           // then
-          return expect(studentRepository.isThereAtLeastOneMatchForTheUserInStudentList).to.not.have.been.called;
-        });
-
-        it('should return an error because organization is not managing students', async () => {
-          // when
-          const promise = usecases.retrieveCampaignInformation({ code: campaignCode, userId: user.id });
-
-          // then
-          return expect(promise).to.be.fulfilled;
+          expect(result).to.be.instanceof(Campaign);
+          expect(result.isRestricted).to.be.false;
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -39,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'id-pix-label': 'company id',
               'token-for-campaign-results': tokenToAccessToCampaign,
               'organization-logo-url': 'some logo',
+              'is-restricted': false,
             },
             relationships: {
               'target-profile': {
@@ -112,6 +113,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'id-pix-label': 'company id',
               'token-for-campaign-results': tokenToAccessToCampaign,
               'organization-logo-url': 'some logo',
+              'is-restricted': false,
             },
             relationships: {
               'target-profile': {

--- a/mon-pix/app/adapters/student.js
+++ b/mon-pix/app/adapters/student.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  urlForQueryRecord(query) {
+    const url = `${this.host}/${this.namespace}/users/${query.userId}/student`;
+    delete query.userId;
+    return url;
+  },
+});

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -1,0 +1,135 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+const ERROR_INPUT_MESSAGE_MAP = {
+  dayOfBirth: 'Votre jour de naissance n’est pas valide.',
+  monthOfBirth: 'Votre mois de naissance n’est pas valide.',
+  yearOfBirth: 'Votre année de naissance n’est pas valide.',
+};
+
+const validation = {
+  dayOfBirth: {
+    message: null
+  },
+  monthOfBirth: {
+    message: null
+  },
+  yearOfBirth: {
+    message: null
+  }
+};
+
+function _pad(num, size) {
+  let s = num + '';
+  while (s.length < size) s = '0' + s;
+  return s;
+}
+
+const isDayValid = (value) => value > 0 && value <= 31;
+const isMonthValid = (value) => value > 0 && value <= 12;
+const isYearValid = (value) => value > 999 && value <= 9999;
+
+export default Controller.extend({
+  store: service(),
+
+  firstName: '',
+  lastName: '',
+  dayOfBirth: '',
+  monthOfBirth: '',
+  yearOfBirth: '',
+  birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+    const monthOfBirth = _pad(this.monthOfBirth, 2);
+    const dayOfBirth = _pad(this.dayOfBirth, 2);
+    return [this.yearOfBirth, monthOfBirth, dayOfBirth].join('-');
+  }),
+
+  isFormNotValid: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+    return !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
+  }),
+
+  isLoading: false,
+  errorMessage: null,
+
+  init() {
+    this._super();
+    this.validation = validation;
+  },
+
+  actions: {
+    attemptNext() {
+      this.set('errorMessage', null);
+      this.set('isLoading', true);
+      this._validateInputDay('dayOfBirth', this.dayOfBirth);
+      this._validateInputMonth('monthOfBirth', this.monthOfBirth);
+      this._validateInputYear('yearOfBirth', this.yearOfBirth);
+      if (this.isFormNotValid) {
+        return this.set('isLoading', false);
+      }
+
+      const campaignCode = this.model;
+      const studentUserAssociation = this.store.createRecord('student-user-association', {
+        id: campaignCode + '_' + this.lastName,
+        firstName: this.firstName,
+        lastName: this.lastName,
+        birthdate: this.birthdate,
+        campaignCode,
+      });
+
+      return studentUserAssociation.save().then(() => {
+        this.set('isLoading', false);
+        this.transitionToRoute('campaigns.start-or-resume', this.model, {
+          queryParams: { associationDone: true }
+        });
+      }, (errorResponse) => {
+        studentUserAssociation.unloadRecord();
+        errorResponse.errors.forEach((error) => {
+          if (error.status === '404') {
+            return this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+          }
+          throw (error);
+        });
+        this.set('isLoading', false);
+      });
+    },
+
+    triggerInputDayValidation(key, value) {
+      this._padNumberInInput('dayOfBirth', value);
+      this._validateInputDay(key, value);
+    },
+
+    triggerInputMonthValidation(key, value) {
+      this._padNumberInInput('monthOfBirth', value);
+      this._validateInputMonth(key, value);
+    },
+
+    triggerInputYearValidation(key, value) {
+      this._validateInputYear(key, value);
+    },
+  },
+
+  _executeFieldValidation(key, value, isValid) {
+    const isInvalidInput = !isValid(value);
+    const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
+    const messageObject = 'validation.' + key + '.message';
+    return this.set(messageObject, message);
+  },
+
+  _validateInputDay(key, value) {
+    this._executeFieldValidation(key, value, isDayValid);
+  },
+
+  _validateInputMonth(key, value) {
+    this._executeFieldValidation(key, value, isMonthValid);
+  },
+
+  _validateInputYear(key, value) {
+    this._executeFieldValidation(key, value, isYearValid);
+  },
+
+  _padNumberInInput(attribute, value) {
+    if (value.trim()) {
+      this.set(attribute, _pad(value, 2));
+    }
+  }
+});

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -31,6 +31,9 @@ const isMonthValid = (value) => value > 0 && value <= 12;
 const isYearValid = (value) => value > 999 && value <= 9999;
 
 export default Controller.extend({
+  queryParams: ['participantExternalId'],
+  participantExternalId: null,
+
   store: service(),
 
   firstName: '',
@@ -79,7 +82,7 @@ export default Controller.extend({
       return studentUserAssociation.save().then(() => {
         this.set('isLoading', false);
         this.transitionToRoute('campaigns.start-or-resume', this.model, {
-          queryParams: { associationDone: true }
+          queryParams: { associationDone: true, participantExternalId: this.get('participantExternalId') }
         });
       }, (errorResponse) => {
         studentUserAssociation.unloadRecord();

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -8,5 +8,6 @@ export default Model.extend({
   title: attr('string'),
   organizationLogoUrl: attr('string'),
   customLandingPageText: attr('string'),
+  isRestricted: attr('boolean'),
   targetProfile: belongsTo('targetProfile'),
 });

--- a/mon-pix/app/models/student-user-association.js
+++ b/mon-pix/app/models/student-user-association.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  lastName: DS.attr('string'),
+  firstName: DS.attr('string'),
+  birthdate: DS.attr('date-only'),
+  campaignCode: DS.attr('string')
+});

--- a/mon-pix/app/models/student.js
+++ b/mon-pix/app/models/student.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  lastName: DS.attr('string'),
+  firstName: DS.attr('string'),
+  birthdate: DS.attr('date-only'),
+  user: DS.belongsTo('user')
+});

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -48,6 +48,7 @@ export default Router.map(function() {
   this.route('campaigns', { path: '/campagnes' }, function() {
     this.route('fill-in-campaign-code', { path: '/' });
     this.route('start-or-resume', { path: '/:campaign_code' });
+    this.route('join-restricted-campaign', { path: '/:campaign_code/rejoindre' });
     this.route('campaign-landing-page', { path: '/:campaign_code/presentation' });
     this.route('fill-in-id-pix', { path: '/:campaign_code/identifiant' });
     this.route('tutorial', { path: '/:campaign_code/didacticiel' });

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -1,12 +1,26 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
 
   campaignCode: null,
+  session: service(),
 
   async model(params) {
     const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
 
     return campaigns.get('firstObject');
+  },
+
+  afterModel(campaign) {
+    if (campaign.isRestricted && this._userIsUnauthenticated()) {
+      return this.replaceWith('campaigns.start-or-resume', campaign.code, {
+        queryParams: { campaignIsRestricted: true }
+      });
+    }
+  },
+
+  _userIsUnauthenticated() {
+    return this.get('session.isAuthenticated') === false;
   },
 });

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -1,8 +1,18 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
+
+  currentUser: service(),
 
   model(params) {
     return params.campaign_code;
+  },
+
+  setupController(controller) {
+    this._super(...arguments);
+    controller.set('firstName', this.currentUser.user.firstName);
+    controller.set('lastName', this.currentUser.user.lastName);
   },
 });

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -1,10 +1,21 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
 
 export default Route.extend(AuthenticatedRouteMixin, {
 
   currentUser: service(),
+
+  async beforeModel(transition) {
+    const student = await this.store.queryRecord('student', { userId: this.currentUser.user.id });
+
+    if (!isEmpty(student)) {
+      return this.replaceWith('campaigns.start-or-resume', transition.to.params.campaign_code, {
+        queryParams: { associationDone: true }
+      });
+    }
+  },
 
   model(params) {
     return params.campaign_code;

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+
+  model(params) {
+    return params.campaign_code;
+  },
+});

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -12,6 +12,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   campaignCode: null,
   campaign: null,
   associationDone: false,
+  campaignIsRestricted: false,
   givenParticipantExternalId: null,
   userHasSeenLanding: false,
   userHasJustConsultedTutorial: false,
@@ -20,11 +21,12 @@ export default Route.extend(AuthenticatedRouteMixin, {
   beforeModel(transition) {
     this.set('campaignCode', transition.to.params.campaign_code);
     this.set('associationDone', transition.to.queryParams.associationDone);
+    this.set('campaignIsRestricted', transition.to.queryParams.campaignIsRestricted);
     this.set('givenParticipantExternalId', transition.to.queryParams.participantExternalId);
     this.set('userHasSeenLanding', transition.to.queryParams.hasSeenLanding);
     this.set('userHasJustConsultedTutorial', transition.to.queryParams.hasJustConsultedTutorial);
 
-    if (this._userIsUnauthenticated() && !this.userHasSeenLanding) {
+    if (this._userIsUnauthenticated() && !this.userHasSeenLanding && !this.campaignIsRestricted) {
       return this.replaceWith('campaigns.campaign-landing-page', this.campaignCode, { queryParams: transition.to.queryParams });
     }
     this._super(...arguments);

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -11,6 +11,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   campaignCode: null,
   campaign: null,
+  associationDone: false,
   givenParticipantExternalId: null,
   userHasSeenLanding: false,
   userHasJustConsultedTutorial: false,
@@ -18,6 +19,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   beforeModel(transition) {
     this.set('campaignCode', transition.to.params.campaign_code);
+    this.set('associationDone', transition.to.queryParams.associationDone);
     this.set('givenParticipantExternalId', transition.to.queryParams.participantExternalId);
     this.set('userHasSeenLanding', transition.to.queryParams.hasSeenLanding);
     this.set('userHasJustConsultedTutorial', transition.to.queryParams.hasJustConsultedTutorial);
@@ -29,13 +31,12 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
 
   async model() {
-    // We don't actually use this model, this request is only made to see if
-    // the campaign exists, if not this query get a 404 error and the start-or-resume
-    // template is shown instead.
-    return this.store.query('campaign', { filter: { code: this.campaignCode } });
+    const campaigns = await this.store.query('campaign', { filter: { code: this.campaignCode } });
+
+    return campaigns.get('firstObject');
   },
 
-  async afterModel() {
+  async afterModel(campaign) {
     const smartPlacementAssessments = await this.store.query(
       'assessment',
       { filter: { type: 'SMART_PLACEMENT', codeCampaign: this.campaignCode } },
@@ -45,7 +46,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
       if (this.userHasSeenLanding) {
         return this.replaceWith('campaigns.fill-in-id-pix', this.campaignCode, { queryParams: { givenParticipantExternalId: this.givenParticipantExternalId } });
       }
-      return this.replaceWith('campaigns.campaign-landing-page', this.campaignCode, { queryParams: { givenParticipantExternalId: this.givenParticipantExternalId } });
+      if (!campaign.isRestricted || this.associationDone) {
+        return this.replaceWith('campaigns.campaign-landing-page', this.campaignCode, { queryParams: { givenParticipantExternalId: this.givenParticipantExternalId } });
+      }
+      return this.replaceWith('campaigns.join-restricted-campaign', this.campaignCode, { queryParams: { givenParticipantExternalId: this.givenParticipantExternalId } });
     }
 
     const assessment = await smartPlacementAssessments.get('firstObject').reload();

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -90,6 +90,7 @@
 @import 'pages/error';
 @import 'pages/fill-in-campaign-code';
 @import 'pages/fill-in-id-pix';
+@import 'pages/join-restricted-campaign';
 @import 'pages/not-connected';
 @import 'pages/profile';
 @import 'pages/sign-form';

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -12,6 +12,10 @@
     border: 2px solid $alto-grey;
     padding-left: 10px;
 
+    &[disabled] {
+      background-color: $alto-grey;
+    }
+
     &.input--error {
       border-color: $pure-orange;
     }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -1,0 +1,101 @@
+.join-restricted-campaign {
+  form {
+    width: 280px;
+    display: block;
+    margin: 0 auto;
+  }
+
+  input {
+    width: 100%;
+    height: 50px;
+    border-radius: 4px;
+    border: 2px solid $alto-grey;
+    padding-left: 10px;
+
+    &.input--error {
+      border-color: $pure-orange;
+    }
+  }
+
+  button {
+    margin: 10px 0 0 0;
+    width: 100%;
+  }
+
+  &__container {
+    padding-bottom: 30px;
+
+    @include device-is('tablet') {
+      padding: 40px;
+    }
+  }
+
+  &__title {
+    color: $nero;
+    font-family: $font-open-sans;
+    font-size: 4.2rem;
+    font-weight: $font-light;
+    text-align: center;
+    margin-bottom: 12px;
+  }
+
+  &__subtitle {
+    color: $nero;
+    font-family: $font-open-sans;
+    font-size: 1.8rem;
+    font-weight: $font-light;
+    text-align: center;
+    margin-bottom: 30px;
+  }
+
+  &__label {
+    font-family: $font-roboto;
+    font-size: 1.5rem;
+    font-weight: $font-medium;
+  }
+
+  &__field-error {
+   color: $pure-orange;
+  }
+
+  &__error {
+    text-align: center;
+    color: $pure-orange;
+    font-size: 1.5rem;
+    padding: 4px 10px;
+
+    @include device-is('tablet') {
+      padding: 0;
+    }
+  }
+
+  &__row {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+    margin-bottom: 20px;
+  }
+
+  &__birthdate {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: center;
+
+    & input {
+      text-align: center;
+      padding-left: 0;
+      margin-bottom: 4px;
+      width: 30%;
+    }
+  }
+
+  &__help-text {
+    color: $charcoal-grey;
+    font-family: $font-open-sans;
+    font-size: 1.4rem;
+    font-weight: $font-normal;
+    text-align: center;
+    margin-top: 26px;
+  }
+}

--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -1,0 +1,47 @@
+<div class="background-banner-wrapper">
+  <div class="background-banner"></div>
+  <div
+    class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container">
+    <div class="join-restricted-campaign">
+      <div class="join-restricted-campaign__title">Un tout petit détail !</div>
+      <div class="join-restricted-campaign__subtitle">Remplissez les informations manquantes</div>
+      <form>
+        <div class="join-restricted-campaign__row">
+          <label class="join-restricted-campaign__label">Prénom</label>
+          {{input id="firstName" type="text" value=firstName placeholder="Prénom" readonly="readonly" disabled=true}}
+        </div>
+        <div class="join-restricted-campaign__row">
+          <label class="join-restricted-campaign__label">Nom</label>
+          {{input id="lastName" type="text" value=lastName placeholder="Nom" readonly="readonly" disabled=true}}
+        </div>
+        <div class="join-restricted-campaign__row">
+          <label class="join-restricted-campaign__label">Date de naissance</label>
+          <div class="join-restricted-campaign__birthdate">
+            {{input id="dayOfBirth" type="text" value=dayOfBirth placeholder="JJ" class=(if validation.dayOfBirth.message 'input--error')
+                    focusOut=(action "triggerInputDayValidation" "dayOfBirth" dayOfBirth)}}
+            {{input id="monthOfBirth" type="text" value=monthOfBirth placeholder="MM" class=(if validation.monthOfBirth.message 'input--error')
+                    focusOut=(action "triggerInputMonthValidation" "monthOfBirth" monthOfBirth)}}
+            {{input id="yearOfBirth" type="text" value=yearOfBirth placeholder="AAAA" class=(if validation.yearOfBirth.message 'input--error')
+                    focusOut=(action "triggerInputYearValidation" "yearOfBirth" yearOfBirth)}}
+          </div>
+          <div class="{{if validation.dayOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.dayOfBirth.message}}</div>
+          <div class="{{if validation.monthOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.monthOfBirth.message}}</div>
+          <div class="{{if validation.yearOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.yearOfBirth.message}}</div>
+        </div>
+        {{#if errorMessage}}
+          <div class="join-restricted-campaign__error" aria-live="polite">{{errorMessage}}</div>
+        {{/if}}
+        {{#if isLoading}}
+          <button class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
+        {{else}}
+          <button type="submit" class="button button--big" {{action "attemptNext"}}>
+            C'est parti !
+          </button>
+        {{/if}}
+      </form>
+      <div class="join-restricted-campaign__help-text">
+        Ce n'est pas vous ?<br>Vérifiez que vous êtes bien connecté à votre ENT ou contactez votre enseignant.
+      </div>
+    </div>
+  </div>
+</div>

--- a/mon-pix/app/transforms/date-only.js
+++ b/mon-pix/app/transforms/date-only.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+
+export default DS.Transform.extend({
+  serialize: function(date) {
+    return date;
+  },
+  deserialize: function(date) {
+    const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
+    if (date.search(dateRegex) === 0) {
+      return date;
+    }
+    return null;
+  }
+});

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -146,4 +146,13 @@ export default function() {
     return new Response(204);
   });
 
+  this.get('/users/:id/student', (schema, request) => {
+    const userId =  request.params.id;
+    const student = schema.students.findBy({ userId });
+
+    if (student) {
+      return student;
+    }
+    return { data: null };
+  });
 }

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -141,4 +141,9 @@ export default function() {
 
   this.get('/competence-evaluations');
   this.post('/competence-evaluations/start-or-resume', postCompetenceEvaluation);
+
+  this.post('/student-user-associations', () => {
+    return new Response(204);
+  });
+
 }

--- a/mon-pix/mirage/data/assessments/ref-assessment-placement.js
+++ b/mon-pix/mirage/data/assessments/ref-assessment-placement.js
@@ -4,7 +4,7 @@ export default {
     id: 'ref_assessment_campaign_id',
     attributes: {
       'type':'SMART_PLACEMENT',
-      'code-campaign': 'codecampagnepix'
+      'code-campaign': 'AZERTY3'
     },
     relationships: {
       course: {

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -118,8 +118,17 @@ export default function(server) {
 
   const campaign3 = server.create('campaign', {
     id: 3,
-    code: 'codecampagnepix',
+    code: 'AZERTY3',
     title: 'Le Titre de la campagne'
+  });
+
+  const campaign4 = server.create('campaign', {
+    id: 4,
+    name: 'Campagne 4 resteinte',
+    code: 'AZERTY4',
+    idPixLabel: 'Mail Pro',
+    organizationLogoUrl: 'data:jpeg;base64=somelogo',
+    isRestricted: true,
   });
 
   const targetProfile = server.create('target-profile', {
@@ -128,6 +137,7 @@ export default function(server) {
   campaign1.targetProfile = targetProfile;
   campaign2.targetProfile = targetProfile;
   campaign3.targetProfile = targetProfile;
+  campaign4.targetProfile = targetProfile;
 
   server.create('password-reset-demand', {
     temporaryKey: 'temporaryKey',

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -220,19 +220,46 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
         });
 
         context('When participant external id is set in the url', function() {
-          beforeEach(async function() {
-            await startCampaignByCodeAndExternalId('AZERTY1');
-            await fillIn('#firstName', 'Jane');
-            await fillIn('#lastName', 'Acme');
-            await fillIn('#email', 'jane@acme.com');
-            await fillIn('#password', 'Jane1234');
-            await click('#pix-cgu');
-            await click('.button');
+
+          context('When campaign is not restricted', function() {
+            beforeEach(async function() {
+              await startCampaignByCodeAndExternalId('AZERTY1');
+              await fillIn('#firstName', 'Jane');
+              await fillIn('#lastName', 'Acme');
+              await fillIn('#email', 'jane@acme.com');
+              await fillIn('#password', 'Jane1234');
+              await click('#pix-cgu');
+              await click('.button');
+            });
+
+            it('should redirect to assessment', async function() {
+              // then
+              expect(currentURL()).to.contains('/didacticiel');
+            });
           });
 
-          it('should redirect to assessment', async function() {
-            // then
-            expect(currentURL()).to.contains('/didacticiel');
+          context('When campaign is restricted', function() {
+            beforeEach(async function() {
+              await visitWithAbortedTransition('/campagnes/AZERTY4?participantExternalId=a73at01r3');
+              await fillIn('#firstName', 'Jane');
+              await fillIn('#lastName', 'Acme');
+              await fillIn('#email', 'jane@acme.com');
+              await fillIn('#password', 'Jane1234');
+              await click('#pix-cgu');
+              await click('.button');
+
+              await fillIn('#dayOfBirth', '10');
+              await fillIn('#monthOfBirth', '12');
+              await fillIn('#yearOfBirth', '2000');
+              await click('.button');
+
+              await click('.campaign-landing-page__start-button');
+            });
+
+            it('should redirect to assessment', async function() {
+              // then
+              expect(currentURL()).to.contains('/didacticiel');
+            });
           });
         });
       });

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -257,13 +257,20 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
           expect(find('.join-restricted-campaign')).to.exist;
         });
 
+        it('should set by default firstName and lastName', async function() {
+          // when
+          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+
+          //then
+          expect(find('#firstName').value).to.equal('Jane');
+          expect(find('#lastName').value).to.equal('Doe');
+        });
+
         it('should redirect to landing page when fields are filled in', async function() {
           // given
           await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
 
           // when
-          await fillIn('#firstName', 'Jane');
-          await fillIn('#lastName', 'Doe');
           await fillIn('#dayOfBirth', '10');
           await fillIn('#monthOfBirth', '12');
           await fillIn('#yearOfBirth', '2000');

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -37,17 +37,73 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
 
       context('When user want to access a campaign with only its code', function() {
 
-        it('should access presentation page', async function() {
-          // given
-          const campaignCode = 'AZERTY1';
-          await visitWithAbortedTransition('/campagnes');
+        context('When campaign code exists', function() {
 
-          // when
-          await fillIn('#campaign-code', campaignCode);
-          await click('.button');
+          context('When campaign is not restricted', function() {
 
-          // then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+            it('should access presentation page', async function() {
+              // given
+              const campaignCode = 'AZERTY1';
+              await visitWithAbortedTransition('/campagnes');
+
+              // when
+              await fillIn('#campaign-code', campaignCode);
+              await click('.button');
+
+              // then
+              expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+            });
+          });
+
+          context('When campaign is restricted', function() {
+            const campaignCode = 'AZERTY4';
+
+            it('should redirect to register page', async function() {
+              // when
+              await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+
+              // then
+              expect(currentURL()).to.equal('/inscription');
+            });
+
+            it('should redirect to join restricted campaign page', async function() {
+              // given
+              await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+
+              // when
+              await fillIn('#firstName', 'Jane');
+              await fillIn('#lastName', 'Acme');
+              await fillIn('#email', 'jane@acme.com');
+              await fillIn('#password', 'Jane1234');
+              await click('#pix-cgu');
+              await click('.button');
+
+              // then
+              expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+            });
+
+            it('should redirect to landing page when fields are filled in', async function() {
+              // given
+              await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+              await fillIn('#firstName', 'Jane');
+              await fillIn('#lastName', 'Acme');
+              await fillIn('#email', 'jane@acme.com');
+              await fillIn('#password', 'Jane1234');
+              await click('#pix-cgu');
+              await click('.button');
+
+              // when
+              await fillIn('#dayOfBirth', '10');
+              await fillIn('#monthOfBirth', '12');
+              await fillIn('#yearOfBirth', '2000');
+
+              await click('.button');
+
+              //then
+              expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+            });
+
+          });
         });
 
         context('When campaign code does not exist', function() {

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -222,12 +222,89 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
         await authenticateAsSimpleUser();
       });
 
-      it('should redirect to landing page', async function() {
-        // when
-        await visitWithAbortedTransition('/campagnes/AZERTY1');
-        expect(currentURL()).to.equal('/campagnes/AZERTY1/presentation');
-        expect(find('.campaign-landing-page__start-button').textContent.trim()).to.equal('Je commence');
-        find('.campaign-landing-page__logo');
+      context('When campaign is not restricted', function() {
+
+        it('should redirect to landing page', async function() {
+          // when
+          await visitWithAbortedTransition('/campagnes/AZERTY1');
+          expect(currentURL()).to.equal('/campagnes/AZERTY1/presentation');
+          expect(find('.campaign-landing-page__start-button').textContent.trim()).to.equal('Je commence');
+        });
+      });
+
+      context('When campaign is restricted', function() {
+        const campaignCode = 'AZERTY4';
+
+        it('should redirect to join restricted campaign page when campaign code is in url', async function() {
+          // when
+          await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+          expect(find('.join-restricted-campaign')).to.exist;
+        });
+
+        it('should redirect to join restricted campaign page', async function() {
+          // given
+          await visitWithAbortedTransition('/campagnes');
+
+          //when
+          await fillIn('#campaign-code', campaignCode);
+          await click('.button');
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+          expect(find('.join-restricted-campaign')).to.exist;
+        });
+
+        it('should redirect to landing page when fields are filled in', async function() {
+          // given
+          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+
+          // when
+          await fillIn('#firstName', 'Jane');
+          await fillIn('#lastName', 'Doe');
+          await fillIn('#dayOfBirth', '10');
+          await fillIn('#monthOfBirth', '12');
+          await fillIn('#yearOfBirth', '2000');
+
+          await click('.button');
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+        });
+
+        it('should redirect to fill-in-id-pix page', async function() {
+          // given
+          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+          await fillIn('#dayOfBirth', '10');
+          await fillIn('#monthOfBirth', '12');
+          await fillIn('#yearOfBirth', '2000');
+          await click('.button');
+
+          // when
+          await click('.button');
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/identifiant`);
+        });
+
+        it('should redirect to tutoriel page', async function() {
+          // given
+          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+          await fillIn('#dayOfBirth', '10');
+          await fillIn('#monthOfBirth', '12');
+          await fillIn('#yearOfBirth', '2000');
+          await click('.button');
+          await click('.button');
+          await fillIn('#id-pix-label', 'truc');
+
+          // when
+          await click('.button');
+
+          //then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/didacticiel`);
+        });
       });
 
       context('When campaign has external id', function() {

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -291,82 +291,113 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
       context('When campaign is restricted', function() {
         const campaignCode = 'AZERTY4';
 
-        it('should redirect to join restricted campaign page when campaign code is in url', async function() {
-          // when
-          await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+        context('When association is not already done', function() {
 
-          //then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
-          expect(find('.join-restricted-campaign')).to.exist;
+          it('should redirect to join restricted campaign page when campaign code is in url', async function() {
+            // when
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+            expect(find('.join-restricted-campaign')).to.exist;
+          });
+
+          it('should redirect to join restricted campaign page', async function() {
+            // given
+            await visitWithAbortedTransition('/campagnes');
+
+            //when
+            await fillIn('#campaign-code', campaignCode);
+            await click('.button');
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+            expect(find('.join-restricted-campaign')).to.exist;
+          });
+
+          it('should set by default firstName and lastName', async function() {
+            // when
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+
+            //then
+            expect(find('#firstName').value).to.equal('Jane');
+            expect(find('#lastName').value).to.equal('Doe');
+          });
+
+          it('should redirect to landing page when fields are filled in', async function() {
+            // given
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+
+            // when
+            await fillIn('#dayOfBirth', '10');
+            await fillIn('#monthOfBirth', '12');
+            await fillIn('#yearOfBirth', '2000');
+
+            await click('.button');
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+          });
+
+          it('should redirect to fill-in-id-pix page', async function() {
+            // given
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+            await fillIn('#dayOfBirth', '10');
+            await fillIn('#monthOfBirth', '12');
+            await fillIn('#yearOfBirth', '2000');
+            await click('.button');
+
+            // when
+            await click('.button');
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/identifiant`);
+          });
+
+          it('should redirect to tutoriel page', async function() {
+            // given
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+            await fillIn('#dayOfBirth', '10');
+            await fillIn('#monthOfBirth', '12');
+            await fillIn('#yearOfBirth', '2000');
+            await click('.button');
+            await click('.button');
+            await fillIn('#id-pix-label', 'truc');
+
+            // when
+            await click('.button');
+
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/didacticiel`);
+          });
         });
 
-        it('should redirect to join restricted campaign page', async function() {
-          // given
-          await visitWithAbortedTransition('/campagnes');
+        context('When association is already done', function() {
 
-          //when
-          await fillIn('#campaign-code', campaignCode);
-          await click('.button');
+          beforeEach(async function() {
+            server.create('student', {
+              userId: 1,
+            });
+          });
 
-          //then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
-          expect(find('.join-restricted-campaign')).to.exist;
-        });
+          it('should redirect to landing page', async function() {
+            // when
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
 
-        it('should set by default firstName and lastName', async function() {
-          // when
-          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
+          });
 
-          //then
-          expect(find('#firstName').value).to.equal('Jane');
-          expect(find('#lastName').value).to.equal('Doe');
-        });
+          it('should redirect to fill-in-id-pix page', async function() {
+            // given
+            await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
 
-        it('should redirect to landing page when fields are filled in', async function() {
-          // given
-          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
+            // when
+            await click('.button');
 
-          // when
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '12');
-          await fillIn('#yearOfBirth', '2000');
-
-          await click('.button');
-
-          //then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/presentation`);
-        });
-
-        it('should redirect to fill-in-id-pix page', async function() {
-          // given
-          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '12');
-          await fillIn('#yearOfBirth', '2000');
-          await click('.button');
-
-          // when
-          await click('.button');
-
-          //then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/identifiant`);
-        });
-
-        it('should redirect to tutoriel page', async function() {
-          // given
-          await visitWithAbortedTransition(`/campagnes/${campaignCode}/rejoindre`);
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '12');
-          await fillIn('#yearOfBirth', '2000');
-          await click('.button');
-          await click('.button');
-          await fillIn('#id-pix-label', 'truc');
-
-          // when
-          await click('.button');
-
-          //then
-          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/didacticiel`);
+            //then
+            expect(currentURL()).to.equal(`/campagnes/${campaignCode}/identifiant`);
+          });
         });
       });
 

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -1,0 +1,345 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
+  setupTest();
+
+  let controller;
+  let storeStub;
+  let studentUserAssociation;
+
+  beforeEach(function() {
+    controller = this.owner.lookup('controller:campaigns/join-restricted-campaign');
+    controller.transitionToRoute = sinon.stub();
+    studentUserAssociation = { save: sinon.stub(), unloadRecord: sinon.stub() };
+    const createStudentUserAssociationStub = sinon.stub().returns(studentUserAssociation);
+    storeStub = { createRecord: createStudentUserAssociationStub };
+    controller.set('store', storeStub);
+    controller.set('model', 'AZERTY999');
+  });
+
+  describe('#triggerInputDayValidation', function() {
+
+    context('when dayOfBirth is invalid', function() {
+
+      [
+        '',
+        ' ',
+        '32',
+        '0',
+        '444',
+        'ee',
+      ].forEach(function(wrongDayOfBirth) {
+        it(`should display an error when dayOfBirth is ${wrongDayOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputDayValidation.call(controller, 'dayOfBirth', wrongDayOfBirth);
+
+          // then
+          expect(controller.get('validation.dayOfBirth.message')).to.equal('Votre jour de naissance n’est pas valide.');
+        });
+      });
+    });
+
+    context('when dayOfBirth is valid', function() {
+
+      [
+        '1',
+        '01',
+        '31',
+      ].forEach(function(validDayOfBirth) {
+        it(`should not display an error when dayOfBirth is ${validDayOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputDayValidation.call(controller, 'dayOfBirth', validDayOfBirth);
+
+          // then
+          expect(controller.get('validation.dayOfBirth.message')).to.equal(null);
+        });
+      });
+    });
+  });
+
+  describe('#triggerInputMonthValidation', function() {
+
+    context('when monthOfBirth is invalid', function() {
+
+      [
+        '',
+        ' ',
+        '13',
+        '0',
+        '444',
+        'ee',
+      ].forEach(function(wrongMonthOfBirth) {
+        it(`should display an error when monthOfBirth is ${wrongMonthOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputMonthValidation.call(controller, 'monthOfBirth', wrongMonthOfBirth);
+
+          // then
+          expect(controller.get('validation.monthOfBirth.message')).to.equal('Votre mois de naissance n’est pas valide.');
+        });
+      });
+    });
+
+    context('when monthOfBirth is valid', function() {
+
+      [
+        '1',
+        '01',
+        '12',
+      ].forEach(function(validMonthOfBirth) {
+        it(`should not display an error when monthOfBirth is ${validMonthOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputMonthValidation.call(controller, 'monthOfBirth', validMonthOfBirth);
+
+          // then
+          expect(controller.get('validation.monthOfBirth.message')).to.equal(null);
+        });
+      });
+    });
+  });
+
+  describe('#triggerInputYearValidation', function() {
+
+    context('when yearOfBirth is invalid', function() {
+
+      [
+        '',
+        ' ',
+        '1',
+        '11',
+        '100',
+        '0000',
+        '0001',
+        '0011',
+        '0111',
+        '10000',
+      ].forEach(function(wrongYearOfBirth) {
+        it(`should display an error when yearOfBirth is ${wrongYearOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputYearValidation.call(controller, 'yearOfBirth', wrongYearOfBirth);
+
+          // then
+          expect(controller.get('validation.yearOfBirth.message')).to.equal('Votre année de naissance n’est pas valide.');
+        });
+      });
+    });
+
+    context('when yearOfBirth is valid', function() {
+
+      [
+        '1000',
+        '9999',
+      ].forEach(function(validYearOfBirth) {
+        it(`should not display an error when yearOfBirth is ${validYearOfBirth}`, async function() {
+          // when
+          await controller.actions.triggerInputYearValidation.call(controller, 'yearOfBirth', validYearOfBirth);
+
+          // then
+          expect(controller.get('validation.yearOfBirth.message')).to.equal(null);
+        });
+      });
+    });
+  });
+
+  describe('#isFormNotValid', function() {
+
+    it('should be true if dayOfBirth is not valid', function() {
+      // given
+      controller.set('dayOfBirth', '99');
+      controller.set('monthOfBirth', '12');
+      controller.set('yearOfBirth', '1999');
+
+      // when
+      const result = controller.get('isFormNotValid');
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should be true if monthOfBirth is not valid', function() {
+      // given
+      controller.set('dayOfBirth', '15');
+      controller.set('monthOfBirth', '99');
+      controller.set('yearOfBirth', '1999');
+
+      // when
+      const result = controller.get('isFormNotValid');
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should be true if yearOfBirth is not valid', function() {
+      // given
+      controller.set('dayOfBirth', '15');
+      controller.set('monthOfBirth', '12');
+      controller.set('yearOfBirth', '99999');
+
+      // when
+      const result = controller.get('isFormNotValid');
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should be false', function() {
+      // given
+      controller.set('dayOfBirth', '15');
+      controller.set('monthOfBirth', '12');
+      controller.set('yearOfBirth', '1999');
+
+      // when
+      const result = controller.get('isFormNotValid');
+
+      // then
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('#attemptNext', function() {
+
+    beforeEach(function() {
+      controller.set('dayOfBirth', '10');
+      controller.set('monthOfBirth', '10');
+      controller.set('yearOfBirth', '2000');
+    });
+
+    it('should display an error on dayOfBirth', async function() {
+      // given
+      controller.set('dayOfBirth', '99');
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.notCalled(storeStub.createRecord);
+      sinon.assert.notCalled(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('errorMessage')).to.equal(null);
+      expect(controller.get('validation.dayOfBirth.message')).to.equal('Votre jour de naissance n’est pas valide.');
+    });
+
+    it('should display an error on monthOfBirth', async function() {
+      // given
+      controller.set('monthOfBirth', '99');
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.notCalled(storeStub.createRecord);
+      sinon.assert.notCalled(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('errorMessage')).to.equal(null);
+      expect(controller.get('validation.monthOfBirth.message')).to.equal('Votre mois de naissance n’est pas valide.');
+    });
+
+    it('should display an error on yearOfBirth', async function() {
+      // given
+      controller.set('yearOfBirth', '99');
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.notCalled(storeStub.createRecord);
+      sinon.assert.notCalled(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('errorMessage')).to.equal(null);
+      expect(controller.get('validation.yearOfBirth.message')).to.equal('Votre année de naissance n’est pas valide.');
+    });
+
+    it('should display an error on all fields', async function() {
+      // given
+      controller.set('dayOfBirth', '');
+      controller.set('monthOfBirth', '');
+      controller.set('yearOfBirth', '');
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.notCalled(storeStub.createRecord);
+      sinon.assert.notCalled(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('errorMessage')).to.equal(null);
+      expect(controller.get('validation.dayOfBirth.message')).to.equal('Votre jour de naissance n’est pas valide.');
+      expect(controller.get('validation.monthOfBirth.message')).to.equal('Votre mois de naissance n’est pas valide.');
+      expect(controller.get('validation.yearOfBirth.message')).to.equal('Votre année de naissance n’est pas valide.');
+    });
+
+    it('should be valid after an error', async function() {
+      // given
+      studentUserAssociation.save.resolves();
+      controller.set('yearOfBirth', '99');
+      await controller.actions.attemptNext.call(controller);
+
+      // when
+      controller.set('yearOfBirth', '2000');
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.calledOnce(storeStub.createRecord);
+      sinon.assert.calledOnce(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      expect(controller.get('errorMessage')).to.equal(null);
+      expect(controller.get('validation.yearOfBirth.message')).to.equal(null);
+    });
+
+    it('should associate user with student and redirect to campaigns.start-or-resume', async function() {
+      // given
+      studentUserAssociation.save.resolves();
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.calledOnce(storeStub.createRecord);
+      sinon.assert.calledOnce(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      expect(controller.get('errorMessage')).to.equal(null);
+    });
+
+    it('should display a general error', async function() {
+      // given
+      studentUserAssociation.save.rejects({ errors: [{ status: '404' }] });
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('isLoading')).to.equal(false);
+    });
+
+    it('should associate user with student and redirect to campaigns.start-or-resume after failing', async function() {
+      // given
+      studentUserAssociation.save
+        .onFirstCall().rejects({ errors: [{ status: '404' }] })
+        .onSecondCall().resolves();
+
+      // when
+      // first
+      await controller.actions.attemptNext.call(controller);
+      // second
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.calledTwice(storeStub.createRecord);
+      sinon.assert.calledTwice(studentUserAssociation.save);
+      expect(controller.get('isLoading')).to.equal(false);
+      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      expect(controller.get('errorMessage')).to.equal(null);
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/join-restricted-campaign-test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | campaigns/join-restricted-campaign', function() {
+  setupTest();
+
+  describe('#model', function() {
+
+    const campaignCode = 'GTFUHBD23';
+
+    it('should return campaign code', async function() {
+      // given
+      const route = this.owner.lookup('route:campaigns/join-restricted-campaign');
+      const params = {
+        campaign_code: campaignCode
+      };
+
+      // when
+      const model = route.model(params);
+
+      // then
+      expect(model).to.equal(campaignCode);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On veut rattacher l'utilisateur qui passe un parcours prescrit à un élève de son organisation.
Une fois rattaché, on ne lui montre plus la page de réconcialiation.

## :robot: Solution
**Back**
- Ajout de l'attribut `isRestricted` à la campagne si l'organisation `isManagingStudent` et de type `SCO`.
- Modification de la méthode utiliser pour trouver un user dans la liste des élèves d'une orga. (ajout de la date de naissance)
- Ajout d'une méthode pour associer le compte user et élève.
- Ajout du endpoint `/api/student-user-associations` et du controller.
- Ajout du endpoint `/api/users/:id/student` et du controller.
- Ajout du usecase pour récupérer l'élève lié à un utilisateur.

**Front**
- Ajout de la page de réconciliation ;
- Gestion des cas :
  - non authentifié ;
  - avec un identifiant externe dans l'URL ;
  - déjà associé à un élève.