### PR TITLE
[TECH] Ajout de datadog

### DIFF
--- a/api/.buildpacks
+++ b/api/.buildpacks
@@ -1,1 +1,2 @@
+https://github.com/DataDog/heroku-buildpack-datadog.git#1.10
 https://github.com/Scalingo/nodejs-buildpack


### PR DESCRIPTION
## :unicorn: Problème
Insuffisance des outils de management des logs et metrics natifs fournis par Scalingo, et recherche d'un outil permettant de débogguer efficacement et garantir un monitoring/alerting à la pointe.

## :robot: Solution
On a choisi d'évaluer l'outil Datadog, qui peut s'intégrer avec Scalingo.

Pour remonter les metrics de l'application on ajoute le buildpack datadog dans l'api. Par ailleurs, on demande l'équipe Scalingo d'activer le logs drain afin que les logs soient transmis à Datadog.

## :rainbow: Remarques
Il faudra ajouter les variables d'environnement: `DD_API_KEY`, `DD_SITE`, et `DD_TOKEN` au niveau du container.

