### PR TITLE
[BUGFIX] Problème du nom de version de sentry.

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -68,7 +68,7 @@ const plugins = [
         client: {
           dsn: settings.sentry.dsn,
           environment: settings.sentry.environment,
-          release: Pack.version,
+          release: `v${Pack.version}`,
           maxBreadcrumbs: settings.sentry.maxBreadcrumbs,
           debug: settings.sentry.debug,
         },


### PR DESCRIPTION
## :unicorn: Problème
Sentry écrit les versions sans le 'v'.

## :robot: Solution
Rajout du 'v' en préfix du numéro de version. 

