### PR TITLE
[FEATURE] Permettre aux utilisateurs non connectés via le GAR de saisir leur nom et prénom lors de la réconciliation (PF-886).

### DIFF
--- a/high-level-tests/e2e/cypress/fixtures/campaigns.json
+++ b/high-level-tests/e2e/cypress/fixtures/campaigns.json
@@ -14,5 +14,12 @@
     "organizationId": 1,
     "creatorId": 1,
     "targetProfileId": 1
+  }, {
+    "id": 3,
+    "name": "Campagne de Winterfell",
+    "code": "WINTER",
+    "organizationId": 2,
+    "creatorId": 3,
+    "targetProfileId": 1
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/memberships.json
+++ b/high-level-tests/e2e/cypress/fixtures/memberships.json
@@ -3,5 +3,9 @@
     "userId": 1,
     "organizationId": 1,
     "organizationRole": "ADMIN"
+  }, {
+    "userId": 3 ,
+    "organizationId": 2,
+    "organizationRole": "ADMIN"
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -4,5 +4,10 @@
     "type": "PRO",
     "name": "Dragon & Co",
     "code": "ICEFIR"
+  }, {
+    "id": 2,
+    "type": "SCO",
+    "name": "The Night Watch",
+    "isManagingStudents": true
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/students.json
+++ b/high-level-tests/e2e/cypress/fixtures/students.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": 1,
+    "firstName": "Daenerys",
+    "middleName": "Khaleesi",
+    "thirdName": "Mother of Dragons",
+    "lastName": "Stormborn",
+    "preferredLastName": "Targaryen",
+    "birthdate": "1986-10-23",
+    "organizationId": 2,
+    "userId": null
+  }
+]

--- a/high-level-tests/e2e/cypress/integration/campaign.feature
+++ b/high-level-tests/e2e/cypress/integration/campaign.feature
@@ -3,7 +3,7 @@ Feature: Campagne
   Background:
     Given les données de test sont chargées
 
-  Scenario: Je commence mon parcours prescrit
+  Scenario: Je rejoins mon parcours prescrit
     Given je vais sur Pix
     And je suis connecté à Pix en tant que "Daenerys Targaryen"
     When je vais sur la page d'accès à une campagne
@@ -20,4 +20,31 @@ Feature: Campagne
     When je clique sur "Je commence"
     And je clique sur "connectez-vous à votre compte"
     And je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Then je vois la page de "didacticiel" de la campagne
+
+  Scenario: Je rejoins mon parcours prescrit restreint
+    Given je vais sur Pix
+    And je suis connecté à Pix en tant que "Daenerys Targaryen"
+    And je vais sur la page d'accès à une campagne
+    When je saisis "WINTER" dans le champ
+    And je clique sur "Commencer mon parcours"
+    Then je vois la page de "rejoindre" de la campagne
+    When je saisis mon prénom "Daenerys"
+    When je saisis mon nom "Targaryen"
+    When je saisis ma date de naissance 23-10-1986
+    And je clique sur "C'est parti !"
+    Then je vois la page de "presentation" de la campagne
+    When je clique sur "Je commence"
+    Then je vois la page de "didacticiel" de la campagne
+
+  Scenario: Je rejoins mon parcours prescrit restreint en étant connecté via un organisme externe
+    Given je vais sur Pix via un organisme externe
+    And je vais sur la page d'accès à une campagne
+    When je saisis "WINTER" dans le champ
+    And je clique sur "Commencer mon parcours"
+    Then je vois la page de "rejoindre" de la campagne
+    When je saisis ma date de naissance 23-10-1986
+    And je clique sur "C'est parti !"
+    Then je vois la page de "presentation" de la campagne
+    When je clique sur "Je commence"
     Then je vois la page de "didacticiel" de la campagne

--- a/high-level-tests/e2e/cypress/plugins/index.js
+++ b/high-level-tests/e2e/cypress/plugins/index.js
@@ -1,7 +1,9 @@
 const { knex } = require('../../../../api/db/knex-database-connection');
 const cucumber = require('cypress-cucumber-preprocessor').default;
 
