### PR TITLE
[FEATURE] Modification de certains textes dans la page de lancement de test de certification (PF-928)

### DIFF
--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -3,7 +3,7 @@
 {{/if}}
 
 <section class="certification-starter">
-    <h2 class="certification-start-page__title">Vous souhaitez participer au test de certification</h2>
+    <h2 class="certification-start-page__title">Vous allez commencer votre test de certification</h2>
 
     <p class="certification-course-page__order">
         Saisissez le code d'accès communiqué par le surveillant
@@ -23,14 +23,14 @@
               <span class="loader-in-button">&nbsp;</span>
             </button>
           {{else}}
-              <button type="submit" class="button button--thin certification-course-page__submit_button" {{ action "submit" }}>Lancer mon test</button>
+              <button type="submit" class="button button--thin certification-course-page__submit_button" {{ action "submit" }}>Commencer mon test</button>
           {{/if}}
         </div>
     </form>
 
     <div class="certification-course-page__cgu">
         <p>
-            En cliquant sur "Lancer mon test", j’accepte que mes données d’identité, le numéro de certification et les
+            En cliquant sur "Commencer mon test", j’accepte que mes données d’identité, le numéro de certification et les
             circonstances de la passation telles que renseignées par le surveillant soient communiquées à Pix. Pix les utilisera
             lors de la délibération du jury pour produire et archiver mes résultats et pour éditer mon certificat. Si cette
             certification m’a été prescrite par une organisation, j’accepte que Pix lui communique mes résultats.


### PR DESCRIPTION
## :robot: Solution
Modification des textes suivants : 
 "Vous souhaitez participer au test de certification" par "Vous allez commencer votre test de certification"
"Lancer mon test" par "Commencer mon test"

## :rainbow: Remarques
