### PR TITLE
[FEATURE] Ajout d'un script déclenchant le déploiement SCO.

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -42,9 +42,10 @@ module.exports = {
       'logo-url': logoUrl,
       'external-id': externalId,
       'province-code': provinceCode,
+      'is-managing-students': isManagingStudents,
     } = request.payload.data.attributes;
 
-    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode })
+    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -5,6 +5,7 @@ module.exports = async function updateOrganizationInformation({
   logoUrl,
   externalId,
   provinceCode,
+  isManagingStudents,
   organizationRepository
 }) {
   const organization = await organizationRepository.get(id);
@@ -14,6 +15,7 @@ module.exports = async function updateOrganizationInformation({
   if (logoUrl) organization.logoUrl = logoUrl;
   if (externalId) organization.externalId = externalId;
   if (provinceCode) organization.provinceCode = provinceCode;
+  if (isManagingStudents) organization.isManagingStudents = isManagingStudents;
 
   await organizationRepository.update(organization);
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -63,7 +63,7 @@ module.exports = {
 
   update(organization) {
 
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode']);
+    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents']);
 
     return new BookshelfOrganization({ id: organization.id })
       .save(organizationRawData, { patch: true })

--- a/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
+++ b/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-console */
+// Usage: BASE_URL=... PIXMASTER_EMAIL=... PIXMASTER_PASSWORD=... node update-sco-organizations-with-is-managing-students-to-true.js path/file.csv
+
+'use strict';
+require('dotenv').config();
+const request = require('request-promise-native');
+
+const { parseCsv } = require('./helpers/csvHelpers');
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+
+function organizeOrganizationsByExternalId(data) {
+  const organizationsByExternalId = {};
+
+  data.forEach((organization) => {
+    if (organization.attributes['external-id']) {
+      organization.attributes['external-id'] = organization.attributes['external-id'].toUpperCase();
+      organizationsByExternalId[organization.attributes['external-id']] = { id: organization.id, ...organization.attributes };
+    }
+  });
+
+  return organizationsByExternalId;
+}
+
+async function updateOrganizations({ accessToken, organizationsByExternalId, csvData }) {
+  for (let i = 0; i < csvData.length; i++) {
+    const [externalIdLowerCase] = csvData[i];
+
+    if (!externalIdLowerCase) {
+      return console.log('Found empty line in input file.');
+    }
+
+    if (require.main === module) {
+      console.log(`${i + 1}/${csvData.length}`);
+    }
+
+    const externalId = externalIdLowerCase.toUpperCase();
+    const existingOrganization = organizationsByExternalId[externalId];
+
+    if (existingOrganization) {
+      await request(_buildPatchOrganizationRequestObject(accessToken, { id: existingOrganization.id }));
+    }
+  }
+}
+
+function _buildAccessTokenRequestObject() {
+  return {
+    method: 'POST',
+    baseUrl,
+    url: '/api/token',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    form: {
+      grant_type: 'password',
+      username: process.env.PIXMASTER_EMAIL,
+      password: process.env.PIXMASTER_PASSWORD,
+    },
+    json: true,
+  };
+}
+
+function _buildGetOrganizationsRequestObject(accessToken) {
+  return {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+    baseUrl,
+    url: '/api/organizations?pageSize=999999999',
+    json: true,
+  };
+}
+
+function _buildPatchOrganizationRequestObject(accessToken, organization) {
+  return {
+    method: 'PATCH',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+    baseUrl,
+    url: `/api/organizations/${organization.id}`,
+    json: true,
+    body: {
+      data: {
+        type: 'organizations',
+        id: organization.id,
+        attributes: {
+          'is-managing-students': true,
+        },
+      },
+    },
+  };
+}
+
+async function main() {
+  console.log('Starting creating or updating SCO organizations.');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading and parsing csv data file... ');
+    const csvData = parseCsv(filePath);
+    console.log('ok');
+
+    console.log('Requesting API access token... ');
+    const { access_token: accessToken } = await request(_buildAccessTokenRequestObject());
+    console.log('ok');
+
+    console.log('Fetching existing organizations... ');
+    const { data: organizations } = await request(_buildGetOrganizationsRequestObject(accessToken));
+    const organizationsByExternalId = organizeOrganizationsByExternalId(organizations);
+    console.log('ok');
+
+    console.log('Updating organizations...');
+    await updateOrganizations({ accessToken, organizationsByExternalId, csvData });
+    console.log('\nDone.');
+
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  organizeOrganizationsByExternalId,
+  updateOrganizations,
+};

--- a/api/tests/acceptance/scripts/update-sco-organizations-with-is-managing-students-to-true_test.js
+++ b/api/tests/acceptance/scripts/update-sco-organizations-with-is-managing-students-to-true_test.js
@@ -1,0 +1,102 @@
+const { expect, nock } = require('../../test-helper');
+
+const { organizeOrganizationsByExternalId, updateOrganizations } = require('../../../scripts/update-sco-organizations-with-is-managing-students-to-true');
+
+describe('Acceptance | Scripts | update-sco-organizations-with-is-managing-students-to-true.js', () => {
+
+  describe('#organizeOrganizationsByExternalId', () => {
+
+    it('should return organizations data by externalId', () => {
+      // given
+      const data = [
+        {
+          id: 1,
+          attributes: {
+            name: 'Lycée Jean Moulin',
+            'external-id': 'a100',
+          },
+        },
+        {
+          id: 2,
+          attributes: {
+            name: 'Lycée Jean Guedin',
+            'external-id': 'b200',
+          },
+        },
+      ];
+
+      const expectedResult = {
+        A100: {
+          id: 1,
+          name: 'Lycée Jean Moulin',
+          'external-id': 'A100',
+        },
+        B200: {
+          id: 2,
+          name: 'Lycée Jean Guedin',
+          'external-id': 'B200',
+        },
+      };
+
+      // when
+      const result = organizeOrganizationsByExternalId(data);
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#updateOrganizations', () => {
+
+    it('should update organizations', async () => {
+      // given
+      const accessToken = 'token';
+
+      const organizationsByExternalId = {
+        A100: {
+          id: 1,
+          'is-managing-students': false,
+        },
+      };
+
+      const csvData = [
+        ['a100', 'true'],
+      ];
+
+      const expectedPatchBody = {
+        data: {
+          type: 'organizations',
+          id: 1,
+          attributes: {
+            'is-managing-students': true,
+          },
+        },
+      };
+
+      let patchCallCount = 0;
+
+      const networkStub = nock(
+        'http://localhost:3000',
+        {
+          reqheaders: {
+            authorization: 'Bearer token',
+          },
+        }
+      )
+        .patch('/api/organizations/1', (body) => JSON.stringify(body) === JSON.stringify(expectedPatchBody))
+        .reply(204, () => {
+          patchCallCount++;
+
+          return {};
+        });
+
+      // when
+      await updateOrganizations({ accessToken, organizationsByExternalId, csvData });
+
+      // then
+      expect(networkStub.isDone()).to.be.true;
+      expect(patchCallCount).to.be.equal(1);
+    });
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -104,6 +104,7 @@ describe('Integration | Repository | Organization', function() {
       organization.logoUrl = 'http://new.logo.url';
       organization.externalId = '999Z527F';
       organization.provinceCode = '999';
+      organization.isManagingStudents = true;
 
       // when
       const organizationSaved = await organizationRepository.update(organization);
@@ -116,6 +117,7 @@ describe('Integration | Repository | Organization', function() {
       expect(organizationSaved.code).to.equal(organization.code);
       expect(organizationSaved.externalId).to.equal(organization.externalId);
       expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
+      expect(organizationSaved.isManagingStudents).to.equal(organization.isManagingStudents);
     });
 
     it('should not modify code property', async () => {

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -14,6 +14,7 @@ describe('Unit | UseCase | update-organization-information', () => {
       logoUrl: 'http://old.logo.url',
       externalId: 'extId',
       provinceCode: '666',
+      isManagingStudents: false,
     });
     organizationRepository = {
       get: sinon.stub().resolves(originalOrganization),
@@ -116,6 +117,25 @@ describe('Unit | UseCase | update-organization-information', () => {
       expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
       expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
       expect(resultOrganization.provinceCode).to.equal(provinceCode);
+    });
+
+    it('should allow to update the organization isManagingStudents (only) if modified', async () => {
+      // given
+      const isManagingStudents = true;
+
+      // when
+      const resultOrganization = await updateOrganizationInformation({
+        id: originalOrganization.id,
+        isManagingStudents,
+        organizationRepository
+      });
+
+      // then
+      expect(resultOrganization.name).to.equal(originalOrganization.name);
+      expect(resultOrganization.type).to.equal(originalOrganization.type);
+      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
+      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
+      expect(resultOrganization.isManagingStudents).to.equal(isManagingStudents);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le déploiement SCO se fait par le biais de l'attribut `isManagingStudents`. Il nous faut un script permettant de mettre à jour ce booléen pour les organisations que l'on souhaite au fur et à mesure du déploiement SCO.

## :robot: Solution
Ajout d'un script prenant en entrée un fichier csv avec juste les UAI des établissements scolaires concernés.
```
035tructruc
044bidule
```