### PR TITLE
[FEATURE] Amélioration des performances de la récupération des résultats collectifs (PO-298).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -39,12 +39,11 @@ async function _fetchData(campaignId) {
 }
 
 async function _fetchFilteredCurrentValidatedParticipantKEs(campaignId, targetedSkillIds) {
-  const knexQuery = Bookshelf.knex('knowledge-elements');
-
-  _joinWithSharedCampaignParticipationsAndFilterBySharedAt(knexQuery);
-  _filterByTargetSkills(targetedSkillIds)(knexQuery);
-  _filterByCampaignId(campaignId)(knexQuery);
-  _keepOnlySharedParticipations(knexQuery);
+  const knexQuery = Bookshelf.knex('knowledge-elements')
+    .modify(_joinWithSharedCampaignParticipationsAndFilterBySharedAt)
+    .modify(_filterByTargetSkills(targetedSkillIds))
+    .modify(_filterByCampaignId(campaignId))
+    .modify(_keepOnlySharedParticipations);
 
   const participantKEsSharedAndInTargetProfile = await knexQuery.select('*');
 


### PR DESCRIPTION
## :unicorn: Problème
La récupération de résultats collectifs d'une campagne sature la mémoire et crash le container.

## :robot: Solution
Refonte du code avec la méthodologie de Refactoring de *Martin Fowler*, au lieu de faire plusieurs requêtes qui nous remontent beaucoup d'informations que nous trions après dans le code.
Nous avons pris le partie de faire des requêtes qui vont directement chercher les bonnes informations déjà triées. 