### PR TITLE
[FEATURE] Dupliquer le bouton d'export des résultats pour les prescripteurs sur la page d'info de session dans Pix Admin (PA-118)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/sessions/info/index.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/index.js
@@ -1,7 +1,22 @@
 import Controller from '@ember/controller';
 import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  // Properties
-  session: alias('model')
+
+  sessionInfoService: service(),
+  notifications: service('notification-messages'),
+
+  session: alias('model'),
+
+  actions: {
+
+    downloadSessionResultFile() {
+      try {
+        this.sessionInfoService.downloadSessionExportFile(this.session);
+      } catch (error) {
+        this.notifications.error(error);
+      }
+    },
+  }
 });

--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -4,12 +4,10 @@ import ENV from 'pix-admin/config/environment';
 
 export default Controller.extend({
 
-  // DI
   session: service(),
   sessionInfoService: service(),
   notifications: service('notification-messages'),
 
-  // Properties
   displayConfirm: false,
   displaySessionReport: false,
   confirmMessage: null,

--- a/admin/app/routes/authenticated/certifications/sessions/info.js
+++ b/admin/app/routes/authenticated/certifications/sessions/info.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  model(params) {
-    return this.store.findRecord('session', params.session_id);
+  async model(params) {
+    const session = await this.store.findRecord('session', params.session_id);
+    await session.certifications;
+    return session;
   },
   setupController(controller, model) {
     this._super(controller, model);

--- a/admin/app/routes/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/routes/authenticated/certifications/sessions/info/list.js
@@ -1,9 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  async model() {
-    const session = this.modelFor('authenticated.certifications.sessions.info');
-    await session.certifications;
-    return session;
+  model() {
+    return this.modelFor('authenticated.certifications.sessions.info');
   }
 });

--- a/admin/app/styles/authenticated/certifications/sessions.scss
+++ b/admin/app/styles/authenticated/certifications/sessions.scss
@@ -14,4 +14,13 @@
 
 .certifications-session-info {
   padding: 20px;
+  padding-bottom: 0px;
+
+  .row--btn {
+    justify-content: flex-end;
+
+    .btn {
+      margin-left: 20px;
+    }
+  }
 }

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -17,7 +17,7 @@
   </div>
   <div class='row'>
     <div class='col'>Date :</div>
-    <div class='col'>{{session.date}}</div>
+    <div class='col'>{{moment-format session.date 'DD/MM/YYYY'}}</div>
   </div>
   <div class='row'>
     <div class='col'>Heure :</div>
@@ -30,5 +30,11 @@
   <div class='row'>
     <div class='col'>Code d'accès :</div>
     <div class='col'>{{session.accessCode}}</div>
+  </div>
+
+  <div class='row row--btn'>
+      <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
+        Exporter les résultats
+      </button>
   </div>
 </div>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -28,6 +28,7 @@ export default function() {
 
     http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
   */
+  this.logging = true;
   this.urlPrefix = 'http://localhost:3000';
   this.namespace = 'api';
 
@@ -35,6 +36,7 @@ export default function() {
   this.get('/organizations/:id');
   this.get('/organizations/:id/memberships', getOrganizationMemberships);
   this.get('/sessions/:id');
+  this.get('/admin/certifications/:id');
   this.get('/users', findUsers);
   this.put('/certifications/attendance-sheet/parsing', upload(function() {
     return [

--- a/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { visit, currentURL, find } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import moment from 'moment';
+
+module('Integration | Component | certifications-session-info', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let session;
+
+  hooks.beforeEach(async function() {
+    await authenticateSession({ userId: 1 });
+    session = this.server.create('session', {
+      id: 1,
+      certificationCenter: 'Tour Gamma',
+      address: '3 rue du tout',
+      room: 'room',
+      examiner: 'poulet',
+      date: '1999-01-01',
+      time: '14:00:00',
+      description: 'pouet',
+      accessCode: '123',
+      certifications: [],
+    });
+  });
+
+  test('it renders the details page with correct info', async function(assert) {
+    // when
+    await visit(`/certifications/sessions/${session.id}`);
+
+    // then
+    const mainDiv = '.certifications-session-info';
+    const row = '.row:nth-child';
+    const col = '.col:nth-child(2)';
+    assert.equal(currentURL(), `/certifications/sessions/${session.id}`);
+    assert.equal(find(`${mainDiv} ${row}(1) ${col}`).textContent, session.certificationCenter);
+    assert.equal(find(`${mainDiv} ${row}(2) ${col}`).textContent, session.address);
+    assert.equal(find(`${mainDiv} ${row}(3) ${col}`).textContent, session.room);
+    assert.equal(find(`${mainDiv} ${row}(4) ${col}`).textContent, session.examiner);
+    assert.equal(find(`${mainDiv} ${row}(5) ${col}`).textContent, moment(session.date, 'YYYY-MM-DD').format('DD/MM/YYYY'));
+    assert.equal(find(`${mainDiv} ${row}(6) ${col}`).textContent, session.time);
+    assert.equal(find(`${mainDiv} ${row}(7) ${col}`).textContent, session.description);
+    assert.equal(find(`${mainDiv} ${row}(8) ${col}`).textContent, session.accessCode);
+    assert.equal(find(`${mainDiv} ${row}(9) ${col}`), undefined);
+  });
+
+});

--- a/admin/tests/unit/controllers/authenticated/certifications/sessions/info/index-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/sessions/info/index-test.js
@@ -1,12 +1,58 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/certifications/sessions/info/index', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:authenticated/certifications/sessions/info/index');
-    assert.ok(controller);
+  let controller;
+  let sessionInfoServiceStub;
+  let model;
+  let error;
+  let downloadSessionExportFile;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/certifications/sessions/info/index');
+
+    // context for sessionInfoService stub
+    model = 'some model';
+    error = { err : 'some error' };
+
+    // sessionInfoService stub
+    downloadSessionExportFile = sinon.stub();
+    downloadSessionExportFile.withArgs(model).returns();
+    downloadSessionExportFile.withArgs().throws(error);
+    sessionInfoServiceStub = { downloadSessionExportFile };
+
+    controller.set('sessionInfoService', sessionInfoServiceStub);
+  });
+
+  module('#downloadSessionResultFile', function() {
+
+    test('should launch the download of result file', function(assert) {
+
+      // given
+      controller.set('model', model);
+
+      // when
+      controller.actions.downloadSessionResultFile.call(controller);
+
+      // then
+      assert.ok(controller.sessionInfoService.downloadSessionExportFile.calledWithExactly(model));
+    });
+
+    test('should throw an error', function(assert) {
+
+      // given
+      const notificationsStub = { error: sinon.stub() };
+      controller.set('notifications', notificationsStub);
+
+      // when
+      controller.actions.downloadSessionResultFile.call(controller);
+
+      // then
+      assert.ok(controller.sessionInfoService.downloadSessionExportFile.calledOnce);
+      assert.ok(controller.notifications.error.calledWithExactly(error));
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'EPIX sur la finalisation de session, des données vont être ajoutées à PixAdmin, ainsi que des déplacements/duplications de fonctionnalités vers la page d'info de session.
Pour rester agiles, nous procédons petits pas par petits pas, en commencant par dupliquer le bouton d'export des résultats pour les prescripteurs vers la page d'info de session.

## :robot: Solution
Duplication du bouton
Ajout de tests

## :rainbow: Remarques
