### PR TITLE
[BUGFIX] Modifier l'affichage du bouton "Connectez-vous" afin qu'il n'apparaisse pas sur deux lignes (PF-1006)

### DIFF
--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -40,7 +40,7 @@
         Votre mot de passe a été modifié avec succès.
       </div>
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        {{#link-to 'login' class="button button--link button--uppercase button--thin button--round button--big"}}
+        {{#link-to 'login' class="button button--link button--uppercase button--thin button--round"}}
           connectez-vous{{/link-to}}
       </div>
     </div>


### PR DESCRIPTION
## :unicorn: Problème
Suite au changement de la font-size de la classe "button--uppercase", le texte du bouton "Connectez-vous" de la page https://app.pix.fr/changer-mot-de-passe/{key} se retrouve sur deux lignes. 

## :robot: Solution
Modifier le design afin que le texte du bouton ne s'affiche que sur une seule ligne.