### PR TITLE
[BUGFIX] Ajouter des line-break dans la consigne des challenges (PF-939).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -5,18 +5,24 @@
   overflow: visible;
 }
 
-.challenge-statement__instruction strong {
-  font-weight: $font-heavy;
-}
+.challenge-statement__instruction {
+  p {
+    word-break: break-all;
+  }
 
-.challenge-statement__instruction a {
-  text-decoration: underline;
-  color: $pix-blue;
+  strong {
+    font-weight: $font-heavy;
+  }
 
-  &:active,
-  &:focus,
-  &:hover {
-    color: $pix-blue-hover;
+  a {
+    text-decoration: underline;
+    color: $pix-blue;
+
+    &:active,
+    &:focus,
+    &:hover {
+      color: $pix-blue-hover;
+    }
   }
 }
 

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -44,6 +44,7 @@
   margin-left: 7px;
   position: relative;
   bottom: 3px;
+  word-break: break-all;
 }
 
 .correction-qroc-box__solution-img {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'écran est trop petit, la question dépasse de l'écran visible.
Exemple sur https://app-pr860.review.pix.fr/challenges/reco62b0R3iX3tQk6/preview

## :robot: Solution
Ajout d'un `word-break` sur les champs concernés.
