### PR TITLE
[TECH] Corrige le TU de GET /api/organizations/{id}/invitations

### DIFF
--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('hapi');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 const organizationController = require('../../../../lib/application/organizations/organization-controller');
+const usecases = require ('../../../../lib/domain/usecases');
 
 let server;
 
@@ -58,7 +59,11 @@ describe('Unit | Router | organization-router', () => {
 
   describe('GET /api/organizations/{id}/invitations', () => {
 
-    it('should exist', async () => {
+    beforeEach(() => {
+      sinon.stub(usecases, 'findPendingOrganizationInvitations').resolves([]);
+    });
+
+    it('should return an empty list when no organization is found', async () => {
       // given
       const options = {
         method: 'GET',
@@ -70,6 +75,7 @@ describe('Unit | Router | organization-router', () => {
 
       // then
       expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Le test unitaire de GET /api/organizations/{id}/invitations échouait quand on lançait les tests unitaires sans base de donnée car son usecase n'était pas bouchonné.

## :robot: Solution

Bouchonner le usecase.

## :rainbow: Remarques

Pour lancer les tests unitaires sans base de données :

    $ TEST_DATABASE_URL=trololo npm run test:api:unit
