### PR TITLE
[FEATURE] Actualiser le design des embed (1/2) (PF-563).

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -29,8 +29,8 @@ export default Component.extend({
       this._unblurSimulator();
     },
 
-    reloadSimulator() {
-      this._reloadSimulator();
+    rebootSimulator() {
+      this._rebootSimulator();
     },
   },
 
@@ -62,7 +62,7 @@ export default Component.extend({
   },
 
   /* This method is not tested because it would be too difficult (add an observer on a complicated stubbed DOM API element!) */
-  _reloadSimulator() {
+  _rebootSimulator() {
     const iframe = this._getIframe();
     const tmpSrc = iframe.src;
 

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -73,14 +73,14 @@
   height: 100%;
 }
 
-.embed__reload-simulator {
+.embed__reboot {
   display:flex;
   justify-content: flex-end;
   position:relative;
   bottom: 6px;
 }
 
-.embed-reload-simulator__content {
+.embed-reboot__content {
   display:flex;
   justify-content: space-between;
   align-items: center;
@@ -91,7 +91,7 @@
   }
 }
 
-.embed-reload-simulator-content__text {
+.embed-reboot-content__text {
   font-family: $font-roboto;
   font-size: 1.5rem;
   text-decoration: underline;

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -1,3 +1,10 @@
+.challenge-embed-simulator {
+  margin: 15px 0;
+  padding: 12px;
+  border: 2px solid $slate-grey;
+  border-radius: 7px;
+}
+
 .embed {
   position: relative;
   height: 100%;

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -73,18 +73,26 @@
   height: 100%;
 }
 
-.embed__reload-button {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  background-color: $white;
-  box-shadow: 0 2px 6px 0 rgba(12,22,58,0.11), 0 1px 3px 0 rgba(0,0,0,0.08);
-  border-radius: 5px;
-  font-family: $font-roboto;
-  font-size: 1.5rem;
-  font-weight: bold;
-  text-align: center;
-  height: 46px;
-  padding: 0 36px;
+.embed__reload-simulator {
+  display:flex;
+  justify-content: flex-end;
+  position:relative;
+  bottom: 6px;
 }
 
+.embed-reload-simulator__content {
+  display:flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100px;
+
+  &:active, &:hover {
+    cursor: pointer;
+  }
+}
+
+.embed-reload-simulator-content__text {
+  font-family: $font-roboto;
+  font-size: 1.5rem;
+  text-decoration: underline;
+}

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -94,5 +94,4 @@
 .embed-reboot-content__text {
   font-family: $font-roboto;
   font-size: 1.5rem;
-  text-decoration: underline;
 }

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -18,9 +18,10 @@
     </iframe>
   </div>
 </div>
-<div class="embed__reload-simulator">
-  <div class="embed-reload-simulator__content" {{action "reloadSimulator"}}>
+
+<div class="embed__reboot">
+  <div class="embed-reboot__content" {{action "rebootSimulator"}}>
     <Fa-Icon @icon="redo-alt"></Fa-Icon>
-    <div class="embed-reload-simulator-content__text"> Réinitialiser </div>
+    <div class="embed-reboot-content__text"> Réinitialiser </div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -19,7 +19,7 @@
   </div>
 </div>
 
-<div class="embed__reboot">
+<div class="link link--grey embed__reboot">
   <div class="embed-reboot__content" {{action "rebootSimulator"}}>
     <Fa-Icon @icon="redo-alt"></Fa-Icon>
     <div class="embed-reboot-content__text"> Réinitialiser </div>

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -16,7 +16,11 @@
             src="{{embedDocument.url}}"
             title="{{embedDocument.title}}">
     </iframe>
-    <button class="embed__reload-button" {{action "reloadSimulator"}}>Recharger l’application</button>
   </div>
 </div>
-
+<div class="embed__reload-simulator">
+  <div class="embed-reload-simulator__content" {{action "reloadSimulator"}}>
+    <Fa-Icon @icon="redo-alt"></Fa-Icon>
+    <div class="embed-reload-simulator-content__text"> Réinitialiser </div>
+  </div>
+</div>

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -5,11 +5,11 @@ import { setupRenderingTest } from 'ember-mocha';
 import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | challenge embed simulator', function() {
+describe('Integration | Component | Challenge Embed Simulator', function() {
 
   setupRenderingTest();
 
-  describe('Aknowledgment overlay', function() {
+  describe('Acknowledgment overlay', function() {
 
     it('should be displayed when component has just been rendered', async function() {
       // when
@@ -38,7 +38,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
     });
 
-    it('should close the aknowledgment overlay when clicked', async function() {
+    it('should close the acknowledgment overlay when clicked', async function() {
       // given
       await render(hbs`{{challenge-embed-simulator}}`);
 
@@ -52,25 +52,25 @@ describe('Integration | Component | challenge embed simulator', function() {
 
   describe('Reload simulator button', () => {
 
-    it('should have text "Recharger le simulateur"', async function() {
+    it('should have text "Réinitialiser"', async function() {
       // when
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.embed__reload-simulator').textContent).to.equal('Recharger l’application');
+      expect(find('.embed__reboot').textContent.trim()).to.equal('Réinitialiser');
     });
 
     it('should reload simulator when user clicked on button reload', async function() {
       // given
-      const stubReloadSimulator = sinon.stub();
-      this.set('stubReloadSimulator', stubReloadSimulator);
-      await render(hbs`{{challenge-embed-simulator _reloadSimulator=stubReloadSimulator}}`);
+      const stubRebootSimulator = sinon.stub();
+      this.set('stubRebootSimulator', stubRebootSimulator);
+      await render(hbs`{{challenge-embed-simulator _rebootSimulator=stubRebootSimulator}}`);
 
       // when
-      await click('.embed__reload-simulator');
+      await click('.embed-reboot__content');
 
       // then
-      sinon.assert.calledOnce(stubReloadSimulator);
+      sinon.assert.calledOnce(stubRebootSimulator);
     });
   });
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -57,7 +57,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator}}`);
 
       // then
-      expect(find('.embed__reload-button').textContent).to.equal('Recharger l’application');
+      expect(find('.embed__reload-simulator').textContent).to.equal('Recharger l’application');
     });
 
     it('should reload simulator when user clicked on button reload', async function() {
@@ -67,7 +67,7 @@ describe('Integration | Component | challenge embed simulator', function() {
       await render(hbs`{{challenge-embed-simulator _reloadSimulator=stubReloadSimulator}}`);
 
       // when
-      await click('.embed__reload-button');
+      await click('.embed__reload-simulator');
 
       // then
       sinon.assert.calledOnce(stubReloadSimulator);


### PR DESCRIPTION
## :unicorn: Problème
Le design des embed n'est plus totalement cohérent avec le design global.

## :robot: Solution
- [x] Mettre le bouton “réinitialiser” en bas du cadre;
- [x] Donner un encadré noir avec bordure blanche au cadre en essayant de systématiser dans les embed le fond gris;
- [x] ~Changer le mode d’affichage des mots selon le mockup (zone gris foncée quand réponse apparaît)~ -> À gérer au niveau des pix-epreuves.

## 💯 Pour tester
https://app-pr974.review.pix.fr/courses/reciMJOtivLZgO9gO
