### PR TITLE
[FEATURE] Script d'envoie des invitations SCO (PF-862)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -158,8 +158,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/invitations',
       config: {
         pre: [{
-          method: securityController.checkUserIsOwnerInOrganization,
-          assign: 'isOwnerInOrganization'
+          method: securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster,
+          assign: 'isOwnerInOrganizationOrHasRolePixMaster'
         }],
         handler: organisationController.sendInvitation,
         notes: [

--- a/api/scripts/organizeOrganizationsByExternalId.js
+++ b/api/scripts/organizeOrganizationsByExternalId.js
@@ -1,0 +1,14 @@
+function organizeOrganizationsByExternalId(data) {
+  const organizationsByExternalId = {};
+
+  data.forEach((organization) => {
+    if (organization.attributes['external-id']) {
+      organization.attributes['external-id'] = organization.attributes['external-id'].toUpperCase();
+      organizationsByExternalId[organization.attributes['external-id']] = { id: organization.id, ...organization.attributes };
+    }
+  });
+
+  return organizationsByExternalId;
+}
+
+module.exports = organizeOrganizationsByExternalId;

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-console */
+// Usage: BASE_URL=... PIXMASTER_EMAIL=... PIXMASTER_PASSWORD=... node send-invitations-to-organizations.js path/file.csv
+
+'use strict';
+require('dotenv').config();
+const request = require('request-promise-native');
+
+const organizeOrganizationsByExternalId = require('./organizeOrganizationsByExternalId');
+const { parseCsv } = require('../scripts/helpers/csvHelpers');
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+
+async function sendInvitations(accessToken, data, organizationsByExternalId) {
+  for (let i = 0; i < data.length; i++) {
+
+    if (require.main === module) {
+      console.log(i + 1);
+    }
+
+    const [externalId,, email] = data[i];
+    const organization = organizationsByExternalId[externalId];
+
+    await request(_buildPostOrganizationInvitationRequestObject(accessToken, organization, email));
+  }
+}
+
+function _buildAccessTokenRequestObject() {
+  return {
+    method: 'POST',
+    baseUrl,
+    url: '/api/token',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    form: {
+      grant_type: 'password',
+      username: process.env.PIXMASTER_EMAIL,
+      password: process.env.PIXMASTER_PASSWORD,
+    },
+    json: true,
+  };
+}
+
+function _buildGetOrganizationsRequestObject(accessToken) {
+  return {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+    baseUrl,
+    url: '/api/organizations?pageSize=999999999',
+    json: true,
+  };
+}
+
+function _buildPostOrganizationInvitationRequestObject(accessToken, organization, email) {
+  return {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+    baseUrl,
+    url: `/api/organizations/${organization.id}/invitations`,
+    json: true,
+    body: {
+      data: {
+        type: 'organization-invitations',
+        attributes: {
+          email,
+        },
+      },
+    },
+  };
+}
+
+async function main() {
+  console.log('Starting creating or updating SCO organizations.');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading and parsing data... ');
+    const data = parseCsv(filePath, { skipEmptyLines: true });
+    console.log('ok');
+
+    console.log('Requesting API access token... ');
+    const response1 = await request(_buildAccessTokenRequestObject());
+    const accessToken = response1.access_token;
+    console.log('ok');
+
+    console.log('Getting organizations list... ');
+    const response2 = await request(_buildGetOrganizationsRequestObject(accessToken));
+    const organizationsByExternalId = organizeOrganizationsByExternalId(response2.data);
+    console.log('ok');
+
+    console.log('Checking if organizations from file are in database...');
+    data.forEach(([externalId, name]) => {
+      if (!organizationsByExternalId[externalId]) {
+        throw new Error(`Organization ${name} - ${externalId} is not in database. Aborting. No email was sent.`);
+      }
+    });
+    console.log('ok');
+
+    console.log('Updating organizations and creating invitations...');
+    await sendInvitations(accessToken, data, organizationsByExternalId);
+    console.log('Done.');
+
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  sendInvitations,
+};

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -1352,7 +1352,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user is not OWNER in organization', async () => {
+      it('should respond with a 403 - forbidden access - if user is not OWNER in organization or PIXMASTER', async () => {
         // given
         const nonPixMasterUserId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
@@ -1363,6 +1363,17 @@ describe('Acceptance | Application | organization-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(403);
+      });
+
+      it('should respond with a 201 - created - if user is PIXMASTER', async () => {
+        // given
+        options.headers.authorization = generateValidRequestAuthorizationHeader();
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(201);
       });
 
       it('should respond with a 421 if membership already exist', async () => {

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -87,7 +87,7 @@ describe('Integration | Application | Organizations | Routes', () => {
   describe('POST /api/organizations/:id/invitations', () => {
 
     beforeEach(() => {
-      sinon.stub(securityController, 'checkUserIsOwnerInOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityController, 'checkUserIsOwnerInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(organisationController, 'sendInvitation').callsFake((request, h) => h.response().created());
 
       return server.register(route);

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -222,7 +222,7 @@ describe('Integration | Application | Organizations | organization-controller', 
       };
 
       beforeEach(() => {
-        securityController.checkUserIsOwnerInOrganization.returns(true);
+        securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster.returns(true);
       });
 
       it('should return an HTTP response with status code 201', async () => {

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -1,0 +1,62 @@
+const { expect, nock } = require('../../test-helper');
+const { sendInvitations } = require('../../../scripts/send-invitations-to-sco-organizations');
+
+describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () => {
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('#sendInvitations', () => {
+
+    it('should update organizations and send invitations', async () => {
+      // given
+      const accessToken = 'token';
+
+      const organizationsByExternalId = {
+        A100: {
+          id: 1,
+          name: 'Lycée Jean Moulin',
+          'external-id': 'A10',
+        },
+      };
+
+      const data = [
+        ['A100', 'Lycée Jean Moulin', 'superpix@pix.fr'],
+      ];
+
+      const expectedPostBody = {
+        data: {
+          type: 'organization-invitations',
+          attributes: {
+            email: 'superpix@pix.fr'
+          },
+        },
+      };
+
+      let postCallCount = 0;
+
+      const networkStub = nock(
+        'http://localhost:3000',
+        {
+          reqheaders: {
+            authorization: 'Bearer token',
+          },
+        }
+      )
+        .post('/api/organizations/1/invitations', (body) => JSON.stringify(body) === JSON.stringify(expectedPostBody))
+        .reply(201, () => {
+          postCallCount++;
+
+          return {};
+        });
+
+      // when
+      await sendInvitations(accessToken, data, organizationsByExternalId);
+
+      // then
+      expect(networkStub.isDone()).to.be.true;
+      expect(postCallCount).to.be.equal(1);
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -60,7 +60,7 @@ async function getCountOfAllRowsInDatabase()
 
 async function insertUserWithRolePixMaster() {
 
-  databaseBuilder.factory.buildUser.withPixRolePixMaster({
+  const user = databaseBuilder.factory.buildUser.withPixRolePixMaster({
     id: 1234,
     firstName: 'Super',
     lastName: 'Papa',
@@ -68,8 +68,9 @@ async function insertUserWithRolePixMaster() {
     password: 'abcd1234',
   });
 
-  return databaseBuilder.commit();
+  await databaseBuilder.commit();
 
+  return user;
 }
 
 async function insertUserWithStandardRole() {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -15,6 +15,7 @@ describe('Unit | Router | organization-router', () => {
 
   beforeEach(() => {
     sinon.stub(securityController, 'checkUserIsOwnerInOrganization').returns(true);
+    sinon.stub(securityController, 'checkUserIsOwnerInOrganizationOrHasRolePixMaster').returns(true);
     sinon.stub(organizationController, 'find').returns('ok');
     sinon.stub(organizationController, 'sendInvitation').callsFake((request, h) => h.response().created());
 

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -136,5 +136,4 @@ describe('Unit | UseCase | update-organization-information', () => {
       expect(error).to.be.instanceOf(NotFoundError);
     });
   });
-
 });

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -68,7 +68,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', () => {
 
       // then
       expect(data.length).to.equal(3);
-      expect(data[0][2]).to.equal('mail1@ac-reims.fr');
+      expect(data[0][2]).to.equal('david.herault@pix.fr');
     });
   });
 

--- a/api/tests/unit/scripts/helpers/valid-organizations-test-file.csv
+++ b/api/tests/unit/scripts/helpers/valid-organizations-test-file.csv
@@ -1,3 +1,3 @@
-0080017A,Collège Les Pixous,mail1@ac-reims.fr
-0080018B,Lycée Pix,mail2@ac-reims.fr
-0080040A,Lycée Tant Pix,mail3@ac-reims.fr
+0080017A,Collège Les Pixous,david.herault@pix.fr
+0080018B,Lycée Pix,david.herault+1@pix.fr
+0080040A,Lycée Tant Pix,david.herault+2@pix.fr

--- a/api/tests/unit/scripts/organizeOrganizationsByExternalId.js
+++ b/api/tests/unit/scripts/organizeOrganizationsByExternalId.js
@@ -1,0 +1,48 @@
+const { expect } = require('../../test-helper');
+const organizeOrganizationsByExternalId = require('../../../scripts/organizeOrganizationsByExternalId');
+
+describe('Unit | Scripts | organizeOrganizationsByExternalId.js', () => {
+
+  describe('#organizeOrganizationsByExternalId', () => {
+
+    it('should return organizations data by externalId', () => {
+      // given
+      const data = [
+        {
+          id: 1,
+          attributes: {
+            name: 'Lycée Jean Moulin',
+            'external-id': 'a100',
+          },
+        },
+        {
+          id: 2,
+          attributes: {
+            name: 'Lycée Jean Guedin',
+            'external-id': 'b200',
+          },
+        },
+      ];
+
+      const expectedResult = {
+        A100: {
+          id: 1,
+          name: 'Lycée Jean Moulin',
+          'external-id': 'A100',
+        },
+        B200: {
+          id: 2,
+          name: 'Lycée Jean Guedin',
+          'external-id': 'B200',
+        },
+      };
+
+      // when
+      const result = organizeOrganizationsByExternalId(data);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+});


### PR DESCRIPTION
## 🐻 Problème
Pour le 5 novembre, il faut pouvoir envoyer des emails en masse aux différents chefs d'établissements scolaires concernés.
Les organisations en questions seront créées par le script d'import d'organisations. Elles sont alors créées avec `isManagingStudents=false`.

## 🍯 Solution
Envoyer des emails en masse avec un script parsant de la donnée format CSV. Le script modifiera aussi le champ `isManagingStudents` en le settant à `true`.