### PR TITLE
[FEATURE] Choisir une épreuve aléatoirement par acquis puis par challenge (PF-900).

### DIFF
--- a/api/lib/domain/services/smart-random/smart-random.js
+++ b/api/lib/domain/services/smart-random/smart-random.js
@@ -63,5 +63,11 @@ function _findFirstChallenge({ challenges, knowledgeElements, targetSkills, cour
 }
 
 function _pickRandomChallenge(challenges) {
-  return _.sample(challenges);
+  const challengesGroupBySkills = _.groupBy(challenges, _firstSkillTestedByChallenge);
+  const challengesForChosenSkill = _.sample(challengesGroupBySkills);
+  return _.sample(challengesForChosenSkill);
+}
+
+function _firstSkillTestedByChallenge(challenge) {
+  return challenge.skills[0].id;
 }


### PR DESCRIPTION
## :unicorn: Problème
Quand on choisit un challenge, on fait choisit de manière aléatoire parmi toutes les questions possibles.

Si à la fin de l'algorithme, il y avait 2 acquis possibles, avec 10 questions, on prenait aléatoirement dans les 10 questions.

Cas problématique : Si un des acquis a 9 réplications et l'autre un seul, l'aléatoire donne 90% de chance de choisir le premier acquis, ce qui fait peu de différence d'un utilisateur à l'autre, et donne une impression de passer toujours par le même chemin.

## :robot: Solution
- Lors du choix aléatoire de l'épreuve, les grouper par acquis, choisir aléatoirement un acquis, puis aléatoirement une épreuve de cet acquis.

## :rainbow: Remarques
Test effectué pour vérifier l'apport du ticket !
Sur la compétence 2.3, Collaborer, il n'y a que 2 acquis de niveau 2 (pour la première épreuve), @skill1 qui possède 6 challenges en tout, et @skill2 qui possède 3 challenges.
Par conséquent, si on choisit aléatoirement parmi les 9 challenges possibles, on a 67% d'avoir @skill1, et 33% d'avoir @skill2.
Objectif du ticket : avoir plutot 50%, car il y a 2 acquis.
Test fait via le pix-algo-research, qui permet de tester l'algo.
Sans modification, sur 100 lancement, j'obtiens 73 fois un challenge de @skill1, et 27 fois un challenge de @skill2 > ça confirme notre hypothèse.
Avec la modification, sur 100 lancement :  j'obtiens 48 fois un challenge de @skill1, et 52 fois un challenge de @skill2 > ça confirme notre changement.
Donc ça aide bien pour avoir une expérience qui sera + différente entre les utilisateurs !
