### PR TITLE
[BUGFIX] L'identifiant externe n'était pas recopié depuis les données candidat vers le certification course à la création de celui ci (PA-120)

### DIFF
--- a/api/db/migrations/20191118173128_copy-external-id-from-candidate-to-course.js
+++ b/api/db/migrations/20191118173128_copy-external-id-from-candidate-to-course.js
@@ -1,0 +1,24 @@
+exports.up = async function(knex) {
+
+  await knex.raw(`
+      UPDATE "public"."certification-courses" as cc
+      SET "externalId" = joinCcAndCca."externalIdCertificationCandidate"
+      FROM
+      ( SELECT 
+             cc."id" AS "idCertificationCourse",
+             cca."externalId" AS "externalIdCertificationCandidate"
+      FROM "public"."certification-courses" AS cc
+      JOIN "public"."certification-candidates" AS cca ON cc."firstName" = cca."firstName"
+      AND cc."lastName" = cca."lastName" AND cc."birthdate" = cca."birthdate"
+      AND cc."sessionId" = cca."sessionId"
+      WHERE cca."externalId" IS NOT NULL
+        AND cc."externalId" IS  NULL ) as joinCcAndCca
+        
+      WHERE cc."id" = joinCcAndCca."idCertificationCourse";
+    `);
+};
+
+exports.down = function() {
+  // no rollback for this case
+};
+

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -60,13 +60,14 @@ async function _startNewCertification({
     };
   } catch (err) {
     if (err instanceof NotFoundError) {
-      const personalInfo = { firstName: null, lastName: null, birthdate: null, birthplace: null };
+      const personalInfo = { firstName: null, lastName: null, birthdate: null, birthplace: null, externalId: null };
       const foundCandidate = await certificationCandidateRepository.findOneBySessionIdAndUserId({ sessionId, userId });
       if (foundCandidate) {
         personalInfo.firstName = foundCandidate.firstName;
         personalInfo.lastName = foundCandidate.lastName;
         personalInfo.birthdate = foundCandidate.birthdate;
         personalInfo.birthplace = foundCandidate.birthCity;
+        personalInfo.externalId = foundCandidate.externalId;
       }
 
       const newCertificationCourse = new CertificationCourse({

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -1,4 +1,5 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
+const { expect, databaseBuilder, knex, airtableBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
+const cache = require('../../../lib/infrastructure/caches/cache');
 const createServer = require('../../../server');
 
 const Assessment = require('../../../lib/domain/models/Assessment');
@@ -399,6 +400,137 @@ describe('Acceptance | API | Certification Course', () => {
       // then
       expect(response.result.data).to.deep.equal(expectedCertificationCourse);
     });
+  });
+
+  describe('POST /api/certification-courses', () => {
+    let options;
+    let response;
+    let userId;
+    let sessionId;
+
+    beforeEach(async() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      sessionId = databaseBuilder.factory.buildSession({ accessCode: '123' }).id;
+      const payload = {
+        data: {
+          attributes: {
+            'access-code': '123',
+          }
+        }
+      };
+      options = {
+        method: 'POST',
+        url: '/api/certification-courses',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+        payload,
+      };
+      return databaseBuilder.commit();
+    });
+
+    context('when the certification course does not exist', () => {
+      let certificationCandidate;
+
+      beforeEach(async () => {
+        // given
+        const { area, competences, skills, challenges, competencesAssociatedSkillsAndChallenges } = airtableBuilder.factory.buildCertificationPrerequisites();
+        airtableBuilder.mockList({ tableName: 'Domaines' })
+          .returns([area])
+          .activate();
+        airtableBuilder.mockList({ tableName: 'Competences' })
+          .returns(competences)
+          .activate();
+        airtableBuilder.mockList({ tableName: 'Acquis' })
+          .returns(skills)
+          .activate();
+        airtableBuilder.mockList({ tableName: 'Epreuves' })
+          .returns(challenges)
+          .activate();
+
+        certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+          sessionId,
+          userId,
+        });
+        const assessmentId = databaseBuilder.factory.buildAssessment({
+          userId,
+        }).id;
+        const commonUserIdAssessmentIdAndEarnedPixForAllKEs = { userId, assessmentId, earnedPix: 4 };
+        competencesAssociatedSkillsAndChallenges.forEach((element) => {
+          const { challengeId, competenceId } = element;
+          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId }).id;
+          databaseBuilder.factory.buildKnowledgeElement({ ...commonUserIdAssessmentIdAndEarnedPixForAllKEs, competenceId, answerId });
+        });
+        await databaseBuilder.commit();
+
+        // when
+        response = await server.inject(options);
+      });
+
+      afterEach(async () => {
+        await knex('certification-challenges').delete();
+        await knex('certification-courses').delete();
+        await knex('knowledge-elements').delete();
+        await knex('answers').delete();
+        await knex('assessments').delete();
+        await databaseBuilder.clean();
+        airtableBuilder.cleanAll();
+        cache.flushAll();
+      });
+
+      it('should respond with 201 status code', () => {
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+
+      it('should have created a certification course', async () => {
+        // then
+        const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
+        expect(certificationCourses).to.have.length(1);
+      });
+
+      it('should have copied matching certification candidate info into created certification course', async () => {
+        // then
+        const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
+        expect(certificationCourses[0].firstName).to.equal(certificationCandidate.firstName);
+        expect(certificationCourses[0].lastName).to.equal(certificationCandidate.lastName);
+        expect(certificationCourses[0].birthdate).to.equal(certificationCandidate.birthdate);
+        expect(certificationCourses[0].birthplace).to.equal(certificationCandidate.birthCity);
+      });
+
+    });
+
+    context('when the certification course already exists', () => {
+      let certificationCourseId;
+
+      beforeEach(async () => {
+        // given
+        certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ userId, sessionId }).id;
+        databaseBuilder.factory.buildAssessment({ userId, courseId: certificationCourseId });
+        await databaseBuilder.commit();
+
+        // when
+        response = await server.inject(options);
+      });
+
+      afterEach(() => {
+        return databaseBuilder.clean();
+      });
+
+      it('should respond with 200 status code', () => {
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should retrieve the already existing certification course', async () => {
+        // then
+        const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
+        expect(certificationCourses).to.have.length(1);
+        expect(certificationCourses[0].id).to.equal(certificationCourseId);
+      });
+
+    });
+
   });
 
 });

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -496,6 +496,7 @@ describe('Acceptance | API | Certification Course', () => {
         expect(certificationCourses[0].lastName).to.equal(certificationCandidate.lastName);
         expect(certificationCourses[0].birthdate).to.equal(certificationCandidate.birthdate);
         expect(certificationCourses[0].birthplace).to.equal(certificationCandidate.birthCity);
+        expect(certificationCourses[0].externalId).to.equal(certificationCandidate.externalId);
       });
 
     });

