### PR TITLE
[FEATURE] Indiquer à l'utilisateur qu'il a déjà répondu (PF-749).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -101,6 +101,10 @@ const ChallengeItemGeneric = Component.extend({
       }
     },
 
+    resumeAssessment() {
+      return this.resumeAssessment(this.assessment);
+    },
+
     skipChallenge() {
       if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
         this.set('errorMessage', null);

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,5 +1,4 @@
 import _ from 'mon-pix/utils/lodash-custom';
-import $ from 'jquery';
 
 import ChallengeItemGeneric from './challenge-item-generic';
 import jsyaml from 'js-yaml';
@@ -21,8 +20,8 @@ const ChallengeItemQrocm = ChallengeItemGeneric.extend({
   // and moreover, is a much more robust solution when you need to test it properly.
   _getRawAnswerValue() {
     const result = {};
-    $('.challenge-proposals input').each(function(index, element) {
-      result[$(element).attr('name')] = $(element).val();
+    document.querySelectorAll('.challenge-proposals input').forEach((element)=> {
+      result[element.getAttribute('name')] = element.value;
     });
     return result;
   },

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -19,7 +19,7 @@ export default Component.extend({
   }),
 
   actions: {
-    checkboxCliked() {
+    checkboxClicked() {
       this.answerChanged();
     }
   }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -79,6 +79,10 @@ export default Route.extend({
       }
     },
 
+    resumeAssessment(assessment) {
+      return this.transitionTo('assessments.resume', assessment.get('id'));
+    },
+
     error() {
       return true;
     }

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -46,7 +46,7 @@
 .challenge-actions__action-skip-text {
   text-align: center;
   flex-grow: 1;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: $font-semi-bold;
   color: $slate-grey;
   text-transform: uppercase;
@@ -87,6 +87,7 @@
     text-decoration: none;
 
   }
+
   &:active,
   &:visited,
   &:focus {
@@ -98,7 +99,7 @@
 .challenge-actions__action-validate-text {
   width: 76px;
   flex-grow: 1;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
   letter-spacing: 1.5px;
@@ -125,4 +126,48 @@
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
+}
+
+.challenge-actions__already-answered {
+  font-family: $font-roboto;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: $tundora-grey;
+  letter-spacing: 0.5px;
+  margin-right: 20px;
+}
+
+.challenge-actions__action-continue {
+  order: 1;
+  width: 150px;
+  height: 46px;
+  border-radius: 23px;
+  background-color: $pix-blue;
+  font-family: $font-roboto;
+  color: $white;
+  @include button-background-transition();
+  text-decoration: none;
+
+  &:hover{
+    background: $pix-blue-hover;
+    text-decoration: none;
+  }
+
+  &:active,
+  &:visited,
+  &:focus {
+    text-decoration: none;
+  }
+}
+
+.challenge-actions__action-continue-text {
+  width: 76px;
+  line-height: 46px;
+  font-family: $font-roboto;
+  font-size: 1.6rem;
+  font-weight: $font-semi-bold;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: white;
+  text-decoration: none;
 }

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -50,7 +50,7 @@
   font-weight: $font-semi-bold;
   color: $slate-grey;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.05rem;
 }
 .challenge-actions__action-skip__loader {
   margin-right: 15px;
@@ -102,7 +102,7 @@
   font-size: 1.6rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
-  letter-spacing: 1.5px;
+  letter-spacing: 0.15rem;
   color: white;
   text-decoration: none;
 }
@@ -133,7 +133,7 @@
   font-size: 1.6rem;
   font-weight: 600;
   color: $tundora-grey;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.05rem;
   margin-right: 20px;
 }
 
@@ -162,12 +162,12 @@
 
 .challenge-actions__action-continue-text {
   width: 76px;
-  line-height: 46px;
+  line-height: 4.6rem;
   font-family: $font-roboto;
   font-size: 1.6rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
-  letter-spacing: 1.5px;
+  letter-spacing: 0.15rem;
   color: white;
   text-decoration: none;
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -43,7 +43,7 @@
   box-shadow: 0 2px 6px 0 rgba(12,22,58,0.11), 0 1px 3px 0 rgba(0,0,0,0.08);
   border: none;
   border-radius: 5px;
-  font-family: Lato, Arial, sans-serif;
+  font-family: $font-roboto;
   font-size: 15px;
   font-weight: bold;
   text-align: center;
@@ -73,7 +73,7 @@
   background-color: $white;
   box-shadow: 0 2px 6px 0 rgba(12,22,58,0.11), 0 1px 3px 0 rgba(0,0,0,0.08);
   border-radius: 5px;
-  font-family: Lato, Arial, sans-serif;
+  font-family: $font-roboto;
   font-size: 15px;
   font-weight: bold;
   text-align: center;

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -44,7 +44,7 @@
   border: none;
   border-radius: 5px;
   font-family: $font-roboto;
-  font-size: 15px;
+  font-size: 1.5rem;
   font-weight: bold;
   text-align: center;
   text-transform: uppercase;
@@ -74,7 +74,7 @@
   box-shadow: 0 2px 6px 0 rgba(12,22,58,0.11), 0 1px 3px 0 rgba(0,0,0,0.08);
   border-radius: 5px;
   font-family: $font-roboto;
-  font-size: 15px;
+  font-size: 1.5rem;
   font-weight: bold;
   text-align: center;
   height: 46px;

--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -43,3 +43,44 @@
   overflow-wrap: break-word;
   line-height: 2.6rem;
 }
+
+form .challenge-response {
+  &--locked {
+    position: relative;
+  }
+
+  &__locked-overlay {
+    position: absolute;
+    opacity: 0;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    -ms-transform: translate(-50%, -50%);
+  }
+}
+
+form .challenge-response.challenge-response--locked {
+  .challenge-proposals {
+    opacity: 0.33;
+    transition: .3s ease;
+  }
+
+  &:hover {
+    .challenge-response__locked-overlay {
+      opacity: 1;
+      transition: .9s ease;
+    }
+  }
+}
+
+form .challenge-response-locked {
+  &__icon {
+    font-size: 5rem;
+    opacity: 1;
+
+    &:hover {
+      opacity: 1;
+      transition: .3s ease;
+    }
+  }
+}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -19,9 +19,11 @@
 
     {{component (get-challenge-component-class model.challenge)
                 challenge=model.challenge
-                assessment=model.assessment
                 answer=model.answer
-                answerValidated=(route-action "saveAnswerAndNavigate")}}
+                assessment=model.assessment
+                answerValidated=(route-action "saveAnswerAndNavigate")
+                resumeAssessment=(route-action "resumeAssessment")
+    }}
   </div>
 </div>
 

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,18 +1,25 @@
-{{#if isValidateButtonEnabled}}
-  <a class="challenge-actions__action challenge-actions__action-validate" {{action validateAnswer}} href="#">
-    <span class="challenge-actions__action-validate-text">Je valide</span>
+{{#if answer}}
+  <span class="challenge-actions__already-answered">Vous avez déjà répondu à cette question</span>
+  <a class="challenge-actions__action challenge-actions__action-continue" {{action resumeAssessment assessment}} href="#">
+    <span class="challenge-actions__action-continue-text">Poursuivre</span>
   </a>
 {{else}}
-  <div class="challenge-actions__action challenge-actions__action-validate__loader">
-    <div class="challenge-actions__action-validate__loader-bar"></div>
-  </div>
-{{/if}}
-{{#if isSkipButtonEnabled}}
-  <a class="challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}} href="#">
-    <span class="challenge-actions__action-skip-text">Je passe</span>
-  </a>
-{{else}}
-  <div class="challenge-actions__action challenge-actions__action-skip__loader">
-    <div class="challenge-actions__action-skip__loader-bar"></div>
-  </div>
+  {{#if isValidateButtonEnabled}}
+    <a class="challenge-actions__action challenge-actions__action-validate" {{action validateAnswer}} href="#">
+      <span class="challenge-actions__action-validate-text">Je valide</span>
+    </a>
+  {{else}}
+    <div class="challenge-actions__action challenge-actions__action-validate__loader">
+      <div class="challenge-actions__action-validate__loader-bar"></div>
+    </div>
+  {{/if}}
+  {{#if isSkipButtonEnabled}}
+    <a class="challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}} href="#">
+      <span class="challenge-actions__action-skip-text">Je passe</span>
+    </a>
+  {{else}}
+    <div class="challenge-actions__action challenge-actions__action-skip__loader">
+      <div class="challenge-actions__action-skip__loader-bar"></div>
+    </div>
+  {{/if}}
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -8,13 +8,20 @@
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     {{challenge-statement challenge=challenge assessment=assessment class="rounded-panel__row"}}
 
-    <div class="rounded-panel__row challenge-response">
+    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
         {{qcm-proposals
+          answer=answer
           answerValue=answer.value
           proposals=challenge.proposals
           answerChanged=(action 'answerChanged')}}
       </div>
+
+      {{#if answer}}
+        <div class="challenge-response__locked-overlay">
+          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+        </div>
+      {{/if}}
       
       {{#if challenge.timer}}
         {{#if hasUserConfirmWarning}}
@@ -34,6 +41,8 @@
     {{#if assessment}}
       {{challenge-actions
         challenge=challenge
+        answer=answer
+        resumeAssessment=(action "resumeAssessment")
         validateAnswer=(action "validateAnswer")
         skipChallenge=(action "skipChallenge")
         isValidateButtonEnabled=isValidateButtonEnabled

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -8,13 +8,20 @@
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     {{challenge-statement challenge=challenge assessment=assessment class="rounded-panel__row"}}
 
-    <div class="rounded-panel__row challenge-response">
+    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
         {{qcu-proposals
+          answer=answer
           answerValue=answer.value
           proposals=challenge.proposals
           answerChanged=(action 'answerChanged')}}
       </div>
+
+      {{#if answer}}
+        <div class="challenge-response__locked-overlay">
+          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+        </div>
+      {{/if}}
       
       {{#if challenge.timer}}
         {{#if hasUserConfirmWarning}}
@@ -34,6 +41,8 @@
     {{#if assessment}}
       {{challenge-actions
         challenge=challenge
+        answer=answer
+        resumeAssessment=(action "resumeAssessment")
         validateAnswer=(action "validateAnswer")
         skipChallenge=(action "skipChallenge")
         isValidateButtonEnabled=isValidateButtonEnabled

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -8,14 +8,21 @@
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     {{challenge-statement challenge=challenge assessment=assessment class="rounded-panel__row"}}
 
-    <div class="rounded-panel__row challenge-response">
+    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
         {{qroc-proposal
+          answer=answer
           format=challenge.format
           proposals=challenge.proposals
           answerValue=answer.value
           answerChanged=(action 'answerChanged')}}
       </div>
+
+      {{#if answer}}
+        <div class="challenge-response__locked-overlay">
+          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+        </div>
+      {{/if}}
 
       {{#if challenge.timer}}
         {{#if hasUserConfirmWarning}}
@@ -35,6 +42,8 @@
     {{#if assessment}}
       {{challenge-actions
         challenge=challenge
+        answer=answer
+        resumeAssessment=(action "resumeAssessment")
         validateAnswer=(action "validateAnswer")
         skipChallenge=(action "skipChallenge")
         isValidateButtonEnabled=isValidateButtonEnabled

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -8,14 +8,21 @@
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     {{challenge-statement challenge=challenge assessment=assessment class="rounded-panel__row"}}
 
-    <div class="rounded-panel__row challenge-response">
+    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
         {{qrocm-proposal
+          answer=answer
           format=challenge.format
           proposals=challenge.proposals
           answersValue=answer._valuesAsMap
           answerChanged=(action 'answerChanged') }}
       </div>
+
+      {{#if answer}}
+        <div class="challenge-response__locked-overlay">
+          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+        </div>
+      {{/if}}
 
       {{#if challenge.timer}}
         {{#if hasUserConfirmWarning}}
@@ -35,6 +42,8 @@
     {{#if assessment}}
       {{challenge-actions
         challenge=challenge
+        answer=answer
+        resumeAssessment=(action "resumeAssessment")
         validateAnswer=(action "validateAnswer")
         skipChallenge=(action "skipChallenge")
         isValidateButtonEnabled=isValidateButtonEnabled

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -6,7 +6,8 @@
          id="checkbox_{{inc index}}"
          checked={{labeledCheckbox.[1]}}
          name="{{inc index}}"
-         onclick={{action "checkboxCliked"}}>
+         onclick={{action "checkboxCliked"}}
+         disabled={{if answer true}}>
 
   {{!-- Surrounding label --}}
   <label for="checkbox_{{inc index}}"

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -6,7 +6,7 @@
          id="checkbox_{{inc index}}"
          checked={{labeledCheckbox.[1]}}
          name="{{inc index}}"
-         onclick={{action "checkboxCliked"}}
+         onclick={{action "checkboxClicked"}}
          disabled={{if answer true}}>
 
   {{!-- Surrounding label --}}

--- a/mon-pix/app/templates/components/qcu-proposals.hbs
+++ b/mon-pix/app/templates/components/qcu-proposals.hbs
@@ -9,7 +9,8 @@
          data-value="{{inc index}}"
          id="radio_{{inc index}}"
          checked={{labeledRadio.[1]}}
-         onclick={{action "radioClicked" index}}>
+         onclick={{action "radioClicked" index}}
+         disabled={{if answer true}}>
 
   {{!-- Surrounding label --}}
   <label for="radio_{{inc index}}"

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -13,7 +13,8 @@
                 placeholder={{block.placeholder}}
                 autocomplete="off"
                 value="{{userAnswer}}"
-                data-uid="qroc-proposal-uid">
+                data-uid="qroc-proposal-uid"
+                disabled={{if answer true}}>
       </textarea>
     {{else if (eq format 'phrase')}}
       <input class="challenge-response__proposal challenge-response__proposal--sentence"
@@ -23,7 +24,8 @@
              placeholder={{block.placeholder}}
              autocomplete="off"
              value="{{userAnswer}}"
-             data-uid="qroc-proposal-uid">
+             data-uid="qroc-proposal-uid"
+             disabled={{if answer true}}>
     {{else}}
       <input class="challenge-response__proposal"
              size="{{get-qroc-input-size format}}"
@@ -33,7 +35,8 @@
              placeholder={{block.placeholder}}
              autocomplete="off"
              value="{{userAnswer}}"
-             data-uid="qroc-proposal-uid">
+             data-uid="qroc-proposal-uid"
+             disabled={{if answer true}}>
     {{/if}}
   {{/if}}
 

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -13,7 +13,8 @@
                 placeholder={{block.placeholder}}
                 autocomplete="off"
                 id="{{block.text}}"
-                value={{property-of answersValue block.input}}>
+                value={{property-of answersValue block.input}}
+                disabled={{if answer true}}>
       </textarea>
     {{else if (eq format 'phrase')}}
       <input class="challenge-response__proposal challenge-response__proposal--sentence"
@@ -23,7 +24,8 @@
              placeholder={{block.placeholder}}
              autocomplete="off"
              id="{{block.text}}"
-             value={{property-of answersValue block.input}}>
+             value={{property-of answersValue block.input}}
+             disabled={{if answer true}}>
     {{else}}
       <input class="challenge-response__proposal"
              size="{{get-qroc-input-size format}}"
@@ -33,7 +35,8 @@
              placeholder={{block.placeholder}}
              autocomplete="off"
              id="{{block.text}}"
-             value={{property-of answersValue block.input}}>
+             value={{property-of answersValue block.input}}
+             disabled={{if answer true}}>
     {{/if}}
 
   {{/if}}

--- a/mon-pix/mirage/data/challenges/ref-qcm-challenge_not_yet_answered.js
+++ b/mon-pix/mirage/data/challenges/ref-qcm-challenge_not_yet_answered.js
@@ -1,0 +1,18 @@
+// QCM challenge with all field filled
+
+export default {
+  data: {
+    type: 'challenge',
+    id: 'ref_qcm_challenge_id_not_yet_answered',
+    attributes: {
+      type: 'QCM',
+      instruction: 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir [plusieurs](http://link.plusieurs.url)',
+      attachments: ['http://example_of_url'],
+      'illustration-url': 'http://fakeimg.pl/350x200/?text=PictureOfQCM',
+      proposals: '- possibilite 1, et/ou' +
+        '\n - possibilite 2, et/ou' +
+        '\n - possibilite 3, et/ou' +
+        '\n - possibilite 4'
+    }
+  }
+};

--- a/mon-pix/mirage/fixtures/assessments.js
+++ b/mon-pix/mirage/fixtures/assessments.js
@@ -1,7 +1,0 @@
-//https://github.com/samselikoff/ember-cli-mirage/issues/584
-export default [
-  { id: 'ref_assessment_id', 'user-id':'user_id', 'user-name': 'Jon Snow', 'user-email': 'jsnow@winterfell.got', course: 'ref_course_id', answers: ['ref_answer_qcm_id', 'ref_answer_qcu_id', 'ref_answer_qroc_id', 'ref_answer_qrocm_id', 'ref_answer_qru_id'] },
-  { id: 'ref_assessment_id', 'user-id':'user_id', 'user-name': 'Jane Doe', 'user-email': 'jane@acme.com', course: 'ref_course_id', answers: ['ref_answer_qcm_id', 'ref_answer_qcu_id', 'ref_answer_qroc_id', 'ref_answer_qrocm_id', 'ref_answer_qru_id'] },
-  { id: 'ref_assessment_id', 'user-id':'user_id', 'user-name': 'Jon Snow', 'user-email': 'jsnow@winterfell.got', course: 'ref_course_id', answers: ['ref_answer_qcm_id', 'ref_answer_qcu_id', 'ref_answer_qroc_id', 'ref_answer_qrocm_id', 'ref_answer_qru_id'] },
-  { id: 'ref_timed_challenge_assessment_id', 'user-id': 'user_id', 'user-name': 'Jon Snow', 'user-email': 'jsnow@winterfell.got', course: 'ref_timed_challenge_course_id', answers: ['ref_timed_answer_id', 'ref_timed_answer_bis_id'] },
-];

--- a/mon-pix/mirage/fixtures/challenges.js
+++ b/mon-pix/mirage/fixtures/challenges.js
@@ -72,5 +72,16 @@ export default [
     timer: 10,
     instruction: 'L\'URL suivante, censée aboutir à un article, donne lieu à une redirection vers la page d\'accueil du site. Retrouvez la page recherchée. Reportez le titre de l’article et son auteur.  \n' + '\n' + '> https://www.cairn.info/revue-reseaux-2011-numero1-page-137.htm',
     proposals: 'Titre : ${titre}\n' + 'Auteur : ${auteur}'
+  },
+  {
+    id: 'ref_qcm_challenge_id_not_yet_answered',
+    type: 'QCM',
+    instruction: 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir [plusieurs](http://link.plusieurs.url)',
+    attachments: ['http://example_of_url'],
+    'illustration-url': 'http://fakeimg.pl/350x200/?text=PictureOfQCM',
+    proposals: '- possibilite 1, et/ou' +
+    '\n - possibilite 2, et/ou' +
+    '\n - possibilite 3, et/ou' +
+    '\n - possibilite 4'
   }
 ];

--- a/mon-pix/mirage/routes/get-answer-by-challenge-and-assessment.js
+++ b/mon-pix/mirage/routes/get-answer-by-challenge-and-assessment.js
@@ -1,60 +1,13 @@
-import _ from 'mon-pix/utils/lodash-custom';
-
-import refQcmAnswer from '../data/answers/ref-qcm-answer';
-import refQcuAnswer from '../data/answers/ref-qcu-answer';
-import refQrocAnswer from '../data/answers/ref-qroc-answer';
-import refQrocmAnswer from '../data/answers/ref-qrocm-answer';
-import refTimedAnswer from '../data/answers/ref-timed-answer';
-import refTimedAnswerBis from '../data/answers/ref-timed-answer-bis';
-
 export default function(schema, request) {
 
   const assessmentId = request.queryParams.assessment;
   const challengeId = request.queryParams.challenge;
 
-  let answers;
-
-  answers = schema.answers.where({ assessmentId, challengeId });
+  const answers = schema.answers.where({ assessmentId, challengeId });
 
   if (answers.models.length !== 0) {
     return answers.models.get('firstObject');
   }
 
-  const allAnswers = [
-    refQcuAnswer,
-    refQcmAnswer,
-    refQrocAnswer,
-    refQrocmAnswer,
-    refTimedAnswer,
-    refTimedAnswerBis
-  ];
-
-  answers = _.map(allAnswers, function(oneAnswer) {
-    return { id: oneAnswer.data.id, obj: oneAnswer };
-  });
-
-  const answer = _.find(answers, (oneAnswer) => {
-    const belongsToAssessment = _.get(oneAnswer.obj, 'data.relationships.assessment.data.id') === assessmentId;
-    const belongsToChallenge = _.get(oneAnswer.obj, 'data.relationships.challenge.data.id') === challengeId;
-    return belongsToAssessment && belongsToChallenge;
-  });
-
-  if (answer) {
-    return answer.obj;
-  }
-
-  // XXX schema.answers.first() (or where(), or findBy()) should return JSONAPI
-  // For unknown reasons, it is not the case here (even if there is no answers found)
-  // We return this valid JSON API to be sure
-  const validJSONAPI = {
-    data : {
-      type : 'answers',
-      id : 'answerId',
-      attributes : {
-        value : ''
-      }
-    }
-  };
-
-  return schema.answers.first() || validJSONAPI;
+  return { data: null };
 }

--- a/mon-pix/mirage/routes/get-next-challenge.js
+++ b/mon-pix/mirage/routes/get-next-challenge.js
@@ -2,6 +2,7 @@ import refQcmChallengeFull from '../data/challenges/ref-qcm-challenge';
 import refQcuChallengeFull from '../data/challenges/ref-qcu-challenge';
 import refQrocChallengeFull from '../data/challenges/ref-qroc-challenge';
 import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
+import refQcmNotYetAnsweredChallengeFull from '../data/challenges/ref-qcm-challenge_not_yet_answered';
 import refTimedChallengeBis from '../data/challenges/ref-timed-challenge-bis';
 import { challengeIds } from '../data/challenges/challenge-ids';
 
@@ -18,13 +19,14 @@ function getNextChallengeForDynamicAssessment(assessment, challenges) {
 function getNextChallengeForTestingAssessment(assessmentId, currentChallengeId) {
   // case 1 : we're trying to reach the first challenge for a given assessment
   if (!currentChallengeId) {
-    return refQcmChallengeFull;
+    return refQcmNotYetAnsweredChallengeFull;
   }
 
   // case 2 : test already started, challenge exists.
   const nextChallenge = {
 
     // ref_course
+    'ref_qcm_challenge_id_not_yet_answered': refQcmChallengeFull,
     'ref_qcm_challenge_id': refQcuChallengeFull,
     'ref_qcu_challenge_id': refQrocChallengeFull,
     'ref_qroc_challenge_id': refQrocmChallengeFull,

--- a/mon-pix/mirage/routes/post-answers.js
+++ b/mon-pix/mirage/routes/post-answers.js
@@ -1,6 +1,7 @@
 import _ from 'mon-pix/utils/lodash-custom';
 
 import refQcmChallengeFull from '../data/challenges/ref-qcm-challenge';
+import refQcmNotYetAnsweredChallengeFull from '../data/challenges/ref-qcm-challenge_not_yet_answered';
 import refQcuChallengeFull from '../data/challenges/ref-qcu-challenge';
 import refQrocChallengeFull from '../data/challenges/ref-qroc-challenge';
 import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
@@ -26,7 +27,8 @@ export default function(schema, request) {
     refQrocChallengeFull,
     refQrocmChallengeFull,
     refTimedChallenge,
-    refTimedChallengeBis
+    refTimedChallengeBis,
+    refQcmNotYetAnsweredChallengeFull,
   ];
 
   const allAnswers = [
@@ -44,8 +46,8 @@ export default function(schema, request) {
 
   const finalAnswer = _.find(answers, { id: challengeId });
 
-  if (finalAnswer) {
-    return finalAnswer.obj;
+  if (finalAnswer && finalAnswer.obj) {
+    return new Response(409);
   } else {
     const newAnswer = this.normalizedRequestAttrs();
     return schema.answers.create(newAnswer);

--- a/mon-pix/tests/acceptance/challenge-commons-test.js
+++ b/mon-pix/tests/acceptance/challenge-commons-test.js
@@ -14,45 +14,79 @@ describe('Acceptance | Common behavior to all challenges', function() {
   beforeEach(async function() {
     defaultScenario(this.server);
     await authenticateAsSimpleUser();
-    await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
   });
 
-  it('should display the name of the test', function() {
-    expect(find('.assessment-banner__title').textContent).to.contain('First Course');
+  context('Challenge answered: the answers inputs should be disabled', function() {
+    beforeEach(async function() {
+      server.create('assessment', {
+        id: 'ref_assessment_id'
+      });
+
+      server.create('answer', {
+        value: 'value',
+        result: 'ko',
+        challengeId: 'ref_qrocm_challenge_id',
+        assessmentId: 'ref_assessment_id',
+      });
+
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
+    });
+
+    it('should display the lock overlay', function() {
+      expect(find('.challenge-response--locked')).to.exist;
+    });
+
+    it('should display the resume button and the information sentence', function() {
+      expect(find('.challenge-actions__action-continue')).to.exist;
+      expect(find('.challenge-actions__already-answered')).to.exist;
+    });
+
   });
 
-  it('should display the challenge instruction', function() {
-    const instructionText = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
-    expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+  context('Challenge not answered', function() {
+    beforeEach(async function() {
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
+    });
+
+    it('should display the name of the test', function() {
+      expect(find('.assessment-banner__title').textContent).to.contain('First Course');
+    });
+
+    it('should display the challenge instruction', function() {
+      const instructionText = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+    });
+
+    it('should format content written as [foo](bar) as clickable link', function() {
+      expect(find('.challenge-statement__instruction a')).to.exist;
+      expect(find('.challenge-statement__instruction a').textContent).to.equal('ouverte');
+      expect(find('.challenge-statement__instruction a').getAttribute('href')).to.equal('http://link.ouverte.url');
+    });
+
+    it('should open links in a new tab', function() {
+      expect(find('.challenge-statement__instruction a').getAttribute('target')).to.equal('_blank');
+    });
+
+    it('should display the skip button', function() {
+      expect(find('.challenge-actions__action-skip')).to.exist;
+    });
+
+    it('should display the validate button', function() {
+      expect(find('.challenge-actions__action-skip')).to.exist;
+    });
+
+    it('should display a button to come back to the courses list', function() {
+      expect(find('.assessment-banner__home-link')).to.exist;
+    });
+
+    it('should come back to the home route when the back button is clicked', async function() {
+      expect(find('.assessment-banner__home-link').getAttribute('href')).to.equal('/');
+    });
+
+    it('should be able to send a feedback about the current challenge', function() {
+      expect(find('.feedback-panel')).to.exist;
+    });
+
   });
 
-  it('should format content written as [foo](bar) as clickable link', function() {
-    expect(find('.challenge-statement__instruction a')).to.exist;
-    expect(find('.challenge-statement__instruction a').textContent).to.equal('ouverte');
-    expect(find('.challenge-statement__instruction a').getAttribute('href')).to.equal('http://link.ouverte.url');
-  });
-
-  it('should open links in a new tab', function() {
-    expect(find('.challenge-statement__instruction a').getAttribute('target')).to.equal('_blank');
-  });
-
-  it('should display the skip button', function() {
-    expect(find('.challenge-actions__action-skip')).to.exist;
-  });
-
-  it('should display the validate button', function() {
-    expect(find('.challenge-actions__action-skip')).to.exist;
-  });
-
-  it('should display a button to come back to the courses list', function() {
-    expect(find('.assessment-banner__home-link')).to.exist;
-  });
-
-  it('should come back to the home route when the back button is clicked', async function() {
-    expect(find('.assessment-banner__home-link').getAttribute('href')).to.equal('/');
-  });
-
-  it('should be able to send a feedback about the current challenge', () => {
-    expect(find('.feedback-panel')).to.exist;
-  });
 });

--- a/mon-pix/tests/acceptance/challenge-feedback-test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback-test.js
@@ -33,16 +33,18 @@ describe('Acceptance | Giving feedback about a challenge', function() {
       assertThatFeedbackPanelExist();
     });
 
-    it('should always reset the feedback form between two consecutive challenges', async () => {
-      // In our Mirage data set, in the "ref course", the QCU challenge is followed by a QRU's one
-      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
-      assertThatFeedbackFormIsClosed();
+    it('should always reset the feedback form between two consecutive challenges', async function() {
+      this.server.create('assessment', {
+        id: 'ref_assessment_id',
+      });
 
+      // In our Mirage data set, in the "ref course", the QCU challenge is followed by a QRU's one
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qcm_challenge_id_not_yet_answered');
+      assertThatFeedbackFormIsClosed();
       await click('.feedback-panel__open-link');
       assertThatFeedbackFormIsOpen();
 
       await click('.challenge-actions__action-skip');
-      await click('.challenge-item-warning button');
       assertThatFeedbackFormIsClosed();
     });
   });

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -17,88 +17,95 @@ describe('Acceptance | Displaying a QCM', function() {
 
   beforeEach(async function() {
     defaultScenario(this.server);
-    await visitTimedChallenge();
   });
 
-  it('should render challenge instruction', function() {
-    // Given
-    const expectedInstruction = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs';
+  context('Challenge answered', function() {
+    beforeEach(async function() {
+      server.create('assessment', {
+        id: 'ref_assessment_id'
+      });
 
-    // Then
-    expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(expectedInstruction);
+      server.create('answer', {
+        value: '2, 4',
+        result: 'ko',
+        challengeId: 'ref_qcm_challenge_id',
+        assessmentId: 'ref_assessment_id',
+      });
+
+      await visitTimedChallenge();
+    });
+
+    it('should mark checkboxes corresponding to the answer', async function() {
+      expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
+      expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
+      expect(findAll('input[type="checkbox"]')[2].checked).to.be.false;
+      expect(findAll('input[type="checkbox"]')[3].checked).to.be.true;
+    });
+
   });
 
-  it('should format content written as [foo](bar) as clickable link', function() {
-    expect(find('.challenge-statement__instruction a')).to.exist;
-    expect(find('.challenge-statement__instruction a').textContent).to.equal('plusieurs');
-    expect(find('.challenge-statement__instruction a').getAttribute('href')).to.equal('http://link.plusieurs.url');
-  });
+  context('Challenge not answered', function() {
+    beforeEach(async function() {
+      await visitTimedChallenge();
+    });
 
-  it('should open the links in a new tab', function() {
-    expect(find('.challenge-statement__instruction a').getAttribute('target')).to.equal('_blank');
-  });
+    it('should render challenge instruction', function() {
+      // Given
+      const expectedInstruction = 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs';
 
-  it('should render a list of checkboxes', function() {
-    expect(findAll('input[type="checkbox"]')).to.have.lengthOf(4);
-  });
+      // Then
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(expectedInstruction);
+    });
 
-  it('should mark checkboxes that have been checked', async function() {
-    await click(findAll('input[type="checkbox"]')[0]);
-    await click(findAll('input[type="checkbox"]')[1]);
+    it('should format content written as [foo](bar) as clickable link', function() {
+      expect(find('.challenge-statement__instruction a')).to.exist;
+      expect(find('.challenge-statement__instruction a').textContent).to.equal('plusieurs');
+      expect(find('.challenge-statement__instruction a').getAttribute('href')).to.equal('http://link.plusieurs.url');
+    });
 
-    expect(findAll('input[type="checkbox"]')[0].checked).to.be.true;
-    expect(findAll('input[type="checkbox"]')[1].checked).to.be.false;
-    expect(findAll('input[type="checkbox"]')[3].checked).to.be.true;
-  });
+    it('should open the links in a new tab', function() {
+      expect(find('.challenge-statement__instruction a').getAttribute('target')).to.equal('_blank');
+    });
 
-  it('should render an ordered list of instruction', function() {
-    expect(findAll('.proposal-text')[0].textContent.trim()).to.equal('possibilite 1, et/ou');
-    expect(findAll('.proposal-text')[1].textContent.trim()).to.equal('possibilite 2, et/ou');
-    expect(findAll('.proposal-text')[2].textContent.trim()).to.equal('possibilite 3, et/ou');
-    expect(findAll('.proposal-text')[3].textContent.trim()).to.equal('possibilite 4');
-  });
+    it('should render a list of checkboxes', function() {
+      expect(findAll('input[type="checkbox"]')).to.have.lengthOf(4);
+    });
 
-  it('should hide the error alert box by default', function() {
-    expect(find('.alert')).to.not.exist;
-  });
+    it('should render an ordered list of instruction', function() {
+      expect(findAll('.proposal-text')[0].textContent.trim()).to.equal('possibilite 1, et/ou');
+      expect(findAll('.proposal-text')[1].textContent.trim()).to.equal('possibilite 2, et/ou');
+      expect(findAll('.proposal-text')[2].textContent.trim()).to.equal('possibilite 3, et/ou');
+      expect(findAll('.proposal-text')[3].textContent.trim()).to.equal('possibilite 4');
+    });
 
-  it('should display the alert box if user validates without checking a checkbox', async function() {
-    // Given
-    await click(findAll('.proposal-text')[1]);
-    await click(findAll('.proposal-text')[3]);
+    it('should hide the error alert box by default', function() {
+      expect(find('.alert')).to.not.exist;
+    });
 
-    // When
-    await click('.challenge-actions__action-validate');
+    it('should display the alert box if user validates without checking a checkbox', async function() {
+      // When
+      await click('.challenge-actions__action-validate');
 
-    expect(find('.alert')).to.exist;
-    expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner au moins une réponse. Sinon, passer.');
-  });
+      expect(find('.alert')).to.exist;
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner au moins une réponse. Sinon, passer.');
+    });
 
-  it('should set the checkbox state as checked when user checks a checkbox', async function() {
-    expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
-    await click(findAll('.proposal-text')[0]);
-    expect(findAll('input[type="checkbox"]')[0].checked).to.be.true;
-  });
+    it('should set the checkbox state as checked when user checks a checkbox', async function() {
+      expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
+      await click(findAll('.proposal-text')[0]);
+      expect(findAll('input[type="checkbox"]')[0].checked).to.be.true;
+    });
 
-  it('should not alter a checkbox state when siblings checkboxes are checked', async function() {
-    expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
-    expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
-    await click(findAll('.proposal-text')[2]);
-    expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
-    expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
-  });
+    it('should hide the alert error after the user interact with checkboxes', async function() {
+      // given
+      await click('.challenge-actions__action-validate');
 
-  it('should only display the error alert checkbox after the user has tried to at least interact with checkboxes', async function() {
-    // given
-    await click(findAll('.proposal-text')[1]);
-    await click(findAll('.proposal-text')[3]);
-    await click('.challenge-actions__action-validate');
+      // when
+      await click(findAll('.proposal-text')[1]);
 
-    // when
-    await click(findAll('.proposal-text')[1]);
-
-    // then
-    expect(find('.alert')).to.not.exist;
+      // then
+      expect(find('.alert')).to.not.exist;
+    });
   });
 
 });

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Displaying a QCM', function() {
     defaultScenario(this.server);
   });
 
-  context('Challenge answered', function() {
+  context('Challenge answered: the answers checkboxes should be disabled', function() {
     beforeEach(async function() {
       server.create('assessment', {
         id: 'ref_assessment_id'
@@ -40,6 +40,8 @@ describe('Acceptance | Displaying a QCM', function() {
       expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
       expect(findAll('input[type="checkbox"]')[2].checked).to.be.false;
       expect(findAll('input[type="checkbox"]')[3].checked).to.be.true;
+
+      findAll('input[type=checkbox]').forEach((checkbox) => expect(checkbox.disabled).to.equal(true));
     });
 
   });

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -81,26 +81,6 @@ describe('Acceptance | Displaying a QCU', function() {
     expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passer.');
   });
 
-  it('should not be possible to select multiple radio buttons', async function() {
-    // when
-    await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
-    await click(findAll('input[type=radio][name="radio"]')[1]);
-
-    expect(findAll('input[type=radio][name="radio"]')[0].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[1].checked).to.equal(true);
-    expect(findAll('input[type=radio][name="radio"]')[2].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[3].checked).to.equal(false);
-
-    // When
-    await click(findAll('.label-checkbox-proposal')[0]);
-
-    // Then
-    expect(findAll('input[type=radio][name="radio"]')[0].checked).to.equal(true);
-    expect(findAll('input[type=radio][name="radio"]')[1].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[2].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[3].checked).to.equal(false);
-  });
-
   it('should send an api request to save the users answer when clicking the validate button', async function() {
     // Given
     this.server.post('/answers', (schema, request) => {

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -6,122 +6,93 @@ import defaultScenario from '../../mirage/scenarios/default';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-let assessment, challenge, answer;
-
-function insertRequiredDataForThisTest(server) {
-  assessment = server.create('assessment');
-  challenge = server.create('challenge', {
-    type: 'QCU',
-    'illustration-url': 'http://fakeimg.pl/350x200/?text=QCU',
-    attachments: ['file.docx', 'file.odt'],
-    instruction: 'Un QCU propose plusieurs choix, l\'utilisateur peut en choisir [un seul](http://link.unseul.url)',
-    proposals: '' +
-      '- 1ere possibilite\n ' +
-      '- 2eme possibilite\n ' +
-      '- 3eme possibilite\n' +
-      '- 4eme possibilite',
-    'embed-url': 'https://1024pix.github.io/dessin.html',
-    'embed-title': 'Notre premier embed',
-    'embed-height': 600
-  });
-  answer = server.create('answer', {
-    value: 2,
-    result: 'ok',
-    challengeId: challenge.id,
-    assessmentId: assessment.id,
-  });
-}
-
 describe('Acceptance | Displaying a QCU', function() {
   setupApplicationTest();
   setupMirage();
 
   beforeEach(function() {
     defaultScenario(this.server);
-    insertRequiredDataForThisTest(this.server);
   });
 
-  it('should display a radio buttons list', async function() {
-    // when
-    await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
+  context('Challenge answered: the answers radio buttons should be disabled', function() {
+    beforeEach(async function() {
+      const assessment = server.create('assessment');
+      const challenge = server.create('challenge', {
+        type: 'QCU',
+        'illustration-url': 'http://fakeimg.pl/350x200/?text=QCU',
+        attachments: ['file.docx', 'file.odt'],
+        instruction: 'Un QCU propose plusieurs choix, l\'utilisateur peut en choisir [un seul](http://link.unseul.url)',
+        proposals: '' +
+          '- 1ere possibilite\n ' +
+          '- 2eme possibilite\n ' +
+          '- 3eme possibilite\n' +
+          '- 4eme possibilite',
+        'embed-url': 'https://1024pix.github.io/dessin.html',
+        'embed-title': 'Notre premier embed',
+        'embed-height': 600
+      });
+      server.create('answer', {
+        value: 2,
+        result: 'ok',
+        challengeId: challenge.id,
+        assessmentId: assessment.id,
+      });
 
-    // then
-    expect(findAll('input[type=radio][name="radio"]')).to.have.lengthOf(4);
-  });
-
-  it('should display the previously saved selected radio button by default', async function() {
-    // when
-    await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
-
-    // then
-    expect(findAll('.proposal-paragraph input[type=radio][name="radio"]')[1].checked).to.be.true;
-  });
-
-  it('should display an ordered list of instructions', async function() {
-    // when
-    await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
-
-    // then
-    expect(findAll('.proposal-text')[0].textContent.trim()).to.equal('1ere possibilite');
-    expect(findAll('.proposal-text')[1].textContent.trim()).to.equal('2eme possibilite');
-    expect(findAll('.proposal-text')[2].textContent.trim()).to.equal('3eme possibilite');
-    expect(findAll('.proposal-text')[3].textContent.trim()).to.equal('4eme possibilite');
-  });
-
-  it('should display the error alter box if users validates with no radio button selected', async function() {
-    // given
-    await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
-    findAll('input[type=radio][name="radio"]')[1].checked = false;
-
-    // when
-    await click('.challenge-actions__action-validate');
-
-    // then
-    expect(find('.alert')).to.exist;
-    expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passer.');
-  });
-
-  it('should send an api request to save the users answer when clicking the validate button', async function() {
-    // Given
-    this.server.post('/answers', (schema, request) => {
-      const params = JSON.parse(request.requestBody);
-
-      expect(params.data.type).to.equal('answers');
-      expect(params.data.attributes.value).to.equal(answer.value);
-
-      return {
-        data: {
-          type: 'answers',
-          id: answer.id,
-          attributes: {
-            value: answer.value
-          }
-        }
-      };
+      await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
     });
 
-    // when
-    await visitWithAbortedTransition('/assessments/' + assessment.id + '/challenges/' + challenge.id);
-    await click(findAll('input[type=radio][name="radio"]')[1]);
+    it('should preselect radio buttons accordingly', async function() {
+      expect(findAll('input[type=radio][name="radio"]')[0].checked).to.equal(false);
+      expect(findAll('input[type=radio][name="radio"]')[1].checked).to.equal(true);
+      expect(findAll('input[type=radio][name="radio"]')[2].checked).to.equal(false);
+      expect(findAll('input[type=radio][name="radio"]')[3].checked).to.equal(false);
 
-    expect(findAll('input[type=radio][name="radio"]')[0].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[1].checked).to.equal(true);
-    expect(findAll('input[type=radio][name="radio"]')[2].checked).to.equal(false);
-    expect(findAll('input[type=radio][name="radio"]')[3].checked).to.equal(false);
+      findAll('input[type=radio][name="radio"]').forEach((radioButton) => expect(radioButton.disabled).to.equal(true));
+    });
 
+    it('should display the previously saved selected radio button by default', async function() {
+      expect(findAll('.proposal-paragraph input[type=radio][name="radio"]')[1].checked).to.be.true;
+    });
   });
 
-  it('should only display an error alert if the user tries to validate after having interacting once with the page', async function() {
-    // given
-    await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
-    findAll('input[type=radio][name="radio"]')[1].checked = false;
-    await click('.challenge-actions__action-validate');
+  context('Challenge not answered', function() {
+    beforeEach(async function() {
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qcu_challenge_id');
+    });
 
-    // when
-    await click(findAll('.label-checkbox-proposal')[0]);
+    it('should display a radio buttons list', async function() {
+      expect(findAll('input[type=radio][name="radio"]')).to.have.lengthOf(4);
+    });
 
-    // then
-    expect(find('.alert')).to.not.exist;
+    it('should display an ordered list of instructions', async function() {
+      expect(findAll('.proposal-text')[0].textContent.trim()).to.equal('1ere possibilite');
+      expect(findAll('.proposal-text')[1].textContent.trim()).to.equal('2eme possibilite');
+      expect(findAll('.proposal-text')[2].textContent.trim()).to.equal('3eme possibilite');
+      expect(findAll('.proposal-text')[3].textContent.trim()).to.equal('4eme possibilite');
+    });
+
+    it('should display the error alter box if users validates with no radio button selected', async function() {
+      // given
+      findAll('input[type=radio][name="radio"]')[1].checked = false;
+
+      // when
+      await click('.challenge-actions__action-validate');
+
+      // then
+      expect(find('.alert')).to.exist;
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passer.');
+    });
+
+    it('should only display an error alert if the user tries to validate after having interacting once with the page', async function() {
+      // given
+      findAll('input[type=radio][name="radio"]')[1].checked = false;
+      await click('.challenge-actions__action-validate');
+
+      // when
+      await click(findAll('.label-checkbox-proposal')[0]);
+
+      // then
+      expect(find('.alert')).to.not.exist;
+    });
   });
-
 });

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -12,24 +12,55 @@ describe('Acceptance | Displaying a QROC', function() {
 
   beforeEach(async function() {
     defaultScenario(this.server);
-    await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qroc_challenge_id');
   });
 
-  it('should render the challenge instruction', function() {
-    const instructionText = 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre';
-    expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+  context('Challenge answered: the answers inputs should be disabled', function() {
+    beforeEach(async function() {
+      server.create('assessment', {
+        id: 'ref_assessment_id'
+      });
+
+      server.create('answer', {
+        value: 'Bill',
+        result: 'ko',
+        challengeId: 'ref_qroc_challenge_id',
+        assessmentId: 'ref_assessment_id',
+      });
+
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qroc_challenge_id');
+    });
+
+    it('should fill inputs corresponding to the answer', async function() {
+      expect(find('.challenge-response__proposal').value).to.equal('Bill');
+      expect(find('.challenge-response__proposal').disabled).to.be.true;
+    });
+
   });
 
-  it('should display only one input text as proposal to user', function() {
-    expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
+  context('Challenge not answered', function() {
+    beforeEach(async function() {
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qroc_challenge_id');
+    });
+
+    it('should render the challenge instruction', function() {
+      const instructionText = 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre';
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+    });
+
+    it('should display only one input text as proposal to user', function() {
+      expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
+      expect(find('.challenge-response__proposal').disabled).to.be.false;
+    });
+
+    it('should display the error alert if the users tries to validate an empty answer', async function() {
+      await fillIn('input[data-uid="qroc-proposal-uid"]', '');
+      expect(find('.alert')).to.not.exist;
+      await click(find('.challenge-actions__action-validate'));
+
+      expect(find('.alert')).to.exist;
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
+    });
+
   });
 
-  it('should display the error alert if the users tries to validate an empty answer', async function() {
-    await fillIn('input[data-uid="qroc-proposal-uid"]', '');
-    expect(find('.alert')).to.not.exist;
-    await click(find('.challenge-actions__action-validate'));
-
-    expect(find('.alert')).to.exist;
-    expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
-  });
 });

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -12,26 +12,58 @@ describe('Acceptance | Displaying un QROCM', function() {
 
   beforeEach(async function() {
     defaultScenario(this.server);
-    await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
   });
 
-  it('should render the challenge instruction', function() {
-    const instructionText = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
-    expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+  context('Challenge answered: the answers inputs should be disabled', function() {
+    beforeEach(async function() {
+      server.create('assessment', {
+        id: 'ref_assessment_id'
+      });
+
+      server.create('answer', {
+        value: 'logiciel1: \'Linux\'\nlogiciel2: \'Open Office\'\nlogiciel3: \'Pix\'\n',
+        result: 'ko',
+        challengeId: 'ref_qrocm_challenge_id',
+        assessmentId: 'ref_assessment_id',
+      });
+
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
+    });
+
+    it('should fill inputs with previously given answer', async function() {
+      expect(findAll('.challenge-response__proposal')[0].value).to.equal('Linux');
+      expect(findAll('.challenge-response__proposal')[1].value).to.equal('Open Office');
+      expect(findAll('.challenge-response__proposal')[2].value).to.equal('Pix');
+
+      findAll('.challenge-response__proposal').forEach((input) => expect(input.disabled).to.equal(true));
+    });
+
   });
 
-  it('should display only one input text as proposal to user', function() {
-    expect(findAll('.challenge-response__proposal')).to.have.lengthOf(3);
+  context('Challenge not answered', function() {
+    beforeEach(async function() {
+      await visitWithAbortedTransition('/assessments/ref_assessment_id/challenges/ref_qrocm_challenge_id');
+    });
+
+    it('should render the challenge instruction', function() {
+      const instructionText = 'Un QROCM est une question ouverte avec plusieurs champs texte libre pour repondre';
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(instructionText);
+    });
+
+    it('should display several inputs as proposal to user', function() {
+      expect(findAll('.challenge-response__proposal')).to.have.lengthOf(3);
+    });
+
+    it('should display an error alert if the user tried to validate without checking anything first', async function() {
+      await fillIn(findAll('input')[0], '');
+      await fillIn(findAll('input')[1], '');
+      await fillIn(findAll('input')[2], '');
+
+      await click(find('.challenge-actions__action-validate'));
+
+      expect(find('.alert')).to.exist;
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir au moins une réponse. Sinon, passer.');
+    });
   });
 
-  it('should display an error alert if the user tried to validate without checking anything first', async function() {
-    await fillIn(findAll('input')[0], '');
-    await fillIn(findAll('input')[1], '');
-    await fillIn(findAll('input')[2], '');
-
-    await click(find('.challenge-actions__action-validate'));
-
-    expect(find('.alert')).to.exist;
-    expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir au moins une réponse. Sinon, passer.');
-  });
 });

--- a/mon-pix/tests/acceptance/resume-campaigns-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-test.js
@@ -40,19 +40,18 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
         expect(currentURL()).to.contains('/inscription');
       });
 
-      it('should redirect to assessment when user is signing up', async function() {
+      it('should redirect to assessment when user logs in', async function() {
         // given
-        await fillIn('#firstName', 'Jane');
-        await fillIn('#lastName', 'Acme');
-        await fillIn('#email', 'jane@acme.com');
+        await click('.sign-form-header__subtitle [href="/connexion"]');
+        await fillIn('#login', 'jane@acme.com');
         await fillIn('#password', 'Jane1234');
-        await click('#pix-cgu');
 
         // when
-        await click('.button');
+        await click('.sign-form-body__bottom-button button');
 
+        // then
         expect(currentURL()).to.contains('/assessments/');
-        expect(findAll('.progress-bar-stepnum.active').length).to.equals(1);
+        expect(findAll('.progress-bar-stepnum.active').length).to.equals(2);
       });
 
     });
@@ -67,7 +66,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
           // then
           expect(currentURL()).to.contains('/assessments/');
-          expect(findAll('.progress-bar-stepnum.active').length).to.equals(1);
+          expect(findAll('.progress-bar-stepnum.active').length).to.equals(2);
         });
       });
 
@@ -79,7 +78,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
           // then
           expect(currentURL()).to.contains('/assessments/');
-          expect(findAll('.progress-bar-stepnum.active').length).to.equals(1);
+          expect(findAll('.progress-bar-stepnum.active').length).to.equals(2);
         });
       });
 

--- a/mon-pix/tests/acceptance/starting-a-course-test.js
+++ b/mon-pix/tests/acceptance/starting-a-course-test.js
@@ -7,7 +7,7 @@ import defaultScenario from '../../mirage/scenarios/default';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-const URL_OF_FIRST_TEST = '/assessments/ref_assessment_id/challenges/ref_qcm_challenge_id';
+const URL_OF_FIRST_TEST = '/assessments/ref_assessment_id/challenges/ref_qcm_challenge_id_not_yet_answered';
 
 describe('Acceptance | Starting a course', function() {
   setupApplicationTest();


### PR DESCRIPTION
## :unicorn: Problème
On ne permet pas de modifier une réponse lorsqu'un challenge a déjà été répondu. On veut rajouter des éléments UI clairs pour montrer à l'utilisateur que cette question a déjà été vue.

## :robot: Solution
Rajouter des éléments UI qui empêchent la modification et expliquent que la question a déjà été traitée et ne peux plus être modifiée :

- attribut disabled sur les champs,
- une opacité sur le bloc .challenge-proposals correspondant aux réponses données,
- un cadenas au hover de cette partie,
- un changement de wording sur les boutons en bas de page, "Valider" devient "Poursuivre" accompagné du texte "Vous avez déjà répondu à cette question".
