### PR TITLE
Widget pix-toogle and add it to register form

### DIFF
--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -36,6 +36,7 @@ export default Component.extend({
   isPasswordVisible: false,
   require: false,
   help: '',
+  disabled: false,
 
   onValidate: () => {},
 

--- a/mon-pix/app/components/pix-toggle.js
+++ b/mon-pix/app/components/pix-toggle.js
@@ -1,0 +1,26 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+
+  valueFirstLabel: '',
+  valueSecondLabel: '',
+  isFirstOn: true,
+
+  firstButtonClass: computed ('isFirstOn', function() {
+    return this.get('isFirstOn') ? 'pix-toogle__on' : 'pix-toogle__off';
+  }),
+
+  secondButtonClass: computed ('isFirstOn', function() {
+    return this.get('isFirstOn') ? 'pix-toogle__off' : 'pix-toogle__on';
+  }),
+
+  actions: {
+    onToggle: function(e) {
+      if (e.target.className === 'pix-toogle__off') {
+        this.toggleProperty('isFirstOn');
+        //this.sendAction('onToggle', this.get('isFirstOn'));
+      }
+    },
+  }
+});

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import { inject } from '@ember/service';
 
 import isEmailValid from '../../utils/email-validator';
+import isUsernameValid from '../../utils/username-validator';
 import isPasswordValid from '../../utils/password-validator';
 
 const ERROR_INPUT_MESSAGE_MAP = {
@@ -25,6 +26,10 @@ const validation = {
     status: 'default',
     message: null
   },
+  username: {
+    status: 'default',
+    message: null
+  },
   password: {
     status: 'default',
     message: null
@@ -44,9 +49,14 @@ export default Component.extend({
   isLoading: false,
   validation: validation,
   isPasswordVisible: false,
+  loginWithEmail: true,
 
   passwordInputType: computed('isPasswordVisible', function() {
     return this.isPasswordVisible ? 'text' : 'password';
+  }),
+  username: computed('user.{firstName,lastName}', function() {
+
+    return `${this.get('user.firstName')}${this.get('user.lastName')}`;
   }),
 
   init() {
@@ -55,11 +65,16 @@ export default Component.extend({
       lastName: '',
       firstName: '',
       email: '',
+      username: '',
       password: ''
     });
   },
 
   actions: {
+
+    updateLoginMode(data) {
+      this.set('loginWithEmail',data);
+    },
     async register() {
       this.set('isLoading', true);
       try {
@@ -87,7 +102,9 @@ export default Component.extend({
     validateInputEmail(key, value) {
       this._executeFieldValidation(key, value, isEmailValid);
     },
-
+    validateInputUsername(key, value) {
+      this._executeFieldValidation(key, value, isUsernameValid);
+    },
     validateInputPassword(key, value) {
       this._executeFieldValidation(key, value, isPasswordValid);
     },

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -82,6 +82,7 @@
 @import 'components/user-logged-menu';
 @import 'components/warning-banner';
 @import 'components/warning-timing-page';
+@import 'components/pix-toggle';
 
 /* pages */
 @import 'pages/assessment-challenge';

--- a/mon-pix/app/styles/components/_pix-toggle.scss
+++ b/mon-pix/app/styles/components/_pix-toggle.scss
@@ -1,0 +1,36 @@
+.pix-toogle {
+
+  margin-top: 20px;
+  font-family:  Roboto,sans-serif;
+  font-size: 1.6rem;
+  font-weight: 500;
+  letter-spacing: 0.45px;
+  color: #585F75;
+  border: 2px solid RGB(221,221,221);
+  height: 44px;
+  width: 359px;
+  display: flex;
+  text-align: center;
+  border-radius: 12px;
+  cursor: pointer;
+
+  &__on{
+    width: 50%;
+    vertical-align: middle;
+    line-height: 4.4rem;
+    background-color: #585f75;
+    border-radius: 10px;
+    color: white;
+  }
+
+  &__off{
+    width: 50%;
+    vertical-align: middle;
+    line-height: 4.4rem;
+    border-radius: 10px;
+
+      &:hover {
+      color:#253858;
+    }
+  }
+}

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -69,4 +69,6 @@
       margin-top: 25px;
     }
   }
+
+
 }

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -14,7 +14,9 @@
           classBinding="inputValidationStatus"
           autocomplete=autocomplete
           ariaDescribedBy='validationMessage'
-          required=require}}
+          required=require
+          disabled=disabled
+          }}
     <div class="form-textfield__icon">
       {{#if isPassword}}
           <button type="button" aria-label="rendre le mot de passe lisible" class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>

--- a/mon-pix/app/templates/components/pix-toggle.hbs
+++ b/mon-pix/app/templates/components/pix-toggle.hbs
@@ -1,0 +1,6 @@
+
+<div class="pix-toogle">
+<span class="{{firstButtonClass}}" onclick={{action 'onToggle'}}>{{valueFirstLabel}}</span>
+<span class="{{secondButtonClass}}" onclick={{action 'onToggle'}}>{{valueSecondLabel}}</span>
+</div>
+{{yield}}

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -24,6 +24,11 @@
               autocomplete="lastname"}}
     </div>
 
+    <div id="login-mode-container">
+              {{pix-toggle onToggle='updateLoginMode' valueFirstLabel='Mon adresse e-mail' valueSecondLabel='Mon identifiant'}}
+    </div>
+
+    {{#if loginWithEmail}}
     <div id="register-email-container">
       {{form-textfield
               label="Adresse e-mail"
@@ -35,7 +40,19 @@
               validationMessage=validation.email.message
               autocomplete="email"}}
     </div>
-
+    {{else}}
+    <div id="register-username-container">
+      {{form-textfield
+              label="Mon identifiant"
+              textfieldName="username"
+              validationStatus=validation.username.status
+              onValidate=(action "validateInputUsername" "username" user.username)
+              inputBindingValue=username
+              validationMessage=validation.username.message
+              autocomplete="username"
+              disabled=true}}
+    </div>
+    {{/if}}
     <div id="register-password-container">
       {{form-textfield
               label="Mot de passe"

--- a/mon-pix/app/utils/username-validator.js
+++ b/mon-pix/app/utils/username-validator.js
@@ -1,0 +1,6 @@
+export default function isUsernameValid(username) {
+  if (!username) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
🦄 Problème

Aujourd'hui, pour s'inscrire il faut obligatoirement un email. 
**Lors de l'inscription, on devrait pas obliger les élèves (hors GAR) à disposer d'un email.** 👎 


🤖 Solution

**Proposition d'un mode de login via username** 👍 

Sur la nouvelle double mire de connexion/inscription, dans la partie ‘inscription’:
Rajouter l'option:

1. L’élève peut rentrer une adresse email
2. L’élève peut choisir d’utiliser un login prédéfini sous le format ‘prenom.nom’ suivi de 4 chiffres (2 chiffres de son jour puis mois de naissance) Exemple: emmeline.barbier0601

Sur la nouvelle double mire de connexion/inscription, dans la partie ‘connexion’:
-Renommer ‘Adresse e-mail’ => ‘Adresse e-mail ou identifiant’ 

🌈 Remarques

Pour répondre à ce besoin:

(1) Coté backend:

-Pouvoir créer un utilisateur avec les deux modes username et email

(2) Coté frontend:

-Un nouveau widget Pix-Toggle
-Modifier la page register-form pour ajouter les deux options
