### PR TITLE
[BUGFIX] Les certifications non 'validated' ne remontaient plus dans le fichier pour le jury (PA-125)

### DIFF
--- a/admin/app/components/certification-session-report.js
+++ b/admin/app/components/certification-session-report.js
@@ -1,62 +1,38 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { filterBy, filter } from '@ember/object/computed';
 import _ from 'lodash';
 
 export default Component.extend({
 
-  // Element
   classNames: ['certification-session-report'],
 
-  // Props
-  candidates: null,
+  outOfSessionCertifications: filterBy('certifications', 'isInSession', false),
 
-  // CPs
-  incomplete: computed('candidates', function() {
-    return this.candidates.filter((candidate) => {
-      return !candidate.lastName || candidate.lastName.trim() === ''
-        || !candidate.firstName || candidate.firstName.trim() === ''
-        || !candidate.birthdate || candidate.birthdate.trim() === ''
-        || !candidate.birthplace || candidate.birthplace.trim() === ''
-        || !candidate.certificationId || candidate.certificationId.trim() === '';
+  incompleteCertifications: filter('certifications', function(certification) {
+    return !certification.lastName
+      ||   !certification.firstName
+      ||   !certification.birthdate
+      ||   !certification.birthplace
+      ||   !certification.id;
+  }),
+
+  duplicateCertificationIds: computed('certifications', function() {
+    const certificationsGroupedByCertifId = _.groupBy(this.certifications, (certification) => {
+      return certification.id;
     });
+    return _.compact(_.map(certificationsGroupedByCertifId, (certifications, certificationId) => {
+      if (certifications.length > 1) {
+        return certificationId;
+      }
+    }));
   }),
 
-  duplicates: computed('candidates', function() {
-    const certificationIds = _.map(this.candidates, 'certificationId');
-    const groupedCertificationIds = _.groupBy(certificationIds, _.identity);
-    return _.uniq(_.flatten(_.filter(groupedCertificationIds, (n) => n.length > 1)));
-  }),
+  noLastScreenSeenCertifications: filterBy('certifications', 'hasSeenLastScreen', false),
 
-  notFromSession:computed('candidates', function() {
-    const certificationIds = this.certifications.map((certification) => parseInt(certification.id));
-    return this.candidates.filter((candidate) => {
-      return certificationIds.indexOf(parseInt(candidate.certificationId)) === -1;
-    });
+  commentedByExaminerCertifications: filter('certifications', function(certification) {
+    return !_.isEmpty(certification.examinerComment);
   }),
-
-  sessionCandidates: computed('candidates', function() {
-    const certificationIds = this.certifications.map((certification) => certification.id);
-    return _.filter(this.candidates, (candidate) => {
-      return candidate.certificationId && certificationIds.includes(candidate.certificationId);
-    });
-  }),
-
-  withoutCandidate:computed('candidates', function() {
-    const candidateCertificationIds = this.candidates.map((candidate) => candidate.certificationId);
-    return this.certifications.filter((certification) => {
-      return candidateCertificationIds.indexOf(certification.id) === -1;
-    });
-  }),
-
-  missingEndScreen: computed('candidates', function() {
-    return _.filter(this.candidates, (candidate) => !candidate.lastScreen || candidate.lastScreen.trim() === '');
-  }),
-
-  comments: computed('candidates', function() {
-    return _.filter(this.candidates, (candidate) => candidate.comments && candidate.comments.trim() !== '');
-  }),
-
-  // Actions
 
   actions: {
     toggleSection(sectionName) {

--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -65,9 +65,7 @@ export default Controller.extend({
     const sessionCertifications = this.model.get('certifications').toArray();
     _.each(this.certificationsInSessionReport, (certificationInReport) => {
       if (certificationInReport.isInSession) {
-        const existingCertification = _.find(sessionCertifications, (sessionCertification) => {
-          return sessionCertification.id === certificationInReport.id;
-        });
+        const existingCertification = _.find(sessionCertifications, { 'id': certificationInReport.id });
         existingCertification.updateUsingCertificationInReport(certificationInReport);
       }
     });
@@ -75,7 +73,6 @@ export default Controller.extend({
 
   actions: {
 
-    // --- Actions for Session Report Analysis Modal
     onCloseSessionReportAnalysis() {
       this.set('certificationsInSessionReport', []);
       this.set('displaySessionReport', false);
@@ -120,7 +117,6 @@ export default Controller.extend({
         this.notifications.error(error);
       }
     },
-    // ---
 
     downloadSessionResultFile() {
       try {

--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -1,11 +1,14 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-admin/config/environment';
+import EmberObject from '@ember/object';
+import _ from 'lodash';
 
 export default Controller.extend({
 
   session: service(),
   sessionInfoService: service(),
+  store: service(),
   notifications: service('notification-messages'),
 
   displayConfirm: false,
@@ -14,36 +17,75 @@ export default Controller.extend({
   confirmAction: null,
   showSelectedActions: false,
   selectedCertifications: null,
+  certificationsInSessionReport: null,
 
   init() {
     this._super();
     this.selected = [];
-    this.importedCandidates = [];
+    this.set('certificationsInSessionReport', []);
     this.confirmAction = () => {
     };
   },
 
+  _extractCertificationsFromSessionReportData(sessionReportData) {
+    const certificationsIdsInSession = this.model.certifications.mapBy('id');
+    return _.map(sessionReportData, (certificationFromReport) => {
+      return EmberObject.create({
+        id: certificationFromReport.certificationId,
+        firstName: certificationFromReport.firstName,
+        lastName: certificationFromReport.lastName,
+        birthdate: certificationFromReport.birthdate,
+        birthplace: certificationFromReport.birthplace,
+        examinerComment: certificationFromReport.comments,
+        externalId: certificationFromReport.externalId,
+        extraTimePercentage: certificationFromReport.extraTimePercentage,
+        hasSeenLastScreen: !_.isEmpty(certificationFromReport.lastScreen),
+        isInSession: _.includes(certificationsIdsInSession, certificationFromReport.certificationId),
+      });
+    });
+  },
+
+  _rollbackCertificationsModifications() {
+    const certifications = this.model.get('certifications').toArray();
+    certifications.forEach((certification) => {
+      certification.rollbackAttributes();
+    });
+  },
+
+  _parseSessionReportData(file) {
+    const { access_token } = this.get('session.data.authenticated');
+    const url = `${ENV.APP.API_HOST}/${ENV.APP.ODS_PARSING_URL}`;
+    return file.upload(url, {
+      headers: { Authorization: `Bearer ${access_token}` },
+      method: 'PUT',
+    });
+  },
+
+  _updateSessionCertificationsWithCertificationsFromSessionReport() {
+    const sessionCertifications = this.model.get('certifications').toArray();
+    _.each(this.certificationsInSessionReport, (certificationInReport) => {
+      if (certificationInReport.isInSession) {
+        const existingCertification = _.find(sessionCertifications, (sessionCertification) => {
+          return sessionCertification.id === certificationInReport.id;
+        });
+        existingCertification.updateUsingCertificationInReport(certificationInReport);
+      }
+    });
+  },
+
   actions: {
 
-    async onSaveReportData(candidatesData) {
-      try {
-        await this.sessionInfoService.updateCertificationsFromCandidatesData(this.model.certifications, candidatesData);
-        this.notifications.success(`${candidatesData.length} lignes correctement importé(e)s.`);
-        this.set('displaySessionReport', false);
-      } catch (error) {
-        this.notifications.error(error);
-      }
+    // --- Actions for Session Report Analysis Modal
+    onCloseSessionReportAnalysis() {
+      this.set('certificationsInSessionReport', []);
+      this.set('displaySessionReport', false);
     },
 
-    async displayCertificationSessionReportModal(file) {
-      const { access_token } = this.get('session.data.authenticated');
-      const url = `${ENV.APP.API_HOST}/${ENV.APP.ODS_PARSING_URL}`;
+    async onDisplaySessionReportAnalysis(file) {
       try {
-        const response = await file.upload(url, {
-          headers: { Authorization: `Bearer ${access_token}` },
-          method: 'PUT',
-        });
-        this.set('importedCandidates', response.body);
+        const { body: sessionReportData } = await this._parseSessionReportData(file);
+        const certifications = this._extractCertificationsFromSessionReportData(sessionReportData);
+        this.set('certificationsInSessionReport', certifications);
         this.set('displaySessionReport', true);
       }
       catch (err) {
@@ -51,17 +93,38 @@ export default Controller.extend({
       }
     },
 
-    downloadSessionResultFile() {
+    async onUpdateSessionCertificationsWithReportData() {
       try {
-        this.sessionInfoService.downloadSessionExportFile(this.model);
+        this._updateSessionCertificationsWithCertificationsFromSessionReport();
+        const certificationsToSave = this.model.get('certifications').filter((certification) => {
+          return certification.hasDirtyAttributes;
+        });
+        await Promise.all(certificationsToSave.map((certification) => {
+          return certification.save({ adapterOptions: { updateMarks: false } });
+        }));
+      } catch (err) {
+        this._rollbackCertificationsModifications();
+        this.notifications.error(err);
+      } finally {
+        this.set('certificationsInSessionReport', []);
+        this.set('displaySessionReport', false);
+      }
+    },
+
+    onDownloadJuryFile() {
+      try {
+        this._updateSessionCertificationsWithCertificationsFromSessionReport();
+        this.sessionInfoService.downloadJuryFile(this.model.id, this.model.certifications);
+        this._rollbackCertificationsModifications();
       } catch (error) {
         this.notifications.error(error);
       }
     },
+    // ---
 
-    downloadJuryFile(attendanceSheetCandidates) {
+    downloadSessionResultFile() {
       try {
-        this.sessionInfoService.downloadJuryFile(this.model, attendanceSheetCandidates);
+        this.sessionInfoService.downloadSessionExportFile(this.model);
       } catch (error) {
         this.notifications.error(error);
       }

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import _ from 'lodash';
 
 export default DS.Model.extend({
   sessionId: DS.attr(),
@@ -11,25 +12,28 @@ export default DS.Model.extend({
   externalId: DS.attr(),
   createdAt: DS.attr(),
   completedAt: DS.attr(),
-  creationDate: computed('createdAt', function() {
-    return (new Date(this.createdAt)).toLocaleString('fr-FR');
-  }),
-  completionDate: computed('completedAt', function() {
-    return (new Date(this.completedAt)).toLocaleString('fr-FR');
-  }),
   status: DS.attr(),
   juryId: DS.attr(),
+  hasSeenLastScreen: DS.attr('boolean', { defaultValue: true }),
+  examinerComment: DS.attr('string'),
   commentForCandidate: DS.attr(),
   commentForOrganization: DS.attr(),
   commentForJury: DS.attr(),
   pixScore: DS.attr(),
   competencesWithMark: DS.attr(),
   isPublished: DS.attr('boolean', { defaultValue: false }),
+  isV2Certification: DS.attr('boolean', { defaultValue: false }),
+
+  creationDate: computed('createdAt', function() {
+    return (new Date(this.createdAt)).toLocaleString('fr-FR');
+  }),
+  completionDate: computed('completedAt', function() {
+    return (new Date(this.completedAt)).toLocaleString('fr-FR');
+  }),
   publishedText: computed('isPublished', function() {
     const value = this.isPublished;
     return value ? 'Oui' : 'Non';
   }),
-  isV2Certification: DS.attr('boolean', { defaultValue: false }),
   isV2CertificationText: computed('isV2Certification', function() {
     const value = this.isV2Certification;
     return value ? 'Oui' : 'Non';
@@ -47,5 +51,15 @@ export default DS.Model.extend({
       result.push(indexedCompetences[value]);
       return result;
     }, []);
-  })
+  }),
+
+  updateUsingCertificationInReport: function(certificationInReport) {
+    _.each(['firstName', 'lastName', 'birthdate', 'birthplace', 'externalId', 'examinerComment'], (attribute) => {
+      if (_.isEmpty(this.get(attribute)) && !_.isEmpty(certificationInReport[attribute])) {
+        this.set(attribute, certificationInReport[attribute].trim());
+      }
+    });
+
+    this.set('hasSeenLastScreen', this.hasSeenLastScreen && certificationInReport.hasSeenLastScreen);
+  },
 });

--- a/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
@@ -8,7 +8,7 @@
         {{#file-upload
           name="session-record-report"
           for="upload-attendance-sheet"
-          onfileadd=(action "displayCertificationSessionReportModal")
+          onfileadd=(action "onDisplaySessionReportAnalysis")
           accept="application/vnd.oasis.opendocument.spreadsheet"
         }}
           {{fa-icon "clipboard-list"}}
@@ -44,8 +44,7 @@
                 show=displayConfirm}}
 
 {{certification-session-report show=displaySessionReport
-                               hide=(action (mut displaySessionReport) false)
-                               getJuryFile=(action "downloadJuryFile")
-                               saveCandidates=(action "onSaveReportData")
-                               candidates=importedCandidates
-                               certifications=model.certifications }}
+                               onHide=(action 'onCloseSessionReportAnalysis')
+                               onDownloadJuryFile=(action 'onDownloadJuryFile')
+                               onSaveSessionReportCertifications=(action 'onUpdateSessionCertificationsWithReportData')
+                               certifications=certificationsInSessionReport}}

--- a/admin/app/templates/components/certification-session-report.hbs
+++ b/admin/app/templates/components/certification-session-report.hbs
@@ -1,4 +1,4 @@
-{{#bs-modal onHide=(action hide) open=show size="lg" as |modal|}}
+{{#bs-modal onHide=onHide open=show size="lg" as |modal|}}
   {{#modal.header}}
     <h4 class="modal-title">Analyse du PV de session</h4>
   {{/modal.header}}
@@ -6,200 +6,173 @@
   {{#modal.body}}
     <div class="certification-session-report__body">
 
-      <section class="data-section data-section--listed-candidates">
-        <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayListedCandidatesSection"}}>Nombre de candidats trouvés</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{candidates.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if candidates.length}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{else}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and candidates.length displayListedCandidatesSection)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each candidates as |candidate|}}
-                <span class="data-section__certification-id">{{candidate.certificationId}}</span>
-              {{/each}}
+        <section class="data-section data-section--total-certifications">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayTotalCertifications"}}>Total</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{certifications.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if certifications.length}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{else}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and certifications.length displayTotalCertifications)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each certifications as |item|}}
+                        <span class="data-section__certification-id">{{item.id}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
 
-      <section class="data-section data-section--unexpected-candidates">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayUnexpectedCandidates"}}>Candidats hors session</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{notFromSession.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if notFromSession.length}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and notFromSession.length displayUnexpectedCandidates)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each notFromSession as |item|}}
-                <span class="data-section__certification-id">{{item.certificationId}}</span>
-              {{/each}}
+        <section class="data-section data-section--out-of-session-certifications">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayOutOfSessionCertifications"}}>Hors session</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{outOfSessionCertifications.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if outOfSessionCertifications.length}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{else}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and outOfSessionCertifications.length displayOutOfSessionCertifications)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each outOfSessionCertifications as |item|}}
+                        <span class="data-section__certification-id">{{item.id}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
 
-      <section class="data-section data-section--incomplete-candidates">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayIncompleteCandidates"}}>Candidats incomplets</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{incomplete.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if incomplete.length}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and incomplete.length displayIncompleteCandidates)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each incomplete as |item|}}
-                <span class="data-section__certification-id">{{item.certificationId}}</span>
-              {{/each}}
+        <section class="data-section data-section--incomplete-certifications">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayIncompleteCertifications"}}>Incomplètes</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{incompleteCertifications.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if incompleteCertifications.length}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{else}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and incompleteCertifications.length displayIncompleteCertifications)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each incompleteCertifications as |item|}}
+                        <span class="data-section__certification-id">{{item.id}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
 
-      <section class="data-section data-section--duplicate-candidates">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayDuplicateCandidates"}}>Nombre de doublons</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{duplicates.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if duplicates.length}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and duplicates.length displayDuplicateCandidates)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each duplicates as |duplicate|}}
-                <span class="data-section__certification-id">{{duplicate}}</span>
-              {{/each}}
+        <section class="data-section data-section--duplicate-certification-ids">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayDuplicateCertificationIds"}}>Doublons</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{duplicateCertificationIds.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if duplicateCertificationIds.length}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{else}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and duplicateCertificationIds.length displayDuplicateCertificationIds)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each duplicateCertificationIds as |item|}}
+                        <span class="data-section__certification-id">{{item}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
 
-      <section class="data-section data-section--missing-candidates">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayMissingCandidates"}}>Certifications sans candidat</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{withoutCandidate.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if withoutCandidate.length}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and withoutCandidate.length displayMissingCandidates)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each withoutCandidate as |item|}}
-                <span class="data-section__certification-id">{{item.id}}</span>
-              {{/each}}
+        <section class="data-section data-section--has-not-seen-last-screen-certifications">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayNoLastScreenSeenCertifications"}}>Écrans de fin de test non vus</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{noLastScreenSeenCertifications.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if noLastScreenSeenCertifications.length}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{else}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and noLastScreenSeenCertifications.length displayNoLastScreenSeenCertifications)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each noLastScreenSeenCertifications as |item|}}
+                        <span class="data-section__certification-id">{{item.id}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
 
-      <section class="data-section data-section--missing-end-screen">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayMissingEndScreen"}}>Écrans de fin non renseignés</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{missingEndScreen.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if missingEndScreen.length}}
-              {{fa-icon "times" class="data-section__status--failure"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and missingEndScreen.length displayMissingEndScreen)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each missingEndScreen as |item|}}
-                <span class="data-section__certification-id">{{item.certificationId}}</span>
-              {{/each}}
+        <section class="data-section data-section--has-examiner-comment-screen-certifications">
+            <div class="row mb-2">
+                <div class="col-8">
+                    <button class="data-section__switch" type="button" {{action "toggleSection" "displayCommentedByExaminerCertifications"}}>Commentaires du surveillant</button>
+                </div>
+                <div class="col-3">
+                    <span class="data-section__counter">{{commentedByExaminerCertifications.length}}</span>
+                </div>
+                <div class="col-1">
+                  {{#if commentedByExaminerCertifications.length}}
+                    {{fa-icon "times" class="data-section__status--failure"}}
+                  {{else}}
+                    {{fa-icon "check" class="data-section__status--success"}}
+                  {{/if}}
+                </div>
             </div>
-          </div>
-        {{/if}}
-      </section>
-
-      <section class="data-section data-section--comments">
-         <div class="row mb-2">
-          <div class="col-8">
-            <button class="data-section__switch" type="button" {{action "toggleSection" "displayCommentedCandidates"}}>Commentaires</button>
-          </div>
-          <div class="col-3">
-            <span class="data-section__counter">{{comments.length}}</span>
-          </div>
-          <div class="col-1">
-            {{#if comments.length}}
-              {{fa-icon "exclamation-triangle" class="data-section__status--warning"}}
-            {{else}}
-              {{fa-icon "check" class="data-section__status--success"}}
-            {{/if}}
-          </div>
-        </div>
-        {{#if (and comments.length displayCommentedCandidates)}}
-          <div class="row mb-4">
-            <div class="col-8 data-section__certification-ids">
-              {{#each comments as |item|}}
-                <span class="data-section__certification-id">{{item.certificationId}}</span>
-              {{/each}}
-            </div>
-          </div>
-        {{/if}}
-      </section>
+          {{#if (and commentedByExaminerCertifications.length displayCommentedByExaminerCertifications)}}
+              <div class="row mb-4">
+                  <div class="col-8 data-section__certification-ids">
+                    {{#each commentedByExaminerCertifications as |item|}}
+                        <span class="data-section__certification-id">{{item.id}}</span>
+                    {{/each}}
+                  </div>
+              </div>
+          {{/if}}
+        </section>
     </div>
 
   {{/modal.body}}
   {{#modal.footer as |footer|}}
     {{#bs-button onClick=(action modal.close) type="default"}}Fermer{{/bs-button}}
-    {{#bs-button onClick=(action getJuryFile candidates) type="primary"}}Récupérer le fichier avant Jury{{/bs-button}}
-    {{#bs-button onClick=(action saveCandidates sessionCandidates) type="primary"}}Enregistrer les infos candidats{{/bs-button}}
+    {{#bs-button onClick=onDownloadJuryFile type="primary"}}Récupérer le fichier avant Jury{{/bs-button}}
+    {{#bs-button onClick=onSaveSessionReportCertifications type="primary"}}Enregistrer les infos certifications{{/bs-button}}
   {{/modal.footer}}
 {{/bs-modal}}

--- a/admin/tests/acceptance/certifications-parsing-uploaded-attendance-sheet-test.js
+++ b/admin/tests/acceptance/certifications-parsing-uploaded-attendance-sheet-test.js
@@ -5,6 +5,13 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { upload } from 'ember-file-upload/test-support';
 
+const TOTAL_CERTIFICATIONS_SECTION = '(1)';
+const OUT_OF_SESSION_CERTIFICATIONS_SECTION = '(2)';
+const INCOMPLETE_CERTIFICATIONS_SECTION = '(3)';
+const DUPLICATE_CERTIFICATIONS_SECTION = '(4)';
+const HAS_NOT_SEEN_LAST_SCREEN_CERTIFICATIONS_SECTION = '(5)';
+const HAS_EXAMINER_COMMENT_CERTIFICATIONS_SECTION = '(6)';
+
 module('Acceptance | Certifications Parsing', function(hooks) {
 
   setupApplicationTest(hooks);
@@ -13,9 +20,6 @@ module('Acceptance | Certifications Parsing', function(hooks) {
   hooks.beforeEach(async function() {
     await authenticateSession({ userId: 1 });
     server.create('session', { id: 1 });
-  });
-
-  hooks.afterEach(function() {
   });
 
   test('it displays the modal the certification session report modal with appropriate info', async function(assert) {
@@ -27,14 +31,15 @@ module('Acceptance | Certifications Parsing', function(hooks) {
     await upload('#upload-attendance-sheet', file);
 
     // then
+    const commonSelector = '.certification-session-report__body section:nth-child';
+    const valueDiv = 'div:nth-child(2)';
     assert.dom('.modal-content').exists();
-    assert.dom('.certification-session-report__body section:nth-child(1) div:nth-child(2)').hasText('2');
-    assert.dom('.certification-session-report__body section:nth-child(2) div:nth-child(2)').hasText('2');
-    assert.dom('.certification-session-report__body section:nth-child(3) div:nth-child(2)').hasText('1');
-    assert.dom('.certification-session-report__body section:nth-child(4) div:nth-child(2)').hasText('0');
-    assert.dom('.certification-session-report__body section:nth-child(5) div:nth-child(2)').hasText('0');
-    assert.dom('.certification-session-report__body section:nth-child(6) div:nth-child(2)').hasText('0');
-    assert.dom('.certification-session-report__body section:nth-child(7) div:nth-child(2)').hasText('1');
+    assert.dom(`${commonSelector}${TOTAL_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('2');
+    assert.dom(`${commonSelector}${OUT_OF_SESSION_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('2');
+    assert.dom(`${commonSelector}${INCOMPLETE_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('1');
+    assert.dom(`${commonSelector}${DUPLICATE_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('0');
+    assert.dom(`${commonSelector}${HAS_NOT_SEEN_LAST_SCREEN_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('0');
+    assert.dom(`${commonSelector}${HAS_EXAMINER_COMMENT_CERTIFICATIONS_SECTION} ${valueDiv}`).hasText('1');
   });
 
 });

--- a/admin/tests/integration/components/certification-session-report-test.js
+++ b/admin/tests/integration/components/certification-session-report-test.js
@@ -1,358 +1,121 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click, render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | certification-session-report', function(hooks) {
 
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function() {
+    this.set('visible', true);
+    this.set('onHide', function() {});
+    this.set('onGetJuryFile', function() {});
+    this.set('onSaveCertificationsReportData', function() {});
+    this.set('sessionId', '3');
+    const buildCertification = function buildCertificationObject({
+      id,
+      firstName = 'default firstName',
+      lastName = 'default lastName',
+      birthdate = 'default birthdate',
+      birthplace = 'default birtplace',
+      examinerComment = '',
+      hasSeenLastScreen = true,
+      isInSession = true, }) {
+      return {
+        id, firstName, lastName, birthplace, birthdate, examinerComment, hasSeenLastScreen, isInSession
+      };
+    };
+    const certifications = [
+      buildCertification({ id: 1 }),
+      buildCertification({ id: 2, birthdate: null }),
+      buildCertification({ id: 3 }),
+      buildCertification({ id: 3 }),
+      buildCertification({ id: 4 }),
+      buildCertification({ id: 4 }),
+      buildCertification({ id: 5, isInSession: false }),
+      buildCertification({ id: 6, hasSeenLastScreen: false }),
+      buildCertification({ id: 7, examinerComment: 'comment' }),
+    ];
+    this.set('certificationsInSessionReport', certifications);
+    return render(hbs`{{certification-session-report 
+      show=visible hide=onHide onDownloadJuryFile=onGetJuryFile 
+      onSaveSessionReportCertifications=onSaveCertificationsReportData certifications=certificationsInSessionReport}}`);
+  });
+
   module('Rendering', function() {
     test('it renders', async function(assert) {
-      // given
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('candidateData', []);
-      this.set('certificationData', []);
-
-      // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-
       // then
       assert.dom('.certification-session-report__body').exists();
     });
   });
 
-  module('When given a list of candidates in JSON', function() {
+  module('When given a list of certifications', function() {
 
-    test('it counts candidates and displays their certification ids', async function(assert) {
-
-      // given
-      this.set('candidateData', [{
-        birthdate: '2000-02-20',
-        birthplace: 'Paris',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123455',
-        firstName: 'Toto',
-        lastName: 'Le Héros',
-        row: 1
-      },{
-        birthdate: '2000-03-20',
-        birthplace: 'Toulouse',
-        certificationId: '33348',
-        email: 'firstname.name@mail.com',
-        externalId: '123456',
-        firstName: 'Titi',
-        lastName: 'Romi',
-        row: 2
-      },{
-        birthdate: '2000-01-20',
-        birthplace: 'Bordeaux',
-        certificationId: '33349',
-        email: 'firstname.name@mail.com',
-        externalId: '123458',
-        firstName: 'Cats',
-        lastName: 'Eyes',
-        row: 3
-      }]);
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('certificationData', []);
-
+    test('it counts and displays total number of certifications', async function(assert) {
       // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-      await click('.data-section--listed-candidates .data-section__switch');
+      await click('.data-section--total-certifications .data-section__switch');
 
       // then
-      assert.dom('.data-section--listed-candidates .data-section__counter').hasText('3');
-      assert.dom('.data-section--listed-candidates .data-section__certification-ids').includesText('33347');
-      assert.dom('.data-section--listed-candidates .data-section__certification-ids').includesText('33348');
-      assert.dom('.data-section--listed-candidates .data-section__certification-ids').includesText('33349');
+      assert.dom('.data-section--total-certifications .data-section__counter').hasText('9');
+      const certificationsIdsElement = find('.data-section--total-certifications .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '123344567');
     });
 
-    test('it detects candidates with incomplete information and displays their certification ids', async function(assert) {
-      // given
-      this.set('candidateData', [{
-        birthdate: '2000-02-20',
-        birthplace: 'Paris',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123455',
-        firstName: 'Toto',
-        lastName: '',
-        row: 1
-      },{
-        birthdate: '2000-03-20',
-        birthplace: '',
-        certificationId: '33348',
-        email: 'firstname.name@mail.com',
-        externalId: '123456',
-        firstName: 'Titi',
-        lastName: 'Romi',
-        row: 2
-      },{
-        birthdate: '2000-01-20',
-        birthplace: 'Bordeaux',
-        certificationId: '33349',
-        email: 'firstname.name@mail.com',
-        externalId: '123458',
-        firstName: 'Cats',
-        lastName: 'Eyes',
-        row: 3
-      },{
-        birthdate: '2000-01-20',
-        birthplace: 'Bordeaux',
-        email: 'firstname.name@mail.com',
-        externalId: '123458',
-        firstName: 'Cats',
-        lastName: 'Eyes',
-        row: 4
-      }]);
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('certificationData', []);
-
+    test('it counts and displays incomplete certifications', async function(assert) {
       // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-      await click('.data-section--incomplete-candidates .data-section__switch');
+      await click('.data-section--incomplete-certifications .data-section__switch');
 
       // then
-      assert.dom('.data-section--incomplete-candidates .data-section__counter').hasText('3');
-      assert.dom('.data-section--incomplete-candidates .data-section__certification-ids').includesText('33347');
-      assert.dom('.data-section--incomplete-candidates .data-section__certification-ids').includesText('33348');
+      assert.dom('.data-section--incomplete-certifications .data-section__counter').hasText('1');
+      const certificationsIdsElement = find('.data-section--incomplete-certifications .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '2');
     });
 
-    test('it detects and displays duplicate certification ids', async function(assert) {
-      // given
-      this.set('candidateData', [{
-        birthdate: '2000-02-20',
-        birthplace: 'Paris',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123455',
-        firstName: 'Toto',
-        lastName: 'Le Héros',
-        row: 1
-      },{
-        birthdate: '2000-03-20',
-        birthplace: 'Toulouse',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123456',
-        firstName: 'Titi',
-        lastName: 'Romi',
-        row: 2
-      },{
-        birthdate: '2000-01-20',
-        birthplace: 'Bordeaux',
-        certificationId: '33349',
-        email: 'firstname.name@mail.com',
-        externalId: '123458',
-        firstName: 'Cats',
-        lastName: 'Eyes',
-        row: 3
-      }]);
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('certificationData', []);
-
+    test('it counts and displays duplicate certification ids', async function(assert) {
       // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-      await click('.data-section--duplicate-candidates .data-section__switch');
+      await click('.data-section--duplicate-certification-ids .data-section__switch');
 
-      //then
-      assert.dom('.data-section--duplicate-candidates .data-section__counter').hasText('1');
-      assert.dom('.data-section--duplicate-candidates .data-section__certification-ids').includesText('33347');
+      // then
+      assert.dom('.data-section--duplicate-certification-ids .data-section__counter').hasText('2');
+      const certificationsIdsElement = find('.data-section--duplicate-certification-ids .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '34');
     });
 
-    test('it detects candidates with missing information for end screen column', async function(assert) {
-      // given
-      this.set('candidateData', [{
-        birthdate: '2000-02-20',
-        birthplace: 'Paris',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123455',
-        firstName: 'Toto',
-        lastName: '',
-        row: 1
-      },{
-        birthdate: '2000-03-20',
-        birthplace: '',
-        certificationId: '33348',
-        email: 'firstname.name@mail.com',
-        externalId: '123456',
-        firstName: 'Titi',
-        lastName: 'Romi',
-        row: 2,
-        lastScreen:'X'
-      }]);
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('certificationData', []);
-
+    test('it counts and displays out of session certification ids', async function(assert) {
       // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-      await click('.data-section--missing-end-screen .data-section__switch');
+      await click('.data-section--out-of-session-certifications .data-section__switch');
 
-      //then
-      assert.dom('.data-section--missing-end-screen .data-section__counter').hasText('1');
-      assert.dom('.data-section--missing-end-screen .data-section__certification-ids').includesText('33347');
+      // then
+      assert.dom('.data-section--out-of-session-certifications .data-section__counter').hasText('1');
+      const certificationsIdsElement = find('.data-section--out-of-session-certifications .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '5');
     });
 
-    test('it detects provided comments and displays corresponding certification ids', async function(assert) {
-      // given
-      this.set('candidateData', [{
-        birthdate: '2000-02-20',
-        birthplace: 'Paris',
-        certificationId: '33347',
-        email: 'firstname.name@mail.com',
-        externalId: '123455',
-        firstName: 'Toto',
-        lastName: '',
-        row: 1,
-        comments: 'a comment'
-      },{
-        birthdate: '2000-03-20',
-        birthplace: '',
-        certificationId: '33348',
-        email: 'firstname.name@mail.com',
-        externalId: '123456',
-        firstName: 'Titi',
-        lastName: 'Romi',
-        row: 2,
-        lastScreen:'X'
-      },{
-        birthdate: '2000-01-20',
-        birthplace: 'Bordeaux',
-        email: 'firstname.name@mail.com',
-        externalId: '123458',
-        firstName: 'Cats',
-        lastName: 'Eyes',
-        certificationId: '33351',
-        row: 3,
-        comments: 'another comment'
-      }]);
-      this.set('visible', true);
-      this.set('onHide', function() {});
-      this.set('onGetJuryFile', function() {});
-      this.set('onSaveReportData', function() {});
-      this.set('certificationData', []);
-
+    test('it counts and displays has not seen last screen certification ids', async function(assert) {
       // when
-      await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-      await click('.data-section--comments .data-section__switch');
+      await click('.data-section--has-not-seen-last-screen-certifications .data-section__switch');
 
-      //then
-      assert.dom('.data-section--comments .data-section__counter').hasText('2');
-      assert.dom('.data-section--comments .data-section__certification-ids').includesText('33347');
-      assert.dom('.data-section--comments .data-section__certification-ids').includesText('33351');
+      // then
+      assert.dom('.data-section--has-not-seen-last-screen-certifications .data-section__counter').hasText('1');
+      const certificationsIdsElement = find('.data-section--has-not-seen-last-screen-certifications .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '6');
     });
 
-    module('When given the list of certifications from the session', function() {
+    test('it counts and displays certification ids that have examiner comment', async function(assert) {
+      // when
+      await click('.data-section--has-examiner-comment-screen-certifications .data-section__switch');
 
-      test('it finds candidates not related to the certification session and displays corresponding certification ids', async function(assert) {
-
-        //given
-        this.set('candidateData', [{
-          birthdate: '2000-02-20',
-          birthplace: 'Paris',
-          certificationId: '33347',
-          email: 'firstname.name@mail.com',
-          externalId: '123455',
-          firstName: 'Toto',
-          lastName: 'Le Héros',
-          row: 1
-        },{
-          birthdate: '2000-03-20',
-          birthplace: 'Toulouse',
-          certificationId: '33348',
-          email: 'firstname.name@mail.com',
-          externalId: '123456',
-          firstName: 'Titi',
-          lastName: 'Romi',
-          row: 2
-        },{
-          birthdate: '2000-01-20',
-          birthplace: 'Bordeaux',
-          certificationId: '33349',
-          email: 'firstname.name@mail.com',
-          externalId: '123458',
-          firstName: 'Cats',
-          lastName: 'Eyes',
-          row: 3
-        }]);
-        this.set('certificationData', [{ id:'33347' }, { id:'33349' }]);
-        this.set('visible', true);
-        this.set('onHide', function() {});
-        this.set('onGetJuryFile', function() {});
-        this.set('onSaveReportData', function() {});
-
-        // when
-        await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-        await click('.data-section--unexpected-candidates .data-section__switch');
-
-        // then
-        assert.dom('.data-section--unexpected-candidates .data-section__counter').hasText('1');
-        assert.dom('.data-section--unexpected-candidates .data-section__certification-ids').includesText('33348');
-      });
-
-      test('it finds certifications that are missing candidate information', async function(assert) {
-
-        //given
-        this.set('candidateData', [{
-          birthdate: '2000-02-20',
-          birthplace: 'Paris',
-          certificationId: '33347',
-          email: 'firstname.name@mail.com',
-          externalId: '123455',
-          firstName: 'Toto',
-          lastName: 'Le Héros',
-          row: 1
-        },{
-          birthdate: '2000-03-20',
-          birthplace: 'Toulouse',
-          certificationId: '33348',
-          email: 'firstname.name@mail.com',
-          externalId: '123456',
-          firstName: 'Titi',
-          lastName: 'Romi',
-          row: 2
-        },{
-          birthdate: '2000-01-20',
-          birthplace: 'Bordeaux',
-          certificationId: '33349',
-          email: 'firstname.name@mail.com',
-          externalId: '123458',
-          firstName: 'Cats',
-          lastName: 'Eyes',
-          row: 3
-        }]);
-        this.set('certificationData', [{ id:'33347' }, { id:'33350' }]);
-        this.set('visible', true);
-        this.set('onHide', function() {});
-        this.set('onGetJuryFile', function() {});
-        this.set('onSaveReportData', function() {});
-
-        // when
-        await render(hbs`{{certification-session-report show=visible hide=onHide getJuryFile=onGetJuryFile saveCandidates=onSaveReportData candidates=candidateData certifications=certificationData}}`);
-        await click('.data-section--missing-candidates .data-section__switch');
-
-        // then
-        assert.dom('.data-section--missing-candidates .data-section__counter').hasText('1');
-        assert.dom('.data-section--missing-candidates .data-section__certification-ids').includesText('33350');
-      });
+      // then
+      assert.dom('.data-section--has-examiner-comment-screen-certifications .data-section__counter').hasText('1');
+      const certificationsIdsElement = find('.data-section--has-examiner-comment-screen-certifications .data-section__certification-ids');
+      const certificationIds = certificationsIdsElement.textContent.trim().replace(/\s/g, '');
+      assert.equal(certificationIds, '7');
     });
   });
 });

--- a/admin/tests/unit/components/certification-session-report-test.js
+++ b/admin/tests/unit/components/certification-session-report-test.js
@@ -10,405 +10,275 @@ module('Unit | Components | certification-session-report', function(hooks) {
     component = this.owner.lookup('component:certification-session-report');
   });
 
-  module('#duplicates', function() {
-    test('should return an empty array when there is no duplicates in candidate list', function(assert) {
+  module('#outOfSessionCertifications', function() {
+    test('should return an empty array when there is no certifications out of current session', function(assert) {
       // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '456' },
-        { row: 3, certificationId: '789' },
+      const certifications = [
+        { id: 123, isInSession: true },
+        { id: 456, isInSession: true },
+        { id: 789, isInSession: true },
       ];
-      component.set('candidates', candidates);
+      component.set('certifications', certifications);
 
       // when
-      const duplicates = component.duplicates;
+      const outOfSessionCertifications = component.outOfSessionCertifications;
 
       // then
       const expectedResult = [];
-      assert.deepEqual(duplicates, expectedResult);
+      assert.deepEqual(outOfSessionCertifications, expectedResult);
     });
 
-    test('should return an array with certifications IDs when there is one duplicate in candidate list', function(assert) {
+    test('should return an array with certifications when some are out of session', function(assert) {
       // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '123' },
-        { row: 3, certificationId: '789' },
+      const certifications = [
+        { id: 123, isInSession: true },
+        { id: 456, isInSession: false },
+        { id: 789, isInSession: false },
       ];
-      component.set('candidates', candidates);
+      component.set('certifications', certifications);
 
       // when
-      const duplicates = component.duplicates;
+      const outOfSessionCertifications = component.outOfSessionCertifications;
 
       // then
-      const expectedResult = ['123'];
-      assert.deepEqual(duplicates, expectedResult);
+      const expectedResult = [
+        { id: 456, isInSession: false },
+        { id: 789, isInSession: false }];
+      assert.deepEqual(outOfSessionCertifications, expectedResult);
     });
+  });
 
-    test('should return an array with certifications IDs when there are duplicates in candidate list', function(assert) {
+  module('#incompleteCertifications', function() {
+    test('should return an empty array when there is no incomplete certifications', function(assert) {
       // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '123' },
-        { row: 1, certificationId: '456' },
-        { row: 2, certificationId: '456' },
-        { row: 3, certificationId: '789' },
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: 456 },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
       ];
-      component.set('candidates', candidates);
+      component.set('certifications', completeCertifications);
 
       // when
-      const duplicates = component.duplicates;
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+
+    test('should return an array with appropriate certifications when first name is missing in some', function(assert) {
+      // given
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: null, lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: 456 },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
+      ];
+      component.set('certifications', completeCertifications);
+
+      // when
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [
+        { firstName: null, lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: 456 }
+      ];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+
+    test('should return an array with appropriate certifications when last name is missing in some', function(assert) {
+      // given
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: 'James', lastName: null, birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: 456 },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
+      ];
+      component.set('certifications', completeCertifications);
+
+      // when
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [
+        { firstName: 'James', lastName: null, birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: 456 }
+      ];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+
+    test('should return an array with appropriate certifications when birthdate is missing in some', function(assert) {
+      // given
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: 'James', lastName: 'Howlett', birthdate: null, birthplace: 'Northwest Territories of Canada', id: 456 },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
+      ];
+      component.set('certifications', completeCertifications);
+
+      // when
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [
+        { firstName: 'James', lastName: 'Howlett', birthdate: null, birthplace: 'Northwest Territories of Canada', id: 456 }
+      ];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+
+    test('should return an array with appropriate certifications when birthplace is missing in some', function(assert) {
+      // given
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: null, id: 456 },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
+      ];
+      component.set('certifications', completeCertifications);
+
+      // when
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [
+        { firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: null, id: 456 }
+      ];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+
+    test('should return an array with appropriate certifications when id is missing in some', function(assert) {
+      // given
+      const completeCertifications = [
+        { firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', id: 123 },
+        { firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: null },
+        { firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', id: 789 },
+        { firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', id: 101112 },
+      ];
+      component.set('certifications', completeCertifications);
+
+      // when
+      const incompleteCertifications = component.incompleteCertifications;
+
+      // then
+      const expectedResult = [
+        { firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', id: null }
+      ];
+      assert.deepEqual(incompleteCertifications, expectedResult);
+    });
+  });
+
+  module('#duplicateCertificationIds', function() {
+    test('should return an empty array when there is no duplicates in certifications list', function(assert) {
+      // given
+      const certifications = [
+        { id: 123 },
+        { id: 456 },
+        { id: 789 },
+      ];
+      component.set('certifications', certifications);
+
+      // when
+      const duplicateCertificationIds = component.duplicateCertificationIds;
+
+      // then
+      const expectedResult = [];
+      assert.deepEqual(duplicateCertificationIds, expectedResult);
+    });
+
+    test('should return an array with certifications IDs when there are duplicates in certifications list', function(assert) {
+      // given
+      const certifications = [
+        { id: 123 },
+        { id: 456 },
+        { id: 123 },
+        { id: 456 },
+        { id: 789 },
+      ];
+      component.set('certifications', certifications);
+
+      // when
+      const duplicateCertificationIds = component.duplicateCertificationIds;
 
       // then
       const expectedResult = ['123', '456'];
-      assert.deepEqual(duplicates, expectedResult);
+      assert.deepEqual(duplicateCertificationIds, expectedResult);
     });
   });
 
-  module('#incomplete', function() {
-    test('should return an empty array when there is no empty candidate', function(assert) {
+  module('#noLastScreenSeenCertifications', function() {
+    test('should return an empty array when all certifications stated seeing last screen by examiner', function(assert) {
       // given
-      const completeCandidates = [
-        { row: 1, firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', certificationId: '123' },
-        { row: 2, firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', certificationId: '456' },
-        { row: 3, firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', certificationId: '789' },
-        { row: 4, firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', certificationId: '101112' },
-      ];
-      component.set('candidates', completeCandidates);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      const expectedResult = [];
-      assert.deepEqual(incomplete, expectedResult);
-    });
-
-    test('should return an array with candidate that miss first name', function(assert) {
-      // given
-      const candidatesMissingFirstName = [
-        { row: 1, lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', certificationId: '123' },
-        { row: 2, firstName: null, lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City', certificationId: '123' },
-        { row: 3, firstName: '', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', certificationId: '456' },
-        { row: 4, firstName: '   ', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', certificationId: '789' },
-      ];
-      component.set('candidates', candidatesMissingFirstName);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      assert.deepEqual(incomplete, candidatesMissingFirstName);
-    });
-
-    test('should return an array with candidate that miss last name', function(assert) {
-      // given
-      const candidatesMissingLastName = [
-        { row: 1, firstName: 'Bruce', birthdate: '19/02/1972', birthplace: 'Gotham City', certificationId: '123' },
-        { row: 2, firstName: 'James', lastName: null, birthdate: '1832', birthplace: 'Northwest Territories of Canada', certificationId: '456' },
-        { row: 3, firstName: 'Natalia', lastName: '', birthdate: '1984', birthplace: 'Stalingrad', certificationId: '789' },
-        { row: 4, firstName: 'Clark', lastName: '    ', birthdate: '1984-05-20', birthplace: 'Smallville', certificationId: '101112' },
-      ];
-      component.set('candidates', candidatesMissingLastName);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      assert.deepEqual(incomplete, candidatesMissingLastName);
-    });
-
-    test('should return an array with candidate that miss birth date', function(assert) {
-      // given
-      const candidatesMissingBirthDate = [
-        { row: 1, firstName: 'Bruce', lastName: 'Wayne', birthplace: 'Gotham City', certificationId: '123' },
-        { row: 2, firstName: 'James', lastName: 'Howlett', birthdate: null, birthplace: 'Northwest Territories of Canada', certificationId: '456' },
-        { row: 3, firstName: 'Natalia', lastName: 'Romanova', birthdate: '', birthplace: 'Stalingrad', certificationId: '789' },
-        { row: 4, firstName: 'Clark', lastName: 'Kent', birthdate: '    ', birthplace: 'Smallville', certificationId: '101112' },
-      ];
-      component.set('candidates', candidatesMissingBirthDate);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      assert.deepEqual(incomplete, candidatesMissingBirthDate);
-    });
-
-    test('should return an array with candidate that miss birth place', function(assert) {
-      // given
-      const candidatesMissingBirthPlace = [
-        { row: 1, firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', certificationId: '123' },
-        { row: 2, firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: null, certificationId: '456' },
-        { row: 3, firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: '', certificationId: '789' },
-        { row: 4, firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: '    ', certificationId: '101112' },
-      ];
-      component.set('candidates', candidatesMissingBirthPlace);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      assert.deepEqual(incomplete, candidatesMissingBirthPlace);
-    });
-
-    test('should return an array with candidate that miss certification ID', function(assert) {
-      // given
-      const candidatesMissingBirthPlace = [
-        { row: 1, firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City' },
-        { row: 2, firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', certificationId: null },
-        { row: 3, firstName: 'Natalia', lastName: 'Romanova', birthdate: '1984', birthplace: 'Stalingrad', certificationId: '789' },
-        { row: 4, firstName: 'Clark', lastName: 'Kent', birthdate: '1984-05-20', birthplace: 'Smallville', certificationId: '  101112  ' },
-      ];
-      component.set('candidates', candidatesMissingBirthPlace);
-
-      // when
-      const incomplete = component.incomplete;
-
-      // then
-      const expected = [
-        { row: 1, firstName: 'Bruce', lastName: 'Wayne', birthdate: '1972-02-19', birthplace: 'Gotham City' },
-        { row: 2, firstName: 'James', lastName: 'Howlett', birthdate: '1832', birthplace: 'Northwest Territories of Canada', certificationId: null },
-      ];
-      assert.deepEqual(incomplete, expected);
-    });
-  });
-
-  module('#withoutCandidate', function() {
-    test('should return an empty array when every certification has an associated candidate', function(assert) {
-      // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '456' },
-        { row: 3, certificationId: '789' },
-      ];
-      component.set('candidates', candidates);
-
       const certifications = [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
+        { id: 123, hasSeenLastScreen: true },
+        { id: 456, hasSeenLastScreen: true },
+        { id: 789, hasSeenLastScreen: true },
       ];
       component.set('certifications', certifications);
 
       // when
-      const certificationsWithoutCandidate = component.withoutCandidate;
+      const noLastScreenSeenCertifications = component.noLastScreenSeenCertifications;
 
       // then
       const expectedResult = [];
-      assert.deepEqual(certificationsWithoutCandidate, expectedResult);
+      assert.deepEqual(noLastScreenSeenCertifications, expectedResult);
     });
 
-    test('should return an array with certifications missing associated candidate', function(assert) {
+    test('should return an array of certifications when some have not stated that examiner saw last screen', function(assert) {
       // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '456' },
-        { row: 3, certificationId: '789' },
-      ];
-      component.set('candidates', candidates);
-
       const certifications = [
-        { id: '123' },
-        { id: '100000' },
-        { id: '200000' },
+        { id: 123, hasSeenLastScreen: true },
+        { id: 456, hasSeenLastScreen: false },
+        { id: 789, hasSeenLastScreen: false },
       ];
       component.set('certifications', certifications);
 
       // when
-      const certificationsWithoutCandidate = component.withoutCandidate;
+      const noLastScreenSeenCertifications = component.noLastScreenSeenCertifications;
 
       // then
       const expectedResult = [
-        { id: '100000' },
-        { id: '200000' }
-      ];
-      assert.deepEqual(certificationsWithoutCandidate, expectedResult);
+        { id: 456, hasSeenLastScreen: false },
+        { id: 789, hasSeenLastScreen: false }];
+      assert.deepEqual(noLastScreenSeenCertifications, expectedResult);
     });
   });
 
-  module('#notFromSession', function() {
-    test('should return an empty array when every candidates certification IDs match an existing certification', function(assert) {
+  module('#commentedByExaminerCertifications', function() {
+    test('should return an empty array when there are no certifications with examiner comment', function(assert) {
       // given
-      const candidates = [
-        { firstName: 'Toto', certificationId: '123' },
-        { firstName: 'Jean', certificationId: '456' },
-        { firstName: 'Michel', certificationId: '789' },
-      ];
-      component.set('candidates', candidates);
-
       const certifications = [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
+        { id: 123, examinerComment: '' },
+        { id: 456, examinerComment: '' },
+        { id: 789, examinerComment: '' },
       ];
       component.set('certifications', certifications);
 
       // when
-      const notFromSession = component.notFromSession;
+      const commentedByExaminerCertifications = component.commentedByExaminerCertifications;
 
       // then
       const expectedResult = [];
-      assert.deepEqual(notFromSession, expectedResult);
+      assert.deepEqual(commentedByExaminerCertifications, expectedResult);
     });
 
-    test('should return an array with candidates missing associated certification', function(assert) {
+    test('should return an array of certifications when some have examiner comment', function(assert) {
       // given
-      const candidateWithCertification =
-        { firstName: 'Candidate with certification', certificationId: '123' };
-      component.set('candidates', candidateWithCertification);
-
-      const candidatesWithoutCertification = [
-        { firstName: 'Candidate without certification 1', certificationId: '456' },
-        { firstName: 'Candidate without certification 2', certificationId: '789' },
-      ];
-      component.set('candidates', candidatesWithoutCertification);
-
       const certifications = [
-        { id: '123' },
-        { id: '100000' },
-        { id: '200000' },
+        { id: 123, examinerComment: '' },
+        { id: 456, examinerComment: 'examComment' },
+        { id: 789, examinerComment: 'other ExamComment' },
       ];
       component.set('certifications', certifications);
 
       // when
-      const notFromSession = component.notFromSession;
-
-      // then
-      assert.deepEqual(notFromSession, candidatesWithoutCertification);
-    });
-  });
-
-  module('#sessionCandidates', function() {
-    test('should return an empty array when no candidates certification IDs match an existing certification', function(assert) {
-      // given
-      const candidates = [
-        { firstName: 'Toto', certificationId: '123' },
-        { firstName: 'Jean', certificationId: '456' },
-        { firstName: 'Michel', certificationId: '789' },
-      ];
-      component.set('candidates', candidates);
-
-      const certifications = [
-        { id: '321' },
-        { id: '654' },
-        { id: '987' },
-      ];
-      component.set('certifications', certifications);
-
-      // when
-      const sessionCandidates = component.sessionCandidates;
-
-      // then
-      const expectedResult = [];
-      assert.deepEqual(sessionCandidates, expectedResult);
-    });
-
-    test('should return an array with candidates corresponding to session certifications', function(assert) {
-      // given
-      const candidates = [
-        { firstName: 'Toto', certificationId: '123' },
-        { firstName: 'Jean', certificationId: '456' },
-        { firstName: 'Michel', certificationId: '0' },
-      ];
-      component.set('candidates', candidates);
-
-      const certifications = [
-        { id: '123' },
-        { id: '456' },
-        { id: '789' },
-      ];
-      component.set('certifications', certifications);
-
-      // when
-      const sessionCandidates = component.sessionCandidates;
+      const commentedByExaminerCertifications = component.commentedByExaminerCertifications;
 
       // then
       const expectedResult = [
-        { firstName: 'Toto', certificationId: '123' },
-        { firstName: 'Jean', certificationId: '456' },
-      ];
-      assert.deepEqual(sessionCandidates, expectedResult);
-    });
-  });
-
-  module('#missingEndScreen', function() {
-    test('should return an empty array when all candidates saw the end screen', function(assert) {
-      // given
-      const candidates = [
-        { row: 1, certificationId: '123', lastScreen: 'X' },
-        { row: 2, certificationId: '456', lastScreen: 'X' },
-        { row: 3, certificationId: '789', lastScreen: 'X' },
-      ];
-      component.set('candidates', candidates);
-
-      // when
-      const missingEndScreen = component.missingEndScreen;
-
-      // then
-      const expectedResult = [];
-      assert.deepEqual(missingEndScreen, expectedResult);
-    });
-
-    test('should return an array with candidates having not seen the end screen', function(assert) {
-      // given
-      const candidates = [
-        { row: 1, certificationId: '123', },
-        { row: 2, certificationId: '456', lastScreen: null },
-        { row: 3, certificationId: '789', lastScreen: '   ' },
-      ];
-      component.set('candidates', candidates);
-
-      // when
-      const missingEndScreen = component.missingEndScreen;
-
-      // then
-      const expectedResult = [
-        { row: 1, certificationId: '123', },
-        { row: 2, certificationId: '456', lastScreen: null },
-        { row: 3, certificationId: '789', lastScreen: '   ' },
-      ];
-      assert.deepEqual(missingEndScreen, expectedResult);
-    });
-  });
-
-  module('#comments', function() {
-    test('should return an empty array when no candidates have comment', function(assert) {
-      // given
-      const candidates = [
-        { row: 1, certificationId: '123' },
-        { row: 2, certificationId: '456', comments: null },
-        { row: 3, certificationId: '789', comments: '      ' },
-      ];
-      component.set('candidates', candidates);
-
-      // when
-      const comments = component.comments;
-
-      // then
-      const expectedResult = [];
-      assert.deepEqual(comments, expectedResult);
-    });
-
-    test('should return an array with candidates having comments', function(assert) {
-      // given
-      const candidates = [
-        { row: 1, certificationId: '123', comments: '' },
-        { row: 2, certificationId: '456', comments: '     ' },
-        { row: 3, certificationId: '456', comments: 'null' },
-        { row: 4, certificationId: '789', comments: 'My comment' },
-      ];
-      component.set('candidates', candidates);
-
-      // when
-      const comments = component.comments;
-
-      // then
-      const expectedResult = [
-        { row: 3, certificationId: '456', comments: 'null' },
-        { row: 4, certificationId: '789', comments: 'My comment' },
-      ];
-      assert.deepEqual(comments, expectedResult);
+        { id: 456, examinerComment: 'examComment' },
+        { id: 789, examinerComment: 'other ExamComment' },];
+      assert.deepEqual(commentedByExaminerCertifications, expectedResult);
     });
   });
 

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -29,7 +29,7 @@ module('Unit | Service | session-info-service', function(hooks) {
     service = this.owner.lookup('service:session-info-service');
   });
 
-  function buildCertification({ id, sessionId = 1, status = 'validated' }) {
+  function buildCertification({ id, sessionId = 1, status = 'validated', hasSeenLastScreen = true, examinerComment = null }) {
     return EmberObject.create({
       id,
       sessionId,
@@ -45,6 +45,8 @@ module('Unit | Service | session-info-service', function(hooks) {
       resultsCreationDate: '20/07/2018 14:23:56',
       status,
       juryId: '',
+      hasSeenLastScreen,
+      examinerComment,
       commentForCandidate: 'candidate',
       commentForOrganization: 'organization',
       commentForJury: 'jury',
@@ -143,120 +145,49 @@ module('Unit | Service | session-info-service', function(hooks) {
 
   module('#downloadJuryFile', function() {
 
-    function buildCandidate(id, certificationId, comments = null, lastScreen = 'X') {
-      return EmberObject.create({
-        id,
-        certificationId,
-        firstName: 'Toto',
-        lastName: 'Le héros',
-        birthdate: '1986-03-20',
-        birthplace: 'une ville',
-        externalId: '1234',
-        comments,
-        lastScreen
-      });
-    }
-
     test('should include certification which status is not "validated"', async function(assert) {
       const session = EmberObject.create({
         id: 5,
         certifications: A([
-          buildCertification({ id: '1', status: 'validated' }),
-          buildCertification({ id: '2', status: 'started' }),
-          buildCertification({ id: '3', status: 'rejected' }),
-          buildCertification({ id: '4', status: 'error' }),
+          buildCertification({ id: '1', status: 'validated', sessionId: 5 }),
+          buildCertification({ id: '2', status: 'started', sessionId: 5 }),
+          buildCertification({ id: '3', status: 'rejected', sessionId: 5 }),
+          buildCertification({ id: '4', status: 'error', sessionId: 5 }),
         ])
       });
 
-      const validSessionCandidates = [
-        buildCandidate(1, '1'),
-        buildCandidate(2, '2'),
-        buildCandidate(3, '3'),
-        buildCandidate(4, '4'),
-      ];
-
       // when
-      service.downloadJuryFile(session, validSessionCandidates);
+      service.downloadJuryFile(session.id, session.certifications);
 
       // then
       assert.equal(fileSaverStub.getContent(), '\uFEFF' +
         '"ID de session";"ID de certification";"Statut de la certification";"Date de debut";"Date de fin";"Commentaire surveillant";"Commentaire pour le jury";"Ecran de fin non renseigné";"Note Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2"\n' +
-        '1;"2";"started";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
-        '1;"3";"rejected";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
-        '1;"4";"error";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
+        '5;"2";"started";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
+        '5;"3";"rejected";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
+        '5;"4";"error";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
         '');
     });
 
-    test('should include certification which corresponding candidate has comments from manager', async function(assert) {
+    test('should include certification with comment from examiner', async function(assert) {
       const session = EmberObject.create({
         id: 5,
         certifications: A([
-          buildCertification({ id: '1', status: 'validated' }),
-          buildCertification({ id: '2', status: 'validated' }),
-          buildCertification({ id: '3', status: 'validated' }),
+          buildCertification({ id: '1', status: 'validated', sessionId: 5, examinerComment: 'examiner comment' }),
+          buildCertification({ id: '2', status: 'validated', sessionId: 5 }),
+          buildCertification({ id: '3', status: 'validated', sessionId: 5 }),
         ])
       });
 
-      const candidateWithoutComments = buildCandidate(1, '1', null);
-      const candidateWithEmptyComments = buildCandidate(1, '1', '   ');
-      const candidateWithComments = buildCandidate(2, '2', 'manager comments');
-
       // when
-      service.downloadJuryFile(session, [candidateWithoutComments, candidateWithEmptyComments, candidateWithComments]);
+      service.downloadJuryFile(session.id, session.certifications);
 
       // then
       assert.equal(fileSaverStub.getContent(), '\uFEFF' +
         '"ID de session";"ID de certification";"Statut de la certification";"Date de debut";"Date de fin";"Commentaire surveillant";"Commentaire pour le jury";"Ecran de fin non renseigné";"Note Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2"\n' +
-        '1;"2";"validated";"20/07/2018 14:23:56";"20/07/2018 14:23:56";"manager comments";"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
+        '5;"1";"validated";"20/07/2018 14:23:56";"20/07/2018 14:23:56";"examiner comment";"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
         '');
     });
-
-    test('should include certifications from candidates whom have not seen the end screen', async function(assert) {
-      const session = EmberObject.create({
-        id: 5,
-        certifications: A([
-          buildCertification({ id: '1', status: 'validated' }),
-          buildCertification({ id: '2', status: 'validated' }),
-          buildCertification({ id: '3', status: 'validated' }),
-        ])
-      });
-
-      const candidateThatSawTheEndScreen = buildCandidate(1, '1', null, '  X  ');
-      const candidateThatDidNotSeeTheEndScreen_null = buildCandidate(2, '2', null, null);
-      const candidateThatDidNotSeeTheEndScreen_emptyString = buildCandidate(3, '3', null, '    ');
-
-      // when
-      service.downloadJuryFile(session, [candidateThatSawTheEndScreen, candidateThatDidNotSeeTheEndScreen_null, candidateThatDidNotSeeTheEndScreen_emptyString]);
-
-      // then
-      assert.equal(fileSaverStub.getContent(), '\uFEFF' +
-        '"ID de session";"ID de certification";"Statut de la certification";"Date de debut";"Date de fin";"Commentaire surveillant";"Commentaire pour le jury";"Ecran de fin non renseigné";"Note Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2"\n' +
-        '1;"2";"validated";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";"non renseigné";100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
-        '1;"3";"validated";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";"non renseigné";100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
-        '');
-    });
-
-    test('should be able to generate the file when some certifications to be reviewed cannot find their candidate in the attendance sheet', async function(assert) {
-      const session = EmberObject.create({
-        id: 5,
-        certifications: A([
-          buildCertification({ id: '1', status: 'error' }),
-          buildCertification({ id: '2', status: 'rejected' }),
-          buildCertification({ id: '3', status: 'error' }),
-        ])
-      });
-
-      const candidate = buildCandidate(1, '1', null, '  X  ');
-
-      // when
-      service.downloadJuryFile(session, [candidate]);
-
-      // then
-      assert.equal(fileSaverStub.getContent(), '\uFEFF' +
-        '"ID de session";"ID de certification";"Statut de la certification";"Date de debut";"Date de fin";"Commentaire surveillant";"Commentaire pour le jury";"Ecran de fin non renseigné";"Note Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2"\n' +
-        '1;"1";"error";"20/07/2018 14:23:56";"20/07/2018 14:23:56";;"jury";;100;1;"";"";"";"";"";"";"";"";"";"";"";"";-1;"";""\n' +
-        '');
-    });
+    
   });
 
 });

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -107,6 +107,22 @@ exports.register = async (server) => {
       }
     },
     {
+      method: 'GET',
+      path: '/api/sessions/{id}/certifications',
+      config: {
+        pre: [{
+          method: securityController.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster'
+        }],
+        handler: sessionController.getCertifications,
+        tags: ['api', 'sessions', 'certifications'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs ayant le rôle PIXMASTER',
+          'Elle retourne les certifications d\'une session',
+        ]
+      }
+    },
+    {
       method: 'POST',
       path: '/api/sessions/{id}/candidate-participation',
       config: {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const sessionSerializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
 const certificationCandidateSerializer = require('../../infrastructure/serializers/jsonapi/certification-candidate-serializer');
+const certificationCourseSerializer = require('../../infrastructure/serializers/jsonapi/certification-course-serializer');
 const tokenService = require('../../domain/services/token-service');
 const { CertificationCandidateAlreadyLinkedToUserError } = require('../../domain/errors');
 const { BadRequestError } = require('../../infrastructure/errors');
@@ -57,6 +58,13 @@ module.exports = {
 
     return usecases.getSessionCertificationCandidates({ userId, sessionId })
       .then((certificationCandidates) => certificationCandidateSerializer.serialize(certificationCandidates));
+  },
+
+  async getCertifications(request) {
+    const sessionId = request.params.id;
+
+    const sessionCertifications = await usecases.getSessionCertifications({ sessionId });
+    return certificationCourseSerializer.serializeResult(sessionCertifications);
   },
 
   async importCertificationCandidatesFromAttendanceSheet(request) {

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -20,7 +20,6 @@ class Session {
     status,
     examinerComment,
     // includes
-    certifications,
     certificationCandidates,
     // references
   } = {}) {
@@ -38,7 +37,6 @@ class Session {
     this.status = status;
     this.examinerComment = examinerComment;
     // includes
-    this.certifications = certifications;
     this.certificationCandidates = certificationCandidates;
     // references
   }

--- a/api/lib/domain/usecases/get-session-certifications.js
+++ b/api/lib/domain/usecases/get-session-certifications.js
@@ -1,0 +1,14 @@
+const _ = require('lodash');
+const certificationService = require('../../domain/services/certification-service');
+
+module.exports = async function getSessionCertificationCandidates({
+  sessionId,
+  certificationCourseRepository,
+}) {
+  const certificationCourseIds = await certificationCourseRepository.findIdsBySessionId(sessionId);
+  const certificationCourseIdsChunks = _.chunk(certificationCourseIds, 10);
+  const certificationResultsChunks = await Promise.all(_.map(certificationCourseIdsChunks, (certificationCourseIdsChunk) => {
+    return Promise.all(_.map(certificationCourseIdsChunk, certificationService.getCertificationResult));
+  }));
+  return _.flatten(certificationResultsChunks);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -118,6 +118,7 @@ module.exports = injectDependencies({
   getScorecard: require('./get-scorecard'),
   getSession: require('./get-session'),
   getSessionCertificationCandidates: require('./get-session-certification-candidates'),
+  getSessionCertifications: require('./get-session-certifications'),
   getUser: require('./get-user'),
   getUserCertificationCenterMemberships: require('./get-user-certification-center-memberships'),
   getUserCertificationWithResultTree: require('./get-user-certification-with-result-tree'),

--- a/api/lib/infrastructure/data/session.js
+++ b/api/lib/infrastructure/data/session.js
@@ -1,19 +1,10 @@
 const Bookshelf = require('../bookshelf');
-const moment = require('moment');
 require('./certification-course');
 require('./certification-candidate');
 
 module.exports = Bookshelf.model('Session', {
   tableName: 'sessions',
   hasTimestamps: ['createdAt', null],
-
-  parse(rawAttributes) {
-    if (rawAttributes && rawAttributes.date) {
-      rawAttributes.date = moment(rawAttributes.date).format('YYYY-MM-DD');
-    }
-
-    return rawAttributes;
-  },
 
   certificationCourses() {
     return this.hasMany('CertificationCourse', 'sessionId');

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -87,7 +87,16 @@ module.exports = {
         return Promise.reject(err);
       });
 
-  }
+  },
+
+  async findIdsBySessionId(sessionId) {
+    const result = await CertificationCourseBookshelf
+      .where({ sessionId })
+      .orderBy('createdAt', 'desc')
+      .fetchAll({ columns: ['id'] });
+
+    return _.map(result.models, 'id');
+  },
 
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -25,7 +25,13 @@ module.exports = {
         'examinerComment',
       ],
       certifications : {
-        ref: ['id']
+        ref: ['id'],
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/sessions/${parent.id}/certifications`;
+          }
+        }
       },
       certificationCandidates: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -25,7 +25,7 @@ module.exports = {
         'examinerComment',
       ],
       certifications : {
-        ref: ['id'],
+        ref: 'id',
         ignoreRelationshipData: true,
         relationshipLinks: {
           related(record, current, parent) {
@@ -42,6 +42,11 @@ module.exports = {
           }
         }
       },
+      transform(session) {
+        const transformedSession = Object.assign({}, session);
+        transformedSession.certifications = [];
+        return transformedSession;
+      }
     }).serialize(sessions);
   },
 

--- a/api/tests/acceptance/application/session/session-controller-get-certifications_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certifications_test.js
@@ -1,0 +1,137 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const { types } = require('../../../../lib/domain/models/Assessment');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | session-controller-get-certifications', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /sessions/{id}/certifications', function() {
+    let sessionId;
+
+    beforeEach(() => {
+      sessionId = databaseBuilder.factory.buildSession().id;
+
+      return databaseBuilder.commit();
+    });
+
+    context('when user has not the role PixMaster', () => {
+      let userId;
+
+      beforeEach(() => {
+        userId = databaseBuilder.factory.buildUser().id;
+        return databaseBuilder.commit();
+      });
+
+      it('should return 403 HTTP status code', async () => {
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/sessions/${sessionId}/certifications`,
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+    });
+
+    context('when user has role PixMaster', () => {
+      let expectedCertificationAttributes;
+      let certificationCourse;
+      let assessment;
+      let assessmentResult;
+      let competenceMark1;
+      let competenceMark2;
+      let request;
+      let pixMasterId;
+
+      beforeEach(() => {
+        pixMasterId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+        certificationCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId });
+        assessment = databaseBuilder.factory.buildAssessment({ type: types.CERTIFICATION, courseId: certificationCourse.id });
+        assessmentResult = databaseBuilder.factory.buildAssessmentResult({ assessmentId: assessment.id });
+        competenceMark1 = databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
+        competenceMark2 = databaseBuilder.factory.buildCompetenceMark({ assessmentResultId: assessmentResult.id });
+
+        expectedCertificationAttributes = {
+          'first-name': certificationCourse.firstName,
+          'last-name': certificationCourse.lastName,
+          'birthdate': certificationCourse.birthdate,
+          'birthplace': certificationCourse.birthplace,
+          'external-id': certificationCourse.externalId,
+          'is-published': certificationCourse.isPublished,
+          'session-id': certificationCourse.sessionId,
+          'is-v2-certification': certificationCourse.isV2Certification,
+          'created-at': certificationCourse.createdAt,
+          'completed-at': certificationCourse.completedAt,
+          'assessment-id': assessment.id,
+          'comment-for-candidate': assessmentResult.commentForCandidate,
+          'comment-for-jury': assessmentResult.commentForJury,
+          'comment-for-organization': assessmentResult.commentForOrganization,
+          'emitter': assessmentResult.emitter,
+          'jury-id': assessmentResult.juryId,
+          'level': assessmentResult.level,
+          'pix-score': assessmentResult.pixScore,
+          'status': assessmentResult.status,
+          'result-created-at': assessmentResult.createdAt,
+          'competences-with-mark': [
+            {
+              'id': competenceMark1.id,
+              'area-code': competenceMark1.area_code,
+              'assessment-result-id': competenceMark1.assessmentResultId,
+              'competence-code': competenceMark1.competence_code,
+              'created-at': competenceMark1.createdAt,
+              'level': competenceMark1.level,
+              'score': competenceMark1.score,
+            },
+            {
+              'id': competenceMark2.id,
+              'area-code': competenceMark2.area_code,
+              'assessment-result-id': competenceMark2.assessmentResultId,
+              'competence-code': competenceMark2.competence_code,
+              'created-at': competenceMark2.createdAt,
+              'level': competenceMark2.level,
+              'score': competenceMark2.score,
+            },
+          ],
+        };
+
+        request = {
+          method: 'GET',
+          url: `/api/sessions/${sessionId}/certifications`,
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(pixMasterId) },
+        };
+
+        return databaseBuilder.commit();
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return the expected data', async () => {
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.result.data[0].attributes).to.deep.equal(expectedCertificationAttributes);
+        expect(response.result.data[0].id).to.deep.equal(certificationCourse.id.toString());
+      });
+
+    });
+
+  });
+
+});

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -10,12 +10,11 @@ describe('Acceptance | Controller | session-controller-get', () => {
   });
 
   describe('GET /sessions/{id}', function() {
-    let session;
     let userId;
     let request;
 
     beforeEach(() => {
-      session = databaseBuilder.factory.buildSession({
+      databaseBuilder.factory.buildSession({
         id: 1,
         certificationCenter: 'Université de dressage de loutres',
         address: 'Nice',
@@ -27,10 +26,6 @@ describe('Acceptance | Controller | session-controller-get', () => {
         status: 'created',
         accessCode: 'ABCD12',
         examinerComment: 'It was a fine session my dear',
-      });
-      databaseBuilder.factory.buildCertificationCourse({
-        id: 3,
-        sessionId: 1
       });
       userId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
       request = {
@@ -62,25 +57,6 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       // then
       expect(response.statusCode).to.equal(404);
-    });
-
-    it('should return sessions information with related certification', async () => {
-      // given
-      request.url = '/api/sessions/1';
-
-      // when
-      const response = await server.inject(request);
-
-      // then
-      expect(response.result.data.attributes['access-code']).to.deep.equal(session.accessCode);
-      expect(response.result.data.relationships.certifications).to.deep.equal({
-        'data': [
-          {
-            'id': '3',
-            'type': 'certifications'
-          }
-        ]
-      });
     });
   });
 
@@ -164,7 +140,9 @@ describe('Acceptance | Controller | session-controller-get', () => {
           },
           'relationships': {
             'certifications': {
-              'data': []
+              'links': {
+                'related': '/api/sessions/1/certifications',
+              }
             },
             'certification-candidates': {
               'links': {
@@ -189,7 +167,9 @@ describe('Acceptance | Controller | session-controller-get', () => {
           },
           'relationships': {
             'certifications': {
-              'data': []
+              'links': {
+                'related': '/api/sessions/2/certifications',
+              }
             },
             'certification-candidates': {
               'links': {

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -256,5 +256,42 @@ describe('Integration | Repository | Certification Course', function() {
       return expect(promise).to.be.rejectedWith(NotFoundError);
     });
   });
+
+  describe('#findIdsBySessionId', () => {
+    let sessionIdWithoutCertificationCourses;
+    let sessionIdWithCertificationCourses;
+    const expectedCertificationCourseIds = [];
+
+    beforeEach(() => {
+      // given
+      sessionIdWithoutCertificationCourses = databaseBuilder.factory.buildSession().id;
+      sessionIdWithCertificationCourses = databaseBuilder.factory.buildSession().id;
+      const unrelatedSessionId = databaseBuilder.factory.buildSession().id;
+
+      expectedCertificationCourseIds.length = 0;
+      expectedCertificationCourseIds.push(databaseBuilder.factory.buildCertificationCourse({ sessionId: sessionIdWithCertificationCourses }).id);
+      expectedCertificationCourseIds.push(databaseBuilder.factory.buildCertificationCourse({ sessionId: sessionIdWithCertificationCourses }).id);
+      databaseBuilder.factory.buildCertificationCourse({ sessionId: unrelatedSessionId });
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return an empty array there is no certification course for given session', async () => {
+      // when
+      const actualCertificationCourseIds = await certificationCourseRepository.findIdsBySessionId(sessionIdWithoutCertificationCourses);
+
+      // then
+      expect(actualCertificationCourseIds).to.be.empty;
+    });
+
+    it('should return an array with the certification course ids when session has some', async () => {
+      // when
+      const actualCertificationCourseIds = await certificationCourseRepository.findIdsBySessionId(sessionIdWithCertificationCourses);
+
+      // then
+      expect(actualCertificationCourseIds).to.include.members(expectedCertificationCourseIds);
+      expect(actualCertificationCourseIds.length).to.equal(expectedCertificationCourseIds.length);
+    });
+  });
 });
 

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -194,8 +194,6 @@ describe('Integration | Repository | Session', function() {
         'description': session.description,
         'accessCode': session.accessCode,
       };
-      _.times(2, () => databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }));
-      _.times(3, () => databaseBuilder.factory.buildCertificationCourse());
       await databaseBuilder.commit();
     });
 
@@ -206,14 +204,6 @@ describe('Integration | Repository | Session', function() {
       // then
       expect(actualSession).to.be.instanceOf(Session);
       expect(actualSession, 'date').to.deep.includes(expectedSessionValues);
-    });
-
-    it('should return associated certifications', async () => {
-      // when
-      const actualSession = await sessionRepository.get(session.id);
-
-      // then
-      expect(_.map(actualSession.certifications, 'sessionId')).to.have.members([session.id, session.id]);
     });
 
     it('should return a Not found error when no session was found', async () => {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -117,6 +117,20 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
+  describe('GET /api/sessions/{id}/certifications', () => {
+
+    beforeEach(() => {
+      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'getCertifications').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/certifications' });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
+
   describe('POST /api/sessions/{id}/candidate-participation', () => {
 
     beforeEach(() => {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -7,6 +7,7 @@ const CertificationCourse = require('../../../../lib/domain/models/Certification
 
 const sessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 const certificationCandidateSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-candidate-serializer');
+const certificationCourseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-course-serializer');
 const _ = require('lodash');
 
 describe('Unit | Controller | sessionController', () => {
@@ -291,6 +292,36 @@ describe('Unit | Controller | sessionController', () => {
 
       // then
       expect(response).to.deep.equal(certificationCandidatesJsonApi);
+    });
+
+  });
+
+  describe('#getCertifications ', () => {
+    let request;
+    const sessionId = 1;
+    const certifications = 'certifications';
+    const certificationsJsonApi = 'certificationsJSONAPI';
+
+    beforeEach(() => {
+      // given
+      request = {
+        params: { id : sessionId },
+        auth: {
+          credentials : {
+            userId,
+          }
+        },
+      };
+      sinon.stub(usecases, 'getSessionCertifications').withArgs({ sessionId }).resolves(certifications);
+      sinon.stub(certificationCourseSerializer, 'serializeResult').withArgs(certifications).returns(certificationsJsonApi);
+    });
+
+    it('should return certifications', async () => {
+      // when
+      const response = await sessionController.getCertifications(request, hFake);
+
+      // then
+      expect(response).to.deep.equal(certificationsJsonApi);
     });
 
   });

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -14,7 +14,6 @@ const SESSION_PROPS = [
   'room',
   'time',
   'status',
-  'certifications',
   'certificationCandidates',
   'examinerComment',
 ];
@@ -37,7 +36,6 @@ describe('Unit | Domain | Models | Session', () => {
       status: '',
       examinerComment: '',
       // includes
-      certifications: [],
       certificationCandidates: [],
     });
   });

--- a/api/tests/unit/domain/usecases/get-session-certifications_test.js
+++ b/api/tests/unit/domain/usecases/get-session-certifications_test.js
@@ -1,0 +1,28 @@
+const { expect, sinon } = require('../../../test-helper');
+const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
+const certificationService = require('../../../../lib/domain/services/certification-service');
+const getSessionCertifications = require('../../../../lib/domain/usecases/get-session-certifications');
+
+describe('Unit | Domain | Use Cases | get-session-certifications', () => {
+
+  const sessionId = 'sessionId';
+  const certificationCourseIds = ['certifCourseId1', 'certifCourseId2'];
+  const certifications = ['resultId1', 'resultId2'];
+
+  beforeEach(() => {
+    // given
+    sinon.stub(certificationCourseRepository, 'findIdsBySessionId').withArgs(sessionId).resolves(certificationCourseIds);
+    const certificationServiceStub = sinon.stub(certificationService, 'getCertificationResult');
+    certificationServiceStub.withArgs(certificationCourseIds[0]).resolves(certifications[0]);
+    certificationServiceStub.withArgs(certificationCourseIds[1]).resolves(certifications[1]);
+  });
+
+  it('should return the product of the certification service calls in an array', async () => {
+    // when
+    const result = await getSessionCertifications({ sessionId, certificationCourseRepository });
+
+    // then
+    expect(result).to.have.members(certifications);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -2,7 +2,6 @@ const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 
 const Session = require('../../../../../lib/domain/models/Session');
-const CertificationCourse = require('../../../../../lib/domain/models/CertificationCourse');
 
 describe('Unit | Serializer | JSONAPI | session-serializer', function() {
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -41,11 +41,13 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         },
         relationships: {
           certifications: {
-            data: null
+            links: {
+              related: '/api/sessions/12/certifications',
+            }
           },
           'certification-candidates': {
-            'links': {
-              'related': '/api/sessions/12/certification-candidates',
+            links: {
+              related: '/api/sessions/12/certification-candidates',
             }
           },
         }
@@ -62,66 +64,6 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       // then
       expect(json).to.deep.equal(jsonApiSession);
     });
-
-    it('should convert certifications relationships into JSON API relationships', () => {
-      // given
-      const certification1 = CertificationCourse.fromAttributes({ id: 1 });
-      const certification2 = CertificationCourse.fromAttributes({ id: 2 });
-      const associatedCertifications = [certification1, certification2];
-      const session = new Session({
-        id: '12',
-        certificationCenter: 'Université de dressage de loutres',
-        certificationCenterId: 42,
-        address: 'Nice',
-        room: '28D',
-        examiner: 'Antoine Toutvenant',
-        date: '2017-01-20',
-        time: '14:30',
-        description: '',
-        accessCode: '',
-        status: 'created',
-        certifications: associatedCertifications,
-        examinerComment: 'It was a fine session my dear',
-      });
-
-      // when
-      const JSONAPISession = serializer.serialize(session);
-
-      // then
-      return expect(JSONAPISession).to.deep.equal({
-        data: {
-          id: '12',
-          type: 'sessions',
-          attributes: {
-            'certification-center': 'Université de dressage de loutres',
-            address: 'Nice',
-            room: '28D',
-            'access-code': '',
-            examiner: 'Antoine Toutvenant',
-            date: '2017-01-20',
-            time: '14:30',
-            description: '',
-            status: 'created',
-            'examiner-comment': 'It was a fine session my dear',
-          },
-          relationships: {
-            certifications: {
-              data: [
-                { type: 'certifications', id: '1' },
-                { type: 'certifications', id: '2' }
-              ]
-            },
-            'certification-candidates': {
-              'links': {
-                'related': '/api/sessions/12/certification-candidates',
-              }
-            },
-          }
-        }
-      });
-
-    });
-
   });
 
   describe('#deserialize()', function() {


### PR DESCRIPTION
## :unicorn: Problème
Avec les _**EPIX**_ de _Début Certification_ et _Commentaires/fin de test_, des bouleversements, et donc des adaptations, sont à prévoir côté **PixAdmin**.
En l'occurrence, avec l'arrivée de ces **EPIX**, l'équipe du pôle certif sait qu'elle n'a plus à analyser le PV de session et à enregistrer les données afin d'avoir des certifications à peu près complètes. Cependant, et particulièrement parce que **_l'EPIX_** _Commentaires/fin de test_ n'est pas encore finie, l'équipe du pôle certif se trouve dans un état un peu de transition où les fonctionnalités ne se suffisent pas à elles-mêmes.
Pour le cas de ce ticket, il se trouve que les certifications dont le statut d'`assessment-result` est différent de `validated` n'étaient pas incluses dans le fichier exporté pour le jury.

## :robot: Solution
On en profite pour faire du nettoyage ;)
Optimisations :
- Une session sérialisée présente maintenant un lien pour récupérer sa sous-ressource certifications via la route :
  ---> **GET /api/sessions/:id/certifications**                   ouverte seulement aux _PixMasters_
De fait, on évite maintenant côté **PixAdmin** d'avoir une requête par certification d'une session au moment d'en afficher la liste. Aussi, on évite de tirer les `certificationsCourses` en jointure à chaque fois qu'on récupère une session depuis la base de données (en effet, les données de certifications dans les `usecases` des sessions n'était jamais utilisées)
- Côté PixAdmin, on fusionne proprement les données des certifications avec les données analysées depuis le PV de session.

## :rainbow: Remarques
