### PR TITLE
[FEATURE] Script de migration permettant d'invalider les CGU pour les utilisateurs provenant du GAR (PF-821)

### DIFF
--- a/api/db/migrations/20200106155510_update_cgu_for_gar_users.js
+++ b/api/db/migrations/20200106155510_update_cgu_for_gar_users.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'users';
+
+exports.up = function(knex) {
+  return knex(TABLE_NAME)
+    .whereNotNull('samlId')
+    .update({ cgu : false });
+};
+
+exports.down = function(knex) {
+  return knex(TABLE_NAME)
+    .whereNotNull('samlId')
+    .update({ cgu : true });
+};


### PR DESCRIPTION
## :unicorn: Problème
Suite à la PF-820, les utilisateurs (étudiants) se connectant à Pix depuis le GAR ne valident plus les CGU par défaut. Néanmoins, les utilisateurs créés avant ce changement ont toujours les CGU validées en base de donnée.

## :robot: Solution
Créer un script de migration afin d'invalider les CGU pour tous les utilisateurs provenant du GAR (samlId non null).