### PR TITLE
[BUGFIX] Utiliser overflow-wrap au lieu de word-break.

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -7,7 +7,7 @@
 
 .challenge-statement__instruction {
   p {
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   strong {

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -44,7 +44,7 @@
   margin-left: 7px;
   position: relative;
   bottom: 3px;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .correction-qroc-box__solution-img {


### PR DESCRIPTION
## :unicorn: Problème
L'initiative lancée par la PR https://github.com/1024pix/pix/pull/860 cause le problème suivant :
![image](https://user-images.githubusercontent.com/46371288/69801385-66e2c580-11d7-11ea-9e5f-7da4cbe09c00.png)

## :robot: Solution
On utilise `overflow-wrap: break-word` au lieu de `word-break: break-all`

## :rainbow: Remarques
> Note : À la différence de word-break, overflow-wrap créera uniquement un saut de ligne si un mot entier ne peut pas être placé sur sa propre ligne sans dépasser.

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
