### PR TITLE
[FEATURE] Ne pas prendre en compte les caractères en trop lors de la réconciliation (PF-935).

### DIFF
--- a/api/lib/application/student-user-associations/index.js
+++ b/api/lib/application/student-user-associations/index.js
@@ -1,4 +1,6 @@
 const studentUserAssociationController = require('./student-user-association-controller');
+const Joi = require('@hapi/joi');
+const JSONAPIError = require('jsonapi-serializer').Error;
 
 exports.register = async function(server) {
   server.route([
@@ -7,6 +9,30 @@ exports.register = async function(server) {
       path: '/api/student-user-associations',
       config: {
         handler: studentUserAssociationController.associate,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'birthdate':Joi.date().iso().required(),
+                'campaign-code': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+              },
+            },
+          }),
+          failAction: (request, h) => {
+            const errorHttpStatusCode = 422;
+            const jsonApiError = new JSONAPIError({
+              status: errorHttpStatusCode.toString(),
+              title: 'Unprocessable entity',
+              detail: 'Un des champs saisis n’est pas valide.',
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          }
+        },
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Elle associe des données de l’utilisateur qui fait la requete, au student de l’organisation'

--- a/api/tests/acceptance/application/student-user-association-controller_test.js
+++ b/api/tests/acceptance/application/student-user-association-controller_test.js
@@ -123,6 +123,34 @@ describe('Acceptance | Controller | Student-user-associations', () => {
         expect(response.statusCode).to.equal(401);
       });
     });
