### PR TITLE
[TECH] Corriger le test d'acceptance de POST /answers

### DIFF
--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -81,7 +81,7 @@ describe('Acceptance | Controller | answer-controller-save', () => {
             data: {
               type: 'answers',
               attributes: {
-                value: '1',
+                value: '1, 5',
                 'elapsed-time': 100,
               },
               relationships: {
@@ -132,7 +132,7 @@ describe('Acceptance | Controller | answer-controller-save', () => {
         return promise.then((response) => {
           const answer = response.result.data;
 
-          new BookshelfAnswer().fetch()
+          return new BookshelfAnswer().fetch()
             .then((model) => {
               expect(model.id).to.be.a('number');
               expect(model.get('value')).to.equal(options.payload.data.attributes.value);
@@ -210,7 +210,5 @@ describe('Acceptance | Controller | answer-controller-save', () => {
       });
 
     });
-
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
- Le test passait en affichant une erreur dans la console. Il devait échouer.

## :robot: Solution
- Ajout d'un `return` manquant
- Modification de la réponse de l'utilisateur pour être correct par rapport à celle crée via le buildChallenge

