### PR TITLE
[FEATURE] Placer le focus sur l'input suivante sur la page de démarrage d'une session de certification.

### DIFF
--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -80,6 +80,26 @@ export default Component.extend({
         this.set('errorMessage',
           'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.');
       }
+    },
+
+    handleDayInputChange(event) {
+      const { value } = event.target;
+
+      if (value.length === 2) {
+        document.getElementById('monthOfBirth').focus();
+      }
+    },
+
+    handleMonthInputChange(event) {
+      const { value } = event.target;
+
+      if (value.length === 2) {
+        document.getElementById('yearOfBirth').focus();
+      }
+    },
+
+    handleInputFocus(value, event) {
+      event.target.select();
     }
   },
 });

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -20,11 +20,11 @@
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Date de naissance</label>
             <div class="certification-joiner__birthdate">
-              {{input min="1" max="31" type="number" value=dayOfBirth placeholder="JJ" id="dayOfBirth"}}
+              {{input min="1" max="31" type="number" value=dayOfBirth placeholder="JJ" id="dayOfBirth" input=(action "handleDayInputChange") focus-in=(action "handleInputFocus")}}
                 <div class="certification-joiner__divider"></div>
-              {{input min="1" max="12" type="number" value=monthOfBirth placeholder="MM" id="monthOfBirth"}}
+              {{input min="1" max="12" type="number" value=monthOfBirth placeholder="MM" id="monthOfBirth" input=(action "handleMonthInputChange") focus-in=(action "handleInputFocus")}}
                 <div class="certification-joiner__divider"></div>
-              {{input min="1900" type="number" value=yearOfBirth placeholder="AAAA" id="yearOfBirth"}}
+              {{input min="1900" type="number" value=yearOfBirth placeholder="AAAA" id="yearOfBirth" focus-in=(action "handleInputFocus")}}
             </div>
         </div>
       {{#if errorMessage}}


### PR DESCRIPTION
## :unicorn: Problème
![image](https://user-images.githubusercontent.com/4154003/72817820-b5a65c00-3c6a-11ea-99e0-a6b6950d85d6.png)

Lors du démarrage d'une session de certification, remplir la date de naissance du candidat ne change pas le focus vers l'input du mois de naissance puis vers celle de l'année de naissance.

## :robot: Solution

Changer le focus au fur et a mesure que l'utilisateur tape.

