### PR TITLE
[TECH] Supprime les mises à jour des branches preview et maths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ workflows:
             branches:
               ignore:
                 - master
-                - math
-                - preview
                 - gh-pages
                 - /release-.*/
 

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -30,18 +30,6 @@ function publish_release_on_sentry {
     npx sentry-cli releases -o pix finalize "v${PACKAGE_VERSION}"
 }
 
-function update_preview_and_maths {
-    for environment in preview maths
-    do
-        echo -e "Updating ${GREEN}${environment}${RESET_COLOR} environment.\n"
-        git checkout ${environment}
-        git pull --rebase
-        git rebase master
-        git push origin ${environment}
-        echo -e "${YELLOW}${environment}${RESET_COLOR} environment is updated to ${YELLOW}master${RESET_COLOR}.\n"
-    done
-}
-
 echo -e "Beginning release publication for version ${GREEN}${PACKAGE_VERSION}${RESET_COLOR}.\n"
 
 push_commit_to_remote_dev
@@ -50,9 +38,8 @@ fetch_and_rebase
 create_a_merge_commit_of_dev_into_master_and_tag_it
 push_commit_and_tag_to_remote_master
 publish_release_on_sentry
-update_preview_and_maths
 checkout_dev
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."
-echo -e "You can check the build progress at : https://circleci.com/gh/1024pix/workflows/pix/tree/master"
-echo -e "You can check the deployment progress at : https://my.scalingo.com/"
+echo -e "You can check the build progress at : https://circleci.com/gh/1024pix/workflows/pix/tree/dev"
+echo -e "You can check the deployment progress at : https://my.osc-fr1.scalingo.com/"


### PR DESCRIPTION
## :unicorn: Problème

Il y a deux branches qui ne sont plus utilisées aujourd'hui et qui sont inclues dans le process de mise en prod.

- La branche `maths` était utilisée au moment de [cette PR][pr] en janvier 2018. Mais aujourd'hui elle n'est plus utilisée, et le domaine `pix-dev.ovh` ne répond plus.
- La branche `preview` était utilisée pour prévisualiser les épreuves, mais ce n'est plus le cas aujourd'hui.

[pr]: https://github.com/betagouv/pix/pull/650

## :robot: Solution

Supprimer les références à ces deux branches dans le script de mise en prod et dans CircleCI.

## :rainbow: Remarques

Se posera ensuite la question de la suppression de ces branches.