### PR TITLE
[BUGFIX] Rendre le champ e-mail obligatoire lors d'une invitation (PO-319).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,3 +1,5 @@
+const Joi = require('@hapi/joi');
+
 const securityController = require('../../interfaces/controllers/security-controller');
 const organisationController = require('./organization-controller');
 const snapshotsAuthorization = require('../../application/preHandlers/snapshot-authorization');
@@ -162,6 +164,18 @@ exports.register = async (server) => {
           assign: 'isAdminInOrganizationOrHasRolePixMaster'
         }],
         handler: organisationController.sendInvitations,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                email: Joi.string().email({ multiple: true }).required(),
+              }
+            }
+          })
+        },
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés en tant que responsables de l\'organisation ou ayant le rôle Pix Master**\n' +
           '- Elle permet d\'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d\'une organisation, via leur **email**'

--- a/orga/app/templates/components/routes/authenticated/team/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/team/new-item.hbs
@@ -9,6 +9,8 @@
       @class="input"
       @value={{organizationInvitation.email}}
       @multiple=true
+      @aria-required="true"
+      @required="required"
     />
   </div>
 

--- a/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | routes/authenticated/team/new-item', function(
 
     // then
     assert.dom('#email').exists();
+    assert.dom('#email').isRequired();
     assert.dom('button[type="submit"]').exists();
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, lors d'une invitation, il est possible d'utiliser une adresse e-mail vide !

## :robot: Solution
1. Rendre ce champ obligatoirement rempli, avant d'envoyer l'invitation. 
2. Ajouter une pré-validation côté API.