### PR TITLE
[BUGFIX] Supprimer les barres de scroll affichées en trop sur Pix Orga (PO-271).

### DIFF
--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -1,6 +1,7 @@
 .app {
   display: flex;
   height: 100%;
+  overflow: hidden;
 
   &__sidebar {
     width: 280px;
@@ -40,7 +41,7 @@
   flex-direction: column;
   height: 100%;
   background-color: $wild-sand;
-  overflow: scroll;
+  overflow: auto;
 
   &__topbar {
     background-color: white;


### PR DESCRIPTION
## :unicorn: Problème
Sous Windows uniquement, deux barres de scroll verticales s'affichent sur la liste des campagnes, et une barre horizontale (alors que désactivée).

## :robot: Solution
Remplacer `overflow: scroll` par `overflow: auto`.

## :rainbow: Remarques
Il faudra sans doute faire de même sur Pix Certif (il y a le même code).
