### PR TITLE
[BUGFIX] Date dépassée dans le test d'acceptance de la création de session

### DIFF
--- a/certif/tests/acceptance/session-new-test.js
+++ b/certif/tests/acceptance/session-new-test.js
@@ -36,7 +36,7 @@ module('Acceptance | Session creation', function(hooks) {
 
     test('it should create a session and redirect to session details', async function(assert) {
       // given
-      const sessionDate = '2019-12-25';
+      const sessionDate = '2029-12-25';
       const sesionFormattedTime = '02/02/2019 13:45';
       const sessionTime = new Date(sesionFormattedTime);
 


### PR DESCRIPTION
## :unicorn: Problème
Le test d'acceptance de création de session simulait la création d'une session planifiée pour la date du 25 décembre 2019. Or, il est impossible de choisir une date de session qui précède la date d'aujourd'hui. Et devinez quel jour on est aujourd'hui ?....

## :robot: Solution
Faire galérer dans 10 ans le prochain dév sur le bug ;) 
