### PR TITLE
[BUGFIX] Ne pas permettre le click multiple sur les boutons de soumission de formulaire (PF-1043).

### DIFF
--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -57,7 +57,7 @@
           <div class="join-restricted-campaign__error" aria-live="polite">{{errorMessage}}</div>
         {{/if}}
         {{#if isLoading}}
-          <button class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
+          <button type="button" disabled class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
           <button type="submit" class="button button--big" {{action "attemptNext"}}>
             C'est parti !

--- a/mon-pix/app/templates/components/routes/login-form.hbs
+++ b/mon-pix/app/templates/components/routes/login-form.hbs
@@ -25,7 +25,7 @@
 
     <div class="login-button-container">
       {{#if isLoading}}
-        <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
+        <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
         <button id="submit-connexion" type="submit" class="button button--uppercase">Je me connecte</button>
       {{/if}}

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -115,7 +115,7 @@
 
     <div class="register-button-container">
       {{#if isLoading}}
-        <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
+        <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
         <button id="submit-registration" type="submit" class="button button--uppercase">Je m'inscris</button>
       {{/if}}

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -57,7 +57,7 @@
     {{#unless matchingStudentFound}}
       <div class="register-button-container">
         {{#if isLoading}}
-          <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
+          <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
           <button id="submit-search" type="submit" class="button button--uppercase">Je m'inscris</button>
         {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur plusieurs formulaires, il est possible de déclencher une requête lorsque l'on clicke plusieurs fois d'affilée (même avec l'affichage du loader) :
- pré-réconciliation (/identification) ;
- création d'utilisateur associé (/identification) ;
- connexion (/identification) ;
- réconciliation simple (/rejoindre).

## :robot: Solution
- spécifier le type = `"button"` pour le bouton loader ;
- ajouter l'attribut `disabled`.
