### PR TITLE
[BUGFIX] Gestion de deux mêmes types de challenge à la suite (PF-828)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -32,10 +32,6 @@ export default Component.extend({
     reloadSimulator() {
       this._reloadSimulator();
     },
-
-    onEmbedLoaded() {
-      this._removePlaceholder();
-    },
   },
 
   // Internals

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -5,7 +5,7 @@ import { htmlSafe } from '@ember/string';
 export default Component.extend({
 
   // Element
-  classNames: ['challenge-embed-simulator rounded-panel'],
+  classNames: ['challenge-embed-simulator'],
   attributeBindings: ['embedDocumentHeightStyle:style'],
 
   // Data props
@@ -31,14 +31,38 @@ export default Component.extend({
 
     reloadSimulator() {
       this._reloadSimulator();
-    }
+    },
+
+    onEmbedLoaded() {
+      this._removePlaceholder();
+    },
   },
 
   // Internals
   _isSimulatorNotYetLaunched: true,
+  _hiddenSimulatorClass: null,
+
+  didUpdateAttrs() {
+    this.set('_isSimulatorNotYetLaunched', true);
+    this.set('_hiddenSimulatorClass', 'hidden-class');
+  },
+
+  didRender() {
+    this._super(...arguments);
+    const iframe = this._getIframe();
+    iframe.onload = () => {
+      this._removePlaceholder();
+    };
+  },
+
+  _removePlaceholder() {
+    if (this.embedDocument.url) {
+      this.set('_hiddenSimulatorClass', null);
+    }
+  },
 
   _getIframe() {
-    return this.element.querySelector('.challenge-embed-simulator__iframe');
+    return this.element.querySelector('.embed__iframe');
   },
 
   /* This method is not tested because it would be too difficult (add an observer on a complicated stubbed DOM API element!) */
@@ -59,7 +83,7 @@ export default Component.extend({
   },
 
   _unblurSimulator() {
-    const $simulatorPanel = this.element.getElementsByClassName('challenge-embed-simulator__simulator').item(0);
+    const $simulatorPanel = this.element.getElementsByClassName('embed__simulator').item(0);
     $simulatorPanel.classList.remove('blurred');
   }
 });

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -12,6 +12,10 @@ export default Component.extend({
   challenge: null,
   assessment: null,
 
+  didReceiveAttrs() {
+    this.set('selectedAttachmentUrl', this.get('challenge.attachments.firstObject'));
+  },
+
   challengeInstruction: computed('challenge.instruction', function() {
     const instruction = this.get('challenge.instruction');
     if (!instruction) {
@@ -36,11 +40,7 @@ export default Component.extend({
     this.id = 'challenge_statement_' + this.get('challenge.id');
   },
 
-  selectedAttachmentUrl: computed('challenge.attachments', function() {
-    return this.get('challenge.attachments.firstObject');
-  }),
-
-  attachmentsData: computed('challenge.attachements', function() {
+  attachmentsData: computed('challenge.attachments', function() {
     return this.get('challenge.attachments');
   }),
 

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.embed__aknowledgment-overlay {
+.embed__acknowledgment-overlay {
   position: absolute;
   width: 100%;
   height: 100%;

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -1,8 +1,27 @@
-.challenge-embed-simulator {
+.embed {
   position: relative;
+  height: 100%;
+
+  &.hidden-class {
+    visibility: hidden;
+  }
+
+  &.placeholder{
+    width: 100%;
+    background-color: $mercury-grey;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 7rem;
+    color: $raven-grey;
+  }
+
+  .rounded-panel {
+    display: block;
+  }
 }
 
-.challenge-embed-simulator__aknowledgment-overlay {
+.embed__aknowledgment-overlay {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -18,7 +37,7 @@
   justify-content: center;
 }
 
-.challenge-embed-simulator__launch-simulator-button {
+.embed__launch-simulator-button {
   background-color: #3D68FF;
   color: #ffffff;
   box-shadow: 0 2px 6px 0 rgba(12,22,58,0.11), 0 1px 3px 0 rgba(0,0,0,0.08);
@@ -33,21 +52,21 @@
   padding: 0 36px;
 }
 
-.challenge-embed-simulator__simulator {
+.embed__simulator {
   height: 100%;
 
   &.blurred {
     filter: blur(5px);
   }
 }
-.challenge-embed-simulator__iframe {
+.embed__iframe {
   position: relative;
   border: none;
   width: 100%;
   height: 100%;
 }
 
-.challenge-embed-simulator__reload-button {
+.embed__reload-button {
   position: absolute;
   bottom: 20px;
   right: 20px;

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -6,7 +6,7 @@
 
 <div class="embed rounded-panel {{_hiddenSimulatorClass}}">
   {{#if _isSimulatorNotYetLaunched}}
-    <div class="embed__aknowledgment-overlay">
+    <div class="embed__acknowledgment-overlay">
       <button class="embed__launch-simulator-button" {{action "launchSimulator"}}>Je lance l’application</button>
     </div>
   {{/if}}

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -1,13 +1,22 @@
-{{#if _isSimulatorNotYetLaunched}}
-  <div class="challenge-embed-simulator__aknowledgment-overlay">
-    <button class="challenge-embed-simulator__launch-simulator-button" {{action "launchSimulator"}}>Je lance l’application</button>
+{{#if _hiddenSimulatorClass}}
+  <div class="embed placeholder" aria-label="Chargement de l'application en cours">
+    {{fa-icon 'image'}}
   </div>
 {{/if}}
 
-<div class="challenge-embed-simulator__simulator blurred">
-  <iframe class="challenge-embed-simulator__iframe"
-          src="{{embedDocument.url}}"
-          title="{{embedDocument.title}}">
-  </iframe>
-  <button class="challenge-embed-simulator__reload-button" {{action "reloadSimulator"}}>Recharger l’application</button>
+<div class="embed rounded-panel {{_hiddenSimulatorClass}}">
+  {{#if _isSimulatorNotYetLaunched}}
+    <div class="embed__aknowledgment-overlay">
+      <button class="embed__launch-simulator-button" {{action "launchSimulator"}}>Je lance l’application</button>
+    </div>
+  {{/if}}
+
+  <div class="embed__simulator blurred">
+    <iframe class="embed__iframe"
+            src="{{embedDocument.url}}"
+            title="{{embedDocument.title}}">
+    </iframe>
+    <button class="embed__reload-button" {{action "reloadSimulator"}}>Recharger l’application</button>
+  </div>
 </div>
+

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -16,7 +16,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.embed__aknowledgment-overlay')).to.exist;
+      expect(find('.embed__acknowledgment-overlay')).to.exist;
     });
 
     it('should contain a button to launch the simulator', async function() {
@@ -24,7 +24,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.embed__aknowledgment-overlay .embed__launch-simulator-button')).to.exist;
+      expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button')).to.exist;
     });
   });
 
@@ -35,7 +35,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.embed__aknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
+      expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
     });
 
     it('should close the aknowledgment overlay when clicked', async function() {
@@ -46,7 +46,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await click('.embed__launch-simulator-button');
 
       // then
-      expect(find('.embed__aknowledgment-overlay')).to.not.exist;
+      expect(find('.embed__acknowledgment-overlay')).to.not.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -16,7 +16,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.challenge-embed-simulator__aknowledgment-overlay')).to.exist;
+      expect(find('.embed__aknowledgment-overlay')).to.exist;
     });
 
     it('should contain a button to launch the simulator', async function() {
@@ -24,7 +24,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button')).to.exist;
+      expect(find('.embed__aknowledgment-overlay .embed__launch-simulator-button')).to.exist;
     });
   });
 
@@ -35,7 +35,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.challenge-embed-simulator__aknowledgment-overlay .challenge-embed-simulator__launch-simulator-button').textContent).to.equal('Je lance l’application');
+      expect(find('.embed__aknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
     });
 
     it('should close the aknowledgment overlay when clicked', async function() {
@@ -43,10 +43,10 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // when
-      await click('.challenge-embed-simulator__launch-simulator-button');
+      await click('.embed__launch-simulator-button');
 
       // then
-      expect(find('.challenge-embed-simulator__aknowledgment-overlay')).to.not.exist;
+      expect(find('.embed__aknowledgment-overlay')).to.not.exist;
     });
   });
 
@@ -57,7 +57,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.challenge-embed-simulator__reload-button').textContent).to.equal('Recharger l’application');
+      expect(find('.embed__reload-button').textContent).to.equal('Recharger l’application');
     });
 
     it('should reload simulator when user clicked on button reload', async function() {
@@ -67,7 +67,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator _reloadSimulator=stubReloadSimulator}}`);
 
       // when
-      await click('.challenge-embed-simulator__reload-button');
+      await click('.embed__reload-button');
 
       // then
       sinon.assert.calledOnce(stubReloadSimulator);
@@ -81,7 +81,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(findAll('.challenge-embed-simulator__simulator')[0].classList.contains('blurred')).to.be.true;
+      expect(findAll('.embed__simulator')[0].classList.contains('blurred')).to.be.true;
     });
 
     it('should be removed when simulator was launched', async function() {
@@ -89,10 +89,10 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // when
-      await click('.challenge-embed-simulator__launch-simulator-button');
+      await click('.embed__launch-simulator-button');
 
       // then
-      expect(findAll('.challenge-embed-simulator__simulator')[0].classList.contains('blurred')).to.be.false;
+      expect(findAll('.embed__simulator')[0].classList.contains('blurred')).to.be.false;
     });
   });
 
@@ -119,11 +119,11 @@ describe('Integration | Component | challenge embed simulator', function() {
     });
 
     it('should define a title attribute on the iframe element that is the one defined in the referential for field "Embed title"', function() {
-      expect(findAll('.challenge-embed-simulator__iframe')[0].title).to.equal('Embed simulator');
+      expect(findAll('.embed__iframe')[0].title).to.equal('Embed simulator');
     });
 
     it('should define a src attribute on the iframe element that is the one defined in the referential for field "Embed URL"', function() {
-      expect(findAll('.challenge-embed-simulator__iframe')[0].src).to.equal('http://embed-simulator.url/');
+      expect(findAll('.embed__iframe')[0].src).to.equal('http://embed-simulator.url/');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Cette PR corrige deux bugs identifiés sur la page des challenges:
- un téléchargement de fichier est lancé sur le premier challenge, passer le challenge, lancer un téléchargement au challenge suivant sans cliquer sur les radio boutons pour spécifier le format du fichier 
  --> **BUG**: le deuxième fichier téléchargé est celui du challenge précédent
  --> épreuve contenant des téléchargements: [http://app.pix.fr/courses/recZpODEGETeIjT6b](http://app.pix.fr/courses/recZpODEGETeIjT6b)
- lorsque le réseau est lent et que deux challenges avec des embed se suivent
  --> **BUG**: le premier embed d'affiche le temps que le deuxième se charge
  --> épreuve avec des embed: [http://app.pix.fr/courses/reciMJOtivLZgO9gO](http://app.pix.fr/courses/reciMJOtivLZgO9gO)
## :robot: Solution
- Lorsque deux même types de challenge se suivent, le même composant est ré-utilisé, seuls les paramètres passés au composant changent. Il est donc nécéssaire de réinitialiser les propriétés internes du composant lorsque le challenge change.
- Une zone grise a été rajoutée en attendant le chargement de l'embed sur la page. Lorsque l'embed est prêt à affiché, la zone grise disparaît.
