### PR TITLE
[BUGFIX] Eviter les erreurs 500 lors du check de date de naissance quand un candidat essaie de rejoindre une session de certification (PF-941)

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -80,12 +80,10 @@ module.exports = {
   async createCandidateParticipation(request, h) {
     const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
-    const firstName = request.payload.data.attributes['first-name'];
-    const lastName = request.payload.data.attributes['last-name'];
-    const birthdate = request.payload.data.attributes['birthdate'];
+    const certificationCandidateWithPersonalInfoOnly = await certificationCandidateSerializer.deserialize(request.payload);
 
     return usecases.linkUserToSessionCertificationCandidate({
-      userId, sessionId, firstName, lastName, birthdate,
+      userId, sessionId, certificationCandidateWithPersonalInfoOnly,
     })
       .then(({ linkCreated, certificationCandidate }) => {
         const serialized = certificationCandidateSerializer.serialize(certificationCandidate);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -306,8 +306,8 @@ class UserNotFoundError extends NotFoundError {
 }
 
 class WrongDateFormatError extends DomainError {
-  constructor() {
-    super();
+  constructor(message) {
+    super(message);
   }
 
   getErrorMessage() {

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -10,12 +10,10 @@ const {
 module.exports = async function linkUserToSessionCertificationCandidate({
   userId,
   sessionId,
-  firstName,
-  lastName,
-  birthdate,
+  certificationCandidateWithPersonalInfoOnly,
   certificationCandidateRepository,
 }) {
-
+  const { firstName, lastName, birthdate } = certificationCandidateWithPersonalInfoOnly;
   const trimmedFirstName = firstName
     ? firstName.trim()
     : firstName;

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -28,8 +28,8 @@ module.exports = {
   },
 
   deserialize(json) {
-    if (!isValidDate(json.data.attributes.birthdate)) {
-      throw new WrongDateFormatError();
+    if (!isValidDate(json.data.attributes.birthdate, 'YYYY-MM-DD')) {
+      throw new WrongDateFormatError('La date de naissance du candidate à la certification n\'a pas un format valide du type JJ/MM/AAAA');
     }
 
     delete json.data.attributes['is-linked'];

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -57,7 +57,8 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
               'first-name': 'José',
               'last-name': 'Bové',
               'birthdate': '2000-01-01',
-            }
+            },
+            type: 'certification-candidates',
           }
         };
         options = {
@@ -116,7 +117,8 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
               attributes: {
                 'first-name': 'José',
                 'last-name': 'Bové',
-              }
+              },
+              type: 'certification-candidates',
             }
           };
           options.payload = payload;

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -302,6 +302,11 @@ describe('Unit | Controller | sessionController', () => {
     const firstName = 'firstName';
     const lastName = 'lastName';
     const birthdate = 'birthdate';
+    const certificationCandidateWithPersonalInfoOnly = {
+      firstName,
+      lastName,
+      birthdate,
+    };
     const linkedCertificationCandidate = 'candidate';
     const serializedCertificationCandidate = 'sCandidate';
 
@@ -317,13 +322,15 @@ describe('Unit | Controller | sessionController', () => {
         payload: {
           data: {
             attributes: {
-              'first-name': 'firstName',
-              'last-name': 'lastName',
-              'birthdate': 'birthdate',
+              'first-name': firstName,
+              'last-name': lastName,
+              'birthdate': birthdate,
             },
+            type: 'certification-candidates',
           }
         }
       };
+      sinon.stub(certificationCandidateSerializer, 'deserialize').withArgs(request.payload).resolves(certificationCandidateWithPersonalInfoOnly);
       sinon.stub(certificationCandidateSerializer, 'serialize').withArgs(linkedCertificationCandidate).returns(serializedCertificationCandidate);
     });
 
@@ -331,7 +338,7 @@ describe('Unit | Controller | sessionController', () => {
 
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
-          .withArgs({ userId, sessionId, firstName, lastName, birthdate }).resolves({
+          .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
             linkCreated: false,
             certificationCandidate: linkedCertificationCandidate
           });
@@ -352,7 +359,7 @@ describe('Unit | Controller | sessionController', () => {
 
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
-          .withArgs({ userId, sessionId, firstName, lastName, birthdate }).resolves({
+          .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
             linkCreated: true,
             certificationCandidate: linkedCertificationCandidate
           });

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -12,12 +12,12 @@ const {
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
   const sessionId = 'sessionId';
   const userId = 'userId';
-  const firstName = 'Charlie';
-  const lastName = 'Bideau';
-  let birthdate;
+  const certificationCandidateWithPersonalInfoOnly = {};
 
   beforeEach(() => {
-    birthdate = '2010-10-10';
+    certificationCandidateWithPersonalInfoOnly.firstName = 'Charlie';
+    certificationCandidateWithPersonalInfoOnly.lastName = 'Bideau';
+    certificationCandidateWithPersonalInfoOnly.birthdate = '2010-10-10';
   });
 
   context('when there is a problem with the personal info', () => {
@@ -25,13 +25,14 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
     context('when a field is missing from the provided personal info', () => {
 
       it('should throw a CertificationCandidatePersonalInfoFieldMissingError when the birthdate is missing', async () => {
+        // given
+        certificationCandidateWithPersonalInfoOnly.birthdate = null;
+
         // when
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
-          firstName,
-          lastName,
-          birthdate: null,
+          certificationCandidateWithPersonalInfoOnly,
           certificationCandidateRepository,
         });
 
@@ -40,13 +41,14 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
       });
 
       it('should throw a CertificationCandidatePersonalInfoFieldMissingError when the firstName is missing', async () => {
+        // given
+        certificationCandidateWithPersonalInfoOnly.firstName = null;
+
         // when
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
-          firstName: null,
-          lastName,
-          birthdate,
+          certificationCandidateWithPersonalInfoOnly,
           certificationCandidateRepository,
         });
 
@@ -55,13 +57,14 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
       });
 
       it('should throw a CertificationCandidatePersonalInfoFieldMissingError when the lastName is missing', async () => {
+        // given
+        certificationCandidateWithPersonalInfoOnly.lastName = null;
+
         // when
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
-          firstName,
-          lastName: null,
-          birthdate,
+          certificationCandidateWithPersonalInfoOnly,
           certificationCandidateRepository,
         });
 
@@ -77,9 +80,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           'findBySessionIdAndPersonalInfo')
           .withArgs({
             sessionId,
-            firstName,
-            lastName,
-            birthdate,
+            firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+            lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+            birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
           }).resolves([]);
       });
 
@@ -88,9 +91,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
-          firstName,
-          lastName,
-          birthdate,
+          certificationCandidateWithPersonalInfoOnly,
           certificationCandidateRepository,
         });
 
@@ -106,9 +107,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           'findBySessionIdAndPersonalInfo')
           .withArgs({
             sessionId,
-            firstName,
-            lastName,
-            birthdate,
+            firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+            lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+            birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
           }).resolves(['candidate1', 'candidate2']);
       });
 
@@ -117,9 +118,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
-          firstName,
-          lastName,
-          birthdate,
+          certificationCandidateWithPersonalInfoOnly,
           certificationCandidateRepository,
         });
 
@@ -142,9 +141,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
             'findBySessionIdAndPersonalInfo')
             .withArgs({
               sessionId,
-              firstName,
-              lastName,
-              birthdate,
+              firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+              lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+              birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
             }).resolves([certificationCandidate]);
         });
 
