### PR TITLE
[POC] Poser la même question à la reprise d'un parcours (PF-889).

### DIFF
--- a/api/db/migrations/20191128173128_add_current_challenge.js
+++ b/api/db/migrations/20191128173128_add_current_challenge.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessments';
+const COLUMN_NAME = 'currentChallenge';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -36,6 +36,7 @@ class Assessment {
     title,
     type,
     isImproving,
+    currentChallenge,
     // includes
     answers = [],
     assessmentResults = [],
@@ -55,6 +56,7 @@ class Assessment {
     this.title = title;
     this.type = type;
     this.isImproving = isImproving;
+    this.currentChallenge = currentChallenge;
     // includes
     this.answers = answers;
     this.assessmentResults = assessmentResults;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -54,6 +54,9 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
 
   const answerSaved = await answerRepository.save(correctedAnswer);
+
+  await assessmentRepository.resetCurrentChallenge(assessment.id);
+
   let savedKnowledgeElements = [];
   if (assessment.isCompetenceEvaluation()) {
     savedKnowledgeElements = await saveKnowledgeElementsForCompetenceEvaluation({

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -7,12 +7,18 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   knowledgeElementRepository,
   challengeRepository,
   answerRepository,
+  assessmentRepository,
   skillRepository,
   assessment,
   userId,
 }) {
 
   _checkIfAssessmentBelongsToUser(assessment, userId);
+
+  if (assessment.currentChallenge) {
+    return challengeRepository.get(assessment.currentChallenge);
+  }
+
   const inputValues = await dataFetcher.fetchForCompetenceEvaluations(...arguments);
 
   const {
@@ -20,10 +26,11 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
     hasAssessmentEnded,
   } = smartRandom.getNextChallenge(inputValues);
 
+  await assessmentRepository.setCurrentChallenge(assessment.id, nextChallenge.id);
+
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();
   }
-
   return nextChallenge;
 };
 

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -21,6 +21,20 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
+  resetCurrentChallenge(id) {
+    return BookshelfAssessment
+      .where({ id })
+      .save({ currentChallenge: null }, { require: true, patch: true })
+      .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
+  },
+
+  setCurrentChallenge(id, currentChallenge) {
+    return BookshelfAssessment
+      .where({ id })
+      .save({ currentChallenge }, { require: true, patch: true })
+      .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
+  },
+
   findLastCompletedAssessmentsForEachCoursesByUser(userId, limitDate) {
     return BookshelfAssessment
       .collection()


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur reprend son parcours de compétences, il ne tombe pas systématiquement sur la dernière question qui lui a été posée. C'est problématique dans les challenges où il y a des fichiers à télécharger.

## :robot: Solution
Lorsque l'utilisateur quitte son parcours, on enregistre dans une nouvelle colonne `currentChallenge` (dans la table assessments) l'id du dernier challenge vu.
Au moment de sauvegarder l'answer, on reset la colonne currentChallenge.
Pour récupérer le nextChallenge, s'il y a un id currentChallenge dans l'assessment, on utilise le challenge associé. Sinon on fait appel a getNextChallenge, comme d'habitude.

## :rainbow: Remarques
Le POC est sur les parcours de compétences pour l'instant.
