### PR TITLE
[TECH] Tentative d'amélioration du temps pris par les tests auto API

### DIFF
--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -490,7 +490,6 @@ describe('Acceptance | API | Certification Course', () => {
         await knex('knowledge-elements').delete();
         await knex('answers').delete();
         await knex('assessments').delete();
-        await databaseBuilder.clean();
         airtableBuilder.cleanAll();
         cache.flushAll();
       });
@@ -529,10 +528,6 @@ describe('Acceptance | API | Certification Course', () => {
 
         // when
         response = await server.inject(options);
-      });
-
-      afterEach(() => {
-        return databaseBuilder.clean();
       });
 
       it('should respond with 200 status code', () => {

--- a/api/tests/acceptance/application/security-controller_test.js
+++ b/api/tests/acceptance/application/security-controller_test.js
@@ -1,5 +1,6 @@
-const { expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../test-helper');
 const createServer = require('../../../server');
+const Membership = require('../../../lib/domain/models/Membership');
 
 describe('Acceptance | Interface | Controller | SecurityController', function() {
 
@@ -11,7 +12,7 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
 
   describe('#checkUserIsAuthenticated', () => {
 
-    it('should disallow access resource with well formed JSON API error', () => {
+    it('should disallow access resource with well formed JSON API error', async () => {
       // given
       const options = {
         method: 'POST',
@@ -20,26 +21,24 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
       };
 
       // when
-      const promise = server.inject(options);
+      const response = await server.inject(options);
 
       // then
-      return promise.then((response) => {
-        const jsonApiError = {
-          errors: [{
-            code: 401,
-            title: 'Unauthorized access',
-            detail: 'Missing or invalid access token in request auhorization headers.'
-          }]
-        };
-        expect(response.statusCode).to.equal(401);
-        expect(response.result).to.deep.equal(jsonApiError);
-      });
+      const jsonApiError = {
+        errors: [{
+          code: 401,
+          title: 'Unauthorized access',
+          detail: 'Missing or invalid access token in request auhorization headers.'
+        }]
+      };
+      expect(response.statusCode).to.equal(401);
+      expect(response.result).to.deep.equal(jsonApiError);
     });
   });
 
   describe('#checkUserHasRolePixMaster', () => {
 
-    it('should return a well formed JSON API error when user in not authorized', () => {
+    it('should return a well formed JSON API error when user is not authorized', async () => {
       // given
       const options = {
         method: 'GET',
@@ -48,20 +47,244 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
       };
 
       // when
-      const promise = server.inject(options);
+      const response = await server.inject(options);
 
       // then
-      return promise.then((response) => {
-        const jsonApiError = {
-          errors: [{
-            code: 403,
-            title: 'Forbidden access',
-            detail: 'Missing or insufficient permissions.'
-          }]
-        };
-        expect(response.statusCode).to.equal(403);
-        expect(response.result).to.deep.equal(jsonApiError);
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+  });
+
+  describe('#checkRequestedUserIsAuthenticatedUser', () => {
+
+    it('should return a well formed JSON API error when user in query params is not the same as authenticated', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/users/1/memberships',
+        headers: { authorization: generateValidRequestAuthorizationHeader(2) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+  });
+
+  describe('#checkUserBelongsToScoOrganizationAndManagesStudents', () => {
+    let userId;
+    let organizationId;
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is in a not sco organization', async () => {
+      // given
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/students`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+    it('should return a well formed JSON API error when user is in a sco orga that does not manage students', async () => {
+      // given
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false }).id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/students`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+  });
+
+  describe('#checkUserIsAdminInOrganization', () => {
+
+    it('should return a well formed JSON API error when user is not admin in orga', async () => {
+      // given
+      const notAdminUserId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({
+        userId: notAdminUserId,
+        organizationId,
+        organizationRole: Membership.roles.MEMBER,
       });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/invitations`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+  });
+
+  describe('#checkUserIsAdminInOrganizationOrHasRolePixMaster', () => {
+
+    it('should return a well formed JSON API error when user is neither admin nor pix_master', async () => {
+      // given
+      const notAdminUserId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({
+        userId: notAdminUserId,
+        organizationId,
+        organizationRole: Membership.roles.MEMBER,
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/memberships`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+  });
+
+  describe('#checkUserIsAdminInScoOrganizationAndManagesStudents', () => {
+
+    it('should return a well formed JSON API error when user is not in sco managing students orga', async () => {
+      // given
+      const notAdminUserId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
+      databaseBuilder.factory.buildMembership({
+        userId: notAdminUserId,
+        organizationId,
+        organizationRole: Membership.roles.MEMBER,
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'POST',
+        url: `/api/organizations/${organizationId}/import-students`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+
+    it('should return a well formed JSON API error when user is in sco managing students orga but not admin', async () => {
+      // given
+      const notAdminUserId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      databaseBuilder.factory.buildMembership({
+        userId: notAdminUserId,
+        organizationId,
+        organizationRole: Membership.roles.MEMBER,
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'POST',
+        url: `/api/organizations/${organizationId}/import-students`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
     });
 
   });

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_test.js
@@ -198,10 +198,6 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
         return databaseBuilder.commit();
       });
 
-      afterEach(() => {
-        return databaseBuilder.clean();
-      });
-
       it('should respond with a 400 when user cant import the candidates', async () => {
         // when
         const response = await server.inject(options);

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -635,10 +635,6 @@ describe('Integration | Repository | CertificationCandidate', function() {
       return databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return databaseBuilder.clean();
-    });
-
     context('when there are candidates in the session that are already linked to a user', () => {
 
       beforeEach(() => {

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -2,7 +2,7 @@ const INITIAL_ID = 100000;
 
 module.exports = {
   objectsToInsert: [],
-  objectsToDelete: [],
+  tablesToDelete: [],
   nextId: INITIAL_ID,
 
   pushInsertable({ tableName, values }) {
@@ -16,6 +16,6 @@ module.exports = {
 
   purge() {
     this.objectsToInsert = [];
-    this.objectsToDelete = [];
+    this.tablesToDelete = [];
   },
 };

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -29,14 +29,14 @@ module.exports = class DatabaseBuilder {
   }
 
   async clean() {
-    if (this.databaseBuffer.tablesToDelete.length > 0) {
-      const trx = await this.knex.transaction();
-      for (const table of this.databaseBuffer.tablesToDelete) {
-        await trx(table).delete();
-      }
+    let rawQuery = '';
+    _.times(this.databaseBuffer.tablesToDelete.length, () => {
+      rawQuery += 'DELETE FROM ??;';
+    });
+    if (rawQuery !== '') {
+      await this.knex.raw(rawQuery, this.databaseBuffer.tablesToDelete);
       this.databaseBuffer.purge();
       this._purgeDirtiness();
-      await trx.commit();
     }
   }
 

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -1,11 +1,13 @@
 const databaseBuffer = require('./database-buffer');
 const factory = require('./factory/index');
 const knexDatabaseConnection = require('../../../db/knex-database-connection');
+const _ = require('lodash');
 
 module.exports = class DatabaseBuilder {
   constructor({ knex }) {
     this.knex = knex;
     this.databaseBuffer = databaseBuffer;
+    this.tablesOrderedByDependencyWithDirtinessMap = [];
     this.factory = factory;
     this.isFirstCommit = true;
   }
@@ -13,25 +15,54 @@ module.exports = class DatabaseBuilder {
   async commit() {
     if (this.isFirstCommit) {
       await knexDatabaseConnection.emptyAllTables();
+      await this._initTablesOrderedByDependencyWithDirtinessMap();
       this.isFirstCommit = false;
     }
     const trx = await this.knex.transaction();
     for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
       await trx(objectToInsert.tableName).insert(objectToInsert.values);
-      this.databaseBuffer.objectsToDelete.unshift(objectToInsert);
+      this._setTableAsDirty(objectToInsert.tableName);
     }
     this.databaseBuffer.objectsToInsert = [];
+    this.databaseBuffer.tablesToDelete = this._selectDirtyTables();
     await trx.commit();
   }
 
   async clean() {
-    if (this.databaseBuffer.objectsToDelete.length > 0) {
+    if (this.databaseBuffer.tablesToDelete.length > 0) {
       const trx = await this.knex.transaction();
-      for (const objectToDelete of this.databaseBuffer.objectsToDelete) {
-        await trx(objectToDelete.tableName).where({ id: objectToDelete.values.id }).delete();
+      for (const table of this.databaseBuffer.tablesToDelete) {
+        await trx(table).delete();
       }
       this.databaseBuffer.purge();
+      this._purgeDirtiness();
       await trx.commit();
     }
+  }
+
+  async _initTablesOrderedByDependencyWithDirtinessMap() {
+    const dependencyOrderedTables = await knexDatabaseConnection.listTablesByDependencyOrderDesc();
+    this.tablesOrderedByDependencyWithDirtinessMap = _.map(dependencyOrderedTables, (table) => {
+      return {
+        table,
+        isDirty: false,
+      };
+    });
+  }
+
+  _setTableAsDirty(table) {
+    const tableWithDirtiness = _.find(this.tablesOrderedByDependencyWithDirtinessMap, { table });
+    tableWithDirtiness.isDirty = true;
+  }
+
+  _selectDirtyTables() {
+    const dirtyTableObjects = _.filter(this.tablesOrderedByDependencyWithDirtinessMap, { isDirty: true });
+    return _.map(dirtyTableObjects, 'table');
+  }
+
+  _purgeDirtiness() {
+    _.each(this.tablesOrderedByDependencyWithDirtinessMap, (table) => {
+      table.isDirty = false;
+    });
   }
 };


### PR DESCRIPTION
## :unicorn: Problème
Comparatif de durée de tests API entre le commit (4 septembre 2019) https://github.com/1024pix/pix/commit/ba4b06a887597d1287bfe32b0491f98b66cff2cb et (aujourd'hui) https://github.com/1024pix/pix/commit/a2e45ffca9acce2964649fddc875a242c5ca61b8 :

https://github.com/1024pix/pix/commit/ba4b06a887597d1287bfe32b0491f98b66cff2cb

| Catégorie | Nombre de tests | Durée (secondes) |
| --- | --- | --- |
| Unitaire | 2192 | 3.354 |
| Intégration | 415 | 10.148 |
| Acceptance | 251 | 14.889 |
| `npm t` | 2878 | 26.971 |

https://github.com/1024pix/pix/commit/a2e45ffca9acce2964649fddc875a242c5ca61b8

| Catégorie | Nombre de tests | Durée (secondes) |
| --- | --- | --- |
| Unitaire | 2200 | 4.123 |
| Intégration | 526 | 10.623 |
| Acceptance | 354 | 23.521 |
| `npm t` | 3100 | 38.041 |

On remarque de gros ralentissements sur les tests d'acceptance mais aussi, même si il ne s'agit que d'une seconde, du ralentissement sur des tests unitaires (or il n'y en a pas beaucoup plus qu'avant ?)...

## :robot: Solution
1) A la fin de chaque test, la fonction `databaseBuilder.clean()` est appelée. Elle est chargée de supprimer les enregistrements en respectant l'ordre dans lesquels ils ont été insérés via le `databaseBuilder.commit()`. Or, cela peut créer du travail en plus :
Imaginons un test qui fabrique 10 `certification-candidates` pour les besoins de son exécution. Lors de son appel au `clean()`, on va exécuter 10 fois une requête de type `DELETE FROM 'certification-candidates' WHERE id = ?`. On irait plus vite en supprimant carrément le contenu de la table, car de toute façon le contenu de la table ne doit pas être important d'un test à l'autre.

2) On évite de tester à répétition les comportements des préhandlers. Typiquement, le test de savoir si la route renvoie bien un 401 quand l'utilisateur n'est pas authentifié est un comportement déjà testé à la fois en unitaire et en acceptance dans le `securityController`.
Réduction du nombre de tests d'acceptance : 354 -> 290
EDIT : La partie 2) de la solution a été pour le moment retiré de la PR. Cela dit, il serait intéressant de faire une autre PR pour s'occuper des cas d'erreurs 40x de façon moins lourde en acceptance, selon la proposition de @sroccaserra .

Résultats :

| Catégorie | Durée (secondes) |
| --- | --- |
| Unitaire | 3.833 |
| Intégration | 9.19 |
| Acceptance | 19.652 |
| `npm t` | 31.251 |

## :rainbow: Remarques
Vous allez voir une requête RAW SQL un peu violente dans le fichier `knexdatabase-connection.js`, elle permet de récupérer la liste des tables d'une base selon l'ordre de dépendance de leurs FK. Comme ça, on s'assure de supprimer le contenu des tables selon un ordre qui ne fera pas lever d'exception sur la violation de contrainte.
