### PR TITLE
[FEATURE] Non validation des CGU lors de la création d'un utilisateur provenant du GAR (PF-820)

### DIFF
--- a/api/lib/domain/usecases/get-or-create-saml-user.js
+++ b/api/lib/domain/usecases/get-or-create-saml-user.js
@@ -25,7 +25,7 @@ module.exports = async function getOrCreateSamlUser({
       lastName: _getLastName(userAttributes),
       samlId: _getSamlId(userAttributes),
       password: '',
-      cgu: true
+      cgu: false
     });
 
     return user;

--- a/api/tests/unit/domain/usecases/get-or-create-saml-user_test.js
+++ b/api/tests/unit/domain/usecases/get-or-create-saml-user_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | get-or-create-saml-user', () => {
     lastName: 'Lopez',
     samlId: 'saml-id-for-adele',
     password: '',
-    cgu: true,
+    cgu: false,
   });
 
   const settings = {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque un étudiant se connecte à Pix via le GAR, un utilisateur est crée en base avec le champ "cgu" à true. Or, cet étudiant n'a jamais réellement accepté les CGU.  

## :robot: Solution
Lors de la création de l'utilisateur pour un étudiant accédant à Pix depuis le GAR, les CGU ne doivent pas être validées par défaut.
