### PR TITLE
[TECH] Loguer toutes les erreurs sortant des contrôleurs API

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -2,8 +2,6 @@
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
 
-const { DomainError } = require('./lib/domain/errors');
-const { InfrastructureError } = require('./lib/infrastructure/errors');
 const errorManager = require('./lib/infrastructure/utils/error-manager');
 
 const Hapi = require('hapi');
@@ -35,7 +33,7 @@ const createServer = async () => {
   const preResponse = function(request, h) {
     const response = request.response;
 
-    if (response instanceof DomainError || response instanceof InfrastructureError) {
+    if (response instanceof Error) {
       return errorManager.send(h, response);
     }
 


### PR DESCRIPTION
## :unicorn: Problème

On a parfois des erreurs qui n'apparaissent pas dans les logs API, comme les erreurs SQL.

## :robot: Cause

À la sortie des contrôleurs, les requêtes sont traitées par un handler de `'onPreResponse'`. Ce handler ne passe que les erreurs dérivant de `DomainError` ou de `InfrastructureError` à l'`errorManager`.

## :rainbow: Solution

Dans le `'onPreResponse'`, passer toutes les erreurs à l'`errorManager`. Il se comporte déjà correctement pour les traiter et il est déjà testé pour ce cas.

Note : les logs passent par Bunyan, donc on a des stack traces en JSON, c'est un brin moins lisible pour l'usage au quotidien.