### PR TITLE
[FEATURE] Afficher le rôle des membres dans Pix Orga (PO-210)

### DIFF
--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -34,7 +34,7 @@ module.exports = {
       .query((qb) => {
         if (orderByName) {
           qb.innerJoin('users', 'memberships.userId', 'users.id');
-          qb.orderByRaw('LOWER(users."lastName") ASC, LOWER(users."firstName") ASC');
+          qb.orderByRaw('"organizationRole" ASC, LOWER(users."lastName") ASC, LOWER(users."firstName") ASC');
         } else {
           qb.orderBy('id', 'ASC');
         }

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -152,21 +152,21 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       expect(_.map(memberships, 'id')).to.deep.include.ordered.members([membership_1.id, membership_2.id, membership_3.id]);
     });
 
-    it('should order memberships by lastName and then by firstName with no sensitive case', async () => {
+    it('should order memberships by organizationRole, user.lastName and user.firstName', async () => {
       // given
       const organization = databaseBuilder.factory.buildOrganization();
 
-      const user_1 = databaseBuilder.factory.buildUser({ lastName: 'Grenier' });
+      const user_1 = databaseBuilder.factory.buildUser({ lastName: 'alphonse', firstName: 'Pierre' });
       const user_2 = databaseBuilder.factory.buildUser({ lastName: 'Avatar', firstName: 'Xavier' });
-      const user_3 = databaseBuilder.factory.buildUser({ lastName: 'Avatar', firstName: 'Arthur' });
-      const user_4 = databaseBuilder.factory.buildUser({ lastName: 'Avatar', firstName: 'MATHURIN' });
+      const user_3 = databaseBuilder.factory.buildUser({ lastName: 'avatar', firstName: 'Arthur' });
+      const user_4 = databaseBuilder.factory.buildUser({ lastName: 'Batiste', firstName: 'Arthur' });
+      const user_5 = databaseBuilder.factory.buildUser({ lastName: 'Baptiste', firstName: 'Ernest' });
 
-      const organizationRole = Membership.roles.ADMIN;
-
-      const membership_1 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_1.id });
-      const membership_2 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_2.id });
-      const membership_3 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_3.id });
-      const membership_4 = databaseBuilder.factory.buildMembership({ organizationRole, organizationId: organization.id, userId: user_4.id });
+      const membership_1 = databaseBuilder.factory.buildMembership({ organizationRole: Membership.roles.ADMIN, organizationId: organization.id, userId: user_1.id });
+      const membership_2 = databaseBuilder.factory.buildMembership({ organizationRole: Membership.roles.MEMBER, organizationId: organization.id, userId: user_2.id });
+      const membership_3 = databaseBuilder.factory.buildMembership({ organizationRole: Membership.roles.MEMBER, organizationId: organization.id, userId: user_3.id });
+      const membership_4 = databaseBuilder.factory.buildMembership({ organizationRole: Membership.roles.ADMIN, organizationId: organization.id, userId: user_4.id });
+      const membership_5 = databaseBuilder.factory.buildMembership({ organizationRole: Membership.roles.MEMBER, organizationId: organization.id, userId: user_5.id });
 
       await databaseBuilder.commit();
 
@@ -174,7 +174,7 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
       const memberships = await membershipRepository.findByOrganizationId({ organizationId: organization.id, orderByName: true });
 
       // then
-      expect(_.map(memberships, 'id')).to.deep.include.ordered.members([membership_3.id, membership_4.id, membership_2.id, membership_1.id]);
+      expect(_.map(memberships, 'id')).to.deep.include.ordered.members([membership_1.id, membership_4.id, membership_3.id, membership_2.id, membership_5.id]);
     });
   });
 

--- a/orga/app/models/membership.js
+++ b/orga/app/models/membership.js
@@ -1,10 +1,19 @@
 import DS from 'ember-data';
-import { equal } from '@ember/object/computed';
+import { computed } from '@ember/object';
+
+const organizationRoleToDisplayRole = {
+  ADMIN: 'Administrateur',
+  MEMBER: 'Membre',
+};
 
 export default DS.Model.extend({
   user: DS.belongsTo('user'),
   organization: DS.belongsTo('organization'),
   organizationRole: DS.attr('string'),
 
-  isAdmin: equal('organizationRole', 'ADMIN'),
+  isAdmin: computed.equal('organizationRole', 'ADMIN'),
+
+  displayRole: computed('organizationRole', function() {
+    return organizationRoleToDisplayRole[this.organizationRole];
+  }),
 });

--- a/orga/app/templates/components/routes/authenticated/team/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/team/list-items.hbs
@@ -32,6 +32,7 @@
         <tr>
           <th>Nom</th>
           <th>Prénom</th>
+          <th>Rôle</th>
         </tr>
       </thead>
       {{#if memberships}}
@@ -40,6 +41,7 @@
             <tr>
               <td>{{membership.user.lastName}}</td>
               <td>{{membership.user.firstName}}</td>
+              <td>{{membership.displayRole}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/orga/tests/acceptance/team-list-test.js
+++ b/orga/tests/acceptance/team-list-test.js
@@ -83,6 +83,7 @@ module('Acceptance | Team List', function(hooks) {
 
         // then
         assert.dom('#table-members tbody tr').exists({ count: 1 });
+        assert.dom('#table-members tbody tr:first-child').hasText('Cover Harry Administrateur');
       });
 
       test('it should list the pending team invitations', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
@@ -1,17 +1,36 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/team | list-items', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display a list of members, their firstName and lastName', async function(assert) {
+  test('it should display a list of members, their firstName, lastName and role', async function(assert) {
     // given
-    this.set('memberships', [
-      { user: { firstName: 'Gigi', lastName: 'La Terreur' } },
-      { user: { firstName: 'Gogo', lastName: 'L\'asticot' } },
-    ]);
+    const store = this.owner.lookup('service:store');
+    const memberships = [
+      run(() => store.createRecord('membership', {
+        id: 1,
+        organizationRole: 'ADMIN',
+        user: run(() => store.createRecord('user', {
+          id: 111,
+          firstName: 'Gigi',
+          lastName: 'La Terreur',
+        })),
+      })),
+      run(() => store.createRecord('membership', {
+        id: 2,
+        organizationRole: 'MEMBER',
+        user: run(() => store.createRecord('user', {
+          id: 112,
+          firstName: 'Gogo',
+          lastName: 'L\'asticot',
+        })),
+      })),
+    ];
+    this.set('memberships', memberships);
 
     // when
     await render(hbs`{{routes/authenticated/team/list-items memberships=memberships}}`);
@@ -19,7 +38,8 @@ module('Integration | Component | routes/authenticated/team | list-items', funct
     // then
     assert.dom('#table-members tbody tr').exists({ count: 2 });
     assert.dom('#table-members tbody tr:first-child td:first-child').hasText('La Terreur');
-    assert.dom('#table-members tbody tr:first-child td:last-child').hasText('Gigi');
+    assert.dom('#table-members tbody tr:first-child td:nth-child(2)').hasText('Gigi');
+    assert.dom('#table-members tbody tr:first-child td:nth-child(3)').hasText('Administrateur');
   });
 
   test('it should display a list of invitations, their email and creation date', async function(assert) {


### PR DESCRIPTION
## 🐻 Problème
La liste des membre n'affichait que le nom et le prénom.

## 🍯 Solution
Afficher le rôle dans la liste des membres.
Trier les membres non pas par date d'ajout (tri de la bdd) mais par rôle d'abord et lastName ensuite.
![image](https://user-images.githubusercontent.com/4154003/68867527-46563e00-06f6-11ea-8c95-0ba657b1f00e.png)
