### PR TITLE
[TECH] Utiliser le pré handler d'autorisation de session pour la route PATCH sessions/:id

### DIFF
--- a/api/lib/application/preHandlers/session-authorization.js
+++ b/api/lib/application/preHandlers/session-authorization.js
@@ -1,5 +1,5 @@
 const sessionAuthorizationService = require('../../domain/services/session-authorization-service');
-const { ForbiddenError } = require('../../infrastructure/errors');
+const { NotFoundError } = require('../../infrastructure/errors');
 
 module.exports = {
   async verify(request) {
@@ -9,7 +9,7 @@ module.exports = {
     const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({ userId, sessionId });
 
     if (!isAuthorized) {
-      throw new ForbiddenError('Vous n\'êtes pas autorisé à accéder à cette session.');
+      throw new NotFoundError('La session n\'existe pas ou son accès est restreint');
     }
 
     return isAuthorized;

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -113,6 +113,15 @@ exports.register = async (server) => {
       method: 'PATCH',
       path: '/api/sessions/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
+        pre: [{
+          method: sessionAuthorization.verify,
+          assign: 'authorizationCheck'
+        }],
         handler: sessionController.update,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/domain/usecases/update-session.js
+++ b/api/lib/domain/usecases/update-session.js
@@ -1,30 +1,9 @@
-const { UserNotAuthorizedToUpdateResourceError } = require('../errors');
 const sessionValidator = require('../validators/session-validator');
 
-module.exports = async function updateSession(
-  {
-    userId,
-    session,
-    userRepository,
-    sessionRepository
-  }) {
-
+module.exports = async function updateSession({ session, sessionRepository }) {
   sessionValidator.validate(session);
-
-  const [ user, sessionToUpdate ] = await Promise.all([
-    userRepository.getWithCertificationCenterMemberships(userId),
-    sessionRepository.get(session.id)
-  ]);
-
-  const certificationCenterId = sessionToUpdate.certificationCenterId;
-
-  if (!user.hasAccessToCertificationCenter(certificationCenterId)) {
-    throw new UserNotAuthorizedToUpdateResourceError(`User does not have an access to the certification center ${certificationCenterId}`);
-  }
-
+  const sessionToUpdate = await sessionRepository.get(session.id);
   Object.assign(sessionToUpdate, session);
 
-  const updatedSession = await sessionRepository.update(sessionToUpdate);
-
-  return updatedSession;
+  return sessionRepository.update(sessionToUpdate);
 };

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -51,7 +51,7 @@ module.exports = {
       return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, session);
     } catch (err) {
       if (err instanceof BookshelfSession.NotFoundError) {
-        throw new NotFoundError();
+        throw new NotFoundError('La session n\'existe pas ou son accès est restreint');
       }
       throw err;
     }
@@ -74,7 +74,7 @@ module.exports = {
       return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, session);
     } catch (err) {
       if (err instanceof BookshelfSession.NotFoundError) {
-        throw new NotFoundError();
+        throw new NotFoundError('La session n\'existe pas ou son accès est restreint');
       }
       throw err;
     }

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         return databaseBuilder.commit();
       });
 
-      it('should return 403 HTTP status code', async () => {
+      it('should return 404 HTTP status code (to keep opacity on whether forbidden or not found)', async () => {
         // when
         const response = await server.inject({
           method: 'GET',
@@ -38,7 +38,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         });
 
         // then
-        expect(response.statusCode).to.equal(403);
+        expect(response.statusCode).to.equal(404);
       });
 
     });

--- a/api/tests/acceptance/application/session/session-controller-patch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch_test.js
@@ -76,21 +76,6 @@ describe('Acceptance | Controller | session-controller-patch', () => {
         });
     });
 