@@ -153,9 +152,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           const result = await usecases.linkUserToSessionCertificationCandidate({
             sessionId,
             userId,
-            firstName,
-            lastName,
-            birthdate,
+            certificationCandidateWithPersonalInfoOnly,
             certificationCandidateRepository,
           });
 
@@ -173,9 +170,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
             'findBySessionIdAndPersonalInfo')
             .withArgs({
               sessionId,
-              firstName,
-              lastName,
-              birthdate,
+              firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+              lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+              birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
             }).resolves([certificationCandidate]);
         });
 
@@ -183,9 +180,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
-            firstName,
-            lastName,
-            birthdate,
+            certificationCandidateWithPersonalInfoOnly,
             certificationCandidateRepository,
           });
 
@@ -205,9 +200,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
             'findBySessionIdAndPersonalInfo')
             .withArgs({
               sessionId,
-              firstName,
-              lastName,
-              birthdate,
+              firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+              lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+              birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
             }).resolves([certificationCandidate]);
           sinon.stub(certificationCandidateRepository,
             'findOneBySessionIdAndUserId')
@@ -218,9 +213,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
-            firstName,
-            lastName,
-            birthdate,
+            certificationCandidateWithPersonalInfoOnly,
             certificationCandidateRepository,
           });
 
@@ -237,9 +230,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           sinon.stub(certificationCandidateRepository, 'findBySessionIdAndPersonalInfo')
             .withArgs({
               sessionId,
-              firstName,
-              lastName,
-              birthdate,
+              firstName: certificationCandidateWithPersonalInfoOnly.firstName,
+              lastName: certificationCandidateWithPersonalInfoOnly.lastName,
+              birthdate: certificationCandidateWithPersonalInfoOnly.birthdate,
             })
             .resolves([certificationCandidate]);
 
@@ -257,9 +250,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
           const result = await usecases.linkUserToSessionCertificationCandidate({
             sessionId,
             userId,
-            firstName,
-            lastName,
-            birthdate,
+            certificationCandidateWithPersonalInfoOnly,
             certificationCandidateRepository,
           });
 
@@ -269,13 +260,15 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
         });
 
         it('should trim spaces in first and last name when searching for a candidate', async () => {
+          // given
+          certificationCandidateWithPersonalInfoOnly.firstName = ` \t${certificationCandidateWithPersonalInfoOnly.firstName} \t`;
+          certificationCandidateWithPersonalInfoOnly.lastName = `  \t${certificationCandidateWithPersonalInfoOnly.lastName} \t`;
+
           // when
           const result = await usecases.linkUserToSessionCertificationCandidate({
             sessionId,
             userId,
-            firstName: ` \t${firstName} \t`,
-            lastName: `  \t${lastName} \t`,
-            birthdate,
+            certificationCandidateWithPersonalInfoOnly,
             certificationCandidateRepository,
           });
 


### PR DESCRIPTION
## :unicorn: Problème
La validation peut encore être améliorée lors de l'étape de réconciliation d'un candidat à une session de certification. Particulièrement, la date de naissance reçue depuis le front n'était pas checkée, ce qui pouvait, au moment du SELECT dans la base de données, déclencher une exception non gérée et donc une erreur 500.

## :robot: Solution
Données désérialisées via le désérialiseur de certification-candidate, et donc on profite de check de validation de la date de naissance.

## :rainbow: Remarques
