### PR TITLE
[TECH] Ne pas faire les appels vers matomo dans les tests E2E.

### DIFF
--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:4200",
   "env": {
     "API_URL": "http://localhost:3000"
-  }
+  },
+  "blacklistHosts": "*stats.pix.fr*"
 }


### PR DESCRIPTION
## :unicorn: Problème
- Durant les tests E2E, on attendait des réponses de stats.pix.fr, qui ne répondais pas ou lentement, et qui faisait planter les tests

## :robot: Solution
Blacklister stats.pix.fr
