### PR TITLE
[FEATURE] Ne pas importer les élèves ayant une date de sortie dans le fichier SIECLE (PO-278).

### DIFF
--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -1039,6 +1039,18 @@ describe('Acceptance | Application | organization-controller', () => {
           '<CODE_MEF>12341234</CODE_MEF>' +
           '<CODE_STATUT>ST</CODE_STATUT>' +
           '</ELEVE>' +
+          '<ELEVE ELEVE_ID="0005">' +
+          '<ID_NATIONAL>00000000126</ID_NATIONAL>' +
+          '<NOM_DE_FAMILLE>VANDOU</NOM_DE_FAMILLE>' +
+          '<PRENOM>Hubert</PRENOM>' +
+          '<DATE_NAISS>31/08/2009</DATE_NAISS>' +
+          '<DATE_SORTIE>01/09/2019</DATE_SORTIE>' +
+          '<CODE_PAYS>100</CODE_PAYS>' +
+          '<CODE_DEPARTEMENT_NAISS>033</CODE_DEPARTEMENT_NAISS>' +
+          '<CODE_COMMUNE_INSEE_NAISS>33318</CODE_COMMUNE_INSEE_NAISS>' +
+          '<CODE_MEF>12341234</CODE_MEF>' +
+          '<CODE_STATUT>ST</CODE_STATUT>' +
+          '</ELEVE>' +
           '</ELEVES>' +
           '<STRUCTURES>' +
           '<STRUCTURES_ELEVE ELEVE_ID="0001">' +
@@ -1056,6 +1068,12 @@ describe('Acceptance | Application | organization-controller', () => {
           '<STRUCTURES_ELEVE ELEVE_ID="0004">' +
           '<STRUCTURE>' +
           '<CODE_STRUCTURE>Inactifs</CODE_STRUCTURE>' +
+          '<TYPE_STRUCTURE>D</TYPE_STRUCTURE>' +
+          '</STRUCTURE>' +
+          '</STRUCTURES_ELEVE>' +
+          '<STRUCTURES_ELEVE ELEVE_ID="0005">' +
+          '<STRUCTURE>' +
+          '<CODE_STRUCTURE>5B</CODE_STRUCTURE>' +
           '<TYPE_STRUCTURE>D</TYPE_STRUCTURE>' +
           '</STRUCTURE>' +
           '</STRUCTURES_ELEVE>' +

--- a/api/tests/integration/domain/services/students-xml-service_test.js
+++ b/api/tests/integration/domain/services/students-xml-service_test.js
@@ -158,6 +158,18 @@ describe('Integration | Services | students-xml-service', () => {
         '<CODE_MEF>12341234</CODE_MEF>' +
         '<CODE_STATUT>AP</CODE_STATUT>' +
         '</ELEVE>' +
+        '<ELEVE ELEVE_ID="0005">' +
+        '<ID_NATIONAL>00000000126</ID_NATIONAL>' +
+        '<NOM_DE_FAMILLE>GRADE</NOM_DE_FAMILLE>' +
+        '<PRENOM>François</PRENOM>' +
+        '<DATE_NAISS>12/12/2008</DATE_NAISS>' +
+        '<DATE_SORTIE>01/09/2019</DATE_SORTIE>' +
+        '<CODE_PAYS>100</CODE_PAYS>' +
+        '<CODE_DEPARTEMENT_NAISS>033</CODE_DEPARTEMENT_NAISS>' +
+        '<CODE_COMMUNE_INSEE_NAISS>33318</CODE_COMMUNE_INSEE_NAISS>' +
+        '<CODE_MEF>123456789</CODE_MEF>' +
+        '<CODE_STATUT>AP</CODE_STATUT>' +
+        '</ELEVE>' +
         '</ELEVES>' +
         '<STRUCTURES>' +
         '<STRUCTURES_ELEVE ELEVE_ID="0002">' +
@@ -176,6 +188,12 @@ describe('Integration | Services | students-xml-service', () => {
         '<STRUCTURE>' +
         '<CODE_STRUCTURE>4e 1</CODE_STRUCTURE>' +
         '<TYPE_STRUCTURE>G</TYPE_STRUCTURE>' +
+        '</STRUCTURE>' +
+        '</STRUCTURES_ELEVE>' +
+        '<STRUCTURES_ELEVE ELEVE_ID="0005">' +
+        '<STRUCTURE>' +
+        '<CODE_STRUCTURE>4e 1</CODE_STRUCTURE>' +
+        '<TYPE_STRUCTURE>D</TYPE_STRUCTURE>' +
         '</STRUCTURE>' +
         '</STRUCTURES_ELEVE>' +
         '</STRUCTURES>' +


### PR DESCRIPTION
## :unicorn: Problème
Il existe plusieurs règles de gestion pour savoir si un élève doit ou non être importé dans Pix Orga à partir du fichier SIECLE. Cette gestion est totalement différente selon les établissements scolaires. Il se trouve ici qu'il y a une règle de gestion que nous n'avions pas identifiée jusqu'alors : ne pas importer les élèves ayant une date de sortie renseignée dans le fichier SIECLE.

## :robot: Solution
Ajouter cette règle de gestion.

## :rainbow: Remarques
Cette règle ne prévaut pas sur les autres règles déjà identifiées, elles ne se recoupent pas.
