### PR TITLE
[A11Y] Ajouter des attributs ALT aux images (PF-669).

### DIFF
--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -4,5 +4,5 @@
   {{outlet}}
 
   <!-- Preloading images -->
-  <img src="{{rootURL}}/images/loader-white.svg" style="display: none">
+  <img src="{{rootURL}}/images/loader-white.svg" alt="Chargement en cours" style="display: none">
 </div>

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -9,7 +9,7 @@
         </div>
         {{#if model.organizationLogoUrl}}
           <div class="campaign-landing-page__logo">
-            <img class="campaign-landing-page__image" src="{{model.organizationLogoUrl}}" alt="Logo de l'organisation">
+            <img class="campaign-landing-page__image" src="{{model.organizationLogoUrl}}" alt="{{model.organizationName}}">
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/campaigns/start-or-resume-error.hbs
+++ b/mon-pix/app/templates/campaigns/start-or-resume-error.hbs
@@ -7,7 +7,7 @@
       </div>
       <div class="campaign-landing-page__marianne-logo">
         <img class="campaign-landing-page__image" src="{{rootURL}}/images/logo-de-la-republique-francaise.svg"
-             alt="Logo de la Marianne">
+             alt="République française">
       </div>
     </div>
     <div class="campaign-landing-page__error-text">

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -5,7 +5,7 @@
       {{pix-logo}}
     </div>
     <div class="navbar-desktop-header-logo__marianne">
-      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="Logo de la Marianne">
+      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
     </div>
   </div>
 

--- a/mon-pix/app/templates/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/templates/components/navbar-mobile-header.hbs
@@ -20,7 +20,7 @@
       {{pix-logo}}
     </div>
     <div class="navbar-mobile-header-logo__marianne">
-      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="Logo de la Marianne">
+      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
     </div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/tutorial-item-on-scorecard.hbs
+++ b/mon-pix/app/templates/components/tutorial-item-on-scorecard.hbs
@@ -5,7 +5,7 @@
   </div>
   <div class="tutorial__statistics">
     <div class="tutorial-statistics__content-type">
-      <img src="/images/icons/icon-{{formatImageName}}-on-scorecard.svg" alt="{{tutorial.format}}">
+      <img src="/images/icons/icon-{{formatImageName}}-on-scorecard.svg" alt="">
       <span>{{tutorial.format}}</span>
     </div>
     <span class="tutorial-statistics__duration">{{fa-icon 'clock'}} {{moment-duration tutorial.duration}}</span>


### PR DESCRIPTION
## :unicorn: Problème
Pour les malvoyants, ajouter un texte alternatif aux images.

## :robot: Solution
Cette PR ajoute un attribut ALT aux images qui n'ont pas encore de textes alternatifs.
