### PR TITLE
[BUGFIX] Limiter le bug de multiples réponses à un même couple challengeId/assessmentId (PF-964)

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -28,7 +28,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);
-  const correctedAnswer = evaluateAnswer(challenge, answer);
+  const correctedAnswer = _evaluateAnswer(challenge, answer);
   let scorecardBeforeAnswer;
   if (correctedAnswer.result.isOK() && (assessment.isCompetenceEvaluation() || assessment.isSmartPlacement())) {
     scorecardBeforeAnswer = await scorecardService.computeScorecard({
@@ -52,7 +52,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   const answerSaved = await answerRepository.save(correctedAnswer);
   let savedKnowledgeElements = [];
   if (assessment.isCompetenceEvaluation()) {
-    savedKnowledgeElements = await saveKnowledgeElementsForCompetenceEvaluation({
+    savedKnowledgeElements = await _saveKnowledgeElementsForCompetenceEvaluation({
       assessment,
       answer: answerSaved,
       challenge,
@@ -63,7 +63,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
 
   if (assessment.isSmartPlacement()) {
-    savedKnowledgeElements = await saveKnowledgeElementsForSmartPlacement({
+    savedKnowledgeElements = await _saveKnowledgeElementsForSmartPlacement({
       answer: answerSaved,
       challenge,
       smartPlacementAssessmentRepository,
@@ -88,16 +88,16 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   return answerSaved;
 };
 
-function evaluateAnswer(challenge, answer) {
+function _evaluateAnswer(challenge, answer) {
   const examiner = new Examiner({ validator: challenge.validator });
   return examiner.evaluate(answer);
 }
 
-async function saveKnowledgeElementsForSmartPlacement({ answer, challenge, smartPlacementAssessmentRepository, knowledgeElementRepository }) {
+async function _saveKnowledgeElementsForSmartPlacement({ answer, challenge, smartPlacementAssessmentRepository, knowledgeElementRepository }) {
 
   const smartPlacementAssessment = await smartPlacementAssessmentRepository.get(answer.assessmentId);
 
-  return saveKnowledgeElements({
+  return _saveKnowledgeElements({
     userId: smartPlacementAssessment.userId,
     targetSkills: smartPlacementAssessment.targetProfile.skills,
     knowledgeElements: smartPlacementAssessment.knowledgeElements,
@@ -107,7 +107,7 @@ async function saveKnowledgeElementsForSmartPlacement({ answer, challenge, smart
   });
 }
 
-async function saveKnowledgeElementsForCompetenceEvaluation({ assessment, answer, challenge, competenceEvaluationRepository, skillRepository, knowledgeElementRepository }) {
+async function _saveKnowledgeElementsForCompetenceEvaluation({ assessment, answer, challenge, competenceEvaluationRepository, skillRepository, knowledgeElementRepository }) {
 
   const competenceEvaluation = await competenceEvaluationRepository.getByAssessmentId(assessment.id);
   const [targetSkills, knowledgeElements] = await Promise.all([
@@ -115,7 +115,7 @@ async function saveKnowledgeElementsForCompetenceEvaluation({ assessment, answer
     knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId })]
   );
 
-  return saveKnowledgeElements({
+  return _saveKnowledgeElements({
     userId: assessment.userId,
     targetSkills,
     knowledgeElements,
@@ -125,7 +125,7 @@ async function saveKnowledgeElementsForCompetenceEvaluation({ assessment, answer
   });
 }
 
-function saveKnowledgeElements({ userId, targetSkills, knowledgeElements, answer, challenge, knowledgeElementRepository }) {
+function _saveKnowledgeElements({ userId, targetSkills, knowledgeElements, answer, challenge, knowledgeElementRepository }) {
 
   const knowledgeElementsToCreate = KnowledgeElement.createKnowledgeElementsForAnswer({
     answer,

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -94,11 +94,10 @@ module.exports = {
       .then((answers) => answers.models.map(_toDomain));
   },
 
-  save(answer) {
-    return Promise.resolve(answer)
-      .then(_adaptModelToDb)
-      .then((rawDBAnswerModel) => new BookshelfAnswer(rawDBAnswerModel))
-      .then((answerBookshelf) => answerBookshelf.save())
-      .then(_toDomain);
+  async save(answer) {
+    const answerForDB = _adaptModelToDb(answer);
+    const newAnswer = await new BookshelfAnswer(answerForDB)
+      .save(null, { require: true, method: 'insert' });
+    return _toDomain(newAnswer);
   },
 };

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -46,13 +46,6 @@ module.exports = {
       .then((challenges) => challenges.models.map(_toDomain));
   },
 
-  /**
-   * @deprecated use findByCertificationCourseId instead
-   */
-  findChallengesByCertificationCourseId(courseId) {
-    return this.findByCertificationCourseId(courseId);
-  },
-
   getNonAnsweredChallengeByCourseId(assessmentId, courseId) {
 
     const answeredChallengeIds = Bookshelf.knex('answers')

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -81,54 +81,6 @@ describe('Integration | Repository | Certification Challenge', function() {
     });
   });
 
-  describe('#findChallengesByCertificationCourseId', () => {
-
-    let certificationCourseId, unusedCertificationCourseId;
-    beforeEach(async () => {
-      // given
-      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
-      unusedCertificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
-      databaseBuilder.factory.buildCertificationChallenge(
-        {
-          challengeId: 'chal123ABC',
-          competenceId: 'comp456DEF',
-          associatedSkill: '@url6',
-          courseId: certificationCourseId,
-        });
-      databaseBuilder.factory.buildCertificationChallenge(
-        {
-          courseId: certificationCourseId,
-        });
-      databaseBuilder.factory.buildCertificationChallenge(
-        {
-          challengeId: 'chal789GHI',
-          competenceId: 'compIUO159',
-          associatedSkill: '@utiliserserv6',
-        });
-
-      await databaseBuilder.commit();
-    });
-
-    it('should find all challenges related to a given certification course id', async () => {
-      // when
-      const certificationChallenges = await certificationChallengeRepository.findChallengesByCertificationCourseId(certificationCourseId);
-      const sortedCertificationChallenges = _.sortBy(certificationChallenges, [(chall) => { return chall.id; }]);
-
-      // then
-      expect(sortedCertificationChallenges).to.have.lengthOf(2);
-      expect(sortedCertificationChallenges[0]).to.be.an.instanceOf(CertificationChallenge);
-      expect(sortedCertificationChallenges[0].challengeId).to.equal('chal123ABC');
-    });
-
-    it('should return an empty array if there is no found challenges', async () => {
-      // when
-      const certificationChallenges = await certificationChallengeRepository.findChallengesByCertificationCourseId(unusedCertificationCourseId);
-
-      // then
-      expect(certificationChallenges.length).to.equal(0);
-    });
-  });
-
   describe('#getNonAnsweredChallengeByCourseId', () => {
 
     context('no non answered certification challenge', () => {


### PR DESCRIPTION
## :unicorn: Problème
En cas de lenteur API, plusieurs réponses à la même question pouvaient être enregistrés.
Ceci a des conséquences, nous pensons particulièrement à la certification : en effet, l'algo compte 2 réponses apportés à une compétence, alors qu'en fait il ne s'agit que d'une seule réponse en double (et donc on oublie de lui poser certaines questions, etc...)

## :robot: Solution
Eviter en toute circonstance ce problème est compliqué étant donné l'existant de la base de données.
En effet, une solution radicale aurait pu être d'ajouter une contrainte d'unicité sur le couple challengeId/assessmentId dans la table `answers`, mais cela implique de nettoyer dans un premier temps les doublons déjà présents dans la table.
Il existe une solution qui peut se traduire par une requête SQL du style : (pseudo SQL) :
```
INSERT INTO "answers" ("result", "resultDetails", "value", "timeout", "elapsedTime", "assessmentId", "challengeId") 
SELECT 'ok', 'some random details', '1', null, 79914, 5, '807072a9-bd0c-4904-82ef-3c5aca6839e4'
FROM "answers" 
WHERE NOT EXISTS (SELECT 1 FROM "answers" WHERE "answers"."assessmentId" = 5 AND "answers"."challengeId" = '807072a9-bd0c-4904-82ef-3c5aca6839e4' LIMIT 1) LIMIT 1
```

Mais 1) j'ai réussi à la faire marcher dans le code (mais sur pgAdmin oui,  :question:)
2) requiert une petite enquête de perf, on parle quand même de la table `answers` ...

Donc pour le moment, la solution apportée va simplement limiter les occurrences de ce bug.
La solution consiste à rapprocher, dans le code, l'opération qui vérifie la potentielle existence d'une réponse, puis la sauvegarde (avant, ces opérations étaient assez éloignées).

## :rainbow: Remarques
A faire dans une PR ensuite : faire une action en profondeur sur le base de données pour ajouter la contrainte d'unicité challengeId/assessmentId