### PR TITLE
[FEATURE] Forcer la mise en majuscule du code d'accès à la session (PF-885)

### DIFF
--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -36,6 +36,7 @@
   $space-between-dashes: 0.6ch;
   $nb-characters: 6;
   $total-width: $nb-characters * (1ch + $space-between-dashes);
+  text-transform: uppercase;
   box-sizing: content-box;
   border: solid 2px $alto-grey;
   border-radius: 3px;


### PR DESCRIPTION
## :unicorn: Problème
Le ticket lié à cette PR évoque en fait 2 problèmes :
1) Sous Firefox, le champ de code d'accès à la session est encadré en rouge
2) On veut forcer la majuscule dans le champ de code d'accès

## :robot: Solution
1) Pas réussi à reproduire
2) Forçage de la majuscule réalisé

## :rainbow: Remarques
REVUE FONC : Tester la non-régression du champ sous tous les navigateurs.
