### PR TITLE
[TECH] Ajout d'une entrée *.ignore* dans le .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ high-level-tests/load-testing/report/*.html
 
 # Answers extracts
 api/scripts/extractions
+
+# Personnal files 
+*.ignore*


### PR DESCRIPTION
## 🤗 Problème
Il arrive parfois que l'on souhaite ajouter des fichiers à son projet dans un dossier quelconque sans que `git` le versionne.

## 🍰 Solution
La solution consiste à ajouter l'entrée `*.ignore*` ce qui aura pour effet de ne pas versionner n'importe quel fichier possédant cette séquence dans son path.

## :rainbow: Remarques
Cette PR permettra par exemple d'avoir dans chaque dossier test un fichier `template.ignore.js` qui serait un template d'expérimentation local. L'extension `.js` permettra d'avoir un vrai fichier `js` tandis que le `.ignore` permettra de le rendre invisible pour `git` afin de pouvoir expérimenter localement.
