### PR TITLE
[BUGFIX] Empêcher l'erreur d'unicité des CampaignParticipation d'arriver jusqu'en base de données (PO-299). 

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -28,6 +28,12 @@ class AlreadyRegisteredEmailError extends DomainError {
   }
 }
 
+class AlreadyExistingCampaignParticipationError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 class AlreadySharedCampaignParticipationError extends DomainError {
   constructor() {
     super('Ces résultats de campagne ont déjà été partagés.');
@@ -347,6 +353,7 @@ class InternalError extends DomainError {
 
 module.exports = {
   DomainError,
+  AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,
   AlreadyExistingOrganizationInvitationError,
   AlreadyRatedAssessmentError,

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -1,6 +1,6 @@
 const Assessment = require('../models/Assessment');
 
-const { NotFoundError } = require('../../domain/errors');
+const { AlreadyExistingCampaignParticipationError, NotFoundError } = require('../../domain/errors');
 
 module.exports = async function startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository }) {
   await _checkCampaignExists(campaignParticipation.campaignId, campaignRepository);
@@ -31,6 +31,11 @@ async function _createSmartPlacementAssessment(userId, assessmentRepository, cam
 }
 
 async function _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository) {
+  const campaignId = campaignParticipation.campaignId;
+  const alreadyExistingCampaignParticipation = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
+  if (alreadyExistingCampaignParticipation) {
+    throw new AlreadyExistingCampaignParticipationError(`User ${userId} has already a campaign participation with campaign ${campaignId}`);
+  }
   campaignParticipation.userId = userId;
   return campaignParticipationRepository.save(campaignParticipation);
 }

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -61,6 +61,13 @@ module.exports = {
       .then(fp.map(_toDomain));
   },
 
+  findOneByCampaignIdAndUserId({ campaignId, userId }) {
+    return BookshelfCampaignParticipation
+      .where({ campaignId, userId })
+      .fetch()
+      .then((campaignParticipation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCampaignParticipation, campaignParticipation));
+  },
+
   findOneByAssessmentIdWithSkillIds(assessmentId) {
     return BookshelfCampaignParticipation
       .query((qb) => {

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -74,6 +74,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.AlreadyExistingCampaignParticipationError) {
     return new InfraErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.AlreadySharedCampaignParticipationError) {
+    return new InfraErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.ForbiddenAccess) {
     return new InfraErrors.ForbiddenError(error.message);
   }

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -71,6 +71,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.AlreadyExistingOrganizationInvitationError) {
     return new InfraErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.AlreadyExistingCampaignParticipationError) {
+    return new InfraErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.ForbiddenAccess) {
     return new InfraErrors.ForbiddenError(error.message);
   }

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -589,7 +589,7 @@ describe('Acceptance | API | Campaign Participations', () => {
     });
   });
 
-  describe('PATH /api/campaign-participations/{id}/begin-improvement', () => {
+  describe('PATCH /api/campaign-participations/{id}/begin-improvement', () => {
     let user, campaignParticipation;
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser();
@@ -660,6 +660,26 @@ describe('Acceptance | API | Campaign Participations', () => {
         return promise.then((response) => {
           expect(response.statusCode).to.equal(403);
         });
+      });
+    });
+
+    context('when user is connected but has already shared his results so he/she cannot improve it', () => {
+      beforeEach(async () => {
+        const sharedCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, isShared: true });
+        await databaseBuilder.commit();
+        options = {
+          method: 'PATCH',
+          url: `/api/campaign-participations/${sharedCampaignParticipation.id}/begin-improvement`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        };
+      });
+
+      it('should return 421 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(421);
       });
     });
   });

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -564,20 +564,29 @@ describe('Acceptance | API | Campaign Participations', () => {
       expect(response.result.data.id).to.exist;
     });
 
-    it('should return 404 error if the campaign related to the participation does not exist', () => {
+    it('should return 404 error if the campaign related to the participation does not exist', async () => {
       // given
       options.payload.data.relationships.campaign.data.id = null;
 
       // when
-      const promise = server.inject(options);
+      const response = await server.inject(options);
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(404);
-      });
-
+      expect(response.statusCode).to.equal(404);
     });
 
+    it('should return 421 error if the user has already participated to the campaign', async () => {
+      // given
+      options.payload.data.relationships.campaign.data.id = campaignId;
+      databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(421);
+    });
   });
 
   describe('PATH /api/campaign-participations/{id}/begin-improvement', () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -252,6 +252,54 @@ describe('Integration | Repository | Campaign Participation', () => {
     });
   });
 
