### PR TITLE
[BUGFIX] Design page finalisation session KO (pc-105)

### DIFF
--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -9,7 +9,6 @@
   }
 
   thead {
-    width: 100%;
     color: $mine-shaft;
   }
 
@@ -30,7 +29,6 @@
   }
 
   tr {
-    width: 100%;
     height: 60px;
     border-top: 2px solid $wild-sand;
   }

--- a/certif/app/styles/pages/authenticated/sessions.scss
+++ b/certif/app/styles/pages/authenticated/sessions.scss
@@ -1,10 +1,3 @@
-.session-layout {
-  display: flex;
-}
-.session-layout > div {
-   flex-grow: 1;
-}
-
 .session-form {
   display: flex;
   flex-direction: column;

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates-tab.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates-tab.scss
@@ -26,7 +26,6 @@
   width: 1.75rem;
   height: 1.75rem;
   display: flex;
-  flex-align: center;
   justify-content: center;
   border: 0.18rem solid;
   border-radius: 0.13rem;

--- a/certif/app/templates/authenticated/sessions.hbs
+++ b/certif/app/templates/authenticated/sessions.hbs
@@ -1,3 +1,2 @@
-<div class="session-layout">
-  {{outlet}}
-</div>
+{{outlet}}
+


### PR DESCRIPTION
## :unicorn: Problème
(Pix certif > http://localhost:4203/sessions/3/finalisation)
Sous notre très cher ami IE, le design de la page de finalization de session était tout cassé.
AVANT
<img width="1670" alt="image" src="https://user-images.githubusercontent.com/38167520/72436533-f866c080-37a0-11ea-91ef-cc04738e5044.png">


## :robot: Solution
En fait, une div parent ("session-layout") était en flex, ce qui sous IE ne fonctionne pas vraiment comme prévu ... Etant donné que cette propriété de sert plus, il suffit de la retirer pour corriger le soucis. 
En regardant un peu sur internet les soucis de flex avec IE, il y a souvent des problèmes avec l'overflow et les `display: flex` nested... 
⬇️ APRES ⬇️ 
<img width="1670" alt="image" src="https://user-images.githubusercontent.com/38167520/72436550-03215580-37a1-11ea-9095-3cc6f4c458de.png">


## :rainbow: Remarques
Une autre solution aurait été de mettre `max-width: 100%` ou `flex-basis: 100%;` ou encore `flex: 1;` (à ne pas confondre avec flex-grow) à l'élément enfant de "session-layout". 
