### PR TITLE
[FEATURE] Retirer le bold des labels des encadrés réponses (PF-963).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -3,6 +3,10 @@
   background-color: $porcelain-grey;
   margin: 6px;
 
+  label {
+    font-weight: $font-normal;
+  }
+
   @include device-is('desktop') {
     font-size: 20px;
   }


### PR DESCRIPTION
## :unicorn: Problème
Les labels des champs de réponses des questions apparaissent en gras.

## :robot: Solution
On met les labels en poids normal pour les champs de réponses.