### PR TITLE
[FEATURE] Modification du lien de la page de résultat d'une démo d'évaluation  (PS-3)

### DIFF
--- a/mon-pix/app/controllers/assessments/results.js
+++ b/mon-pix/app/controllers/assessments/results.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
-import ENV from 'mon-pix/config/environment';
 
 export default Controller.extend({
-
-  urlHome: ENV.APP.HOME_HOST,
 
   isShowingModal: false,
   answer: null,

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -104,9 +104,7 @@
 }
 
 .assessment-results__index-a-link {
-  align-items: flex-start;
-  text-align: center;
-  padding-top: 10px;
+  width: 355px;
 }
 
 .assessment-results__index-link__element:hover {
@@ -114,8 +112,6 @@
 }
 
 .assessment-results__link-back {
-  width: 277px;
-  height: 22px;
   text-transform: uppercase;
   font-size: 16px;
   font-weight: $font-semi-bold;

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -19,9 +19,9 @@
 
     <div class="assessment-results__index-link-container">
       {{#if model.isDemo}}
-        <a href={{urlHome}} class="assessment-results__index-link__element assessment-results__index-a-link">
-          <span class="assessment-results__link-back">Revenir à l'accueil</span>
-        </a>
+        {{#link-to 'inscription' class='assessment-results__index-link__element assessment-results__index-a-link' tagName='button'}}
+          <span class="assessment-results__link-back">Poursuivre son expérience sur Pix</span>
+        {{/link-to}}
       {{else}}
         {{#link-to 'index' class='assessment-results__index-link__element' tagName='button'}}
           <span class="assessment-results__link-back">Revenir à l'accueil</span>


### PR DESCRIPTION
## :rainbow: Remarques
Sans avoir créer de compte au préalable, il est possible de participer à une démo d'évaluation. Une fois cette évaluation terminée, sur la page de résultat, un bouton "Retour à l'accueil" est présent est renvoie vers la racine du site.
Il a été décidé de renommer ce bouton en "Poursuivre son expérience sur Pix" et de rediriger l'utilisateur sur la page d'inscription lorsqu'il cliquera sur ce dernier.
