### PR TITLE
[BUGFIX] Ne plus afficher d'ancients examinerComment dans le champs de text prévu à cet effet. (PC-93)

### DIFF
--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -1,14 +1,14 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
-  finalize(model, { examinerComment }) {
+  finalize(model) {
     const url = this.buildURL('session', model.id) + '/finalization';
 
-    return this.ajax(url, 'PUT', { 
+    return this.ajax(url, 'PUT', {
       data: {
         data: {
           attributes: {
-            'examiner-comment': examinerComment,
+            'examiner-comment': model.get('examinerComment'),
           },
         },
       },

--- a/certif/app/components/session-finalization-examiner-comment-step.js
+++ b/certif/app/components/session-finalization-examiner-comment-step.js
@@ -5,18 +5,13 @@ import Component from '@ember/component';
 export default Component.extend({
   textareaMaxLength: 500,
 
-  init() {
-    this._super(...arguments);
-    this.set('examinerComment', '');
-  },
-
   actions: {
     updateTextareaValue(text) {
       const textareaMaxLength = this.get('textareaMaxLength');
 
       if (text.length <= textareaMaxLength) {
-        this.set('examinerComment', text);
+        this.get('session').set('examinerComment', text);
       }
-    }
-  }
+    },
+  },
 });

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -8,7 +8,6 @@ export default Controller.extend({
   notifications: service('notification-messages'),
 
   showConfirmModal: false,
-  examinerComment: '',
 
   showErrorNotification(message) {
     const { autoClear, clearDuration } = config.notifications;
@@ -22,12 +21,10 @@ export default Controller.extend({
 
   actions: {
     finalizeSession() {
-      
       this.set('isLoading', true);
+
       return this.model
-        .finalize({
-          examinerComment: this.get('examinerComment'),
-        })
+        .finalize()
         .then(() => {
           this.showSuccessNotification('Les informations de la session ont été transmises avec succès.');
         })

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -17,6 +17,7 @@ export default DS.Model.extend({
   session: service(),
   status: DS.attr(),
   isFinalized: equal('status', 'finalized'),
+  examinerComment: DS.attr(),
 
   urlToDownload: computed('id', function() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.get('id')}/attendance-sheet?accessToken=${this.get('session.data.authenticated.access_token')}`;
@@ -26,8 +27,8 @@ export default DS.Model.extend({
     return `${ENV.APP.API_HOST}/api/sessions/${this.get('id')}/certification-candidates/import`;
   }),
 
-  finalize(data) {
-    return this.store.adapterFor('session').finalize(this, data);
+  finalize() {
+    return this.store.adapterFor('session').finalize(this);
   },
 
 });

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -4,5 +4,4 @@
   openModal=(action 'openModal')
   closeModal=(action 'closeModal')
   showConfirmModal=showConfirmModal
-  examinerComment=examinerComment
 }}

--- a/certif/app/templates/components/routes/authenticated/sessions/session-finalizer.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/session-finalizer.hbs
@@ -20,7 +20,7 @@
           @title="Commenter la session (facultatif)"
           @icon="/icons/session-finalization-edit.svg"
           @iconAlt="">
-    <SessionFinalizationExaminerCommentStep @examinerComment={{examinerComment}} />
+    <SessionFinalizationExaminerCommentStep @session={{session}} />
   </SessionFinalizationStepContainer>
   <ActionButton
     class="session-finalizer__button"

--- a/certif/app/templates/components/session-finalization-examiner-comment-step.hbs
+++ b/certif/app/templates/components/session-finalization-examiner-comment-step.hbs
@@ -4,13 +4,13 @@
         Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.
     </label>
     <div class="session-finalization-examiner-comment-step__characters-information">
-      {{examinerComment.length}} / {{textareaMaxLength}}
+      {{session.examinerComment.length}} / {{textareaMaxLength}}
     </div>
   </div>
   <textarea
     id="examiner-comment"
     class="session-finalization-examiner-comment-step__textarea"
-    value={{examinerComment}}
+    value={{session.examinerComment}}
     oninput={{action "updateTextareaValue" value="target.value"}}
     maxlength={{textareaMaxLength}}
   />

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -71,7 +71,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         await fillIn('#examiner-comment', 'You are a wizard Harry!');
 
         // then
-        assert.equal(finalizeController.examinerComment, expectedComment);
+        assert.equal(finalizeController.model.examinerComment, expectedComment);
         assert.dom('.session-finalization-examiner-comment-step__characters-information').exists();
         assert.dom('.session-finalization-examiner-comment-step__characters-information').hasText(expectedIndicator);
       });

--- a/certif/tests/integration/components/session-finalization-examiner-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-comment-step-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, find } from '@ember/test-helpers';
+import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | session-finalization-examiner-comment-step', function(hooks) {
@@ -11,9 +12,9 @@ module('Integration | Component | session-finalization-examiner-comment-step', f
   hooks.beforeEach(async function() {
     firstComment = 'You are a wizard Harry !';
     this.set('textareaMaxLength', 500);
-    this.set('examinerComment', firstComment);
+    this.set('session', Object.create({ examinerComment: '' }));
 
-    await render(hbs`<SessionFinalizationExaminerCommentStep @examinerComment={{this.examinerComment}}  />`);
+    await render(hbs`<SessionFinalizationExaminerCommentStep @session={{this.session}}  />`);
     await fillIn('#examiner-comment', firstComment);
   });
 
@@ -24,7 +25,7 @@ module('Integration | Component | session-finalization-examiner-comment-step', f
     );
     assert.equal(
       find('div.session-finalization-examiner-comment-step__characters-information').textContent.trim(),
-      this.examinerComment.length + ' / ' + this.textareaMaxLength
+      this.session.examinerComment.length + ' / ' + this.textareaMaxLength
     );
     assert.equal(
       find('textarea').value.trim(),
@@ -37,7 +38,7 @@ module('Integration | Component | session-finalization-examiner-comment-step', f
       await fillIn('#examiner-comment', 'You are no more a wizard Harry!');
       assert.equal(
         find('div.session-finalization-examiner-comment-step__characters-information').textContent.trim(),
-        this.examinerComment.length + ' / ' + this.textareaMaxLength
+        this.session.examinerComment.length + ' / ' + this.textareaMaxLength
       );
       assert.equal(find('#examiner-comment').value.trim(),
         'You are no more a wizard Harry!'


### PR DESCRIPTION
## :unicorn: Problème
Les commentaires globaux de fin de session pouvaient réapparaître d'une page de session finalisation à une autre.

## :robot: Solution
- Utiliser `session.examinerComment` comme vecteur de ce commentaire.
- Supprimer l'ancien `examinerComment` global.
