### PR TITLE
[TECH] Ajout d'un prehandler de vérification d'accès à une session (PC-92)

### DIFF
--- a/api/lib/application/preHandlers/session-authorization.js
+++ b/api/lib/application/preHandlers/session-authorization.js
@@ -1,0 +1,17 @@
+const sessionAuthorizationService = require('../../domain/services/session-authorization-service');
+const { ForbiddenError } = require('../../infrastructure/errors');
+
+module.exports = {
+  async verify(request) {
+    const userId = request.auth.credentials.userId;
+    const sessionId = parseInt(request.params.id);
+
+    const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+    if (!isAuthorized) {
+      throw new ForbiddenError('Vous n\'êtes pas autorisé à accéder à cette session.');
+    }
+
+    return isAuthorized;
+  }
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -1,6 +1,7 @@
 const Joi = require('@hapi/joi');
 const securityController = require('../../interfaces/controllers/security-controller');
 const sessionController = require('./session-controller');
+const sessionAuthorization = require('../preHandlers/session-authorization');
 
 exports.register = async (server) => {
   server.route([
@@ -24,6 +25,10 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}',
       config: {
+        pre: [{
+          method: sessionAuthorization.verify,
+          assign: 'authorizationCheck'
+        }],
         handler: sessionController.get,
         tags: ['api']
       }

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -78,6 +78,10 @@ exports.register = async (server) => {
           allow: 'multipart/form-data',
           maxBytes: 1048576 * 10, // 10MB
         },
+        pre: [{
+          method: sessionAuthorization.verify,
+          assign: 'authorizationCheck'
+        }],
         handler: sessionController.importCertificationCandidatesFromAttendanceSheet,
         tags: ['api', 'sessions'],
         notes: [

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -25,6 +25,11 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
         pre: [{
           method: sessionAuthorization.verify,
           assign: 'authorizationCheck'
@@ -62,6 +67,11 @@ exports.register = async (server) => {
       method: 'PUT',
       path: '/api/sessions/{id}/finalization',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
         pre: [{
           method: sessionAuthorization.verify,
           assign: 'authorizationCheck'
@@ -78,6 +88,11 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/sessions/{id}/certification-candidates/import',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
         payload: {
           allow: 'multipart/form-data',
           maxBytes: 1048576 * 10, // 10MB
@@ -111,6 +126,11 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}/certification-candidates',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
         pre: [{
           method: sessionAuthorization.verify,
           assign: 'authorizationCheck'

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -62,6 +62,10 @@ exports.register = async (server) => {
       method: 'PUT',
       path: '/api/sessions/{id}/finalization',
       config: {
+        pre: [{
+          method: sessionAuthorization.verify,
+          assign: 'authorizationCheck'
+        }],
         handler: sessionController.finalize,
         tags: ['api', 'sessions'],
         notes: [

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -107,6 +107,10 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}/certification-candidates',
       config: {
+        pre: [{
+          method: sessionAuthorization.verify,
+          assign: 'authorizationCheck'
+        }],
         handler: sessionController.getCertificationCandidates,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -15,9 +15,8 @@ module.exports = {
   },
 
   async get(request) {
-    const userId = request.auth.credentials.userId;
     const sessionId = parseInt(request.params.id);
-    const session = await usecases.getSession({ userId, sessionId });
+    const session = await usecases.getSession({ sessionId });
 
     return sessionSerializer.serialize(session);
   },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -53,9 +53,8 @@ module.exports = {
 
   async getCertificationCandidates(request) {
     const sessionId = request.params.id;
-    const userId = request.auth.credentials.userId;
 
-    return usecases.getSessionCertificationCandidates({ userId, sessionId })
+    return usecases.getSessionCertificationCandidates({ sessionId })
       .then((certificationCandidates) => certificationCandidateSerializer.serialize(certificationCandidates));
   },
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -97,11 +97,10 @@ module.exports = {
   },
 
   finalize(request) {
-    const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
     const examinerComment = request.payload.data.attributes['examiner-comment'];
 
-    return usecases.finalizeSession({ userId, sessionId, examinerComment })
+    return usecases.finalizeSession({ sessionId, examinerComment })
       .then((updatedSession) => sessionSerializer.serializeForFinalization(updatedSession));
   },
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -67,12 +67,11 @@ module.exports = {
   },
 
   async importCertificationCandidatesFromAttendanceSheet(request) {
-    const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
     const odsBuffer = request.payload.file;
 
     try {
-      await usecases.importCertificationCandidatesFromAttendanceSheet({ userId, sessionId, odsBuffer });
+      await usecases.importCertificationCandidatesFromAttendanceSheet({ sessionId, odsBuffer });
     }
     catch (err) {
       if (err instanceof CertificationCandidateAlreadyLinkedToUserError) {

--- a/api/lib/domain/services/session-authorization-service.js
+++ b/api/lib/domain/services/session-authorization-service.js
@@ -1,0 +1,17 @@
+const sessionRepository = require('../../infrastructure/repositories/session-repository');
+const userRepository = require('../../infrastructure/repositories/user-repository');
+
+module.exports = {
+
+  async isAuthorizedToAccessSession({ userId, sessionId }) {
+    const hasMembershipAccess = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
+    if (!hasMembershipAccess) {
+      const isPixMaster = await userRepository.hasRolePixMaster(userId);
+      if (!isPixMaster) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -1,23 +1,14 @@
-const {
-  ForbiddenAccess,
-  SessionAlreadyFinalizedError,
-} = require('../errors');
+const { SessionAlreadyFinalizedError } = require('../errors');
 
 const {
   statuses
 } = require('../../domain/models/Session');
 
 module.exports = async function finalizeSession({
-  userId,
   sessionId,
   examinerComment,
   sessionRepository,
 } = {}) {
-  try {
-    await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
-  } catch (err) {
-    throw new ForbiddenAccess('User does not have the rights to finalize this session');
-  }
   const isSessionAlreadyFinalized = await sessionRepository.isFinalized(sessionId);
   if (isSessionAlreadyFinalized) {
     throw new SessionAlreadyFinalizedError('Cannot finalize session more than once');

--- a/api/lib/domain/usecases/get-session-certification-candidates.js
+++ b/api/lib/domain/usecases/get-session-certification-candidates.js
@@ -1,5 +1,3 @@
-module.exports = async function getSessionCertificationCandidates({ userId, sessionId, sessionRepository, certificationCandidateRepository }) {
-  await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
-
+module.exports = function getSessionCertificationCandidates({ sessionId, certificationCandidateRepository }) {
   return certificationCandidateRepository.findBySessionId(sessionId);
 };

--- a/api/lib/domain/usecases/get-session.js
+++ b/api/lib/domain/usecases/get-session.js
@@ -1,14 +1,7 @@
-module.exports = async function getSession(
+module.exports = function getSession(
   {
-    userId,
     sessionId,
     sessionRepository,
-    userRepository,
   } = {}) {
-  const isPixMaster = await userRepository.hasRolePixMaster(userId);
-  if (!isPixMaster) {
-    await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
-  }
-
   return sessionRepository.get(sessionId);
 };

--- a/api/lib/domain/usecases/import-certification-candidates-from-attendance-sheet.js
+++ b/api/lib/domain/usecases/import-certification-candidates-from-attendance-sheet.js
@@ -1,15 +1,11 @@
 const { CertificationCandidateAlreadyLinkedToUserError } = require('../../domain/errors');
 
 module.exports = async function importCertificationCandidatesFromAttendanceSheet({
-  userId,
   sessionId,
   odsBuffer,
   certificationCandidatesOdsService,
-  sessionRepository,
   certificationCandidateRepository,
 }) {
-  await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
-
   const linkedCandidateInSessionExists = await certificationCandidateRepository.doesLinkedCertificationCandidateInSessionExist({ sessionId });
 
   if (linkedCandidateInSessionExists) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -39,6 +39,7 @@ const dependencies = {
   settings: require('../../config'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   smartPlacementAssessmentRepository: require('../../infrastructure/repositories/smart-placement-assessment-repository'),
+  sessionAuthorizationService: require('../../domain/services/session-authorization-service'),
   sessionRepository: require('../../infrastructure/repositories/session-repository'),
   snapshotsCsvConverter: require('../../infrastructure/converter/snapshots-csv-converter'),
   snapshotRepository: require('../../infrastructure/repositories/snapshot-repository'),

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const BookshelfSession = require('../data/session');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const Bookshelf = require('../bookshelf');
-const { NotFoundError, UserNotAuthorizedToAccessEntity } = require('../../domain/errors');
+const { NotFoundError } = require('../../domain/errors');
 const { statuses } = require('../../domain/models/Session');
 
 module.exports = {
@@ -120,20 +120,6 @@ module.exports = {
       .fetchAll({});
 
     return bookshelfToDomainConverter.buildDomainObjects(BookshelfSession, foundSessions);
-  },
-
-  async ensureUserHasAccessToSession(userId, sessionId) {
-    try {
-      await BookshelfSession
-        .where({ 'sessions.id': sessionId, 'certification-center-memberships.userId': userId })
-        .query((qb) => {
-          qb.innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId');
-          qb.innerJoin('certification-center-memberships', 'certification-center-memberships.certificationCenterId', 'certification-centers.id');
-        })
-        .fetch({ require: true });
-    } catch (_err) {
-      throw new UserNotAuthorizedToAccessEntity(sessionId);
-    }
   },
 
   async doesUserHaveCertificationCenterMembershipForSession(userId, sessionId) {

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -136,6 +136,17 @@ module.exports = {
     }
   },
 
+  async doesUserHaveCertificationCenterMembershipForSession(userId, sessionId) {
+    const session = await BookshelfSession
+      .where({ 'sessions.id': sessionId, 'certification-center-memberships.userId': userId })
+      .query((qb) => {
+        qb.innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId');
+        qb.innerJoin('certification-center-memberships', 'certification-center-memberships.certificationCenterId', 'certification-centers.id');
+      })
+      .fetch({ columns: 'sessions.id' });
+    return Boolean(session);
+  },
+
   async updateStatusAndExaminerComment(session) {
     const sessionDataToUpdate = _.pick(session, [
       'status',

--- a/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-attendance-sheet_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | session-controller-get-attendance-sheet', ()
       databaseBuilder.factory.buildCertificationCenterMembership({ userId: otherUserId, certificationCenterId: otherCertificationCenterId });
 
       sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-      sessionIdNotAllowed = databaseBuilder.factory.buildSession({ certificationCenterId: otherCertificationCenterId });
+      sessionIdNotAllowed = databaseBuilder.factory.buildSession({ certificationCenterId: otherCertificationCenterId }).id;
 
       await databaseBuilder.commit();
     });

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
@@ -13,7 +13,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
   });
 
   describe('POST /api/sessions/{id}/certification-candidates/import', () => {
-    let user, sessionIdAllowed, sessionIdNotAllowed;
+    let user, sessionIdAllowed;
 
     beforeEach(async () => {
       // given
@@ -26,7 +26,6 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
       databaseBuilder.factory.buildCertificationCenterMembership({ userId: otherUserId, certificationCenterId: otherCertificationCenterId });
 
       sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-      sessionIdNotAllowed = databaseBuilder.factory.buildSession({ certificationCenterId: otherCertificationCenterId });
 
       await databaseBuilder.commit();
     });
@@ -169,39 +168,6 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
 
         // then
         expect(response.statusCode).to.equal(400);
-      });
-
-    });
-
-    context('The user can\'t access the session', () => {
-
-      const odsFileName = 'files/import-certification-candidates-test-ok.ods';
-      const odsFilePath = `${__dirname}/${odsFileName}`;
-      let options;
-
-      beforeEach(async () => {
-        // given
-        const form = new FormData();
-        form.append('file', fs.createReadStream(odsFilePath), { knownLength: fs.statSync(odsFilePath).size });
-        const payload = await streamToPromise(form);
-        const authHeader = generateValidRequestAuthorizationHeader(user.id);
-        const token = authHeader.replace('Bearer ', '');
-        const headers = Object.assign({}, form.getHeaders(), { 'authorization': `Bearer ${token}` });
-        options = {
-          method: 'POST',
-          url: `/api/sessions/${sessionIdNotAllowed}/certification-candidates/import`,
-          headers,
-          payload,
-        };
-
-      });
-
-      it('should respond with a 403 when user cant access the session', async () => {
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(403);
       });
 
     });

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -499,6 +499,44 @@ describe('Integration | Repository | Session', function() {
 
   });
 
+  describe('#doesUserHaveCertificationCenterMembershipForSession', () => {
+    let userId, userIdNotAllowed, sessionId, certificationCenterId, certificationCenterNotAllowedId;
+
+    beforeEach(async () => {
+      // given
+      userId = 1;
+      userIdNotAllowed = 2;
+      databaseBuilder.factory.buildUser({ id: userId });
+      databaseBuilder.factory.buildUser({ id: userIdNotAllowed });
+      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      certificationCenterNotAllowedId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId: userIdNotAllowed, certificationCenterId: certificationCenterNotAllowedId });
+
+      // when
+      sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return true if user has membership in the certification center that originated the session', async () => {
+      // when
+      const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
+
+      // then
+      expect(hasMembership).to.be.true;
+    });
+
+    it('should return false if user has no membership in the certification center that originated the session', async () => {
+      // when
+      const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userIdNotAllowed, sessionId);
+
+      // then
+      expect(hasMembership).to.be.false;
+    });
+
+  });
+
   describe('#updateStatusAndExaminerComment', () => {
     let session;
 

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -459,46 +459,6 @@ describe('Integration | Repository | Session', function() {
 
   });
 
-  describe('#ensureUserHasAccessToSession', () => {
-    let requestErr, userId, userIdNotAllowed, sessionId, certificationCenterId, certificationCenterNotAllowedId;
-
-    beforeEach(async () => {
-    // given
-      userId = 1;
-      userIdNotAllowed = 2;
-      databaseBuilder.factory.buildUser({ id: userId });
-      databaseBuilder.factory.buildUser({ id: userIdNotAllowed });
-      certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      certificationCenterNotAllowedId = databaseBuilder.factory.buildCertificationCenter().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-      databaseBuilder.factory.buildCertificationCenterMembership({ userId: userIdNotAllowed, certificationCenterId: certificationCenterNotAllowedId });
-
-      // when
-      sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-
-      await databaseBuilder.commit();
-    });
-
-    it('should not throw an error if the user has access to the session', async () => {
-      try {
-        await sessionRepository.ensureUserHasAccessToSession(userId, sessionId);
-      } catch (err) {
-        requestErr = err;
-      }
-      expect(requestErr).to.be.undefined;
-    });
-
-    it('should throw an error if the user does not have access to the session', async () => {
-      try {
-        await sessionRepository.ensureUserHasAccessToSession(userIdNotAllowed, sessionId);
-      } catch (err) {
-        requestErr = err;
-      }
-      expect(requestErr).to.be.instanceOf(Error);
-    });
-
-  });
-
   describe('#doesUserHaveCertificationCenterMembershipForSession', () => {
     let userId, userIdNotAllowed, sessionId, certificationCenterId, certificationCenterNotAllowedId;
 

--- a/api/tests/unit/application/preHandlers/assessment-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/assessment-authorization_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
-const AssessmentAuhorization = require('../../../../lib/application/preHandlers/assessment-authorization');
+const AssessmentAuthorization = require('../../../../lib/application/preHandlers/assessment-authorization');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 
@@ -21,7 +21,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
 
     it('should be a function', () => {
       // then
-      expect(AssessmentAuhorization.verify).to.be.a('function');
+      expect(AssessmentAuthorization.verify).to.be.a('function');
     });
 
     it('should get userId from token', () => {
@@ -31,7 +31,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
       assessmentRepository.getByAssessmentIdAndUserId.resolves();
 
       // when
-      const promise = AssessmentAuhorization.verify(request, hFake);
+      const promise = AssessmentAuthorization.verify(request, hFake);
 
       // then
       return promise.then(() => {
@@ -50,7 +50,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
         assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
 
         // when
-        const response = await AssessmentAuhorization.verify(request, hFake);
+        const response = await AssessmentAuthorization.verify(request, hFake);
 
         // then
         sinon.assert.calledOnce(assessmentRepository.getByAssessmentIdAndUserId);
@@ -69,7 +69,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
         assessmentRepository.getByAssessmentIdAndUserId.resolves(fetchedAssessment);
 
         // when
-        const response = await AssessmentAuhorization.verify(request, hFake);
+        const response = await AssessmentAuthorization.verify(request, hFake);
 
         // then
         sinon.assert.calledOnce(assessmentRepository.getByAssessmentIdAndUserId);
@@ -85,7 +85,7 @@ describe('Unit | Pre-handler | Assessment Authorization', () => {
         tokenService.extractUserId.returns(extractedUserId);
         assessmentRepository.getByAssessmentIdAndUserId.rejects();
         // when
-        const response = await AssessmentAuhorization.verify(request, hFake);
+        const response = await AssessmentAuthorization.verify(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(401);

--- a/api/tests/unit/application/preHandlers/session-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-authorization_test.js
@@ -1,0 +1,55 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const SessionAuthorization = require('../../../../lib/application/preHandlers/session-authorization');
+const sessionAuthorizationService = require('../../../../lib/domain/services/session-authorization-service');
+const { ForbiddenError } = require('../../../../lib/infrastructure/errors');
+
+describe('Unit | Pre-handler | Session Authorization', () => {
+  const userId = 1;
+  const sessionId = 2;
+
+  describe('#verify', () => {
+    const request = {
+      auth: { credentials: { accessToken: 'valid.access.token', userId } },
+      params: {
+        id: sessionId,
+      }
+    };
+
+    beforeEach(() => {
+      sinon.stub(sessionAuthorizationService, 'isAuthorizedToAccessSession');
+    });
+
+    it('should be a function', () => {
+      // then
+      expect(SessionAuthorization.verify).to.be.a('function');
+    });
+
+    context('when user has access to session', () => {
+
+      it('should reply with true', async () => {
+        // given
+        sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(true);
+
+        // when
+        const response = await SessionAuthorization.verify(request);
+
+        // then
+        expect(response).to.deep.equal(true);
+      });
+    });
+
+    context('when user has no access to session', () => {
+
+      it('should throw a ForbiddenError', async () => {
+        // given
+        sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(false);
+
+        // when
+        const error = await catchErr(SessionAuthorization.verify)(request);
+
+        // then
+        expect(error).to.be.instanceOf(ForbiddenError);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -76,6 +76,7 @@ describe('Unit | Application | Sessions | Routes', () => {
     let options;
     beforeEach(async () => {
       // given
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
       sinon.stub(sessionController, 'importCertificationCandidatesFromAttendanceSheet').returns('ok');
       fs.writeFileSync(testFilePath, Buffer.alloc(0));
       const form = new FormData();

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -2,6 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('@hapi/hapi');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 const sessionController = require('../../../../lib/application/sessions/session-controller');
+const sessionAuthorization = require('../../../../lib/application/preHandlers/session-authorization');
 const route = require('../../../../lib/application/sessions');
 const fs = require('fs');
 const FormData = require('form-data');
@@ -17,7 +18,7 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/sessions/{id}', () => {
 
     beforeEach(() => {
-      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
       sinon.stub(sessionController, 'get').returns('ok');
       return server.register(route);
     });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -149,6 +149,7 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('PUT /api/sessions/{id}/finalization', () => {
     beforeEach(() => {
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
       sinon.stub(sessionController, 'finalize').returns('ok');
       return server.register(route);
     });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -16,6 +16,7 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('GET /api/sessions/{id}', () => {
+    let sessionId;
 
     beforeEach(() => {
       sinon.stub(sessionAuthorization, 'verify').returns(null);
@@ -24,8 +25,22 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}' });
+      // given
+      sessionId = 3;
+
+      const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}` });
       expect(res.statusCode).to.equal(200);
+    });
+
+    context('when session ID params is not a number', () => {
+
+      it('should return 400', async () => {
+        // given
+        sessionId = 'salut';
+
+        const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}` });
+        expect(res.statusCode).to.equal(400);
+      });
     });
   });
 
@@ -71,6 +86,7 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('POST /api/sessions/{id}/certification-candidates/import', () => {
+    let sessionId;
 
     const testFilePath = `${__dirname}/testFile_temp.ods`;
     let options;
@@ -84,7 +100,6 @@ describe('Unit | Application | Sessions | Routes', () => {
       const payload = await streamToPromise(form);
       options = {
         method: 'POST',
-        url: '/api/sessions/{id}/certification-candidates/import',
         headers: form.getHeaders(),
         payload,
       };
@@ -97,6 +112,10 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
+      // given
+      sessionId = 3;
+      options.url = `/api/sessions/${sessionId}/certification-candidates/import`;
+
       // when
       const res = await server.inject(options);
 
@@ -104,9 +123,25 @@ describe('Unit | Application | Sessions | Routes', () => {
       expect(res.statusCode).to.equal(200);
     });
 
+    context('when session ID params is not a number', () => {
+
+      it('should return 400', async () => {
+        // given
+        sessionId = 'salut';
+        options.url = `/api/sessions/${sessionId}/certification-candidates/import`;
+
+        // when
+        const res = await server.inject(options);
+
+        // then
+        expect(res.statusCode).to.equal(400);
+      });
+    });
+
   });
 
   describe('GET /api/sessions/{id}/certification-candidates', () => {
+    let sessionId;
 
     beforeEach(() => {
       sinon.stub(sessionAuthorization, 'verify').returns(null);
@@ -115,8 +150,22 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/certification-candidates' });
+      //given
+      sessionId = 3;
+
+      const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}/certification-candidates` });
       expect(res.statusCode).to.equal(200);
+    });
+
+    context('when session ID params is not a number', () => {
+
+      it('should return 400', async () => {
+        // given
+        sessionId = 'salut';
+
+        const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}/certification-candidates` });
+        expect(res.statusCode).to.equal(400);
+      });
     });
   });
 
@@ -148,6 +197,8 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('PUT /api/sessions/{id}/finalization', () => {
+    let sessionId;
+
     beforeEach(() => {
       sinon.stub(sessionAuthorization, 'verify').returns(null);
       sinon.stub(sessionController, 'finalize').returns('ok');
@@ -155,8 +206,22 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'PUT', url: '/api/sessions/{id}/finalization' });
+      // given
+      sessionId = 3;
+
+      const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/finalization` });
       expect(res.statusCode).to.equal(200);
+    });
+
+    context('when session ID params is not a number', () => {
+
+      it('should return 400', async () => {
+        // given
+        sessionId = 'salut';
+
+        const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/finalization` });
+        expect(res.statusCode).to.equal(400);
+      });
     });
   });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -109,6 +109,7 @@ describe('Unit | Application | Sessions | Routes', () => {
   describe('GET /api/sessions/{id}/certification-candidates', () => {
 
     beforeEach(() => {
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
       sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
       return server.register(route);
     });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -233,7 +233,6 @@ describe('Unit | Controller | sessionController', () => {
   describe('#getCertificationCandidates ', () => {
     let request;
     const sessionId = 1;
-    const userId = 2;
     const certificationCandidates = 'candidates';
     const certificationCandidatesJsonApi = 'candidatesJSONAPI';
 
@@ -241,13 +240,8 @@ describe('Unit | Controller | sessionController', () => {
       // given
       request = {
         params: { id : sessionId },
-        auth: {
-          credentials : {
-            userId,
-          }
-        },
       };
-      sinon.stub(usecases, 'getSessionCertificationCandidates').withArgs({ userId, sessionId }).resolves(certificationCandidates);
+      sinon.stub(usecases, 'getSessionCertificationCandidates').withArgs({ sessionId }).resolves(certificationCandidates);
       sinon.stub(certificationCandidateSerializer, 'serialize').withArgs(certificationCandidates).returns(certificationCandidatesJsonApi);
     });
 

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -3,7 +3,6 @@ const { expect, sinon, hFake } = require('../../../test-helper');
 const sessionController = require('../../../../lib/application/sessions/session-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const Session = require('../../../../lib/domain/models/Session');
-const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 
 const sessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 const certificationCandidateSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-candidate-serializer');
@@ -107,43 +106,12 @@ describe('Unit | Controller | sessionController', () => {
 
     context('when session exists', () => {
 
-      it('should get session informations with certifications associated', async function() {
-        // given
-        usecases.getSession.resolves();
-
-        // when
-        await sessionController.get(request, hFake);
-
-        // then
-        expect(usecases.getSession).to.have.been.calledWith({ userId, sessionId });
-      });
-
-      it('should serialize session informations', async function() {
-        // given
-        const certification = CertificationCourse.fromAttributes({ id: 'certifId', sessionId: 'sessionId' });
-        const session = new Session({
-          id: 'sessionId',
-          certifications: [certification]
-        });
-        usecases.getSession.resolves(session);
-
-        // when
-        await sessionController.get(request, hFake);
-
-        // then
-        expect(sessionSerializer.serialize).to.have.been.calledWith(session);
-      });
-
       it('should reply serialized session informations', async function() {
         // given
-        const serializedSession = {
-          data: {
-            type: 'sessions',
-            id: 'id',
-          }
-        };
-        sessionSerializer.serialize.resolves(serializedSession);
-        usecases.getSession.resolves();
+        const foundSession = Symbol('foundSession');
+        const serializedSession = Symbol('serializedSession');
+        usecases.getSession.withArgs({ sessionId }).resolves(foundSession);
+        sessionSerializer.serialize.withArgs(foundSession).resolves(serializedSession);
 
         // when
         const response = await sessionController.get(request, hFake);
@@ -370,9 +338,9 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
-            linkCreated: false,
-            certificationCandidate: linkedCertificationCandidate
-          });
+          linkCreated: false,
+          certificationCandidate: linkedCertificationCandidate
+        });
       });
 
       it('should return a certification candidate', async () => {
@@ -391,9 +359,9 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
-            linkCreated: true,
-            certificationCandidate: linkedCertificationCandidate
-          });
+          linkCreated: true,
+          certificationCandidate: linkedCertificationCandidate
+        });
       });
 
       it('should return a certification candidate', async () => {
@@ -421,7 +389,7 @@ describe('Unit | Controller | sessionController', () => {
     beforeEach(() => {
       // given
       request = {
-        params: { 
+        params: {
           id: sessionId,
         },
         auth: {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -203,13 +203,11 @@ describe('Unit | Controller | sessionController', () => {
   describe('#importCertificationCandidatesFromAttendanceSheet', () => {
 
     const sessionId = 2;
-    const userId = 1;
     let request;
     const odsBuffer = 'File Buffer';
     beforeEach(() => {
       // given
       request = {
-        auth: { credentials: { userId } },
         params: { id: sessionId },
         payload: { file: odsBuffer },
       };
@@ -226,7 +224,6 @@ describe('Unit | Controller | sessionController', () => {
 
       // then
       expect(usecases.importCertificationCandidatesFromAttendanceSheet).to.have.been.calledWith({
-        userId,
         sessionId,
         odsBuffer,
       });
@@ -338,9 +335,9 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
-          linkCreated: false,
-          certificationCandidate: linkedCertificationCandidate
-        });
+            linkCreated: false,
+            certificationCandidate: linkedCertificationCandidate
+          });
       });
 
       it('should return a certification candidate', async () => {
@@ -359,9 +356,9 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
-          linkCreated: true,
-          certificationCandidate: linkedCertificationCandidate
-        });
+            linkCreated: true,
+            certificationCandidate: linkedCertificationCandidate
+          });
       });
 
       it('should return a certification candidate', async () => {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -372,7 +372,6 @@ describe('Unit | Controller | sessionController', () => {
   describe('#finalize ', () => {
     let request;
     const sessionId = 1;
-    const userId = 2;
     const updatedSession = Symbol('updatedSession');
     const serializedUpdatedSession = Symbol('updated session serialized');
     const examinerComment = 'It was a fine session my dear';
@@ -383,11 +382,6 @@ describe('Unit | Controller | sessionController', () => {
         params: {
           id: sessionId,
         },
-        auth: {
-          credentials: {
-            userId,
-          }
-        },
         payload: {
           data: {
             attributes: {
@@ -396,7 +390,7 @@ describe('Unit | Controller | sessionController', () => {
           },
         },
       };
-      sinon.stub(usecases, 'finalizeSession').withArgs({ userId, sessionId, examinerComment }).resolves(updatedSession);
+      sinon.stub(usecases, 'finalizeSession').withArgs({ sessionId, examinerComment }).resolves(updatedSession);
       sinon.stub(sessionSerializer, 'serializeForFinalization').withArgs(updatedSession).resolves(serializedUpdatedSession);
     });
 

--- a/api/tests/unit/domain/services/session-authorization-service_test.js
+++ b/api/tests/unit/domain/services/session-authorization-service_test.js
@@ -1,0 +1,70 @@
+const { expect, sinon } = require('../../../test-helper');
+const sessionAuthorizationService = require('../../../../lib/domain/services/session-authorization-service');
+const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+describe('Unit | Service | SessionAuthorizationService', () => {
+
+  describe('#isAuthorizedToAccessSession', () => {
+    const userId = 'userId';
+    const sessionId = 'sessionId';
+
+    it('should exist', () => {
+      expect(sessionAuthorizationService.isAuthorizedToAccessSession).to.exist.and.to.be.a('function');
+    });
+
+    beforeEach(() => {
+      sinon.stub(userRepository, 'hasRolePixMaster');
+      sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession');
+    });
+
+    context('when user has membership for session', () => {
+
+      it('should return', async () => {
+        // given
+        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(true);
+
+        // when
+        const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+        // then
+        expect(isAuthorized).to.be.true;
+      });
+    });
+
+    context('when user has no membership for session', () => {
+
+      beforeEach(() => {
+        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).returns(false);
+      });
+
+      context('when user is PixMaster', () => {
+
+        it('should return true', async () => {
+          // given
+          userRepository.hasRolePixMaster.withArgs(userId).returns(true);
+
+          // when
+          const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+          // then
+          expect(isAuthorized).to.be.true;
+        });
+      });
+
+      context('when user is not PixMaster', () => {
+
+        it('should return false', async () => {
+          // given
+          userRepository.hasRolePixMaster.withArgs(userId).returns(false);
+
+          // when
+          const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
+
+          // then
+          expect(isAuthorized).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -2,75 +2,54 @@ const {
   sinon,
   expect,
   catchErr,
-  testErr,
 } = require('../../../test-helper');
 
 const finalizeSession = require('../../../../lib/domain/usecases/finalize-session');
-const { ForbiddenAccess, SessionAlreadyFinalizedError } = require('../../../../lib/domain/errors');
+const { SessionAlreadyFinalizedError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | finalize-session', () => {
 
-  let userId, sessionId, sessionRepository, updatedSession, examinerComment;
+  let sessionId, sessionRepository, updatedSession, examinerComment;
 
   beforeEach(async () => {
-
-    userId = 'dummy user id';
     sessionId = 'dummy session id';
     updatedSession = Symbol('updated session');
     examinerComment = 'It was a fine session my dear.';
     sessionRepository = {
       updateStatusAndExaminerComment: sinon.stub(),
-      ensureUserHasAccessToSession: sinon.stub(),
       isFinalized: sinon.stub(),
     };
 
   });
-  context('When the user does not have the right to finalize the session', () => {
 
-    beforeEach(async () => {
-      sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).rejects(testErr);
-    });
-
-    it('should throw a ForbiddenAccess error', async () => {
-      const err = await catchErr(finalizeSession)({ userId, sessionId, sessionRepository, examinerComment });
-      expect(err).to.be.instanceOf(ForbiddenAccess);
-    });
-  });
-  context('When the user has the rights', () => {
+  context('When the session status is already finalized', () => {
 
     beforeEach(() => {
-      sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).resolves();
+      sessionRepository.isFinalized.withArgs(sessionId).resolves(true);
     });
 
-    context('When the session status is already finalized', () => {
+    it('should throw a SessionAlreadyFinalizedError error', async () => {
+      // when
+      const err = await catchErr(finalizeSession)({ sessionId, examinerComment, sessionRepository });
 
-      beforeEach(() => {
-        sessionRepository.isFinalized.withArgs(sessionId).resolves(true);
-      });
+      // then
+      expect(err).to.be.instanceOf(SessionAlreadyFinalizedError);
+    });
+  });
 
-      it('should throw a SessionAlreadyFinalizedError error', async () => {
-        // when
-        const err = await catchErr(finalizeSession)({ userId, sessionId, examinerComment, sessionRepository });
+  context('When the session status is not finalized yet ', () => {
 
-        // then
-        expect(err).to.be.instanceOf(SessionAlreadyFinalizedError);
-      });
+    beforeEach(() => {
+      sessionRepository.isFinalized.withArgs(sessionId).resolves(false);
+      sessionRepository.updateStatusAndExaminerComment.withArgs({ id: sessionId, status: 'finalized', examinerComment }).resolves(updatedSession);
     });
 
-    context('When the session status is not finalized yet ', () => {
+    it('should return the updated session', async () => {
+      // when
+      const res = await finalizeSession({ sessionId, examinerComment, sessionRepository });
 
-      beforeEach(() => {
-        sessionRepository.isFinalized.withArgs(sessionId).resolves(false);
-        sessionRepository.updateStatusAndExaminerComment.withArgs({ id: sessionId, status: 'finalized', examinerComment }).resolves(updatedSession);
-      });
-
-      it('should return the updated session', async () => {
-        // when
-        const res = await finalizeSession({ userId, sessionId, examinerComment, sessionRepository });
-
-        // then
-        expect(res).to.deep.equal(updatedSession);
-      });
+      // then
+      expect(res).to.deep.equal(updatedSession);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', () => {
   let result;
   const userId = 'dummyUserId';
   const sessionId = 'dummySessionId';
-  const sessionRepository = { getWithCertificationCandidates: _.noop, ensureUserHasAccessToSession: _.noop };
+  const sessionRepository = { getWithCertificationCandidates: _.noop, doesUserHaveCertificationCenterMembershipForSession: _.noop };
 
   const sessionWithCandidates = {
     id: 1,
@@ -104,7 +104,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', () => {
 
     context('user has access to the session', () => {
       beforeEach(async () => {
-        sinon.stub(sessionRepository, 'ensureUserHasAccessToSession').resolves();
+        sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession').resolves(true);
         result = await getAttendanceSheet({ userId, sessionId, sessionRepository });
       });
       // then
@@ -130,7 +130,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', () => {
 
     context('user does not have access to the session', () => {
       beforeEach(async () => {
-        sinon.stub(sessionRepository, 'ensureUserHasAccessToSession').rejects(new UserNotAuthorizedToAccessEntity());
+        sinon.stub(sessionRepository, 'doesUserHaveCertificationCenterMembershipForSession').resolves(false);
         try {
           result = await getAttendanceSheet({ userId, sessionId, sessionRepository });
         } catch (err) {

--- a/api/tests/unit/domain/usecases/get-session-certification-candidates_test.js
+++ b/api/tests/unit/domain/usecases/get-session-certification-candidates_test.js
@@ -1,49 +1,23 @@
-const { expect, sinon, catchErr } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
+const { expect, sinon } = require('../../../test-helper');
 const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
 const getSessionCertificationCandidates = require('../../../../lib/domain/usecases/get-session-certification-candidates');
 
 describe('Unit | Domain | Use Cases | get-session-certification-candidates', () => {
 
   const sessionId = 'sessionId';
-  const userId = 'userId';
+  const certificationCandidates = 'candidates';
 
-  context('when user has no access to the session', () => {
-
-    beforeEach(() => {
-      // given
-      sinon.stub(sessionRepository, 'ensureUserHasAccessToSession').rejects(new UserNotAuthorizedToAccessEntity());
-    });
-
-    it('should throw with a UserNotAuthorizedToAccessEntity', async () => {
-      // when
-      const result = await catchErr(getSessionCertificationCandidates)({ userId, sessionId, sessionRepository, certificationCandidateRepository });
-
-      // then
-      expect(result).to.be.an.instanceOf(UserNotAuthorizedToAccessEntity);
-    });
-
+  beforeEach(() => {
+    // given
+    sinon.stub(certificationCandidateRepository, 'findBySessionId').withArgs(sessionId).resolves(certificationCandidates);
   });
 
-  context('when user has access to the session', () => {
-    const certificationCandidates = 'candidates';
+  it('should return the certification candidates', async () => {
+    // when
+    const actualCandidates = await getSessionCertificationCandidates({ sessionId, certificationCandidateRepository });
 
-    beforeEach(() => {
-      // given
-      sinon.stub(sessionRepository, 'ensureUserHasAccessToSession').resolves();
-      sinon.stub(certificationCandidateRepository, 'findBySessionId').withArgs(sessionId).resolves(certificationCandidates);
-    });
-
-    it('should return the certification candidates', async () => {
-      // when
-      const actualCandidates = await getSessionCertificationCandidates({ userId, sessionId, sessionRepository, certificationCandidateRepository });
-
-      // then
-      expect(actualCandidates).to.equal(certificationCandidates);
-      expect(certificationCandidateRepository.findBySessionId.calledAfter(sessionRepository.ensureUserHasAccessToSession)).to.be.true;
-    });
-
+    // then
+    expect(actualCandidates).to.equal(certificationCandidates);
   });
 
 });

--- a/api/tests/unit/domain/usecases/get-session_test.js
+++ b/api/tests/unit/domain/usecases/get-session_test.js
@@ -1,126 +1,47 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const getSession = require('../../../../lib/domain/usecases/get-session');
-const { NotFoundError, UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-session', () => {
 
   const sessionId = 'sessionId';
-  const session = {
-    id: sessionId,
-    name: 'mySession',
-  };
-  const userId = 'userId';
   let sessionRepository;
-  let userRepository;
 
   beforeEach(() => {
     sessionRepository = {
       get: sinon.stub(),
-      ensureUserHasAccessToSession: sinon.stub(),
-    };
-    userRepository = {
-      hasRolePixMaster: sinon.stub(),
     };
   });
 
-  context('when the user has role pixmaster', () => {
+  context('when the session exists', () => {
+    const sessionToFind = Symbol('sessionToFind');
 
     beforeEach(() => {
-      userRepository.hasRolePixMaster.withArgs(userId).resolves(true);
-      sessionRepository.ensureUserHasAccessToSession.rejects();
+      sessionRepository.get.withArgs(sessionId).resolves(sessionToFind);
     });
 
-    context('when the session can be retrieved', () => {
+    it('should get the session', async () => {
+      // when
+      const actualSession = await getSession({ sessionId, sessionRepository });
 
-      beforeEach(() => {
-        sessionRepository.get.withArgs(sessionId).resolves(session);
-      });
-
-      it('should get the session', async () => {
-        // when
-        const actualSession = await getSession({ userId, sessionId, sessionRepository, userRepository });
-
-        // then
-        expect(actualSession.name).to.equal(session.name);
-      });
+      // then
+      expect(actualSession).to.equal(sessionToFind);
     });
-
-    context('when the session could not be retrieved', () => {
-
-      beforeEach(() => {
-        sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
-      });
-
-      it('should throw an error the session', async () => {
-        // when
-        const err = await catchErr(getSession)({ userId, sessionId, sessionRepository, userRepository });
-
-        // then
-        expect(err).to.be.an.instanceof(NotFoundError);
-      });
-    });
-
   });
 
-  context('when the user has no role pixmaster', () => {
+  context('when the session does not exist', () => {
 
     beforeEach(() => {
-      userRepository.hasRolePixMaster.withArgs(userId).resolves(false);
+      sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
     });
 
-    context('when the user has access to session', () => {
+    it('should throw an error the session', async () => {
+      // when
+      const err = await catchErr(getSession)({ sessionId, sessionRepository });
 
-      beforeEach(() => {
-        sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).resolves();
-      });
-
-      context('when the session can be retrieved', () => {
-
-        beforeEach(() => {
-          sessionRepository.get.withArgs(sessionId).resolves(session);
-        });
-
-        it('should get the session', async () => {
-          // when
-          const actualSession = await getSession({ userId, sessionId, sessionRepository, userRepository });
-
-          // then
-          expect(actualSession.name).to.equal(session.name);
-        });
-      });
-
-      context('when the session could not be retrieved', () => {
-
-        beforeEach(() => {
-          sessionRepository.get.withArgs(sessionId).rejects(new NotFoundError());
-        });
-
-        it('should throw an error the session', async () => {
-          // when
-          const err = await catchErr(getSession)({ userId, sessionId, sessionRepository, userRepository });
-
-          // then
-          expect(err).to.be.an.instanceof(NotFoundError);
-        });
-      });
+      // then
+      expect(err).to.be.an.instanceof(NotFoundError);
     });
-
-    context('when the user has no access to session', () => {
-
-      beforeEach(() => {
-        sessionRepository.get.withArgs(sessionId).resolves(session);
-        sessionRepository.ensureUserHasAccessToSession.withArgs(userId, sessionId).rejects(new UserNotAuthorizedToAccessEntity());
-      });
-
-      it('should throw an error the session', async () => {
-        // when
-        const err = await catchErr(getSession)({ userId, sessionId, sessionRepository, userRepository });
-
-        // then
-        expect(err).to.be.an.instanceof(UserNotAuthorizedToAccessEntity);
-      });
-    });
-
   });
 
 });

--- a/api/tests/unit/domain/usecases/import-certification-candidates-from-attendance-sheet_test.js
+++ b/api/tests/unit/domain/usecases/import-certification-candidates-from-attendance-sheet_test.js
@@ -1,113 +1,69 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity, CertificationCandidateAlreadyLinkedToUserError } = require('../../../../lib/domain/errors');
+const { CertificationCandidateAlreadyLinkedToUserError } = require('../../../../lib/domain/errors');
 const importCertificationCandidatesFromAttendanceSheet = require('../../../../lib/domain/usecases/import-certification-candidates-from-attendance-sheet');
 const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
 const certificationCandidatesOdsService = require('../../../../lib/domain/services/certification-candidates-ods-service');
 
 describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet', () => {
 
   describe('#importCertificationCandidatesFromAttendanceSheet', () => {
-    const userId = 'userId';
     const sessionId = 'sessionId';
     const odsBuffer = 'buffer';
     const certificationCandidates = 'extractedCandidates';
 
-    context('when user does not have access to session', () => {
+    context('when session contains already linked certification candidates', () => {
 
       beforeEach(() => {
-        sinon.stub(sessionRepository, 'ensureUserHasAccessToSession')
-          .withArgs(userId, sessionId)
-          .rejects(new UserNotAuthorizedToAccessEntity(sessionId));
+        sinon.stub(certificationCandidateRepository, 'doesLinkedCertificationCandidateInSessionExist')
+          .withArgs({ sessionId })
+          .resolves(true);
       });
 
-      it('should throw a UserNotAuthorizedToAccessEntity error', async () => {
+      it('should throw a BadRequestError', async () => {
         // when
         const result = await catchErr(importCertificationCandidatesFromAttendanceSheet)({
-          userId,
           sessionId,
           odsBuffer,
           certificationCandidatesOdsService,
-          sessionRepository,
           certificationCandidateRepository,
         });
 
         // then
-        expect(result).to.be.an.instanceOf(UserNotAuthorizedToAccessEntity);
+        expect(result).to.be.an.instanceOf(CertificationCandidateAlreadyLinkedToUserError);
       });
 
     });
 
-    context('when user has access to session', () => {
+    context('when session contains zero linked certification candidates', () => {
 
       beforeEach(() => {
-        sinon.stub(sessionRepository, 'ensureUserHasAccessToSession')
-          .withArgs(userId, sessionId)
+        sinon.stub(certificationCandidateRepository, 'doesLinkedCertificationCandidateInSessionExist')
+          .withArgs({ sessionId })
+          .resolves(false);
+        sinon.stub(certificationCandidatesOdsService, 'extractCertificationCandidatesFromAttendanceSheet')
+          .withArgs({ sessionId, odsBuffer })
+          .resolves(certificationCandidates);
+        sinon.stub(certificationCandidateRepository, 'setSessionCandidates')
+          .withArgs(sessionId, certificationCandidates)
           .resolves();
       });
 
-      context('when session contains already linked certification candidates', () => {
-
-        beforeEach(() => {
-          sinon.stub(certificationCandidateRepository, 'doesLinkedCertificationCandidateInSessionExist')
-            .withArgs({ sessionId })
-            .resolves(true);
+      it('should call the appropriate methods', async function() {
+        // when
+        await importCertificationCandidatesFromAttendanceSheet({
+          sessionId,
+          odsBuffer,
+          certificationCandidatesOdsService,
+          certificationCandidateRepository,
         });
 
-        it('should throw a BadRequestError', async () => {
-          // when
-          const result = await catchErr(importCertificationCandidatesFromAttendanceSheet)({
-            userId,
-            sessionId,
-            odsBuffer,
-            certificationCandidatesOdsService,
-            sessionRepository,
-            certificationCandidateRepository,
-          });
-
-          // then
-          expect(result).to.be.an.instanceOf(CertificationCandidateAlreadyLinkedToUserError);
-        });
-
+        // then
+        expect(certificationCandidateRepository.doesLinkedCertificationCandidateInSessionExist).to.have.been.calledWith({ sessionId });
+        expect(certificationCandidatesOdsService.extractCertificationCandidatesFromAttendanceSheet).to.have.been.calledWith({ sessionId, odsBuffer });
+        expect(certificationCandidateRepository.setSessionCandidates).to.have.been.calledWith(sessionId, certificationCandidates);
+        expect(certificationCandidateRepository.setSessionCandidates.calledAfter(certificationCandidatesOdsService.extractCertificationCandidatesFromAttendanceSheet))
+          .to.be.true;
       });
-
-      context('when session contains zero linked certification candidates', () => {
-
-        beforeEach(() => {
-          sinon.stub(certificationCandidateRepository, 'doesLinkedCertificationCandidateInSessionExist')
-            .withArgs({ sessionId })
-            .resolves(false);
-          sinon.stub(certificationCandidatesOdsService, 'extractCertificationCandidatesFromAttendanceSheet')
-            .withArgs({ sessionId, odsBuffer })
-            .resolves(certificationCandidates);
-          sinon.stub(certificationCandidateRepository, 'setSessionCandidates')
-            .withArgs(sessionId, certificationCandidates)
-            .resolves();
-        });
-
-        it('should call the appropriate methods', async function() {
-          // when
-          await importCertificationCandidatesFromAttendanceSheet({
-            userId,
-            sessionId,
-            odsBuffer,
-            certificationCandidatesOdsService,
-            sessionRepository,
-            certificationCandidateRepository,
-          });
-
-          // then
-          expect(sessionRepository.ensureUserHasAccessToSession).to.have.been.calledWith(userId, sessionId);
-          expect(certificationCandidateRepository.doesLinkedCertificationCandidateInSessionExist).to.have.been.calledWith({ sessionId });
-          expect(certificationCandidatesOdsService.extractCertificationCandidatesFromAttendanceSheet).to.have.been.calledWith({ sessionId, odsBuffer });
-          expect(certificationCandidatesOdsService.extractCertificationCandidatesFromAttendanceSheet.calledAfter(sessionRepository.ensureUserHasAccessToSession))
-            .to.be.true;
-          expect(certificationCandidateRepository.setSessionCandidates).to.have.been.calledWith(sessionId, certificationCandidates);
-          expect(certificationCandidateRepository.setSessionCandidates.calledAfter(certificationCandidatesOdsService.extractCertificationCandidatesFromAttendanceSheet))
-            .to.be.true;
-        });
-      });
-
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
L'accès à des sessions peut se faire via des routes communes utilisées par PixAdmin et PixCertif.
A ce titre, on peut être amené à vérifier si l'utilisateur a bien accès à la session en vérifiant dans le usecase :
- Si l'utilisateur a le rôle PixMaster
- Ou bien si l'utilisateur fait bien partie du centre de certification à l'origine de la création de la session

## :robot: Solution
On factorise ce besoin dans un pre-handler.

## :rainbow: Remarques
- Application de ce prehandler sur toutes les routes dont le usecase dépendant utilisait ensureUserHasAccessToSession()
- Tests de validation : 
- non reg sur Pix certif
- consultation d'une session sur Pix admin