### PR TITLE
[TECH] Ajouter la preResponse dans HttpTestServer

### DIFF
--- a/api/lib/infrastructure/utils/pre-response-utils.js
+++ b/api/lib/infrastructure/utils/pre-response-utils.js
@@ -1,0 +1,17 @@
+const errorManager = require('./error-manager');
+const { DomainError } = require('../../domain/errors');
+const { InfrastructureError } = require('../errors');
+
+function catchDomainAndInfrastructureErrors(request, h) {
+  const response = request.response;
+
+  if (response instanceof DomainError || response instanceof InfrastructureError) {
+    return errorManager.send(h, response);
+  }
+
+  return h.continue;
+}
+
+module.exports = {
+  catchDomainAndInfrastructureErrors,
+};

--- a/api/server.js
+++ b/api/server.js
@@ -1,12 +1,9 @@
 // As early as possible in your application, require and configure dotenv.
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
-
-const { DomainError } = require('./lib/domain/errors');
-const { InfrastructureError } = require('./lib/infrastructure/errors');
-const errorManager = require('./lib/infrastructure/utils/error-manager');
-
 const Hapi = require('@hapi/hapi');
+
+const preResponseUtils = require('./lib/infrastructure/utils/pre-response-utils')
 
 const routes = require('./lib/routes');
 const plugins = require('./lib/plugins');
@@ -32,17 +29,7 @@ const createServer = async () => {
     }
   });
 
-  const preResponse = function(request, h) {
-    const response = request.response;
-
-    if (response instanceof DomainError || response instanceof InfrastructureError) {
-      return errorManager.send(h, response);
-    }
-
-    return h.continue;
-  };
-
-  server.ext('onPreResponse', preResponse);
+  server.ext('onPreResponse', preResponseUtils.catchDomainAndInfrastructureErrors);
 
   server.auth.scheme('jwt-access-token', security.scheme);
   server.auth.strategy('default', 'jwt-access-token');

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -4,6 +4,10 @@ const usecases = require('../../../../lib/domain/usecases');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const moduleUnderTest = require('../../../../lib/application/organization-invitations');
 
+const {
+  AlreadyExistingOrganizationInvitationError, NotFoundError, UserNotFoundError
+} = require('../../../../lib/domain/errors');
+
 describe('Integration | Application | Organization-invitations | organization-invitation-controller', () => {
 
   let sandbox;
@@ -49,8 +53,41 @@ describe('Integration | Application | Organization-invitations | organization-in
       });
     });
 
