### PR TITLE
[BUGFIX] Une page oups! s'affichait lorsque l'utilisateur souhaitait voir ses certifications

### DIFF
--- a/admin/app/transforms/date-only.js
+++ b/admin/app/transforms/date-only.js
@@ -6,7 +6,7 @@ export default DS.Transform.extend({
   },
   deserialize: function(date) {
     const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
-    if (date.search(dateRegex) === 0) {
+    if (date && date.search(dateRegex) === 0) {
       return date;
     }
     return null;

--- a/api/db/seeds/data/certification-courses-builder.js
+++ b/api/db/seeds/data/certification-courses-builder.js
@@ -7,10 +7,10 @@ module.exports = function certificationCoursesBuilder({ databaseBuilder }) {
     createdAt: new Date('2018-02-15T15:14:46Z'),
     firstName: 'Pix',
     lastName: 'Aile',
-    birthdate: '1960-12-12',
+    birthdate: null,
     birthplace: 'Paris',
     sessionId: 1,
-    externalId: 'NumeroEtudiantHubert',
+    externalId: 'CertificationCourseSansBirthdate',
     isPublished: true
   });
 

--- a/certif/app/transforms/date-only.js
+++ b/certif/app/transforms/date-only.js
@@ -6,7 +6,7 @@ export default DS.Transform.extend({
   },
   deserialize: function(date) {
     const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
-    if (date.search(dateRegex) === 0) {
+    if (date && date.search(dateRegex) === 0) {
       return date;
     }
     return null;

--- a/mon-pix/app/transforms/date-only.js
+++ b/mon-pix/app/transforms/date-only.js
@@ -6,7 +6,7 @@ export default DS.Transform.extend({
   },
   deserialize: function(date) {
     const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
-    if (date.search(dateRegex) === 0) {
+    if (date && date.search(dateRegex) === 0) {
       return date;
     }
     return null;

--- a/orga/app/transforms/date-only.js
+++ b/orga/app/transforms/date-only.js
@@ -6,7 +6,7 @@ export default DS.Transform.extend({
   },
   deserialize: function(date) {
     const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
-    if (date.search(dateRegex) === 0) {
+    if (date && date.search(dateRegex) === 0) {
       return date;
     }
     return null;


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur avait des certifications en attente ou publiées et que celles-ci contenaient une date de naissance vide, une page oups! était rendue suite au clic de 'Mes certifications'

## :robot: Solution
Bugfix apparu suite au merge de la PR https://github.com/1024pix/pix/pull/747. Une regex est opérée dans le cadre des transfomations ajoutées dans les fronts `date-only`, même pour les valeurs 'falsy' ce qui générait un plantage côté front.
Ligne en cause :
`// date-only.js`
`    if (date.search(dateRegex) === 0) {`

Solution : 
`// date-only.js`
`    if (date && date.search(dateRegex) === 0) {`

## :rainbow: Remarques
Application de la solution dans tous les fronts + ajout de seeds permettant d'illustrer les cas possibles
