### PR TITLE
[BUGFIX] Ne pas prendre en compte les espaces et retour à la ligne inutile (PF-953).

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -53,7 +53,7 @@ export default Route.extend({
     async saveAnswerAndNavigate(challenge, assessment, answerValue, answerTimeout, answerElapsedTime) {
       const answer = this._findOrCreateAnswer(challenge, assessment);
       answer.setProperties({
-        value: answerValue,
+        value: answerValue.trim(),
         timeout: answerTimeout,
         elapsedTime: answerElapsedTime
       });

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -79,7 +79,7 @@ describe('Unit | Route | Assessments | Challenge', function() {
   describe('#saveAnswerAndNavigate', function() {
     let answerToChallengeOne;
 
-    const answerValue = '';
+    let answerValue = 'example';
     const answerTimeout = 120;
     const answerElapsedTime = 65;
     const challengeOne = EmberObject.create({ id: 'recChallengeOne' });
@@ -139,6 +139,27 @@ describe('Unit | Route | Assessments | Challenge', function() {
       sinon.assert.calledOnce(answerToChallengeOne.save);
       sinon.assert.calledWith(answerToChallengeOne.setProperties, {
         value: answerValue,
+        timeout: answerTimeout,
+        elapsedTime: answerElapsedTime
+      });
+    });
+
+    it('should trim the answer value to avoid useless char', function() {
+      // given
+      answerValue = '  exemple \n ';
+      const answerValueWithoutUselessChar = 'exemple';
+      const assessment = EmberObject.create({ answers: [answerToChallengeOne] });
+      createRecordStub.returns(answerToChallengeOne);
+      queryRecordStub.resolves(nextChallenge);
+
+      // when
+      route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout, answerElapsedTime);
+
+      // then
+      sinon.assert.callOrder(answerToChallengeOne.setProperties, answerToChallengeOne.save);
+      sinon.assert.calledOnce(answerToChallengeOne.save);
+      sinon.assert.calledWith(answerToChallengeOne.setProperties, {
+        value: answerValueWithoutUselessChar,
         timeout: answerTimeout,
         elapsedTime: answerElapsedTime
       });


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves de copier/coller, quand on utiliser le text-area, des personnes peuvent ajouter sans faire exprès (via un glissement, en appuyant sur entrée, etc..) des retours à la ligne et des espaces sur la fin de la solution.

## :robot: Solution
- Trim la réponse avant de l'envoyer au back.

## :rainbow: Remarques
- A faire peut être dans le deserializer coté back, ou dans le Examiner qui corrige les answers, vous en pensez quoi ?
