### PR TITLE
[FEATURE] Affichage du commentaire global de la session dans la page de détails de session dans PixAdmin (PA-121)

### DIFF
--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -1,15 +1,16 @@
 import DS from 'ember-data';
+const { attr, Model } = DS;
 import { computed } from '@ember/object';
 
-export default DS.Model.extend({
-  competencesWithMark: DS.attr(),
-  totalScore: DS.attr(),
-  percentageCorrectAnswers: DS.attr(),
-  createdAt: DS.attr(),
-  userId: DS.attr(),
-  status: DS.attr(),
-  completedAt: DS.attr(),
-  listChallengesAndAnswers: DS.attr(),
+export default Model.extend({
+  competencesWithMark: attr(),
+  totalScore: attr(),
+  percentageCorrectAnswers: attr(),
+  createdAt: attr(),
+  userId: attr(),
+  status: attr(),
+  completedAt: attr(),
+  listChallengesAndAnswers: attr(),
   competences: computed('competencesWithMark', 'listChallengesAndAnswers', function() {
     const competenceData = this.competencesWithMark;
     const answers = this.listChallengesAndAnswers;

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,29 +1,29 @@
 import DS from 'ember-data';
+const { attr, Model } = DS;
 import { computed } from '@ember/object';
 import _ from 'lodash';
 
-export default DS.Model.extend({
-  sessionId: DS.attr(),
-  assessmentId: DS.attr(),
-  firstName: DS.attr(),
-  lastName: DS.attr(),
-  birthdate: DS.attr('date-only'),
-  birthplace: DS.attr(),
-  externalId: DS.attr(),
-  createdAt: DS.attr(),
-  completedAt: DS.attr(),
-  status: DS.attr(),
-  juryId: DS.attr(),
-  hasSeenLastScreen: DS.attr('boolean', { defaultValue: true }),
-  examinerComment: DS.attr('string'),
-  commentForCandidate: DS.attr(),
-  commentForOrganization: DS.attr(),
-  commentForJury: DS.attr(),
-  pixScore: DS.attr(),
-  competencesWithMark: DS.attr(),
-  isPublished: DS.attr('boolean', { defaultValue: false }),
-  isV2Certification: DS.attr('boolean', { defaultValue: false }),
-
+export default Model.extend({
+  sessionId: attr(),
+  assessmentId: attr(),
+  firstName: attr(),
+  lastName: attr(),
+  birthdate: attr('date-only'),
+  birthplace: attr(),
+  externalId: attr(),
+  createdAt: attr(),
+  completedAt: attr(),
+  status: attr(),
+  juryId: attr(),
+  hasSeenLastScreen: attr('boolean', { defaultValue: true }),
+  examinerComment: attr('string'),
+  commentForCandidate: attr(),
+  commentForOrganization: attr(),
+  commentForJury: attr(),
+  pixScore: attr(),
+  competencesWithMark: attr(),
+  isPublished: attr('boolean', { defaultValue: false }),
+  isV2Certification: attr('boolean', { defaultValue: false }),
   creationDate: computed('createdAt', function() {
     return (new Date(this.createdAt)).toLocaleString('fr-FR');
   }),

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -1,14 +1,13 @@
 import DS from 'ember-data';
+const { attr, belongsTo, Model } = DS;
 import { computed } from '@ember/object';
-
-const { attr, belongsTo } = DS;
 
 const displayedOrganizationRoles = {
   ADMIN: 'Administrateur',
   MEMBER: 'Membre',
 };
 
-export default DS.Model.extend({
+export default Model.extend({
 
   // Attributes
   organizationRole: attr(),

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -1,8 +1,7 @@
 import DS from 'ember-data';
+const { attr, hasMany, Model } = DS;
 
-const { attr, hasMany } = DS;
-
-export default DS.Model.extend({
+export default Model.extend({
 
   // Attributes
   name: attr(),

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,20 +1,21 @@
 import DS from 'ember-data';
+const { attr, hasMany, Model } = DS;
 import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import _ from 'lodash';
 
-export default DS.Model.extend({
-  certificationCenter: DS.attr(),
-  address: DS.attr(),
-  room: DS.attr(),
-  examiner: DS.attr(),
-  date: DS.attr('date-only'),
-  time: DS.attr(),
-  description: DS.attr(),
-  accessCode: DS.attr(),
-  status: DS.attr(),
+export default Model.extend({
+  certificationCenter: attr(),
+  address: attr(),
+  room: attr(),
+  examiner: attr(),
+  date: attr('date-only'),
+  time: attr(),
+  description: attr(),
+  accessCode: attr(),
+  status: attr(),
   isFinalized: equal('status', 'finalized'),
-  certifications: DS.hasMany('certification'),
+  certifications: hasMany('certification'),
   countNonValidatedCertifications : computed('certifications.[]', function() {
     return _.reduce(this.certifications.toArray(), (count, certification) => {
       return certification.status !== 'validated' ? ++count : count;

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -15,10 +15,14 @@ export default Model.extend({
   accessCode: attr(),
   status: attr(),
   isFinalized: equal('status', 'finalized'),
+  examinerComment: attr(),
   certifications: hasMany('certification'),
   countNonValidatedCertifications : computed('certifications.[]', function() {
     return _.reduce(this.certifications.toArray(), (count, certification) => {
       return certification.status !== 'validated' ? ++count : count;
     }, 0);
+  }),
+  hasExaminerComment : computed('examinerComment', function() {
+    return this.examinerComment && this.examinerComment.length > 0;
   }),
 });

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -1,8 +1,7 @@
 import DS from 'ember-data';
+const { attr, hasMany, Model } = DS;
 
-const { attr, hasMany } = DS;
-
-export default DS.Model.extend({
+export default Model.extend({
 
   // Attributes
   firstName: attr(),

--- a/admin/app/styles/authenticated/certifications/sessions/info/index.scss
+++ b/admin/app/styles/authenticated/certifications/sessions/info/index.scss
@@ -13,4 +13,8 @@
   &__stats {
     padding-top: 40px;
   }
+
+  &__actions {
+    padding-top: 32px;
+  }
 }

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -43,11 +43,19 @@
         <div class='col'>Nombre de certifications non terminées :</div>
         <div class='col' data-test-id='certifications-session-info__count-non-validated-certifications'>{{session.countNonValidatedCertifications}}</div>
     </div>
+    {{#if (and session.isFinalized session.hasExaminerComment)}}
+    <div class='row'>
+        <div class='col'>Commentaire global :</div>
+        <div class='col' data-test-id='certifications-session-info__examiner-comment'>{{session.examinerComment}}</div>
+    </div>
+    {{/if}}
   </div>
 
-  <div class='row row--btn'>
-    <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
-      Exporter les résultats
-    </button>
+  <div class="certifications-session-info__actions">
+    <div class='row row--btn'>
+        <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
+            Exporter les résultats
+        </button>
+    </div>
   </div>
 </div>

--- a/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit, currentURL, find } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import moment from 'moment';
 
@@ -61,6 +61,30 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       // then
       assert.dom('[data-test-id="certifications-session-info__is-finalized"]').hasText('Finalisée');
     });
+
+    test('it renders the examinerComment if any', async function(assert) {
+      // given
+      sessionData.status = 'finalized';
+      sessionData.examinerComment = 'Bonjour je suis le commentaire du surveillant';
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+
+      assert.dom('[data-test-id="certifications-session-info__examiner-comment"]').hasText(session.examinerComment);
+    });
+
+    test('it does not render the examinerComment row if no comment', async function(assert) {
+      // given
+      sessionData.status = 'finalized';
+      sessionData.examinerComment = '';
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+
+      assert.equal(find('[data-test-id="certifications-session-info__examiner-comment"]'), undefined);
+    });
   });
 
   module('when the session is not finalized', function() {
@@ -75,6 +99,18 @@ module('Integration | Component | certifications-session-info', function(hooks) 
 
       // then
       assert.dom('[data-test-id="certifications-session-info__is-finalized"]').hasText('Prête');
+    });
+
+    test('it does not render the examinerComment row', async function(assert) {
+      // given
+      sessionData.status = 'started';
+      sessionData.examinerComment = 'AAA';
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+
+      assert.equal(find('[data-test-id="certifications-session-info__examiner-comment"]'), undefined);
     });
   });
 

--- a/api/db/seeds/data/sessions-builder.js
+++ b/api/db/seeds/data/sessions-builder.js
@@ -49,6 +49,8 @@ module.exports = function sessionsBuilder({ databaseBuilder }) {
     description: 'Session',
     room: 'Salle Opette',
     accessCode: 'JKL78',
+    status: 'finalized',
     certificationCenterId: 1,
+    examinerComment: 'Le Lorem Ipsum est simplement du faux texte employé dans la composition et la mise en page avant impression. Le Lorem Ipsum est le faux texte standard de l\'imprimerie depuis les années 1500, quand un imprimeur anonyme assembla ensemble des morceaux de texte pour réaliser un livre spécimen de polices de texte. Il n\'a pas fait que survivre cinq siècles, mais s\'est aussi adapté à la bureautique informatique, sans que son contenu n\'en soit modifié.',
   });
 };


### PR DESCRIPTION
## :unicorn: Contexte
Dans le cadre de l'EPIX de Commentaire/Fin de test, les utilisateurs appartenant à un centre de certification peuvent finaliser une session et laisser un commentaire global pour signaler un problème ou un quelconque souci rencontré durant le déroulé de celle-ci. Ce commentaire n'est pas encore visible par les utilisateurs de PixAdmin.

## :robot: Solution
Affichage du commentaire global dans la page de détails de session dans PixAdmin.

## :rainbow: Remarques
