### PR TITLE
TECH-Enabling knex to automatically reconnect on create connection failure instead of throwing the error

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -7,6 +7,7 @@ function localPostgresEnv(databaseUrl) {
     pool: {
       min: 1,
       max: 4,
+      propagateCreateError: false,
     },
     migrations: {
       tableName: 'knex_migrations',
@@ -30,6 +31,7 @@ module.exports = {
     pool: {
       min: 1,
       max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4),
+      propagateCreateError: false,
     },
     migrations: {
       tableName: 'knex_migrations',
@@ -46,6 +48,7 @@ module.exports = {
     pool: {
       min: 1,
       max: (parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4),
+      propagateCreateError: false,
     },
     migrations: {
       tableName: 'knex_migrations',


### PR DESCRIPTION
## :unicorn: Problème 
> _Beaucoup de TimeoutError en production 👎 
Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?._

## :robot: Solution
> _The attribute propagateCreateError should be set to false to prevent the Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call? error. 👍 

Example pool configuration:

"pool": {
  "min": 2,
  "max": 6,
  "createTimeoutMillis": 3000,
  "acquireTimeoutMillis": 30000,
  "idleTimeoutMillis": 30000,
  "reapIntervalMillis": 1000,
  "createRetryIntervalMillis": 100,
  "propagateCreateError": false // <- default is true, set to false
},
Explanation:
The propagateCreateError is set to true by default in Knex and throws a TimeoutError if the first create connection to the database fails, preventing tarn (the connection pool manager) from re-connecting automatically.

The solution is to set propagateCreateError to false thus enabling knex to automatically reconnect on create connection failure instead of throwing the error._

## :rainbow: Remarques
> _https://github.com/knex/knex/issues/2820_
> _https://sentry.io/organizations/pix/issues/1229074689/?project=1398749&referrer=slack_
