### PR TITLE
[A11Y] Mettre des titres sur chaque page (PF-655).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/page-title.feature
@@ -1,0 +1,19 @@
+Feature: Titre des pages
+
+  Scenario: j'accède à la page de connexion
+    When je vais sur la page de connexion
+    Then je vois le titre de la page "Connexion | Pix"
+
+  Scenario: j'accède à la page profil
+    Given tous les comptes sont créés
+    And je vais sur Pix
+    And je suis connecté à Pix en tant que "Daenerys Targaryen"
+    When j'accède à mon profil
+    Then je vois le titre de la page "Votre Profil | Pix"
+
+  Scenario: j'accède à la page compétence
+    Given tous les comptes sont créés
+    And je vais sur Pix
+    And je suis connecté à Pix en tant que "Daenerys Targaryen"
+    When je vais sur la compétence "1_recsvLz0W2ShyfD63"
+    Then je vois le titre de la page "Compétence | Mener une recherche et une veille d’information | Pix"

--- a/high-level-tests/e2e/cypress/support/step_definitions/page-title.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/page-title.js
@@ -1,0 +1,11 @@
+when('je vais sur la page de connexion', () => {
+  cy.visitMonPix('/connexion');
+});
+
+when(`je vais sur la compétence {string}`, (challengeCode) => {
+  cy.visitMonPix(`/competences/${challengeCode}`);
+});
+
+then(`je vois le titre de la page {string}`, (pageTitle) => {
+  cy.title().should('equal', pageTitle);
+});

