### PR TITLE
[FEATURE] Afficher une phrase de contexte (SCO) en haut de la double mire de connexion (PF-992 ).

### DIFF
--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -9,6 +9,7 @@ class Campaign {
     idPixLabel,
     createdAt,
     organizationLogoUrl,
+    organizationName,
     customLandingPageText,
     isRestricted = false,
     // includes
@@ -28,6 +29,7 @@ class Campaign {
     this.idPixLabel = idPixLabel;
     this.createdAt = createdAt;
     this.organizationLogoUrl = organizationLogoUrl;
+    this.organizationName = organizationName;
     this.customLandingPageText = customLandingPageText;
     this.isRestricted = isRestricted;
     // includes

--- a/api/lib/domain/usecases/retrieve-campaign-information.js
+++ b/api/lib/domain/usecases/retrieve-campaign-information.js
@@ -13,6 +13,7 @@ module.exports = async function retrieveCampaignInformation({
   const organizationId = foundCampaign.organizationId;
   const foundOrganization = await organizationRepository.get(organizationId);
   foundCampaign.organizationLogoUrl = foundOrganization.logoUrl;
+  foundCampaign.organizationName = foundOrganization.name;
 
   if (foundOrganization.isManagingStudents && foundOrganization.type === 'SCO') {
     foundCampaign.isRestricted = true;

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -76,7 +76,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted']);
+    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted']);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
   serialize(campaigns, { tokenForCampaignResults, ignoreCampaignReportRelationshipData = true } = {}) {
 
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted'],
+      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted'],
       transform: (record) => {
         const campaign = Object.assign({}, record);
         campaign.tokenForCampaignResults = tokenForCampaignResults;

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -81,6 +81,7 @@ describe('Acceptance | API | Campaign Controller', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data[0].attributes.code).to.equal(campaign.code);
         expect(response.result.data[0].attributes['organization-logo-url']).to.equal(organization.logoUrl);
+        expect(response.result.data[0].attributes['organization-name']).to.equal(organization.name);
         expect(response.result.data[0].attributes['is-restricted']).to.be.false;
       });
     });
@@ -107,6 +108,7 @@ describe('Acceptance | API | Campaign Controller', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data[0].attributes.code).to.equal(campaign.code);
         expect(response.result.data[0].attributes['organization-logo-url']).to.equal(organization.logoUrl);
+        expect(response.result.data[0].attributes['organization-name']).to.equal(organization.name);
         expect(response.result.data[0].attributes['is-restricted']).to.be.true;
       });
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -78,12 +78,14 @@ describe('Integration | Repository | Campaign', () => {
 
     let creatorId, organizationId, targetProfileId;
     let savedCampaign, campaignToSave;
+
     beforeEach(async () => {
       // given
       creatorId = databaseBuilder.factory.buildUser({}).id;
       organizationId = databaseBuilder.factory.buildOrganization({}).id;
       targetProfileId = databaseBuilder.factory.buildTargetProfile({}).id;
       await databaseBuilder.commit();
+
       campaignToSave = domainBuilder.buildCampaign({
         name: 'Evaluation niveau 1 recherche internet',
         code: 'BCTERD153',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -22,6 +22,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           creatorId: 3453,
           organizationId: 10293,
           organizationLogoUrl: 'some logo',
+          organizationName: 'College Victor Hugo',
           idPixLabel: 'company id',
           targetProfile: domainBuilder.buildTargetProfile({ id: '123', name: 'TargetProfile1' }),
         });
@@ -39,6 +40,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'id-pix-label': 'company id',
               'token-for-campaign-results': tokenToAccessToCampaign,
               'organization-logo-url': 'some logo',
+              'organization-name': 'College Victor Hugo',
               'is-restricted': false,
             },
             relationships: {
@@ -95,6 +97,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           creatorId: 3453,
           organizationId: 10293,
           organizationLogoUrl: 'some logo',
+          organizationName: 'College Victor Hugo',
           idPixLabel: 'company id',
           targetProfile: domainBuilder.buildTargetProfile({ id: '123', name: 'TargetProfile1' }),
           campaignReport
@@ -113,6 +116,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'id-pix-label': 'company id',
               'token-for-campaign-results': tokenToAccessToCampaign,
               'organization-logo-url': 'some logo',
+              'organization-name': 'College Victor Hugo',
               'is-restricted': false,
             },
             relationships: {

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -7,6 +7,7 @@ export default Model.extend({
   idPixLabel: attr('string'),
   title: attr('string'),
   organizationLogoUrl: attr('string'),
+  organizationName: attr('string'),
   customLandingPageText: attr('string'),
   isRestricted: attr('boolean'),
   targetProfile: belongsTo('targetProfile'),

--- a/mon-pix/app/routes/login-or-register-to-access-restricted-campaign.js
+++ b/mon-pix/app/routes/login-or-register-to-access-restricted-campaign.js
@@ -3,4 +3,9 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
 
 export default Route.extend(UnauthenticatedRouteMixin, {
 
+  async model(params) {
+    const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
+    return campaigns.firstObject;
+  }
+
 });

--- a/mon-pix/app/styles/components/_login-or-register.scss
+++ b/mon-pix/app/styles/components/_login-or-register.scss
@@ -36,6 +36,15 @@
     width: 159px;
   }
 
+  &__invitation {
+    font-family: $font-roboto;
+    font-size: 2rem;
+    font-weight: 500;
+    color: $dove-gray;
+    text-align: center;
+    margin-top: 24px;
+  }
+
   &__forms-container {
     display: flex;
     margin-top: 10px;

--- a/mon-pix/app/templates/components/routes/login-or-register.hbs
+++ b/mon-pix/app/templates/components/routes/login-or-register.hbs
@@ -3,6 +3,7 @@
     <div>
       <img src="/images/pix-logo.svg" alt="Pix" class="login-or-register-panel__logo">
     </div>
+    <span class="login-or-register-panel__invitation">{{organizationName}} vous invite à rejoindre Pix</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
         <h1 class="form-title">Je m’inscris sur Pix</h1>

--- a/mon-pix/app/templates/login-or-register-to-access-restricted-campaign.hbs
+++ b/mon-pix/app/templates/login-or-register-to-access-restricted-campaign.hbs
@@ -1,3 +1,3 @@
 <div class="login-or-register-to-access-restricted-campaign">
-  {{routes/login-or-register}}
+  {{routes/login-or-register organizationName=model.organizationName}}
 </div>

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -131,6 +131,16 @@ export default function(server) {
     isRestricted: true,
   });
 
+  const campaign5 = server.create('campaign', {
+    id: 5,
+    name: 'Campagne 5 resteinte',
+    code: 'RESTRICTD',
+    idPixLabel: 'Mail Pro',
+    organizationLogoUrl: 'data:jpeg;base64=somelogo',
+    organizationName: 'College Victor Hugo',
+    isRestricted: true,
+  });
+
   const targetProfile = server.create('target-profile', {
     name: 'Target Profile'
   });
@@ -138,6 +148,7 @@ export default function(server) {
   campaign2.targetProfile = targetProfile;
   campaign3.targetProfile = targetProfile;
   campaign4.targetProfile = targetProfile;
+  campaign5.targetProfile = targetProfile;
 
   server.create('password-reset-demand', {
     temporaryKey: 'temporaryKey',

--- a/mon-pix/tests/acceptance/login-or-register-to-access-restricted-campaign-test.js
+++ b/mon-pix/tests/acceptance/login-or-register-to-access-restricted-campaign-test.js
@@ -15,6 +15,15 @@ describe('Acceptance | login-or-register-to-access-restricted-campaign', functio
     defaultScenario(this.server);
   });
 
+  it('should contain the organization name', async function() {
+    // when
+    await visitWithAbortedTransition('/campagnes/RESTRICTD/identification');
+
+    // then
+    expect(find('.login-or-register-panel__invitation').textContent)
+      .to.equal('College Victor Hugo vous invite à rejoindre Pix');
+  });
+
   it('should contain an open register form and closed login form', async function() {
     // when
     await visitWithAbortedTransition('/campagnes/AZERTY1/identification');

--- a/mon-pix/tests/unit/components/routes/login-or-register-test.js
+++ b/mon-pix/tests/unit/components/routes/login-or-register-test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Unit | Component | routes/login-or-register', () => {
+
+  setupRenderingTest();
+
+  it('should render', async () => {
+    // when
+    await render(hbs`{{routes/login-or-register}}`);
+
+    // then
+    expect(find('.login-or-register')).to.exist;
+  });
+
+  it('should display the organization name the user is invited to', async () => {
+    // when
+    await render(hbs`{{routes/login-or-register organizationName='Organization Aztec'}}`);
+
+    // then
+    expect(find('.login-or-register-panel__invitation').textContent)
+      .to.equal('Organization Aztec vous invite à rejoindre Pix');
+  });
+
+});

--- a/mon-pix/tests/unit/routes/login-or-register-to-access-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/routes/login-or-register-to-access-restricted-campaign-test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+describe('Unit | Route | login-or-register-to-access-restricted-campaign', () => {
+
+  setupTest();
+
+  let route;
+  let storeStub;
+  let queryStub;
+
+  beforeEach(function() {
+    queryStub = sinon.stub();
+    storeStub = Service.create({
+      query: queryStub
+    });
+
+    route = this.owner.lookup('route:login-or-register-to-access-restricted-campaign');
+    route.set('store', storeStub);
+  });
+
+  it('exists', function() {
+    expect(route).to.be.ok;
+  });
+
+  it('should retrieve a campain by his code', async function() {
+    // given
+    const expectedCampains = [{ id: 1 }];
+    queryStub.resolves(expectedCampains);
+
+    const expectedCode = 'RESTRICTD';
+    const params = { campaign_code: expectedCode };
+
+    // when
+    const model = await route.model(params);
+
+    // then
+    sinon.assert.calledWith(queryStub, 'campaign', { filter: { code: expectedCode } });
+    expect(model.id).to.equal(1);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour les élèves qui vont accéder à un parcours prescrit (SCO), s’ils ne sont pas connectés au préalable, leur donner plus de contexte.

## :robot: Solution
Ajoutez la phrase : [Nom de l'Organisation] vous invite à rejoindre Pix