### PR TITLE
[FEATURE] Ajouter la colonne "Statut" à la liste des sessions de Certif (PC-96).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -1,8 +1,10 @@
 import { notEmpty } from '@ember/object/computed';
 import Controller from '@ember/controller';
+import config from '../../../config/environment';
 
 export default Controller.extend({
   hasSession: notEmpty('model'),
+  isSessionFinalizationActive: config.APP.isSessionFinalizationActive,
 
   actions: {
     goToDetails(sessionId) {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -4,6 +4,11 @@ import { equal } from '@ember/object/computed';
 import ENV from 'pix-certif/config/environment';
 import { inject as service } from '@ember/service';
 
+const statusToDisplayName = {
+  started: 'Prête',
+  finalized: 'Finalisée',
+};
+
 export default DS.Model.extend({
   address: DS.attr(),
   accessCode: DS.attr(),
@@ -28,6 +33,10 @@ export default DS.Model.extend({
 
   urlToUpload: computed('id', function() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.get('id')}/certification-candidates/import`;
+  }),
+
+  displayStatus: computed('status', function() {
+    return statusToDisplayName[this.status];
   }),
 
   finalize() {

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -3,6 +3,7 @@
     {{routes/authenticated/sessions/list-items
       sessions=model
       goToDetails=(action 'goToDetails')
+      isSessionFinalizationActive=isSessionFinalizationActive
     }}
   {{else}}
     {{routes/authenticated/sessions/no-session-panel}}

--- a/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
@@ -20,7 +20,9 @@
           <th class="table__column">Date</th>
           <th class="table__column table__column--small">Heure</th>
           <th class="table__column table__column--wide">Surveillant(s)</th>
-          <th class="table__column table__column--wide">Statut</th>
+          {{#if isSessionFinalizationActive }}
+            <th class="table__column table__column--wide">Statut</th>
+          {{/if}}
         </tr>
       </thead>
 
@@ -33,7 +35,9 @@
             <td>{{moment-format session.date 'DD/MM/YYYY' allow-empty=true}}</td>
             <td>{{moment-format session.time 'HH:mm' 'HH:mm:ss' allow-empty=true}}</td>
             <td>{{session.examiner}}</td>
-            <td>{{session.displayStatus}}</td>
+            {{#if isSessionFinalizationActive }}
+              <td>{{session.displayStatus}}</td>
+            {{/if}}
           </tr>
         {{/each}}
       </tbody>

--- a/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
+++ b/certif/app/templates/components/routes/authenticated/sessions/list-items.hbs
@@ -20,6 +20,7 @@
           <th class="table__column">Date</th>
           <th class="table__column table__column--small">Heure</th>
           <th class="table__column table__column--wide">Surveillant(s)</th>
+          <th class="table__column table__column--wide">Statut</th>
         </tr>
       </thead>
 
@@ -32,6 +33,7 @@
             <td>{{moment-format session.date 'DD/MM/YYYY' allow-empty=true}}</td>
             <td>{{moment-format session.time 'HH:mm' 'HH:mm:ss' allow-empty=true}}</td>
             <td>{{session.examiner}}</td>
+            <td>{{session.displayStatus}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -56,7 +56,7 @@ module('Acceptance | Session List', function(hooks) {
       assert.dom('.page-title').hasText('Créez votre première session de certification');
     });
 
-    test('it should list the sessions', async function(assert) {
+    test('it should list the sessions and their attributes', async function(assert) {
       // given
       server.createList('session', 12, { certificationCenterId });
 
@@ -65,6 +65,7 @@ module('Acceptance | Session List', function(hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: 12 });
+      assert.dom('table tbody tr:first-child').hasText('1 Centre Mozart Salle Timbanque 23/02/2019 14:00 Leslie Prête');
     });
 
     test('it should redirect to detail page of session id 1 on click on first row', async function(assert) {

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -18,4 +18,19 @@ module('Unit | Model | session', function(hooks) {
     }));
     assert.equal(model.id, 123);
   });
+
+  test('it should return the correct displayName', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model1 = run(() => store.createRecord('session', {
+      id: 123,
+      status: 'started',
+    }));
+    const model2 = run(() => store.createRecord('session', {
+      id: 1234,
+      status: 'finalized',
+    }));
+
+    assert.equal(model1.displayStatus, 'Prête');
+    assert.equal(model2.displayStatus, 'Finalisée');
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
La liste des sessions de status n'affichait pas le statut des sessions.

## :robot: Solution
Ajouter cette colonne :
![image](https://user-images.githubusercontent.com/4154003/71666599-e416d280-2d61-11ea-9096-ea9d6b9fba73.png)