### PR TITLE
[FEATURE] Ajouter une étape d'ajout de commentaire global lors de la finalisation de la session (PC-86) 

### DIFF
--- a/api/db/migrations/20191129100835_add_column_comment_to_session.js
+++ b/api/db/migrations/20191129100835_add_column_comment_to_session.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'examinerComment';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME, 500);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -94,8 +94,9 @@ module.exports = {
   finalize(request) {
     const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
+    const examinerComment = request.payload.data.attributes['examiner-comment'];
 
-    return usecases.finalizeSession({ userId, sessionId })
+    return usecases.finalizeSession({ userId, sessionId, examinerComment })
       .then((updatedSession) => sessionSerializer.serializeForFinalization(updatedSession));
   },
 

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -18,6 +18,7 @@ class Session {
     room,
     time,
     status,
+    examinerComment,
     // includes
     certifications,
     certificationCandidates,
@@ -35,6 +36,7 @@ class Session {
     this.room = room;
     this.time = time;
     this.status = status;
+    this.examinerComment = examinerComment;
     // includes
     this.certifications = certifications;
     this.certificationCandidates = certificationCandidates;

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -10,6 +10,7 @@ const {
 module.exports = async function finalizeSession({
   userId,
   sessionId,
+  examinerComment,
   sessionRepository,
 } = {}) {
   try {
@@ -21,6 +22,10 @@ module.exports = async function finalizeSession({
   if (isSessionAlreadyFinalized) {
     throw new SessionAlreadyFinalizedError('Cannot finalize session more than once');
   }
-  await sessionRepository.updateStatus({ sessionId, status: statuses.FINALIZED });
-  return sessionRepository.get(sessionId);
+
+  return sessionRepository.updateStatusAndExaminerComment({
+    id: sessionId,
+    status: statuses.FINALIZED,
+    examinerComment,
+  });
 };

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -90,18 +90,17 @@ module.exports = {
   },
 
   update(session) {
-    const sessionDataToUpdate = _.pick(
-      session,
-      [
-        'address',
-        'room',
-        'accessCode',
-        'examiner',
-        'date',
-        'time',
-        'description'
-      ]
-    );
+    const sessionDataToUpdate = _.pick(session, [
+      'address',
+      'room',
+      'accessCode',
+      'examiner',
+      'date',
+      'time',
+      'description',
+      'status',
+      'examinerComment',
+    ]);
 
     return new BookshelfSession({ id: session.id })
       .save(sessionDataToUpdate, { patch: true })
@@ -145,10 +144,15 @@ module.exports = {
       });
   },
 
-  updateStatus({ sessionId, status }) {
-    return BookshelfSession
-      .where({ id: sessionId })
-      .save({ status }, { patch: true, require: true })
-      .then((bookshelfSession) => bookshelfToDomainConverter.buildDomainObject(BookshelfSession, bookshelfSession));
+  updateStatusAndExaminerComment(session) {
+    const sessionDataToUpdate = _.pick(session, [
+      'status',
+      'examinerComment',
+    ]);
+
+    return new BookshelfSession({ id: session.id })
+      .save(sessionDataToUpdate, { patch: true })
+      .then((model) => model.refresh())
+      .then(_toDomain);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -22,6 +22,7 @@ module.exports = {
         'accessCode',
         'certifications',
         'certificationCandidates',
+        'examinerComment',
       ],
       certifications : {
         ref: ['id']
@@ -50,6 +51,7 @@ module.exports = {
         'status',
         'description',
         'accessCode',
+        'examinerComment',
       ],
     }).serialize(sessions);
   },
@@ -73,6 +75,7 @@ module.exports = {
       time: attributes.time,
       status: attributes.status,
       description: attributes.description,
+      examinerComment: attributes['examiner-comment'],
     });
   }
 };

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -25,7 +25,8 @@ describe('Acceptance | Controller | session-controller-get', () => {
         time: '14:30',
         description: 'ahah',
         status: 'created',
-        accessCode: 'ABCD12'
+        accessCode: 'ABCD12',
+        examinerComment: 'It was a fine session my dear',
       });
       databaseBuilder.factory.buildCertificationCourse({
         id: 3,
@@ -101,6 +102,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
         accessCode: 'ABC123',
         description: '',
         status: 'started',
+        examinerComment: 'It was a fine session my dear',
         createdAt: new Date('2017-12-08T08:00:00Z'),
       });
 
@@ -116,6 +118,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
         accessCode: 'DEF456',
         description: '',
         status: 'started',
+        examinerComment: 'It was a fine session my dear',
         createdAt: new Date('2017-12-07T09:00:00Z'),
       });
 
@@ -157,6 +160,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'room': 'Salle 1',
             'time': '14:30:00',
             'status': 'started',
+            'examiner-comment': 'It was a fine session my dear',
           },
           'relationships': {
             'certifications': {
@@ -181,6 +185,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'room': 'Salle 2',
             'time': '14:30:00',
             'status': 'started',
+            'examiner-comment': 'It was a fine session my dear',
           },
           'relationships': {
             'certifications': {

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -9,6 +9,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
   let userId;
   let certificationCenterId;
   let sessionId;
+  const examinerComment = 'It was a fine session my dear';
 
   const sessionDomain = {
     accessCode: 'ABC123',
@@ -27,7 +28,13 @@ describe('Acceptance | Controller | sessions-controller', () => {
 
     options = {
       method: 'PUT',
-      payload: {},
+      payload: {
+        data: {
+          attributes: {
+            'examiner-comment': examinerComment,
+          },
+        },
+      },
       headers: {},
     };
   });
@@ -89,9 +96,6 @@ describe('Acceptance | Controller | sessions-controller', () => {
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
         options.url = `/api/sessions/${sessionId}/finalization`;
 
-        // when
-        const promise = server.inject(options);
-
         const expectedSessionJSONAPI = {
           data: {
             type: 'sessions',
@@ -106,9 +110,13 @@ describe('Acceptance | Controller | sessions-controller', () => {
               'time': sessionDomain.time,
               'room': sessionDomain.room,
               'status': 'finalized',
+              'examiner-comment': examinerComment,
             },
           },
         };
+
+        // when
+        const promise = server.inject(options);
 
         // then
         return promise.then((response) => {

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -297,7 +297,8 @@ describe('Integration | Repository | Session', function() {
       const bookshelfSession = databaseBuilder.factory.buildSession({
         id: 1,
         room: '28D',
-        examiner: 'Roger'
+        examiner: 'Roger',
+        status: Session.statuses.STARTED,
       });
       session = domainBuilder.buildSession(bookshelfSession);
 
@@ -316,6 +317,8 @@ describe('Integration | Repository | Session', function() {
       // given
       session.room = 'New room';
       session.examiner = 'New examiner';
+      session.examinerComment = 'It was a fine session my dear';
+      session.status = Session.statuses.FINALIZED;
 
       // when
       const sessionSaved = await sessionRepository.update(session);
@@ -324,6 +327,8 @@ describe('Integration | Repository | Session', function() {
       expect(sessionSaved.id).to.equal(session.id);
       expect(sessionSaved.room).to.equal('New room');
       expect(sessionSaved.examiner).to.equal('New examiner');
+      expect(sessionSaved.examinerComment).to.equal('It was a fine session my dear');
+      expect(sessionSaved.status).to.equal(Session.statuses.FINALIZED);
     });
 
     it('should not add row in table "sessions"', async () => {
@@ -464,7 +469,7 @@ describe('Integration | Repository | Session', function() {
 
   });
 
-  describe('ensureUserHasAccessToSession', () => {
+  describe('#ensureUserHasAccessToSession', () => {
     let requestErr, userId, userIdNotAllowed, sessionId, certificationCenterId, certificationCenterNotAllowedId;
 
     beforeEach(async () => {
@@ -504,22 +509,39 @@ describe('Integration | Repository | Session', function() {
 
   });
 
-  describe('updateStatus', () => {
-    let sessionId;
-    const status = 'some status';
-    beforeEach(async () => {
-      sessionId = databaseBuilder.factory.buildSession().id;
-      await databaseBuilder.commit();
+  describe('#updateStatusAndExaminerComment', () => {
+    let session;
+
+    beforeEach(() => {
+      const bookshelfSession = databaseBuilder.factory.buildSession({
+        id: 1,
+        status: Session.statuses.STARTED,
+      });
+      session = domainBuilder.buildSession(bookshelfSession);
+
+      return databaseBuilder.commit();
     });
-    it('should update the status and return only the status', async () => {
-      const updatedSession = await sessionRepository.updateStatus({ sessionId, status });
-      expect(updatedSession.status).to.equal(status);
-      expect(updatedSession.id).to.be.undefined;
+
+    it('should return a Session domain object', async () => {
+      // when
+      const sessionSaved = await sessionRepository.updateStatusAndExaminerComment(session);
+
+      // then
+      expect(sessionSaved).to.be.an.instanceof(Session);
     });
-    it('should throw an error when the session is not found', async () => {
-      const err = await catchErr(sessionRepository.updateStatus)({ sessionId: sessionId + 1, status });
-      expect(err).to.be.instanceOf(Error);
+
+    it('should update model in database', async () => {
+      // given
+      session.examinerComment = 'It was a fine session my dear';
+      session.status = Session.statuses.FINALIZED;
+
+      // when
+      const sessionSaved = await sessionRepository.updateStatusAndExaminerComment(session);
+
+      // then
+      expect(sessionSaved.id).to.deep.equal(session.id);
+      expect(sessionSaved.examinerComment).to.deep.equal('It was a fine session my dear');
+      expect(sessionSaved.status).to.deep.equal(Session.statuses.FINALIZED);
     });
   });
-
 });

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -18,6 +18,7 @@ module.exports = function buildSession({
   description = faker.random.words(),
   createdAt = faker.date.recent(),
   status = Session.statuses.STARTED,
+  examinerComment,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -38,6 +39,7 @@ module.exports = function buildSession({
     description,
     createdAt,
     status,
+    examinerComment,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -383,20 +383,30 @@ describe('Unit | Controller | sessionController', () => {
     let request;
     const sessionId = 1;
     const userId = 2;
-    const updatedSession = 'updatedSession';
-    const serializedUpdatedSession = 'updated session serialized';
+    const updatedSession = Symbol('updatedSession');
+    const serializedUpdatedSession = Symbol('updated session serialized');
+    const examinerComment = 'It was a fine session my dear';
 
     beforeEach(() => {
       // given
       request = {
-        params: { id: sessionId },
+        params: { 
+          id: sessionId,
+        },
         auth: {
           credentials: {
             userId,
           }
         },
+        payload: {
+          data: {
+            attributes: {
+              'examiner-comment': examinerComment,
+            },
+          },
+        },
       };
-      sinon.stub(usecases, 'finalizeSession').withArgs({ userId, sessionId }).resolves(updatedSession);
+      sinon.stub(usecases, 'finalizeSession').withArgs({ userId, sessionId, examinerComment }).resolves(updatedSession);
       sinon.stub(sessionSerializer, 'serializeForFinalization').withArgs(updatedSession).resolves(serializedUpdatedSession);
     });
 

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -16,6 +16,7 @@ const SESSION_PROPS = [
   'status',
   'certifications',
   'certificationCandidates',
+  'examinerComment',
 ];
 
 describe('Unit | Domain | Models | Session', () => {
@@ -34,6 +35,7 @@ describe('Unit | Domain | Models | Session', () => {
       room: '',
       time: '',
       status: '',
+      examinerComment: '',
       // includes
       certifications: [],
       certificationCandidates: [],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
     description: '',
     accessCode: '',
     status: 'created',
+    examinerComment: 'It was a fine session my dear',
   });
 
   let jsonApiSession;
@@ -35,7 +36,8 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
           date: '2017-01-20',
           time: '14:30',
           status: 'created',
-          description: ''
+          description: '',
+          'examiner-comment': 'It was a fine session my dear'
         },
         relationships: {
           certifications: {
@@ -78,7 +80,8 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         description: '',
         accessCode: '',
         status: 'created',
-        certifications: associatedCertifications
+        certifications: associatedCertifications,
+        examinerComment: 'It was a fine session my dear',
       });
 
       // when
@@ -99,6 +102,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
             time: '14:30',
             description: '',
             status: 'created',
+            'examiner-comment': 'It was a fine session my dear',
           },
           relationships: {
             certifications: {
@@ -147,6 +151,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       expect(session.date).to.equal('2017-01-20');
       expect(session.time).to.equal('14:30');
       expect(session.description).to.equal('');
+      expect(session.examinerComment).to.equal('It was a fine session my dear');
     });
 
     context('when there is no certification center ID', () => {

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -1,8 +1,17 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
-  finalize(model) {
+  finalize(model, { examinerComment }) {
     const url = this.buildURL('session', model.id) + '/finalization';
-    return this.ajax(url, 'PUT');
+
+    return this.ajax(url, 'PUT', { 
+      data: {
+        data: {
+          attributes: {
+            'examiner-comment': examinerComment,
+          },
+        },
+      },
+    });
   }
 });

--- a/certif/app/components/session-finalization-examiner-comment-step.js
+++ b/certif/app/components/session-finalization-examiner-comment-step.js
@@ -1,0 +1,22 @@
+import Component from '@ember/component';
+
+// Bug known : carriages return under Safari in textareas
+// are '\r\n' so the browser counts it as 2 characters
+export default Component.extend({
+  textareaMaxLength: 500,
+
+  init() {
+    this._super(...arguments);
+    this.set('examinerComment', '');
+  },
+
+  actions: {
+    updateTextareaValue(text) {
+      const textareaMaxLength = this.get('textareaMaxLength');
+
+      if (text.length <= textareaMaxLength) {
+        this.set('examinerComment', text);
+      }
+    }
+  }
+});

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -8,6 +8,7 @@ export default Controller.extend({
   notifications: service('notification-messages'),
 
   showConfirmModal: false,
+  examinerComment: '',
 
   showErrorNotification(message) {
     const { autoClear, clearDuration } = config.notifications;
@@ -21,8 +22,12 @@ export default Controller.extend({
 
   actions: {
     finalizeSession() {
+      
       this.set('isLoading', true);
-      return this.model.finalize()
+      return this.model
+        .finalize({
+          examinerComment: this.get('examinerComment'),
+        })
         .then(() => {
           this.showSuccessNotification('Les informations de la session ont été transmises avec succès.');
         })

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -26,8 +26,8 @@ export default DS.Model.extend({
     return `${ENV.APP.API_HOST}/api/sessions/${this.get('id')}/certification-candidates/import`;
   }),
 
-  finalize() {
-    return this.store.adapterFor('session').finalize(this);
+  finalize(data) {
+    return this.store.adapterFor('session').finalize(this, data);
   },
 
 });

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -28,6 +28,7 @@
 @import "components/session-finalizer";
 @import "components/session-finalization-step-container";
 @import "components/session-finalization-formbuilder-link-step";
+@import "components/session-finalization-examiner-comment-step";
 
 body, html{
   margin: 0;

--- a/certif/app/styles/components/session-finalization-examiner-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-comment-step.scss
@@ -1,23 +1,22 @@
 .session-finalization-examiner-comment-step {
 
-  padding: 22px 8px 22px 38px;
+  padding: 22px 32px;
 
   &__header-container{
+    color: $grey;
     display: flex;
     justify-content: space-between;
   }
 
   &__label {
+    flex: 1;
     margin-bottom: 14px;
-    color: $grey;
-    font-weight: bold;
-    display: block;
   }
 
   &__characters-information {
-    color: $grey;
+    min-width: max-content;
     font-size: 0.85rem;
-    align-self: end;
+    align-self: flex-end;
   }
 
   &__textarea {
@@ -36,6 +35,7 @@
     &:focus {
       outline: 2px solid $mariner;
       -moz-outline-radius: 4px;
+      border: none;
     }
   }
 }

--- a/certif/app/styles/components/session-finalization-examiner-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-comment-step.scss
@@ -1,0 +1,41 @@
+.session-finalization-examiner-comment-step {
+
+  padding: 22px 8px 22px 38px;
+
+  &__header-container{
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__label {
+    margin-bottom: 14px;
+    color: $grey;
+    font-weight: bold;
+    display: block;
+  }
+
+  &__characters-information {
+    color: $grey;
+    font-size: 0.85rem;
+    align-self: end;
+  }
+
+  &__textarea {
+    box-sizing: border-box;
+    width: 100%;
+    height: 116px;
+    resize: none;
+    border-color: $alto;
+    border-style: solid;
+    border-radius: 4px;
+    padding: 4px;
+    font-family: $roboto;
+    color: $grey;
+    font-size: 1rem;
+
+    &:focus {
+      outline: 2px solid $mariner;
+      -moz-outline-radius: 4px;
+    }
+  }
+}

--- a/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
+++ b/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
@@ -1,6 +1,5 @@
 .session-finalization-formbuilder-link-step {
-  margin: 8px 8px 8px 8px;
-  padding: 24px 0 26px 32px;
+  padding: 26px 32px;
   font-family: $roboto;
   color: $grey;
 

--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -6,10 +6,10 @@
   &__title {
     display: flex;
     background: $wild-sand;
-    margin: 8px 8px 8px 8px;
+    margin: 8px;
     color: $comet;
-    font-weight: 700;
-    padding: 20px 0 19px 32px;
+    font-weight: bold;
+    padding: 20px 0 19px 24px;
   }
 
   &__icon {

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -65,7 +65,7 @@
   flex-direction: column;
   height: 100%;
   background-color: $wild-sand;
-  overflow: scroll;
+  overflow: auto;
 
   &__topbar {
     background-color: white;

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -4,4 +4,5 @@
   openModal=(action 'openModal')
   closeModal=(action 'closeModal')
   showConfirmModal=showConfirmModal
+  examinerComment=examinerComment
 }}

--- a/certif/app/templates/components/routes/authenticated/sessions/session-finalizer.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/session-finalizer.hbs
@@ -15,6 +15,13 @@
           @iconAlt="">
     <SessionFinalizationFormbuilderLinkStep/>
   </SessionFinalizationStepContainer>
+  <SessionFinalizationStepContainer
+          @number="3"
+          @title="Commenter la session (facultatif)"
+          @icon="/icons/session-finalization-edit.svg"
+          @iconAlt="">
+    <SessionFinalizationExaminerCommentStep @examinerComment={{examinerComment}} />
+  </SessionFinalizationStepContainer>
   <ActionButton
     class="session-finalizer__button"
     data-test-id="session-finalizer__button"

--- a/certif/app/templates/components/session-finalization-examiner-comment-step.hbs
+++ b/certif/app/templates/components/session-finalization-examiner-comment-step.hbs
@@ -1,0 +1,17 @@
+<div class="session-finalization-examiner-comment-step">
+  <div class="session-finalization-examiner-comment-step__header-container">
+    <label for="examiner-comment" class="session-finalization-examiner-comment-step__label">
+        Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.
+    </label>
+    <div class="session-finalization-examiner-comment-step__characters-information">
+      {{examinerComment.length}} / {{textareaMaxLength}}
+    </div>
+  </div>
+  <textarea
+    id="examiner-comment"
+    class="session-finalization-examiner-comment-step__textarea"
+    value={{examinerComment}}
+    oninput={{action "updateTextareaValue" value="target.value"}}
+    maxlength={{textareaMaxLength}}
+  />
+</div>

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { createUserWithMembership } from '../helpers/test-init';
@@ -60,6 +60,20 @@ module('Acceptance | Session Finalization', function(hooks) {
       hooks.beforeEach(function() {
         finalizeController = this.owner.lookup('controller:authenticated.sessions.finalize');
         return visit('/sessions/1/finalisation');
+      });
+
+      test('it should allow the user to comment the session in textarea', async function(assert) {
+        // given
+        const expectedComment = 'You are a wizard Harry!';
+        const expectedIndicator = expectedComment.length + ' / 500';
+
+        // when
+        await fillIn('#examiner-comment', 'You are a wizard Harry!');
+
+        // then
+        assert.equal(finalizeController.examinerComment, expectedComment);
+        assert.dom('.session-finalization-examiner-comment-step__characters-information').exists();
+        assert.dom('.session-finalization-examiner-comment-step__characters-information').hasText(expectedIndicator);
       });
 
       test('it should open the confirm modal', async function(assert) {

--- a/certif/tests/integration/components/session-finalization-examiner-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-comment-step-test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | session-finalization-examiner-comment-step', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let firstComment;
+
+  hooks.beforeEach(async function() {
+    firstComment = 'You are a wizard Harry !';
+    this.set('textareaMaxLength', 500);
+    this.set('examinerComment', firstComment);
+
+    await render(hbs`<SessionFinalizationExaminerCommentStep @examinerComment={{this.examinerComment}}  />`);
+    await fillIn('#examiner-comment', firstComment);
+  });
+
+  test('it renders', async function(assert) {
+    assert.equal(
+      find('label').textContent.trim(),
+      'Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.'
+    );
+    assert.equal(
+      find('div.session-finalization-examiner-comment-step__characters-information').textContent.trim(),
+      this.examinerComment.length + ' / ' + this.textareaMaxLength
+    );
+    assert.equal(
+      find('textarea').value.trim(),
+      firstComment
+    );
+  });
+
+  module('when changing textarea content', function() {
+    test('it changes the textarea content and characters indicator', async function(assert) {
+      await fillIn('#examiner-comment', 'You are no more a wizard Harry!');
+      assert.equal(
+        find('div.session-finalization-examiner-comment-step__characters-information').textContent.trim(),
+        this.examinerComment.length + ' / ' + this.textareaMaxLength
+      );
+      assert.equal(find('#examiner-comment').value.trim(),
+        'You are no more a wizard Harry!'
+      );
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Contexte
Suite de l'EPIX Commentaires/fin de test (pix admin app), on ajoute la deuxième étape, à savoir le commentaire global de la session. Nous nommerons ce commentaire, ajouté par le surveillant après la fin de la session, "examiner-comment". 

## :robot: Solution
Ajout d'une nouvelle étape dans la page de finalisation de session.

## :rainbow: Remarques
AVANT
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/38167520/69882573-e43e3100-12d0-11ea-96ab-30cd331065a6.png">
APRES  ⬇️ 
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/38167520/69882554-d12b6100-12d0-11ea-8720-5216b5f75fea.png">

Global comment = examiner comment

TODO : 
- [x] réparer l'arbre git cassé à cause du rebase avec dev
- [x] check anno-so + quentin UX/UI
- [x] reset migration sur intégration
- [x] injection sql dans textarea ? 