+  describe('#findOneByCampaignIdAndUserId', () => {
+
+    let userId;
+    let campaignId;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+
+      campaignId = databaseBuilder.factory.buildCampaign().id;
+      const otherCampaignId = databaseBuilder.factory.buildCampaign().id;
+
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId: otherUserId,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: otherCampaignId,
+        userId,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should return the campaign participation found', async () => {
+      // given
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        userId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
+
+      // then
+      expect(response).to.be.instanceOf(CampaignParticipation);
+      expect(response.id).to.deep.equal(campaignParticipation.id);
+    });
+
+    it('should return no campaign participation', async () => {
+      // when
+      const response = await campaignParticipationRepository.findOneByCampaignIdAndUserId({ campaignId, userId });
+
+      // then
+      expect(response).to.equal(null);
+    });
+  });
+
   describe('#findOneByAssessmentIdWithSkillIds', () => {
 
     const assessmentId = 12345;

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -1,76 +1,84 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const usecases = require('../../../../lib/domain/usecases');
-const { NotFoundError } = require('../../../../lib/domain/errors');
+const { AlreadyExistingCampaignParticipationError, NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | start-campaign-participation', () => {
 
   const userId = 19837482;
   const campaignParticipation = domainBuilder.buildCampaignParticipation({});
   const campaignRepository = { get: () => undefined };
-  const campaignParticipationRepository = { save: () => undefined };
+  const campaignParticipationRepository = { save: () => undefined, findOneByCampaignIdAndUserId: () => undefined };
   const assessmentRepository = { save: () => undefined };
 
   beforeEach(() => {
     sinon.stub(campaignRepository, 'get');
     sinon.stub(campaignParticipationRepository, 'save');
+    sinon.stub(campaignParticipationRepository, 'findOneByCampaignIdAndUserId');
     sinon.stub(assessmentRepository, 'save');
 
     campaignRepository.get.resolves(domainBuilder.buildCampaign());
+    campaignParticipationRepository.findOneByCampaignIdAndUserId.resolves(null);
   });
 
-  it('should throw an error if the campaign does not exists', () => {
+  it('should throw an error if the campaign does not exists', async () => {
     // given
     campaignRepository.get.resolves(null);
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
-    return expect(promise).to.be.rejectedWith(NotFoundError);
+    return expect(error).to.be.instanceOf(NotFoundError);
   });
-  it('should save the campaign participation with userId', () => {
+
+  it('should throw an error if the user has already participated to the campaign', async () => {
+    // given
+    campaignParticipationRepository.findOneByCampaignIdAndUserId.resolves({});
+
+    // when
+    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+
+    // then
+    return expect(error).to.be.instanceOf(AlreadyExistingCampaignParticipationError);
+  });
+
+  it('should save the campaign participation with userId', async () => {
     // given
     const assessmentId = 987654321;
     assessmentRepository.save.resolves({ id: assessmentId });
     campaignParticipationRepository.save.resolves({});
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
-    return promise.then(() => {
-      expect(campaignParticipationRepository.save).to.have.been.called;
-
-      const campaignParticipationToSave = campaignParticipationRepository.save.firstCall.args[0];
-      expect(campaignParticipationToSave.userId).to.equal(userId);
-      expect(campaignParticipationToSave).to.deep.equal(campaignParticipation);
-    });
+    expect(campaignParticipationRepository.save).to.have.been.called;
+    const campaignParticipationToSave = campaignParticipationRepository.save.firstCall.args[0];
+    expect(campaignParticipationToSave.userId).to.equal(userId);
+    expect(campaignParticipationToSave).to.deep.equal(campaignParticipation);
   });
 
-  it('should create a smart placement assessment', () => {
+  it('should create a smart placement assessment', async () => {
     // given
     assessmentRepository.save.resolves({});
     campaignParticipationRepository.save.resolves({ id: 1 });
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
-    return promise.then(() => {
-      expect(assessmentRepository.save).to.have.been.called;
-
-      const assessmentToSave = assessmentRepository.save.firstCall.args[0];
-      expect(assessmentToSave.type).to.equal(Assessment.types.SMARTPLACEMENT);
-      expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
-      expect(assessmentToSave.userId).to.equal(userId);
-      expect(assessmentToSave.courseId).to.equal('Smart Placement Tests CourseId Not Used');
-      expect(assessmentToSave.campaignParticipationId).to.equal(campaignParticipation.id);
-    });
+    expect(assessmentRepository.save).to.have.been.called;
+    const assessmentToSave = assessmentRepository.save.firstCall.args[0];
+    expect(assessmentToSave.type).to.equal(Assessment.types.SMARTPLACEMENT);
+    expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
+    expect(assessmentToSave.userId).to.equal(userId);
+    expect(assessmentToSave.courseId).to.equal('Smart Placement Tests CourseId Not Used');
+    expect(assessmentToSave.campaignParticipationId).to.equal(campaignParticipation.id);
   });
 
-  it('should return the saved campaign participation', () => {
+  it('should return the saved campaign participation', async () => {
     // given
     const assessmentId = 987654321;
     const createdCampaignParticipation = domainBuilder.buildCampaignParticipation();
@@ -78,12 +86,9 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.save.resolves(createdCampaignParticipation);
 
     // when
-    const promise = usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const campaignParticipationReturned = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
-    return promise.then((campaignParticipation) => {
-      expect(campaignParticipation).to.deep.equal(createdCampaignParticipation);
-    });
+    expect(campaignParticipationReturned).to.deep.equal(createdCampaignParticipation);
   });
-
 });

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -3,9 +3,11 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   queryParams: ['participantExternalId'],
   participantExternalId: null,
+  isLoading: false,
 
   actions: {
     startCampaignParticipation() {
+      this.set('isLoading', true);
       return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
         queryParams: { hasSeenLanding: true, participantExternalId: this.get('participantExternalId') }
       });

--- a/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 export default Controller.extend({
 
   participantExternalId: null,
-  loading: false,
+  isLoading: false,
   errorMessage: null,
 
   actions: {
@@ -14,7 +14,7 @@ export default Controller.extend({
       const participantExternalId = this.participantExternalId;
 
       if (participantExternalId) {
-        this.set('loading', true);
+        this.set('isLoading', true);
         return this.start(this.model, participantExternalId);
       } else {
         return this.set('errorMessage', `Merci de renseigner votre ${this.get('model.idPixLabel')}.`);
@@ -23,7 +23,7 @@ export default Controller.extend({
 
     cancel() {
       this.set('errorMessage', null);
-      
+
       return this.transitionToRoute('campaigns.campaign-landing-page', this.model.code);
     },
   }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -6,6 +6,10 @@ export default Route.extend({
   campaignCode: null,
   session: service(),
 
+  deactivate() {
+    this.controller.set('isLoading', false);
+  },
+
   async model(params) {
     const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
 

--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -11,7 +11,7 @@ export default Route.extend({
 
   deactivate() {
     this.controller.set('participantExternalId', null);
-    this.controller.set('loading', false);
+    this.controller.set('isLoading', false);
   },
 
   async beforeModel(transition) {

--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -49,14 +49,14 @@ export default Route.extend({
   start(campaign, participantExternalId = null) {
     return this.store.createRecord('campaign-participation', { campaign, participantExternalId })
       .save()
-      .catch((err) => {
-        if (_.get(err, 'errors[0].status') === 403) {
-          return this.session.invalidate();
-        }
-        return this.send('error');
-      })
       .then(() => {
         return this.transitionTo('campaigns.start-or-resume', campaign.code);
+      }, (err) => {
+        if (_.get(err, 'errors[0].status') === 403) {
+          this.session.invalidate();
+          return this.transitionTo('campaigns.start-or-resume', campaign.code);
+        }
+        return this.send('error', err, this.transitionTo('campaigns.start-or-resume', campaign.code));
       });
   },
 }, AuthenticatedRouteMixin);

--- a/mon-pix/app/styles/pages/_fill-in-id-pix.scss
+++ b/mon-pix/app/styles/pages/_fill-in-id-pix.scss
@@ -36,6 +36,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.fill-in-id-pix-form__section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   @include device-is('tablet') {
     display: block;

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -15,12 +15,23 @@
       </div>
       <div class="campaign-landing-page__start__text">
         <p class="campaign-landing-page__start__text__title">Commencez votre parcours</p>
-        <p class="campaign-landing-page__start__text__announcement">Démarrez votre parcours d'évaluation
-          personnalisé.<br>
-          Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.</p>
-        <button class="campaign-landing-page__start-button button button--big"
-          {{action "startCampaignParticipation" model}}> Je commence
-        </button>
+        <p class="campaign-landing-page__start__text__announcement">
+          Démarrez votre parcours d'évaluation personnalisé.<br>
+          Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.
+        </p>
+
+        <form {{action "startCampaignParticipation" on="submit"}}>
+          {{#if isLoading}}
+              <button type="button" disabled class="campaign-landing-page__start-button button button--big">
+                <span class="loader-in-button ">&nbsp;</span>
+              </button>
+          {{else}}
+            <button type="submit" class="campaign-landing-page__start-button button button--big">
+              Je commence
+            </button>
+          {{/if}}
+        </form>
+
         <p class="campaign-landing-page__start__text__legal">
           Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre
           de

--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -2,30 +2,37 @@
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
     <h1 class="fill-in-id-pix-text fill-in-id-pix-text__title">Avant de commencer</h1>
-    <p class="fill-in-id-pix-text fill-in-id-pix-text__announcement">L'organisateur de votre parcours a besoin de l'information ci-dessous
-      pour pouvoir vous accompagner :</p>
-    <div class="fill-in-id-pix__form">
-      <div class="fill-in-id-pix__form-field">
-        <label for="id-pix-label">{{model.idPixLabel}} :</label>
-        {{input required id="id-pix-label" value=participantExternalId}}
+    <p class="fill-in-id-pix-text fill-in-id-pix-text__announcement">
+      L'organisateur de votre parcours a besoin de l'information ci-dessous pour pouvoir vous accompagner :
+    </p>
+
+    <form {{action "submit" on="submit"}} class="fill-in-id-pix__form">
+      <div class="fill-in-id-pix-form__section">
+        <div class="fill-in-id-pix__form-field">
+          <label for="id-pix-label">{{model.idPixLabel}} :</label>
+          {{input required id="id-pix-label" value=participantExternalId}}
+        </div>
+        {{#if isLoading}}
+          <button type="button" disabled class="button button--big">
+            <span class="loader-in-button">&nbsp;</span>
+          </button>
+        {{else}}
+          <button type="submit" class="button button--big">Continuer</button>
+        {{/if}}
+        {{#if errorMessage}}
+          <div class="fill-in-id-pix__form__error-message">{{errorMessage}}</div>
+        {{/if}}
       </div>
-      {{#if loading}}
-        <button type="button" disabled class="button button--big">
-          <span class="loader-in-button">&nbsp;</span>
+
+      {{#if isLoading}}
+        <button type="button" disabled class="button button--regular button--no-color fill-in-id-pix__cancel-button">
+          Annuler
         </button>
       {{else}}
-        <button type="submit" class="button button--big" {{action "submit"}}>Continuer</button>
+        <button type="button" {{action "cancel"}} class="button button--regular button--no-color fill-in-id-pix__cancel-button">
+          Annuler
+        </button>
       {{/if}}
-      {{#if errorMessage}}
-        <div class="fill-in-id-pix__form__error-message">{{errorMessage}}</div>
-      {{/if}}
-    </div>
-    {{#if loading}}
-      <button class="button button--regular button--no-color fill-in-id-pix__cancel-button">Annuler</button>
-    {{else}}
-      <button class="button button--regular button--no-color fill-in-id-pix__cancel-button" {{action "cancel"}}>
-        Annuler
-      </button>
-    {{/if}}
+    </form>
   </div>
 </div>

--- a/mon-pix/tests/acceptance/resume-campaigns-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-test.js
@@ -36,7 +36,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
         await click('.campaign-landing-page__start-button');
       });
 
-      it('should propose to signup', async function() {
+      it('should propose to signup', function() {
         expect(currentURL()).to.contains('/inscription');
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Sentry nous remonte ce type d'erreur : 
```
error
insert into "campaign-participations" ("campaignId", "createdAt", "participantExternalId", "userId") values ($1, $2, $3, $4) returning "id" - duplicate key value violates unique constraint "campaign_participations_campaignid_userid_unique"
environment
production
```

Après investigation, nous supposons avec @octo-thlo qu'il s'agit de double-click, venant de plusieurs page différentes.

## :robot: Solution
- Empêcher la demander de sauvegarde d'aller jusqu'en base où l'erreur d'unicité est levée (et cause une erreur HTTP 500), mais la thrower bien avant pour la renvoyer au format HTTP Precondition Failed.
- Essayer d'endiguer le double-click sur les pages de présentation de campagne (landing page) et d'identifiant externe (fill-in-id-pix page).

## :rainbow: Remarques
Toutes les erreurs Precondition Failed sont gérées dans Pix comme étant des erreurs 421 ; pourtant le code d'erreur de celle-ci est le 412 (cf https://developer.mozilla.org/fr/docs/Web/HTTP/Status/412). À changer dans une autre PR.