### PR TITLE
[FEATURE] Remplacement du mot campagne par parcours dans un message d'erreur (PF-914).

### DIFF
--- a/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
@@ -23,7 +23,7 @@ export default Controller.extend({
           .then(() => true,
             (error) => {
               if (error.errors[0].status === '403') {
-                this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+                this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
                 return false;
               }
               if (error.errors[0].status === '404') {

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -88,7 +88,7 @@ export default Controller.extend({
         studentUserAssociation.unloadRecord();
         errorResponse.errors.forEach((error) => {
           if (error.status === '404') {
-            return this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+            return this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
           }
           throw (error);
         });

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
@@ -66,7 +66,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
     });
   });
 

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -317,7 +317,7 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de la campagne.');
+      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un élève essaye de rejoindre une campagne et que la réconciliation ne peut être effectuée, un message d'erreur est affiché l'invitant à contacter l'organisateur de sa campagne. Le terme "campagne" n'est pas le bon et doit être remplacé par "parcours". 

## :robot: Solution
Remplacer "campagne" par "parcours".
