### PR TITLE
[TECH] Cacher nos sites de staging des crawlers (PF-303).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,12 +1,15 @@
 import { inject as service } from '@ember/service';
+import { set } from '@ember/object';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import Route from '@ember/routing/route';
+import ENV from 'mon-pix/config/environment';
 
 export default Route.extend(ApplicationRouteMixin, {
 
   splash: service(),
   currentUser: service(),
   session: service(),
+  headData: service(),
 
   activate() {
     this.splash.hide();
@@ -23,6 +26,10 @@ export default Route.extend(ApplicationRouteMixin, {
   async beforeModel(transition) {
     await this._checkForURLAuthentication(transition);
     return this._loadCurrentUser();
+  },
+
+  afterModel() {
+    set(this, 'headData.disallowRobotIndexing', ENV.APP.DISALLOW_ROBOT_INDEXING);
   },
 
   async sessionAuthenticated() {

--- a/mon-pix/app/templates/head.hbs
+++ b/mon-pix/app/templates/head.hbs
@@ -4,3 +4,6 @@ here. The 'model' available in this template can be populated by
 setting values on the 'head-data' service.
 --}}
 <title>{{model.title}}</title>
+{{#if model.disallowRobotIndexing}}
+  <meta name="robots" content="noindex" />
+{{/if}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function(environment) {
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
       IS_RECAPTCHA_ENABLED: process.env.IS_RECAPTCHA_ENABLED === 'true',
       IS_WARNING_BANNER_ENABLED: process.env.IS_WARNING_BANNER_ENABLED === 'true',
+      DISALLOW_ROBOT_INDEXING: process.env.DISALLOW_ROBOT_INDEXING === 'true',
     },
 
     googleFonts: [

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -44,4 +44,10 @@ location /api/ {
   proxy_redirect default;
 }
 
+location ~ /robots.txt {
+  if ($host != 'app.pix.fr') {
+    return 404;
+  }
+}
+
 <% end %>


### PR DESCRIPTION
## :unicorn: Problème
Nos sites en version staging apparaissent dans les moteurs de recherche. C'est particulièrement gênant pour Mon-Pix où les utilisateurs se positionnent sur une base de données isolée de la production et donc des centres de certification

## :robot: Solution
Les crawlers indexent les sites grâce au fichier `robots.txt` présent à la racine des projets web. Chaque sous-domaine possède un `robots.txt` qui lui est propre. Lorsque l'host de l'application est différent du domain standard, alors on retourne un 404 aux crawlers.

## 📚 Recherches
https://serverfault.com/questions/527328/disable-robots-txt-for-subdomains-in-nginx

https://stackoverflow.com/questions/26308779/nginx-different-robots-txt-for-alternte-domain

## 📋 À faire si solution validée
- [x] Mon-Pix
- [ ] Orga
- [ ] Certif
- [ ] Admin