### PR TITLE
[FEATURE] Passer toutes les anciennes sessions au statut "Finalisée" (pc-87)

### DIFF
--- a/api/db/migrations/20200113162127_switch-old-session-status-to-finalized.js
+++ b/api/db/migrations/20200113162127_switch-old-session-status-to-finalized.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'sessions';
+
+exports.up = function(knex) {
+    return knex(TABLE_NAME)
+      .where('date', '<', knex.fn.now())
+      .update({ status: 'finalized' });
+};
+
+exports.down = function(knex) {
+    return knex(TABLE_NAME)
+      .where('date', '<', knex.fn.now())
+      .update({ status: 'started' });
+};


### PR DESCRIPTION
## :unicorn: Problème
_"préparer un script qui au jour où il tourne passe toutes les sessions avec une date (de session et non de création) < aujourd’hui au statut “Finalisée”"_

## :robot: Solution
Faire une migration qui update la colonne "status" des sessions

## :rainbow: Remarques
Le script pour "défaire" cette migration utilise aussi la date du jour, or si entre temps il y a eu une session finalisée volontairement, cette dernière repassera en status "started" ... 
D'un autre côté les scripts pour "défaires" les migrations sont juste pour nous les dev non ? 