-    // TODO HTTP Error cases
+    context('Error cases', () => {
 
+      it('should respond an HTTP response with status code 421 when AlreadyExistingOrganizationInvitationError', async () => {
+        // given
+        usecases.answerToOrganizationInvitation.rejects(new AlreadyExistingOrganizationInvitationError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+        // then
+        expect(response.statusCode).to.equal(421);
+      });
+
+      it('should respond an HTTP response with status code 404 when NotFoundError', async () => {
+        // given
+        usecases.answerToOrganizationInvitation.rejects(new NotFoundError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+
+      it('should respond an HTTP response with status code 404 when UserNotFoundError', async () => {
+        // given
+        usecases.answerToOrganizationInvitation.rejects(new UserNotFoundError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
   });
 
 });

--- a/api/tests/integration/infrastructure/utils/pre-response-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/pre-response-utils_test.js
@@ -1,0 +1,51 @@
+const { expect, hFake } = require('../../../test-helper');
+
+const {
+  BadRequestError, ConflictError, ForbiddenError,
+  InfrastructureError, MissingQueryParamError, NotFoundError,
+  PreconditionFailedError, UnauthorizedError, UnprocessableEntityError
+} = require('../../../../lib/infrastructure/errors');
+
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+const { catchDomainAndInfrastructureErrors } = require('../../../../lib/infrastructure/utils/pre-response-utils');
+
+describe('Integration | Infrastructure | Utils | PreResponse-utils', () => {
+
+  describe('#catchDomainAndInfrastructureErrors', () => {
+
+    const invalidAttributes = [{
+      attribute: 'type',
+      message: 'Error message'
+    }];
+
+    const successfulCases = [
+      { should: 'should return HTTP code 400 when BadRequestError', response: new BadRequestError('Error message'), expectedStatusCode: 400 },
+      { should: 'should return HTTP code 400 when MissingQueryParamError', response: new MissingQueryParamError('Error message'), expectedStatusCode: 400 },
+      { should: 'should return HTTP code 401 when UnauthorizedError', response: new UnauthorizedError('Error message'), expectedStatusCode: 401 },
+      { should: 'should return HTTP code 403 when ForbiddenError', response: new ForbiddenError('Error message'), expectedStatusCode: 403 },
+      { should: 'should return HTTP code 404 when NotFoundError', response: new NotFoundError('Error message'), expectedStatusCode: 404 },
+      { should: 'should return HTTP code 409 when ConflictError', response: new ConflictError('Error message'), expectedStatusCode: 409 },
+      { should: 'should return HTTP code 421 when PreconditionFailedError', response: new PreconditionFailedError('Error message'), expectedStatusCode: 421 },
+      { should: 'should return HTTP code 422 when EntityValidationError', response: new EntityValidationError({ invalidAttributes }), expectedStatusCode: 422 },
+      { should: 'should return HTTP code 422 when UnprocessableEntityError', response: new UnprocessableEntityError('Error message'), expectedStatusCode: 422 },
+      { should: 'should return HTTP code 500 when InfrastructureError', response: new InfrastructureError('Error message'), expectedStatusCode: 500 },
+    ];
+
+    successfulCases.forEach((testCase) => {
+      it(testCase.should, async () => {
+        // given
+        const request = {
+          response: testCase.response
+        };
+
+        // when
+        const response = await catchDomainAndInfrastructureErrors(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(testCase.expectedStatusCode);
+      });
+    });
+  });
+
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -128,7 +128,8 @@ const hFake = {
   },
   file(path, options) {
     return this.response({ path, options });
-  }
+  },
+  continue: Symbol('continue'),
 };
 
 function streamToPromise(stream) {

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -1,4 +1,5 @@
 const Hapi = require('@hapi/hapi');
+const preResponseUtils = require('../../../lib/infrastructure/utils/pre-response-utils');
 
 /**
  * ⚠️ You must declare your stubs before calling the HttpTestServer constructor (because of Node.Js memoization).
@@ -15,6 +16,7 @@ class HttpTestServer {
 
   constructor(moduleUnderTest) {
     this.hapiServer = Hapi.server();
+    this.hapiServer.ext('onPreResponse', preResponseUtils.catchDomainAndInfrastructureErrors);
     this.hapiServer.register(moduleUnderTest);
   }
 

--- a/api/tests/unit/infrastructure/utils/pre-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/pre-response-utils_test.js
@@ -1,0 +1,60 @@
+const { expect, sinon, hFake } = require('../../../test-helper');
+
+const errorManager = require('../../../../lib/infrastructure/utils/error-manager');
+
+const { DomainError } = require('../../../../lib/domain/errors');
+const { InfrastructureError } = require('../../../../lib/infrastructure/errors');
+
+const { catchDomainAndInfrastructureErrors } = require('../../../../lib/infrastructure/utils/pre-response-utils');
+
+describe('Unit | Infrastructure | Utils | PreResponse-utils', () => {
+
+  describe('#catchDomainAndInfrastructureErrors', () => {
+
+    beforeEach(() => {
+      sinon.stub(errorManager, 'send').resolves();
+    });
+
+    it('should continue the process when not DomainError or InfrastructureError', async () => {
+      // given
+      const request = {
+        response: {
+          statusCode: 200
+        }
+      };
+      const expectedString = 'Symbol(continue)';
+
+      // when
+      const response = await catchDomainAndInfrastructureErrors(request, hFake);
+
+      // then
+      expect(typeof response).to.be.equal('symbol');
+      expect(response.toString()).to.be.equal(expectedString);
+    });
+
+    it('should manage DomainError', async () => {
+      const request = {
+        response: new DomainError('Error message')
+      };
+
+      // when
+      await catchDomainAndInfrastructureErrors(request, hFake);
+
+      // then
+      expect(errorManager.send).to.have.been.calledWithExactly(hFake, request.response);
+    });
+
+    it('should manage InfrastructureError', async () => {
+      const request = {
+        response: new InfrastructureError('Error message')
+      };
+
+      // when
+      await catchDomainAndInfrastructureErrors(request, hFake);
+
+      // then
+      expect(errorManager.send).to.have.been.calledWithExactly(hFake, request.response);
+    });
+  });
+
+});

--- a/api/tests/unit/tooling/http-test-server_test.js
+++ b/api/tests/unit/tooling/http-test-server_test.js
@@ -1,0 +1,24 @@
+const { expect } = require('../../test-helper');
+
+const HttpTestServer = require('../../tooling/server/http-test-server');
+
+describe('Unit | Tooling | Http-test-server', () => {
+
+  describe('#constructor', () => {
+    let httpTestServer;
+
+    before(() => {
+      httpTestServer = new HttpTestServer([]);
+    });
+
+    it('should create hapi server', () => {
+      // then
+      expect(httpTestServer.hapiServer).to.exist;
+    });
+
+    it('Should use pre-response-utils function', () => {
+      // then
+      expect(httpTestServer.hapiServer._core.extensions.route.onPreResponse.nodes[0].func.name).to.equal('catchDomainAndInfrastructureErrors');
+    });
+  });
+});


### PR DESCRIPTION
## :mag_right: Problème
Dans l'API, lors des tests d'intégration la prise en compte des preResponse n'existe pas dans le helper HttpTestServer.
cf. Issue #767

## :gift: Solution
Inclure la fonction preResponse dans le helper.