### PR TITLE
[TECH] Corriger `UserCompetence.hasEnoughChallenges()` (PF-1026)

### DIFF
--- a/api/lib/domain/models/UserCompetence.js
+++ b/api/lib/domain/models/UserCompetence.js
@@ -49,7 +49,7 @@ class UserCompetence {
   }
 
   hasEnoughChallenges() {
-    return this.challenges.length < MAX_CHALLENGES_PER_SKILL_FOR_CERTIFICATION;
+    return this.challenges.length >= MAX_CHALLENGES_PER_SKILL_FOR_CERTIFICATION;
   }
 
   isCertifiable() {

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -48,7 +48,7 @@ async function fillCertificationProfileWithCertificationChallenges(certification
   certificationProfile.userCompetences.forEach((userCompetence) => {
     const testedSkills = [];
     userCompetence.skills.forEach((skill) => {
-      if (userCompetence.hasEnoughChallenges()) {
+      if (!userCompetence.hasEnoughChallenges()) {
         const challengesToValidateCurrentSkill = Challenge.findPublishedBySkill(allChallenges, skill);
         const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
 


### PR DESCRIPTION
## :unicorn: Contexte

Le choix des épreuves à la création d'un test de certification.

## :robot: Problème

La méthode `UserCompetence.hasEnoughChallenges()` a un comportement inverse à son nom : elle renvoie vrai si on n'a pas assez de challenges 😬

## :rainbow: Solution

Faire que cette méthode se comporte comme son non l'indique, et inverser la condition de sa seule utilisation.

## :taco: Fonc revue
FONC REVUE : @asrodride Tester comportement normal lors de la génération d'un test de certification