### PR TITLE
[FEATURE] Ajouter un loader pendant le calcul des résultats collectifs (PO-275).

### DIFF
--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -8,6 +8,7 @@
 @import "globals/buttons";
 @import "globals/errors";
 @import "globals/forms";
+@import "globals/loading";
 @import "globals/pages";
 @import "globals/panels";
 @import "globals/pix-modal";

--- a/orga/app/styles/globals/loading.scss
+++ b/orga/app/styles/globals/loading.scss
@@ -1,0 +1,18 @@
+.app-loader {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background-color: $porcelain;
+}
+
+.app-loader__text {
+  display: block;
+  font-size: 1.2rem;
+  padding: 20px;
+  text-align: center;
+}
+
+

--- a/orga/app/templates/authenticated/campaigns/details/collective-results-loading.hbs
+++ b/orga/app/templates/authenticated/campaigns/details/collective-results-loading.hbs
@@ -1,0 +1,6 @@
+<div class="app-loader">
+    <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+    <p class="app-loader__text">
+        En cours de chargement
+    </p>
+</div>


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, si les données concernant une campagne sont très importantes, l'ouverture de l'onglet **Résultats collectifs** peut durer plusieurs secondes.
Durant ce temps, aucune information est présente pour prévenir l'utilisateur.

## :robot: Solution
Inclure un loader accompagné d'un texte pour prévenir l'utilisateur.