### PR TITLE
[TECH] Détails des violations Joi dans la reponse http

### DIFF
--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -20,6 +20,11 @@ exports.register = async (server) => {
             scope: Joi.string(),
           })
         },
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form'
+          }
+        },
         handler: AuthenticationController.authenticateUser,
         tags: ['api']
       }

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -18,16 +18,7 @@ exports.register = async (server) => {
             username: Joi.string().email().required(),
             password: Joi.string().required(),
             scope: Joi.string(),
-          }),
-          failAction: (request, h) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: 'The server could not understand the request due to invalid syntax.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          }
+          })
         },
         handler: AuthenticationController.authenticateUser,
         tags: ['api']

--- a/api/server.js
+++ b/api/server.js
@@ -22,12 +22,15 @@ const createServer = async () => {
         failAction: async (request, h, err) => {
           if (process.env.NODE_ENV === 'production') {
             // In prod, log a limited error message and throw the default Bad Request error.
-            console.error('ValidationError:', err.message);
             throw Boom.badRequest('The server could not understand the request due to invalid syntax.');
           } else {
             // During development, log and respond with the full error.
-            console.error(err);
-            throw err;
+            if (err.isJoi && Array.isArray(err.details) && err.details.length > 0) {
+              const invalidItem = err.details[0];
+              return h.response(`Pix Data Validation Error. Schema violation. <${invalidItem.path}> \nDetails: ${JSON.stringify(err.details)}`)
+                .code(400)
+                .takeover();
+            }
           }
         }
       },

--- a/api/server.js
+++ b/api/server.js
@@ -12,11 +12,25 @@ const routes = require('./lib/routes');
 const plugins = require('./lib/plugins');
 const config = require('./lib/config');
 const security = require('./lib/infrastructure/security');
+const Boom = require('boom');
 
 const createServer = async () => {
 
   const server = new Hapi.server({
     routes: {
+      validate: {
+        failAction: async (request, h, err) => {
+          if (process.env.NODE_ENV === 'production') {
+            // In prod, log a limited error message and throw the default Bad Request error.
+            console.error('ValidationError:', err.message);
+            throw Boom.badRequest('The server could not understand the request due to invalid syntax.');
+          } else {
+            // During development, log and respond with the full error.
+            console.error(err);
+            throw err;
+          }
+        }
+      },
       cors: {
         origin: ['*'],
         additionalHeaders: ['X-Requested-With']


### PR DESCRIPTION
## :unicorn: Problème
> _Pas de détails dans la réponse d'api pour les erreurs Joi ( Bad Request) ce qui n'aide pas à comprendre l'origine de l'erreur et faire un retry avec la correction :._

Exemple pour l'api d'authentification:

```
[ 
   { 
      "status":"400",
      "title":"Bad request",
      "detail":"The server could not understand the request due to invalid syntax."
   }
]
```

## :robot: Solution
> _Utilisez la fonction failAction de Joy dans un niveau global pour permettre de donner du détail sur l'erreur dans les environnements hors production et la mutualiser dans un seul endroit au lieu de le faire à chaque fois par route._

```
Pix Data Validation Error. Schema violation. <username> 
Details:[ 
   { 
      "message":"\"username\" must be a valid email",
      "path":[ 
         "username"
      ],
      "type":"string.email",
      "context":{ 
         "value":" ",
         "invalids":[ 
            " "
         ],
         "label":"username",
         "key":"username"
      }
   }
]
```
## :rainbow: Remarques
> __
Pour tester la mire de login de monpix sinon en utilisant l'apidoc fixée ci-dessous:

https://api-pr925.review.pix.fr/api/documentation#/default/postToken 