### PR TITLE
[FEATURE] Améliorer les performances de l'export CSV (PO-296).

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -132,7 +132,7 @@ function _getCommonColumns({
     targetProfileName: targetProfile.name,
     participantLastName,
     participantFirstName,
-    percentageProgression: percentageProgression,
+    percentageProgression,
     createdAt: moment.utc(campaignParticipationResultData.createdAt).format('YYYY-MM-DD'),
     isShared: campaignParticipationResultData.isShared ? 'Oui' : 'Non',
     ...(campaign.idPixLabel ? { participantExternalId: campaignParticipationResultData.participantExternalId } : {}),

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -74,13 +74,8 @@ function _createHeaderOfCSV(skillNames, competences, areas, idPixLabel) {
   return headers;
 }
 
-function _addCellByHeadersTitleForNumber(title, data, line, headers) {
+function _addCellByHeadersTitle(title, data, line, headers) {
   line[headers.indexOf(title)] = data;
-  return line;
-}
-
-function _addCellByHeadersTitleForText(title, data, line, headers) {
-  line[headers.indexOf(title)] = data.toString();
   return line;
 }
 
@@ -138,7 +133,7 @@ function _createOneLineOfCSV(
   smartPlacementAssessmentRepository,
   knowledgeElementRepository,
 ) {
-  let line = headers.map(() => 'NA');
+  const line = headers.map(() => 'NA');
 
   return smartPlacementAssessmentRepository.get(campaignParticipation.assessmentId)
     .then((assessment) => {
@@ -150,16 +145,16 @@ function _createOneLineOfCSV(
     })
     .then(([assessment, user, allKnowledgeElements]) => {
 
-      line = _addCellByHeadersTitleForText('Nom de l\'organisation', organization.name, line, headers);
-      line = _addCellByHeadersTitleForNumber('ID Campagne', parseInt(campaign.id), line, headers);
-      line = _addCellByHeadersTitleForText('Nom de la campagne', campaign.name, line, headers);
-      line = _addCellByHeadersTitleForText('Nom du Profil Cible', targetProfile.name, line, headers);
+      _addCellByHeadersTitle('Nom de l\'organisation', organization.name, line, headers);
+      _addCellByHeadersTitle('ID Campagne', parseInt(campaign.id), line, headers);
+      _addCellByHeadersTitle('Nom de la campagne', campaign.name, line, headers);
+      _addCellByHeadersTitle('Nom du Profil Cible', targetProfile.name, line, headers);
 
-      line = _addCellByHeadersTitleForText('Nom du Participant', user.lastName, line, headers);
-      line = _addCellByHeadersTitleForText('Prénom du Participant', user.firstName, line, headers);
+      _addCellByHeadersTitle('Nom du Participant', user.lastName, line, headers);
+      _addCellByHeadersTitle('Prénom du Participant', user.firstName, line, headers);
 
       if (campaign.idPixLabel) {
-        line = _addCellByHeadersTitleForText(campaign.idPixLabel, campaignParticipation.participantExternalId, line, headers);
+        _addCellByHeadersTitle(campaign.idPixLabel, campaignParticipation.participantExternalId, line, headers);
       }
 
       const knowledgeElements = allKnowledgeElements
@@ -170,8 +165,8 @@ function _createOneLineOfCSV(
         3,
       );
       const percentageProgression = (assessment.isCompleted) ? 1 : notCompletedPercentageProgression;
-      line = _addCellByHeadersTitleForNumber('% de progression', percentageProgression, line, headers);
-      line = _addCellByHeadersTitleForNumber(
+      _addCellByHeadersTitle('% de progression', percentageProgression, line, headers);
+      _addCellByHeadersTitle(
         'Date de début',
         moment.utc(assessment.createdAt).format('YYYY-MM-DD'),
         line,
@@ -179,13 +174,13 @@ function _createOneLineOfCSV(
       );
 
       const textForParticipationShared = campaignParticipation.isShared ? 'Oui' : 'Non';
-      line = _addCellByHeadersTitleForText('Partage (O/N)', textForParticipationShared, line, headers);
+      _addCellByHeadersTitle('Partage (O/N)', textForParticipationShared, line, headers);
 
       if (assessment.isCompleted && campaignParticipation.isShared) {
 
-        line = _addCellByHeadersTitleForNumber('Date du partage', moment.utc(campaignParticipation.sharedAt).format('YYYY-MM-DD'), line, headers);
+        _addCellByHeadersTitle('Date du partage', moment.utc(campaignParticipation.sharedAt).format('YYYY-MM-DD'), line, headers);
 
-        line = _addCellByHeadersTitleForNumber(
+        _addCellByHeadersTitle(
           '% maitrise de l\'ensemble des acquis du profil',
           _percentageSkillsValidated(knowledgeElements, targetProfile),
           line,
@@ -206,19 +201,19 @@ function _createOneLineOfCSV(
           const numberOfSkillsValidatedForThisCompetence = _getSkillsValidatedForCompetence(skillsForThisCompetence,
             knowledgeElements);
           const percentage = _.round(numberOfSkillsValidatedForThisCompetence / skillsForThisCompetence.length, 2);
-          line = _addCellByHeadersTitleForNumber(
+          _addCellByHeadersTitle(
             `% de maitrise des acquis de la compétence ${competence.name}`,
             percentage,
             line,
             headers,
           );
-          line = _addCellByHeadersTitleForNumber(
+          _addCellByHeadersTitle(
             `Nombre d'acquis du profil cible dans la compétence ${competence.name}`,
             skillsForThisCompetence.length,
             line,
             headers,
           );
-          line = _addCellByHeadersTitleForNumber(
+          _addCellByHeadersTitle(
             `Acquis maitrisés dans la compétence ${competence.name}`,
             numberOfSkillsValidatedForThisCompetence,
             line,
@@ -236,17 +231,17 @@ function _createOneLineOfCSV(
         _.forEach(areaSkills, (area) => {
           const percentage = _.round(area.numberSkillsValidated / area.numberSkillsTested, 2);
 
-          line = _addCellByHeadersTitleForNumber(`% de maitrise des acquis du domaine ${area.title}`,
+          _addCellByHeadersTitle(`% de maitrise des acquis du domaine ${area.title}`,
             percentage,
             line,
             headers);
-          line = _addCellByHeadersTitleForNumber(
+          _addCellByHeadersTitle(
             `Nombre d'acquis du profil cible du domaine ${area.title}`,
             area.numberSkillsTested,
             line,
             headers,
           );
-          line = _addCellByHeadersTitleForNumber(
+          _addCellByHeadersTitle(
             `Acquis maitrisés du domaine ${area.title}`,
             area.numberSkillsValidated,
             line,
@@ -257,7 +252,7 @@ function _createOneLineOfCSV(
 
         // By Skills
         _.forEach(targetProfile.skills, (skill) => {
-          line = _addCellByHeadersTitleForText(`${skill.name}`,
+          _addCellByHeadersTitle(`${skill.name}`,
             _stateOfSkill(skill.id, knowledgeElements),
             line,
             headers);

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -274,7 +274,7 @@ module.exports = async function startWritingCampaignResultsToStream(
 
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
-  const [targetProfile, allCompetences, organization, listCampaignParticipation] = await Promise.all([
+  const [targetProfile, allCompetences, organization, campaignParticipations] = await Promise.all([
     targetProfileRepository.get(campaign.targetProfileId),
     competenceRepository.list(),
     organizationRepository.get(campaign.organizationId),
@@ -299,7 +299,7 @@ module.exports = async function startWritingCampaignResultsToStream(
   // after this function's returned promise resolves. If we await the mapSeries
   // function, node will keep all the data in memory until the end of the
   // complete operation.
-  bluebird.mapSeries(listCampaignParticipation, async (campaignParticipation) => {
+  bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
     const { user, userKnowledgeElements } = await _fetchUserData(
       campaignParticipation,
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -243,11 +243,11 @@ module.exports = async function startWritingCampaignResultsToStream(
     campaignParticipationRepository.findByCampaignId(campaign.id),
   ]);
 
-  const listSkillsId = targetProfile.skills.map((skill) => skill.id);
-
-  const competences = allCompetences.filter((competence) => {
-    return listSkillsId.some((skillId) => competence.skills.includes(skillId));
-  });
+  const competences = _(targetProfile.skills)
+    .map('competenceId')
+    .uniq()
+    .map((competenceId) => _.find(allCompetences, { id: competenceId }))
+    .value();
 
   const areas = _.uniqBy(competences.map((competence) => competence.area), 'code');
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -176,7 +176,6 @@ function _createOneLineOfCSV({
 
     const competenceStats = _.map(competences, (competence) => {
       const skillsForThisCompetence = _getSkillsOfCompetenceByTargetProfile(competence, targetProfile);
-
       const skillCount = skillsForThisCompetence.length;
       const validatedSkillCount = _getSkillsValidatedForCompetence(skillsForThisCompetence, knowledgeElements);
 
@@ -188,17 +187,10 @@ function _createOneLineOfCSV({
       };
     });
 
-    _.forEach(competenceStats, ({ id, skillCount, validatedSkillCount }) => {
-      lineMap[`competence_${id}_percentageValidated`] = _.round(validatedSkillCount / skillCount, 2);
-      lineMap[`competence_${id}_skillCount`] = skillCount;
-      lineMap[`competence_${id}_validatedSkillCount`] = validatedSkillCount;
-    });
-
     const areaStats = _.map(areas, ({ id }) => {
-      const areaCompetences = _.filter(competenceStats, { areaId: id });
-
-      const skillCount = _.sumBy(areaCompetences, 'skillCount');
-      const validatedSkillCount  = _.sumBy(areaCompetences, 'validatedSkillCount');
+      const areaCompetenceStats = _.filter(competenceStats, { areaId: id });
+      const skillCount = _.sumBy(areaCompetenceStats, 'skillCount');
+      const validatedSkillCount  = _.sumBy(areaCompetenceStats, 'validatedSkillCount');
 
       return {
         id,
@@ -207,11 +199,14 @@ function _createOneLineOfCSV({
       };
     });
 
-    _.forEach(areaStats, ({ id, skillCount, validatedSkillCount }) => {
-      lineMap[`area_${id}_percentageValidated`] = _.round(validatedSkillCount / skillCount, 2);
-      lineMap[`area_${id}_skillCount`] = skillCount;
-      lineMap[`area_${id}_validatedSkillCount`] = validatedSkillCount;
-    });
+    const addStatsColumns = (prefix) => ({ id, skillCount, validatedSkillCount }) => {
+      lineMap[`${prefix}_${id}_percentageValidated`] = _.round(validatedSkillCount / skillCount, 2);
+      lineMap[`${prefix}_${id}_skillCount`] = skillCount;
+      lineMap[`${prefix}_${id}_validatedSkillCount`] = validatedSkillCount;
+    };
+
+    _.forEach(competenceStats, addStatsColumns('competence'));
+    _.forEach(areaStats, addStatsColumns('area'));
 
     _.forEach(targetProfile.skills, ({ id }) => {
       lineMap[`skill_${id}`] = _stateOfSkill(id, knowledgeElements);

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -30,7 +30,7 @@ function _csvSerializeValue(data) {
       return `"${data.replace(/"/g, '""')}"`;
     }
   } else {
-    throw new Error(`Unknown value type in _csvSerializeValue: ${typeof data}`);
+    throw new Error(`Unknown value type in _csvSerializeValue: ${typeof data}: ${data}`);
   }
 }
 
@@ -39,39 +39,36 @@ function _csvSerializeLine(line) {
 }
 
 function _createHeaderOfCSV(skillNames, competences, areas, idPixLabel) {
-  const headers = [];
-  headers.push('Nom de l\'organisation');
-  headers.push('ID Campagne');
-  headers.push('Nom de la campagne');
-  headers.push('Nom du Profil Cible');
-  headers.push('Nom du Participant');
-  headers.push('Prénom du Participant');
-  if (idPixLabel) {
-    headers.push(idPixLabel);
-  }
-  headers.push('% de progression');
-  headers.push('Date de début');
-  headers.push('Partage (O/N)');
-  headers.push('Date du partage');
-  headers.push('% maitrise de l\'ensemble des acquis du profil');
+  return [
+    'Nom de l\'organisation',
+    'ID Campagne',
+    'Nom de la campagne',
+    'Nom du Profil Cible',
+    'Nom du Participant',
+    'Prénom du Participant',
 
-  competences.forEach((competence) => {
-    headers.push(`% de maitrise des acquis de la compétence ${competence.name}`);
-    headers.push(`Nombre d'acquis du profil cible dans la compétence ${competence.name}`);
-    headers.push(`Acquis maitrisés dans la compétence ${competence.name}`);
-  });
+    ...(idPixLabel ? [ idPixLabel ] : []),
 
-  areas.forEach((area) => {
-    headers.push(`% de maitrise des acquis du domaine ${area.title}`);
-    headers.push(`Nombre d'acquis du profil cible du domaine ${area.title}`);
-    headers.push(`Acquis maitrisés du domaine ${area.title}`);
-  });
+    '% de progression',
+    'Date de début',
+    'Partage (O/N)',
+    'Date du partage',
+    '% maitrise de l\'ensemble des acquis du profil',
 
-  skillNames.forEach((skillName) => {
-    headers.push(skillName);
-  });
+    ...(_.flatMap(competences, (competence) => [
+      `% de maitrise des acquis de la compétence ${competence.name}`,
+      `Nombre d'acquis du profil cible dans la compétence ${competence.name}`,
+      `Acquis maitrisés dans la compétence ${competence.name}`,
+    ])),
 
-  return headers;
+    ...(_.flatMap(areas, (area) => [
+      `% de maitrise des acquis du domaine ${area.title}`,
+      `Nombre d'acquis du profil cible du domaine ${area.title}`,
+      `Acquis maitrisés du domaine ${area.title}`,
+    ])),
+
+    ...skillNames,
+  ];
 }
 
 function _totalValidatedSkills(knowledgeElements) {

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -111,7 +111,7 @@ function _getSkillsValidatedForCompetence(skills, knowledgeElements) {
 
 }
 
-function _fetchUserData(
+function _fetchParticipantData(
   campaignParticipation,
 
   userRepository,
@@ -300,7 +300,7 @@ module.exports = async function startWritingCampaignResultsToStream(
   // function, node will keep all the data in memory until the end of the
   // complete operation.
   bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
-    const { user, userKnowledgeElements } = await _fetchUserData(
+    const { user, userKnowledgeElements } = await _fetchParticipantData(
       campaignParticipation,
 
       userRepository,

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -40,34 +40,34 @@ function _csvSerializeLine(line) {
 
 function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
   return [
-    'Nom de l\'organisation',
-    'ID Campagne',
-    'Nom de la campagne',
-    'Nom du Profil Cible',
-    'Nom du Participant',
-    'Prénom du Participant',
+    { title: 'Nom de l\'organisation' },
+    { title: 'ID Campagne' },
+    { title: 'Nom de la campagne' },
+    { title: 'Nom du Profil Cible' },
+    { title: 'Nom du Participant' },
+    { title: 'Prénom du Participant' },
 
-    ...(idPixLabel ? [ idPixLabel ] : []),
+    ...(idPixLabel ? [ { title: idPixLabel } ] : []),
 
-    '% de progression',
-    'Date de début',
-    'Partage (O/N)',
-    'Date du partage',
-    '% maitrise de l\'ensemble des acquis du profil',
+    { title: '% de progression' },
+    { title: 'Date de début' },
+    { title: 'Partage (O/N)' },
+    { title: 'Date du partage' },
+    { title: '% maitrise de l\'ensemble des acquis du profil' },
 
     ...(_.flatMap(competences, (competence) => [
-      `% de maitrise des acquis de la compétence ${competence.name}`,
-      `Nombre d'acquis du profil cible dans la compétence ${competence.name}`,
-      `Acquis maitrisés dans la compétence ${competence.name}`,
+      { title: `% de maitrise des acquis de la compétence ${competence.name}` },
+      { title: `Nombre d'acquis du profil cible dans la compétence ${competence.name}` },
+      { title: `Acquis maitrisés dans la compétence ${competence.name}` },
     ])),
 
     ...(_.flatMap(areas, (area) => [
-      `% de maitrise des acquis du domaine ${area.title}`,
-      `Nombre d'acquis du profil cible du domaine ${area.title}`,
-      `Acquis maitrisés du domaine ${area.title}`,
+      { title: `% de maitrise des acquis du domaine ${area.title}` },
+      { title: `Nombre d'acquis du profil cible du domaine ${area.title}` },
+      { title: `Acquis maitrisés du domaine ${area.title}` },
     ])),
 
-    ...(_.map(skills, 'name')),
+    ...(_.map(skills, (skill) => ({ title: `${skill.name}` }))),
   ];
 }
 
@@ -140,7 +140,7 @@ function _createOneLineOfCSV({
   user,
   userKnowledgeElements,
 }) {
-  const lineMap = _.fromPairs(headers.map((h) => [h, 'NA']));
+  const lineMap = _.fromPairs(headers.map((h) => [h.title, 'NA']));
 
   lineMap['Nom de l\'organisation'] = organization.name;
   lineMap['ID Campagne'] = parseInt(campaign.id);
@@ -215,7 +215,7 @@ function _createOneLineOfCSV({
     });
   }
 
-  const lineArray = headers.map((title) => {
+  const lineArray = headers.map(({ title }) => {
     return lineMap[title];
   });
 
@@ -270,7 +270,7 @@ module.exports = async function startWritingCampaignResultsToStream(
   // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
   // - https://en.wikipedia.org/wiki/Byte_order_mark
   // - https://stackoverflow.com/a/38192870
-  const headerLine = '\uFEFF' + _csvSerializeLine(headers);
+  const headerLine = '\uFEFF' + _csvSerializeLine(_.map(headers, 'title'));
 
   writableStream.write(headerLine);
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -26,38 +26,38 @@ function _cleanText(text) {
 
 function _createHeaderOfCSV(skillNames, competences, areas, idPixLabel) {
   const headers = [];
-  headers.push('"Nom de l\'organisation"');
-  headers.push('"ID Campagne"');
-  headers.push('"Nom de la campagne"');
-  headers.push('"Nom du Profil Cible"');
-  headers.push('"Nom du Participant"');
-  headers.push('"Prénom du Participant"');
+  headers.push('Nom de l\'organisation');
+  headers.push('ID Campagne');
+  headers.push('Nom de la campagne');
+  headers.push('Nom du Profil Cible');
+  headers.push('Nom du Participant');
+  headers.push('Prénom du Participant');
   if (idPixLabel) {
-    headers.push(_cleanText(idPixLabel));
+    headers.push(idPixLabel);
   }
-  headers.push('"% de progression"');
-  headers.push('"Date de début"');
-  headers.push('"Partage (O/N)"');
-  headers.push('"Date du partage"');
-  headers.push('"% maitrise de l\'ensemble des acquis du profil"');
+  headers.push('% de progression');
+  headers.push('Date de début');
+  headers.push('Partage (O/N)');
+  headers.push('Date du partage');
+  headers.push('% maitrise de l\'ensemble des acquis du profil');
 
   competences.forEach((competence) => {
-    headers.push(`"% de maitrise des acquis de la compétence ${competence.name}"`);
-    headers.push(`"Nombre d'acquis du profil cible dans la compétence ${competence.name}"`);
-    headers.push(`"Acquis maitrisés dans la compétence ${competence.name}"`);
+    headers.push(`% de maitrise des acquis de la compétence ${competence.name}`);
+    headers.push(`Nombre d'acquis du profil cible dans la compétence ${competence.name}`);
+    headers.push(`Acquis maitrisés dans la compétence ${competence.name}`);
   });
 
   areas.forEach((area) => {
-    headers.push(`"% de maitrise des acquis du domaine ${area.title}"`);
-    headers.push(`"Nombre d'acquis du profil cible du domaine ${area.title}"`);
-    headers.push(`"Acquis maitrisés du domaine ${area.title}"`);
+    headers.push(`% de maitrise des acquis du domaine ${area.title}`);
+    headers.push(`Nombre d'acquis du profil cible du domaine ${area.title}`);
+    headers.push(`Acquis maitrisés du domaine ${area.title}`);
   });
 
   skillNames.forEach((skillName) => {
-    headers.push(`"${skillName}"`);
+    headers.push(skillName);
   });
 
-  return headers;
+  return headers.map(_cleanText);
 }
 
 function _addCellByHeadersTitleForNumber(title, data, line, headers) {
@@ -66,7 +66,7 @@ function _addCellByHeadersTitleForNumber(title, data, line, headers) {
 }
 
 function _addCellByHeadersTitleForText(title, data, line, headers) {
-  line[headers.indexOf(title)] = `"${data.toString().replace(/"/g, '""')}"`;
+  line[headers.indexOf(title)] = _cleanText(data.toString());
   return line;
 }
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -251,7 +251,13 @@ function _extractCompetences(allCompetences, skills) {
   return _(skills)
     .map('competenceId')
     .uniq()
-    .map((competenceId) => _.find(allCompetences, { id: competenceId }))
+    .map((competenceId) => {
+      const competence = _.find(allCompetences, { id: competenceId });
+      if (!competence) {
+        throw new Error(`Unknown competence ${competenceId}`);
+      }
+      return competence;
+    })
     .value();
 }
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -111,19 +111,6 @@ function _getSkillsValidatedForCompetence(skills, knowledgeElements) {
 
 }
 
-function _fetchParticipantData(
-  campaignParticipationResultData,
-
-  knowledgeElementRepository,
-) {
-  return bluebird.props({
-    participantKnowledgeElements: knowledgeElementRepository.findUniqByUserId({
-      userId: campaignParticipationResultData.userId,
-      limitDate: campaignParticipationResultData.sharedAt,
-    }),
-  });
-}
-
 function _getCommonColumns({
   organization,
   campaign,
@@ -310,11 +297,10 @@ module.exports = async function startWritingCampaignResultsToStream(
   // function, node will keep all the data in memory until the end of the
   // complete operation.
   bluebird.mapSeries(campaignParticipationResultDatas, async (campaignParticipationResultData) => {
-    const { participantKnowledgeElements } = await _fetchParticipantData(
-      campaignParticipationResultData,
-
-      knowledgeElementRepository,
-    );
+    const participantKnowledgeElements = await knowledgeElementRepository.findUniqByUserId({
+      userId: campaignParticipationResultData.userId,
+      limitDate: campaignParticipationResultData.sharedAt,
+    });
 
     const csvLine = _createOneLineOfCSV({
       headers,

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -4,20 +4,18 @@ const bluebird = require('bluebird');
 
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignWithoutOrganizationError } = require('../errors');
 
-function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
+async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   if (_.isNil(organizationId)) {
-    return Promise.reject(new CampaignWithoutOrganizationError(`Campaign without organization : ${organizationId}`));
+    throw new CampaignWithoutOrganizationError(`Campaign without organization : ${organizationId}`);
   }
 
-  return userRepository.getWithMemberships(userId)
-    .then((user) => {
-      if (user.hasAccessToOrganization(organizationId)) {
-        return Promise.resolve();
-      }
-      return Promise.reject(
-        new UserNotAuthorizedToGetCampaignResultsError(`User does not have an access to the organization ${organizationId}`),
-      );
-    });
+  const user = await userRepository.getWithMemberships(userId);
+
+  if (!user.hasAccessToOrganization(organizationId)) {
+    throw new UserNotAuthorizedToGetCampaignResultsError(
+      `User does not have an access to the organization ${organizationId}`
+    );
+  }
 }
 
 function _csvSerializeValue(data) {

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -165,11 +165,9 @@ function _getSharedColumns({
   };
 
   const addStatsColumns = (prefix) => ({ id, skillCount, validatedSkillCount }) => {
-    _.assign(lineMap, {
-      [`${prefix}_${id}_percentageValidated`]: _.round(validatedSkillCount / skillCount, 2),
-      [`${prefix}_${id}_skillCount`]: skillCount,
-      [`${prefix}_${id}_validatedSkillCount`]: validatedSkillCount,
-    });
+    lineMap[`${prefix}_${id}_percentageValidated`] = _.round(validatedSkillCount / skillCount, 2);
+    lineMap[`${prefix}_${id}_skillCount`] = skillCount;
+    lineMap[`${prefix}_${id}_validatedSkillCount`] = validatedSkillCount;
   };
 
   _.forEach(competenceStats, addStatsColumns('competence'));

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -236,7 +236,7 @@ module.exports = async function startWritingCampaignResultsToStream(
 
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
-  const [targetProfile, listAllCompetences, organization, listCampaignParticipation] = await Promise.all([
+  const [targetProfile, allCompetences, organization, listCampaignParticipation] = await Promise.all([
     targetProfileRepository.get(campaign.targetProfileId),
     competenceRepository.list(),
     organizationRepository.get(campaign.organizationId),
@@ -245,7 +245,7 @@ module.exports = async function startWritingCampaignResultsToStream(
 
   const listSkillsId = targetProfile.skills.map((skill) => skill.id);
 
-  const competences = listAllCompetences.filter((competence) => {
+  const competences = allCompetences.filter((competence) => {
     return listSkillsId.some((skillId) => competence.skills.includes(skillId));
   });
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -84,16 +84,6 @@ function _addCellByHeadersTitleForText(title, data, line, headers) {
   return line;
 }
 
-/*function _totalPixScore(knowledgeElements) {
- const sumTotalPixScore = _.reduce(knowledgeElements, function(sumPix, knowledgeElement) {
- if (knowledgeElement.isValidated) {
- return sumPix + knowledgeElement.pixScore;
- }
- return sumPix;
- }, 0);
- return sumTotalPixScore;
- }*/
-
 function _totalValidatedSkills(knowledgeElements) {
   const sumValidatedSkills = _.reduce(knowledgeElements, function(validatedSkill, knowledgeElement) {
     if (knowledgeElement.isValidated) {

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -117,8 +117,8 @@ function _createOneLineOfCSV(
   headers,
   organization,
   campaign,
-  listCompetences,
-  listArea,
+  competences,
+  areas,
   campaignParticipation,
   targetProfile,
   userRepository,
@@ -166,7 +166,7 @@ function _createOneLineOfCSV(
 
         lineMap['% maitrise de l\'ensemble des acquis du profil'] = _percentageSkillsValidated(knowledgeElements, targetProfile);
 
-        const areaSkills = listArea.map((area) => {
+        const areaSkills = areas.map((area) => {
           return {
             title: area.title,
             numberSkillsValidated: 0,
@@ -175,7 +175,7 @@ function _createOneLineOfCSV(
         });
 
         // By Competences
-        _.forEach(listCompetences, (competence) => {
+        _.forEach(competences, (competence) => {
           const skillsForThisCompetence = _getSkillsOfCompetenceByTargetProfile(competence, targetProfile);
           const numberOfSkillsValidatedForThisCompetence = _getSkillsValidatedForCompetence(skillsForThisCompetence,
             knowledgeElements);
@@ -246,14 +246,14 @@ module.exports = async function startWritingCampaignResultsToStream(
   const listSkillsName = targetProfile.skills.map((skill) => skill.name);
   const listSkillsId = targetProfile.skills.map((skill) => skill.id);
 
-  const listCompetences = listAllCompetences.filter((competence) => {
+  const competences = listAllCompetences.filter((competence) => {
     return listSkillsId.some((skillId) => competence.skills.includes(skillId));
   });
 
-  const listArea = _.uniqBy(listCompetences.map((competence) => competence.area), 'code');
+  const areas = _.uniqBy(competences.map((competence) => competence.area), 'code');
 
   //Create HEADER of CSV
-  const headersAsArray = _createHeaderOfCSV(listSkillsName, listCompetences, listArea, campaign.idPixLabel);
+  const headersAsArray = _createHeaderOfCSV(listSkillsName, competences, areas, campaign.idPixLabel);
 
   // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
   // - https://en.wikipedia.org/wiki/Byte_order_mark
@@ -267,8 +267,8 @@ module.exports = async function startWritingCampaignResultsToStream(
       headersAsArray,
       organization,
       campaign,
-      listCompetences,
-      listArea,
+      competences,
+      areas,
       campaignParticipation,
       targetProfile,
       userRepository,

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -119,7 +119,10 @@ function _fetchParticipantData(
 ) {
   return bluebird.props({
     user: userRepository.get(campaignParticipationResultData.userId),
-    participantKnowledgeElements: knowledgeElementRepository.findUniqByUserId({ userId: campaignParticipationResultData.userId, limitDate: campaignParticipationResultData.sharedAt }),
+    participantKnowledgeElements: knowledgeElementRepository.findUniqByUserId({
+      userId: campaignParticipationResultData.userId,
+      limitDate: campaignParticipationResultData.sharedAt,
+    }),
   });
 }
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -114,11 +114,9 @@ function _getSkillsValidatedForCompetence(skills, knowledgeElements) {
 function _fetchParticipantData(
   campaignParticipationResultData,
 
-  userRepository,
   knowledgeElementRepository,
 ) {
   return bluebird.props({
-    user: userRepository.get(campaignParticipationResultData.userId),
     participantKnowledgeElements: knowledgeElementRepository.findUniqByUserId({
       userId: campaignParticipationResultData.userId,
       limitDate: campaignParticipationResultData.sharedAt,
@@ -312,17 +310,11 @@ module.exports = async function startWritingCampaignResultsToStream(
   // function, node will keep all the data in memory until the end of the
   // complete operation.
   bluebird.mapSeries(campaignParticipationResultDatas, async (campaignParticipationResultData) => {
-    const { user, participantKnowledgeElements } = await _fetchParticipantData(
+    const { participantKnowledgeElements } = await _fetchParticipantData(
       campaignParticipationResultData,
 
-      userRepository,
       knowledgeElementRepository,
     );
-
-    _.assign(campaignParticipationResultData, {
-      participantFirstName: user.firstName,
-      participantLastName: user.lastName,
-    });
 
     const csvLine = _createOneLineOfCSV({
       headers,

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -217,6 +217,18 @@ function _createOneLineOfCSV(
     });
 }
 
+function _extractCompetences(allCompetences, skills) {
+  return _(skills)
+    .map('competenceId')
+    .uniq()
+    .map((competenceId) => _.find(allCompetences, { id: competenceId }))
+    .value();
+}
+
+function _extractAreas(competences) {
+  return _.uniqBy(competences.map((competence) => competence.area), 'code');
+}
+
 module.exports = async function startWritingCampaignResultsToStream(
   {
     userId,
@@ -243,13 +255,9 @@ module.exports = async function startWritingCampaignResultsToStream(
     campaignParticipationRepository.findByCampaignId(campaign.id),
   ]);
 
-  const competences = _(targetProfile.skills)
-    .map('competenceId')
-    .uniq()
-    .map((competenceId) => _.find(allCompetences, { id: competenceId }))
-    .value();
+  const competences = _extractCompetences(allCompetences, targetProfile.skills);
 
-  const areas = _.uniqBy(competences.map((competence) => competence.area), 'code');
+  const areas = _extractAreas(competences);
 
   //Create HEADER of CSV
   const headersAsArray = _createHeaderOfCSV(targetProfile.skills, competences, areas, campaign.idPixLabel);

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -135,14 +135,11 @@ function _createOneLineOfCSV(
 ) {
   const line = headers.map(() => 'NA');
 
-  return smartPlacementAssessmentRepository.get(campaignParticipation.assessmentId)
-    .then((assessment) => {
-      return Promise.all([
-        assessment,
-        userRepository.get(assessment.userId),
-        knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId, limitDate: campaignParticipation.sharedAt })
-      ]);
-    })
+  return Promise.all([
+    smartPlacementAssessmentRepository.get(campaignParticipation.assessmentId),
+    userRepository.get(campaignParticipation.userId),
+    knowledgeElementRepository.findUniqByUserId({ userId: campaignParticipation.userId, limitDate: campaignParticipation.sharedAt }),
+  ])
     .then(([assessment, user, allKnowledgeElements]) => {
 
       _addCellByHeadersTitle('Nom de l\'organisation', organization.name, line, headers);

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -176,7 +176,7 @@ function _createOneLineOfCSV(
       const textForParticipationShared = campaignParticipation.isShared ? 'Oui' : 'Non';
       _addCellByHeadersTitle('Partage (O/N)', textForParticipationShared, line, headers);
 
-      if (assessment.isCompleted && campaignParticipation.isShared) {
+      if (campaignParticipation.isShared) {
 
         _addCellByHeadersTitle('Date du partage', moment.utc(campaignParticipation.sharedAt).format('YYYY-MM-DD'), line, headers);
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -40,34 +40,34 @@ function _csvSerializeLine(line) {
 
 function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
   return [
-    { title: 'Nom de l\'organisation' },
-    { title: 'ID Campagne' },
-    { title: 'Nom de la campagne' },
-    { title: 'Nom du Profil Cible' },
-    { title: 'Nom du Participant' },
-    { title: 'Prénom du Participant' },
+    { title: 'Nom de l\'organisation', property: 'organizationName' },
+    { title: 'ID Campagne', property: 'campaignId' },
+    { title: 'Nom de la campagne', property: 'campaignName' },
+    { title: 'Nom du Profil Cible', property: 'targetProfileName' },
+    { title: 'Nom du Participant', property: 'participantLastName' },
+    { title: 'Prénom du Participant', property: 'participantFirstName' },
 
-    ...(idPixLabel ? [ { title: idPixLabel } ] : []),
+    ...(idPixLabel ? [ { title: idPixLabel, property: 'participantExternalId' } ] : []),
 
-    { title: '% de progression' },
-    { title: 'Date de début' },
-    { title: 'Partage (O/N)' },
-    { title: 'Date du partage' },
-    { title: '% maitrise de l\'ensemble des acquis du profil' },
+    { title: '% de progression', property: 'percentageProgression' },
+    { title: 'Date de début', property: 'createdAt' },
+    { title: 'Partage (O/N)', property: 'isShared' },
+    { title: 'Date du partage', property: 'sharedAt' },
+    { title: '% maitrise de l\'ensemble des acquis du profil', property: 'percentageSkillValidated' },
 
     ...(_.flatMap(competences, (competence) => [
-      { title: `% de maitrise des acquis de la compétence ${competence.name}` },
-      { title: `Nombre d'acquis du profil cible dans la compétence ${competence.name}` },
-      { title: `Acquis maitrisés dans la compétence ${competence.name}` },
+      { title: `% de maitrise des acquis de la compétence ${competence.name}`, property: `competence_${competence.id}_percentageValidated` },
+      { title: `Nombre d'acquis du profil cible dans la compétence ${competence.name}`, property: `competence_${competence.id}_skillCount` },
+      { title: `Acquis maitrisés dans la compétence ${competence.name}`, property: `competence_${competence.id}_validatedSkillCount` },
     ])),
 
     ...(_.flatMap(areas, (area) => [
-      { title: `% de maitrise des acquis du domaine ${area.title}` },
-      { title: `Nombre d'acquis du profil cible du domaine ${area.title}` },
-      { title: `Acquis maitrisés du domaine ${area.title}` },
+      { title: `% de maitrise des acquis du domaine ${area.title}`, property: `area_${area.id}_percentageValidated` },
+      { title: `Nombre d'acquis du profil cible du domaine ${area.title}`, property: `area_${area.id}_skillCount` },
+      { title: `Acquis maitrisés du domaine ${area.title}`, property: `area_${area.id}_validatedSkillCount` },
     ])),
 
-    ...(_.map(skills, (skill) => ({ title: `${skill.name}` }))),
+    ...(_.map(skills, (skill) => ({ title: `${skill.name}`, property: `skill_${skill.id}` }))),
   ];
 }
 

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -301,6 +301,10 @@ module.exports = async function startWritingCampaignResultsToStream(
 
   writableStream.write(headerLine);
 
+  // No return/await here, we need the writing to continue in the background
+  // after this function's returned promise resolves. If we await the mapSeries
+  // function, node will keep all the data in memory until the end of the
+  // complete operation.
   bluebird.mapSeries(listCampaignParticipation, async (campaignParticipation) => {
     const { assessment, user, userKnowledgeElements } = await _fetchUserData(
       campaignParticipation,

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -38,7 +38,7 @@ function _csvSerializeLine(line) {
   return line.map(_csvSerializeValue).join(';') + '\n';
 }
 
-function _createHeaderOfCSV(skillNames, competences, areas, idPixLabel) {
+function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
   return [
     'Nom de l\'organisation',
     'ID Campagne',
@@ -67,7 +67,7 @@ function _createHeaderOfCSV(skillNames, competences, areas, idPixLabel) {
       `Acquis maitrisés du domaine ${area.title}`,
     ])),
 
-    ...skillNames,
+    ...(_.map(skills, 'name')),
   ];
 }
 
@@ -243,7 +243,6 @@ module.exports = async function startWritingCampaignResultsToStream(
     campaignParticipationRepository.findByCampaignId(campaign.id),
   ]);
 
-  const listSkillsName = targetProfile.skills.map((skill) => skill.name);
   const listSkillsId = targetProfile.skills.map((skill) => skill.id);
 
   const competences = listAllCompetences.filter((competence) => {
@@ -253,7 +252,7 @@ module.exports = async function startWritingCampaignResultsToStream(
   const areas = _.uniqBy(competences.map((competence) => competence.area), 'code');
 
   //Create HEADER of CSV
-  const headersAsArray = _createHeaderOfCSV(listSkillsName, competences, areas, campaign.idPixLabel);
+  const headersAsArray = _createHeaderOfCSV(targetProfile.skills, competences, areas, campaign.idPixLabel);
 
   // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
   // - https://en.wikipedia.org/wiki/Byte_order_mark

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -182,7 +182,6 @@ function _createOneLineOfCSV({
       };
     });
 
-    // By Competences
     _.forEach(competences, (competence) => {
       const skillsForThisCompetence = _getSkillsOfCompetenceByTargetProfile(competence, targetProfile);
 
@@ -194,7 +193,6 @@ function _createOneLineOfCSV({
       lineMap[`competence_${competence.id}_skillCount`] = skillCount;
       lineMap[`competence_${competence.id}_validatedSkillCount`] = validatedSkillCount;
 
-      // Add on Area
       const areaSkillsForThisCompetence = _.find(areaSkills, { id: competence.area.id });
       areaSkillsForThisCompetence.numberSkillsValidated =
         areaSkillsForThisCompetence.numberSkillsValidated + validatedSkillCount;
@@ -202,7 +200,6 @@ function _createOneLineOfCSV({
         areaSkillsForThisCompetence.numberSkillsTested + skillCount;
     });
 
-    // By Area
     _.forEach(areaSkills, (areaSkill) => {
       const skillCount = areaSkill.numberSkillsTested;
       const validatedSkillCount  = areaSkill.numberSkillsValidated;
@@ -213,7 +210,6 @@ function _createOneLineOfCSV({
       lineMap[`area_${areaSkill.id}_validatedSkillCount`] = validatedSkillCount;
     });
 
-    // By Skills
     _.forEach(targetProfile.skills, ({ id }) => {
       lineMap[`skill_${id}`] = _stateOfSkill(id, knowledgeElements);
     });

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -147,7 +147,7 @@ function _getCommonColumns({
     participantLastName: user.lastName,
     participantFirstName: user.firstName,
     percentageProgression: assessment.isCompleted ? 1 : notCompletedPercentageProgression,
-    createdAt: moment.utc(assessment.createdAt).format('YYYY-MM-DD'),
+    createdAt: moment.utc(campaignParticipation.createdAt).format('YYYY-MM-DD'),
     isShared: campaignParticipation.isShared ? 'Oui' : 'Non',
     ...(campaign.idPixLabel ? { participantExternalId: campaignParticipation.participantExternalId } : {}),
   };

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -47,7 +47,11 @@ module.exports = {
   async findResultDataByCampaignId(campaignId) {
     const { models } = await BookshelfCampaignParticipation
       .where({ campaignId })
-      .fetchAll({});
+      .fetchAll({
+        withRelated: {
+          user: (qb) => { qb.columns('id', 'firstName', 'lastName'); }
+        }
+      });
 
     return models.map((bookshelfCampaignParticipation) => {
       return {
@@ -58,6 +62,9 @@ module.exports = {
         createdAt: new Date(bookshelfCampaignParticipation.get('createdAt')),
         participantExternalId: bookshelfCampaignParticipation.get('participantExternalId'),
         userId: bookshelfCampaignParticipation.get('userId'),
+
+        participantFirstName: bookshelfCampaignParticipation.related('user').get('firstName'),
+        participantLastName: bookshelfCampaignParticipation.related('user').get('lastName'),
       };
     });
   },

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -56,10 +56,10 @@ module.exports = {
     return models.map((bookshelfCampaignParticipation) => {
       return {
         id: bookshelfCampaignParticipation.get('id'),
+        createdAt: new Date(bookshelfCampaignParticipation.get('createdAt')),
 
         isShared: Boolean(bookshelfCampaignParticipation.get('isShared')),
         sharedAt: bookshelfCampaignParticipation.get('sharedAt'),
-        createdAt: new Date(bookshelfCampaignParticipation.get('createdAt')),
         participantExternalId: bookshelfCampaignParticipation.get('participantExternalId'),
         userId: bookshelfCampaignParticipation.get('userId'),
 

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -44,12 +44,22 @@ module.exports = {
       .then(_toDomain);
   },
 
-  findResultDataByCampaignId(campaignId) {
-    return BookshelfCampaignParticipation
+  async findResultDataByCampaignId(campaignId) {
+    const { models } = await BookshelfCampaignParticipation
       .where({ campaignId })
-      .fetchAll({ withRelated: ['campaign', 'assessments'] })
-      .then((bookshelfCampaignParticipation) => bookshelfCampaignParticipation.models)
-      .then(fp.map(_toDomain));
+      .fetchAll({});
+
+    return models.map((bookshelfCampaignParticipation) => {
+      return {
+        id: bookshelfCampaignParticipation.get('id'),
+
+        isShared: Boolean(bookshelfCampaignParticipation.get('isShared')),
+        sharedAt: bookshelfCampaignParticipation.get('sharedAt'),
+        createdAt: new Date(bookshelfCampaignParticipation.get('createdAt')),
+        participantExternalId: bookshelfCampaignParticipation.get('participantExternalId'),
+        userId: bookshelfCampaignParticipation.get('userId'),
+      };
+    });
   },
 
   findByUserId(userId) {

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -44,7 +44,7 @@ module.exports = {
       .then(_toDomain);
   },
 
-  findByCampaignId(campaignId) {
+  findResultDataByCampaignId(campaignId) {
     return BookshelfCampaignParticipation
       .where({ campaignId })
       .fetchAll({ withRelated: ['campaign', 'assessments'] })

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -184,9 +184,6 @@ describe('Integration | Repository | Campaign Participation', () => {
     let campaign1;
     let campaign2;
     let campaignParticipation1;
-    let campaignParticipation2;
-    let assessmentId1;
-    let assessmentId2;
 
     beforeEach(async () => {
       campaign1 = databaseBuilder.factory.buildCampaign({});
@@ -196,12 +193,6 @@ describe('Integration | Repository | Campaign Participation', () => {
         campaignId: campaign1.id,
         isShared: true
       });
-      campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign1.id,
-        isShared: true
-      });
-      assessmentId1 = databaseBuilder.factory.buildAssessment({ campaignParticipationId: campaignParticipation1.id }).id;
-      assessmentId2 = databaseBuilder.factory.buildAssessment({ campaignParticipationId: campaignParticipation2.id }).id;
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign2.id,
         isShared: true
@@ -209,21 +200,25 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    it('should return all the campaign-participation links to the given campaign', () => {
+    it('should return all the campaign-participation links to the given campaign', async () => {
       // given
       const campaignId = campaign1.id;
 
       // when
-      const promise = campaignParticipationRepository.findResultDataByCampaignId(campaignId);
+      const participationResultDatas = await campaignParticipationRepository.findResultDataByCampaignId(campaignId);
 
       // then
-      return promise.then((campaignParticipationsFind) => {
-        expect(campaignParticipationsFind.length).to.equal(2);
-        expect(campaignParticipationsFind[0].campaign.id).to.equal(campaignParticipation1.campaignId);
-        expect(campaignParticipationsFind[1].campaign.id).to.equal(campaignParticipation2.campaignId);
-        expect(campaignParticipationsFind[0].assessmentId).to.equal(assessmentId1);
-        expect(campaignParticipationsFind[1].assessmentId).to.equal(assessmentId2);
-      });
+      expect(participationResultDatas).to.deep.equal([
+        {
+          id: campaignParticipation1.id,
+
+          isShared: true,
+          sharedAt: campaignParticipation1.sharedAt,
+          createdAt: campaignParticipation1.createdAt,
+          participantExternalId: campaignParticipation1.participantExternalId,
+          userId: campaignParticipation1.userId,
+        }
+      ]);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -179,7 +179,7 @@ describe('Integration | Repository | Campaign Participation', () => {
     });
   });
 
-  describe('#findByCampaignId', () => {
+  describe('#findResultDataByCampaignId', () => {
 
     let campaign1;
     let campaign2;
@@ -214,7 +214,7 @@ describe('Integration | Repository | Campaign Participation', () => {
       const campaignId = campaign1.id;
 
       // when
-      const promise = campaignParticipationRepository.findByCampaignId(campaignId);
+      const promise = campaignParticipationRepository.findResultDataByCampaignId(campaignId);
 
       // then
       return promise.then((campaignParticipationsFind) => {

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -184,18 +184,24 @@ describe('Integration | Repository | Campaign Participation', () => {
     let campaign1;
     let campaign2;
     let campaignParticipation1;
+    let userId;
 
     beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser({
+        firstName: 'First',
+        lastName: 'Last',
+      }).id;
       campaign1 = databaseBuilder.factory.buildCampaign({});
       campaign2 = databaseBuilder.factory.buildCampaign({});
 
       campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign1.id,
-        isShared: true
+        userId,
+        isShared: true,
       });
       databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign2.id,
-        isShared: true
+        isShared: true,
       });
       await databaseBuilder.commit();
     });
@@ -217,6 +223,9 @@ describe('Integration | Repository | Campaign Participation', () => {
           createdAt: campaignParticipation1.createdAt,
           participantExternalId: campaignParticipation1.participantExternalId,
           userId: campaignParticipation1.userId,
+
+          participantFirstName: 'First',
+          participantLastName: 'Last',
         }
       ]);
     });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -83,6 +83,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
         courseId: 'recComp1',
         skills: listSkills.map((skill) => skill.id),
         area: new Area({
+          id: 'recArea1',
           code: '1',
           title: 'Domain 1',
         }),
@@ -94,6 +95,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
         courseId: 'recComp2',
         skills: [],
         area: new Area({
+          id: 'recArea3',
           code: '3',
           title: 'Domain 3',
         }),

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -107,7 +107,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
     const targetProfileRepository = { get: () => undefined };
     const competenceRepository = { list: () => undefined };
     const organizationRepository = { get: () => undefined };
-    const campaignParticipationRepository = { findByCampaignId: () => undefined };
+    const campaignParticipationRepository = { findResultDataByCampaignId: () => undefined };
     const smartPlacementAssessmentRepository = { get: () => undefined };
     const knowledgeElementRepository = { findUniqByUserId: () => undefined };
 
@@ -126,7 +126,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
       sinon.stub(userRepository, 'get').resolves(user);
       sinon.stub(smartPlacementAssessmentRepository, 'get').resolves(assessment);
       sinon.stub(knowledgeElementRepository, 'findUniqByUserId').resolves(knowledgeElements);
-      findCampaignParticipationStub = sinon.stub(campaignParticipationRepository, 'findByCampaignId');
+      findCampaignParticipationStub = sinon.stub(campaignParticipationRepository, 'findResultDataByCampaignId');
 
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -13,6 +13,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
     const user = domainBuilder.buildUser();
     const organization = user.memberships[0].organization;
     const listSkills = domainBuilder.buildSkillCollection({ name: 'web', minLevel: 1, maxLevel: 5 });
+    listSkills.forEach((skill) => { skill.competenceId = 'recCompetence1'; });
     const listSkillsNotInTargetProfile = domainBuilder.buildSkillCollection({ name: 'url', minLevel: 1, maxLevel: 2 });
     const [skillWeb1, skillWeb2, skillWeb3, skillWeb4, skillWeb5] = listSkills;
     const [skillUrl1, skillUrl2] = listSkillsNotInTargetProfile;
@@ -76,6 +77,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
     });
     const competences = [
       {
+        id: 'recCompetence1',
         name: 'Competence1',
         index: '1.1',
         courseId: 'recComp1',
@@ -86,6 +88,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
         }),
       },
       {
+        id: 'recCompetence2',
         name: 'Competence2',
         index: '3.2',
         courseId: 'recComp2',

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -184,7 +184,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
       it('should return the complete line with user results for her participation', async () => {
         // given
-        const factoryCampaignParticipation = domainBuilder.buildCampaignParticipation({ isShared: true, sharedAt: new Date('2019-03-01T23:04:05Z') });
+        const factoryCampaignParticipation = domainBuilder.buildCampaignParticipation({
+          isShared: true,
+          createdAt: new Date('2019-02-25T10:00:00Z'),
+          sharedAt: new Date('2019-03-01T23:04:05Z'),
+        });
         factoryCampaignParticipation.assessmentId = domainBuilder.buildAssessment({ campaignParticipationId: factoryCampaignParticipation.id }).id;
         findCampaignParticipationStub.resolves([factoryCampaignParticipation]);
 
@@ -196,7 +200,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           `"${user.firstName}";` +
           `"${factoryCampaignParticipation.participantExternalId}";` +
           '1;' +
-          '2017-05-09;' +
+          '2019-02-25;' +
           '"Oui";' +
           '2019-03-01;' +
           '0,6;' +
@@ -240,7 +244,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
       it('should return the beginning of the line with user information for her participation', async () => {
         // given
 
-        const factoryCampaignParticipation = domainBuilder.buildCampaignParticipation({ isShared: false });
+        const factoryCampaignParticipation = domainBuilder.buildCampaignParticipation({
+          isShared: false,
+          createdAt: new Date('2019-02-25T10:00:00Z'),
+        });
         factoryCampaignParticipation.assessmentId = domainBuilder.buildAssessment({ campaignParticipationId: factoryCampaignParticipation.id }).id;
 
         findCampaignParticipationStub.resolves([factoryCampaignParticipation]);
@@ -254,7 +261,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           `"${user.firstName}";` +
           `"${factoryCampaignParticipation.participantExternalId}";` +
           '1;' +
-          '2017-05-09;' +
+          '2019-02-25;' +
           '"Non";' +
           '"NA";' +
           '"NA";' +

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -97,7 +97,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
     ];
 
     const campaignRepository = { get: () => undefined };
-    const userRepository = { getWithMemberships: () => undefined, get: () => undefined };
+    const userRepository = { getWithMemberships: () => undefined };
     const targetProfileRepository = { get: () => undefined };
     const competenceRepository = { list: () => undefined };
     const organizationRepository = { get: () => undefined };
@@ -116,7 +116,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
       sinon.stub(targetProfileRepository, 'get').resolves(targetProfile);
       sinon.stub(userRepository, 'getWithMemberships').resolves(user);
       sinon.stub(organizationRepository, 'get').resolves(organization);
-      sinon.stub(userRepository, 'get').resolves(user);
       sinon.stub(knowledgeElementRepository, 'findUniqByUserId').resolves(knowledgeElements);
       findResultDataByCampaignIdStub = sinon.stub(campaignParticipationRepository, 'findResultDataByCampaignId');
 
@@ -182,6 +181,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           sharedAt: new Date('2019-03-01T23:04:05Z'),
           participantExternalId: 'Mon mail pro',
           userId: 123,
+          participantFirstName: user.firstName,
+          participantLastName: user.lastName,
         };
         findResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
 
@@ -243,6 +244,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           sharedAt: new Date('2019-03-01T23:04:05Z'),
           participantExternalId: 'Mon mail pro',
           userId: 123,
+          participantFirstName: user.firstName,
+          participantLastName: user.lastName,
         };
 
         findResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
@@ -301,6 +304,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           isShared: false,
           createdAt: new Date('2019-02-25T10:00:00Z'),
           userId: 123,
+          participantFirstName: user.firstName,
+          participantLastName: user.lastName,
         };
 
         findResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);


### PR DESCRIPTION
## 🌎   Contexte
L'export du CSV est un besoin fonctionnel des organisations. Ces dernières cherchent à obtenir sous forme de CSV les résultats de chaque participant. Ces lignes servent par exemple, à donner une note à des étudiants, dans le cas des université. Certaines université ont donc parfois besoin d'avoir des CSV avec 3000 étudiants. Si la campagne en question concerne l'ensemble des 16 compétences, cela peut représenter plusieurs millions de cellules `csv`. 

## 📆  Histoire
Dans un premier temps, toutes les données étaient remontées en mémoire avant de faire des calculs. Avec certaines campagnes, cela ne tenait pas en mémoire, faisant crasher les conteneurs à chaque demande d'export. Une première solution a donc été mise en place, consistant à utiliser un `stream` afin d'alléger la pression sur la mémoire, et de construire le `csv` itérativement. 

## 🌵  Aujourd'hui
Certains utilisateurs contactent le support : le `csv` met parfois _plusieurs heures_ à être téléchargé. Mais que se passe-t-il ?

## 👩‍⚕  Diagnostic
La raison d'un temps de chargement si long est la suivante : le nombre faramineux de requêtes `SQL`. En effet, à la lecture du code, il semble que pour chaque ligne, on effectue 3 requêtes. Hors l'analyse a révélé qu'en réalité, c'était bien pire. En utilisant des méthodes de `repository` déjà existantes, beaucoup d'entres elles embarquaient des `withRelated` complètement inutiles dans le contexte du `csv` ce qui faisait exploser linéairement le nombre de requêtes. 

## 🍰  Solution
La solution consiste à faire le moins de requêtes possibles afin d'accélérer au maximum la requête. Cela passe notamment par l'utilisation de calculs _dans_ la base via des jointures, par opposition à des calculs dans l'application node.

## 💊  Prescription
On peut retenir de cette PR le pattern suivant concernant tout ce qui concerne les performances, dont on peut estimer qu'elles se dégraderont au fur et à mesure que le nombre d'utilisateurs grandira: 
- Commencer au plus simple par un code applicatif utilisant les méthodes de répo existantes 
- Mettre plus de calcul dans la base quand les premiers signes de problème de performance se font sentir, et prendre le relais côté applicatif
- Dès que le volume de donnée ne tient plus en mémoire, même en en ayant délégué une partie dans la base, combiner les deux approches (stream + calcul dans base) en rajoutant des `streams`