### PR TITLE
[BUGFIX] Aligner les règles css sur tablettes avec celles sur desktop (PF-978).

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -6,7 +6,7 @@
   }
 
   .competence-card__header {
-    height: 179px;
+    height: 110px;
     overflow: hidden;
     text-align: center;
     padding: 10px 0;
@@ -171,11 +171,5 @@
       margin-left: 8px;
       transition: all 0.1s linear;
     }
-  }
-}
-
-@include device-is('desktop') {
-  .competence-card__header {
-    height: 110px;
   }
 }

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -20,7 +20,7 @@
           {{#each model.scorecards as |scorecard|}}
             {{#if (eq areaCode scorecard.area.code)}}
               <div class="rounded-panel-body__competence-card">
-                {{#if media.isDesktop}}
+                {{#if media.isTablet}}
                   {{competence-card-desktop scorecard=scorecard}}
                 {{else}}
                   {{competence-card scorecard=scorecard}}

--- a/mon-pix/tests/acceptance/competence-profile-test.js
+++ b/mon-pix/tests/acceptance/competence-profile-test.js
@@ -6,6 +6,7 @@ import visitWithAbortedTransition from '../helpers/visit';
 import defaultScenario from '../../mirage/scenarios/default';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setBreakpointForIntegrationTest } from '../helpers/responsive';
 
 describe('Acceptance | Profile | Start competence', function() {
   setupApplicationTest();
@@ -23,7 +24,8 @@ describe('Acceptance | Profile | Start competence', function() {
     it('can start a competence', async function() {
       // when
       await visitWithAbortedTransition('/profil');
-      await click('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card__button ');
+      await setBreakpointForIntegrationTest(this, 'tablet');
+      await click('.rounded-panel-body__areas:first-child .rounded-panel-body__competence-card:first-child .competence-card__button');
 
       // then
       expect(currentURL()).to.contains('/assessments/');

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -59,7 +59,7 @@ describe('Integration | Component | Profile-content', function() {
     context('When user is on tablet/desktop ', function() {
       it('should be rendered in tablet/desktop mode with big cards', async function() {
         // when
-        setBreakpointForIntegrationTest(this, 'desktop');
+        setBreakpointForIntegrationTest(this, 'tablet');
         this.set('model', model);
         this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
         await render(hbs`{{profile-content model=model media=media}}`);


### PR DESCRIPTION
## :unicorn: Problème
L'affichage sur tablettes est cassé entre 768px et 890px, parce que le `media.isDesktop` renvoie le layout en mode mobile jusqu'à 980px alors que le css `is-device('tablet')` applique le CSS pour tablettes dès 768px.

## :robot: Solution
Aligner le mode tablette sur le mode desktop et ne plus avoir de différence tablette/desktop (jusqu'à ce qu'on ait un design spécifique tablettes).
