### PR TITLE
[TECH] Supprimer un appel superflu sur la récupérations des utilisateurs dans Pix Admin (PA-115).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -86,27 +86,19 @@ module.exports = {
       .then((certificationCenterMemberships) => certificationCenterMembershipSerializer.serialize(certificationCenterMemberships));
   },
 
-  find(request) {
+  async find(request) {
     const filters = {
       firstName: request.query['firstName'],
       lastName: request.query['lastName'],
       email: request.query['email'],
     };
-    const pagination = {
+    const requestedPagination = {
       page: request.query['page'] ? request.query['page'] : 1,
       pageSize: request.query['pageSize'] ? request.query['pageSize'] : 10,
     };
 
-    return usecases.findUsers({ filters, pagination })
-      .then((searchResultList) => {
-        const meta = {
-          page: searchResultList.page,
-          pageSize: searchResultList.pageSize,
-          itemsCount: searchResultList.totalResults,
-          pagesCount: searchResultList.pagesCount,
-        };
-        return userSerializer.serialize(searchResultList.paginatedResults, meta);
-      });
+    const { models: users, pagination } = await usecases.findUsers({ filters, pagination: requestedPagination });
+    return userSerializer.serialize(users, pagination);
   },
 
   getCampaignParticipations(request) {

--- a/api/lib/domain/usecases/find-users.js
+++ b/api/lib/domain/usecases/find-users.js
@@ -1,17 +1,10 @@
-const SearchResultList = require('../models/SearchResultList');
-
 module.exports = function findUsers({ filters, pagination, userRepository }) {
-
-  return Promise.all([
-    userRepository.find(filters, pagination),
-    userRepository.count(filters)
-  ]).then(([paginatedResults, totalResults]) => {
-
-    return new SearchResultList({
+  return userRepository.find(filters, pagination).then(({ models, pagination }) => ({
+    models, pagination: {
       page: pagination.page,
       pageSize: pagination.pageSize,
-      totalResults,
-      paginatedResults
-    });
-  });
+      itemsCount: pagination.rowCount,
+      pagesCount: pagination.pageCount,
+    }
+  }));
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -8,6 +8,7 @@ const Membership = require('../../domain/models/Membership');
 const CertificationCenter = require('../../domain/models/CertificationCenter');
 const CertificationCenterMembership = require('../../domain/models/CertificationCenterMembership');
 const Organization = require('../../domain/models/Organization');
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 
 function _toCertificationCenterMembershipsDomain(certificationCenterMembershipBookshelf) {
   return certificationCenterMembershipBookshelf.map((bookshelf) => {
@@ -135,11 +136,10 @@ module.exports = {
     const { page, pageSize } = pagination;
     return BookshelfUser.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb))
       .fetchPage({ page, pageSize })
-      .then((results) => results.map(_toDomain));
-  },
-
-  count(filters) {
-    return BookshelfUser.query((qb) => _setSearchFiltersForQueryBuilder(filters, qb)).count();
+      .then(({ models, pagination }) => {
+        const users = bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, models);
+        return { models: users, pagination };
+      });
   },
 
   getWithMemberships(userId) {

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -326,24 +326,20 @@ describe('Unit | Controller | user-controller', () => {
       expect(userSerializer.serialize).to.have.been.calledOnce;
     });
 
-    it('should return a JSON API response with pagination information in the data field "meta"', async () => {
+    it('should return a JSON API response with pagination information', async () => {
       // given
       const request = { query: {} };
-      const searchResultList = new SearchResultList({
-        page: 2,
-        pageSize: 25,
-        totalResults: 100,
-        paginatedResults: [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })],
-      });
-      usecases.findUsers.resolves(searchResultList);
+      const expectedResults = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
+      const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
+
+      usecases.findUsers.resolves({ models: expectedResults, pagination: expectedPagination });
 
       // when
       await userController.find(request, hFake);
 
       // then
-      const expectedResults = searchResultList.paginatedResults;
-      const expectedMeta = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4, };
-      expect(userSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedMeta);
+
+      expect(userSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination);
     });
 
     it('should allow to filter users by first name', async () => {

--- a/api/tests/unit/domain/usecases/find-users_test.js
+++ b/api/tests/unit/domain/usecases/find-users_test.js
@@ -1,34 +1,32 @@
-const { expect } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
-const SearchResultList = require('../../../../lib/domain/models/SearchResultList');
 const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | UseCase | find-users', () => {
 
-  it('should result a SearchResultList object that take into account User search with filtering and pagination', () => {
+  it('should result a SearchResultList object that take into account User search with filtering and pagination', async () => {
     // given
     const filters = {};
-    const pagination = { page: 1, pageSize: 10 };
+    const pagination = { page: 1, pageSize: 2 };
+    const resolvedPagination = { page: 1, pageSize: 2, rowCount: 3, pageCount: 2 };
     const matchingUsers = [
       new User({ id: 1 }),
       new User({ id: 2 }),
       new User({ id: 3 }),
     ];
     const userRepository = {
-      find: () => matchingUsers,
-      count: () => matchingUsers.length
+      find: sinon.stub()
     };
+    userRepository.find.withArgs(filters, pagination).resolves({ models: matchingUsers, pagination: resolvedPagination });
 
     // when
-    const promise = usecases.findUsers({ filters, pagination, userRepository });
+    const response = await usecases.findUsers({ filters, pagination, userRepository });
 
     // then
-    return expect(promise).to.be.fulfilled.then((response) => {
-      expect(response).to.be.an.instanceOf(SearchResultList);
-      expect(response.page).to.equal(1);
-      expect(response.pageSize).to.equal(10);
-      expect(response.totalResults).to.equal(3);
-      expect(response.paginatedResults).to.deep.equal(matchingUsers);
-    });
+    expect(response.models).to.equal(matchingUsers);
+    expect(response.pagination.page).to.equal(resolvedPagination.page);
+    expect(response.pagination.pageSize).to.equal(resolvedPagination.pageSize);
+    expect(response.pagination.itemsCount).to.equal(resolvedPagination.rowCount);
+    expect(response.pagination.pagesCount).to.equal(resolvedPagination.pageCount);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la recherche des utilisateurs dans Pix Admin, la recherche est longue.

## :robot: Solution
2 appels identiques étaient réalisés pour récupérer les utilisateurs : 
- un premier pour les récupérer véritablement en fonction de filtres et d'une pagination ;
- un second qui effectuait exactement la même requête mais faisait un `.count()` derrière.

Or en faisant un `.fetchPage()` on peut récupérer de base le nombre total d'utilisateurs correspondant aux filtres.

## 🌵Remarque
Il est possible que cela ne change pas grand chose, mais c'est déjà ça :)