### PR TITLE
 [FEATURE] Homogénéiser le comportement de cloture des notifications de succès mobile et desktop (PF-899).

### DIFF
--- a/mon-pix/app/components/levelup-notif.js
+++ b/mon-pix/app/components/levelup-notif.js
@@ -11,6 +11,6 @@ export default Component.extend({
   actions: {
     close: function() {
       this.set('closeLevelup', true);
-    }
+    },
   },
 });

--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -10,10 +10,10 @@
   color: $pix-grey-hover;
   animation-duration: 1s;
   animation-name: slidein;
+  user-select: none;
+  background-color: rgba(255,255,255,0.92);
 
-  background-color: rgba(255,255,255,0.90);
-
-  @include device-is('desktop') {
+  @include device-is('tablet') {
     width: 362px;
   }
 
@@ -30,18 +30,26 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    padding: 10px 0;
+    padding: 10px 10px 10px 0;
   }
 
   &__close {
-    margin: 5px;
+    background-color: transparent;
     cursor: pointer;
-    opacity: 0.5;
-    height: 30px;
+    color: $slate-grey;
+    font-size: 2.4rem;
+    width: 70px;
+    border: none;
+    border-left: 1px solid $alto-grey;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    &:active, &:hover {
-      background-color: transparent;
-      opacity: 1;
+    &:hover, &:focus, &:active {
+      color: $tundora-grey;
+      background-color: $mercury-grey;
+      border-bottom-right-radius: 5px;
+      border-top-right-radius: 5px;
     }
   }
 }
@@ -53,12 +61,20 @@
     font-family: $font-open-sans;
     text-transform: uppercase;
     margin-bottom: 2px;
+
+    @include device-is('mobile') {
+      font-size: 1.4rem;
+    }
   }
 
   &__name {
     font-size: 1.4rem;
     line-height: 1.8rem;
     font-family: $font-roboto;
+
+    @include device-is('mobile') {
+      font-size: 1.3rem;
+    }
   }
 }
 

--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -44,6 +44,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
 
     &:hover, &:focus, &:active {
       color: $tundora-grey;

--- a/mon-pix/app/templates/components/levelup-notif.hbs
+++ b/mon-pix/app/templates/components/levelup-notif.hbs
@@ -6,8 +6,12 @@
       <div class="levelup-competence__level">Niveau {{level}} gagné !</div>
       <div class="levelup-competence__name">{{competenceName}}</div>
     </div>
-    <div class="icon-button levelup__close" {{action "close"}}>
+    <button role = "button"
+            class="levelup__close"
+            aria-labelledby="button-label"
+            {{action "close"}}>
+        <span id="button-label" hidden>Fermer</span>
       {{fa-icon 'times'}}
-    </div>
+    </button>
   </div>
 {{/unless}}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, pour fermer la notification d'un succès, il faut cliquer sur la croix. Cette action n'est pas pratique à faire sur mobile.

## :robot: Solution
- Bien séparer la croix du texte de la notification.
- Agrandir la zone d'action du bouton contenant la croix, pour la rendre plus facilement cliquable sur mobile
