### PR TITLE
[FEATURE] Affichage du nombre de certifications non validées sur la page de détails d'une session PixAdmin (PA-126)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,5 +1,7 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
+import _ from 'lodash';
 
 export default DS.Model.extend({
   certificationCenter: DS.attr(),
@@ -13,4 +15,9 @@ export default DS.Model.extend({
   status: DS.attr(),
   isFinalized: equal('status', 'finalized'),
   certifications: DS.hasMany('certification'),
+  countNonValidatedCertifications : computed('certifications.[]', function() {
+    return _.reduce(this.certifications.toArray(), (count, certification) => {
+      return certification.status !== 'validated' ? ++count : count;
+    }, 0);
+  }),
 });

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -25,6 +25,7 @@
 @import 'authenticated/certifications/info';
 @import 'authenticated/certifications/sessions';
 @import 'authenticated/certifications/sessions/info/list';
+@import 'authenticated/certifications/sessions/info/index';
 @import 'authenticated/certifications/sessions-list';
 /* components */
 @import 'components/menu-bar';

--- a/admin/app/styles/authenticated/certifications/sessions.scss
+++ b/admin/app/styles/authenticated/certifications/sessions.scss
@@ -11,16 +11,3 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
-
-.certifications-session-info {
-  padding: 20px;
-  padding-bottom: 0px;
-
-  .row--btn {
-    justify-content: flex-end;
-
-    .btn {
-      margin-left: 20px;
-    }
-  }
-}

--- a/admin/app/styles/authenticated/certifications/sessions/info/index.scss
+++ b/admin/app/styles/authenticated/certifications/sessions/info/index.scss
@@ -1,0 +1,16 @@
+.certifications-session-info {
+  padding: 20px;
+  padding-bottom: 0px;
+
+  .row--btn {
+    justify-content: flex-end;
+
+    .btn {
+      margin-left: 20px;
+    }
+  }
+
+  &__stats {
+    padding-top: 40px;
+  }
+}

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -1,39 +1,48 @@
 <div class="certifications-session-info">
-  <div class='row'>
-    <div class='col'>Centre :</div>
-    <div class='col'>{{session.certificationCenter}}</div>
+  <div class="certifications-session-info__details">
+      <div class='row'>
+          <div class='col'>Centre :</div>
+          <div class='col' data-test-id='certifications-session-info__certification-center'>{{session.certificationCenter}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Adresse :</div>
+          <div class='col' data-test-id='certifications-session-info__address'>{{session.address}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Pièce :</div>
+          <div class='col' data-test-id='certifications-session-info__room'>{{session.room}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Surveillant :</div>
+          <div class='col' data-test-id='certifications-session-info__examiner'>{{session.examiner}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Date :</div>
+          <div class='col' data-test-id='certifications-session-info__date'>{{moment-format session.date 'DD/MM/YYYY'}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Heure :</div>
+          <div class='col' data-test-id='certifications-session-info__time'>{{session.time}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Description :</div>
+          <div class='col' data-test-id='certifications-session-info__description'>{{session.description}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Code d'accès :</div>
+          <div class='col' data-test-id='certifications-session-info__access-code'>{{session.accessCode}}</div>
+      </div>
+      <div class='row'>
+          <div class='col'>Statut :</div>
+          <div class='col' data-test-id='certifications-session-info__is-finalized'>{{if session.isFinalized 'Finalisée' 'Prête'}}</div>
+      </div>
   </div>
-  <div class='row'>
-    <div class='col'>Adresse :</div>
-    <div class='col'>{{session.address}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Pièce :</div>
-    <div class='col'>{{session.room}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Surveillant :</div>
-    <div class='col'>{{session.examiner}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Date :</div>
-    <div class='col'>{{moment-format session.date 'DD/MM/YYYY'}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Heure :</div>
-    <div class='col'>{{session.time}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Description :</div>
-    <div class='col'>{{session.description}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Code d'accès :</div>
-    <div class='col'>{{session.accessCode}}</div>
-  </div>
-  <div class='row'>
-    <div class='col'>Statut :</div>
-    <div class='col'>{{if session.isFinalized 'Finalisée' 'Prête'}}</div>
+
+  <div class="certifications-session-info__stats">
+    <div class='row'>
+        <div class='col'>Nombre de certifications non terminées :</div>
+        <div class='col' data-test-id='certifications-session-info__count-non-validated-certifications'>{{session.countNonValidatedCertifications}}</div>
+    </div>
   </div>
 
   <div class='row row--btn'>

--- a/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
@@ -1,20 +1,9 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { visit, currentURL, find } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import moment from 'moment';
-
-const CERTIFICATION_CENTER_ROW = '(1)';
-const ADDRESS_ROW = '(2)';
-const ROOM_ROW = '(3)';
-const EXAMINER_ROW = '(4)';
-const DATE_ROW = '(5)';
-const TIME_ROW = '(6)';
-const DESCRIPTION_ROW = '(7)';
-const ACCESS_CODE_ROW = '(8)';
-const STATUS_ROW = '(9)';
-const CHECK_NO_ADDITIONAL_INFO_ROW_EXISTS = '(10)';
 
 module('Integration | Component | certifications-session-info', function(hooks) {
   setupApplicationTest(hooks);
@@ -22,8 +11,6 @@ module('Integration | Component | certifications-session-info', function(hooks) 
 
   let session;
   let sessionData;
-  const commonSelector = '.certifications-session-info .row:nth-child';
-  const col = '.col:nth-child(2)';
 
   hooks.beforeEach(async function() {
     await authenticateSession({ userId: 1 });
@@ -37,11 +24,11 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       time: '14:00:00',
       description: 'pouet',
       accessCode: '123',
-      certifications: []
+      certifications: [],
     };
   });
 
-  test('it rendersaaa the details page with correct info when session is finalized', async function(assert) {
+  test('it renders the details page with correct info', async function(assert) {
     // given
     session = this.server.create('session', sessionData);
 
@@ -50,25 +37,15 @@ module('Integration | Component | certifications-session-info', function(hooks) 
 
     // then
     assert.equal(currentURL(), `/certifications/sessions/${session.id}`);
-    assert.equal(find(`${commonSelector}${CERTIFICATION_CENTER_ROW} ${col}`).textContent, session.certificationCenter);
-    assert.equal(find(`${commonSelector}${ADDRESS_ROW} ${col}`).textContent, session.address);
-    assert.equal(find(`${commonSelector}${ROOM_ROW} ${col}`).textContent, session.room);
-    assert.equal(find(`${commonSelector}${EXAMINER_ROW} ${col}`).textContent, session.examiner);
-    assert.equal(find(`${commonSelector}${DATE_ROW} ${col}`).textContent, moment(session.date, 'YYYY-MM-DD').format('DD/MM/YYYY'));
-    assert.equal(find(`${commonSelector}${TIME_ROW} ${col}`).textContent, session.time);
-    assert.equal(find(`${commonSelector}${DESCRIPTION_ROW} ${col}`).textContent, session.description);
-    assert.equal(find(`${commonSelector}${ACCESS_CODE_ROW} ${col}`).textContent, session.accessCode);
-  });
-
-  test('it should not present unexpected row info', async function(assert) {
-    // given
-    session = this.server.create('session', sessionData);
-
-    // when
-    await visit(`/certifications/sessions/${session.id}`);
-
-    // then
-    assert.equal(find(`${commonSelector}${CHECK_NO_ADDITIONAL_INFO_ROW_EXISTS} ${col}`), undefined);
+    assert.dom('[data-test-id="certifications-session-info__certification-center"]').hasText(session.certificationCenter);
+    assert.dom('[data-test-id="certifications-session-info__address"]').hasText(session.address);
+    assert.dom('[data-test-id="certifications-session-info__room"]').hasText(session.room);
+    assert.dom('[data-test-id="certifications-session-info__examiner"]').hasText(session.examiner);
+    assert.dom('[data-test-id="certifications-session-info__date"]').hasText(moment(session.date, 'YYYY-MM-DD').format('DD/MM/YYYY'));
+    assert.dom('[data-test-id="certifications-session-info__time"]').hasText(session.time);
+    assert.dom('[data-test-id="certifications-session-info__description"]').hasText(session.description);
+    assert.dom('[data-test-id="certifications-session-info__access-code"]').hasText(session.accessCode);
+    assert.dom('[data-test-id="certifications-session-info__count-non-validated-certifications"]').hasText('0');
   });
 
   module('when the session is finalized', function() {
@@ -82,7 +59,7 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       await visit(`/certifications/sessions/${session.id}`);
 
       // then
-      assert.equal(find(`${commonSelector}${STATUS_ROW} ${col}`).textContent.trim(), 'Finalisée');
+      assert.dom('[data-test-id="certifications-session-info__is-finalized"]').hasText('Finalisée');
     });
   });
 
@@ -97,7 +74,7 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       await visit(`/certifications/sessions/${session.id}`);
 
       // then
-      assert.equal(find(`${commonSelector}${STATUS_ROW} ${col}`).textContent.trim(), 'Prête');
+      assert.dom('[data-test-id="certifications-session-info__is-finalized"]').hasText('Prête');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Contexte
On souhaite enrichir les informations fournies par l'application aux utilisateurs. Dans notre cas,
on veut afficher, dans la page de détails d'une session, le nombre de certifications non terminées.
Il s'agit, plus techniquement, des certifications qui ne sont pas validées, c a d : pas terminées, pas validées, assessment manquant, etc...

## :robot: Solution
Ajout d'une ligne sur la page de détails de session. Nous disposions déjà des infos nécessaires pour produire cette information, pas de sollicitation supplémentaire sur l'API.
Ajout d'un `computed` dans le modèle de session côté front pour compter le nombre de certifications pas validées.

## :rainbow: Remarques
