### PR TITLE
[BUGFIX] Problème d'ajout des commits dans les versions de Sentry.

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -26,7 +26,7 @@ function push_commit_and_tag_to_remote_master {
 
 function publish_release_on_sentry {
     npx sentry-cli releases -o pix new -p pix-admin -p pix-api -p pix-app -p pix-orga -p pix-certif "v${PACKAGE_VERSION}"
-    npx sentry-cli releases -o pix set-commits "v${PACKAGE_VERSION}" --auto
+    npx sentry-cli releases -o pix set-commits "1024pix/pix@$( git rev-parse HEAD )" "v${PACKAGE_VERSION}"
     npx sentry-cli releases -o pix finalize "v${PACKAGE_VERSION}"
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Sentry ajoutait tous les commits faits depuis la dernière version même ceux hors master. 

## :robot: Solution
Ne pas utiliser le mode commit auto de Sentry mais saisir le SHA du commit de la branche que l'on souhaite. 
