### PR TITLE
[TECH] Préparation (refactoring) à l'ajout d'un cache de second niveau pour les modules Datasource.

### DIFF
--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -63,10 +63,20 @@ async function findRecordsSkipCache(tableName, fields) {
   return recordsAsJson.map((rawJson) => new AirtableRecord(tableName, rawJson.id, rawJson));
 }
 
+async function preload(tableName, usedFields) {
+  const records = await findRecordsSkipCache(tableName, usedFields);
+
+  return Promise.all(records.map((record) => {
+    const cacheKey = generateCacheKey(tableName, record.id);
+    return cache.set(cacheKey, record._rawJson);
+  })).then(() => true);
+}
+
 module.exports = {
   generateCacheKey,
   getRecord,
   getRecordSkipCache,
   findRecords,
   findRecordsSkipCache,
+  preload,
 };

--- a/api/lib/infrastructure/caches/preloader.js
+++ b/api/lib/infrastructure/caches/preloader.js
@@ -1,35 +1,15 @@
 const airtable = require('../airtable');
-const cache = require('./cache');
 const AirtableDatasources = require('../datasources/airtable');
 const _ = require('lodash');
-
-function _cacheIndividually(records, tablename) {
-  return Promise.all(records.map((record) => {
-    const cacheKey = airtable.generateCacheKey(tablename, record.id);
-    return cache.set(cacheKey, record._rawJson);
-  }));
-}
-
-async function _loadDatasourceContent(airtableDatasource) {
-  const airtableName = airtableDatasource.tableName;
-  const fields = airtableDatasource.usedFields;
-
-  const records = await airtable.findRecordsSkipCache(airtableName, fields);
-  return _cacheIndividually(records, airtableName);
-}
-
-function _loadRecord(tableName, recordId) {
-  return airtable.getRecordSkipCache(tableName, recordId);
-}
 
 module.exports = {
 
   loadAllTables() {
-    return Promise.all(_.map(AirtableDatasources, _loadDatasourceContent));
+    return Promise.all(_.map(AirtableDatasources, (datasource) => datasource.preload()));
   },
 
   load({ tableName, recordId }) {
-    return _loadRecord(tableName, recordId);
+    return airtable.getRecordSkipCache(tableName, recordId);
   }
 
 };

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -1,4 +1,4 @@
-const airtable = require('../../airtable');
+const datasource = require('./datasource');
 
 const tableName = 'Domaines';
 
@@ -19,7 +19,7 @@ function fromAirTableObject(airtableDomaineObject) {
   };
 }
 
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -27,11 +27,5 @@ module.exports = {
 
   fromAirTableObject,
 
-  list() {
-    return airtable.findRecords(tableName, usedFields)
-      .then((airtableRawObjects) => {
-        return airtableRawObjects.map(fromAirTableObject);
-      });
-  },
-};
+});
 

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -11,13 +11,13 @@ module.exports = datasource.extend({
     'Competences (identifiants)',
   ],
 
-  fromAirTableObject(airtableDomaineObject) {
+  fromAirTableObject(airtableRecord) {
     return {
-      id: airtableDomaineObject.getId(),
-      code: airtableDomaineObject.get('Code'),
-      name: airtableDomaineObject.get('Nom'),
-      title: airtableDomaineObject.get('Titre'),
-      competenceIds: airtableDomaineObject.get('Competences (identifiants)'),
+      id: airtableRecord.getId(),
+      code: airtableRecord.get('Code'),
+      name: airtableRecord.get('Nom'),
+      title: airtableRecord.get('Titre'),
+      competenceIds: airtableRecord.get('Competences (identifiants)'),
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -1,31 +1,25 @@
 const datasource = require('./datasource');
 
-const tableName = 'Domaines';
-
-const usedFields = [
-  'Code',
-  'Nom',
-  'Titre',
-  'Competences (identifiants)',
-];
-
-function fromAirTableObject(airtableDomaineObject) {
-  return {
-    id: airtableDomaineObject.getId(),
-    code: airtableDomaineObject.get('Code'),
-    name: airtableDomaineObject.get('Nom'),
-    title: airtableDomaineObject.get('Titre'),
-    competenceIds: airtableDomaineObject.get('Competences (identifiants)'),
-  };
-}
-
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Domaines',
 
-  usedFields,
+  usedFields: [
+    'Code',
+    'Nom',
+    'Titre',
+    'Competences (identifiants)',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableDomaineObject) {
+    return {
+      id: airtableDomaineObject.getId(),
+      code: airtableDomaineObject.get('Code'),
+      name: airtableDomaineObject.get('Nom'),
+      title: airtableDomaineObject.get('Titre'),
+      competenceIds: airtableDomaineObject.get('Competences (identifiants)'),
+    };
+  },
 
 });
 

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -2,6 +2,8 @@ const datasource = require('./datasource');
 
 module.exports = datasource.extend({
 
+  modelName: 'Area',
+
   tableName: 'Domaines',
 
   usedFields: [

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,8 +1,5 @@
 const _ = require('lodash');
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
-
-const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Epreuves';
 
@@ -85,18 +82,6 @@ module.exports = datasource.extend({
   usedFields,
 
   fromAirTableObject,
-
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject)
-      .catch((err) => {
-        if (err.error === 'NOT_FOUND') {
-          throw new AirtableResourceNotFound();
-        }
-
-        throw err;
-      });
-  },
 
   findBySkillIds(skillIds) {
     const foundInSkillIds = (skillId) => _.includes(skillIds, skillId);

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -5,6 +5,8 @@ const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
 
 module.exports = datasource.extend({
 
+  modelName: 'Challenge',
+
   tableName: 'Epreuves',
 
   usedFields: [

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,87 +1,81 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const tableName = 'Epreuves';
-
-const usedFields = [
-  'Illustration de la consigne',
-  'Pièce jointe',
-  'Compétences (via tube)',
-  'Timer',
-  'Consigne',
-  'Propositions',
-  'Type d\'épreuve',
-  'Bonnes réponses',
-  'T1 - Espaces, casse & accents',
-  'T2 - Ponctuation',
-  'T3 - Distance d\'édition',
-  'Scoring',
-  'Statut',
-  'Acquix',
-  'acquis',
-  'Embed URL',
-  'Embed title',
-  'Embed height',
-  'Texte alternatif illustration',
-  'Format',
-];
-
 const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
-
-function fromAirTableObject(airtableEpreuveObject) {
-
-  let illustrationUrl;
-  if (airtableEpreuveObject.get('Illustration de la consigne')) {
-    illustrationUrl = airtableEpreuveObject.get('Illustration de la consigne')[0].url;
-  }
-
-  let attachments;
-  if (airtableEpreuveObject.get('Pièce jointe')) {
-    attachments = airtableEpreuveObject.get('Pièce jointe').map((attachment) => attachment.url).reverse();
-  }
-
-  let competenceId;
-  if (airtableEpreuveObject.get('Compétences (via tube)')) {
-    competenceId = airtableEpreuveObject.get('Compétences (via tube)')[0];
-  }
-
-  let timer;
-  if (airtableEpreuveObject.get('Timer')) {
-    timer = parseInt(airtableEpreuveObject.get('Timer'));
-  }
-
-  return {
-    id: airtableEpreuveObject.getId(),
-    instruction: airtableEpreuveObject.get('Consigne'),
-    proposals: airtableEpreuveObject.get('Propositions'),
-    type: airtableEpreuveObject.get('Type d\'épreuve'),
-    solution: airtableEpreuveObject.get('Bonnes réponses'),
-    t1Status: airtableEpreuveObject.get('T1 - Espaces, casse & accents'),
-    t2Status: airtableEpreuveObject.get('T2 - Ponctuation'),
-    t3Status: airtableEpreuveObject.get('T3 - Distance d\'édition'),
-    scoring: airtableEpreuveObject.get('Scoring'),
-    status: airtableEpreuveObject.get('Statut'),
-    skillIds: airtableEpreuveObject.get('Acquix') || [],
-    skills: airtableEpreuveObject.get('acquis') || [],
-    embedUrl: airtableEpreuveObject.get('Embed URL'),
-    embedTitle: airtableEpreuveObject.get('Embed title'),
-    embedHeight: airtableEpreuveObject.get('Embed height'),
-    timer,
-    illustrationUrl,
-    attachments,
-    competenceId,
-    illustrationAlt: airtableEpreuveObject.get('Texte alternatif illustration'),
-    format: airtableEpreuveObject.get('Format') || 'mots',
-  };
-}
 
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Epreuves',
 
-  usedFields,
+  usedFields: [
+    'Illustration de la consigne',
+    'Pièce jointe',
+    'Compétences (via tube)',
+    'Timer',
+    'Consigne',
+    'Propositions',
+    'Type d\'épreuve',
+    'Bonnes réponses',
+    'T1 - Espaces, casse & accents',
+    'T2 - Ponctuation',
+    'T3 - Distance d\'édition',
+    'Scoring',
+    'Statut',
+    'Acquix',
+    'acquis',
+    'Embed URL',
+    'Embed title',
+    'Embed height',
+    'Texte alternatif illustration',
+    'Format',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableEpreuveObject) {
+
+    let illustrationUrl;
+    if (airtableEpreuveObject.get('Illustration de la consigne')) {
+      illustrationUrl = airtableEpreuveObject.get('Illustration de la consigne')[0].url;
+    }
+
+    let attachments;
+    if (airtableEpreuveObject.get('Pièce jointe')) {
+      attachments = airtableEpreuveObject.get('Pièce jointe').map((attachment) => attachment.url).reverse();
+    }
+
+    let competenceId;
+    if (airtableEpreuveObject.get('Compétences (via tube)')) {
+      competenceId = airtableEpreuveObject.get('Compétences (via tube)')[0];
+    }
+
+    let timer;
+    if (airtableEpreuveObject.get('Timer')) {
+      timer = parseInt(airtableEpreuveObject.get('Timer'));
+    }
+
+    return {
+      id: airtableEpreuveObject.getId(),
+      instruction: airtableEpreuveObject.get('Consigne'),
+      proposals: airtableEpreuveObject.get('Propositions'),
+      type: airtableEpreuveObject.get('Type d\'épreuve'),
+      solution: airtableEpreuveObject.get('Bonnes réponses'),
+      t1Status: airtableEpreuveObject.get('T1 - Espaces, casse & accents'),
+      t2Status: airtableEpreuveObject.get('T2 - Ponctuation'),
+      t3Status: airtableEpreuveObject.get('T3 - Distance d\'édition'),
+      scoring: airtableEpreuveObject.get('Scoring'),
+      status: airtableEpreuveObject.get('Statut'),
+      skillIds: airtableEpreuveObject.get('Acquix') || [],
+      skills: airtableEpreuveObject.get('acquis') || [],
+      embedUrl: airtableEpreuveObject.get('Embed URL'),
+      embedTitle: airtableEpreuveObject.get('Embed title'),
+      embedHeight: airtableEpreuveObject.get('Embed height'),
+      timer,
+      illustrationUrl,
+      attachments,
+      competenceId,
+      illustrationAlt: airtableEpreuveObject.get('Texte alternatif illustration'),
+      format: airtableEpreuveObject.get('Format') || 'mots',
+    };
+  },
 
   findBySkillIds(skillIds) {
     const foundInSkillIds = (skillId) => _.includes(skillIds, skillId);
@@ -92,7 +86,8 @@ module.exports = datasource.extend({
         && _.some(rawChallenge.fields.Acquix, foundInSkillIds)
       )
     });
-  },
+  }
+  ,
 
   findByCompetenceId(competenceId) {
     return this.list({
@@ -102,6 +97,8 @@ module.exports = datasource.extend({
         && _.includes(rawChallenge.fields['Compétences (via tube)'], competenceId)
       )
     });
-  },
-});
+  }
+  ,
+})
+;
 

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
+
 const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Epreuves';
@@ -76,7 +78,7 @@ function fromAirTableObject(airtableEpreuveObject) {
   };
 }
 
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -96,36 +98,25 @@ module.exports = {
       });
   },
 
