### PR TITLE
[FEATURE] Afficher le nom d'utilisateur dans le menu utilisateur (PF-1022) 

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -11,7 +11,7 @@ module.exports = {
         return user;
       },
       attributes: [
-        'firstName', 'lastName', 'email', 'cgu', 'pixOrgaTermsOfServiceAccepted',
+        'firstName', 'lastName', 'email', 'username', 'cgu', 'pixOrgaTermsOfServiceAccepted',
         'pixCertifTermsOfServiceAccepted', 'memberships',
         'certificationCenterMemberships', 'pixScore', 'scorecards',
         'campaignParticipations', 'hasSeenAssessmentInstructions', 'certificationProfile',

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -34,6 +34,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             'first-name': user.firstName,
             'last-name': user.lastName,
             email: user.email.toLowerCase(),
+            username: user.username,
             cgu: true,
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -22,13 +22,14 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
 
   describe('#serialize', () => {
 
-    it('should serialize excluding email and password', () => {
+    it('should serialize excluding password', () => {
       // given
       const modelObject = new User({
         id: '234567',
         firstName: 'Luke',
         lastName: 'Skywalker',
         email: 'lskywalker@deathstar.empire',
+        username: 'luke.skywalker1234',
         cgu: true,
         pixOrgaTermsOfServiceAccepted: false,
         pixCertifTermsOfServiceAccepted: false,
@@ -46,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
             'first-name': 'Luke',
             'last-name': 'Skywalker',
             'email': 'lskywalker@deathstar.empire',
+            'username': 'luke.skywalker1234',
             'cgu': true,
             'pix-orga-terms-of-service-accepted': false,
             'pix-certif-terms-of-service-accepted': false,

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -16,12 +16,15 @@ export default Component.extend(EmberKeyboardMixin, {
 
   keyboardActivated: true,
   _canDisplayMenu: false,
-  _user: null,
 
   canDisplayLinkToProfile: computed('routing.currentRouteName', function() {
     const currentRouteName = this.get('routing.currentRouteName');
 
     return currentRouteName !== 'profile' && currentRouteName !== 'board';
+  }),
+
+  displayedIdentifier: computed('currentUser.user.email', function() {
+    return this.currentUser.user.email ? this.currentUser.user.email : this.currentUser.user.username;
   }),
 
   closeOnEsc: on(keyDown('Escape'), function() {

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -7,6 +7,7 @@ export default Model.extend({
   firstName: attr('string'),
   lastName: attr('string'),
   email: attr('string'),
+  username: attr('string'),
   password: attr('string'),
   cgu: attr('boolean'),
   hasSeenAssessmentInstructions: attr('boolean'),

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -79,7 +79,7 @@
   text-overflow: ellipsis;
 }
 
-.logged-user-menu-details__email {
+.logged-user-menu-details__identifier {
   font-size: 1.3rem;
   color: $dove-gray;
 }

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -11,7 +11,7 @@
       <div class="logged-user-menu">
         <div class="logged-user-menu__details">
           <div class="logged-user-menu-details__fullname">{{currentUser.user.fullName}}</div>
-          <div class="logged-user-menu-details__email">{{currentUser.user.email}}</div>
+          <div class="logged-user-menu-details__identifier">{{displayedIdentifier}}</div>
         </div>
         {{#link-to 'user-certifications' class="logged-user-menu__link"}}
           Mes certifications

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -57,7 +57,7 @@ describe('Integration | Component | user logged menu', function() {
         // then
         expect(find('.logged-user-menu')).to.exist;
         expect(find('.logged-user-menu-details__fullname').textContent.trim()).to.equal('FHI 4EVER');
-        expect(find('.logged-user-menu-details__email').textContent.trim()).to.equal('FHI@4EVER.fr');
+        expect(find('.logged-user-menu-details__identifier').textContent.trim()).to.equal('FHI@4EVER.fr');
       });
     });
 

--- a/mon-pix/tests/unit/components/user-logged-menu-test.js
+++ b/mon-pix/tests/unit/components/user-logged-menu-test.js
@@ -81,4 +81,60 @@ describe('Unit | Component | User logged Menu', function() {
       expect(result).to.be.true;
     });
   });
+
+  describe('displayedIdentifier', function() {
+
+    it('should return user\'s email if not undefined', function() {
+      // given
+      const component = this.owner.lookup('component:user-logged-menu');
+      component.set('currentUser', Service.create({
+        user: {
+          email: 'email@example.net'
+        }
+      }));
+
+      // then
+      expect(component.get('displayedIdentifier')).to.equal('email@example.net');
+    });
+
+    it('should return user\'s username if not undefined and no email defined', function() {
+      // given
+      const component = this.owner.lookup('component:user-logged-menu');
+      component.set('currentUser', Service.create({
+        user: {
+          username: 'my username'
+        }
+      }));
+
+      // then
+      expect(component.get('displayedIdentifier')).to.equal('my username');
+    });
+
+    it('should return user\'s email if email and username are defined', function() {
+      // given
+      const component = this.owner.lookup('component:user-logged-menu');
+      component.set('currentUser', Service.create({
+        user: {
+          email: 'email@example.net',
+          username: 'my username'
+        }
+      }));
+
+      // then
+      expect(component.get('displayedIdentifier')).to.equal('email@example.net');
+    });
+
+    it('should return undefined if no email or username are defined', function() {
+      // given
+      const component = this.owner.lookup('component:user-logged-menu');
+      component.set('currentUser', Service.create({
+        user: {
+
+        }
+      }));
+
+      // then
+      expect(component.get('displayedIdentifier')).to.equal(undefined);
+    });
+  });
 });


### PR DESCRIPTION
## :robot: Solution
Suite à la possibilité pour un utilisateur de s'inscrire/se connecter via un identifiant et non plus une adresse email, il a été décidé d'afficher cet identifiant en lieu et place de l'adresse email dans le menu utilisateur.

## :rainbow: Remarques
On affichera toujours l'adresse email si celle-ci est renseignée, le nom d'utilisateur sinon.
