### PR TITLE
[BUGFIX] Corrige le message de profil non certifiable en cas de coupure réseau (PF-962)

### DIFF
--- a/mon-pix/app/styles/globals/_loading.scss
+++ b/mon-pix/app/styles/globals/_loading.scss
@@ -1,4 +1,4 @@
-.app-loader {
+.app-loader, .app-nested-loader {
   position: absolute;
   top: 0;
   left: 0;
@@ -15,4 +15,9 @@
   font-size: 26px;
   padding: 20px;
   text-align: center;
+}
+
+.app-nested-loader {
+  position: relative;
+  padding: 40px;
 }

--- a/mon-pix/app/templates/certifications/start-loading.hbs
+++ b/mon-pix/app/templates/certifications/start-loading.hbs
@@ -2,10 +2,14 @@
   {{#burger.outlet}}
 
     {{navbar-header class="navbar-header--white" burger=burger}}
-
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
-        {{certification-not-certifiable}}
+
+      <div class="app-nested-loader rounded-panel--over-background-banner rounded-panel rounded-panel--strong">
+        <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+        <p class="app-loader__text">Chargement en cours…</p>
+      </div>
+
     </div>
 
   {{/burger.outlet}}


### PR DESCRIPTION
## :unicorn: Problème

En cas de coupure réseau, l'onglet certifications affichait le message "Votre profil n'est pas encore certifiable" même pour les utilisateurs dont le profil est certifiable.

<img width="1149" alt="Capture d’écran 2019-12-03 à 17 39 53" src="https://user-images.githubusercontent.com/7529/70070500-ff23e480-15f3-11ea-8e1f-904ef34ce066.png">

## :robot: Solution

Supprimer la page d'erreur de la route `certifications.start`.

## :rainbow: Remarques

Ça a pour effet d'afficher la page d'erreur par défaut (page Oups) en cas d'erreur réseau.

<img width="1152" alt="Capture d’écran 2019-12-03 à 17 41 37" src="https://user-images.githubusercontent.com/7529/70070588-2e3a5600-15f4-11ea-94e5-fcb17d9c0be5.png">

Et d'afficher une page de chargement en cas de lenteurs :
![Capture d’écran de 2019-12-05 10-24-30](https://user-images.githubusercontent.com/48727874/70222023-a0707f00-1749-11ea-8ebd-233bcfa95c79.png)
