### PR TITLE
[TECH] Retrait du code lié à la création de session via POSTMAN (PF-1025)

### DIFF
--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -4,13 +4,6 @@ const sessionValidator = require('../validators/session-validator');
 
 const sessionCodeService = require('../services/session-code-service');
 
-function _createSessionAsPixMaster(certificationCenterId, session, certificationCenterRepository, sessionRepository) {
-  if (certificationCenterId) {
-    return _setCertifCenterNameInSessionAndSave(session, certificationCenterId, certificationCenterRepository, sessionRepository);
-  }
-  return sessionRepository.save(session);
-}
-
 async function _createSessionAsNormalUser(userId, certificationCenterId, session, certificationCenterRepository, sessionRepository, userRepository) {
   const userWithCertifCenters = await userRepository.getWithCertificationCenterMemberships(userId);
 
@@ -34,13 +27,6 @@ module.exports = async function createSession({ userId, session, certificationCe
   sessionWithCode.accessCode = sessionCode;
 
   const certificationCenterId = sessionWithCode.certificationCenterId;
-  const isPixMaster = await userRepository.isPixMaster(userId);
-
-  // We keep this code here so that PIX-MASTER can still create the sessions the old way through Postman, for now :)
-  // To remove when we will not create sessions with no certifCenterId through Postman anymore
-  if (isPixMaster) {
-    return _createSessionAsPixMaster(certificationCenterId, sessionWithCode, certificationCenterRepository, sessionRepository);
-  }
 
   return _createSessionAsNormalUser(userId, certificationCenterId, sessionWithCode, certificationCenterRepository, sessionRepository, userRepository);
 };


### PR DESCRIPTION
## :unicorn: Problème
Portion de code plus utilisée permettant de créer une session en tant que PixMaster. Historiquement, ça permettait aux PixMasters, en utilisant l'outil POSTMAN, de créer une session directement via la route appropriée.

## :robot: Solution
On retire le code et on ré-ajuste les tests.

## :rainbow: Remarques
FONC REVUE : tester la non-régression de création de session via pix certif