-    it('should return 404 HTTP status code when session cannot be found', () => {
-      // when
-      const promise = server.inject({
-        method: 'PATCH',
-        url: '/api/sessions/2',
-        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        payload
-      });
-
-      // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(404);
-      });
-    });
-
     it('should respond with a 403 when user is not authorized to update the session', function() {
       const options = {
         method: 'PATCH',

--- a/api/tests/acceptance/application/session/session-controller-patch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch_test.js
@@ -76,7 +76,7 @@ describe('Acceptance | Controller | session-controller-patch', () => {
         });
     });
 
-    it('should respond with a 403 when user is not authorized to update the session', function() {
+    it('should respond with a 404 when user is not authorized to update the session (to keep opacity on whether forbidden or not found)', function() {
       const options = {
         method: 'PATCH',
         url: `/api/sessions/${session.id}`,
@@ -89,7 +89,7 @@ describe('Acceptance | Controller | session-controller-patch', () => {
 
       // then
       return promise.then((response) => {
-        expect(response.statusCode).to.equal(403);
+        expect(response.statusCode).to.equal(404);
       });
     });
 

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -62,7 +62,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
         });
       });
 
-      it('should respond with a 403 Unauthorized the if user is not authorized', async () => {
+      it('should respond with a 404 NotFound the if user is not authorized (to keep opacity on whether forbidden or not found)', async () => {
         // given
         userId = databaseBuilder.factory.buildUser().id;
         sessionId = databaseBuilder.factory.buildSession(sessionDomain).id;
@@ -77,7 +77,7 @@ describe('Acceptance | Controller | sessions-controller', () => {
 
         // then
         return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
+          expect(response.statusCode).to.equal(404);
         });
       });
     });

--- a/api/tests/unit/application/preHandlers/session-authorization_test.js
+++ b/api/tests/unit/application/preHandlers/session-authorization_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const SessionAuthorization = require('../../../../lib/application/preHandlers/session-authorization');
 const sessionAuthorizationService = require('../../../../lib/domain/services/session-authorization-service');
-const { ForbiddenError } = require('../../../../lib/infrastructure/errors');
+const { NotFoundError } = require('../../../../lib/infrastructure/errors');
 
 describe('Unit | Pre-handler | Session Authorization', () => {
   const userId = 1;
@@ -40,7 +40,7 @@ describe('Unit | Pre-handler | Session Authorization', () => {
 
     context('when user has no access to session', () => {
 
-      it('should throw a ForbiddenError', async () => {
+      it('should throw a NotFoundError', async () => {
         // given
         sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(false);
 
@@ -48,7 +48,7 @@ describe('Unit | Pre-handler | Session Authorization', () => {
         const error = await catchErr(SessionAuthorization.verify)(request);
 
         // then
-        expect(error).to.be.instanceOf(ForbiddenError);
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -85,6 +85,34 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
+  describe('PATCH /api/sessions/{id}', () => {
+    let sessionId;
+
+    beforeEach(() => {
+      sessionId = 1;
+      sinon.stub(sessionAuthorization, 'verify').returns(null);
+      sinon.stub(sessionController, 'update').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject({ method: 'PATCH', url: `/api/sessions/${sessionId}` });
+
+      expect(res.statusCode).to.equal(200);
+    });
+
+    context('when session ID params is not a number', () => {
+
+      it('should return 400', async () => {
+        // given
+        sessionId = 'salut';
+
+        const res = await server.inject({ method: 'PATCH', url: `/api/sessions/${sessionId}` });
+        expect(res.statusCode).to.equal(400);
+      });
+    });
+  });
+
   describe('POST /api/sessions/{id}/certification-candidates/import', () => {
     let sessionId;
 

--- a/api/tests/unit/domain/usecases/update-session_test.js
+++ b/api/tests/unit/domain/usecases/update-session_test.js
@@ -1,13 +1,10 @@
 const { expect, sinon } = require('../../../test-helper');
 const updateSession = require('../../../../lib/domain/usecases/update-session');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
-const { UserNotAuthorizedToUpdateResourceError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | update-session', () => {
   let originalSession;
-  let userWithCertificationCenterMemberships;
   let sessionRepository;
-  let userRepository;
 
   const certificationCenterId = 1;
 
@@ -24,23 +21,15 @@ describe('Unit | UseCase | update-session', () => {
       description: 'miam',
       accessCode: 'ABCD12'
     };
-    userWithCertificationCenterMemberships = {
-      id: 1,
-      certificationCenterMemberships: [{ certificationCenter: { id: certificationCenterId } }],
-      hasAccessToCertificationCenter: sinon.stub(),
-    };
-    userRepository = { getWithCertificationCenterMemberships: sinon.stub() };
     sessionRepository = {
       get: sinon.stub(),
-      update: sinon.stub()
+      update: sinon.stub(),
     };
     sinon.stub(sessionValidator, 'validate');
 
     sessionRepository.get.withArgs(originalSession.id).resolves(originalSession);
     sessionRepository.update.callsFake((updatedSession) => updatedSession);
     sessionValidator.validate.withArgs(originalSession).returns();
-    userRepository.getWithCertificationCenterMemberships.withArgs(userWithCertificationCenterMemberships.id).resolves(userWithCertificationCenterMemberships);
-    userWithCertificationCenterMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
   });
 
   context('when session exists', () => {
@@ -61,9 +50,7 @@ describe('Unit | UseCase | update-session', () => {
 
       // when
       const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
         session: updatedSession,
-        userRepository,
         sessionRepository: sessionRepository,
       });
 
@@ -91,9 +78,7 @@ describe('Unit | UseCase | update-session', () => {
 
       // when
       const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
         session: updatedSession,
-        userRepository,
         sessionRepository: sessionRepository,
       });
 
@@ -112,9 +97,7 @@ describe('Unit | UseCase | update-session', () => {
 
       // when
       const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
         session: originalSession,
-        userRepository,
         sessionRepository: sessionRepository,
       });
 
@@ -128,46 +111,12 @@ describe('Unit | UseCase | update-session', () => {
 
       // when
       const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
         session: originalSession,
-        userRepository,
         sessionRepository: sessionRepository,
       });
 
       // then
       return expect(promise).to.be.rejected;
-    });
-
-    it('should throw an error when the user with memberships could not be retrieved', () => {
-      // given
-      userRepository.getWithCertificationCenterMemberships.withArgs(userWithCertificationCenterMemberships.id).rejects();
-
-      // when
-      const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
-        session: originalSession,
-        userRepository,
-        sessionRepository: sessionRepository,
-      });
-
-      // then
-      return expect(promise).to.be.rejected;
-    });
-
-    it('should throw an error when the user does not have an access to the session organization', () => {
-      // given
-      userWithCertificationCenterMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
-
-      // when
-      const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
-        session: originalSession,
-        userRepository,
-        sessionRepository: sessionRepository,
-      });
-
-      // then
-      return expect(promise).to.be.rejectedWith(UserNotAuthorizedToUpdateResourceError);
     });
 
     it('should throw an error when the session could not be updated', () => {
@@ -176,9 +125,7 @@ describe('Unit | UseCase | update-session', () => {
 
       // when
       const promise = updateSession({
-        userId: userWithCertificationCenterMemberships.id,
         session: originalSession,
-        userRepository,
         sessionRepository: sessionRepository,
       });
 


### PR DESCRIPTION
## :unicorn: Contexte
Récemment, un pré handler qui vérifie l'autorisation d'accès à une session a été crée. Appliquons-le là où il faut !

## :robot: Solution
Dans la route PATCH /sessions/:id, on vérifiait l'autorisation pour la mise à jour via la récupération d'un user complet avec ses memberships etc, donc plusieurs requêtes SQL dans le usecase. Puisqu'on dispose de l'ID de la session, alors on peut se servir du pré handler ici.

## :rainbow: Remarques
Simplement tester la mise à jour d'une session via PixCertif pour le fonc.