### PR TITLE
[BUGFIX] Le code d'accès à la session était forcé en majuscules seulement à l'affichage, mais pas lors de l'envoi du formulaire (PF-1032)

### DIFF
--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -8,7 +9,10 @@ export default Component.extend({
   currentUser: service(),
 
   isLoading: false,
-  accessCode: null,
+  inputAccessCode: null,
+  accessCode: computed('inputAccessCode', function() {
+    return this.inputAccessCode.toUpperCase();
+  }),
   errorMessage: null,
   classNames: [],
 

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -6,7 +6,7 @@
     </p>
     <form autocomplete="off">
         <div class="certification-course-page__session-code-input">
-          {{input required=true id="session-code" type="text" value=accessCode maxlength="6" spellcheck=false}}
+          {{input required=true id="session-code" type="text" value=inputAccessCode maxlength="6" spellcheck=false}}
           {{#if errorMessage}}
               <div class="certification-course-page__errors">{{errorMessage}}</div>
           {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Récemment, on avait forcé la majuscule dans le champ code d'accès à la session, et on a oublié d'aussi forcer la majuscule lors de l'envoi du formulaire.

## :robot: Solution
Mise en majuscule pour de bon

## :rainbow: Remarques
