### PR TITLE
[TECH] BSR - Suppression de l'usage déprécié du ChallengeId lors de l'appel à la route /assessments/:id/next.

### DIFF
--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -24,13 +24,12 @@ exports.register = async function(server) {
     },
     {
       method: 'GET',
-      path: '/api/assessments/{id}/next/{challengeId?}',
+      path: '/api/assessments/{id}/next',
       config: {
         auth: false,
         handler: assessmentController.getNextChallenge,
         notes: [
-          '- Récupération de la question suivante pour l\'évaluation donnée\n' +
-          '- L\'utilisation de **challengeId** est déprécié'
+          '- Récupération de la question suivante pour l\'évaluation donnée'
         ],
         tags: ['api']
       }


### PR DESCRIPTION
## :unicorn: Problème
La route /assessments/:id/next n'a plus besoin du `challengeId`. Cet usage a été supprimé avec #327 . Pour ne pas provoquer d'erreurs pour l'utilisateur si son front est dans une version inférieure, il a été choisi de rendre optionnel et déprécié l'utilisation de `challengeId`.

## :robot: Solution
Maintenant que cela fait suffisamment longtemps que #327 a été mergée, nous pouvons supprimer cet usage déprécié.

## :rainbow: Remarques
Ceci est un BSR - Boy Scout Rule
_Leave your code better than you found it._