### PR TITLE
[FEATURE] Affichage du statut de la session dans PixAdmin (PA-119)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { equal } from '@ember/object/computed';
 
 export default DS.Model.extend({
   certificationCenter: DS.attr(),
@@ -9,5 +10,7 @@ export default DS.Model.extend({
   time: DS.attr(),
   description: DS.attr(),
   accessCode: DS.attr(),
-  certifications: DS.hasMany('certification')
+  status: DS.attr(),
+  isFinalized: equal('status', 'finalized'),
+  certifications: DS.hasMany('certification'),
 });

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -31,10 +31,14 @@
     <div class='col'>Code d'accès :</div>
     <div class='col'>{{session.accessCode}}</div>
   </div>
+  <div class='row'>
+    <div class='col'>Statut :</div>
+    <div class='col'>{{if session.isFinalized 'Finalisée' 'Prête'}}</div>
+  </div>
 
   <div class='row row--btn'>
-      <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
-        Exporter les résultats
-      </button>
+    <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
+      Exporter les résultats
+    </button>
   </div>
 </div>

--- a/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
@@ -5,15 +5,29 @@ import { visit, currentURL, find } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import moment from 'moment';
 
+const CERTIFICATION_CENTER_ROW = '(1)';
+const ADDRESS_ROW = '(2)';
+const ROOM_ROW = '(3)';
+const EXAMINER_ROW = '(4)';
+const DATE_ROW = '(5)';
+const TIME_ROW = '(6)';
+const DESCRIPTION_ROW = '(7)';
+const ACCESS_CODE_ROW = '(8)';
+const STATUS_ROW = '(9)';
+const CHECK_NO_ADDITIONAL_INFO_ROW_EXISTS = '(10)';
+
 module('Integration | Component | certifications-session-info', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let session;
+  let sessionData;
+  const commonSelector = '.certifications-session-info .row:nth-child';
+  const col = '.col:nth-child(2)';
 
   hooks.beforeEach(async function() {
     await authenticateSession({ userId: 1 });
-    session = this.server.create('session', {
+    sessionData = {
       id: 1,
       certificationCenter: 'Tour Gamma',
       address: '3 rue du tout',
@@ -23,28 +37,68 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       time: '14:00:00',
       description: 'pouet',
       accessCode: '123',
-      certifications: [],
-    });
+      certifications: []
+    };
   });
 
-  test('it renders the details page with correct info', async function(assert) {
+  test('it rendersaaa the details page with correct info when session is finalized', async function(assert) {
+    // given
+    session = this.server.create('session', sessionData);
+
     // when
     await visit(`/certifications/sessions/${session.id}`);
 
     // then
-    const mainDiv = '.certifications-session-info';
-    const row = '.row:nth-child';
-    const col = '.col:nth-child(2)';
     assert.equal(currentURL(), `/certifications/sessions/${session.id}`);
-    assert.equal(find(`${mainDiv} ${row}(1) ${col}`).textContent, session.certificationCenter);
-    assert.equal(find(`${mainDiv} ${row}(2) ${col}`).textContent, session.address);
-    assert.equal(find(`${mainDiv} ${row}(3) ${col}`).textContent, session.room);
-    assert.equal(find(`${mainDiv} ${row}(4) ${col}`).textContent, session.examiner);
-    assert.equal(find(`${mainDiv} ${row}(5) ${col}`).textContent, moment(session.date, 'YYYY-MM-DD').format('DD/MM/YYYY'));
-    assert.equal(find(`${mainDiv} ${row}(6) ${col}`).textContent, session.time);
-    assert.equal(find(`${mainDiv} ${row}(7) ${col}`).textContent, session.description);
-    assert.equal(find(`${mainDiv} ${row}(8) ${col}`).textContent, session.accessCode);
-    assert.equal(find(`${mainDiv} ${row}(9) ${col}`), undefined);
+    assert.equal(find(`${commonSelector}${CERTIFICATION_CENTER_ROW} ${col}`).textContent, session.certificationCenter);
+    assert.equal(find(`${commonSelector}${ADDRESS_ROW} ${col}`).textContent, session.address);
+    assert.equal(find(`${commonSelector}${ROOM_ROW} ${col}`).textContent, session.room);
+    assert.equal(find(`${commonSelector}${EXAMINER_ROW} ${col}`).textContent, session.examiner);
+    assert.equal(find(`${commonSelector}${DATE_ROW} ${col}`).textContent, moment(session.date, 'YYYY-MM-DD').format('DD/MM/YYYY'));
+    assert.equal(find(`${commonSelector}${TIME_ROW} ${col}`).textContent, session.time);
+    assert.equal(find(`${commonSelector}${DESCRIPTION_ROW} ${col}`).textContent, session.description);
+    assert.equal(find(`${commonSelector}${ACCESS_CODE_ROW} ${col}`).textContent, session.accessCode);
+  });
+
+  test('it should not present unexpected row info', async function(assert) {
+    // given
+    session = this.server.create('session', sessionData);
+
+    // when
+    await visit(`/certifications/sessions/${session.id}`);
+
+    // then
+    assert.equal(find(`${commonSelector}${CHECK_NO_ADDITIONAL_INFO_ROW_EXISTS} ${col}`), undefined);
+  });
+
+  module('when the session is finalized', function() {
+
+    test('it renders the status row with finalized value', async function(assert) {
+      // given
+      sessionData.status = 'finalized';
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+
+      // then
+      assert.equal(find(`${commonSelector}${STATUS_ROW} ${col}`).textContent.trim(), 'Finalisée');
+    });
+  });
+
+  module('when the session is not finalized', function() {
+
+    test('it renders the status row with not finalized value', async function(assert) {
+      // given
+      sessionData.status = 'started';
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+
+      // then
+      assert.equal(find(`${commonSelector}${STATUS_ROW} ${col}`).textContent.trim(), 'Prête');
+    });
   });
 
 });

--- a/api/db/seeds/data/sessions-builder.js
+++ b/api/db/seeds/data/sessions-builder.js
@@ -23,6 +23,7 @@ module.exports = function sessionsBuilder({ databaseBuilder }) {
     description: 'Session de rattrapage',
     room: 'Salle Eau',
     accessCode: 'DEF34',
+    status: 'finalized',
   });
 
   databaseBuilder.factory.buildSession({

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -24,7 +24,6 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}',
       config: {
-        auth: false,
         handler: sessionController.get,
         tags: ['api']
       }

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -14,8 +14,9 @@ module.exports = {
   },
 
   async get(request) {
+    const userId = request.auth.credentials.userId;
     const sessionId = parseInt(request.params.id);
-    const session = await usecases.getSession({ sessionId });
+    const session = await usecases.getSession({ userId, sessionId });
 
     return sessionSerializer.serialize(session);
   },

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,6 +1,6 @@
 const statuses = {
-  CREATED: 'created',
-  COMPLETED: 'completed',
+  STARTED: 'started',
+  FINALIZED: 'finalized',
 };
 
 class Session {

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -16,6 +16,6 @@ module.exports = async function finalizeSession({
   } catch (err) {
     throw new ForbiddenAccess('User does not have the rights to finalize this session');
   }
-  return sessionRepository.updateStatus({ sessionId, status: statuses.COMPLETED })
+  return sessionRepository.updateStatus({ sessionId, status: statuses.FINALIZED })
     .then(() => sessionRepository.get(sessionId));
 };

--- a/api/lib/domain/usecases/get-session.js
+++ b/api/lib/domain/usecases/get-session.js
@@ -1,7 +1,14 @@
-module.exports = function getSession(
+module.exports = async function getSession(
   {
+    userId,
     sessionId,
     sessionRepository,
+    userRepository,
   } = {}) {
+  const isPixMaster = await userRepository.hasRolePixMaster(userId);
+  if (!isPixMaster) {
+    await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
+  }
+
   return sessionRepository.get(sessionId);
 };

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -11,6 +11,8 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
   describe('GET /sessions/{id}', function() {
     let session;
+    let userId;
+    let request;
 
     beforeEach(() => {
       session = databaseBuilder.factory.buildSession({
@@ -29,58 +31,54 @@ describe('Acceptance | Controller | session-controller-get', () => {
         id: 3,
         sessionId: 1
       });
-      databaseBuilder.factory.buildUser.withPixRolePixMaster();
+      userId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+      request = {
+        method: 'GET',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {},
+      };
 
       return databaseBuilder.commit();
     });
 
-    it('should return 200 HTTP status code', () => {
+    it('should return 200 HTTP status code', async () => {
+      // given
+      request.url = '/api/sessions/1';
+
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/sessions/1',
-        payload: {},
-      });
+      const response = await server.inject(request);
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
 
-    it('should return 404 HTTP status code when session does not exist', () => {
+    it('should return 404 HTTP status code when session does not exist', async () => {
+      // given
+      request.url = '/api/sessions/2';
+
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/sessions/2',
-        payload: {},
-      });
+      const response = await server.inject(request);
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(404);
-      });
+      expect(response.statusCode).to.equal(404);
     });
 
-    it('should return sessions information with related certification', () => {
+    it('should return sessions information with related certification', async () => {
+      // given
+      request.url = '/api/sessions/1';
+
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/sessions/1',
-        payload: {},
-      });
+      const response = await server.inject(request);
 
       // then
-      return promise.then((response) => {
-        expect(response.result.data.attributes['access-code']).to.deep.equal(session.accessCode);
-        expect(response.result.data.relationships.certifications).to.deep.equal({
-          'data': [
-            {
-              'id': '3',
-              'type': 'certifications'
-            }
-          ]
-        });
+      expect(response.result.data.attributes['access-code']).to.deep.equal(session.accessCode);
+      expect(response.result.data.relationships.certifications).to.deep.equal({
+        'data': [
+          {
+            'id': '3',
+            'type': 'certifications'
+          }
+        ]
       });
     });
   });

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
     examiner: 'Forster Nakamura',
     room: 'B',
     time: '14:40:00',
-    status: 'created',
+    status: 'started',
   };
 
   beforeEach(async () => {
@@ -105,7 +105,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
               'date': sessionDomain.date,
               'time': sessionDomain.time,
               'room': sessionDomain.room,
-              'status': 'completed',
+              'status': 'finalized',
             },
           },
         };

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -1,6 +1,6 @@
-const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | sessions-controller', () => {
 

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -1,6 +1,7 @@
 const faker = require('faker');
 const buildCertificationCenter = require('./build-certification-center');
 const databaseBuffer = require('../database-buffer');
+const Session = require('../../../../lib/domain/models/Session');
 const _ = require('lodash');
 const moment = require ('moment');
 
@@ -16,7 +17,7 @@ module.exports = function buildSession({
   time = faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0'),
   description = faker.random.words(),
   createdAt = faker.date.recent(),
-  status,
+  status = Session.statuses.STARTED,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -12,7 +12,7 @@ module.exports = function buildSession({
   examiner = faker.name.findName(),
   date = moment(faker.date.recent()).format('YYYY-MM-DD'),
   time = '14:30',
-  status = 'started',
+  status = Session.statuses.STARTED,
   description = faker.random.words(),
 } = {}) {
   return new Session({

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -97,6 +97,7 @@ describe('Unit | Controller | sessionController', () => {
       sinon.stub(usecases, 'getSession');
       sinon.stub(sessionSerializer, 'serialize');
       request = {
+        auth: { credentials: { userId } },
         params: {
           id: sessionId.toString(),
         }
@@ -113,7 +114,7 @@ describe('Unit | Controller | sessionController', () => {
         await sessionController.get(request, hFake);
 
         // then
-        expect(usecases.getSession).to.have.been.calledWith({ sessionId });
+        expect(usecases.getSession).to.have.been.calledWith({ userId, sessionId });
       });
 
       it('should serialize session informations', async function() {

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -25,20 +25,24 @@ describe('Unit | UseCase | finalize-session', () => {
 
   });
   context('When the user does not have the right to finalize the session', () => {
+
     beforeEach(async () => {
       sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).rejects(testErr);
     });
+
     it('should throw a ForbiddenAccess error', async () => {
       const err = await catchErr(finalizeSession)({ userId, sessionId, sessionRepository });
       expect(err).to.be.instanceOf(ForbiddenAccess);
     });
   });
   context('When the user has the rights', () => {
+
     beforeEach(async () => {
       sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).resolves();
-      sessionRepository.updateStatus.withArgs({ sessionId, status: 'completed' }).resolves();
+      sessionRepository.updateStatus.withArgs({ sessionId, status: 'finalized' }).resolves();
       sessionRepository.get.withArgs(sessionId).resolves(updatedSession);
     });
+
     it('should return the updated session', async () => {
       const res = await finalizeSession({ userId, sessionId, sessionRepository });
       expect(res).to.deep.equal(updatedSession);


### PR DESCRIPTION
## :unicorn: Contexte
Avec l'introduction de la notion de statut sur une session, on souhaite disposer de cette information sur PixAdmin.

## :robot: Solution
Ajout d'une entrée **"Statut:   nom_du_statut"** dans la page d'info de la session sur PixAdmin

## :rainbow: Remarques
Au passage, sécurisation de la route `GET /sessions/:id`   (à voir si c'est OK, si il n'y a pas de transmission de lien en démo ou autres)
