### PR TITLE
[TECH] utiliser un Airtable minimal pour nos tests e2e (Cypress)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -30,8 +30,8 @@ module.exports = (function() {
     },
 
     airtable: {
-      apiKey: process.env.AIRTABLE_API_KEY,
-      base: process.env.AIRTABLE_BASE,
+      apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
+      base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
     },
 
     app: {

--- a/high-level-tests/e2e/cypress/fixtures/target-profiles_skills.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profiles_skills.json
@@ -2,56 +2,11 @@
   {
     "id": 1,
     "targetProfileId": 1,
-    "skillId": "rectL2ZZeWPc7yezp"
+    "skillId": "rec98HYctM7sl9Hyq"
   },
   {
     "id": 2,
     "targetProfileId": 1,
-    "skillId": "recGd7oJ2wVEyKmPS"
-  },
-  {
-    "id": 3,
-    "targetProfileId": 1,
-    "skillId": "recHvlTH8v706UYvc"
-  },
-  {
-    "id": 4,
-    "targetProfileId": 1,
-    "skillId": "recl2o6fA6oyMGPkb"
-  },
-  {
-    "id": 5,
-    "targetProfileId": 1,
-    "skillId": "recVgnoo6RjCxjCQp"
-  },
-  {
-    "id": 6,
-    "targetProfileId": 1,
-    "skillId": "recUQEnFmSvPBA807"
-  },
-  {
-    "id": 7,
-    "targetProfileId": 1,
-    "skillId": "recINVk1gM5DHCbs7"
-  },
-  {
-    "id": 8,
-    "targetProfileId": 1,
-    "skillId": "recpyHTeNkGnFnqhZ"
-  },
-  {
-    "id": 9,
-    "targetProfileId": 1,
-    "skillId": "rec9iiMaoi1GLzWVn"
-  },
-  {
-    "id": 10,
-    "targetProfileId": 1,
-    "skillId": "rec336WB21z6wKR6q"
-  },
-  {
-    "id": 11,
-    "targetProfileId": 1,
-    "skillId": "recVywppdS4hGEekR"
+    "skillId": "recJieHaORILprKhL"
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/demo.feature
+++ b/high-level-tests/e2e/cypress/integration/demo.feature
@@ -1,35 +1,19 @@
 Feature: Demo
 
-  Scenario: Je lance une démo pour Protection et sécurité
+  Scenario: Je lance une démo
     Given je vais sur Pix
-    When je lance le course "recboy5Db4p4wy6AN"
+    When je lance le course "rec5UecGJn0kr2odZ"
     Then je suis redirigé vers une page d'épreuve
-    And le titre sur l'épreuve est "Protection"
-
-  Scenario: Je lance une démo pour Création de contenu
-    Given je vais sur Pix
-    When je lance le course "recvPKiqKKHipEOjK"
-    Then je suis redirigé vers une page d'épreuve
-    And le titre sur l'épreuve est "Création"
-
-  Scenario: Je lance une démo pour Communication et collaboration
-    Given je vais sur Pix
-    When je lance le course "recq1wh5cKtibXDZu"
-    Then je suis redirigé vers une page d'épreuve
-    And le titre sur l'épreuve est "Communication"
-
-  Scenario: Je lance une démo pour Information et données
-    Given je vais sur Pix
-    When je lance le course "rec8rnpOgmfZyd2Ng"
-    Then je suis redirigé vers une page d'épreuve
-    And le titre sur l'épreuve est "Information"
-
-  Scenario: Je commence la démo Communication et collaboration
-    Given je vais sur Pix
-    When je lance le course "recq1wh5cKtibXDZu"
-    Then je suis redirigé vers une page d'épreuve
-    When l'épreuve contient le texte "émoticônes"
-    Then je clique sur "Je passe"
-    When l'épreuve contient le texte "Parmi ces démarches administratives"
-    Then je choisis la réponse "radio_3"
-    Then je clique sur "Je valide"
+    And le titre sur l'épreuve est "Démo essentiels"
+    When l'épreuve contient le texte "Combien font 2 + 2 ?"
+    And je clique sur "Je passe"
+    And l'épreuve contient le texte "Quel mot est synonyme de"
+    And je choisis la réponse "radio_3"
+    And je clique sur "Je valide"
+    And l'épreuve contient le texte "quel est le verbe ?"
+    And je saisis "manger" dans le champ
+    And je clique sur "Je valide"
+    Then je vois la page de résultats
+    And j'ai passé à "Combien font 2 + 2 ?"
+    And j'ai mal répondu à "Quel mot est synonyme de"
+    And j'ai bien répondu à "quel est le verbe ?"

--- a/high-level-tests/e2e/cypress/integration/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/page-title.feature
@@ -15,5 +15,5 @@ Feature: Titre des pages
     Given tous les comptes sont créés
     And je vais sur Pix
     And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    When je vais sur la compétence "recsvLz0W2ShyfD63"
-    Then je vois le titre de la page "Compétence | Mener une recherche et une veille d’information | Pix"
+    When je vais sur la compétence "recH9MjIzN54zXlwr"
+    Then je vois le titre de la page "Compétence | Mathématiques | Pix"

--- a/high-level-tests/e2e/cypress/integration/preview.feature
+++ b/high-level-tests/e2e/cypress/integration/preview.feature
@@ -6,7 +6,7 @@ Feature: Preview
   Scenario: Je peux voir la prévisualisation d'une question
     Given je vais sur Pix
     And je suis connecté à Pix en tant qu'administrateur
-    When je lance la preview du challenge "reckOAMc6UyX74W1x"
+    When je lance la preview du challenge "recc3QU4nKAk4byGv"
     Then je suis redirigé vers une page d'épreuve
-    Then l'épreuve contient le texte "lesquels contiennent des données personnelles"
+    Then l'épreuve contient le texte "Quelle est la capitale de la Lettonie ?"
 

--- a/high-level-tests/e2e/cypress/integration/profile.feature
+++ b/high-level-tests/e2e/cypress/integration/profile.feature
@@ -7,5 +7,5 @@ Feature: Profil
     Given je vais sur Pix
     And je suis connecté à Pix en tant que "Daenerys Targaryen"
     When j'accède à mon profil
-    And je clique sur le rond de niveau de la compétence "Traiter des données"
-    Then je vois la page de détails de la compétence "Traiter des données"
+    And je clique sur le rond de niveau de la compétence "Géographie"
+    Then je vois la page de détails de la compétence "Géographie"

--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -21,3 +21,23 @@ when(`l'épreuve contient le texte {string}`, (texte) => {
 then(`je choisis la réponse {string}`, (number) => {
   cy.get('#'+number).click();
 });
+
+then(`je vois la page de résultats`, (number) => {
+  cy.get('.assessment-results').should('exist');
+});
+
+then(`j'ai passé à {string}`, (challenge) => {
+  cy.contains('.result-item', challenge).find('.result-item__icon svg')
+    .should('have.class', 'fa-times-circle').and('have.class', 'result-item__icon--grey');
+});
+
+then(`j'ai mal répondu à {string}`, (challenge) => {
+  cy.contains('.result-item', challenge).find('.result-item__icon svg')
+    .should('have.class', 'fa-times-circle').and('have.class', 'result-item__icon--red');
+});
+
+
+then(`j'ai bien répondu à {string}`, (challenge) => {
+  cy.contains('.result-item', challenge).find('.result-item__icon svg')
+    .should('have.class', 'fa-check-circle').and('have.class', 'result-item__icon--green');
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous ne pouvons pas répondre à des questions parce que Airtable met trop de temps à répondre. 
Donc nous Cypress tombe en time Out 😭.

## :robot: Solution
Faire un référentiel Airtable minimal et le lier à CircleCi.

## :rainbow: Remarques
Cette base pourra être partager en Read-Only avec des invités qui souhaitent jouer avec la base de données.
(Début de création de communauté sur Github 😎 ?!) 
