### PR TITLE
[BUGFIX] Corriger l'affichage d'un bouton de mon-pix sous Safari. (PF-1042)

### DIFF
--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -76,7 +76,7 @@
   font-weight: $font-bold;
   text-align: center;
   color: $white;
-  padding: 6px 25px;
+  padding: 6px 15px;
   background: $pix-blue;
   border-radius: 5px;
   margin: 12px auto;


### PR DESCRIPTION
## :unicorn: Problème
Un bouton s'affiche mal sous Safari en fin de certification.

![image](https://user-images.githubusercontent.com/4154003/72799370-5d109800-3c45-11ea-9b8a-3d86660d53fe.png)

## :robot: Solution

Modifier son padding.

![image](https://user-images.githubusercontent.com/4154003/72799498-a660e780-3c45-11ea-9e9e-572a90c02f2e.png)