-  list() {
-    return airtable.findRecords(tableName, usedFields)
-      .then((challengeDataObjects) => challengeDataObjects.map(fromAirTableObject));
-  },
-
   findBySkillIds(skillIds) {
     const foundInSkillIds = (skillId) => _.includes(skillIds, skillId);
 
-    return airtable.findRecords(tableName, usedFields)
-      .then((challengeDataObjects) => {
-        return challengeDataObjects
-          .filter((rawChallenge) => (
-            _.includes(VALIDATED_CHALLENGES, rawChallenge.fields.Statut)
-            && _.some(rawChallenge.fields.Acquix, foundInSkillIds)
-          ))
-          .map(fromAirTableObject);
-      });
+    return this.list({
+      filter: (rawChallenge) => (
+        _.includes(VALIDATED_CHALLENGES, rawChallenge.fields.Statut)
+        && _.some(rawChallenge.fields.Acquix, foundInSkillIds)
+      )
+    });
   },
 
   findByCompetenceId(competenceId) {
-    return airtable.findRecords(tableName, usedFields)
-      .then((challengeDataObjects) => {
-        return challengeDataObjects
-          .filter((rawChallenge) => (
-            _.includes(VALIDATED_CHALLENGES, rawChallenge.fields.Statut)
-            && !_.isEmpty(rawChallenge.fields.Acquix)
-            && _.includes(rawChallenge.fields['Compétences (via tube)'], competenceId)
-          ))
-          .map(fromAirTableObject);
-      });
+    return this.list({
+      filter: (rawChallenge) => (
+        _.includes(VALIDATED_CHALLENGES, rawChallenge.fields.Statut)
+        && !_.isEmpty(rawChallenge.fields.Acquix)
+        && _.includes(rawChallenge.fields['Compétences (via tube)'], competenceId)
+      )
+    });
   },
-};
+});
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -13,15 +13,15 @@ module.exports = datasource.extend({
     'Acquis (via Tubes)'
   ],
 
-  fromAirTableObject(rawAirtableCompetence) {
+  fromAirTableObject(airtableRecord) {
     return {
-      id: rawAirtableCompetence.getId(),
-      name: rawAirtableCompetence.get('Titre'),
-      index: rawAirtableCompetence.get('Sous-domaine'),
-      description: rawAirtableCompetence.get('Description'),
-      areaId: rawAirtableCompetence.get('Domaine') ? rawAirtableCompetence.get('Domaine')[0] : '',
-      courseId: rawAirtableCompetence.get('Tests') ? rawAirtableCompetence.get('Tests')[0] : '',
-      skillIds: rawAirtableCompetence.get('Acquis (via Tubes)') || [],
+      id: airtableRecord.getId(),
+      name: airtableRecord.get('Titre'),
+      index: airtableRecord.get('Sous-domaine'),
+      description: airtableRecord.get('Description'),
+      areaId: airtableRecord.get('Domaine') ? airtableRecord.get('Domaine')[0] : '',
+      courseId: airtableRecord.get('Tests') ? airtableRecord.get('Tests')[0] : '',
+      skillIds: airtableRecord.get('Acquis (via Tubes)') || [],
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,4 +1,5 @@
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
 
 const tableName = 'Competences';
 
@@ -23,7 +24,7 @@ function fromAirTableObject(rawAirtableCompetence) {
   };
 }
 
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -31,14 +32,9 @@ module.exports = {
 
   fromAirTableObject,
 
-  list() {
-    return airtable.findRecords(tableName, usedFields)
-      .then((airtableRawObjects) => airtableRawObjects.map(fromAirTableObject));
-  },
-
   get(id) {
     return airtable.getRecord(tableName, id)
       .then(fromAirTableObject);
   }
-};
+});
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -2,6 +2,8 @@ const datasource = require('./datasource');
 
 module.exports = datasource.extend({
 
+  modelName: 'Competence',
+
   tableName: 'Competences',
 
   usedFields: [

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,35 +1,29 @@
 const datasource = require('./datasource');
 
-const tableName = 'Competences';
-
-const usedFields = [
-  'Titre',
-  'Sous-domaine',
-  'Description',
-  'Domaine',
-  'Tests',
-  'Acquis (via Tubes)'
-];
-
-function fromAirTableObject(rawAirtableCompetence) {
-  return {
-    id: rawAirtableCompetence.getId(),
-    name: rawAirtableCompetence.get('Titre'),
-    index: rawAirtableCompetence.get('Sous-domaine'),
-    description: rawAirtableCompetence.get('Description'),
-    areaId: rawAirtableCompetence.get('Domaine') ? rawAirtableCompetence.get('Domaine')[0] : '',
-    courseId: rawAirtableCompetence.get('Tests') ? rawAirtableCompetence.get('Tests')[0] : '',
-    skillIds: rawAirtableCompetence.get('Acquis (via Tubes)') || [],
-  };
-}
-
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Competences',
 
-  usedFields,
+  usedFields: [
+    'Titre',
+    'Sous-domaine',
+    'Description',
+    'Domaine',
+    'Tests',
+    'Acquis (via Tubes)'
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(rawAirtableCompetence) {
+    return {
+      id: rawAirtableCompetence.getId(),
+      name: rawAirtableCompetence.get('Titre'),
+      index: rawAirtableCompetence.get('Sous-domaine'),
+      description: rawAirtableCompetence.get('Description'),
+      areaId: rawAirtableCompetence.get('Domaine') ? rawAirtableCompetence.get('Domaine')[0] : '',
+      courseId: rawAirtableCompetence.get('Tests') ? rawAirtableCompetence.get('Tests')[0] : '',
+      skillIds: rawAirtableCompetence.get('Acquis (via Tubes)') || [],
+    };
+  },
 
 });
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,4 +1,3 @@
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
 
 const tableName = 'Competences';
@@ -32,9 +31,5 @@ module.exports = datasource.extend({
 
   fromAirTableObject,
 
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject);
-  }
 });
 

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -1,4 +1,3 @@
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
 
 const tableName = 'Tests';
@@ -41,8 +40,4 @@ module.exports = datasource.extend({
     return this.list({ filter: (rawCourse) => rawCourse.get('Adaptatif ?') && rawCourse.get('Statut') === 'Publié' });
   },
 
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject);
-  }
 });

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -1,5 +1,5 @@
-const _ = require('lodash');
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
 
 const tableName = 'Tests';
 
