### PR TITLE
[FEATURE] Inversion des champs "Nom" et "Prénom" dans page permettant de rejoindre une Orga via invitation (PO-295)

### DIFF
--- a/orga/app/templates/components/routes/register-form.hbs
+++ b/orga/app/templates/components/routes/register-form.hbs
@@ -1,20 +1,6 @@
 <div class="register-form">
   <form {{action 'register' on='submit'}}>
 
-    <div id="register-lastName-container" class="input-container">
-      <label for="register-lastName" class="label">Nom</label>
-      <div class="{{if validation.lastName.message 'alert-input alert-input--error'}}" role="alert">{{validation.lastName.message}}</div>
-      <Input
-        @id="register-lastName"
-        @name="lastName"
-        @type="lastName"
-        @class="input {{if validation.lastName.message 'input--error'}}"
-        @value={{user.lastName}}
-        @focusOut={{action "validateInput" "lastName" user.lastName}}
-        @autocomplete="lastname"
-      />
-    </div>
-
     <div id="register-firstName-container" class="input-container">
       <label for="register-firstName" class="label">Prénom</label>
       <div class="{{if validation.firstName.message 'alert-input alert-input--error'}}" role="alert">{{validation.firstName.message}}</div>
@@ -26,6 +12,20 @@
         @value={{user.firstName}}
         @focusOut={{action "validateInput" "firstName" user.firstName}}
         @autocomplete="firstname"
+      />
+    </div>
+
+    <div id="register-lastName-container" class="input-container">
+      <label for="register-lastName" class="label">Nom</label>
+      <div class="{{if validation.lastName.message 'alert-input alert-input--error'}}" role="alert">{{validation.lastName.message}}</div>
+      <Input
+        @id="register-lastName"
+        @name="lastName"
+        @type="lastName"
+        @class="input {{if validation.lastName.message 'input--error'}}"
+        @value={{user.lastName}}
+        @focusOut={{action "validateInput" "lastName" user.lastName}}
+        @autocomplete="lastname"
       />
     </div>
 


### PR DESCRIPTION
## :unicorn: Problème
Sur la page d'inscription de l'application Pix, l'utilisateur est invité à renseigné son "Prénom" avant son "Nom" alors que c'est l'inverse sur la page permettant de rejoindre une organisation à travers une invitation dans Pix Orga.

## :robot: Solution
Dans un soucis d'uniformisation, il a été décidé d'inverser l'ordre des champs "Nom" et "Prénom" dans la page permettant de rejoindre une organisation afin que le "Prénom" soit situé avant le "Nom" dans le formulaire.