### PR TITLE
[FEATURE] Remplacer le rôle OWNER par ADMIN (PA-106).

### DIFF
--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -4,7 +4,7 @@ import { computed } from '@ember/object';
 const { attr, belongsTo } = DS;
 
 const displayedOrganizationRoles = {
-  OWNER: 'Responsable',
+  ADMIN: 'Administrateur',
   MEMBER: 'Membre',
 };
 

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -51,7 +51,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       // given
       const organization = this.server.create('organization');
       const user = this.server.create('user', { firstName: 'Denise', lastName: 'Ter Hegg', email: 'denise@example.com' });
-      this.server.create('membership', { user, organization, organizationRole: 'OWNER' });
+      this.server.create('membership', { user, organization, organizationRole: 'ADMIN' });
 
       // when
       await visit(`/organizations/${organization.id}`);
@@ -69,7 +69,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       assert.dom('div.member-list table > tbody').includesText('Denise');
       assert.dom('div.member-list table > tbody').includesText('Ter Hegg');
       assert.dom('div.member-list table > tbody').includesText('denise@example.com');
-      assert.dom('div.member-list table > tbody').includesText('Responsable');
+      assert.dom('div.member-list table > tbody').includesText('Administrateur');
     });
 
     test('should display the correct user data when the user is a MEMBER', async function(assert) {

--- a/api/db/migrations/20191112121128_update_memberships_modify_organizationRole.js
+++ b/api/db/migrations/20191112121128_update_memberships_modify_organizationRole.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'memberships';
+
+exports.up = function(knex) {
+  return knex(TABLE_NAME)
+    .where('organizationRole', '=', 'OWNER')
+    .update({ organizationRole: 'ADMIN' });
+};
+
+exports.down = function(knex) {
+  return knex(TABLE_NAME)
+    .where('organizationRole', '=', 'ADMIN')
+    .update({ organizationRole: 'OWNER' });
+};

--- a/api/db/seeds/data/dragon-and-co-builder.js
+++ b/api/db/seeds/data/dragon-and-co-builder.js
@@ -35,7 +35,7 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: proUserDaenerys.id,
     organizationId: dragonAndCoCompany.id,
-    organizationRole: Membership.roles.OWNER,
+    organizationRole: Membership.roles.ADMIN,
   });
 
   databaseBuilder.factory.buildMembership({
@@ -84,7 +84,7 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: proUserSub.id,
     organizationId: dragonAndCoSubsidiary.id,
-    organizationRole: Membership.roles.OWNER,
+    organizationRole: Membership.roles.ADMIN,
   });
 
   databaseBuilder.factory.buildTargetProfileShare({
@@ -112,7 +112,7 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: proUserSub2.id,
     organizationId: dragonAndCoSubsidiary2.id,
-    organizationRole: Membership.roles.OWNER,
+    organizationRole: Membership.roles.ADMIN,
   });
 
   const invitedUsers = [];

--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -12,7 +12,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: 3,
     organizationId: 2,
