### PR TITLE
[FEATURE] Modification du lien de la page de résultat d'une démo d'évaluation (PF-1031)

### DIFF
--- a/mon-pix/app/controllers/assessments/results.js
+++ b/mon-pix/app/controllers/assessments/results.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
-import ENV from 'mon-pix/config/environment';
 
 export default Controller.extend({
-
-  urlHome: ENV.APP.HOME_HOST,
 
   isShowingModal: false,
   answer: null,

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -100,13 +100,10 @@
   border-radius: 23px;
   background-color: $pix-blue;
   border: none;
-
 }
 
 .assessment-results__index-a-link {
-  align-items: flex-start;
-  text-align: center;
-  padding-top: 10px;
+  width: 355px;
 }
 
 .assessment-results__index-link__element:hover {
@@ -114,8 +111,6 @@
 }
 
 .assessment-results__link-back {
-  width: 277px;
-  height: 22px;
   text-transform: uppercase;
   font-size: 16px;
   font-weight: $font-semi-bold;

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -19,9 +19,9 @@
 
     <div class="assessment-results__index-link-container">
       {{#if model.isDemo}}
-        <a href={{urlHome}} class="assessment-results__index-link__element assessment-results__index-a-link">
-          <span class="assessment-results__link-back">Revenir à l'accueil</span>
-        </a>
+        {{#link-to 'inscription' class='assessment-results__index-link__element assessment-results__index-a-link' tagName='button'}}
+          <span class="assessment-results__link-back">Continuer mon expérience Pix</span>
+        {{/link-to}}
       {{else}}
         {{#link-to 'index' class='assessment-results__index-link__element' tagName='button'}}
           <span class="assessment-results__link-back">Revenir à l'accueil</span>

--- a/mon-pix/tests/acceptance/course-ending-screen-test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen-test.js
@@ -1,4 +1,4 @@
-import { currentURL, find, findAll } from '@ember/test-helpers';
+import { click, currentURL, find, findAll } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
@@ -48,6 +48,15 @@ describe('Acceptance | Course ending screen', function() {
 
   it('should display the course banner', function() {
     expect(find('.assessment-results__assessment-banner')).to.exist;
+  });
+
+  it('should display a button that redirect to inscription page', async function() {
+    expect(find('.assessment-results__index-link__element')).to.exist;
+    expect(find('.assessment-results__link-back').textContent).to.contains('Continuer mon expérience Pix');
+
+    await click(find('.assessment-results__index-link__element'));
+
+    expect(currentURL()).to.equal('/inscription');
   });
 
 });


### PR DESCRIPTION
## :rainbow: Remarques
Sans avoir créer de compte au préalable, il est possible de participer à une démo d'évaluation. Une fois cette évaluation terminée, sur la page de résultat, un bouton "Retour à l'accueil" est présent et renvoie vers la racine du site.
Il a été décidé de renommer ce bouton en "Poursuivre son expérience sur Pix" et de rediriger l'utilisateur sur la page d'inscription lorsqu'il cliquera sur ce dernier.
