### PR TITLE
[FEATURE] Ajout des colonnes 'externalId' et 'type' dans la table 'certification-centers'. (PF-944)

### DIFF
--- a/api/db/migrations/20191202152127_add_column_externalId_to_certification_centers.js
+++ b/api/db/migrations/20191202152127_add_column_externalId_to_certification_centers.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'externalId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20191202152240_add_column_type_to_certification_centers.js
+++ b/api/db/migrations/20191202152240_add_column_type_to_certification_centers.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'type';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.enu(COLUMN_NAME, ['SCO', 'SUP', 'PRO']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certification ne sont pas typés et ne possèdent pas d'identifiants externe.

## :robot: Solution
Créer des scripts de migration afin d'ajouter les colonnes 'externalId' et 'type' dans la table 'certification-centers'.

## :rainbow: Remarques
Afin de limiter les impacts pour les centres de certifications existants déjà en production, la colonne 'type' n'est pas obligatoire pour le moment. Elle sera rendue obligatoire dans le futur.
