### PR TITLE
[BUGFIX] Vérifier que le code d'accès correspond à la session de certif (PF 931)

### DIFF
--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -24,16 +24,16 @@ module.exports = {
       .then(certificationSerializer.serializeFromCertificationCourse);
   },
 
-  save(request, h) {
+  async save(request, h) {
     const userId = request.auth.credentials.userId;
     const accessCode = request.payload.data.attributes['access-code'];
 
-    return usecases.retrieveLastOrCreateCertificationCourse({ accessCode, userId })
-      .then(({ created, certificationCourse }) => {
-        const serialized = certificationCourseSerializer.serialize(certificationCourse);
+    const { created, certificationCourse } =
+      await usecases.retrieveLastOrCreateCertificationCourse({ accessCode, userId });
 
-        return created ? h.response(serialized).created() : serialized;
-      });
+    const serialized = certificationCourseSerializer.serialize(certificationCourse);
+
+    return created ? h.response(serialized).created() : serialized;
   },
 
   async get(request) {

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -27,11 +27,12 @@ module.exports = {
   async save(request, h) {
     const userId = request.auth.credentials.userId;
     const accessCode = request.payload.data.attributes['access-code'];
+    const sessionId = request.payload.data.attributes['session-id'];
 
     const { created, certificationCourse } =
-      await usecases.retrieveLastOrCreateCertificationCourse({ accessCode, userId });
+      await usecases.retrieveLastOrCreateCertificationCourse({ sessionId, accessCode, userId });
 
-    const serialized = certificationCourseSerializer.serialize(certificationCourse);
+    const serialized = await certificationCourseSerializer.serialize(certificationCourse);
 
     return created ? h.response(serialized).created() : serialized;
   },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -82,14 +82,13 @@ module.exports = {
     const sessionId = request.params.id;
     const certificationCandidateWithPersonalInfoOnly = await certificationCandidateSerializer.deserialize(request.payload);
 
-    return usecases.linkUserToSessionCertificationCandidate({
+    const { linkCreated, certificationCandidate } = await usecases.linkUserToSessionCertificationCandidate({
       userId, sessionId, certificationCandidateWithPersonalInfoOnly,
-    })
-      .then(({ linkCreated, certificationCandidate }) => {
-        const serialized = certificationCandidateSerializer.serialize(certificationCandidate);
+    });
 
-        return linkCreated ? h.response(serialized).created() : serialized;
-      });
+    const serialized = certificationCandidateSerializer.serialize(certificationCandidate);
+
+    return linkCreated ? h.response(serialized).created() : serialized;
   },
 
   finalize(request) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -86,7 +86,7 @@ module.exports = {
       userId, sessionId, certificationCandidateWithPersonalInfoOnly,
     });
 
-    const serialized = certificationCandidateSerializer.serialize(certificationCandidate);
+    const serialized = await certificationCandidateSerializer.serialize(certificationCandidate);
 
     return linkCreated ? h.response(serialized).created() : serialized;
   },

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -347,8 +347,8 @@ class InternalError extends DomainError {
 
 module.exports = {
   DomainError,
-  AlreadyExistingOrganizationInvitationError,
   AlreadyExistingMembershipError,
+  AlreadyExistingOrganizationInvitationError,
   AlreadyRatedAssessmentError,
   AlreadyRegisteredEmailError,
   AlreadySharedCampaignParticipationError,
@@ -356,7 +356,6 @@ module.exports = {
   AssessmentNotCompletedError,
   CampaignCodeError,
   CampaignWithoutOrganizationError,
-  CompetenceResetError,
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
@@ -367,6 +366,7 @@ module.exports = {
   CertificationCenterMembershipCreationError,
   CertificationComputeError,
   ChallengeAlreadyAnsweredError,
+  CompetenceResetError,
   EntityValidationError,
   FileValidationError,
   ForbiddenAccess,

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -3,6 +3,7 @@ const Assessment = require('../models/Assessment');
 const { UserNotAuthorizedToCertifyError, NotFoundError } = require('../errors');
 
 module.exports = async function retrieveLastOrCreateCertificationCourse({
+  sessionId,
   accessCode,
   userId,
   sessionRepository,
@@ -12,9 +13,15 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   certificationCourseRepository,
   assessmentRepository,
 }) {
-  const { id: sessionId } = await sessionRepository.getByAccessCode(accessCode);
+  const session = await sessionRepository.get(sessionId);
+
+  if (session.accessCode !== accessCode) {
+    throw new NotFoundError('Session not found');
+  }
+
   try {
     const certificationCourse = await certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
+
     return {
       created: false,
       certificationCourse,
@@ -50,10 +57,12 @@ async function _startNewCertification({
   if (!certificationProfile.isCertifiable()) {
     throw new UserNotAuthorizedToCertifyError();
   }
+
   await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
 
   try {
     const certificationCourse = await certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
+
     return {
       created: false,
       certificationCourse,
@@ -80,6 +89,7 @@ async function _startNewCertification({
       const savedCertificationCourse = await certificationCourseRepository.save(newCertificationCourse);
       const assessment = await _createAssessmentForCertificationCourse({ userId, certificationCourseId: savedCertificationCourse.id, assessmentRepository });
       savedCertificationCourse.assessment = assessment;
+
       return {
         created: true,
         certificationCourse: await certificationChallengesService.saveChallenges(certificationProfile.userCompetences, savedCertificationCourse),
@@ -100,4 +110,3 @@ function _createAssessmentForCertificationCourse({ userId, certificationCourseId
 
   return assessmentRepository.save(assessment);
 }
-

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -70,14 +70,13 @@ async function _startNewCertification({
   } catch (err) {
     if (err instanceof NotFoundError) {
       const personalInfo = { firstName: null, lastName: null, birthdate: null, birthplace: null, externalId: null };
-      const foundCandidate = await certificationCandidateRepository.findOneBySessionIdAndUserId({ sessionId, userId });
-      if (foundCandidate) {
-        personalInfo.firstName = foundCandidate.firstName;
-        personalInfo.lastName = foundCandidate.lastName;
-        personalInfo.birthdate = foundCandidate.birthdate;
-        personalInfo.birthplace = foundCandidate.birthCity;
-        personalInfo.externalId = foundCandidate.externalId;
-      }
+      const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({ sessionId, userId });
+
+      personalInfo.firstName = certificationCandidate.firstName;
+      personalInfo.lastName = certificationCandidate.lastName;
+      personalInfo.birthdate = certificationCandidate.birthdate;
+      personalInfo.birthplace = certificationCandidate.birthCity;
+      personalInfo.externalId = certificationCandidate.externalId;
 
       const newCertificationCourse = new CertificationCourse({
         userId,

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -1,6 +1,7 @@
 const CertificationCandidateBookshelf = require('../data/certification-candidate');
 const bookshelfToDomainConverter = require('../../infrastructure/utils/bookshelf-to-domain-converter');
 const {
+  NotFoundError,
   CertificationCandidateCreationOrUpdateError,
   CertificationCandidateDeletionError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
@@ -56,6 +57,20 @@ module.exports = {
       })
       .fetchAll()
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(CertificationCandidateBookshelf, results));
+  },
+
+  getBySessionIdAndUserId({ sessionId, userId }) {
+    return CertificationCandidateBookshelf
+      .where({ sessionId, userId })
+      .fetch({ require: true })
+      .then((result) => bookshelfToDomainConverter.buildDomainObject(CertificationCandidateBookshelf, result))
+      .catch((error) => {
+        if (error instanceof CertificationCandidateBookshelf.NotFoundError) {
+          throw new NotFoundError(`Candidate not found for certification session id ${sessionId} and user id ${userId}`);
+        }
+
+        throw error;
+      });
   },
 
   findOneBySessionIdAndUserId({ sessionId, userId }) {

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -415,6 +415,7 @@ describe('Acceptance | API | Certification Course', () => {
         data: {
           attributes: {
             'access-code': '123',
+            'session-id': sessionId,
           }
         }
       };
@@ -427,6 +428,22 @@ describe('Acceptance | API | Certification Course', () => {
         payload,
       };
       return databaseBuilder.commit();
+    });
+
+    context('when the given access code does not correspond to the session', () => {
+
+      beforeEach(async () => {
+        // given
+        options.payload.data.attributes['access-code'] = 'wrongcode';
+
+        // when
+        response = await server.inject(options);
+      });
+
+      it('should respond with 404 status code', () => {
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
     });
 
     context('when the certification course does not exist', () => {

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -66,6 +66,7 @@ export default Component.extend({
     },
 
     async attemptNext() {
+      this.set('stepsData.joiner', { sessionId: this.sessionId });
       this.set('isLoading', true);
       try {
         await this.joinCertificationSession();

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -42,7 +42,7 @@ export default Component.extend({
 
   async createCertificationCourseIfValid() {
     try {
-      await this.store.createRecord('certification-course', { accessCode: this.accessCode }).save();
+      await this.store.createRecord('certification-course', { accessCode: this.accessCode, sessionId: this.stepsData.joiner.sessionId }).save();
     } catch (err) {
       this.getCurrentCertificationCourse().deleteRecord();
       throw err;
@@ -50,6 +50,6 @@ export default Component.extend({
   },
 
   getCurrentCertificationCourse() {
-    return this.peeker.findOne('certification-course', { accessCode: this.accessCode });
+    return this.peeker.findOne('certification-course', { accessCode: this.accessCode, sessionId: this.stepsData.joiner.sessionId });
   },
 });

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -1,8 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
-import config from 'mon-pix/config/environment';
-
 export default Component.extend({
   store: service(),
   peeker: service(),
@@ -15,7 +13,6 @@ export default Component.extend({
   classNames: [],
 
   certificationCourse: null,
-  showCongratulationsBanner: !config.APP.isNewCertificationStartActive,
 
   actions: {
     async submit() {
@@ -41,10 +38,6 @@ export default Component.extend({
         this.set('isLoading', false);
       }
     },
-
-    closeBanner() {
-      this.set('showCongratulationsBanner', false);
-    }
   },
 
   async createCertificationCourseIfValid() {

--- a/mon-pix/app/components/stepper.js
+++ b/mon-pix/app/components/stepper.js
@@ -5,9 +5,12 @@ import { inject as service } from '@ember/service';
 
 export default Component.extend(ProgressionTrackerMixin, {
   router: service(),
+  stepsData: {},
+
   activeComponentName: computed('activeStep', function() {
     return this.activeStep;
   }),
+
   actions: {
     didMove() {
       this.next();

--- a/mon-pix/app/controllers/certifications/start.js
+++ b/mon-pix/app/controllers/certifications/start.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
-import config from 'mon-pix/config/environment';
-
 export default Controller.extend({
   currentUser: service(),
-  isNewCertificationStartActive: config.APP.isNewCertificationStartActive,
 });

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -4,5 +4,6 @@ const { Model, attr, belongsTo } = DS;
 export default Model.extend({
   nbChallenges: attr('number'),
   accessCode : attr('string'),
+  sessionId : attr('number'),
   assessment: belongsTo('assessment'),
 });

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -9,11 +9,7 @@
         <div
           class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner certification-start-page__panel">
           <div class="certification-stepper">
-            {{#if isNewCertificationStartActive}}
-              <Stepper @steps={{array "certification-stepper-join" "certification-stepper-start"}}/>
-            {{else}}
-              <Stepper @steps={{array "certification-stepper-start"}}/>
-            {{/if}}
+            <Stepper @steps={{array "certification-stepper-join" "certification-stepper-start"}}/>
           </div>
         </div>
       {{else}}

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -1,7 +1,3 @@
-{{#if this.showCongratulationsBanner }}
-  <CongratulationsCertificationBanner @fullName={{currentUser.user.fullName}} @closeBanner={{action "closeBanner"}}/>
-{{/if}}
-
 <section class="certification-starter">
     <h2 class="certification-start-page__title">Vous allez commencer votre test de certification</h2>
 

--- a/mon-pix/app/templates/components/stepper.hbs
+++ b/mon-pix/app/templates/components/stepper.hbs
@@ -1,7 +1,7 @@
 <div class="stepper">
   <section>
     {{#component this.activeComponentName as |Active|}}
-      <Active.main @success={{action "didMove"}}/>
+      <Active.main @success={{action "didMove"}} @stepsData={{stepsData}} />
     {{/component}}
   </section>
 </div>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -34,7 +34,6 @@ module.exports = function(environment) {
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
       IS_RECAPTCHA_ENABLED: process.env.IS_RECAPTCHA_ENABLED === 'true',
       IS_WARNING_BANNER_ENABLED: process.env.IS_WARNING_BANNER_ENABLED === 'true',
-      isNewCertificationStartActive: process.env.FT_IS_NEW_CERTIFICATION_START_ACTIVE === 'true',
     },
 
     googleFonts: [

--- a/mon-pix/tests/unit/components/certification-starter-test.js
+++ b/mon-pix/tests/unit/components/certification-starter-test.js
@@ -30,6 +30,7 @@ describe('Unit | Component | certification-starter', function() {
     context('when access code is provided', function() {
 
       let accessCode;
+      let sessionId;
       let certificationId;
       let peekerFindOneStub;
       let peekerStub;
@@ -38,6 +39,7 @@ describe('Unit | Component | certification-starter', function() {
 
       beforeEach(() => {
         accessCode = 'accessCode';
+        sessionId = 111;
         peekerFindOneStub = sinon.stub();
         peekerStub = {
           findOne: peekerFindOneStub,
@@ -47,6 +49,7 @@ describe('Unit | Component | certification-starter', function() {
           replaceWith: replaceWithStub,
         };
         component.set('accessCode', accessCode);
+        component.set('stepsData', { joiner: { sessionId } });
         component.set('router', routerStub);
         component.set('peeker', peekerStub);
       });
@@ -101,7 +104,7 @@ describe('Unit | Component | certification-starter', function() {
             await component.send('submit');
 
             // then
-            sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode });
+            sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
             await sinon.assert.called(storeSaveStub);
             sinon.assert.calledWith(replaceWithStub, 'certifications.resume', certificationId);
           });
@@ -132,7 +135,7 @@ describe('Unit | Component | certification-starter', function() {
               await component.send('submit');
 
               // then
-              sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode });
+              sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
               await sinon.assert.called(courseDeleteRecordStub);
               expect(component.get('errorMessage')).to.equal('Ce code n’existe pas ou n’est plus valide.');
             });
@@ -152,7 +155,7 @@ describe('Unit | Component | certification-starter', function() {
               await component.send('submit');
 
               // then
-              sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode });
+              sinon.assert.calledWithExactly(storeCreateRecordStub, 'certification-course', { accessCode, sessionId });
               await sinon.assert.called(courseDeleteRecordStub);
               expect(component.get('errorMessage')).to.equal('Une erreur serveur inattendue vient de se produire');
             });


### PR DESCRIPTION
## :unicorn: Problème

Dans le démarrage d'une certification, l'utilisateur pouvait entrer un id de session suivi d'un code d'accès qui ne correspondait pas à ladite session.

## :robot: Solution

Vérifier que le code d'accès correspond bien à la session.

## :rainbow: Remarques

Nous avons supprimé le feature toggle `FT_IS_NEW_CERTIFICATION_START_ACTIVE` qui n'est plus nécessaire.