### PR TITLE
[TECH] Mise en place de choix aléatoire des questions à poser lors d'un test de certification

### DIFF
--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -52,7 +52,8 @@ async function fillCertificationProfileWithCertificationChallenges(certification
         const challengesToValidateCurrentSkill = Challenge.findPublishedBySkill(allChallenges, skill);
         const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
 
-        const challenge = (_.isEmpty(challengesLeftToAnswer)) ? _.first(challengesToValidateCurrentSkill) : _.first(challengesLeftToAnswer);
+        const challengesPoolToPickChallengeFrom = (_.isEmpty(challengesLeftToAnswer)) ? challengesToValidateCurrentSkill : challengesLeftToAnswer;
+        const challenge = _.sample(challengesPoolToPickChallengeFrom);
 
         //TODO : Mettre le skill en entier (Skill{id, name})
         challenge.testedSkill = skill.name;


### PR DESCRIPTION
## :unicorn: Problème
Lors de la génération d'un test de certification, l'algorithme récupère un ensemble de challenges et sélectionne en priorité des challenges qui n'ont pas encore été posés au candidat pendant ses positionnements/campagnes. Par contre, c'est toujours la première question non posée qui est choisie. Et comme l'ensemble des challenges est récupéré toujours selon le même ordre, c'est souvent les mêmes questions qui sont posées (certaines questions n'ont même jamais été présentées en test de certification !)

## :robot: Solution
Remplacer `_.first()` par `_.sample()` pour sélectionner aléatoirement une question.

## :rainbow: Remarques
Vu avec le métier, vu qu'on choisit parmi les variantes d'un même challenge, c'est ok.