### PR TITLE
[BUGFIX] Afficher les prochaines notifications de succès après une fermeture (PF-913).

### DIFF
--- a/mon-pix/app/components/levelup-notif.js
+++ b/mon-pix/app/components/levelup-notif.js
@@ -3,6 +3,11 @@ import Component from '@ember/component';
 export default Component.extend({
   closeLevelup: false,
 
+  didUpdateAttrs() {
+    this._super(...arguments);
+    this.set('closeLevelup', false);
+  },
+
   actions: {
     close: function() {
       this.set('closeLevelup', true);


### PR DESCRIPTION
## :unicorn: Problème
À la fermeture d'une notification de succès entre deux checkpoints, les notifications suivantes ne s'affichaient plus. On pouvait par exemple voir un niveau 2 puis un niveau 4 après checkpoint sans voir le niveau 3.

## :robot: Solution
Le problème avait lieu plus précisément lorsque on obtenait le niveau 2 à la question N puis le niveau 3 à la question N+1. À ce moment là, le composant n'est pas détruit mais réutilisé lors de l'acquisition d'un nouveau niveau. 

Il faut donc utiliser la méthode `didUpdateAttrs` pour réinitialiser la condition d'affichage au moment du recyclage du composant.

## :rainbow: Remarques
Si on avait détruit le composant, on aurait utilisé le double de ressources. ♻️