+
+    context('when a field is not valid', () => {
+
+      it('should respond with a 422 - Unprocessable Entity', async () => {
+        // given
+        const options = {
+          method: 'POST',
+          url: '/api/student-user-associations',
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          payload: {
+            data: {
+              attributes: {
+                'campaign-code': campaign.code,
+                'first-name': ' ',
+                'last-name': student.lastName,
+                'birthdate': student.birthdate
+              }
+            }
+          }
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+    });
   });
 
   describe('GET /api/student-user-associations', () => {

--- a/api/tests/integration/application/student-user-associations/index_test.js
+++ b/api/tests/integration/application/student-user-associations/index_test.js
@@ -6,7 +6,7 @@ describe('Integration | Application | Route | student-user-associations', () => 
   let server;
 
   beforeEach(() => {
-    sinon.stub(studentUserAssociationController, 'associate').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(studentUserAssociationController, 'associate').callsFake((request, h) => h.response('ok').code(204));
     sinon.stub(studentUserAssociationController, 'findAssociation').callsFake((request, h) => h.response('ok').code(200));
     server = Hapi.server();
     return server.register(require('../../../../lib/application/student-user-associations'));
@@ -18,7 +18,46 @@ describe('Integration | Application | Route | student-user-associations', () => 
 
   describe('POST /api/student-user-associations', () => {
 
-    it('should exist', () => {
+    it('should succeed', () => {
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': 'Smith',
+          birthdate: '2012-12-12',
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(204);
+      });
+    });
+
+    it('should succeed when there is a space', () => {
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert ',
+          'last-name': 'Smith',
+          birthdate: '2012-12-12',
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(204);
+        expect(res.request.payload.data.attributes['first-name']).to.equal('Robert ');
+      });
+    });
+
+    it('should return an error when there is no payload', () => {
       // when
       const promise = server.inject({
         method: 'POST',
@@ -27,11 +66,141 @@ describe('Integration | Application | Route | student-user-associations', () => 
 
       // then
       return promise.then((res) => {
-        expect(res.statusCode).to.equal(201);
+        expect(res.statusCode).to.equal(422);
       });
-
     });
 
+    it('should return an error when there is an invalid first name attribute in the payload', () => {
+      // given
+      const INVALID_FIRSTNAME = ' ';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': INVALID_FIRSTNAME,
+          'last-name': 'Smith',
+          birthdate: '2012-12-12',
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
+
+    it('should return an error when there is an invalid last name attribute in the payload', () => {
+      // given
+      const INVALID_LASTNAME = '';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': INVALID_LASTNAME,
+          birthdate: '2012-12-12',
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
+
+    it('should return an error when there is an invalid a birthdate attribute (with space) in the payload', () => {
+      // given
+      const INVALID_BIRTHDATE = '2012- 12-12';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': 'Smith',
+          birthdate: INVALID_BIRTHDATE,
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
+
+    it('should return an error when there is an invalid birthdate attribute (with extra zeros) in the payload', () => {
+      // given
+      const INVALID_BIRTHDATE = '2012-012-12';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': 'Smith',
+          birthdate: INVALID_BIRTHDATE,
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
+
+    it('should return an error when there is an invalid birthdate attribute (not a proper date) in the payload', () => {
+      // given
+      const INVALID_BIRTHDATE = '1999-99-99';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': 'Smith',
+          birthdate: INVALID_BIRTHDATE,
+          'campaign-code': 'CODE',
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
+
+    it('should return an error when there is an invalid campaign code attribute in the payload', () => {
+      // given
+      const INVALID_CAMPAIGNCODE = '';
+
+      // when
+      const promise = server.inject({
+        method: 'POST',
+        url: '/api/student-user-associations',
+        payload: { data: { attributes: {
+          'first-name': 'Robert',
+          'last-name': 'Smith',
+          birthdate: '2012-12-12',
+          'campaign-code': INVALID_CAMPAIGNCODE,
+        } } },
+      });
+
+      // then
+      return promise.then((res) => {
+        expect(res.statusCode).to.equal(422);
+      });
+    });
   });
 
   describe('GET /api/student-user-associations', () => {

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 
 const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'Votre prénom n’est pas renseigné.',
@@ -28,12 +29,6 @@ const validation = {
   }
 };
 
-function _pad(num, size) {
-  let s = parseInt(num) + '';
-  while (s.length < size) s = '0' + s;
-  return s;
-}
-
 const isDayValid = (value) => value > 0 && value <= 31;
 const isMonthValid = (value) => value > 0 && value <= 12;
 const isYearValid = (value) => value > 999 && value <= 9999;
@@ -52,9 +47,10 @@ export default Controller.extend({
   monthOfBirth: '',
   yearOfBirth: '',
   birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
-    const monthOfBirth = _pad(this.monthOfBirth.trim(), 2);
-    const dayOfBirth = _pad(this.dayOfBirth.trim(), 2);
-    return [this.yearOfBirth.trim(), monthOfBirth, dayOfBirth].join('-');
+    const dayOfBirth = standardizeNumberInTwoDigitFormat(this.dayOfBirth.trim());
+    const monthOfBirth = standardizeNumberInTwoDigitFormat(this.monthOfBirth.trim());
+    const yearOfBirth = this.yearOfBirth.trim();
+    return [yearOfBirth, monthOfBirth, dayOfBirth].join('-');
   }),
 
   isFormNotValid: computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
@@ -119,13 +115,13 @@ export default Controller.extend({
 
     triggerInputDayValidation(key, value) {
       value = value.trim();
-      this._padNumberInInput('dayOfBirth', value);
+      this._standardizeNumberInInput('dayOfBirth', value);
       this._validateInputDay(key, value);
     },
 
     triggerInputMonthValidation(key, value) {
       value = value.trim();
-      this._padNumberInInput('monthOfBirth', value);
+      this._standardizeNumberInInput('monthOfBirth', value);
       this._validateInputMonth(key, value);
     },
 
@@ -159,9 +155,9 @@ export default Controller.extend({
     this._executeFieldValidation(key, value, isYearValid);
   },
 
-  _padNumberInInput(attribute, value) {
+  _standardizeNumberInInput(attribute, value) {
     if (value) {
-      this.set(attribute, _pad(value, 2));
+      this.set(attribute, standardizeNumberInTwoDigitFormat(value));
     }
   }
 });

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -29,7 +29,7 @@ const validation = {
 };
 
 function _pad(num, size) {
-  let s = num + '';
+  let s = parseInt(num) + '';
   while (s.length < size) s = '0' + s;
   return s;
 }
@@ -52,9 +52,9 @@ export default Controller.extend({
   monthOfBirth: '',
   yearOfBirth: '',
   birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
-    const monthOfBirth = _pad(this.monthOfBirth, 2);
-    const dayOfBirth = _pad(this.dayOfBirth, 2);
-    return [this.yearOfBirth, monthOfBirth, dayOfBirth].join('-');
+    const monthOfBirth = _pad(this.monthOfBirth.trim(), 2);
+    const dayOfBirth = _pad(this.dayOfBirth.trim(), 2);
+    return [this.yearOfBirth.trim(), monthOfBirth, dayOfBirth].join('-');
   }),
 
   isFormNotValid: computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
@@ -107,7 +107,7 @@ export default Controller.extend({
           if (error.status === '404') {
             return this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
           }
-          throw (error);
+          return this.set('errorMessage', error.detail);
         });
         this.set('isLoading', false);
       });
@@ -118,16 +118,20 @@ export default Controller.extend({
     },
 
     triggerInputDayValidation(key, value) {
+      value = value.trim();
       this._padNumberInInput('dayOfBirth', value);
       this._validateInputDay(key, value);
     },
 
     triggerInputMonthValidation(key, value) {
+      value = value.trim();
       this._padNumberInInput('monthOfBirth', value);
       this._validateInputMonth(key, value);
     },
 
     triggerInputYearValidation(key, value) {
+      value = value.trim();
+      this.set('yearOfBirth', value);
       this._validateInputYear(key, value);
     },
   },
@@ -156,7 +160,7 @@ export default Controller.extend({
   },
 
   _padNumberInInput(attribute, value) {
-    if (value.trim()) {
+    if (value) {
       this.set(attribute, _pad(value, 2));
     }
   }

--- a/mon-pix/app/utils/standardize-number.js
+++ b/mon-pix/app/utils/standardize-number.js
@@ -1,0 +1,14 @@
+function standardizeNumber(number, size) {
+  let numberInString = parseInt(number) + '';
+  while (numberInString.length < size) numberInString = '0' + numberInString;
+  return numberInString;
+}
+
+function standardizeNumberInTwoDigitFormat(number) {
+  return standardizeNumber(number, 2);
+}
+
+export {
+  standardizeNumber,
+  standardizeNumberInTwoDigitFormat,
+};

--- a/mon-pix/tests/unit/utils/standardize-number-test.js
+++ b/mon-pix/tests/unit/utils/standardize-number-test.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { standardizeNumber, standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
+
+describe('Unit | Utility | standardizeNumber', function() {
+
+  describe('standardizeNumber', function() {
+    const testData = [
+      { number: 2, size: 2, expected: '02' },
+      { number: 12, size: undefined, expected: '12' },
+      { number: 12, size: 2, expected: '12' },
+      { number: '042', size: undefined, expected: '42' },
+      { number: '042', size: 4, expected: '0042' },
+      { number: '40', size: undefined, expected: '40' },
+    ];
+
+    testData.forEach(({ number, size, expected }) => {
+
+      it(`When number is ${number} with size ${size} it should return ${expected}`, function() {
+        expect(standardizeNumber(number, size)).to.equal(expected);
+      });
+    });
+  });
+
+  describe('standardizeNumberInTwoDigitFormat', function() {
+    const testData = [
+      { number: 2, expected: '02' },
+      { number: 12, expected: '12' },
+      { number: '042', expected: '42' },
+      { number: '40', expected: '40' },
+    ];
+
+    testData.forEach(({ number, expected }) => {
+
+      it(`When number is ${number} it should return ${expected}`, function() {
+        expect(standardizeNumberInTwoDigitFormat(number)).to.equal(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lors de la réconciliation entre un élève et un compte Pix, l'utilisateur (identifié avec son compte Pix) doit saisir sa date de naissance. S'il saisis un caractère en trop comme un espace ou bien un zéro supplémentaire, on se retrouve avec une date de naissance "valide" dans le formulaire, qui transite jusqu'au back, et finalement la base de données nous fait savoir que ce n'est pas une date valide.
Exemple : "2012- 12-12" ou "2012-009-12"

## :robot: Solution
- Ajouter des checks côté front
- Ajouter des checks côtés back avec les validateurs Joi

## :rainbow: Remarques
Il y a 2 types de validateurs : 
- ceux du domaine, associé à un modèle du domaine, et définis dans un fichier à part ;
- ceux plus "application", associé à un payload, et implémentés directement dans la définition de la route dans `index.js`.

Dans notre cas cela ne correspond à aucun modèle du domaine, donc il a été choisi la 2e méthode :)
