### PR TITLE
[BUGFIX] Une sur-erreur survient en cas de problème dans la méth…

### DIFF
--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -1,7 +1,9 @@
 const _ = require('lodash');
-const courseRepository = require('../../../lib/infrastructure/repositories/course-repository');
 const Course = require('../models/Course');
-const { NotFoundError } = require('../../../lib/domain/errors');
+const { NotFoundError } = require('../../domain/errors');
+
+const courseRepository = require('../../infrastructure/repositories/course-repository');
+const { InfrastructureError } = require('../../infrastructure/errors');
 
 module.exports = {
 
@@ -18,9 +20,10 @@ module.exports = {
         .then((airtableCourse) => {
           return new Course(airtableCourse);
         }).catch((err) => {
-          if ('MODEL_ID_NOT_FOUND' === err.error.type || 'NOT_FOUND' === err.error) {
+          if ('NOT_FOUND' === err.error || (_.has(err, 'error.type') && 'MODEL_ID_NOT_FOUND' === err.error.type)) {
             throw new NotFoundError();
           }
+          throw new InfrastructureError(err.message);
         });
     }
 

--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -4,6 +4,7 @@ const { NotFoundError } = require('../../domain/errors');
 
 const courseRepository = require('../../infrastructure/repositories/course-repository');
 const { InfrastructureError } = require('../../infrastructure/errors');
+const logger = require('../../infrastructure/logger');
 
 module.exports = {
 
@@ -20,6 +21,7 @@ module.exports = {
         .then((airtableCourse) => {
           return new Course(airtableCourse);
         }).catch((err) => {
+          logger.error(err);
           if ('NOT_FOUND' === err.error || (_.has(err, 'error.type') && 'MODEL_ID_NOT_FOUND' === err.error.type)) {
             throw new NotFoundError();
           }

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -2,9 +2,11 @@ const courseService = require('../../../../lib/domain/services/course-service');
 
 const Course = require('../../../../lib/domain/models/Course');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const { InfrastructureError } = require('../../../../lib/infrastructure/errors');
 
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
-const { expect, sinon } = require('../../../test-helper');
+const logger = require('../../../../lib/infrastructure/logger');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 
 describe('Unit | Service | Course Service', () => {
 
@@ -52,18 +54,30 @@ describe('Unit | Service | Course Service', () => {
 
     });
 
-    context('when the course was not found', () => {
+    context('when an error occurred', () => {
 
-      const error = {
-        error: {
-          type: 'MODEL_ID_NOT_FOUND',
-          message: 'Could not find row by id unknown_id'
-        }
-      };
-
-      it('should return a NotFoundError ', function() {
+      it('should throw an InfrastructureException by default', async () => {
         // given
         const givenCourseId = 'recAirtableId';
+        const error = new Error('Some message');
+        courseRepository.get.rejects(error);
+
+        // when
+        const err = await catchErr(courseService.getCourse)({ courseId: givenCourseId, userId });
+
+        // then
+        expect(err).to.be.an.instanceof(InfrastructureError);
+      });
+
+      it('should throw a NotFoundError if the course was not found', () => {
+        // given
+        const givenCourseId = 'recAirtableId';
+        const error = {
+          error: {
+            type: 'MODEL_ID_NOT_FOUND',
+            message: 'Could not find row by id unknown_id'
+          }
+        };
         courseRepository.get.rejects(error);
 
         // when
@@ -72,9 +86,6 @@ describe('Unit | Service | Course Service', () => {
         // then
         return expect(promise).to.be.rejectedWith(NotFoundError);
       });
-
     });
-
   });
-
 });

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -17,6 +17,7 @@ describe('Unit | Service | Course Service', () => {
 
     beforeEach(() => {
       sinon.stub(courseRepository, 'get');
+      sinon.stub(logger, 'error');
     });
 
     it('should call the course repository', () => {
@@ -55,6 +56,22 @@ describe('Unit | Service | Course Service', () => {
     });
 
     context('when an error occurred', () => {
+
+      it('should log the error', async () => {
+        // given
+        const givenCourseId = 'recAirtableId';
+        const error = new Error();
+        courseRepository.get.rejects(error);
+
+        try {
+          // when
+          await courseService.getCourse({ courseId: givenCourseId, userId });
+
+        } catch (err) {
+          // then
+          expect(logger.error).to.have.been.calledWith(error);
+        }
+      });
 
       it('should throw an InfrastructureException by default', async () => {
         // given


### PR DESCRIPTION
## :unicorn: Problème

En cas d'erreur dans la méthode `courseRepository#getCourse()`, on provoque une sur-erreur qui génère l'évènement Sentry suivant : https://sentry.io/organizations/pix/issues/1230703028/?project=1398749&query=is%3Aunresolved&statsPeriod=14d.

## :robot: Solution

La solution consiste à vérifier l'existence de la propriété `error.type` (merci LoDash) avant de l'utiliser.

## :rainbow: Remarques

Commit n°1 : 
- Il y a un micro-nettoyage dans les imports (on évite de faire `../lib` alors qu'on est déjà dans le répertoire `lib`).
- Et enfin une micro-réorganisation

Commit n°2 : 
- On en profite pour tracer l'erreur.