### PR TITLE
[BUGFIX] Echec du déploiement des seeds en RA (PF-1028)

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -55,8 +55,8 @@ async function listTablesByDependencyOrderDesc() {
     'select t.oid as reloid, ' +
     't.relname as table_name, ' +
     's.nspname as schema_name, ' +
-    'null::text as referenced_table_name, ' +
-    'null::text as referenced_schema_name, ' +
+    'null::name as referenced_table_name, ' +
+    'null::name as referenced_schema_name, ' +
     '1 as level ' +
     'from pg_class t ' +
     'join pg_namespace s on s.oid = t.relnamespace ' +


### PR DESCRIPTION
## :unicorn: Problème
La configuration (sujet très bas niveau) de la BDD PostgreSQL entre notre instance locale Docker et l'addon fourni par Scalingo semble être légèrement différente. En tout cas, suffisamment différente pour faire échouer une raw query déclenchée lors de l'initialisation du _databaseBuilder_ qui permet de récupérer la liste des tables ordonnées selon leurs inter-dépendances de clés étrangères.
Cette requête est utilisée depuis peu pour l'optimisation du temps des tests API

UPDATE : Il semblerait que ce soit aussi lié à la version de PG. Sur Scalingo on est en PG12, docker en PG10. La requête marche sur 10, pas 12 :/

## :robot: Solution
https://www.postgresql.org/message-id/28491.1560519572%40sss.pgh.pa.us

## :rainbow: Remarques
J'ai vérifié, les seeds ont bien été déployées ce coup-ci
