### PR TITLE
[FEATURE] Modification du nom de fichier de résultats de la session dans PixAdmin (PA-130)

### DIFF
--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -28,7 +28,15 @@ export default Service.extend({
     const data = _buildSessionExportFileData(session);
     const fileHeaders = _buildSessionExportFileHeaders();
     const csv = json2csv.parse(data, { fields: fileHeaders, delimiter: ';', withBOM: true });
-    const fileName = 'resultats_session_' + session.id + ' ' + (new Date()).toLocaleString('fr-FR') + '.csv';
+    const sessionDateTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const { day, month, year, hour, minute } = {
+      day: sessionDateTime.format('DD'),
+      month: sessionDateTime.format('MM'),
+      year: sessionDateTime.format('YYYY'),
+      hour: sessionDateTime.format('HH'),
+      minute: sessionDateTime.format('mm'),
+    };
+    const fileName = `${year}${month}${day}_${hour}${minute}_resultats_session_${session.id}.csv`;
     this.fileSaver.saveAs(csv + '\n', fileName);
   },
 


### PR DESCRIPTION
## :unicorn: Problème
Le nom du fichier csv téléchargé lorsqu'on télécharge les résultats de la session dans PixAdmin contient la date à laquelle le fichier a été crée, ce qui n'est plus très utile.

## :robot: Solution
Le nom du fichier a maintenant la forme suivante: 
`<annee><mois><jour>_<heure><minute>_resultats_session_<id de la session>.csv`
Exemple pour une session d'id 5 du 4 janvier 1990 à 9h00 :
19900104_0900_resultats_session_5.csv

## :rainbow: Remarques
@Krysthalia merci, voici des recommandations suivies par cette PR concernant le nommage de fichier : https://doranum.fr/stockage-archivage/comment-nommer-fichiers/ 