### PR TITLE
[BUGFIX] Patch sentry-cli releases dans le script de release publish.

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -25,9 +25,9 @@ function push_commit_and_tag_to_remote_master {
 }
 
 function publish_release_on_sentry {
-    npx sentry-cli releases new -p pix-admin -p pix-api -p pix-app -p pix-orga -p pix-certif "v${PACKAGE_VERSION}"
-    npx sentry-cli releases set-commits --auto "v${PACKAGE_VERSION}"
-    npx sentry-cli releases finalize "v${PACKAGE_VERSION}"
+    npx sentry-cli releases -o pix new -p pix-admin -p pix-api -p pix-app -p pix-orga -p pix-certif "v${PACKAGE_VERSION}"
+    npx sentry-cli releases -o pix set-commits "v${PACKAGE_VERSION}" --auto
+    npx sentry-cli releases -o pix finalize "v${PACKAGE_VERSION}"
 }
 
 function update_preview_and_maths {


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une mise en production, la release sentry ne fonctionne pas.

## :robot: Solution
- Ajout de l'organisation dans les commandes `sentry-cli`. 
- Mettre dans l'ordre les options pour associer les commits à la release
