### PR TITLE
[TECH] Utiliser des méthodes communes dans les repositories.

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -149,6 +149,12 @@ class ChallengeAlreadyAnsweredError extends DomainError {
   }
 }
 
+class DeletionError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 class EntityValidationError extends DomainError {
   constructor({ invalidAttributes }) {
     super();
@@ -361,6 +367,7 @@ module.exports = {
   CertificationCenterMembershipCreationError,
   CertificationComputeError,
   ChallengeAlreadyAnsweredError,
+  DeletionError,
   EntityValidationError,
   FileValidationError,
   ForbiddenAccess,

--- a/api/lib/infrastructure/createCommonRepositoryMethods.js
+++ b/api/lib/infrastructure/createCommonRepositoryMethods.js
@@ -1,0 +1,111 @@
+const { NotFoundError, DeletionError } = require('../domain/errors');
+const bookshelfToDomainConverter = require('./utils/bookshelf-to-domain-converter');
+
+const _identity = (any) => any;
+const _createDefaultToDomain = (BookshelfModel) => {
+  return (results) => {
+    if (Array.isArray(results)) {
+      return bookshelfToDomainConverter.buildDomainObjects(BookshelfModel, results);
+    }
+
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfModel, results);
+  };
+};
+
+// Add CRUD operations to repository
+function createCommonRepositoryMethods({
+  BookshelfModel,
+  toDomain,
+  adaptToDatabaseForCreate = _identity,
+  adaptToDatabaseForUpdate = _identity,
+}) {
+
+  if (!toDomain) {
+    toDomain = _createDefaultToDomain(BookshelfModel);
+  }
+
+  const methods = {
+    // Get by id
+    get(id) {
+      return BookshelfModel
+        .where({ id })
+        .fetch({ require: true })
+        .then(toDomain)
+        .catch((error) => {
+          if (error instanceof BookshelfModel.NotFoundError) {
+            throw new NotFoundError(`Not found ${BookshelfModel.bookshelfName}#get(${id})`);
+          }
+
+          throw error;
+        });
+    },
+    // Get by attributes object describing the where clause
+    getByAttributes(attributes) {
+      return BookshelfModel
+        .where(attributes)
+        .fetch({ require: true })
+        .then(toDomain)
+        .catch((error) => {
+          if (error instanceof BookshelfModel.NotFoundError) {
+            throw new NotFoundError(`Not found ${BookshelfModel.bookshelfName}#getByAttributes(${JSON.stringify(attributes)})`);
+          }
+
+          throw error;
+        });
+    },
+    // Find one by attributes object describing the where clause
+    findOneByAttributes(attributes) {
+      return BookshelfModel
+        .where(attributes)
+        .fetch({ required: false })
+        .then(toDomain);
+    },
+    // Find many by attributes object describing the where clause
+    findByAttributes(attributes) {
+      return BookshelfModel
+        .where(attributes)
+        .orderBy('createdAt')
+        .fetchAll()
+        .then((result) => result.models.map(toDomain));
+    },
+    // Create one from attributes object
+    create(attributes) {
+      return new BookshelfModel(adaptToDatabaseForCreate(attributes))
+        .save()
+        .then(toDomain);
+    },
+    // Update one from attributes object
+    update(attributes) {
+      const adaptedAttributes = adaptToDatabaseForUpdate(attributes);
+
+      return new BookshelfModel({ id: adaptedAttributes.id })
+        .save(adaptedAttributes, { patch: true })
+        .then((model) => model.refresh())
+        .then(toDomain);
+    },
+    // Delete one by id
+    delete(id) {
+      return BookshelfModel
+        .where({ id })
+        .destroy({ require: true })
+        .then(() => true)
+        .catch(() => {
+          throw new DeletionError(`An error occurred while deleting the ${BookshelfModel.bookshelfName} id ${id}`);
+        });
+    },
+    // Delete one by attributes
+    deleteByAttributes(attributes) {
+      return BookshelfModel
+        .where(attributes)
+        .destroy({ require: true })
+        .then(() => true)
+        .catch(() => {
+          throw new DeletionError(`An error occurred while deleting the ${BookshelfModel.bookshelfName} by ${JSON.stringify(attributes)}`);
+        });
+    },
+  };
+
+  return methods;
+}
+
+module.exports = createCommonRepositoryMethods;


### PR DESCRIPTION
Fans de refactoring bonjour !

## 🐭 Problème

Dans les repositories on peut voir des méthodes comme ceci:
```js
get(answerId) {	
    return BookshelfAnswer.where('id', answerId)	
      .fetch({ require: true })	
      .then(_toDomain)	
      .catch((error) => {	
        if (error instanceof BookshelfAnswer.NotFoundError) {	
          throw new NotFoundError(`Not found answer for ID ${answerId}`);	
        }	

        throw error;	
      });	
  },
```
Ou comme cela:
```js
findByChallengeAndAssessment({ challengeId, assessmentId }) {	
    return BookshelfAnswer	
      .where({ challengeId, assessmentId })	
      .fetch()	
      .then(_toDomain);	
  },
```
On remarque alors que la première est un`get` générique et que la seconde est un `findOneByAttributes`, générique aussi.

Ces méthodes sont multipliées et demandent des tests, or à travers les nombreux repositories c'est les mêmes méthodes que l'on revient à tester, encore et encore.

## 🐱 Solution

Créer, pour l'ensemble des repositories, des méthodes communes:
- `get`
- `findOneByAttributes`
- `findByAttributes`
- `create`
- `update`
- `delete`
- `deleteOneByAttributes`

Utilisables à la demande par les repositories.

Je montre ici un exemple sur le answer repositories. Notez comment tester `get` et `save` et même les autres méthodes devient inutile si ces méthodes de base sont bien testées.

J'attends vos commentaires avant d'implémenter la solution sur le reste des répositories.