### PR TITLE
[BUGFIX] Il arrive que le seeding soit en échec à cause d'une violation de contrainte d'unicité sur les emails de la table users

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,4 +1,5 @@
 'use strict';
+const faker = require('faker');
 const DatabaseBuilder = require('../../tests/tooling/database-builder/database-builder');
 const answersBuilder = require('./data/answers-builder');
 const assessmentsBuilder = require('./data/assessments-builder');
@@ -22,9 +23,11 @@ const usersBuilder = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 
 const SEQUENCE_RESTART_AT_NUMBER = 10000000;
+const SEED_NUMBER = 20110228;
 
 exports.seed = (knex) => {
-
+  faker.seed(SEED_NUMBER);
+  
   const databaseBuilder = new DatabaseBuilder({ knex });
 
   usersBuilder({ databaseBuilder });


### PR DESCRIPTION
## :unicorn: Problème
Ponctuellement, lors du déploiement des _seeds_ dans la base, il arrive que cette opération soit en échec à cause d'une violation de la contrainte d'unicité dans la colonne `email` de la table `users`.

## :mag: Explication
Récemment, une colonne (fk) `userId` a été ajoutée à la table `certification-candidates`. Elle représente le lien qui peut exister entre un utilisateur et son inscription à une session de certification. De fait, selon la règle des _builders_ (notamment _databaseBuilder_), si l'on passe la valeur `userId = undefined` dans le _builder_ de _certificationCandidate_, alors un lien est automatiquement crée (aka, un appel à _buildUser_ est effectué).
Dans les seeds sont crées environ 300 certification candidates. Et pour l'ensemble de ces candidats, un user est généré. Pour ces utilisateurs, on utilise **faker** afin de créer des adresses mails. Et, pas de chance, **faker** se débrouille pour (sur un échantillon de 300 ... :( ) générer parfois deux fois la même adresse mail.

## :robot: Solution
On rend déterministe la génération des données avec un seed dont on sait qu'il ne crée pas de collisions.

## :rainbow: Remarques
