### PR TITLE
[FEATURE] Afficher une bulle d'information sur les Pix (PF-803).

### DIFF
--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -3,9 +3,18 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
-  pixScore: null,
+  displayHelp: 'hexagon-score__information--hide',
 
   score: computed('pixScore', function() {
     return (isNone(this.pixScore) || this.pixScore === 0) ? '–' : Math.floor(this.pixScore);
-  })
+  }),
+
+  actions: {
+    hideHelp: function() {
+      this.set('displayHelp', 'hexagon-score__information--hide');
+    },
+    showHelp: function() {
+      this.set('displayHelp', 'hexagon-score__information--show');
+    }
+  }
 });

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
-  displayHelp: 'hexagon-score__information--hide',
+  displayHelp: 'hexagon-score__information--hidden',
 
   score: computed('pixScore', function() {
     return (isNone(this.pixScore) || this.pixScore === 0) ? '–' : Math.floor(this.pixScore);
@@ -11,10 +11,10 @@ export default Component.extend({
 
   actions: {
     hideHelp: function() {
-      this.set('displayHelp', 'hexagon-score__information--hide');
+      this.set('displayHelp', 'hexagon-score__information--hidden');
     },
     showHelp: function() {
-      this.set('displayHelp', 'hexagon-score__information--show');
+      this.set('displayHelp', 'hexagon-score__information--visible');
     }
   }
 });

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -69,7 +69,6 @@
   box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
   border-radius:3px;
   z-index: 300;
-  display: none;
 
   width: 300px;
   padding: 20px 36px;
@@ -104,9 +103,20 @@
       border-right: none;
     }
   }
+  &--show {
+    display: block;
+  }
+  &--hide {
+    display: none;
+  }
 
 }
 
-.hexagon-score:hover > .hexagon-score__information{
-  display: block;
+.hexagon-score-information__close {
+  float: right;
+  font-size: 2rem;
+  @include device-is('desktop') {
+    display: none;
+  }
 }
+

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -30,12 +30,6 @@
   border-top: 1px solid $dusty-grey;
 }
 
