### PR TITLE
[BUGFIX] Enlever le retour à la ligne après les inputs dans la zone de réponse

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -24,6 +24,10 @@
   &__row {
     padding: 20px;
   }
+
+  &__row label {
+    display: inline;
+  }
 }
 
 .rounded-panel hr {


### PR DESCRIPTION
## :unicorn: Problème
Des retours à la lignes sont faits après certains champs `input` dans la zone de réponse.
Par exemple sur le challenge [recAQDoflZcaBLqq3](https://app-pr919.review.pix.fr/assessments/10000004/challenges/recAQDoflZcaBLqq3)

## :robot: Solution
Le label en `inline-block` par défaut a été overridé par `inline`.