--- a/mon-pix/app/components/head-content.js
+++ b/mon-pix/app/components/head-content.js
@@ -4,12 +4,12 @@ import { inject as service } from '@ember/service';
 import DS from 'ember-data';
 
 const PAGE_TITLE_MAP = {
-  'assessments.challenge': 'Evaluation en cours',
-  'assessments.checkpoint': 'Avancement du parcours',
+  'assessments.challenge': 'Évaluation en cours',
+  'assessments.checkpoint': 'Avancement de l\'évaluation',
   'assessments.checkpoint.final': 'Fin de votre évaluation',
   'campaigns.campaign-landing-page': 'Présentation | Parcours',
-  'campaigns.fill-in-campaign-code': 'Commencer un parcours',
-  'campaigns.skill-review': 'Résultat de votre parcours',
+  'campaigns.fill-in-campaign-code': 'Commencer | Parcours',
+  'campaigns.skill-review': 'Résultats | Parcours',
   'campaigns.tutorial': 'Didacticiel | Parcours',
   'certifications.start': 'Rejoindre une certification',
   'competence-details': 'Compétence',
@@ -17,7 +17,7 @@ const PAGE_TITLE_MAP = {
   'inscription': 'Inscription',
   'login': 'Connexion',
   'password-reset-demand': 'Oubli de mot de passe',
-  'not-connected': 'Vous n\'êtes plus connecté',
+  'not-connected': 'Déconnecté',
   'profile': 'Votre Profil',
   'reset-password': 'Changer mon mot de passe',
   'user-certifications.index': 'Mes certifications',

--- a/mon-pix/app/components/head-content.js
+++ b/mon-pix/app/components/head-content.js
@@ -1,0 +1,95 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import DS from 'ember-data';
+
+const PAGE_TITLE_MAP = {
+  'assessments.challenge': 'Evaluation en cours',
+  'assessments.checkpoint': 'Avancement du parcours',
+  'assessments.checkpoint.final': 'Fin de votre évaluation',
+  'campaigns.campaign-landing-page': 'Présentation | Parcours',
+  'campaigns.fill-in-campaign-code': 'Commencer un parcours',
+  'campaigns.skill-review': 'Résultat de votre parcours',
+  'campaigns.tutorial': 'Didacticiel | Parcours',
+  'certifications.start': 'Rejoindre une certification',
+  'competence-details': 'Compétence',
+  'competences.results': 'Résultat de votre compétence',
+  'inscription': 'Inscription',
+  'login': 'Connexion',
+  'password-reset-demand': 'Oubli de mot de passe',
+  'not-connected': 'Vous n\'êtes plus connecté',
+  'profile': 'Votre Profil',
+  'reset-password': 'Changer mon mot de passe',
+  'user-certifications.index': 'Mes certifications',
+};
+
+const CUSTOM_PAGES = [
+  'assessments.challenge',
+  'assessments.checkpoint',
+  'competence-details',
+  'competences.results',
+];
+
+const PAGE_TITLE_SUFFIX = ' | Pix';
+const DEFAULT_PAGE_TITLE = 'Pix – Mesurez, développez et valorisez vos compétences numériques';
+
+export default Component.extend({
+  router: service(),
+  store: service(),
+
+  pageTitle: computed('router.currentRouteName', function() {
+    return DS.PromiseObject.create({
+      promise: this._buildPageTitleName()
+    });
+  }),
+
+  async _buildPageTitleName() {
+    const routeName = this.router.currentRouteName;
+    if (CUSTOM_PAGES.includes(routeName)
+      && this.router.currentRoute.queryParams.finalCheckpoint) {
+      return PAGE_TITLE_MAP['assessments.checkpoint.final']
+        + await this._computeNameToAppend('assessments.checkpoint.final')
+        + PAGE_TITLE_SUFFIX;
+    }
+    else if (CUSTOM_PAGES.includes(routeName)) {
+      return PAGE_TITLE_MAP[routeName]
+        + await this._computeNameToAppend(routeName)
+        + PAGE_TITLE_SUFFIX;
+    }
+    else if (PAGE_TITLE_MAP[routeName] != null) {
+      return PAGE_TITLE_MAP[routeName]
+        + PAGE_TITLE_SUFFIX;
+    }
+    return DEFAULT_PAGE_TITLE;
+  },
+
+  async _computeNameToAppend(page) {
+    let nameToAppend = '';
+    switch (page) {
+      case 'competence-details': {
+        const scorecard = await this.store.findRecord('scorecard', this.router.currentRoute.params.scorecard_id);
+        if (scorecard) {
+          nameToAppend = ' | ' + scorecard.get('name');
+        }
+        break;
+      }
+      case 'assessments.challenge':
+      case 'assessments.checkpoint.final': {
+        const checkpointAssessment = await this.store.findRecord('assessment', this.router.currentRoute.parent.params.assessment_id);
+        if (checkpointAssessment) {
+          nameToAppend = ' | ' + checkpointAssessment.get('title');
+        }
+        break;
+      }
+      case 'competences.results': {
+        const resultAssessment = await this.store.findRecord('assessment', this.router.currentRoute.params.assessment_id);
+        if (resultAssessment) {
+          nameToAppend = ' | ' + resultAssessment.get('title');
+        }
+        break;
+      }
+    }
+    return nameToAppend;
+  }
+
+});

--- a/mon-pix/app/index.html
+++ b/mon-pix/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Pix – Mesurez, développez et valorisez vos compétences numériques</title>
     <meta name="description" content="Pix est une plateforme en ligne d'évaluation et de certification des compétences numériques des citoyens francophones (élèves, étudiant•e•s, décrocheur•se•s, demandeur•se•s d'emploi, sénior•e•s).">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/mon-pix/app/templates/components/head-content.hbs
+++ b/mon-pix/app/templates/components/head-content.hbs
@@ -1,0 +1,1 @@
+<title>{{pageTitle.content}}</title>

--- a/mon-pix/app/templates/head.hbs
+++ b/mon-pix/app/templates/head.hbs
@@ -1,6 +1,0 @@
-{{!--
-Add content you wish automatically added to the documents head
-here. The 'model' available in this template can be populated by
-setting values on the 'head-data' service.
---}}
-<title>{{model.title}}</title>

--- a/mon-pix/app/templates/inscription.hbs
+++ b/mon-pix/app/templates/inscription.hbs
@@ -1,4 +1,3 @@
-{{title "Inscription | Pix"}}
 <div class="sign-form-page">
   {{signup-form user=model refresh="refresh" authenticateUser=(route-action "authenticateUser")}}
 </div>

--- a/mon-pix/app/templates/login.hbs
+++ b/mon-pix/app/templates/login.hbs
@@ -1,4 +1,3 @@
-{{title "Connexion | Pix"}}
 <div class="sign-form-page">
   {{signin-form authenticateUser=(route-action 'authenticate')}}
 </div>

--- a/mon-pix/tests/unit/components/head-content-test.js
+++ b/mon-pix/tests/unit/components/head-content-test.js
@@ -1,0 +1,100 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import EmberObject from '@ember/object';
+import { begin, end } from '@ember/runloop';
+import Service from '@ember/service';
+
+describe('Unit | Component | head-content', function() {
+  setupTest();
+
+  describe('When page title is static', () => {
+    [
+      { route: 'assessments.checkpoint', expectedTitle: 'Avancement de l\'évaluation | Pix', routeParams: { queryParams: {}, params: { assessment_id: 'assessmentId' } } },
+      { route: 'campaigns.campaign-landing-page', expectedTitle: 'Présentation | Parcours | Pix', currentRoute: { params: { campaign_code: 'campaignCode' } } },
+      { route: 'campaigns.fill-in-campaign-code', expectedTitle: 'Commencer | Parcours | Pix', routeParams: {} },
+      { route: 'campaigns.tutorial', expectedTitle: 'Didacticiel | Parcours | Pix', routeParams: { params: { campaign_code: 'campaignCode' } } },
+      { route: 'certifications.start', expectedTitle: 'Rejoindre une certification | Pix', routeParams: {} },
+      { route: 'login', expectedTitle: 'Connexion | Pix', routeParams: {} },
+      { route: 'inscription', expectedTitle: 'Inscription | Pix', routeParams: {} },
+      { route: 'not-connected', expectedTitle: 'Déconnecté | Pix', routeParams: {} },
+      { route: 'password-reset-demand', expectedTitle: 'Oubli de mot de passe | Pix', routeParams: {} },
+      { route: 'profile', expectedTitle: 'Votre Profil | Pix', routeParams: {} },
+      { route: 'reset-password', expectedTitle: 'Changer mon mot de passe | Pix', routeParams: { params: { temporary_key: 'temporaryKey' } } },
+      { route: 'user-certifications.index', expectedTitle: 'Mes certifications | Pix', routeParams: {} },
+    ].forEach((usecase) => {
+      it(`should display title ${usecase.expectedTitle} for route ${usecase.route}`, async function() {
+        // given
+        const routerStub = Service.extend({ currentRouteName: usecase.route, currentRoute: usecase.routeParams });
+
+        // when
+        this.owner.register('service:router', routerStub);
+        const component = this.owner.lookup('component:head-content');
+
+        // then
+        begin();
+        const title = await component.get('pageTitle');
+        expect(title).to.equal(usecase.expectedTitle);
+        end();
+      });
+    });
+  });
+
+  describe('When page title is dynamic', () => {
+
+    it('should display title "Compétence | Partager et publier | Pix" for route "competence-details"', async function() {
+      // given
+      const findRecordStub = sinon.stub();
+      const storeStub = Service.create({
+        findRecord: findRecordStub
+      });
+      const scorecardName = 'Partager et publier';
+      const routeName = 'competence-details';
+      const expectedPageTitle = `Compétence | ${scorecardName} | Pix`;
+      const routerStub = Service.extend({ currentRouteName: routeName, currentRoute: { queryParams: {}, params: { scorecard_id: 'scorecard_id' } } });
+      findRecordStub.resolves(EmberObject.create({
+        name: scorecardName
+      }));
+
+      // when
+      this.owner.register('service:router', routerStub);
+      const component = this.owner.lookup('component:head-content');
+      component.set('store', storeStub);
+
+      // then
+      begin();
+      const title = await component.get('pageTitle');
+      expect(title).to.equal(expectedPageTitle);
+      end();
+    });
+
+    it('should display title "Résultat de votre compétence | Partager et publier | Pix" for route "competence-details"', async function() {
+      // given
+      const findRecordStub = sinon.stub();
+      const storeStub = Service.create({
+        findRecord: findRecordStub
+      });
+      const assessmentName = 'Partager et publier';
+      const routeName = 'competences.results';
+      const expectedPageTitle = `Résultat de votre compétence | ${assessmentName} | Pix`;
+      const routerStub = Service.extend({ currentRouteName: routeName, currentRoute: { queryParams: {}, params: { scorecard_id: 'scorecard_id' } } });
+      findRecordStub.resolves(EmberObject.create({
+        title: assessmentName
+      }));
+
+      // when
+      this.owner.register('service:router', routerStub);
+      const component = this.owner.lookup('component:head-content');
+      component.set('store', storeStub);
+
+      // then
+      begin();
+      const title = await component.get('pageTitle');
+      expect(title).to.equal(expectedPageTitle);
+      end();
+    });
+
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
La plupart des pages utilisent le même titre défini dans `index.html`. Il n'est dont pas possible pour l'utilisateur de distinguer sur quelle page du site il se trouve.

## :robot: Solution
Grâce au plugin `ember-page-title`, le contenu du fichier `head*.hbs` est injecté de façon dynamique à chaque changement de page.

## :rainbow: Remarques
Il n'y a pas de tests d'acceptance car Testem change les titres de chaque page pour mettre une valeur incrémentale représentant l'avancée des tests.
Du coup j'ai fait quelques tests cypress. Si vous avez des solutions pour pouvoir remettre les tests d'acceptance sur ces titres de pages, je suis preneuse =)