@@ -29,7 +29,7 @@ function fromAirTableObject(airtableRecord) {
   };
 }
 
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -38,19 +38,11 @@ module.exports = {
   fromAirTableObject,
 
   getAdaptiveCourses() {
-    return airtable.findRecords(tableName, usedFields)
-      .then((airtableRawObjects) => {
-        return _.filter(airtableRawObjects, {
-          fields: {
-            'Adaptatif ?': true,
-            'Statut': 'Publié',
-          }
-        }).map(fromAirTableObject);
-      });
+    return this.list({ filter: (rawCourse) => rawCourse.get('Adaptatif ?') && rawCourse.get('Statut') === 'Publié' });
   },
 
   get(id) {
     return airtable.getRecord(tableName, id)
       .then(fromAirTableObject);
   }
-};
+});

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -2,6 +2,8 @@ const datasource = require('./datasource');
 
 module.exports = datasource.extend({
 
+  modelName: 'Course',
+
   tableName: 'Tests',
 
   usedFields: [

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -26,12 +26,16 @@ module.exports = datasource.extend({
       adaptive: airtableRecord.get('Adaptatif ?'),
       competences: airtableRecord.get('Competence'),
       challenges: airtableRecord.get('Épreuves'),
+      status: airtableRecord.get('Statut'),
       imageUrl,
     };
   },
 
-  getAdaptiveCourses() {
-    return this.list({ filter: (rawCourse) => rawCourse.get('Adaptatif ?') && rawCourse.get('Statut') === 'Publié' });
+  async findAdaptiveCourses() {
+    const courses = await this.list();
+    return courses.filter((courseData) =>
+      courseData.adaptive &&
+      courseData.status === 'Publié');
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -1,40 +1,34 @@
 const datasource = require('./datasource');
 
-const tableName = 'Tests';
-
-const usedFields = [
-  'Nom',
-  'Description',
-  'Adaptatif ?',
-  'Competence',
-  'Épreuves',
-  'Image',
-];
-
-function fromAirTableObject(airtableRecord) {
-  let imageUrl;
-  if (airtableRecord.get('Image')) {
-    imageUrl = airtableRecord.get('Image')[0].url;
-  }
-
-  return {
-    id: airtableRecord.getId(),
-    name: airtableRecord.get('Nom'),
-    description: airtableRecord.get('Description'),
-    adaptive: airtableRecord.get('Adaptatif ?'),
-    competences: airtableRecord.get('Competence'),
-    challenges: airtableRecord.get('Épreuves'),
-    imageUrl,
-  };
-}
-
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Tests',
 
-  usedFields,
+  usedFields: [
+    'Nom',
+    'Description',
+    'Adaptatif ?',
+    'Competence',
+    'Épreuves',
+    'Image',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableRecord) {
+    let imageUrl;
+    if (airtableRecord.get('Image')) {
+      imageUrl = airtableRecord.get('Image')[0].url;
+    }
+
+    return {
+      id: airtableRecord.getId(),
+      name: airtableRecord.get('Nom'),
+      description: airtableRecord.get('Description'),
+      adaptive: airtableRecord.get('Adaptatif ?'),
+      competences: airtableRecord.get('Competence'),
+      challenges: airtableRecord.get('Épreuves'),
+      imageUrl,
+    };
+  },
 
   getAdaptiveCourses() {
     return this.list({ filter: (rawCourse) => rawCourse.get('Adaptatif ?') && rawCourse.get('Statut') === 'Publié' });

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
 const AirtableResourceNotFound = require('./AirtableResourceNotFound');
+const cache = require('../../caches/cache');
 
 const _DatasourcePrototype = {
 

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
 const AirtableResourceNotFound = require('./AirtableResourceNotFound');
-const cache = require('../../caches/cache');
 
 const _DatasourcePrototype = {
 

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -1,0 +1,24 @@
+const airtable = require('../../airtable');
+
+const datasourcePrototype = {
+
+  airtableFilter() {
+    return true;
+  },
+
+  list({ filter } = {}) {
+    return airtable.findRecords(this.tableName, this.usedFields)
+      .then((airtableRawObjects) => {
+        return airtableRawObjects.filter((record) => this.airtableFilter(record) && (filter ? filter(record) : true)).map(this.fromAirTableObject);
+      });
+  },
+
+};
+
+module.exports = {
+
+  extend(props) {
+    return Object.assign(Object.create(datasourcePrototype), props);
+  },
+
+};

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -1,9 +1,20 @@
+const _ = require('lodash');
 const airtable = require('../../airtable');
+const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
-const datasourcePrototype = {
+const _DatasourcePrototype = {
 
   airtableFilter() {
     return true;
+  },
+
+  get(id) {
+    return airtable.getRecord(this.tableName, id).then(this.fromAirTableObject).catch((err) => {
+      if (err.error === 'NOT_FOUND') {
+        throw new AirtableResourceNotFound();
+      }
+      throw err;
+    });
   },
 
   list({ filter } = {}) {
@@ -18,7 +29,9 @@ const datasourcePrototype = {
 module.exports = {
 
   extend(props) {
-    return Object.assign(Object.create(datasourcePrototype), props);
+    const result = Object.assign({}, _DatasourcePrototype, props);
+    _.bindAll(result, _.functions(result));
+    return result;
   },
 
 };

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -4,10 +4,6 @@ const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const _DatasourcePrototype = {
 
-  airtableFilter() {
-    return true;
-  },
-
   get(id) {
     return airtable.getRecord(this.tableName, id).then(this.fromAirTableObject).catch((err) => {
       if (err.error === 'NOT_FOUND') {
@@ -17,10 +13,10 @@ const _DatasourcePrototype = {
     });
   },
 
-  list({ filter } = {}) {
+  list() {
     return airtable.findRecords(this.tableName, this.usedFields)
       .then((airtableRawObjects) => {
-        return airtableRawObjects.filter((record) => this.airtableFilter(record) && (filter ? filter(record) : true)).map(this.fromAirTableObject);
+        return airtableRawObjects.map(this.fromAirTableObject);
       });
   },
 

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -20,6 +20,10 @@ const _DatasourcePrototype = {
       });
   },
 
+  preload() {
+    return airtable.preload(this.tableName, this.usedFields);
+  },
+
 };
 
 module.exports = {

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
 
 const tableName = 'Acquis';
 
@@ -29,18 +30,7 @@ function fromAirTableObject(airtableSkillObject) {
   };
 }
 
-function _doQuery(filter) {
-  return airtable.findRecords(tableName, usedFields)
-    .then((rawSkills) => {
-      return _(rawSkills)
-        .filter(filter)
-        .filter((rawSkill) => _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS))
-        .map(fromAirTableObject)
-        .value();
-    });
-}
-
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -48,20 +38,21 @@ module.exports = {
 
   fromAirTableObject,
 
+  airtableFilter(rawSkill) {
+    return _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS);
+  },
+
   get(id) {
     return airtable.getRecord(tableName, id)
       .then(fromAirTableObject);
   },
 
   findByRecordIds(skillRecordIds) {
-    return _doQuery((rawSkill) => _.includes(skillRecordIds, rawSkill.id));
+    return this.list({ filter: (rawSkill) => _.includes(skillRecordIds, rawSkill.id) });
   },
 
   findByCompetenceId(competenceId) {
-    return _doQuery((rawSkill) => _.includes(rawSkill.fields['Compétence (via Tube)'], competenceId));
+    return this.list({ filter: (rawSkill) => _.includes(rawSkill.fields['Compétence (via Tube)'], competenceId) });
   },
 
-  list() {
-    return _doQuery({});
-  }
-};
+});

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -34,22 +34,19 @@ module.exports = datasource.extend({
 
   async findActiveSkills() {
     const skills = await this.list();
-    return skills.filter((skillData) =>
-      _.includes(skillData.status, ACTIVATED_STATUS));
+    return _.filter(skills, { status: ACTIVATED_STATUS });
   },
 
-  async findByRecordIds(skillRecordIds) {
+  async findByRecordIds(skillIds) {
     const skills = await this.list();
     return skills.filter((skillData) =>
-      _.includes(skillData.status, ACTIVATED_STATUS) &&
-      _.includes(skillRecordIds, skillData.id));
+      skillData.status === ACTIVATED_STATUS &&
+      _.includes(skillIds, skillData.id));
   },
 
   async findByCompetenceId(competenceId) {
     const skills = await this.list();
-    return skills.filter((skillData) =>
-      _.includes(skillData.status, ACTIVATED_STATUS) &&
-      _.includes(skillData.competenceId, competenceId));
+    return _.filter(skills, { status: ACTIVATED_STATUS, competenceId });
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -5,6 +5,8 @@ const ACTIVATED_STATUS = 'actif';
 
 module.exports = datasource.extend({
 
+  modelName: 'Skill',
+
   tableName: 'Acquis',
 
   usedFields: [
@@ -19,6 +21,12 @@ module.exports = datasource.extend({
   ],
 
   fromAirTableObject(airtableRecord) {
+
+    let competenceId;
+    if (airtableRecord.get('Compétence (via Tube)')) {
+      competenceId = airtableRecord.get('Compétence (via Tube)')[0];
+    }
+
     return {
       id: airtableRecord.getId(),
       name: airtableRecord.get('Nom'),
@@ -27,7 +35,7 @@ module.exports = datasource.extend({
       tutorialIds: airtableRecord.get('Comprendre') || [],
       learningMoreTutorialIds: airtableRecord.get('En savoir plus') || [],
       pixValue: airtableRecord.get('PixValue'),
-      competenceId: airtableRecord.get('Compétence (via Tube)')[0],
+      competenceId,
       status: airtableRecord.get('Status'),
     };
   },

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
 
 const tableName = 'Acquis';
@@ -40,11 +39,6 @@ module.exports = datasource.extend({
 
   airtableFilter(rawSkill) {
     return _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS);
-  },
-
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject);
   },
 
   findByRecordIds(skillRecordIds) {

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,41 +1,35 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const tableName = 'Acquis';
-
-const usedFields = [
-  'Nom',
-  'Indice',
-  'Statut de l\'indice',
-  'Comprendre',
-  'En savoir plus',
-  'PixValue',
-  'Compétence (via Tube)',
-  'Status',
-];
-
 const ACTIVATED_STATUS = ['actif'];
-
-function fromAirTableObject(airtableSkillObject) {
-  return {
-    id: airtableSkillObject.getId(),
-    name: airtableSkillObject.get('Nom'),
-    hint: airtableSkillObject.get('Indice'),
-    hintStatus: airtableSkillObject.get('Statut de l\'indice') || 'no status',
-    tutorialIds: airtableSkillObject.get('Comprendre') || [],
-    learningMoreTutorialIds: airtableSkillObject.get('En savoir plus') || [],
-    pixValue: airtableSkillObject.get('PixValue'),
-    competenceId: airtableSkillObject.get('Compétence (via Tube)')[0],
-  };
-}
 
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Acquis',
 
-  usedFields,
+  usedFields: [
+    'Nom',
+    'Indice',
+    'Statut de l\'indice',
+    'Comprendre',
+    'En savoir plus',
+    'PixValue',
+    'Compétence (via Tube)',
+    'Status',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableSkillObject) {
+    return {
+      id: airtableSkillObject.getId(),
+      name: airtableSkillObject.get('Nom'),
+      hint: airtableSkillObject.get('Indice'),
+      hintStatus: airtableSkillObject.get('Statut de l\'indice') || 'no status',
+      tutorialIds: airtableSkillObject.get('Comprendre') || [],
+      learningMoreTutorialIds: airtableSkillObject.get('En savoir plus') || [],
+      pixValue: airtableSkillObject.get('PixValue'),
+      competenceId: airtableSkillObject.get('Compétence (via Tube)')[0],
+    };
+  },
 
   airtableFilter(rawSkill) {
     return _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS);

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const ACTIVATED_STATUS = ['actif'];
+const ACTIVATED_STATUS = 'actif';
 
 module.exports = datasource.extend({
 
@@ -18,29 +18,38 @@ module.exports = datasource.extend({
     'Status',
   ],
 
-  fromAirTableObject(airtableSkillObject) {
+  fromAirTableObject(airtableRecord) {
     return {
-      id: airtableSkillObject.getId(),
-      name: airtableSkillObject.get('Nom'),
-      hint: airtableSkillObject.get('Indice'),
-      hintStatus: airtableSkillObject.get('Statut de l\'indice') || 'no status',
-      tutorialIds: airtableSkillObject.get('Comprendre') || [],
-      learningMoreTutorialIds: airtableSkillObject.get('En savoir plus') || [],
-      pixValue: airtableSkillObject.get('PixValue'),
-      competenceId: airtableSkillObject.get('Compétence (via Tube)')[0],
+      id: airtableRecord.getId(),
+      name: airtableRecord.get('Nom'),
+      hint: airtableRecord.get('Indice'),
+      hintStatus: airtableRecord.get('Statut de l\'indice') || 'no status',
+      tutorialIds: airtableRecord.get('Comprendre') || [],
+      learningMoreTutorialIds: airtableRecord.get('En savoir plus') || [],
+      pixValue: airtableRecord.get('PixValue'),
+      competenceId: airtableRecord.get('Compétence (via Tube)')[0],
+      status: airtableRecord.get('Status'),
     };
   },
 
-  airtableFilter(rawSkill) {
-    return _.includes(rawSkill.fields['Status'], ACTIVATED_STATUS);
+  async findActiveSkills() {
+    const skills = await this.list();
+    return skills.filter((skillData) =>
+      _.includes(skillData.status, ACTIVATED_STATUS));
   },
 
-  findByRecordIds(skillRecordIds) {
-    return this.list({ filter: (rawSkill) => _.includes(skillRecordIds, rawSkill.id) });
+  async findByRecordIds(skillRecordIds) {
+    const skills = await this.list();
+    return skills.filter((skillData) =>
+      _.includes(skillData.status, ACTIVATED_STATUS) &&
+      _.includes(skillRecordIds, skillData.id));
   },
 
-  findByCompetenceId(competenceId) {
-    return this.list({ filter: (rawSkill) => _.includes(rawSkill.fields['Compétence (via Tube)'], competenceId) });
+  async findByCompetenceId(competenceId) {
+    const skills = await this.list();
+    return skills.filter((skillData) =>
+      _.includes(skillData.status, ACTIVATED_STATUS) &&
+      _.includes(skillData.competenceId, competenceId));
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
 const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Tubes';
@@ -23,17 +24,7 @@ function fromAirTableObject(airtableRecord) {
   };
 }
 
-function _doQuery(filter) {
-  return airtable.findRecords(tableName, usedFields)
-    .then((rawTubes) => {
-      return _(rawTubes)
-        .filter(filter)
-        .map(fromAirTableObject)
-        .value();
-    });
-}
-
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -42,7 +33,7 @@ module.exports = {
   fromAirTableObject,
 
   findByNames(tubeNames) {
-    return _doQuery((rawTube) => _.includes(tubeNames, rawTube.fields['Nom']));
+    return this.list({ filter: (rawTube) => _.includes(tubeNames, rawTube.fields['Nom']) });
   },
 
   get(id) {
@@ -55,8 +46,4 @@ module.exports = {
         throw err;
       });
   },
-
-  list() {
-    return _doQuery({});
-  },
-};
+});

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -3,6 +3,8 @@ const datasource = require('./datasource');
 
 module.exports = datasource.extend({
 
+  modelName: 'Tube',
+
   tableName: 'Tubes',
 
   usedFields: [

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,34 +1,28 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const tableName = 'Tubes';
-
-const usedFields = [
-  'Nom',
-  'Titre',
-  'Description',
-  'Titre pratique',
-  'Description pratique',
-];
-
-function fromAirTableObject(airtableRecord) {
-  return {
-    id: airtableRecord.getId(),
-    name: airtableRecord.get('Nom'),
-    title: airtableRecord.get('Titre'),
-    description: airtableRecord.get('Description'),
-    practicalTitle: airtableRecord.get('Titre pratique'),
-    practicalDescription: airtableRecord.get('Description pratique'),
-  };
-}
-
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Tubes',
 
-  usedFields,
+  usedFields: [
+    'Nom',
+    'Titre',
+    'Description',
+    'Titre pratique',
+    'Description pratique',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableRecord) {
+    return {
+      id: airtableRecord.getId(),
+      name: airtableRecord.get('Nom'),
+      title: airtableRecord.get('Titre'),
+      description: airtableRecord.get('Description'),
+      practicalTitle: airtableRecord.get('Titre pratique'),
+      practicalDescription: airtableRecord.get('Description pratique'),
+    };
+  },
 
   findByNames(tubeNames) {
     return this.list({ filter: (rawTube) => _.includes(tubeNames, rawTube.fields['Nom']) });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -24,8 +24,9 @@ module.exports = datasource.extend({
     };
   },
 
-  findByNames(tubeNames) {
-    return this.list({ filter: (rawTube) => _.includes(tubeNames, rawTube.fields['Nom']) });
+  async findByNames(tubeNames) {
+    const tubes = await this.list();
+    return tubes.filter((tubeData) => _.includes(tubeNames, tubeData.name));
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,7 +1,5 @@
 const _ = require('lodash');
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
-const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Tubes';
 
@@ -36,14 +34,4 @@ module.exports = datasource.extend({
     return this.list({ filter: (rawTube) => _.includes(tubeNames, rawTube.fields['Nom']) });
   },
 
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject)
-      .catch((err) => {
-        if (err.error === 'NOT_FOUND') {
-          throw new AirtableResourceNotFound();
-        }
-        throw err;
-      });
-  },
 });

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -1,34 +1,28 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const tableName = 'Tutoriels';
-
-const usedFields = [
-  'Durée',
-  'Format',
-  'Lien',
-  'Source',
-  'Titre',
-];
-
-function fromAirTableObject(airtableTutorialObject) {
-  return {
-    id: airtableTutorialObject.getId(),
-    duration: airtableTutorialObject.get('Durée'),
-    format: airtableTutorialObject.get('Format'),
-    link: airtableTutorialObject.get('Lien'),
-    source: airtableTutorialObject.get('Source'),
-    title: airtableTutorialObject.get('Titre'),
-  };
-}
-
 module.exports = datasource.extend({
 
-  tableName,
+  tableName: 'Tutoriels',
 
-  usedFields,
+  usedFields: [
+    'Durée',
+    'Format',
+    'Lien',
+    'Source',
+    'Titre',
+  ],
 
-  fromAirTableObject,
+  fromAirTableObject(airtableTutorialObject) {
+    return {
+      id: airtableTutorialObject.getId(),
+      duration: airtableTutorialObject.get('Durée'),
+      format: airtableTutorialObject.get('Format'),
+      link: airtableTutorialObject.get('Lien'),
+      source: airtableTutorialObject.get('Source'),
+      title: airtableTutorialObject.get('Titre'),
+    };
+  },
 
   findByRecordIds(tutorialRecordIds) {
     return this.list({ filter: (rawTutorial) => _.includes(tutorialRecordIds, rawTutorial.id) });

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const airtable = require('../../airtable');
+const datasource = require('./datasource');
 const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Tutoriels';
@@ -23,17 +24,7 @@ function fromAirTableObject(airtableTutorialObject) {
   };
 }
 
-function _doQuery(filter) {
-  return airtable.findRecords(tableName, usedFields)
-    .then((rawTutorials) => {
-      return _(rawTutorials)
-        .filter(filter)
-        .map(fromAirTableObject)
-        .value();
-    });
-}
-
-module.exports = {
+module.exports = datasource.extend({
 
   tableName,
 
@@ -42,7 +33,7 @@ module.exports = {
   fromAirTableObject,
 
   findByRecordIds(tutorialRecordIds) {
-    return _doQuery((rawTutorial) => _.includes(tutorialRecordIds, rawTutorial.id));
+    return this.list({ filter: (rawTutorial) => _.includes(tutorialRecordIds, rawTutorial.id) });
   },
 
   get(id) {
@@ -55,5 +46,5 @@ module.exports = {
         throw err;
       });
   },
-};
+});
 

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -1,7 +1,5 @@
 const _ = require('lodash');
-const airtable = require('../../airtable');
 const datasource = require('./datasource');
-const AirtableResourceNotFound = require('./AirtableResourceNotFound');
 
 const tableName = 'Tutoriels';
 
@@ -36,15 +34,5 @@ module.exports = datasource.extend({
     return this.list({ filter: (rawTutorial) => _.includes(tutorialRecordIds, rawTutorial.id) });
   },
 
-  get(id) {
-    return airtable.getRecord(tableName, id)
-      .then(fromAirTableObject)
-      .catch((err) => {
-        if (err.error === 'NOT_FOUND') {
-          throw new AirtableResourceNotFound();
-        }
-        throw err;
-      });
-  },
 });
 

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -13,19 +13,20 @@ module.exports = datasource.extend({
     'Titre',
   ],
 
-  fromAirTableObject(airtableTutorialObject) {
+  fromAirTableObject(airtableRecord) {
     return {
-      id: airtableTutorialObject.getId(),
-      duration: airtableTutorialObject.get('Durée'),
-      format: airtableTutorialObject.get('Format'),
-      link: airtableTutorialObject.get('Lien'),
-      source: airtableTutorialObject.get('Source'),
-      title: airtableTutorialObject.get('Titre'),
+      id: airtableRecord.getId(),
+      duration: airtableRecord.get('Durée'),
+      format: airtableRecord.get('Format'),
+      link: airtableRecord.get('Lien'),
+      source: airtableRecord.get('Source'),
+      title: airtableRecord.get('Titre'),
     };
   },
 
-  findByRecordIds(tutorialRecordIds) {
-    return this.list({ filter: (rawTutorial) => _.includes(tutorialRecordIds, rawTutorial.id) });
+  async findByRecordIds(tutorialRecordIds) {
+    const tutorials = await this.list();
+    return tutorials.filter((tutorialData) => _.includes(tutorialRecordIds, tutorialData.id));
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -3,6 +3,8 @@ const datasource = require('./datasource');
 
 module.exports = datasource.extend({
 
+  modelName: 'Tutorial',
+
   tableName: 'Tutoriels',
 
   usedFields: [

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -43,7 +43,7 @@ module.exports = {
 };
 
 function _generateChallengeDomainModels(challengeDataObjects) {
-  return skillDatasource.list().then((allSkills) => {
+  return skillDatasource.findActiveSkills().then((allSkills) => {
     const lookupSkill = (id) => _.find(allSkills, { id });
 
     return challengeDataObjects.map((challengeDataObject) => {

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -18,7 +18,7 @@ function _toDomain(courseDataObject) {
 module.exports = {
 
   getAdaptiveCourses() {
-    return courseDatasource.getAdaptiveCourses().then((courseDataObjects) => {
+    return courseDatasource.findAdaptiveCourses().then((courseDataObjects) => {
       return courseDataObjects.map(_toDomain);
     });
   },

--- a/api/tests/integration/infrastructure/airtable_test.js
+++ b/api/tests/integration/infrastructure/airtable_test.js
@@ -95,6 +95,7 @@ describe('Integration | Infrastructure | airtable', () => {
       });
     });
   });
+
   describe('#findRecords{SkipCache}', () => {
 
     const tableName = 'Tests';
@@ -109,7 +110,7 @@ describe('Integration | Infrastructure | airtable', () => {
     }, {
       id: 'recId2',
       fields: {
-        foo:'bar',
+        foo: 'bar',
         titi: 'toto',
         toto: 'titi'
       }
@@ -238,6 +239,47 @@ describe('Integration | Infrastructure | airtable', () => {
         // then
         return expect(promise).to.have.been.rejectedWith(error);
       });
+    });
+  });
+
+  describe('#preload', () => {
+
+    const tableName = 'Tests';
+
+    const airtableRecordsJsonWithSpecificFields = [{
+      id: 'recId1',
+      fields: {
+        field_A: 'Foo_1',
+        field_B: 'Bar_1'
+      }
+    }, {
+      id: 'recId2',
+      fields: {
+        field_A: 'Foo_2',
+        field_B: 'Bar_2'
+      }
+    }];
+
+    beforeEach(() => {
+      airtableBuilder
+        .mockList({ tableName })
+        .respondsToQuery({
+          'fields[]': ['field_A', 'field_B']
+        })
+        .returns(airtableRecordsJsonWithSpecificFields)
+        .activate();
+    });
+
+    it('should load all the table records and cache all Airtable Records (with the list indexed one)', async () => {
+      // given
+      const usedFields = ['field_A', 'field_B'];
+
+      // when
+      const success = await airtable.preload(tableName, usedFields);
+
+      // then
+      expect(success).to.be.true;
+      expect(cache.set).to.have.been.calledThrice;
     });
   });
 

--- a/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
@@ -7,6 +7,7 @@ module.exports = function SkillAirtableDataObjectFixture({
   learningMoreTutorialIds = ['recQbjXNAPsVJthXh', 'rec3DkUX0a6RNi2Hz'],
   competenceId = 'recofJCxg0NqTqTdP',
   pixValue = 2.4,
+  status = 'actif',
 } = {}) {
   return {
     id,
@@ -16,6 +17,7 @@ module.exports = function SkillAirtableDataObjectFixture({
     tutorialIds,
     learningMoreTutorialIds,
     competenceId,
-    pixValue
+    pixValue,
+    status,
   };
 };

--- a/api/tests/unit/infrastructure/caches/preloader_test.js
+++ b/api/tests/unit/infrastructure/caches/preloader_test.js
@@ -1,257 +1,39 @@
+const _ = require('lodash');
 const { expect, sinon } = require('../../../test-helper');
-const AirtableRecord = require('airtable').Record;
-const airtable = require('../../../../lib/infrastructure/airtable');
-const cache = require('../../../../lib/infrastructure/caches/cache');
+const AirtableDatasources = require('../../../../lib/infrastructure/datasources/airtable');
 const preloader = require('../../../../lib/infrastructure/caches/preloader');
+const airtable = require('../../../../lib/infrastructure/airtable');
 
-describe('Unit | Infrastructure | preloader', () => {
-
-  const airtableSkill_1 = new AirtableRecord('Acquis', 'recSkill1', { fields: { 'Nom': '@skill1' } });
-  const airtableSkill_2 = new AirtableRecord('Acquis', 'recSkill2', { fields: { 'Nom': '@skill2' } });
-
-  const airtableArea_1 = new AirtableRecord('Domaines', 'recArea1', {
-    fields: {
-      'Nom': '1. Information et données',
-      'Code': '1',
-      'Titre': 'Information et données'
-    }
-  });
-  const airtableArea_2 = new AirtableRecord('Domaines', 'recArea2', {
-    fields: {
-      'Nom': '2. Communication et collaboration',
-      'Code': '2',
-      'Titre': 'Communication et collaboration'
-    }
-  });
-
-  const airtableCompetence_1 = new AirtableRecord('Competences', 'recCompetence1', {
-    fields: {
-      'Titre': 'Mener une recherche d’information',
-      'Sous-domaine': '1.1',
-      'Tests Record ID': ['recAY0W7x9urA11OLZJJ'],
-      'Acquis': ['@url2', '@url5', '@utiliserserv6'],
-      'Domaine': ['recArea'],
-      'Domaine Code': ['1'],
-      'Domaine Titre': ['Information et données'],
-    }
-  });
-  const airtableCompetence_2 = new AirtableRecord('Competences', 'recCompetence2', {
-    fields: {
-      'Titre': 'Gérer des données',
-      'Sous-domaine': '1.2',
-      'Tests Record ID': ['recAY0W7x9urA11OLZJJ'],
-      'Acquis': ['@url2', '@url5', '@utiliserserv6'],
-      'Domaine': ['recArea'],
-      'Domaine Code': ['1'],
-      'Domaine Titre': ['Information et données'],
-    }
-  });
-
-  const airtableProgressionCourse = new AirtableRecord('Tests', 'recProgressionCourse', {
-    fields: {
-      'Nom': 'Test de positionnement 1.1',
-      'Description': 'A single line of text.',
-      'Adaptatif ?': true,
-      'Competence': ['recCompetence1'],
-      'Image': ['https://dl.airtable.com/foo.jpg'],
-      'Épreuves': ['recChallenge1']
-    }
-  });
-  const airtableAdaptiveCourse = new AirtableRecord('Tests', 'recAdaptiveCourse', {
-    fields: {
-      'Nom': 'Gérer des données 1.2',
-      'Description': 'A single line of text.',
-      'Adaptatif ?': false,
-      'Competence': ['recCompetence2'],
-      'Image': ['https://dl.airtable.com/foo.jpg'],
-      'Épreuves': ['recChallenge2']
-    }
-  });
-  const airtableWeekCourse = new AirtableRecord('Tests', 'recWeekCourse', {
-    fields: {
-      'Nom': 'Création de contenu 1.3',
-      'Description': 'A single line of text.',
-      'Adaptatif ?': false,
-      'Competence': ['recCompetence3'],
-      'Image': ['https://dl.airtable.com/foo.jpg'],
-      'Épreuves': ['recChallenge3']
-    }
-  });
-
-  const airtableChallenge_1 = new AirtableRecord('Epreuves', 'recChallenge1', {
-    fields: {
-      'Consigne': 'Instruction #1',
-      'Propositions': 'Proposal #1',
-      'Statut': 'validé'
-    }
-  });
-  const airtableChallenge_2 = new AirtableRecord('Epreuves', 'recChallenge2', {
-    fields: {
-      'Consigne': 'Instruction #2',
-      'Propositions': 'Proposal #2',
-      'Statut': 'pré-validé'
-    }
-  });
-
-  const airtableTube_1 = new AirtableRecord('Tubes', 'recTube1', {
-    fields: {
-      'id': 'recTube1',
-      'name': '@Moteur',
-      'title': 'Titre',
-      'description': 'Description',
-      'practicalTitle': 'Titre pratique',
-      'practicalDescription': 'Description pratique',
-    }
-  });
-
-  const airtableTube_2 = new AirtableRecord('Tubes', 'recTube2', {
-    fields: {
-      'id': 'recTube2',
-      'name': '@enregistrer',
-      'title': 'Titre',
-      'description': 'Description',
-      'practicalTitle': 'Titre pratique',
-      'practicalDescription': 'Description pratique',
-    }
-  });
-
-  const airtableTutorial = new AirtableRecord('Tutoriels', 'recTutorial', {
-    fields: {
-      'Titre': 'Les formats de cellule',
-      'Format': 'page',
-      'Durée': '00:02:00',
-      'Source': '2i2l',
-      'Lien': 'http://www.2i2l.fr/spip.php?article137',
-    }
-  });
-
-  beforeEach(() => {
-    sinon.stub(airtable, 'findRecordsSkipCache');
-    sinon.stub(airtable, 'getRecordSkipCache');
-    sinon.stub(cache, 'set').resolves();
-  });
-
-  afterEach(() => {
-    airtable.findRecordsSkipCache.restore();
-    airtable.getRecordSkipCache.restore();
-    cache.set.restore();
-  });
+describe('Unit | Infrastructure | Caches | preloader', () => {
 
   describe('#loadAllTables', () => {
-    let promise = null;
 
-    beforeEach(() => {
+    it('should preload all Airtable data sources', async () => {
       // given
-      airtable.findRecordsSkipCache
-        .withArgs('Acquis')
-        .resolves([ airtableSkill_1, airtableSkill_2 ]);
+      _.map(AirtableDatasources, (datasource) => sinon.stub(datasource, 'preload'));
 
-      airtable.findRecordsSkipCache
-        .withArgs('Domaines')
-        .resolves([ airtableArea_1, airtableArea_2 ]);
+      // when
+      await preloader.loadAllTables();
 
-      airtable.findRecordsSkipCache
-        .withArgs('Epreuves')
-        .resolves([ airtableChallenge_1, airtableChallenge_2 ]);
-
-      airtable.findRecordsSkipCache
-        .withArgs('Competences')
-        .resolves([ airtableCompetence_1, airtableCompetence_2 ]);
-
-      airtable.findRecordsSkipCache
-        .withArgs('Tests')
-        .resolves([ airtableProgressionCourse, airtableAdaptiveCourse, airtableWeekCourse ]);
-
-      airtable.findRecordsSkipCache
-        .withArgs('Tubes')
-        .resolves([ airtableTube_1, airtableTube_2 ]);
-
-      airtable.findRecordsSkipCache
-        .withArgs('Tutoriels')
-        .resolves([ airtableTutorial ]);
-
-      promise = preloader.loadAllTables();
-    });
-
-    it('should fetch skills and cache them individually', () => {
       // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Acquis_recSkill1', airtableSkill_1._rawJson);
-          expect(cache.set).to.have.been.calledWith('Acquis_recSkill2', airtableSkill_2._rawJson);
-        });
-    });
-
-    it('should fetch all areas and cache them individually', () => {
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Domaines_recArea1', airtableArea_1._rawJson);
-          expect(cache.set).to.have.been.calledWith('Domaines_recArea2', airtableArea_2._rawJson);
-        });
-    });
-
-    it('should fetch all challenges and cache them individually', () => {
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Epreuves_recChallenge1', airtableChallenge_1._rawJson);
-          expect(cache.set).to.have.been.calledWith('Epreuves_recChallenge2', airtableChallenge_2._rawJson);
-        });
-    });
-
-    it('should fetch all competences and cache them individually', () => {
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Competences_recCompetence1', airtableCompetence_1._rawJson);
-          expect(cache.set).to.have.been.calledWith('Competences_recCompetence2', airtableCompetence_2._rawJson);
-        });
-    });
-
-    it('should fetch courses and cache them individually', () => {
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Tests_recProgressionCourse', airtableProgressionCourse._rawJson);
-          expect(cache.set).to.have.been.calledWith('Tests_recAdaptiveCourse', airtableAdaptiveCourse._rawJson);
-          expect(cache.set).to.have.been.calledWith('Tests_recWeekCourse', airtableWeekCourse._rawJson);
-        });
-    });
-
-    it('should fetch tutorials and cache them individually', () => {
-      // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.set).to.have.been.calledWith('Tutoriels_recTutorial', airtableTutorial._rawJson);
-        });
+      _.map(AirtableDatasources, (datasource) => expect(datasource.preload).to.have.been.calledOnce);
     });
   });
 
   describe('#load', () => {
-    let promise = null;
 
-    context('When the key is a record',() => {
-      beforeEach(() => {
-        // given
-        airtable.getRecordSkipCache
-          .withArgs('Epreuves', 'recChallenge1')
-          .resolves(airtableChallenge_1);
+    it('should load given Airtable record', async () => {
+      // given
+      const tableName = 'Table';
+      const recordId = 'recXYZ';
+      const options = { tableName, recordId };
+      sinon.stub(airtable, 'getRecordSkipCache').withArgs(tableName, recordId).resolves(true);
 
-        return promise = preloader.load({ tableName: 'Epreuves', recordId: 'recChallenge1' });
-      });
+      // when
+      const success = await preloader.load(options);
 
-      it('For record "Epreuves_recChallenge1", should fetch only the challenge', () => {
-        // then
-        return promise
-          .then(() => {
-            expect(airtable.getRecordSkipCache).to.have.been.calledWith('Epreuves', 'recChallenge1');
-            expect(airtable.getRecordSkipCache).to.not.have.been.calledWith('Epreuves', 'recChallenge2');
-          });
-      });
-
+      // then
+      expect(success).to.be.true;
     });
-
   });
-
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
@@ -26,7 +26,8 @@ describe('Unit | Infrastructure | Datasource | Airtable | AreaDatasource', () =>
       sinon.stub(airtable, 'findRecords').resolves([areaRawAirTableFixture()]);
 
       // when
-      const promise = areaDatasource.list();
+      const unboundMethod = areaDatasource.list;
+      const promise = unboundMethod();
 
       // then
       return promise.then((areas) => {

--- a/api/tests/unit/infrastructure/datasources/airtable/course-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/course-datasource_test.js
@@ -19,6 +19,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
             'recChallenge1',
             'recChallenge2',
           ],
+          'Statut': 'Publié',
           'Competence': ['recCompetence123'],
           'Image': [
             {
@@ -36,6 +37,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
         id: 'recCourse123',
         name: 'course-name',
         adaptive: false,
+        status: 'Publié',
 
         competences: ['recCompetence123'],
         description: 'course-description',
@@ -48,7 +50,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
     });
   });
 
-  describe('#getAdaptiveCourses', () => {
+  describe('#findAdaptiveCourses', () => {
 
     it('should call airtable on Tests table, filter and return Course dataObjects', () => {
       // given
@@ -59,7 +61,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
       ]);
 
       // when
-      const promise = courseDatasource.getAdaptiveCourses();
+      const promise = courseDatasource.findAdaptiveCourses();
 
       // then
       return promise.then((courses) => {

--- a/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
@@ -100,4 +100,19 @@ describe('Unit | Infrastructure | Datasource | Airtable | datasource', () => {
       expect(record).to.deep.equal([{ record: { tableName: 'Airtable_table', usedFields: ['Shi', 'Foo', 'Bar'] } }]);
     });
   });
+
+  describe('#preload', () => {
+
+    it('should load all the Airtable table content in the cache (and return them)', async () => {
+      // given
+      sinon.stub(airtable, 'preload').withArgs(someDatasource.tableName, someDatasource.usedFields).resolves(true);
+
+      // when
+      const success = await someDatasource.preload();
+
+      // then
+      expect(success).to.be.true;
+    });
+  });
+
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
@@ -1,0 +1,103 @@
+const { expect, sinon } = require('../../../../test-helper');
+const dataSource = require('../../../../../lib/infrastructure/datasources/airtable/datasource');
+const airtable = require('../../../../../lib/infrastructure/airtable');
+const AirtableResourceNotFound = require('../../../../../lib/infrastructure/datasources/airtable/AirtableResourceNotFound');
+
+describe('Unit | Infrastructure | Datasource | Airtable | datasource', () => {
+
+  const someDatasource = dataSource.extend({
+    tableName: 'Airtable_table',
+
+    usedFields: ['Shi', 'Foo', 'Bar'],
+
+    fromAirTableObject: (record) => ({ record }),
+  });
+
+  describe('#get', () => {
+
+    context('(success cases)', () => {
+
+      beforeEach(() => {
+        sinon.stub(airtable, 'getRecord').callsFake(async (tableName, id) => {
+          return { tableName, id };
+        });
+      });
+
+      it('should fetch a single record from Airtable (or its cached copy)', async () => {
+        // when
+        const record = await someDatasource.get('some-record-id');
+
+        // then
+        expect(record).to.deep.equal({ record: { tableName: 'Airtable_table', id: 'some-record-id' } });
+      });
+
+      it('should correctly manage the `this` context', async () => {
+        // given
+        const unboundGet = someDatasource.get;
+
+        // when
+        const record = await unboundGet('some-record-id');
+
+        // then
+        expect(record).to.deep.equal({ record: { tableName: 'Airtable_table', id: 'some-record-id' } });
+      });
+
+    });
+
+    context('(error cases)', () => {
+
+      it('should throw an AirtableResourceNotFound if record was not found', () => {
+        // given
+        const err = new Error();
+        err.error = 'NOT_FOUND';
+        sinon.stub(airtable, 'getRecord').rejects(err);
+
+        // when
+        const promise = someDatasource.get('some-record-id');
+
+        // then
+        return expect(promise).to.have.been.rejectedWith(AirtableResourceNotFound);
+      });
+
+      it('should dispatch error in case of generic error', () => {
+        // given
+        const err = new Error();
+        sinon.stub(airtable, 'getRecord').rejects(err);
+
+        // when
+        const promise = someDatasource.get('some-record-id');
+
+        // then
+        return expect(promise).to.have.been.rejectedWith(err);
+      });
+    });
+  });
+
+  describe('#list', () => {
+
+    beforeEach(() => {
+      sinon.stub(airtable, 'findRecords').callsFake(async (tableName, usedFields) => {
+        return [{ tableName, usedFields }];
+      });
+    });
+
+    it('should fetch all the records of a given type (table) from Airtable (or its cached copy)', async () => {
+      // when
+      const record = await someDatasource.list();
+
+      // then
+      expect(record).to.deep.equal([{ record: { tableName: 'Airtable_table', usedFields: ['Shi', 'Foo', 'Bar'] } }]);
+    });
+
+    it('should correctly manage the `this` context', async () => {
+      // given
+      const unboundList = someDatasource.list;
+
+      // when
+      const record = await unboundList();
+
+      // then
+      expect(record).to.deep.equal([{ record: { tableName: 'Airtable_table', usedFields: ['Shi', 'Foo', 'Bar'] } }]);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -84,14 +84,14 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
     });
   });
 
-  describe('#list', () => {
+  describe('#findActiveSkills', () => {
 
     it('should query Airtable skills with empty query', () => {
       // given
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([]));
 
       // when
-      const promise = skillDatasource.list();
+      const promise = skillDatasource.findActiveSkills();
 
       // then
       return promise.then(() => {
@@ -107,7 +107,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2]));
 
       // when
-      const promise = skillDatasource.list();
+      const promise = skillDatasource.findActiveSkills();
 
       // then
       return promise.then((foundSkills) => {
@@ -125,7 +125,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2, rawSkill3]));
 
       // when
-      const promise = skillDatasource.list();
+      const promise = skillDatasource.findActiveSkills();
 
       // then
       return promise.then((foundSkills) => {

--- a/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tutorial-datasource_test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { expect, sinon } = require('../../../../test-helper');
 const airtable = require('../../../../../lib/infrastructure/airtable');
 const tutorialDatasource = require('../../../../../lib/infrastructure/datasources/airtable/tutorial-datasource');
@@ -5,7 +6,6 @@ const tutorialAirtableDataObjectFixture = require('../../../../tooling/fixtures/
 const tutorialRawAirTableFixture = require('../../../../tooling/fixtures/infrastructure/tutorialRawAirtableFixture');
 const { Record: AirtableRecord, Error: AirtableError } = require('airtable');
 const AirtableResourceNotFound = require('../../../../../lib/infrastructure/datasources/airtable/AirtableResourceNotFound');
-const _ = require('lodash');
 
 function makeAirtableFake(records) {
   return async (tableName, fieldList) => {

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -195,8 +195,8 @@ describe('Unit | Repository | challenge-repository', () => {
       });
       skills = [skillWeb1, skillURL2, skillURL3];
       sinon.stub(skillDatasource, 'get');
-      sinon.stub(skillDatasource, 'list');
-      skillDatasource.list.resolves(skills);
+      sinon.stub(skillDatasource, 'findActiveSkills');
+      skillDatasource.findActiveSkills.resolves(skills);
     });
 
     describe('#list', () => {

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -44,7 +44,7 @@ describe('Unit | Repository | course-repository', function() {
   describe('#getAdaptiveCourses', () => {
 
     beforeEach(() => {
-      sinon.stub(courseDatasource, 'getAdaptiveCourses')
+      sinon.stub(courseDatasource, 'findAdaptiveCourses')
         .resolves([{
           id: 'recTestAdaptative',
           name: 'adaptive-course-name',

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -7,7 +7,7 @@ describe('Unit | Repository | skill-repository', function() {
 
   beforeEach(() => {
     sinon.stub(skillDatasource, 'findByCompetenceId');
-    sinon.stub(skillDatasource, 'list');
+    sinon.stub(skillDatasource, 'findActiveSkills');
   });
 
   describe('#findByCompetenceId', function() {


### PR DESCRIPTION
## :unicorn: Problème
On exécute beaucoup trop de traitements de conversions à chaque requête client. Ce phénomène consomme trop de RAM + CPU + entrées I/O + temps. Ce qui dégrade ou limite les perfs du système et sa capacité à encaisser de la charge.

## :robot: Solution

L'objet de cette PR est de préparer la mise en oeuvre d'un nouveau cache applicatif, toujours basé sur Redis (donc avec des valeurs stockées sous forme de String), mais au niveau des Datasources plutôt que de Airtable, dont l'objectif sera de réduire la quantité de ressources nécessaires pour l'éxécution des requêtes client.

Changements contenus dans cette PR:

- Mutualiser la logique d'appel (pour des besoins de type `get(id)` ou `list`) au module `infrastructure/airtable.js` pour toutes les Datasources dans un module de type pseudo-classe-mère (l'équivalent d'une _classe abstraite_ en langage objet) `infrastructure/datasources/airtable/datasource.js`
- Faire étendre toutes les Datasources de cette classe `datasource`
- Faire en sorte que toutes les Datasources suivent le même pattern, aient exactement la même tête (style et nom de variables internes aux méthodes comprises)
- Revoir la façon de filtrer les objets référentiels désirés (au niveau du Datasource plutôt que de la requête à Airtable)
- Modifier les classes intervenant dans le processus de `preload` du cache en le répartissant mieux entre le Preloader global (boucle sur toutes les datasoures), le prototype de Datasource (requête correctement Airtable) et le gestionnaire Airtable (gère le réseau et la mise en cache des réponses).
- Au passage, petit renommage d'une méthode `getXxxRecords` en `findXxxRecords` pour être consistant

## :rainbow: Remarques
- Normalement, chaque commit est unitaire, vert et porte une seule intention
- Par rapport à nos perormances actuelles, cette PR dégrade très très légèrement les perfs, du fait de l'inversion du filtre, auparavant au niveau du réseau et de l'appel Airtable, désormais au niveau de la Datasource. D'après nos scénarios Artillery, la dégradation est de l'ordre de 2% de temps de réponse.
- Ce n'est pas très grave, d'autant plus que la PR de mise en cache au niveau de la Datasource devrait venir très rapidement dans la foulée. 
- On peut donc merger en prod cette PR si nécessaire.
