### PR TITLE
[BUGFIX] Le payload contenant les certifications pour PixAdmin pouvait avoir comme id celui de son assessment-result (PA-129)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -3,7 +3,6 @@ import { computed } from '@ember/object';
 
 export default DS.Model.extend({
   sessionId: DS.attr(),
-  certificationId: DS.attr(),
   assessmentId: DS.attr(),
   firstName: DS.attr(),
   lastName: DS.attr(),

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -33,7 +33,6 @@ module('Unit | Service | session-info-service', function(hooks) {
     return EmberObject.create({
       id,
       sessionId,
-      certificationId: id,
       assessmentId: 5,
       firstName: 'Toto',
       lastName: 'Le héros',

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository');
@@ -45,17 +46,14 @@ module.exports = {
     // TODO: Back this unnamed composite object with a real domain object
     // TODO: model and do the necessary adjustements in PixAdmin.
     return {
-      ...certification,
-      ...lastAssessmentResultFull,
-      ...{
-        assessmentId: assessment ? assessment.id : null,
-        certificationId: certification.id,
-        createdAt: certification.createdAt,
-        resultCreatedAt: lastAssessmentResultFull.createdAt,
-        competencesWithMark: lastAssessmentResultFull.competenceMarks,
-      },
+      ..._.pick(certification, ['id', 'createdAt', 'completedAt', 'firstName', 'lastName',
+        'birthdate', 'birthplace', 'sessionId', 'externalId', 'isPublished', 'isV2Certification']),
+      ..._.pick(lastAssessmentResultFull, ['level', 'emitter', 'commentForJury', 'commentForCandidate',
+        'commentForOrganization', 'status', 'pixScore', 'juryId']),
+      assessmentId: assessment ? assessment.id : null,
+      resultCreatedAt: lastAssessmentResultFull.createdAt,
+      competencesWithMark: lastAssessmentResultFull.competenceMarks,
     };
-
   },
 
   _computeAnswersSuccessRate,

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -31,7 +31,6 @@ module.exports = {
   serializeResult(certificationCourseResult) {
     return new Serializer('results', {
       attributes: [
-        'certificationId',
         'assessmentId',
         'level',
         'pixScore',

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -93,6 +93,7 @@ describe('Unit | Service | Certification Service', function() {
   });
 
   describe('#getCertificationResult', () => {
+    const certificationCourseId = 1;
 
     context('when certification is finished', () => {
 
@@ -105,6 +106,7 @@ describe('Unit | Service | Certification Service', function() {
           ],
         }));
         sinon.stub(certificationCourseRepository, 'get').resolves(new CertificationCourse({
+          id: certificationCourseId,
           createdAt: new Date('2017-12-23T15:23:12Z'),
           completedAt: new Date('2017-12-23T16:23:12Z'),
           firstName: 'Pumba',
@@ -121,9 +123,6 @@ describe('Unit | Service | Certification Service', function() {
       });
 
       it('should return certification results with pix score, date and certified competences levels', () => {
-        // given
-        const certificationCourseId = 1;
-
         // when
         const promise = certificationService.getCertificationResult(certificationCourseId);
 
@@ -145,14 +144,12 @@ describe('Unit | Service | Certification Service', function() {
       });
 
       it('should return certified user informations', function() {
-        // given
-        const certificationCourseId = 1;
-
         // when
         const promise = certificationService.getCertificationResult(certificationCourseId);
 
         // then
         return promise.then((certification) => {
+          expect(certification.id).to.deep.equal(certificationCourseId);
           expect(certification.firstName).to.deep.equal('Pumba');
           expect(certification.lastName).to.deep.equal('De La Savane');
           expect(certification.birthplace).to.deep.equal('Savane');
@@ -170,6 +167,7 @@ describe('Unit | Service | Certification Service', function() {
           state: 'started',
         }));
         sinon.stub(certificationCourseRepository, 'get').resolves(new CertificationCourse({
+          id: certificationCourseId,
           createdAt: new Date('2017-12-23T15:23:12Z'),
           firstName: 'Pumba',
           lastName: 'De La Savane',


### PR DESCRIPTION
## :unicorn: Problème
Quand on charge une certification depuis PixAdmin et qu'on regarde le détail du payload, l'id du JsonApi object contenu dans celui-ci pouvait être erroné. C'est supposé être l'id du `certification-course` correspondant, mais parfois c'était celui de son `assessment-result`.

## :robot: Solution
Corriger la manière dont est créé le certification-result dans le service correspondant +
retrait de la propriété `certificationId` qui apporte de la confusion et qui est redondant avec la propriété `id`

## :rainbow: Remarques