--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -26,4 +26,5 @@ module.exports = class AirtableBuilder {
   cleanAll() {
     this.nock.cleanAll();
   }
+
 };

--- a/api/tests/tooling/airtable-builder/factory/build-certification-prerequisites.js
+++ b/api/tests/tooling/airtable-builder/factory/build-certification-prerequisites.js
@@ -1,0 +1,38 @@
+const buildSkill = require('./build-skill');
+const buildChallenge = require('./build-challenge');
+const buildCompetence = require('./build-competence');
+const buildArea = require('./build-area');
+
+const {
+  MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY,
+  MAX_CHALLENGES_PER_SKILL_FOR_CERTIFICATION,
+} = require('../../../../lib/domain/constants');
+const _ = require('lodash');
+
+module.exports = function buildCertificationPrerequisites() {
+  const area = buildArea();
+  const competences = _.times(MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY, () => {
+    return buildCompetence();
+  });
+
+  const skills = [];
+  const challenges = [];
+  const skillsAndChallengesByCompetences = _.map(competences, (competence) => {
+    return _.times(MAX_CHALLENGES_PER_SKILL_FOR_CERTIFICATION, () => {
+      const skill = buildSkill({ 'compétenceViaTube': competence.id });
+      const challenge = buildChallenge({ statut: 'validé', competences:[competence.id], acquix: [skill.id] });
+      skills.push(skill);
+      challenges.push(challenge);
+      return { competenceId: competence.id, skillId: skill.id, challengeId: challenge.id };
+    });
+  });
+  const competencesAssociatedSkillsAndChallenges = _.flattenDeep(skillsAndChallengesByCompetences);
+
+  return {
+    area,
+    competences,
+    skills,
+    challenges,
+    competencesAssociatedSkillsAndChallenges,
+  };
+};

--- a/api/tests/tooling/airtable-builder/factory/index.js
+++ b/api/tests/tooling/airtable-builder/factory/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildArea: require('./build-area'),
+  buildCertificationPrerequisites: require('./build-certification-prerequisites'),
   buildChallenge: require('./build-challenge'),
   buildCompetence: require('./build-competence'),
   buildCourse: require('./build-course'),


### PR DESCRIPTION
## :unicorn: Problème
L'identifiant local du candidat, pourtant indiqué lors de l'inscription de celui-ci, n'est pas reporté
dans le certification-course lors de sa création, comme il devrait l'être à l'image des autres infos perso (nom, prénom, ddn et lieu de naissance)

## :robot: Solution
Recopier cette information depuis le certification-candidate vers le certification-course lors de la création de ce dernier

## :rainbow: Remarques
- Cette PR inclut enfin des tests d'acceptance sur la route POST /api/certification-courses.
- Un script est prévu dans les semaines à venir pour recopier les identifiants externes qui ont manqué de l'être dans les sessions avant MEP.
