### PR TITLE
[FEATURE] Cacher le bouton de finalisation de session tant qu'il n'existe pas au moins un candidat lié (PC-97)

### DIFF
--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -16,7 +16,6 @@ export default DS.Model.extend({
   certificationCourseId: DS.attr('number'),
   examinerComment: DS.attr(),
   hasSeenEndTestScreen: DS.attr('boolean'),
-  user: DS.belongsTo('user'),
 
   certificationCourseIdReadable: computed('certificationCourseId', function() {
     if (this.certificationCourseId) {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -18,6 +18,9 @@ export default DS.Model.extend({
   status: DS.attr(),
   examinerComment: DS.attr(),
   isFinalized: equal('status', 'finalized'),
+  hasStarted: computed('certificationCandidates.@each.isLinked', function() {
+    return this.certificationCandidates.isAny('isLinked');
+  }),
 
   urlToDownload: computed('id', function() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.get('id')}/attendance-sheet?accessToken=${this.get('session.data.authenticated.access_token')}`;

--- a/certif/app/templates/components/routes/authenticated/sessions/details/certification-candidates-tab.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/details/certification-candidates-tab.hbs
@@ -87,15 +87,15 @@
         <tbody>
           {{#each certificationCandidates as |candidate|}}
             <tr>
-              <td data-test-id='panel-candidate__lastName'>{{candidate.lastName}}</td>
-              <td data-test-id='panel-candidate__firstName'>{{candidate.firstName}}</td>
-              <td data-test-id='panel-candidate__birthdate'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
-              <td data-test-id='panel-candidate__birthCity'>{{candidate.birthCity}}</td>
-              <td data-test-id='panel-candidate__birthProvinceCode'>{{candidate.birthProvinceCode}}</td>
-              <td data-test-id='panel-candidate__birthCountry'>{{candidate.birthCountry}}</td>
-              <td data-test-id='panel-candidate__email'>{{candidate.email}}</td>
-              <td data-test-id='panel-candidate__externalId'>{{candidate.externalId}}</td>
-              <td data-test-id='panel-candidate__extraTimePercentage'>{{format-percentage candidate.extraTimePercentage}}</td>
+              <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
+              <td data-test-id='panel-candidate__firstName__{{candidate.id}}'>{{candidate.firstName}}</td>
+              <td data-test-id='panel-candidate__birthdate__{{candidate.id}}'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
+              <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
+              <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
+              <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
+              <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+              <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
+              <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/certif/app/templates/components/routes/authenticated/sessions/details/parameters-tab.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/details/parameters-tab.hbs
@@ -53,7 +53,7 @@
     </div>
 
     <div class="session-details-row">
-      {{#if isSessionFinalizationActive }}
+      {{#if (and isSessionFinalizationActive session.hasStarted) }}
         <div class="session-details-buttons">
           {{#link-to "authenticated.sessions.update" session.id
                      class="button button--regular button--grey button--link session-details-content__update-button"}}

--- a/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
@@ -25,7 +25,7 @@
 
       <tbody>
         {{#each sortedSessions as |session|}}
-          <tr onclick={{action goToDetails session}}>
+          <tr data-test-id="session-list-row__{{session.id}}" onclick={{action goToDetails session}}>
             <td>{{session.id}}</td>
             <td>{{session.address}}</td>
             <td>{{session.room}}</td>

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -1,0 +1,74 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+import moment from 'moment';
+
+export default Factory.extend({
+
+  firstName() {
+    return faker.name.firstName();
+  },
+
+  lastName() {
+    return faker.name.lastName();
+  },
+
+  birthdate() {
+    return moment(faker.date.past(30)).format('YYYY-MM-DD');
+  },
+
+  birthCity() {
+    return faker.address.city();
+  },
+
+  birthProvinceCode() {
+    return faker.random.alphaNumeric(3);
+  },
+
+  birthCountry() {
+    return faker.address.country();
+  },
+
+  email() {
+    return faker.internet.email();
+  },
+
+  externalId() {
+    return faker.random.uuid();
+  },
+
+  extraTimePercentage() {
+    if (faker.random.boolean()) {
+      return 0.3;
+    }
+
+    return null;
+  },
+
+  isLinked() {
+    return faker.random.boolean();
+  },
+
+  certificationCourseId() {
+    if (this.isLinked) {
+      return faker.random.number();
+    }
+
+    return null;
+  },
+
+  examinerComment() {
+    if (faker.random.boolean()) {
+      return faker.lorem.sentence();
+    }
+
+    return '';
+  },
+
+  hasSeenEndTestScreen() {
+    if (this.isLinked) {
+      return faker.random.boolean();
+    }
+
+    return false;
+  },
+});

--- a/certif/mirage/factories/certification-center-membership.js
+++ b/certif/mirage/factories/certification-center-membership.js
@@ -1,0 +1,8 @@
+import { Factory, association } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  certificationCenter: association(),
+
+  user: association(),
+});

--- a/certif/mirage/factories/certification-center.js
+++ b/certif/mirage/factories/certification-center.js
@@ -1,0 +1,9 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+
+  name() {
+    return faker.company.companyName();
+  },
+});

--- a/certif/mirage/factories/session.js
+++ b/certif/mirage/factories/session.js
@@ -1,10 +1,11 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, association } from 'ember-cli-mirage';
 import faker from 'faker';
+import moment from 'moment';
 
 export default Factory.extend({
 
-  examiner() {
-    return faker.company.companyName();
+  address() {
+    return faker.address.streetName();
   },
 
   accessCode() {
@@ -12,15 +13,38 @@ export default Factory.extend({
   },
 
   date() {
-    return '2019-02-23';
+    return moment(faker.date.recent()).format('YYYY-MM-DD');
+  },
+
+  description() {
+    return faker.random.words();
+  },
+
+  examiner() {
+    return faker.company.companyName();
+  },
+
+  room() {
+    return faker.random.alphaNumeric(9);
   },
 
   time() {
-    return '14:00';
+    return faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') +
+    ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0') +
+    ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0');
   },
 
-  createdAt() {
-    return faker.date.recent();
+  status() {
+    return 'started';
   },
 
+  examinerComment(i) {
+    if (i % 2 === 0) {
+      return faker.random.words();
+    }
+
+    return '';
+  },
+
+  certificationCenter: association(),
 });

--- a/certif/mirage/factories/user.js
+++ b/certif/mirage/factories/user.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
 
 export default Factory.extend({
 
@@ -16,6 +17,5 @@ export default Factory.extend({
 
   pixCertifTermsOfServiceAccepted() {
     return faker.random.boolean();
-  }
-
+  },
 });

--- a/certif/mirage/scenarios/default.js
+++ b/certif/mirage/scenarios/default.js
@@ -1,25 +1,2 @@
-function _createSignedUpUser(server) {
-  const user = server.create('user', {
-    email: 'pro@example.net',
-  });
-
-  const userCertificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification du Pix'
-  });
-
-  const userMembership = server.create('certification-center-membership', {
-    certificationCenterId: userCertificationCenter.id,
-    userId: user.id
-  });
-
-  user.certificationCenterMemberships = [userMembership];
-}
-
-function _createSessions(server) {
-  server.createList('session', 6);
-}
-
-export default function(server) {
-  _createSignedUpUser(server);
-  _createSessions(server);
+export default function(_server) {
 }

--- a/certif/mirage/serializers/certification-center-membership.js
+++ b/certif/mirage/serializers/certification-center-membership.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['certificationCenter'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude
 });

--- a/certif/mirage/serializers/certification-center.js
+++ b/certif/mirage/serializers/certification-center.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   links(certificationCenter) {
     return {
       'sessions': {

--- a/certif/mirage/serializers/session.js
+++ b/certif/mirage/serializers/session.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  links(session) {
+    return {
+      'certificationCandidates': {
+        related: `/api/sessions/${session.id}/certification-candidates`,
+      }
+    };
+  }
+});

--- a/certif/mirage/serializers/user.js
+++ b/certif/mirage/serializers/user.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   links(user) {
     return {
       'certificationCenterMemberships': {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -3179,64 +3179,11 @@
         "@glimmer/util": "^0.35.11"
       }
     },
-    "@miragejs/server": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@miragejs/server/-/server-0.1.23.tgz",
-      "integrity": "sha512-WgcuN4fjWDzqGo/f9f1G1df0JbCUS4ulOGHaWYgrhvDTMq7LDbn1g31xO30IWdZ4USxiLR79CskXg6DuqZlXAw==",
-      "dev": true,
-      "requires": {
-        "inflected": "^2.0.4",
-        "lodash.assign": "^4.2.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.compact": "^3.0.1",
-        "lodash.find": "^4.6.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.forin": "^4.4.0",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "lodash.invokemap": "^4.6.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.lowerfirst": "^4.3.1",
-        "lodash.map": "^4.6.0",
-        "lodash.mapvalues": "^4.6.0",
-        "lodash.pick": "^4.4.0",
-        "lodash.snakecase": "^4.1.1",
-        "lodash.uniq": "^4.5.0",
-        "lodash.uniqby": "^4.7.0",
-        "lodash.values": "^4.3.0",
-        "pretender": "3.0.2"
-      },
-      "dependencies": {
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-          "dev": true
-        },
-        "lodash.flatten": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-          "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-          "dev": true
-        },
-        "lodash.isfunction": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-          "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-          "dev": true
-        },
-        "lodash.values": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-          "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
-          "dev": true
-        }
-      }
+    "@miragejs/pretender-node-polyfill": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
+      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -6041,16 +5988,6 @@
             "jsonfile": "^2.1.0"
           }
         }
-      }
-    },
-    "broccoli-string-replace": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
-      "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
-      "dev": true,
-      "requires": {
-        "broccoli-persistent-filter": "^1.1.5",
-        "minimatch": "^3.0.3"
       }
     },
     "broccoli-templater": {
@@ -9980,33 +9917,22 @@
       }
     },
     "ember-cli-mirage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-1.1.1.tgz",
-      "integrity": "sha512-dJrtkVMmNfAn8vXctecvbcPdlXbraSL2gpi0coWBocJF0r6yerFjnMTl23umWZ8GkQbisuSYS+A2ont+uEVavw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-1.1.6.tgz",
+      "integrity": "sha512-xvW9ziv9JUKv9IA7SnmeCg0/pKiacro2Vg/kv8iqzFTRGMos51QrrsCI/2rXjAloGJM1SnaKL1TWUp25e76RVw==",
       "dev": true,
       "requires": {
-        "@miragejs/server": "0.1.23",
         "broccoli-file-creator": "^2.1.1",
         "broccoli-funnel": "^2.0.1",
         "broccoli-merge-trees": "^3.0.2",
-        "broccoli-string-replace": "^0.1.2",
-        "chalk": "^2.4.2",
         "ember-auto-import": "^1.2.19",
         "ember-cli-babel": "^7.5.0",
         "ember-get-config": "^0.2.2",
         "ember-inflector": "^2.0.0 || ^3.0.0",
-        "lodash-es": "^4.17.11"
+        "lodash-es": "^4.17.11",
+        "miragejs": "^0.1.31"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "broccoli-file-creator": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
@@ -10048,17 +9974,6 @@
             "merge-trees": "^2.0.0"
           }
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
@@ -10067,15 +9982,6 @@
           "requires": {
             "fs-updater": "^1.0.4",
             "heimdalljs": "^0.2.5"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12330,9 +12236,9 @@
       }
     },
     "ember-inflector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-3.0.0.tgz",
-      "integrity": "sha512-tLWfYolZAkLnkTvvBkjizy4Wmj8yI8wqHZFK+leh0iScHiC3r1Yh5C4qO+OMGiBTMLwfTy+YqVoE/Nu3hGNkcA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-3.0.1.tgz",
+      "integrity": "sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.6.0"
@@ -12427,9 +12333,9 @@
           }
         },
         "rsvp": {
-          "version": "4.8.4",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
-          "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
           "dev": true
         }
       }
@@ -14763,9 +14669,9 @@
       "dev": true
     },
     "fake-xml-http-request": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.0.0.tgz",
-      "integrity": "sha512-UjNnynb6eLAB0lyh2PlTEkjRJORnNsVF1hbzU+PQv89/cyBV9GDRCy7JAcLQgeCLYT+3kaumWWZKEJvbaK74eQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz",
+      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
       "dev": true
     },
     "faker": {
@@ -18430,6 +18336,66 @@
         }
       }
     },
+    "miragejs": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.32.tgz",
+      "integrity": "sha512-HVA79I/Ta3H9/uQ60XcsKyeiq9vGUN0JDyaC6XZrGnSBXxj2ZEZurrdkvYNXeYd2cJELD/f3750IjB0lRkXBgA==",
+      "dev": true,
+      "requires": {
+        "@miragejs/pretender-node-polyfill": "^0.1.0",
+        "inflected": "^2.0.4",
+        "lodash.assign": "^4.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.compact": "^3.0.1",
+        "lodash.find": "^4.6.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.forin": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "lodash.invokemap": "^4.6.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.lowerfirst": "^4.3.1",
+        "lodash.map": "^4.6.0",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqby": "^4.7.0",
+        "lodash.values": "^4.3.0",
+        "pretender": "3.1.0"
+      },
+      "dependencies": {
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+          "dev": true
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+          "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+          "dev": true
+        },
+        "lodash.isfunction": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+          "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+          "dev": true
+        },
+        "lodash.values": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+          "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
+          "dev": true
+        }
+      }
+    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -20219,12 +20185,12 @@
       "dev": true
     },
     "pretender": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.0.2.tgz",
-      "integrity": "sha512-6gIDHUaJKRZv7ZgP3CsKicvxtBB3brBr2LWKvJYvEyZRicG9JV2SKokK2TIK0b4Zz9+4C79y57MZHpqUjvJqDg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.1.0.tgz",
+      "integrity": "sha512-BxCsLXzbD7LsHBF7t8phgDa9EBWxJEYR8YqvYgrwri/YHnm9r6EiDThqHumW5FdxHlk4F10/xT2rv24C929r1Q==",
       "dev": true,
       "requires": {
-        "fake-xml-http-request": "^2.0.0",
+        "fake-xml-http-request": "^2.1.1",
         "route-recognizer": "^0.3.3",
         "whatwg-fetch": "^3.0.0"
       }

--- a/certif/package.json
+++ b/certif/package.json
@@ -48,7 +48,7 @@
     "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-matomo-tag-manager": "^1.1.2",
-    "ember-cli-mirage": "^1.1.1",
+    "ember-cli-mirage": "^1.1.6",
     "ember-cli-moment-shim": "^3.7.1",
     "ember-cli-notifications": "^4.3.3",
     "ember-cli-sass": "^10.0.1",

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -12,13 +12,13 @@ module('Acceptance | Session Details', function(hooks) {
   setupMirage(hooks);
 
   let user;
-  let sessionFinalizedId;
-  let sessionNotFinalizedId;
+  let sessionFinalized;
+  let sessionNotFinalized;
 
   hooks.beforeEach(function() {
     user = createUserWithMembership();
-    sessionFinalizedId = server.create('session', { id: 1, status: 'finalized' }).id;
-    sessionNotFinalizedId = server.create('session', { id: 2, status: 'started' }).id;
+    sessionFinalized = server.create('session', { status: 'finalized' });
+    sessionNotFinalized = server.create('session', { status: 'started' });
   });
 
   hooks.afterEach(function() {
@@ -30,7 +30,7 @@ module('Acceptance | Session Details', function(hooks) {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
-      await visit(`/sessions/${sessionFinalizedId}`);
+      await visit(`/sessions/${sessionFinalized.id}`);
 
       // then
       assert.equal(currentURL(), '/connexion');
@@ -57,26 +57,26 @@ module('Acceptance | Session Details', function(hooks) {
 
       test('it should be accessible for an authenticated user', async function(assert) {
         // when
-        await visit(`/sessions/${sessionFinalizedId}`);
+        await visit(`/sessions/${sessionFinalized.id}`);
 
         // then
-        assert.equal(currentURL(), `/sessions/${sessionFinalizedId}`);
+        assert.equal(currentURL(), `/sessions/${sessionFinalized.id}`);
       });
 
       test('it should redirect to update page on click on update button', async function(assert) {
         // given
-        await visit(`/sessions/${sessionFinalizedId}`);
+        await visit(`/sessions/${sessionFinalized.id}`);
 
         // when
         await click('.session-details-content__update-button');
 
         // then
-        assert.equal(currentURL(), `/sessions/${sessionFinalizedId}/modification`);
+        assert.equal(currentURL(), `/sessions/${sessionFinalized.id}/modification`);
       });
 
       test('it should redirect to update page on click on return button', async function(assert) {
         // given
-        await visit(`/sessions/${sessionFinalizedId}`);
+        await visit(`/sessions/${sessionFinalized.id}`);
 
         // when
         await click('.session-details-content__return-button');
@@ -96,7 +96,7 @@ module('Acceptance | Session Details', function(hooks) {
 
       test('it should still redirect to update page on click on return button', async function(assert) {
         // given
-        await visit(`/sessions/${sessionFinalizedId}`);
+        await visit(`/sessions/${sessionFinalized.id}`);
 
         // when
         await click('.session-details-content__return-button');
@@ -108,36 +108,36 @@ module('Acceptance | Session Details', function(hooks) {
       module('when the session is not finalized', function() {
         test('it should redirect to finalize page on click on finalize button', async function(assert) {
           // given
-          await visit(`/sessions/${sessionNotFinalizedId}`);
+          await visit(`/sessions/${sessionNotFinalized.id}`);
 
           // when
           await click('.session-details-content__finalize-button');
 
           // then
-          assert.equal(currentURL(), `/sessions/${sessionNotFinalizedId}/finalisation`);
+          assert.equal(currentURL(), `/sessions/${sessionNotFinalized.id}/finalisation`);
         });
       });
 
       module('when the session is finalized', function() {
         test('it should not redirect to finalize page on click on finalize button', async function(assert) {
           // given
-          await visit(`/sessions/${sessionFinalizedId}`);
+          await visit(`/sessions/${sessionFinalized.id}`);
 
           // when
           await click('.session-details-content__finalize-button');
 
           // then
-          assert.equal(currentURL(), `/sessions/${sessionFinalizedId}`);
+          assert.equal(currentURL(), `/sessions/${sessionFinalized.id}`);
         });
 
         test('it should throw an error on visiting /finalisation url', async function(assert) {
           // given
-          await visit(`/sessions/${sessionFinalizedId}`);
+          await visit(`/sessions/${sessionFinalized.id}`);
           const transitionError = new Error('TransitionAborted');
 
           // then
           assert.rejects(
-            visit(`/sessions/${sessionFinalizedId}/finalisation`),
+            visit(`/sessions/${sessionFinalized.id}/finalisation`),
             transitionError,
             'error raised when visiting finalisation route'
           );

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -106,19 +106,40 @@ module('Acceptance | Session Details', function(hooks) {
       });
 
       module('when the session is not finalized', function() {
-        test('it should redirect to finalize page on click on finalize button', async function(assert) {
-          // given
-          await visit(`/sessions/${sessionNotFinalized.id}`);
 
-          // when
-          await click('.session-details-content__finalize-button');
+        module('when the session has not started', function() {
+          test('it should not display the finalize button', async function(assert) {
+            // when
+            await visit(`/sessions/${sessionNotFinalized.id}`);
 
-          // then
-          assert.equal(currentURL(), `/sessions/${sessionNotFinalized.id}/finalisation`);
+            // then
+            assert.dom('.session-details-content__finalize-button').doesNotExist();
+          });
+        });
+
+        module('when the session has started', function() {
+          test('it should redirect to finalize page on click on finalize button', async function(assert) {
+            // given
+            const candidatesWithStartingCertif = server.createList('certification-candidate', 2, { isLinked: true });
+            sessionNotFinalized.update({ certificationCandidates: candidatesWithStartingCertif });
+            await visit(`/sessions/${sessionNotFinalized.id}`);
+
+            // when
+            await click('.session-details-content__finalize-button');
+
+            // then
+            assert.equal(currentURL(), `/sessions/${sessionNotFinalized.id}/finalisation`);
+          });
         });
       });
 
       module('when the session is finalized', function() {
+
+        hooks.beforeEach(async function() {
+          const candidatesWithStartingCertif = server.createList('certification-candidate', 2, { isLinked: true });
+          sessionFinalized.update({ certificationCandidates: candidatesWithStartingCertif });
+        });
+
         test('it should not redirect to finalize page on click on finalize button', async function(assert) {
           // given
           await visit(`/sessions/${sessionFinalized.id}`);

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -12,10 +12,12 @@ module('Acceptance | Session Finalization', function(hooks) {
   setupMirage(hooks);
 
   let user;
+  let session;
 
   hooks.beforeEach(function() {
     user = createUserWithMembership();
-    server.create('session', { id: 1 });
+    const certificationCenterId = user.certificationCenterMemberships.models[0].certificationCenterId;
+    session = server.create('session', { certificationCenterId });
   });
 
   hooks.afterEach(function() {
@@ -27,7 +29,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
-      await visit('/sessions/1/finalisation');
+      await visit(`/sessions/${session.id}/finalisation`);
 
       // then
       assert.equal(currentURL(), '/connexion');
@@ -47,10 +49,10 @@ module('Acceptance | Session Finalization', function(hooks) {
 
     test('it should be accessible for an authenticated user', async function(assert) {
       // when
-      await visit('/sessions/1/finalisation');
+      await visit(`/sessions/${session.id}/finalisation`);
 
       // then
-      assert.equal(currentURL(), '/sessions/1/finalisation');
+      assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
     });
 
     module('When user click on "Finaliser" button', function(hooks) {
@@ -59,7 +61,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
       hooks.beforeEach(function() {
         finalizeController = this.owner.lookup('controller:authenticated.sessions.finalize');
-        return visit('/sessions/1/finalisation');
+        return visit(`/sessions/${session.id}/finalisation`);
       });
 
       test('it should allow the user to comment the session in textarea', async function(assert) {
@@ -82,7 +84,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
         // then
         assert.equal(finalizeController.showConfirmModal, true);
-        assert.equal(currentURL(), '/sessions/1/finalisation');
+        assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
       });
 
       module('when confirm modal is open', function(hooks) {
@@ -96,7 +98,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
           // then
           assert.equal(finalizeController.showConfirmModal, false);
-          assert.equal(currentURL(), '/sessions/1/finalisation');
+          assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
         });
 
         test('it should close the modal on cancel button click', async function(assert) {
@@ -105,7 +107,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
           // then
           assert.equal(finalizeController.showConfirmModal, false);
-          assert.equal(currentURL(), '/sessions/1/finalisation');
+          assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
         });
 
         test('it should close the modal on confirm button click', async function(assert) {
@@ -121,7 +123,7 @@ module('Acceptance | Session Finalization', function(hooks) {
           await click('[data-test-id="finalize-session-modal__confirm-button"]');
 
           // then
-          assert.equal(currentURL(), '/sessions/1');
+          assert.equal(currentURL(), `/sessions/${session.id}`);
         });
 
         test('it should show a success notification on session details page', async function(assert) {

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -3,7 +3,6 @@ import { click, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { createUserWithMembership } from '../helpers/test-init';
-import { waitFor } from '@ember/test-helpers';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -13,6 +12,7 @@ module('Acceptance | Session List', function(hooks) {
   setupMirage(hooks);
 
   let user;
+  let certificationCenterId;
 
   module('When user is not authenticated', function() {
 
@@ -30,6 +30,7 @@ module('Acceptance | Session List', function(hooks) {
 
     hooks.beforeEach(async () => {
       user = createUserWithMembership();
+      certificationCenterId = user.certificationCenterMemberships.models[0].certificationCenterId;
 
       await authenticateSession({
         user_id: user.id,
@@ -57,7 +58,7 @@ module('Acceptance | Session List', function(hooks) {
 
     test('it should list the sessions', async function(assert) {
       // given
-      server.createList('session', 12);
+      server.createList('session', 12, { certificationCenterId });
 
       // when
       await visit('/sessions/liste');
@@ -68,16 +69,15 @@ module('Acceptance | Session List', function(hooks) {
 
     test('it should redirect to detail page of session id 1 on click on first row', async function(assert) {
       // given
-      server.createList('session', 2);
+      const sessions = server.createList('session', 2, { certificationCenterId });
 
       await visit('/sessions/liste');
-      await waitFor('table tbody tr');
 
       // when
-      await click('table tbody tr:nth-child(1)');
+      await click(`[data-test-id="session-list-row__${sessions[0].id}"]`);
 
       // then
-      assert.equal(currentURL(), '/sessions/1');
+      assert.equal(currentURL(), `/sessions/${sessions[0].id}`);
     });
   });
 });

--- a/certif/tests/acceptance/session-new-test.js
+++ b/certif/tests/acceptance/session-new-test.js
@@ -37,8 +37,8 @@ module('Acceptance | Session creation', function(hooks) {
     test('it should create a session and redirect to session details', async function(assert) {
       // given
       const sessionDate = '2029-12-25';
-      const sesionFormattedTime = '02/02/2019 13:45';
-      const sessionTime = new Date(sesionFormattedTime);
+      const sessionFormattedTime = '02/02/2019 13:45';
+      const sessionTime = new Date(sessionFormattedTime);
 
       await visit('/sessions/creation');
       await fillIn('#session-address', 'My address');
@@ -52,7 +52,7 @@ module('Acceptance | Session creation', function(hooks) {
       await click('button[type="submit"]');
 
       // then
-      const session = server.db.sessions[0];
+      const session = server.schema.sessions.findBy({ date: sessionDate });
       assert.equal(session.address, 'My address');
       assert.equal(session.room, 'My room');
       assert.equal(session.examiner, 'My examiner');
@@ -62,15 +62,18 @@ module('Acceptance | Session creation', function(hooks) {
       assert.equal(currentURL(), `/sessions/${session.id}`);
     });
 
-    test('it should go back to sessions list on cancel', async function(assert) {
+    test('it should go back to sessions list on cancel without creating any sessions', async function(assert) {
       // given
+      const previousSessionsCount = server.schema.sessions.all().length;
       await visit('/sessions/creation');
 
       // when
       await click('.button--no-color');
 
       // then
+      const actualSessionsCount = server.schema.sessions.all().length;
       assert.equal(currentURL(), '/sessions/liste');
+      assert.equal(previousSessionsCount, actualSessionsCount);
     });
   });
 });

--- a/certif/tests/acceptance/session-update-test.js
+++ b/certif/tests/acceptance/session-update-test.js
@@ -21,9 +21,9 @@ module('Acceptance | Session Update', function(hooks) {
     });
   });
 
-  test('it should allow to update a session and redirect to the session #1 details', async function(assert) {
+  test('it should allow to update a session and redirect to the session details', async function(assert) {
     // given
-    const session = server.create('session', { id: 1, date: '2010-10-12', time: '13:00' });
+    const session = server.create('session', { room: 'beforeRoom', examiner: 'beforeExaminer' });
     const newRoom = 'New room';
     const newExaminer = 'New examiner';
 
@@ -35,14 +35,15 @@ module('Acceptance | Session Update', function(hooks) {
     await click('button[type="submit"]');
 
     // then
-    assert.equal(server.db.sessions.find(1).room, newRoom);
-    assert.equal(server.db.sessions.find(1).examiner, newExaminer);
+    session.reload();
+    assert.equal(session.room, newRoom);
+    assert.equal(session.examiner, newExaminer);
     assert.equal(currentURL(), `/sessions/${session.id}`);
   });
 
   test('it should not update a session when cancel button is clicked and redirect to the session #1 details', async function(assert) {
     // given
-    const session = server.create('session', { id: 1, room: 'current room', examiner: 'current examiner', date: '2010-10-12', time: '13:00' });
+    const session = server.create('session', { room: 'beforeRoom', examiner: 'beforeExaminer' });
     const newRoom = 'New room';
     const newExaminer = 'New examiner';
 
@@ -54,8 +55,9 @@ module('Acceptance | Session Update', function(hooks) {
     await click('button[data-action="cancel"]');
 
     // then
-    assert.equal(server.db.sessions.find(1).room, 'current room');
-    assert.equal(server.db.sessions.find(1).examiner, 'current examiner');
+    session.reload();
+    assert.equal(session.room, 'beforeRoom');
+    assert.equal(session.examiner, 'beforeExaminer');
     assert.equal(currentURL(), `/sessions/${session.id}`);
   });
 });

--- a/certif/tests/acceptance/terms-of-service-test.js
+++ b/certif/tests/acceptance/terms-of-service-test.js
@@ -9,12 +9,10 @@ import {
   createUserWithMembership,
   createUserWithMembershipAndTermsOfServiceAccepted
 } from '../helpers/test-init';
-import { Response } from 'ember-cli-mirage';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | terms-of-service', function(hooks) {
-
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -44,25 +42,17 @@ module('Acceptance | terms-of-service', function(hooks) {
 
     test('it should send request for saving Pix-certif terms of service acceptation when submitting', async function(assert) {
       // given
-      let pixCertifTermsOfServiceAccepted = null;
-      server.patch('/users/:id/pix-certif-terms-of-service-acceptance', () => {
-        pixCertifTermsOfServiceAccepted = true;
-        return new Response(200, { some: 'header' }, {
-          data: [{
-            type: 'users',
-            id: user.id,
-            attributes: { 'pix-certif-terms-of-service-accepted': pixCertifTermsOfServiceAccepted }
-          }]
-        });
-      });
-
+      const previousPixCertifTermsOfServiceVal = user.pixCertifTermsOfServiceAccepted;
       await visit('/cgu');
 
       // when
       await click('button[type=submit]');
 
       // then
-      assert.equal(pixCertifTermsOfServiceAccepted, true);
+      user.reload();
+      const actualPixCertifTermsOfServiceVal = user.pixCertifTermsOfServiceAccepted;
+      assert.equal(actualPixCertifTermsOfServiceVal, true);
+      assert.equal(previousPixCertifTermsOfServiceVal, false);
     });
 
     test('it should redirect to session list after saving terms of service acceptation', async function(assert) {

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -1,17 +1,20 @@
 export function createUserWithMembership() {
-  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixCertifTermsOfServiceAccepted': false });
-
+  const user = server.create('user', {
+    firstName: 'Harry',
+    lastName: 'Cover',
+    email: 'harry@cover.com',
+    'pixCertifTermsOfServiceAccepted': false,
+  });
   const certificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification du pix'
+    name: 'Centre de certification du pix',
   });
-
-  const memberships = server.create('certificationCenterMembership', {
-    certificationCenterId: certificationCenter.id,
+  const certificationCenterMembership = server.create('certificationCenterMembership', {
     certificationCenter,
-    userId: user.id
+    user,
   });
+  user.certificationCenterMemberships = [certificationCenterMembership];
+  user.save();
 
-  user.certificationCenterMemberships = [memberships];
   return user;
 }
 
@@ -20,18 +23,17 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
-    'pixCertifTermsOfServiceAccepted': true
+    'pixCertifTermsOfServiceAccepted': true,
   });
-
   const certificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification du pix'
+    name: 'Centre de certification du pix',
   });
-
-  const memberships = server.create('certificationCenterMembership', {
-    certificationCenterId: certificationCenter.id,
-    userId: user.id
+  const certificationCenterMembership = server.create('certificationCenterMembership', {
+    certificationCenter,
+    user,
   });
+  user.certificationCenterMemberships = [certificationCenterMembership];
+  user.save();
 
-  user.certificationCenterMemberships = [memberships];
   return user;
 }

--- a/certif/tests/integration/components/routes/authenticated/sessions/details/certification-candidates-tab-test.js
+++ b/certif/tests/integration/components/routes/authenticated/sessions/details/certification-candidates-tab-test.js
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import _ from 'lodash';
-
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/session | certification-candidates-tab', function(hooks) {
@@ -39,8 +38,8 @@ module('Integration | Component | routes/authenticated/session | certification-c
   test('it should display the list of certification candidates', async function(assert) {
     // given
     const certificationCandidates = _.map([
-      { firstName: 'A', lastName: 'B', birthdate: '1990-01-01', birthCity: 'Ville', email: 'a@b.c', birthProvinceCode: 'Dep01', birthCountry: 'Pays', extraTimePercentage: 0.3 },
-      { firstName: 'C', lastName: 'D', birthdate: '1990-12-25', birthCity: 'LABA', externalId: 'CDLABA' }
+      { id: 1, firstName: 'A', lastName: 'B', birthdate: '1990-01-01', birthCity: 'Ville', email: 'a@b.c', birthProvinceCode: 'Dep01', birthCountry: 'Pays', extraTimePercentage: 0.3 },
+      { id: 2, firstName: 'C', lastName: 'D', birthdate: '1990-12-25', birthCity: 'LABA', externalId: 'CDLABA' }
     ], (certificationCandidate) => run(() => store.createRecord('certification-candidate', certificationCandidate)));
     this.set('certificationCandidates', certificationCandidates);
 
@@ -48,24 +47,24 @@ module('Integration | Component | routes/authenticated/session | certification-c
     await render(hbs`{{routes/authenticated/sessions/details/certification-candidates-tab certificationCandidates=certificationCandidates importAllowed=true importCertificationCandidates=importCertificationCandidatesSpy}}`);
 
     // then
-    assert.dom('[data-test-id="panel-candidate__lastName"]').hasText('B');
-    assert.dom('[data-test-id="panel-candidate__firstName"]').hasText('A');
-    assert.dom('[data-test-id="panel-candidate__birthdate"]').hasText('01/01/1990');
-    assert.dom('[data-test-id="panel-candidate__birthCity"]').hasText('Ville');
-    assert.dom('[data-test-id="panel-candidate__birthProvinceCode"]').hasText('Dep01');
-    assert.dom('[data-test-id="panel-candidate__birthCountry"]').hasText('Pays');
-    assert.dom('[data-test-id="panel-candidate__email"]').hasText('a@b.c');
-    assert.dom('[data-test-id="panel-candidate__externalId"]').hasText('');
-    assert.dom('[data-test-id="panel-candidate__extraTimePercentage"]').hasText('30 %');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__lastName"]').hasText('D');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__firstName"]').hasText('C');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__birthdate"]').hasText('25/12/1990');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__birthCity"]').hasText('LABA');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__birthProvinceCode"]').hasText('');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__birthCountry"]').hasText('');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__email"]').hasText('');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__externalId"]').hasText('CDLABA');
-    assert.dom('tr:nth-child(2) [data-test-id="panel-candidate__extraTimePercentage"]').hasText('');
+    assert.dom('[data-test-id="panel-candidate__lastName__1"]').hasText('B');
+    assert.dom('[data-test-id="panel-candidate__firstName__1"]').hasText('A');
+    assert.dom('[data-test-id="panel-candidate__birthdate__1"]').hasText('01/01/1990');
+    assert.dom('[data-test-id="panel-candidate__birthCity__1"]').hasText('Ville');
+    assert.dom('[data-test-id="panel-candidate__birthProvinceCode__1"]').hasText('Dep01');
+    assert.dom('[data-test-id="panel-candidate__birthCountry__1"]').hasText('Pays');
+    assert.dom('[data-test-id="panel-candidate__email__1"]').hasText('a@b.c');
+    assert.dom('[data-test-id="panel-candidate__externalId__1"]').hasText('');
+    assert.dom('[data-test-id="panel-candidate__extraTimePercentage__1"]').hasText('30 %');
+    assert.dom('[data-test-id="panel-candidate__lastName__2"]').hasText('D');
+    assert.dom('[data-test-id="panel-candidate__firstName__2"]').hasText('C');
+    assert.dom('[data-test-id="panel-candidate__birthdate__2"]').hasText('25/12/1990');
+    assert.dom('[data-test-id="panel-candidate__birthCity__2"]').hasText('LABA');
+    assert.dom('[data-test-id="panel-candidate__birthProvinceCode__2"]').hasText('');
+    assert.dom('[data-test-id="panel-candidate__birthCountry__2"]').hasText('');
+    assert.dom('[data-test-id="panel-candidate__email__2"]').hasText('');
+    assert.dom('[data-test-id="panel-candidate__externalId__2"]').hasText('CDLABA');
+    assert.dom('[data-test-id="panel-candidate__extraTimePercentage__2"]').hasText('');
   });
 
   test('it should display a sentence when there is no certification candidates yet', async function(assert) {

--- a/certif/tests/integration/components/routes/authenticated/sessions/details/certification-candidates-tab-test.js
+++ b/certif/tests/integration/components/routes/authenticated/sessions/details/certification-candidates-tab-test.js
@@ -18,6 +18,24 @@ module('Integration | Component | routes/authenticated/session | certification-c
     });
   });
 
+  test('it should display a download button', async function(assert) {
+    // when
+    await render(hbs`{{routes/authenticated/sessions/details/certification-candidates-tab certificationCandidates=certificationCandidates importAllowed=true importCertificationCandidates=importCertificationCandidatesSpy}}`);
+
+    // then
+    assert.dom('[data-test-id="attendance_sheet_download_button"]').exists();
+    assert.dom('[data-test-id="attendance_sheet_download_button"]').hasText('Télécharger (.ods)');
+  });
+
+  test('it should display an upload button', async function(assert) {
+    // when
+    await render(hbs`{{routes/authenticated/sessions/details/certification-candidates-tab certificationCandidates=certificationCandidates importAllowed=true importCertificationCandidates=importCertificationCandidatesSpy}}`);
+
+    // then
+    assert.dom('[data-test-id="attendance_sheet_upload_button"]').exists();
+    assert.dom('[data-test-id="attendance_sheet_upload_button"]').hasText('Importer (.ods)');
+  });
+
   test('it should display the list of certification candidates', async function(assert) {
     // given
     const certificationCandidates = _.map([


### PR DESCRIPTION
## :unicorn: Problème
Le bouton de finalisation de session est accessible même lorsqu'il n'a pas lieu d'être, c'est-à-dire même lorsqu'aucun candidat n'est finalisable (n'as pas encore passé sa certif)

## :robot: Solution
Tant qu'aucun candidat n'a été lié à un user, on cache le bouton

## :rainbow: Remarques
Cette PR améliore (un peu) le setup Mirage sur PixCertif