-module.exports = (on) => {
+module.exports = (on, config) => {
+  config.env.AUTH_SECRET = process.env.AUTH_SECRET;
+
   on('file:preprocessor', cucumber());
   on('task', {
     async 'db:fixture' (data) {
@@ -14,5 +16,6 @@ module.exports = (on) => {
       return file;
     }
   });
+  return config;
 };
 

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -1,3 +1,5 @@
+const jsonwebtoken = require('jsonwebtoken');
+
 Cypress.Commands.add('login', (username, password) => {
   cy.server();
   cy.route('/api/users/me').as('getCurrentUser');
@@ -46,20 +48,15 @@ Cypress.Commands.add('loginAdmin', (username, password) => {
   cy.wait(['@getCurrentUser']);
 });
 
-Cypress.Commands.add('loginToken', (username, password) => {
+Cypress.Commands.add('loginExternalPlatform', () => {
   cy.server();
   cy.route('/api/users/me').as('getCurrentUser');
-  cy.request({
-    url: `${Cypress.env('API_URL')}/api/token`,
-    method: 'POST',
-    form: true,
-    body: {
-      username,
-      password,
-    }
-  }).then((response) => {
-    cy.visitMonPix(`/?token=${response.body.access_token}`)
-  });
+  const token = jsonwebtoken.sign(
+    { user_id: 1, source: 'external' },
+    Cypress.env('AUTH_SECRET'),
+    { expiresIn: '1h' }
+  );
+  cy.visitMonPix(`/?token=${token}`);
   cy.wait(['@getCurrentUser']);
 });
 

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -13,3 +13,17 @@ then(`je vois la page de {string} de la campagne`, (page) => {
 then(`je vois le bandeau de reprise de parcours`, () => {
   cy.get('.resume-campaign-banner__container').should('exist');
 });
+
+when(`je saisis mon prénom {string}`, (firstName) => {
+  cy.get('input#firstName').type(firstName);
+});
+
+when(`je saisis mon nom {string}`, (lastName) => {
+  cy.get('input#lastName').type(lastName);
+});
+
+when(`je saisis ma date de naissance {int}-{int}-{int}`, (dayOfBirth, monthOfBirth, yearOfBirth) => {
+  cy.get('input#dayOfBirth').type(dayOfBirth);
+  cy.get('input#monthOfBirth').type(monthOfBirth);
+  cy.get('input#yearOfBirth').type(yearOfBirth);
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -6,6 +6,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'target-profiles_skills');
   cy.task('db:fixture', 'campaigns');
   cy.task('db:fixture', 'users_pix_roles');
+  cy.task('db:fixture', 'students');
 });
 
 given('tous les comptes sont créés', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/login.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login.js
@@ -14,7 +14,7 @@ given(`je m'inscris avec le prénom {string}, le nom {string}, le mail {string} 
 });
 
 when('je vais sur Pix via un organisme externe', () => {
-  cy.loginToken('daenerys.targaryen@pix.fr', 'pix123');
+  cy.loginExternalPlatform();
 });
 
 when(`je vais sur l'inscription de Pix`, () => {

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1755,6 +1755,11 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2662,6 +2667,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "electron-to-chromium": {
@@ -4789,6 +4802,30 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4799,6 +4836,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -5019,6 +5075,36 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -5028,8 +5114,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -6137,8 +6222,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6164,8 +6248,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "serialize-error": {
       "version": "2.1.0",

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -30,5 +30,8 @@
     "eslint": "^5.13.0",
     "eslint-plugin-cypress": "^2.6.1",
     "npm-run-all": "^4.1.5"
+  },
+  "dependencies": {
+    "jsonwebtoken": "^8.5.1"
   }
 }

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -3,12 +3,20 @@ import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 const ERROR_INPUT_MESSAGE_MAP = {
+  firstName: 'Votre prénom n’est pas renseigné.',
+  lastName: 'Votre nom n’est pas renseigné.',
   dayOfBirth: 'Votre jour de naissance n’est pas valide.',
   monthOfBirth: 'Votre mois de naissance n’est pas valide.',
   yearOfBirth: 'Votre année de naissance n’est pas valide.',
 };
 
 const validation = {
+  firstName: {
+    message: null
+  },
+  lastName: {
+    message: null
+  },
   dayOfBirth: {
     message: null
   },
@@ -29,6 +37,7 @@ function _pad(num, size) {
 const isDayValid = (value) => value > 0 && value <= 31;
 const isMonthValid = (value) => value > 0 && value <= 12;
 const isYearValid = (value) => value > 999 && value <= 9999;
+const isStringValid = (value) => !!value.trim();
 
 export default Controller.extend({
   queryParams: ['participantExternalId'],
@@ -48,8 +57,9 @@ export default Controller.extend({
     return [this.yearOfBirth, monthOfBirth, dayOfBirth].join('-');
   }),
 
-  isFormNotValid: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
-    return !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
+  isFormNotValid: computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+    return !isStringValid(this.firstName) || !isStringValid(this.lastName)
+    || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
   }),
 
   isDisabled: computed('session.data.authenticated.source', function() {
@@ -68,6 +78,8 @@ export default Controller.extend({
     attemptNext() {
       this.set('errorMessage', null);
       this.set('isLoading', true);
+      this._validateInputName('firstName', this.firstName);
+      this._validateInputName('lastName', this.lastName);
       this._validateInputDay('dayOfBirth', this.dayOfBirth);
       this._validateInputMonth('monthOfBirth', this.monthOfBirth);
       this._validateInputYear('yearOfBirth', this.yearOfBirth);
@@ -101,6 +113,10 @@ export default Controller.extend({
       });
     },
 
+    triggerInputStringValidation(key, value) {
+      this._validateInputName(key, value);
+    },
+
     triggerInputDayValidation(key, value) {
       this._padNumberInInput('dayOfBirth', value);
       this._validateInputDay(key, value);
@@ -121,6 +137,10 @@ export default Controller.extend({
     const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
     const messageObject = 'validation.' + key + '.message';
     return this.set(messageObject, message);
+  },
+
+  _validateInputName(key, value) {
+    this._executeFieldValidation(key, value, isStringValid);
   },
 
   _validateInputDay(key, value) {

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -35,6 +35,7 @@ export default Controller.extend({
   participantExternalId: null,
 
   store: service(),
+  session: service(),
 
   firstName: '',
   lastName: '',
@@ -49,6 +50,10 @@ export default Controller.extend({
 
   isFormNotValid: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
     return !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
+  }),
+
+  isDisabled: computed('session.data.authenticated.source', function() {
+    return this.session.data.authenticated.source === 'external';
   }),
 
   isLoading: false,

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 export default Route.extend(AuthenticatedRouteMixin, {
 
   currentUser: service(),
+  session: service(),
 
   async beforeModel(transition) {
     const campaignCode = transition.to.params.campaign_code;
@@ -24,7 +25,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   setupController(controller) {
     this._super(...arguments);
-    controller.set('firstName', this.currentUser.user.firstName);
-    controller.set('lastName', this.currentUser.user.lastName);
+    if (this.session.data.authenticated.source === 'external') {
+      controller.set('firstName', this.currentUser.user.firstName);
+      controller.set('lastName', this.currentUser.user.lastName);
+    }
   },
 });

--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -6,28 +6,51 @@
       <div class="join-restricted-campaign__title">Un tout petit détail !</div>
       <div class="join-restricted-campaign__subtitle">Remplissez les informations manquantes</div>
       <form>
+
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Prénom</label>
-          {{input id="firstName" type="text" value=firstName placeholder="Prénom" readonly=isDisabled disabled=isDisabled}}
+          {{input id="firstName" type="text" value=firstName placeholder="Prénom" readonly=isDisabled disabled=isDisabled
+                  class=(if validation.firstName.message 'input--error')
+                  focusOut=(action "triggerInputStringValidation" "firstName" firstName)}}
+          <div class="{{if validation.firstName.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{validation.firstName.message}}
+          </div>
         </div>
+
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Nom</label>
-          {{input id="lastName" type="text" value=lastName placeholder="Nom" readonly=isDisabled disabled=isDisabled}}
+          {{input id="lastName" type="text" value=lastName placeholder="Nom" readonly=isDisabled disabled=isDisabled
+                  class=(if validation.lastName.message 'input--error')
+                  focusOut=(action "triggerInputStringValidation" "lastName" lastName)}}
+          <div class="{{if validation.lastName.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{validation.lastName.message}}
+          </div>
         </div>
+
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Date de naissance</label>
           <div class="join-restricted-campaign__birthdate">
-            {{input id="dayOfBirth" type="text" value=dayOfBirth placeholder="JJ" class=(if validation.dayOfBirth.message 'input--error')
+            {{input id="dayOfBirth" type="text" value=dayOfBirth placeholder="JJ"
+                    class=(if validation.dayOfBirth.message 'input--error')
                     focusOut=(action "triggerInputDayValidation" "dayOfBirth" dayOfBirth)}}
-            {{input id="monthOfBirth" type="text" value=monthOfBirth placeholder="MM" class=(if validation.monthOfBirth.message 'input--error')
+            {{input id="monthOfBirth" type="text" value=monthOfBirth placeholder="MM"
+                    class=(if validation.monthOfBirth.message 'input--error')
                     focusOut=(action "triggerInputMonthValidation" "monthOfBirth" monthOfBirth)}}
-            {{input id="yearOfBirth" type="text" value=yearOfBirth placeholder="AAAA" class=(if validation.yearOfBirth.message 'input--error')
+            {{input id="yearOfBirth" type="text" value=yearOfBirth placeholder="AAAA"
+                    class=(if validation.yearOfBirth.message 'input--error')
                     focusOut=(action "triggerInputYearValidation" "yearOfBirth" yearOfBirth)}}
           </div>
-          <div class="{{if validation.dayOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.dayOfBirth.message}}</div>
-          <div class="{{if validation.monthOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.monthOfBirth.message}}</div>
-          <div class="{{if validation.yearOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">{{validation.yearOfBirth.message}}</div>
+          <div class="{{if validation.dayOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{validation.dayOfBirth.message}}
+          </div>
+          <div class="{{if validation.monthOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{validation.monthOfBirth.message}}
+          </div>
+          <div class="{{if validation.yearOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{validation.yearOfBirth.message}}
+          </div>
         </div>
+
         {{#if errorMessage}}
           <div class="join-restricted-campaign__error" aria-live="polite">{{errorMessage}}</div>
         {{/if}}

--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -8,11 +8,11 @@
       <form>
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Prénom</label>
-          {{input id="firstName" type="text" value=firstName placeholder="Prénom" readonly="readonly" disabled=true}}
+          {{input id="firstName" type="text" value=firstName placeholder="Prénom" readonly=isDisabled disabled=isDisabled}}
         </div>
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Nom</label>
-          {{input id="lastName" type="text" value=lastName placeholder="Nom" readonly="readonly" disabled=true}}
+          {{input id="lastName" type="text" value=lastName placeholder="Nom" readonly=isDisabled disabled=isDisabled}}
         </div>
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Date de naissance</label>

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -8,6 +8,7 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
 
   let controller;
   let storeStub;
+  let sessionStub;
   let studentUserAssociation;
 
   beforeEach(function() {
@@ -16,7 +17,9 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
     studentUserAssociation = { save: sinon.stub(), unloadRecord: sinon.stub() };
     const createStudentUserAssociationStub = sinon.stub().returns(studentUserAssociation);
     storeStub = { createRecord: createStudentUserAssociationStub };
+    sessionStub = { data: { authenticated: { source: 'pix' } } };
     controller.set('store', storeStub);
+    controller.set('session', sessionStub);
     controller.set('model', 'AZERTY999');
   });
 
@@ -195,6 +198,28 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
 
       // then
       expect(result).to.equal(false);
+    });
+  });
+
+  describe('#isDisabled', function() {
+
+    it('should be false if source is not external', function() {
+      // when
+      const result = controller.get('isDisabled');
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should be true if source is external', function() {
+      // given
+      sessionStub.data.authenticated.source = 'external';
+
+      // when
+      const result = controller.get('isDisabled');
+
+      // then
+      expect(result).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs hors GAR peuvent d'ors et déjà se réconcilier, mais ne peuvent pas changer leur nom et prénom, puisque ceux-ci sont grisés pour les utilisateurs venant du GAR.

## :robot: Solution
Checker si l'utilisateur authentifié vient du GAR ou non, et lui permettre de saisir son nom et prénom ou non.
