### PR TITLE
[TECH] Corrige un test qui échoue au hasard

### DIFF
--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -68,6 +68,7 @@ module.exports = {
         );
         qb.where('certification-courses.userId', userId);
         qb.where('assessments.state', Assessment.states.COMPLETED);
+        qb.orderBy('id', 'desc');
       })
       .fetchAll({
         required: false,


### PR DESCRIPTION
## :unicorn: Problème

Le test du diff échouait environ une fois sur 130.

## :robot: Solution

Rendre `certificationRepository.findByUserId()` déterministe.

## :rainbow: Remarques

J'ai choisi `orderBy('id', 'desc')`, qui était l'ordre remonté le plus souvent par le test. Est-ce bien le bon ordre ?

Pour faire mes stats, j'ai utilisé une boucle while qui écrivait un `.` en cas de succès, et un `E` en cas d'erreur (c'est du fish shell, il faut que je pense à repasser à bash).

```
while true ; env NODE_ENV=test npx mocha --exit api/tests/integration/infrastructure/repositories/certification-repository_test.js | awk '/7 passing/ {printf "."} ; /AssertionError/ {print "E"}' | tee out.log ; end
```