-    organizationRole: Membership.roles.OWNER,
+    organizationRole: Membership.roles.ADMIN,
   });
 
   databaseBuilder.factory.buildOrganization({
@@ -27,7 +27,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: 4,
     organizationId: 3,
-    organizationRole: Membership.roles.OWNER,
+    organizationRole: Membership.roles.ADMIN,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -93,8 +93,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/memberships',
       config: {
         pre: [{
-          method: securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster,
-          assign: 'isOwnerInOrganizationOrHasRolePixMaster'
+          method: securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster,
+          assign: 'isAdminInOrganizationOrHasRolePixMaster'
         }],
         handler: organisationController.getMemberships,
         tags: ['api', 'organizations'],
@@ -137,8 +137,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/import-students',
       config: {
         pre: [{
-          method: securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents,
-          assign: 'isOwnerInScoOrganizationAndManagesStudents'
+          method: securityController.checkUserIsAdminInScoOrganizationAndManagesStudents,
+          assign: 'isAdminInScoOrganizationAndManagesStudents'
         }],
         payload: {
           maxBytes: 1048576 * 10, // 10MB
@@ -158,8 +158,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/invitations',
       config: {
         pre: [{
-          method: securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster,
-          assign: 'isOwnerInOrganizationOrHasRolePixMaster'
+          method: securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster,
+          assign: 'isAdminInOrganizationOrHasRolePixMaster'
         }],
         handler: organisationController.sendInvitation,
         notes: [
@@ -174,8 +174,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/invitations',
       config: {
         pre: [{
-          method: securityController.checkUserIsOwnerInOrganization,
-          assign: 'isOwnerInOrganization'
+          method: securityController.checkUserIsAdminInOrganization,
+          assign: 'isAdminInOrganization'
         }],
         handler: organisationController.findPendingInvitations,
         tags: ['api', 'invitations'],

--- a/api/lib/application/usecases/checkUserIsAdminInOrganization.js
+++ b/api/lib/application/usecases/checkUserIsAdminInOrganization.js
@@ -4,6 +4,6 @@ module.exports = {
 
   execute(userId, organizationId) {
     return membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId })
-      .then((memberships) => memberships.reduce((isOwnerInOrganization, membership) => isOwnerInOrganization || membership.isOwner, false));
+      .then((memberships) => memberships.reduce((isAdminInOrganization, membership) => isAdminInOrganization || membership.isAdmin, false));
   }
 };

--- a/api/lib/domain/models/Membership.js
+++ b/api/lib/domain/models/Membership.js
@@ -1,5 +1,5 @@
 const roles = {
-  OWNER: 'OWNER', // Is resposible for the organization, has ADMIN capabilities, there must be only one per organzation
+  ADMIN: 'ADMIN',
   MEMBER: 'MEMBER',
 };
 
@@ -23,8 +23,8 @@ class Membership {
     // references
   }
 
-  get isOwner() {
-    return this.organizationRole === roles.OWNER;
+  get isAdmin() {
+    return this.organizationRole === roles.ADMIN;
   }
 }
 

--- a/api/lib/domain/usecases/answer-to-organization-invitation.js
+++ b/api/lib/domain/usecases/answer-to-organization-invitation.js
@@ -27,7 +27,7 @@ module.exports = async function answerToOrganizationInvitation({
         throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
       }
 
-      const organizationRole = memberships.length ? roles.MEMBER : roles.OWNER;
+      const organizationRole = memberships.length ? roles.MEMBER : roles.ADMIN;
       await membershipRepository.create(userFound.id, organizationId, organizationRole);
 
       return organizationInvitationRepository.markAsAccepted(organizationInvitationId);

--- a/api/lib/domain/usecases/create-membership.js
+++ b/api/lib/domain/usecases/create-membership.js
@@ -2,7 +2,7 @@ const { roles } = require('../models/Membership');
 
 module.exports = async function createMembership({ membershipRepository, userId, organizationId }) {
   const memberships = await membershipRepository.findByOrganizationId({ organizationId });
-  const organizationRole =  memberships.length ? roles.MEMBER : roles.OWNER;
+  const organizationRole =  memberships.length ? roles.MEMBER : roles.ADMIN;
 
   return membershipRepository.create(userId, organizationId, organizationRole);
 };

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -2,7 +2,7 @@ const logger = require('../../infrastructure/logger');
 const tokenService = require('../../domain/services/token-service');
 const checkUserIsAuthenticatedUseCase = require('../../application/usecases/checkUserIsAuthenticated');
 const checkUserHasRolePixMasterUseCase = require('../../application/usecases/checkUserHasRolePixMaster');
-const checkUserIsOwnerInOrganizationUseCase = require('../../application/usecases/checkUserIsOwnerInOrganization');
+const checkUserIsAdminInOrganizationUseCase = require('../../application/usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase  = require('../../application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
@@ -88,7 +88,7 @@ function checkRequestedUserIsAuthenticatedUser(request, h) {
   return authenticatedUserId === requestedUserId ? h.response(true) : _replyWithAuthorizationError(h);
 }
 
-function checkUserIsOwnerInOrganization(request, h) {
+function checkUserIsAdminInOrganization(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyWithAuthorizationError(h);
   }
@@ -96,9 +96,9 @@ function checkUserIsOwnerInOrganization(request, h) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
 
-  return checkUserIsOwnerInOrganizationUseCase.execute(userId, organizationId)
-    .then((isOwnerInOrganization) => {
-      if (isOwnerInOrganization) {
+  return checkUserIsAdminInOrganizationUseCase.execute(userId, organizationId)
+    .then((isAdminInOrganization) => {
+      if (isAdminInOrganization) {
         return h.response(true);
       }
       return _replyWithAuthorizationError(h);
@@ -109,7 +109,7 @@ function checkUserIsOwnerInOrganization(request, h) {
     });
 }
 
-async function checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, h) {
+async function checkUserIsAdminInOrganizationOrHasRolePixMaster(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyWithAuthorizationError(h);
   }
@@ -117,8 +117,8 @@ async function checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, h) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
 
-  const isOwnerInOrganization = await checkUserIsOwnerInOrganizationUseCase.execute(userId, organizationId);
-  if (isOwnerInOrganization) {
+  const isAdminInOrganization = await checkUserIsAdminInOrganizationUseCase.execute(userId, organizationId);
+  if (isAdminInOrganization) {
     return h.response(true);
   }
 
@@ -153,7 +153,7 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   return _replyWithAuthorizationError(h);
 }
 
-async function checkUserIsOwnerInScoOrganizationAndManagesStudents(request, h) {
+async function checkUserIsAdminInScoOrganizationAndManagesStudents(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyWithAuthorizationError(h);
   }
@@ -164,8 +164,8 @@ async function checkUserIsOwnerInScoOrganizationAndManagesStudents(request, h) {
   const belongsToScoOrganizationAndManageStudents = await checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
   if (belongsToScoOrganizationAndManageStudents) {
 
-    const isOwnerInOrganization = await checkUserIsOwnerInOrganizationUseCase.execute(userId, organizationId);
-    if (isOwnerInOrganization) {
+    const isAdminInOrganization = await checkUserIsAdminInOrganizationUseCase.execute(userId, organizationId);
+    if (isAdminInOrganization) {
       return h.response(true);
     }
   }
@@ -178,7 +178,7 @@ module.exports = {
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
   checkUserIsAuthenticated,
-  checkUserIsOwnerInOrganization,
-  checkUserIsOwnerInOrganizationOrHasRolePixMaster,
-  checkUserIsOwnerInScoOrganizationAndManagesStudents,
+  checkUserIsAdminInOrganization,
+  checkUserIsAdminInOrganizationOrHasRolePixMaster,
+  checkUserIsAdminInScoOrganizationAndManagesStudents,
 };

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -744,7 +744,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user is not OWNER in organization nor PIX_MASTER', async () => {
+      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization nor PIX_MASTER', async () => {
         // given
         const nonPixMasterUserId = 9999;
         options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
@@ -945,7 +945,7 @@ describe('Acceptance | Application | organization-controller', () => {
     beforeEach(async () => {
       const connectedUser = databaseBuilder.factory.buildUser();
       organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: connectedUser.id, organizationRole: Membership.roles.OWNER });
+      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: connectedUser.id, organizationRole: Membership.roles.ADMIN });
       await databaseBuilder.commit();
 
       options = {
@@ -1194,7 +1194,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should respond with a 403 - Forbidden access - if Organization type is not SCO', async () => {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: true }).id;
-        const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId, organizationRole: Membership.roles.OWNER }).id;
+        const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId, organizationRole: Membership.roles.ADMIN }).id;
         await databaseBuilder.commit();
 
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
@@ -1210,7 +1210,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should respond with a 403 - Forbidden access - if Organization does not manage students', async () => {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false }).id;
-        const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId, organizationRole: Membership.roles.OWNER }).id;
+        const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId, organizationRole: Membership.roles.ADMIN }).id;
         await databaseBuilder.commit();
 
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
@@ -1223,7 +1223,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(403);
       });
 
-      it('should respond with a 403 - Forbidden access - if user is not OWNER', async () => {
+      it('should respond with a 403 - Forbidden access - if user is not ADMIN', async () => {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
         const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId, organizationRole: Membership.roles.MEMBER }).id;
@@ -1250,12 +1250,12 @@ describe('Acceptance | Application | organization-controller', () => {
     context('Expected output', () => {
 
       beforeEach(async () => {
-        const ownerUserId = databaseBuilder.factory.buildUser().id;
+        const adminUserId = databaseBuilder.factory.buildUser().id;
         organization = databaseBuilder.factory.buildOrganization();
         databaseBuilder.factory.buildMembership({
-          userId: ownerUserId,
+          userId: adminUserId,
           organizationId: organization.id,
-          organizationRole: Membership.roles.OWNER,
+          organizationRole: Membership.roles.ADMIN,
         });
 
         user = databaseBuilder.factory.buildUser();
@@ -1263,7 +1263,7 @@ describe('Acceptance | Application | organization-controller', () => {
         options = {
           method: 'POST',
           url: `/api/organizations/${organization.id}/invitations`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(ownerUserId) },
+          headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
           payload: {
             data: {
               type: 'organization-invitations',
@@ -1307,12 +1307,12 @@ describe('Acceptance | Application | organization-controller', () => {
     context('Resource access management', () => {
 
       beforeEach(async () => {
-        const ownerUserId = databaseBuilder.factory.buildUser().id;
+        const adminUserId = databaseBuilder.factory.buildUser().id;
         organization = databaseBuilder.factory.buildOrganization();
         databaseBuilder.factory.buildMembership({
-          userId: ownerUserId,
+          userId: adminUserId,
           organizationId: organization.id,
-          organizationRole: Membership.roles.OWNER,
+          organizationRole: Membership.roles.ADMIN,
         });
 
         user = databaseBuilder.factory.buildUser();
@@ -1320,7 +1320,7 @@ describe('Acceptance | Application | organization-controller', () => {
         options = {
           method: 'POST',
           url: `/api/organizations/${organization.id}/invitations`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(ownerUserId) },
+          headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
           payload: {
             data: {
               type: 'organization-invitations',
@@ -1350,7 +1350,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user is not OWNER in organization or PIXMASTER', async () => {
+      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization or PIXMASTER', async () => {
         // given
         const nonPixMasterUserId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
@@ -1408,13 +1408,13 @@ describe('Acceptance | Application | organization-controller', () => {
     let options;
 
     beforeEach(async () => {
-      const ownerUserId = databaseBuilder.factory.buildUser().id;
+      const adminUserId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
 
       databaseBuilder.factory.buildMembership({
-        userId: ownerUserId,
+        userId: adminUserId,
         organizationId: organization.id,
-        organizationRole: Membership.roles.OWNER,
+        organizationRole: Membership.roles.ADMIN,
       });
 
       databaseBuilder.factory.buildOrganizationInvitation({
@@ -1438,7 +1438,7 @@ describe('Acceptance | Application | organization-controller', () => {
       options = {
         method: 'GET',
         url: `/api/organizations/${organization.id}/invitations`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(ownerUserId) },
+        headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
       };
 
       await databaseBuilder.commit();
@@ -1499,7 +1499,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if user is not OWNER in organization', async () => {
+      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization', async () => {
         // given
         const nonPixMasterUserId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         databaseBuilder.factory.buildMembership({
           userId: adminOrganizationUserId,
           organizationId,
-          organizationRole: Membership.roles.OWNER,
+          organizationRole: Membership.roles.ADMIN,
         });
 
         const userToInviteEmail = databaseBuilder.factory.buildUser().email;

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -63,7 +63,7 @@ describe('Integration | Application | Organizations | Routes', () => {
   describe('POST /api/organizations/:id/import-students', () => {
 
     beforeEach(() => {
-      sinon.stub(securityController, 'checkUserIsOwnerInScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
+      sinon.stub(securityController, 'checkUserIsAdminInScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
       sinon.stub(organisationController, 'importStudentsFromSIECLE').callsFake((request, h) => h.response('ok').code(201));
       return server.register(route);
     });
@@ -87,7 +87,7 @@ describe('Integration | Application | Organizations | Routes', () => {
   describe('POST /api/organizations/:id/invitations', () => {
 
     beforeEach(() => {
-      sinon.stub(securityController, 'checkUserIsOwnerInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(securityController, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
       sinon.stub(organisationController, 'sendInvitation').callsFake((request, h) => h.response().created());
 
       return server.register(route);
@@ -117,7 +117,7 @@ describe('Integration | Application | Organizations | Routes', () => {
   describe('GET /api/organizations/:id/invitations', () => {
 
     beforeEach(() => {
-      sinon.stub(securityController, 'checkUserIsOwnerInOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityController, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
       sinon.stub(organisationController, 'findPendingInvitations').returns('ok');
       return server.register(route);
     });

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -24,8 +24,8 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(usecases, 'findPendingOrganizationInvitations');
 
     sandbox.stub(securityController, 'checkUserHasRolePixMaster');
-    sandbox.stub(securityController, 'checkUserIsOwnerInOrganization');
-    sandbox.stub(securityController, 'checkUserIsOwnerInOrganizationOrHasRolePixMaster');
+    sandbox.stub(securityController, 'checkUserIsAdminInOrganization');
+    sandbox.stub(securityController, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
     sandbox.stub(securityController, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -106,7 +106,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     context('Success cases', () => {
 
       beforeEach(() => {
-        securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster.returns(true);
+        securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster.returns(true);
       });
 
       const membership = domainBuilder.buildMembership();
@@ -222,7 +222,7 @@ describe('Integration | Application | Organizations | organization-controller', 
       };
 
       beforeEach(() => {
-        securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster.returns(true);
+        securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster.returns(true);
       });
 
       it('should return an HTTP response with status code 201', async () => {
@@ -270,7 +270,7 @@ describe('Integration | Application | Organizations | organization-controller', 
       });
 
       beforeEach(() => {
-        securityController.checkUserIsOwnerInOrganization.returns(true);
+        securityController.checkUserIsAdminInOrganization.returns(true);
       });
 
       it('should return an HTTP response with status code 200', async () => {

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -21,7 +21,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
     let userId;
     let organizationId;
-    const organizationRole = Membership.roles.OWNER;
+    const organizationRole = Membership.roles.ADMIN;
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
@@ -47,7 +47,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
 
       // then
       expect(membership).to.be.an.instanceOf(Membership);
-      expect(membership.organizationRole).to.equal(Membership.roles.OWNER);
+      expect(membership.organizationRole).to.equal(Membership.roles.ADMIN);
     });
 
     context('Error cases', () => {
@@ -72,7 +72,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const organization = databaseBuilder.factory.buildOrganization();
       const user = databaseBuilder.factory.buildUser();
       const otherUserId = databaseBuilder.factory.buildUser().id;
-      const organizationRole = Membership.roles.OWNER;
+      const organizationRole = Membership.roles.ADMIN;
 
       // Matching membership
       databaseBuilder.factory.buildMembership({
@@ -94,7 +94,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const anyMembership = memberships[0];
       expect(anyMembership).to.be.an.instanceOf(Membership);
 
-      expect(anyMembership.organizationRole).to.equal(Membership.roles.OWNER);
+      expect(anyMembership.organizationRole).to.equal(Membership.roles.ADMIN);
       expect(anyMembership.organizationRole.id).to.equal(organizationRole.id);
       expect(anyMembership.organizationRole.name).to.equal(organizationRole.name);
 
@@ -114,7 +114,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const user_2 = databaseBuilder.factory.buildUser();
       const user_3 = databaseBuilder.factory.buildUser();
 
-      const organizationRole = Membership.roles.OWNER;
+      const organizationRole = Membership.roles.ADMIN;
 
       databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization_1.id, userId: user_1.id });
       databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization_1.id, userId: user_2.id });
@@ -137,7 +137,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const user_2 = databaseBuilder.factory.buildUser();
       const user_3 = databaseBuilder.factory.buildUser();
 
-      const organizationRole = Membership.roles.OWNER;
+      const organizationRole = Membership.roles.ADMIN;
 
       const membership_3 = databaseBuilder.factory.buildMembership({ id: 789, organizationRole, organizationId: organization.id, userId: user_3.id });
       const membership_2 = databaseBuilder.factory.buildMembership({ id: 456, organizationRole, organizationId: organization.id, userId: user_2.id });
@@ -161,7 +161,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const user_3 = databaseBuilder.factory.buildUser({ lastName: 'Avatar', firstName: 'Arthur' });
       const user_4 = databaseBuilder.factory.buildUser({ lastName: 'Avatar', firstName: 'MATHURIN' });
 
-      const organizationRole = Membership.roles.OWNER;
+      const organizationRole = Membership.roles.ADMIN;
 
       const membership_1 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_1.id });
       const membership_2 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_2.id });
@@ -186,7 +186,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
         // given
         const organization = databaseBuilder.factory.buildOrganization();
         const user1 = databaseBuilder.factory.buildUser();
-        const organizationRole1 = Membership.roles.OWNER;
+        const organizationRole1 = Membership.roles.ADMIN;
         const user2 = databaseBuilder.factory.buildUser();
         const organizationRole2 = Membership.roles.MEMBER;
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -35,7 +35,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
 
     userInDB = databaseBuilder.factory.buildUser(userToInsert);
-    organizationRoleInDB = Membership.roles.OWNER;
+    organizationRoleInDB = Membership.roles.ADMIN;
 
     membershipInDB = databaseBuilder.factory.buildMembership({
       userId: userInDB.id,

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -100,7 +100,7 @@ buildUser.withMembership = function buildUserWithMemberships({
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
   hasSeenAssessmentInstructions = false,
-  organizationRole = Membership.roles.OWNER,
+  organizationRole = Membership.roles.ADMIN,
   organizationId = null,
 } = {}) {
 

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -14,8 +14,8 @@ function startServer() {
 describe('Unit | Router | organization-router', () => {
 
   beforeEach(() => {
-    sinon.stub(securityController, 'checkUserIsOwnerInOrganization').returns(true);
-    sinon.stub(securityController, 'checkUserIsOwnerInOrganizationOrHasRolePixMaster').returns(true);
+    sinon.stub(securityController, 'checkUserIsAdminInOrganization').returns(true);
+    sinon.stub(securityController, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').returns(true);
     sinon.stub(organizationController, 'find').returns('ok');
     sinon.stub(organizationController, 'sendInvitation').callsFake((request, h) => h.response().created());
 

--- a/api/tests/unit/application/usecases/checkUserIsAdminInOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserIsAdminInOrganization_test.js
@@ -1,22 +1,22 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
-const useCase = require('../../../../lib/application/usecases/checkUserIsOwnerInOrganization');
+const useCase = require('../../../../lib/application/usecases/checkUserIsAdminInOrganization');
 const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
 const Membership = require('../../../../lib/domain/models/Membership');
 
-describe('Unit | Application | Use Case | CheckUserIsOwnerInOrganization', () => {
+describe('Unit | Application | Use Case | CheckUserIsAdminInOrganization', () => {
 
   beforeEach(() => {
     membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
   });
 
-  context('When user is owner in organization', () => {
+  context('When user is admin in organization', () => {
 
     it('should return true', async () => {
       // given
       const userId = 1234;
       const organizationId = 789;
 
-      const membership = domainBuilder.buildMembership({ organizationRole: Membership.roles.OWNER });
+      const membership = domainBuilder.buildMembership({ organizationRole: Membership.roles.ADMIN });
       membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
 
       // when
@@ -31,9 +31,9 @@ describe('Unit | Application | Use Case | CheckUserIsOwnerInOrganization', () =>
       const userId = 1234;
       const organizationId = 789;
 
-      const membershipOwner = domainBuilder.buildMembership({ organizationRole: Membership.roles.OWNER });
+      const membershipAdmin = domainBuilder.buildMembership({ organizationRole: Membership.roles.ADMIN });
       const membershipMember = domainBuilder.buildMembership({ organizationRole: Membership.roles.MEMBER });
-      membershipRepository.findByUserIdAndOrganizationId.resolves([membershipOwner, membershipMember]);
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membershipAdmin, membershipMember]);
 
       // when
       const response = await useCase.execute(userId, organizationId);
@@ -43,7 +43,7 @@ describe('Unit | Application | Use Case | CheckUserIsOwnerInOrganization', () =>
     });
   });
 
-  context('When user is not owner in organization', () => {
+  context('When user is not admin in organization', () => {
 
     it('should return false', async () => {
       // given

--- a/api/tests/unit/domain/usecases/create-membership_test.js
+++ b/api/tests/unit/domain/usecases/create-membership_test.js
@@ -4,7 +4,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 
 describe('Unit | UseCase | create-membership', () => {
 
-  it('should insert a new membership with role OWNER', async () => {
+  it('should insert a new membership with role ADMIN', async () => {
     // given
     const membershipRepository = {
       create: sinon.stub(),
@@ -12,7 +12,7 @@ describe('Unit | UseCase | create-membership', () => {
     };
     const userId = 1;
     const organizationId = 2;
-    const role = Membership.roles.OWNER;
+    const role = Membership.roles.ADMIN;
 
     // when
     await createMembership({ membershipRepository, userId, organizationId });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -16,7 +16,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
           type: 'SUP',
           code: 'WASABI666',
         },
-        organizationRole: Membership.roles.OWNER,
+        organizationRole: Membership.roles.ADMIN,
       });
 
       const expectedSerializedMembership = {
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
           type: 'memberships',
           id: '5',
           attributes: {
-            'organization-role': Membership.roles.OWNER,
+            'organization-role': Membership.roles.ADMIN,
           },
           relationships: {
             organization: {

--- a/api/tests/unit/interfaces/controllers/security-controller_test.js
+++ b/api/tests/unit/interfaces/controllers/security-controller_test.js
@@ -3,7 +3,7 @@ const securityController = require('../../../../lib/interfaces/controllers/secur
 const tokenService = require('../../../../lib/domain/services/token-service');
 const checkUserIsAuthenticatedUseCase = require('../../../../lib/application/usecases/checkUserIsAuthenticated');
 const checkUserHasRolePixMasterUseCase = require('../../../../lib/application/usecases/checkUserHasRolePixMaster');
-const checkUserIsOwnerInOrganizationUseCase = require('../../../../lib/application/usecases/checkUserIsOwnerInOrganization');
+const checkUserIsAdminInOrganizationUseCase = require('../../../../lib/application/usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('../../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 
 describe('Unit | Interfaces | Controllers | SecurityController', () => {
@@ -215,26 +215,26 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
     });
   });
 
-  describe('#checkUserIsOwnerInOrganization', () => {
-    let isOwnerInOrganizationStub;
+  describe('#checkUserIsAdminInOrganization', () => {
+    let isAdminInOrganizationStub;
 
     beforeEach(() => {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      isOwnerInOrganizationStub = sinon.stub(checkUserIsOwnerInOrganizationUseCase, 'execute');
+      isAdminInOrganizationStub = sinon.stub(checkUserIsAdminInOrganizationUseCase, 'execute');
     });
 
     context('Successful case', () => {
       const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } }, params: { id: 5678 } };
 
       beforeEach(() => {
-        isOwnerInOrganizationStub.resolves(true);
+        isAdminInOrganizationStub.resolves(true);
       });
 
-      it('should authorize access to resource when the user is authenticated and is OWNER in Organization', async () => {
+      it('should authorize access to resource when the user is authenticated and is ADMIN in Organization', async () => {
         // given
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganization(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganization(request, hFake);
 
         // then
         expect(response.source).to.equal(true);
@@ -250,19 +250,19 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
         delete request.auth.credentials;
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganization(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganization(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
       });
 
-      it('should forbid resource access when user is not OWNER in Organization', async () => {
+      it('should forbid resource access when user is not ADMIN in Organization', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.resolves(false);
+        checkUserIsAdminInOrganizationUseCase.execute.resolves(false);
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganization(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganization(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -271,10 +271,10 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
       it('should forbid resource access when an error is thrown by use case', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.rejects(new Error('Some error'));
+        checkUserIsAdminInOrganizationUseCase.execute.rejects(new Error('Some error'));
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganization(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganization(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -284,13 +284,13 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
     });
   });
 
-  describe('#checkUserIsOwnerInOrganizationOrHasRolePixMaster', () => {
-    let isOwnerInOrganizationStub;
+  describe('#checkUserIsAdminInOrganizationOrHasRolePixMaster', () => {
+    let isAdminInOrganizationStub;
     let hasRolePixMasterStub;
 
     beforeEach(() => {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      isOwnerInOrganizationStub = sinon.stub(checkUserIsOwnerInOrganizationUseCase, 'execute');
+      isAdminInOrganizationStub = sinon.stub(checkUserIsAdminInOrganizationUseCase, 'execute');
       hasRolePixMasterStub = sinon.stub(checkUserHasRolePixMasterUseCase, 'execute');
     });
 
@@ -298,37 +298,37 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
       const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } }, params: { id: 5678 } };
 
       beforeEach(() => {
-        isOwnerInOrganizationStub.resolves(true);
+        isAdminInOrganizationStub.resolves(true);
         hasRolePixMasterStub.resolves(true);
       });
 
       it('should authorize access to resource when the user is authenticated and is PIX_MASTER', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.resolves(false);
+        checkUserIsAdminInOrganizationUseCase.execute.resolves(false);
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.source).to.equal(true);
       });
 
-      it('should authorize access to resource when the user is authenticated and is OWNER in Organization', async () => {
+      it('should authorize access to resource when the user is authenticated and is ADMIN in Organization', async () => {
         // given
         checkUserHasRolePixMasterUseCase.execute.resolves(false);
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.source).to.equal(true);
       });
 
-      it('should authorize access to resource when the user is authenticated and is OWNER in Organization and is PIX_MASTER', async () => {
+      it('should authorize access to resource when the user is authenticated and is ADMIN in Organization and is PIX_MASTER', async () => {
         // given
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.source).to.equal(true);
@@ -344,20 +344,20 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
         delete request.auth.credentials;
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
       });
 
-      it('should forbid resource access when user is not OWNER in Organization not PIX_MASTER', async () => {
+      it('should forbid resource access when user is not ADMIN in Organization not PIX_MASTER', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.resolves(false);
+        checkUserIsAdminInOrganizationUseCase.execute.resolves(false);
         checkUserHasRolePixMasterUseCase.execute.resolves(false);
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -366,10 +366,10 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
       it('should forbid resource access when an error is thrown by use case', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.rejects(new Error('Some error'));
+        checkUserIsAdminInOrganizationUseCase.execute.rejects(new Error('Some error'));
 
         // when
-        const response = await securityController.checkUserIsOwnerInOrganizationOrHasRolePixMaster(request, hFake);
+        const response = await securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -456,13 +456,13 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
     });
   });
 
-  describe('#checkUserIsOwnerInScoOrganizationAndManagesStudents', () => {
-    let isOwnerInOrganizationStub;
+  describe('#checkUserIsAdminInScoOrganizationAndManagesStudents', () => {
+    let isAdminInOrganizationStub;
     let belongsToScoOrganizationAndManagesStudentsStub;
 
     beforeEach(() => {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      isOwnerInOrganizationStub = sinon.stub(checkUserIsOwnerInOrganizationUseCase, 'execute');
+      isAdminInOrganizationStub = sinon.stub(checkUserIsAdminInOrganizationUseCase, 'execute');
       belongsToScoOrganizationAndManagesStudentsStub = sinon.stub(checkUserBelongsToScoOrganizationAndManagesStudentsUseCase, 'execute');
     });
 
@@ -470,15 +470,15 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
       const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } }, params: { id: 5678 } };
 
       beforeEach(() => {
-        isOwnerInOrganizationStub.resolves(true);
+        isAdminInOrganizationStub.resolves(true);
         belongsToScoOrganizationAndManagesStudentsStub.resolves(true);
       });
 
-      it('should authorize access to resource when the user is authenticated and is OWNER in Organization and belongs to a SCO Organization that manages students', async () => {
+      it('should authorize access to resource when the user is authenticated and is ADMIN in Organization and belongs to a SCO Organization that manages students', async () => {
         // given
 
         // when
-        const response = await securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityController.checkUserIsAdminInScoOrganizationAndManagesStudents(request, hFake);
 
         // then
         expect(response.source).to.equal(true);
@@ -494,20 +494,20 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
         delete request.auth.credentials;
 
         // when
-        const response = await securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityController.checkUserIsAdminInScoOrganizationAndManagesStudents(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
       });
 
-      it('should forbid resource access when user is not OWNER in Organization', async () => {
+      it('should forbid resource access when user is not ADMIN in Organization', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.resolves(false);
+        checkUserIsAdminInOrganizationUseCase.execute.resolves(false);
         checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute.resolves(true);
 
         // when
-        const response = await securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityController.checkUserIsAdminInScoOrganizationAndManagesStudents(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -516,11 +516,11 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
       it('should forbid resource access when user does not belong to a SCO Organization or does not manage students', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.resolves(true);
+        checkUserIsAdminInOrganizationUseCase.execute.resolves(true);
         checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute.resolves(false);
 
         // when
-        const response = await securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityController.checkUserIsAdminInScoOrganizationAndManagesStudents(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -529,10 +529,10 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
       it('should forbid resource access when an error is thrown by use case', async () => {
         // given
-        checkUserIsOwnerInOrganizationUseCase.execute.rejects(new Error('Some error'));
+        checkUserIsAdminInOrganizationUseCase.execute.rejects(new Error('Some error'));
 
         // when
-        const response = await securityController.checkUserIsOwnerInScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityController.checkUserIsAdminInScoOrganizationAndManagesStudents(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/high-level-tests/e2e/cypress/fixtures/memberships.json
+++ b/high-level-tests/e2e/cypress/fixtures/memberships.json
@@ -2,6 +2,6 @@
   {
     "userId": 1,
     "organizationId": 1,
-    "organizationRole": "OWNER"
+    "organizationRole": "ADMIN"
   }
 ]

--- a/orga/app/models/membership.js
+++ b/orga/app/models/membership.js
@@ -6,5 +6,5 @@ export default DS.Model.extend({
   organization: DS.belongsTo('organization'),
   organizationRole: DS.attr('string'),
 
-  isOwner: equal('organizationRole', 'OWNER'),
+  isAdmin: equal('organizationRole', 'ADMIN'),
 });

--- a/orga/app/routes/authenticated/team.js
+++ b/orga/app/routes/authenticated/team.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
   beforeModel() {
     this._super(...arguments);
-    if (!this.currentUser.isOwnerInOrganization) {
+    if (!this.currentUser.isAdminInOrganization) {
       return this.replaceWith('application');
     }
   },

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -14,12 +14,12 @@ export default Service.extend({
         const userMemberships = await user.get('memberships');
         const userMembership = await userMemberships.get('firstObject');
         const organization = await userMembership.organization;
-        const isOwnerInOrganization = userMembership.isOwner;
+        const isAdminInOrganization = userMembership.isAdmin;
         const canAccessStudentsPage = organization.isSco && organization.isManagingStudents;
 
         this.set('user', user);
         this.set('organization', organization);
-        this.set('isOwnerInOrganization', isOwnerInOrganization);
+        this.set('isAdminInOrganization', isAdminInOrganization);
         this.set('canAccessStudentsPage', canAccessStudentsPage);
       } catch (error) {
         if (_.get(error, 'errors[0].code') === 401) {

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -1,6 +1,6 @@
 <div class="list-students-page__header">
   <div class="page__title page-title">Élèves</div>
-  {{#if currentUser.isOwnerInOrganization}}
+  {{#if currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
       {{#file-upload name="file-upload"
                      for="students-file-upload"

--- a/orga/app/templates/components/sidebar-menu.hbs
+++ b/orga/app/templates/components/sidebar-menu.hbs
@@ -2,7 +2,7 @@
   {{#link-to 'authenticated.campaigns' class="sidebar-menu__item sidebar--padding-left sidebar--padding-right"}}
     Campagnes
   {{/link-to}}
-  {{#if currentUser.isOwnerInOrganization}}
+  {{#if currentUser.isAdminInOrganization}}
     {{#link-to 'authenticated.team' class="sidebar-menu__item sidebar--padding-left sidebar--padding-right"}}
       Équipe
     {{/link-to}}

--- a/orga/mirage/scenarios/default.js
+++ b/orga/mirage/scenarios/default.js
@@ -47,7 +47,7 @@ function _createStudents(server) {
   const userMembership = server.create('membership', {
     organizationId: organization.id,
     userId: user.id,
-    organizationRole: 'OWNER'
+    organizationRole: 'ADMIN'
   });
 
   user.memberships = [userMembership];
@@ -69,7 +69,7 @@ function _createOrganizationInvitations(server) {
   const userMembership = server.create('membership', {
     organizationId: organization.id,
     userId: user.id,
-    organizationRole: 'OWNER'
+    organizationRole: 'ADMIN'
   });
 
   user.memberships = [userMembership];

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -177,11 +177,11 @@ module('Acceptance | authentication', function(hooks) {
       });
     });
 
-    module('When user is owner', function() {
+    module('When user is admin', function() {
 
       test('should display team menu', async function(assert) {
         // given
-        const user = createUserMembershipWithRole('OWNER');
+        const user = createUserMembershipWithRole('ADMIN');
         await authenticateSession({
           user_id: user.id,
           access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
@@ -201,7 +201,7 @@ module('Acceptance | authentication', function(hooks) {
 
       test('should redirect to team page', async function(assert) {
         // given
-        const user = createUserMembershipWithRole('OWNER');
+        const user = createUserMembershipWithRole('ADMIN');
         await authenticateSession({
           user_id: user.id,
           access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
@@ -224,7 +224,7 @@ module('Acceptance | authentication', function(hooks) {
         let user;
 
         hooks.beforeEach(async () => {
-          user = createUserManagingStudents('OWNER');
+          user = createUserManagingStudents('ADMIN');
 
           await authenticateSession({
             user_id: user.id,

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -92,10 +92,10 @@ module('Acceptance | Student List', function(hooks) {
         assert.dom('.table tbody tr').exists({ count: 6 });
       });
 
-      module('When user is owner in organization', function(hooks) {
+      module('When user is admin in organization', function(hooks) {
 
         hooks.beforeEach(async () => {
-          user = createUserManagingStudents('OWNER');
+          user = createUserManagingStudents('ADMIN');
           await authenticateSession({
             user_id: user.id,
             access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
@@ -180,7 +180,7 @@ module('Acceptance | Student List', function(hooks) {
         });
       });
 
-      module('When user is not owner in organization', function() {
+      module('When user is not admin in organization', function() {
 
         test('it should not display import button', async function(assert) {
           // given

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -46,10 +46,10 @@ module('Acceptance | Team Creation', function(hooks) {
       });
     });
 
-    module('When user is an owner', function(hooks) {
+    module('When user is an admin', function(hooks) {
 
       hooks.beforeEach(async () => {
-        user = createUserMembershipWithRole('OWNER');
+        user = createUserMembershipWithRole('ADMIN');
         organizationId = server.db.organizations[0].id;
 
         await authenticateSession({

--- a/orga/tests/acceptance/team-list-test.js
+++ b/orga/tests/acceptance/team-list-test.js
@@ -48,10 +48,10 @@ module('Acceptance | Team List', function(hooks) {
       });
     });
 
-    module('When user is an owner', function(hooks) {
+    module('When user is an admin', function(hooks) {
 
       hooks.beforeEach(async () => {
-        user = createUserMembershipWithRole('OWNER');
+        user = createUserMembershipWithRole('ADMIN');
 
         await authenticateSession({
           user_id: user.id,

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -42,11 +42,11 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     assert.dom('.table tbody tr:first-child td:last-child').hasText('01/02/2010');
   });
 
-  module('when user is owner in organization', (hooks) => {
+  module('when user is admin in organization', (hooks) => {
 
     hooks.beforeEach(function() {
       this.set('importStudentsSpy', () => {});
-      this.owner.register('service:current-user', Service.extend({ isOwnerInOrganization: true }));
+      this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: true }));
       this.set('students', []);
     });
 
@@ -59,11 +59,11 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     });
   });
 
-  module('when user is not owner in organization', () => {
+  module('when user is not admin in organization', () => {
 
     test('it should not display import button', async function(assert) {
       // given
-      this.owner.register('service:current-user', Service.extend({ isOwnerInOrganization: false }));
+      this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: false }));
 
       this.set('students', []);
 

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -61,11 +61,11 @@ module('Unit | Service | current-user', function(hooks) {
       assert.equal(currentUser.organization, organization);
     });
 
-    test('should set isOwnerInOrganization to true', async function(assert) {
+    test('should set isAdminInOrganization to true', async function(assert) {
       // Given
       const connectedUserId = 1;
       const organization = Object.create({ id: 9 });
-      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'OWNER', isOwner: true });
+      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
         memberships: [membership]
@@ -85,14 +85,14 @@ module('Unit | Service | current-user', function(hooks) {
       await currentUser.load();
 
       // Then
-      assert.equal(currentUser.isOwnerInOrganization, true);
+      assert.equal(currentUser.isAdminInOrganization, true);
     });
 
-    test('should set isOwnerInOrganization to false', async function(assert) {
+    test('should set isAdminInOrganization to false', async function(assert) {
       // Given
       const connectedUserId = 1;
       const organization = Object.create({ id: 9 });
-      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'MEMBER', isOwner: false });
+      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'MEMBER', isAdmin: false });
       const connectedUser = Object.create({
         id: connectedUserId,
         memberships: [membership]
@@ -112,14 +112,14 @@ module('Unit | Service | current-user', function(hooks) {
       await currentUser.load();
 
       // Then
-      assert.equal(currentUser.isOwnerInOrganization, false);
+      assert.equal(currentUser.isAdminInOrganization, false);
     });
 
     test('should set canAccessStudentsPage to true', async function(assert) {
       // Given
       const connectedUserId = 1;
       const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: true, isSco: true });
-      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'OWNER', isOwner: true });
+      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
         memberships: [membership]
@@ -146,7 +146,7 @@ module('Unit | Service | current-user', function(hooks) {
       // Given
       const connectedUserId = 1;
       const organization = Object.create({ id: 9, type: 'PRO', isManagingStudents: true, isSco: false });
-      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'OWNER', isOwner: true });
+      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
         memberships: [membership]
@@ -173,7 +173,7 @@ module('Unit | Service | current-user', function(hooks) {
       // Given
       const connectedUserId = 1;
       const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
-      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'OWNER', isOwner: true });
+      const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
         memberships: [membership]


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, le rôle OWNER est affiché en "Responsable". 

## :robot: Solution
Remplacer le rôle OWNER par ADMIN et afficher "Administrateur" dans Pix Admin

## :rainbow: Remarques
Toutes les références à "owner" dans les noms de fonctions ou tests doivent être supprimées
