### PR TITLE
[BUGFIX] Correction de l'erreur 500 quand la date de naissance est hors limite lors de la réconciliation en certification (PF-984)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -163,11 +163,6 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/sessions/{id}/candidate-participation',
       config: {
-        validate: {
-          params: Joi.object({
-            id: Joi.number().required()
-          }),
-        },
         handler: sessionController.createCandidateParticipation,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -85,10 +85,12 @@ module.exports = {
   async createCandidateParticipation(request, h) {
     const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
-    const certificationCandidateWithPersonalInfoOnly = await certificationCandidateSerializer.deserialize(request.payload);
+    const firstName = request.payload.data.attributes['first-name'];
+    const lastName = request.payload.data.attributes['last-name'];
+    const birthdate = request.payload.data.attributes['birthdate'];
 
     const { linkCreated, certificationCandidate } = await usecases.linkUserToSessionCertificationCandidate({
-      userId, sessionId, certificationCandidateWithPersonalInfoOnly,
+      userId, sessionId, firstName, lastName, birthdate,
     });
 
     const serialized = await certificationCandidateSerializer.serialize(certificationCandidate);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -137,6 +137,12 @@ class CertificationCandidatePersonalInfoFieldMissingError extends DomainError {
   }
 }
 
+class CertificationCandidatePersonalInfoWrongFormat extends DomainError {
+  constructor(message = 'Information transmise par le candidat de certification au mauvais format.') {
+    super(message);
+  }
+}
+
 class CertificationComputeError extends DomainError {
   constructor(message = 'Erreur lors du calcul de la certification.') {
     super(message);
@@ -378,6 +384,7 @@ module.exports = {
   CertificationCandidateDeletionError,
   CertificationCandidateMultipleUserLinksWithinSessionError,
   CertificationCandidatePersonalInfoFieldMissingError,
+  CertificationCandidatePersonalInfoWrongFormat,
   CertificationCenterMembershipCreationError,
   CertificationComputeError,
   ChallengeAlreadyAnsweredError,

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joi')
+  .extend(require('@hapi/joi-date'));
 const { InvalidCertificationCandidate } = require('../errors');
 
 const certificationCandidateValidationJoiSchema_v1 = Joi.object({
@@ -30,6 +31,21 @@ const certificationCandidateValidationJoiSchema_v2 = Joi.object({
   extraTimePercentage: Joi.number().allow(null).optional(),
   sessionId: Joi.number().required(),
   userId: Joi.number().allow(null).optional(),
+});
+
+const certificationCandidateParticipationJoiSchema = Joi.object({
+  id: Joi.any().allow(null).optional(),
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  birthCity: Joi.any().allow(null).optional(),
+  birthProvinceCode: Joi.any().allow(null).optional(),
+  birthCountry: Joi.any().allow(null).optional(),
+  externalId: Joi.any().allow(null).optional(),
+  birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required(),
+  createdAt: Joi.any().allow(null).optional(),
+  extraTimePercentage: Joi.any().allow(null).optional(),
+  sessionId: Joi.number().required(),
+  userId: Joi.any().allow(null).optional(),
 });
 
 class CertificationCandidate {
@@ -84,6 +100,13 @@ class CertificationCandidate {
     const { error } = usedSchema.validate(this);
     if (error) {
       throw new InvalidCertificationCandidate();
+    }
+  }
+
+  validateParticipation() {
+    const { error } = certificationCandidateParticipationJoiSchema.validate(this);
+    if (error) {
+      throw error;
     }
   }
 }

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -62,6 +62,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.CertificationCandidatePersonalInfoFieldMissingError) {
     return new InfraErrors.BadRequestError('Un ou plusieurs champs d\'informations d\'identité sont manquants.');
   }
+  if (error instanceof DomainErrors.CertificationCandidatePersonalInfoWrongFormat) {
+    return new InfraErrors.BadRequestError('Un ou plusieurs champs d\'informations d\'identité sont au mauvais format.');
+  }
   if (error instanceof DomainErrors.CertificationCenterMembershipCreationError) {
     return new InfraErrors.BadRequestError('Le membre ou le centre de certification n\'existe pas.');
   }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -341,6 +341,14 @@
         "@hapi/topo": "^3.1.3"
       }
     },
+    "@hapi/joi-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi-date/-/joi-date-2.0.1.tgz",
+      "integrity": "sha512-8be8JUEC8Wm1Do3ryJy+TXmkAL13b2JwXn7gILBoor8LopY/M+hJskodzOOxfJdckkfWnbmbnMEyJW3d/gZMfA==",
+      "requires": {
+        "moment": "2.x.x"
+      }
+    },
     "@hapi/mimos": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "@hapi/hapi": "^18.4.0",
     "@hapi/inert": "^5.2.2",
     "@hapi/joi": "^16.1.8",
+    "@hapi/joi-date": "^2.0.1",
     "@hapi/vision": "^5.5.4",
     "airtable": "^0.8.0",
     "bcrypt": "^3.0.7",

--- a/api/tests/integration/infrastructure/utils/error-manager_test.js
+++ b/api/tests/integration/infrastructure/utils/error-manager_test.js
@@ -313,6 +313,17 @@ describe('Integration | Utils | Error Manager', function() {
       expect(result.statusCode).to.equal(400);
     });
 
+    it('should return 400 on domain CertificationCandidatePersonalInfoWrongFormat', function() {
+      // given
+      const error = new DomainErrors.CertificationCandidatePersonalInfoWrongFormat();
+
+      // when
+      const result = send(hFake, error);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
     it('should return 400 on domain CertificationCenterMembershipCreationError', function() {
       // given
       const error = new DomainErrors.CertificationCenterMembershipCreationError();

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -289,16 +289,11 @@ describe('Unit | Controller | sessionController', () => {
     let request;
     const sessionId = 1;
     const userId = 2;
-    const firstName = 'firstName';
-    const lastName = 'lastName';
-    const birthdate = 'birthdate';
-    const certificationCandidateWithPersonalInfoOnly = {
-      firstName,
-      lastName,
-      birthdate,
-    };
-    const linkedCertificationCandidate = 'candidate';
-    const serializedCertificationCandidate = 'sCandidate';
+    const firstName = Symbol('firstName');
+    const lastName = Symbol('lastName');
+    const birthdate = Symbol('birthdate');
+    const linkedCertificationCandidate = Symbol('candidate');
+    const serializedCertificationCandidate = Symbol('sCandidate');
 
     beforeEach(() => {
       // given
@@ -320,7 +315,6 @@ describe('Unit | Controller | sessionController', () => {
           }
         }
       };
-      sinon.stub(certificationCandidateSerializer, 'deserialize').withArgs(request.payload).resolves(certificationCandidateWithPersonalInfoOnly);
       sinon.stub(certificationCandidateSerializer, 'serialize').withArgs(linkedCertificationCandidate).returns(serializedCertificationCandidate);
     });
 
@@ -328,7 +322,7 @@ describe('Unit | Controller | sessionController', () => {
 
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
-          .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
+          .withArgs({ userId, sessionId, firstName, lastName, birthdate }).resolves({
             linkCreated: false,
             certificationCandidate: linkedCertificationCandidate
           });
@@ -349,7 +343,7 @@ describe('Unit | Controller | sessionController', () => {
 
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
-          .withArgs({ userId, sessionId, certificationCandidateWithPersonalInfoOnly }).resolves({
+          .withArgs({ userId, sessionId, firstName, lastName, birthdate }).resolves({
             linkCreated: true,
             certificationCandidate: linkedCertificationCandidate
           });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -31,6 +31,10 @@ describe('Unit | Domain | Errors', () => {
     expect(errors.CertificationCandidatePersonalInfoFieldMissingError).to.exist;
   });
 
+  it('should export a CertificationCandidatePersonalInfoWrongFormat', () => {
+    expect(errors.CertificationCandidatePersonalInfoWrongFormat).to.exist;
+  });
+
   it('should export a NotFoundError', () => {
     expect(errors.NotFoundError).to.exist;
   });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -1,6 +1,7 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const CertificationCandidate = require('../../../../lib/domain/models/CertificationCandidate');
 const { InvalidCertificationCandidate } = require('../../../../lib/domain/errors');
+const { ValidationError } = require('@hapi/joi');
 
 describe('Unit | Domain | Models | Certification Candidate', () => {
 
@@ -42,18 +43,24 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
 
-      // when/then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
+      // when
+      certificationCandidate.validate();
+
+      // then
+      expect(true).to.be.true;
     });
 
     it('should return an error if id is not a number nor undefined', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ id: 'salut' });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if firstName is not defined', () => {
@@ -61,18 +68,26 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.firstName = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if firstName is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ firstName: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if lastName is not defined', () => {
@@ -80,18 +95,26 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.lastName = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if lastName is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ lastName: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthCity is not defined', () => {
@@ -99,18 +122,26 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.birthCity = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthCity is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthCity: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthProvinceCode is not defined', () => {
@@ -118,18 +149,26 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.birthProvinceCode = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthProvinceCode is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthProvinceCode: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthCountry is not defined', () => {
@@ -137,74 +176,52 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.birthCountry = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthCountry is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthCountry: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
-    });
-
-    it('should not throw an error if externalId is null', () => {
-      // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ externalId: null });
-
-      // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
-    });
-
-    it('should not throw an error if externalId is undefined', () => {
-      // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({});
-      certificationCandidate.externalId = undefined;
-
-      // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if externalId is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ externalId: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
-    });
-
-    it('should not throw an error if extraTimePercentage is null', () => {
-      // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ extraTimePercentage: null });
-
-      // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
-    });
-
-    it('should not throw an error if extraTimePercentage is undefined', () => {
-      // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({});
-      certificationCandidate.extraTimePercentage = undefined;
-
-      // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if extraTimePercentage is not a number', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ extraTimePercentage: 'aaa' });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthdate is not defined', () => {
@@ -212,27 +229,39 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.birthdate = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthdate is not a string', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: 123 });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if birthdate is not of size 10 (to ensure YYY-MM-DD)', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: 'salut' });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if sessionId is not defined', () => {
@@ -240,37 +269,175 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
       const certificationCandidate = domainBuilder.buildCertificationCandidate();
       certificationCandidate.sessionId = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
     it('should return an error if sessionId is not a number', () => {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: 'a' });
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .to.throw(InvalidCertificationCandidate);
+      // when
+      try {
+        certificationCandidate.validate();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(InvalidCertificationCandidate);
+      }
     });
 
-    it('should not throw an error if createdAt is null', () => {
+  });
+
+  describe('validateParticipation', () => {
+
+    it('should not throw when the object is valid', () => {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ createdAt: null });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+
+      // when
+      certificationCandidate.validateParticipation();
 
       // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
+      expect(true).to.be.true;
     });
 
-    it('should not throw an error if createdAt is undefined', () => {
+    it('should return an error if firstName is not defined', () => {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({});
-      certificationCandidate.createdAt = undefined;
+      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      certificationCandidate.firstName = undefined;
 
-      // then
-      return expect(() => certificationCandidate.validate())
-        .not.to.throw;
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if firstName is not a string', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ firstName: 123 });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if lastName is not defined', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      certificationCandidate.lastName = undefined;
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if lastName is not a string', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ lastName: 123 });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if birthdate is not defined', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      certificationCandidate.birthdate = undefined;
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if birthdate is not a date in iso format', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '04/01/1990' });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if birthdate not greater than 1900-01-01', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '1899-06-06' });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if birthdate does not exist (such as 31th November)', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '1999-11-31' });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if sessionId is not defined', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      certificationCandidate.sessionId = undefined;
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
+    });
+
+    it('should return an error if sessionId is not a number', () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: 'a' });
+
+      // when
+      try {
+        certificationCandidate.validateParticipation();
+        expect.fail('Expected error to have been thrown');
+      } catch (err) { // then
+        expect(err).to.be.instanceOf(ValidationError);
+      }
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Une erreur 500 était captée sur Sentry lorsque, lors de la réconciliation avec un utilisateur inscrit à une session, une date de naissance hors limite était indiquée (par exemple : 0000-01-01)

## :robot: Solution
On utilise Joi pour valider l'ensemble de la donnée entrante. Depuis la nouvelle version de Joi, on peut faire une validation propre sur les dates avec format ISO.

## :rainbow: Remarques
Pour tester fonctionnellement, aller sur la page de réconciliation, afficher les requêtes réseaux sur la console du navigateur et entrer 01 01 0000 en date de naissance. Constater une erreur 400 et pas 500.
