### PR TITLE
[BUGFIX] Ajout d'un état "loading" quand on clique sur le bouton de création de son compte (PF-904)

### DIFF
--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -37,6 +37,7 @@ export default Component.extend({
   _tokenHasBeenUsed: null,
   urlHome: ENV.APP.HOME_HOST,
   isRecaptchaEnabled: ENV.APP.IS_RECAPTCHA_ENABLED,
+  isLoading: false,
 
   init() {
     this._super(...arguments);
@@ -130,6 +131,7 @@ export default Component.extend({
 
     signup() {
       this.set('_notificationMessage', null);
+      this.set('isLoading', true);
       this.user.save().then(() => {
         const credentials = { email: this.get('user.email'), password: this.get('user.password') };
         this.authenticateUser(credentials);
@@ -138,6 +140,7 @@ export default Component.extend({
       }).catch(() => {
         this._updateInputsStatus();
         this.set('_tokenHasBeenUsed', true);
+        this.set('isLoading', false);
       });
     }
   }

--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -1,4 +1,7 @@
 <div class="body">
   <WarningBanner />
   {{outlet}}
+
+  <!-- Preloading images -->
+  <img src="{{rootURL}}/images/loader-white.svg" style="display: none">
 </div>

--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -10,7 +10,9 @@
         {{input required id="id-pix-label" value=participantExternalId}}
       </div>
       {{#if loading}}
-        <button type="submit" class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
+        <button type="button" disabled class="button button--big">
+          <span class="loader-in-button">&nbsp;</span>
+        </button>
       {{else}}
         <button type="submit" class="button button--big" {{action "submit"}}>Continuer</button>
       {{/if}}

--- a/mon-pix/app/templates/campaigns/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/skill-review.hbs
@@ -40,7 +40,7 @@
         {{/if}}
 
         {{#if displayLoadingButton}}
-          <button class="button button--extra-big skill-review-share__button">
+          <button type="button" disabled class="button button--extra-big skill-review-share__button">
             <span class="loader-in-button">&nbsp;</span>
           </button>
         {{else}}

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -19,8 +19,9 @@
         <div class="certification-course-page__field-button">
 
           {{#if isLoading}}
-              <button class="button button--thin certification-course-page__submit_button" disabled><span
-                      class="loader-in-button">&nbsp;</span></button>
+            <button type="button" disabled class="button button--thin certification-course-page__submit_button">
+              <span class="loader-in-button">&nbsp;</span>
+            </button>
           {{else}}
               <button type="submit" class="button button--thin certification-course-page__submit_button" {{ action "submit" }}>Lancer mon test</button>
           {{/if}}

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -91,7 +91,7 @@
 
     <div class="sign-form-body__bottom-button {{if isRecaptchaEnabled "" "sign-form-body__bottom-button--margin-top"}}">
       {{#if isLoading}}
-        <button class="button button--uppercase button--thin button--round button--big">
+        <button type="button" disabled class="button button--uppercase button--thin button--round button--big">
           <span class="loader-in-button">&nbsp;</span>
         </button>
       {{else}}

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -90,9 +90,15 @@
     {{/if}}
 
     <div class="sign-form-body__bottom-button {{if isRecaptchaEnabled "" "sign-form-body__bottom-button--margin-top"}}">
-      <button type="submit" class="button button--uppercase button--thin button--round button--big">
-        Je m'inscris
-      </button>
+      {{#if isLoading}}
+        <button class="button button--uppercase button--thin button--round button--big">
+          <span class="loader-in-button">&nbsp;</span>
+        </button>
+      {{else}}
+        <button type="submit" class="button button--uppercase button--thin button--round button--big">
+          Je m'inscris
+        </button>
+      {{/if}}
     </div>
 
     <div class="signup-form__legal-details-container">

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -483,6 +483,32 @@ describe('Integration | Component | signup form', function() {
         expect(find(CAPTCHA_CONTAINER)).to.exist;
       });
     });
-
   });
+
+  describe('Loading management', () => {
+
+    it('should not display any loading spinner by default', async function() {
+      // given
+      this.set('user', userEmpty);
+
+      // when
+      await render(hbs`{{signup-form user=user}}`);
+
+      // then
+      expect(find('.sign-form-body__bottom-button .loader-in-button')).to.not.exist;
+    });
+
+    it('should display a loading spinner when loading certification', async function() {
+      // given
+      this.set('user', userEmpty);
+      this.set('isLoading', true);
+
+      // when
+      await render(hbs`{{signup-form user=user isLoading=isLoading}}`);
+
+      // then
+      expect(find('.sign-form-body__bottom-button .loader-in-button')).to.exist;
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Il arrive que des utilisateurs double-clic sur le bouton de soumission du formulaire de création de compte sur la page `/inscription`. Ce comportement génère des erreurs mal gérées côté API, en particulier des erreurs de base de données liées à la contrainte d'unicité de l'e-mail. 

## :robot: Solution
Cette PR propose une petite correction rapide et efficace pour empêcher le double-clic, tout en donnant un feedback de traitement (le loader) à l'utilisateur.

## :rainbow: Remarques
L'erreur visée est celle-ci ~ https://sentry.io/organizations/pix/issues/1226792847/?project=1398749&query=is%3Aunresolved