-@mixin hexagon-score-information-text{
-  font-family: $font-open-sans;
-  font-size: 1.6rem;
-  line-height: 2.2rem;
-}
-
 .hexagon-score-content {
   &__title {
     @include hexagon-score-title;
@@ -63,7 +57,6 @@
 }
 
 .hexagon-score__information {
-  @include hexagon-score-information-text;
   position: absolute;
   background-color: $white;
   box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
@@ -81,10 +74,6 @@
     margin : 135px 0 0 -520px;
   }
 
-  &-strong {
-    font-weight: $font-bold;
-  }
-
   &::before {
     content: '';
     position: absolute;
@@ -98,23 +87,32 @@
 
     @include device-is('desktop') {
       right: 0px;
-      border-bottom: 20px solid white;
-      border-left: 20px solid transparent;
       border-right: none;
     }
   }
-  &--show {
+  &--visible {
     display: block;
   }
-  &--hide {
+  &--hidden {
     display: none;
   }
 
 }
 
+.hexagon-score-information__text {
+  font-family: $font-open-sans;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+
+  &--strong {
+    font-weight: $font-bold;
+  }
+}
 .hexagon-score-information__close {
   float: right;
   font-size: 2rem;
+  padding: 10px;
+  margin-top: -10px;
   @include device-is('desktop') {
     display: none;
   }

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -30,6 +30,12 @@
   border-top: 1px solid $dusty-grey;
 }
 
+@mixin hexagon-score-information-text{
+  font-family: $font-open-sans;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+}
+
 .hexagon-score-content {
   &__title {
     @include hexagon-score-title;
@@ -56,3 +62,51 @@
   }
 }
 
+.hexagon-score__information {
+  @include hexagon-score-information-text;
+  position: absolute;
+  background-color: $white;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
+  border-radius:3px;
+  z-index: 300;
+  display: none;
+
+  width: 300px;
+  padding: 20px 36px;
+  margin: 150px 0 0 -80px;
+
+  @include device-is('desktop') {
+    height: 161px;
+    width: 587px;
+    padding: 20px 36px;
+    margin : 135px 0 0 -520px;
+  }
+
+  &-strong {
+    font-weight: $font-bold;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    top: -17px;
+    right: 130px;
+    border-bottom: 20px solid white;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+
+    @include device-is('desktop') {
+      right: 0px;
+      border-bottom: 20px solid white;
+      border-left: 20px solid transparent;
+      border-right: none;
+    }
+  }
+
+}
+
+.hexagon-score:hover > .hexagon-score__information{
+  display: block;
+}

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -2,10 +2,11 @@
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">PIX</div>
     <div class="hexagon-score-content__pix-score">{{score}}</div>
-    <div class="hexagon-score-content__pix-total">1024 {{fa-icon 'info-circle'}}</div>
+    <div class="hexagon-score-content__pix-total">1024 <Fa-Icon @icon="info-circle"/></div>
   </div>
-    <div class="hexagon-score__information {{this.displayHelp}}">
-        <span class="hexagon-score__information-strong">Pourquoi 1024 Pix ?</span> <span class="hexagon-score-information__close" {{action 'hideHelp'}}>{{fa-icon 'times'}}</span>
+    <div class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
+        <span class="hexagon-score-information__text--strong">Pourquoi 1024 Pix ?</span>
+        <span class="hexagon-score-information__close" {{action 'hideHelp'}}><Fa-Icon @icon="times"/></span>
         <br><br>C’est le score maximum atteignable dès que le niveau 8 des compétences sera disponible.
-        <span class="hexagon-score__information-strong">Le score maximum à ce jour est 640 Pix</span> car les compétences sont pour l’instant limitées au niveau 5.</div>
+        <span class="hexagon-score-information__text--strong">Le score maximum à ce jour est 640 Pix</span> car les compétences sont pour l’instant limitées au niveau 5.</div>
 </div>

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -2,6 +2,10 @@
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">PIX</div>
     <div class="hexagon-score-content__pix-score">{{score}}</div>
-    <div class="hexagon-score-content__pix-total">1024</div>
+    <div class="hexagon-score-content__pix-total">1024 {{fa-icon 'info-circle'}}</div>
   </div>
+    <div class="hexagon-score__information">
+        <span class="hexagon-score__information-strong">Pourquoi 1024 Pix ?</span>
+        <br><br>C’est le score maximum atteignable dès que le niveau 8 des compétences sera disponible.
+        <span class="hexagon-score__information-strong">Le score maximum à ce jour est 640 Pix</span> car les compétences sont pour l’instant limitées au niveau 5.</div>
 </div>

--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -1,11 +1,11 @@
-<div class="hexagon-score">
+<div class="hexagon-score" onmouseover={{action 'showHelp'}} onmouseout={{action 'hideHelp'}}>
   <div class="hexagon-score__content">
     <div class="hexagon-score-content__title">PIX</div>
     <div class="hexagon-score-content__pix-score">{{score}}</div>
     <div class="hexagon-score-content__pix-total">1024 {{fa-icon 'info-circle'}}</div>
   </div>
-    <div class="hexagon-score__information">
-        <span class="hexagon-score__information-strong">Pourquoi 1024 Pix ?</span>
+    <div class="hexagon-score__information {{this.displayHelp}}">
+        <span class="hexagon-score__information-strong">Pourquoi 1024 Pix ?</span> <span class="hexagon-score-information__close" {{action 'hideHelp'}}>{{fa-icon 'times'}}</span>
         <br><br>C’est le score maximum atteignable dès que le niveau 8 des compétences sera disponible.
         <span class="hexagon-score__information-strong">Le score maximum à ce jour est 640 Pix</span> car les compétences sont pour l’instant limitées au niveau 5.</div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
- Nous indiquons que le nombre de Pix maximum est de 1024, alors qu'actuellement les utilisateurs peuvent en avoir 640 maximum

## :robot: Solution
- Afficher une info bulle lorsque l'utilisateur passe sur l'hexagone contenant le score total.
- Ajout d'une div avec les informations
- Une croix seulement sur mobile pour fermer la bulle d'information

## :rainbow: Remarques
- Utilisation du `::before` pour l'effet de décoché
- Utilisation de deux classe `show` et `hide` modifié via `onmouseover` ou par clique sur la croix.