### PR TITLE
[BUGFIX] Rendre l'instruction des challenges non cliquable (PF-956).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import $ from 'jquery';
 import config from 'mon-pix/config/environment';
 
 export default Component.extend({
@@ -9,9 +8,6 @@ export default Component.extend({
   mailGenerator: service(),
 
   classNames: ['challenge-statement'],
-
-  attributeBindings: ['tabindex'],
-  tabindex: -1,
 
   challenge: null,
   assessment: null,
@@ -37,16 +33,6 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     this.id = 'challenge_statement_' + this.get('challenge.id');
-  },
-
-  didReceiveAttrs() {
-    this._super(...arguments);
-    $(`#${this.id}`).focus();
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-    $(`#${this.id}`).focus();
   },
 
   selectedAttachmentUrl: computed('challenge.attachments', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on clique sur l'instruction des challenges, on observe le comportement suivant sur Chrome (sur Firefox, la ligne est en pointillés).

<img width="1024" alt="Screenshot 2019-11-29 at 11 20 43" src="https://user-images.githubusercontent.com/46371288/69863380-f3a38700-129c-11ea-828c-19caab7bca7a.png">

## :robot: Solution
Cette manifestation visuelle est induite par l'utilisation de `tabindex="-1"`.

Initialement, on s'en servait pour faire un autofocus sur l'instruction du challenge en cours. 

Aujourd'hui, il semblerait que cet autofocus ne soit plus nécessaire et aucune référence à un id suivant le schéma `#challenge_statement_<id>` n'a été trouvé sur la page. 

On enlève donc les déclarations liées à `tabindex="-1"`.

## :rainbow: Remarques
> A negative value (usually tabindex="-1") means that the element is not reachable via sequential keyboard navigation, but could be focused with Javascript or visually. It's mostly useful to create accessible widgets with JavaScript. You can observe the Tabindex Accessibility example below to clear confusion.

— https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

Une alternative conservatrice serait de déclarer la spécification suivante dans `_challenge-statement.scss`

```css
[tabindex="-1"]:focus {
	outline: 0;
}
```