### PR TITLE
[FEATURE] Changer le mot de passe d'un étudiant connecté via un nom d'utilisateur (PO-322)

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -44,4 +44,37 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     organizationId: 3,
     userId: null
   });
+
+  const user1Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'George',
+    lastName: 'De Cambridge',
+    email: null,
+    username: 'george.decambridge2207',
+    rawPassword: 'Pix123',
+    cgu: false
+  }).id;
+  const user2Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'Blue Ivy',
+    lastName: 'Carter',
+    email: null,
+    username: 'blueivy.carter0701',
+    rawPassword: 'Pix123',
+    cgu: false
+  }).id;
+
+  databaseBuilder.factory.buildStudent({
+    firstName: 'George',
+    lastName: 'De Cambridge',
+    birthdate: '2013-07-22',
+    organizationId: 3,
+    userId: user1Id
+  });
+  databaseBuilder.factory.buildStudent({
+    firstName: 'Blue Ivy',
+    lastName: 'Carter',
+    birthdate: '2012-01-07',
+    organizationId: 3,
+    userId: user2Id
+  });
+
 };

--- a/api/lib/application/preHandlers/user-existence-verification.js
+++ b/api/lib/application/preHandlers/user-existence-verification.js
@@ -1,5 +1,4 @@
 const userRepository = require('../../../lib/infrastructure/repositories/user-repository');
-const User = require('../../infrastructure/data/user');
 const errorSerializer = require('../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 const { UserNotFoundError } = require('../../domain/errors');
 
@@ -8,7 +7,7 @@ module.exports = {
     return userRepository
       .get(parseInt(request.params.id))
       .catch((err) => {
-        if (err instanceof User.NotFoundError) {
+        if (err instanceof UserNotFoundError) {
           const serializedError = errorSerializer.serialize(new UserNotFoundError().getErrorMessage());
           return h.response(serializedError).code(404).takeover();
         }

--- a/api/lib/application/student-dependent-users/index.js
+++ b/api/lib/application/student-dependent-users/index.js
@@ -1,4 +1,8 @@
 const studentDependentUserController = require('./student-dependent-user-controller');
+const securityController = require('../../interfaces/controllers/security-controller');
+const Joi = require('@hapi/joi');
+const { passwordValidationPattern } = require('../../config').account;
+const XRegExp = require('xregexp');
 
 exports.register = async function(server) {
   server.route([
@@ -13,6 +17,36 @@ exports.register = async function(server) {
           'appartient la campagne spécifiée'
         ],
         tags: ['api', 'studentDependentUser']
+      }
+    },
+    {
+      method: 'POST',
+      path: '/api/student-dependent-users/password-update',
+      config: {
+        pre: [{
+          method: securityController.checkUserBelongsToScoOrganizationAndManagesStudents,
+          assign: 'belongsToScoOrganizationAndManageStudents'
+        }],
+        handler: studentDependentUserController.updatePassword,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'organization-id': Joi.number().required(),
+                'student-id': Joi.number().required(),
+                password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+              }
+            }
+          })
+        },
+        notes : [
+          '- Met à jour le mot de passe d\'un utilisateur identifié par son identifiant élève\n' +
+          '- La demande de modification du mot de passe doit être effectuée par un membre de l\'organisation à laquelle appartient l\'élève.'
+        ],
+        tags: ['api', 'studentDependentUser'],
       }
     },
   ]);

--- a/api/lib/application/student-dependent-users/student-dependent-user-controller.js
+++ b/api/lib/application/student-dependent-users/student-dependent-user-controller.js
@@ -18,5 +18,22 @@ module.exports = {
     const createdUser = await usecases.createAndAssociateUserToStudent({ userAttributes, campaignCode: payload['campaign-code'] });
 
     return h.response(userSerializer.serialize(createdUser)).created();
-  }
+  },
+
+  async updatePassword(request) {
+    const payload = request.payload.data.attributes;
+    const userId = parseInt(request.auth.credentials.userId);
+    const organizationId = parseInt(payload['organization-id']);
+    const studentId = parseInt(payload['student-id']);
+    const password = payload.password;
+
+    const updatedUser = await usecases.updateStudentDependentUserPassword({
+      userId,
+      organizationId,
+      studentId,
+      password,
+    });
+
+    return userSerializer.serialize(updatedUser);
+  },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -347,6 +347,12 @@ class UserNotAuthorizedToCertifyError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToUpdateStudentPasswordError extends DomainError {
+  constructor(message = 'Cet utilisateur n\'est pas autorisé à mettre à jour le mot de passe de l\'étudiant.') {
+    super(message);
+  }
+}
+
 class UserNotFoundError extends NotFoundError {
   constructor(message = 'Ce compte est introuvable.') {
     super(message);
@@ -447,6 +453,7 @@ module.exports = {
   CertificationCourseUpdateError,
   InvalidCertificationReportForFinalization,
   UserNotAuthorizedToUpdateResourceError,
+  UserNotAuthorizedToUpdateStudentPasswordError,
   UserNotFoundError,
   WrongDateFormatError,
 };

--- a/api/lib/domain/usecases/find-organization-students.js
+++ b/api/lib/domain/usecases/find-organization-students.js
@@ -1,3 +1,13 @@
-module.exports = function findOrganizationStudents({ organizationId, studentRepository }) {
-  return studentRepository.findByOrganizationId({ organizationId });
+module.exports = async function findOrganizationStudents({ organizationId, studentRepository, userRepository }) {
+
+  const students = await studentRepository.findByOrganizationId({ organizationId });
+
+  for (const student of students) {
+    if (student.userId) {
+      const user = await userRepository.get(student.userId);
+      student.username = user.username;
+    }
+  }
+
+  return students;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -152,6 +152,7 @@ module.exports = injectDependencies({
   updateMembershipRole: require('./update-membership-role'),
   updateOrganizationInformation: require('./update-organization-information'),
   updateSession: require('./update-session'),
+  updateStudentDependentUserPassword: require('./update-student-dependent-user-password'),
   updateUserPassword: require('./update-user-password'),
   writeOrganizationSharedProfilesAsCsvToStream: require('./write-organization-shared-profiles-as-csv-to-stream'),
 });

--- a/api/lib/domain/usecases/update-student-dependent-user-password.js
+++ b/api/lib/domain/usecases/update-student-dependent-user-password.js
@@ -1,0 +1,26 @@
+const _ = require('lodash');
+
+const { UserNotAuthorizedToUpdateStudentPasswordError, DomainError } = require('../errors');
+
+module.exports = async function updateStudentDependentUserPassword({
+  userId, organizationId, studentId, password,
+  encryptionService,
+  userRepository, studentRepository
+}) {
+
+  const userWithMemberships = await userRepository.getWithMemberships(userId);
+  const student = await studentRepository.get(studentId);
+
+  if (!userWithMemberships.hasAccessToOrganization(organizationId) || student.organizationId !== organizationId) {
+    throw new UserNotAuthorizedToUpdateStudentPasswordError();
+  }
+
+  const userStudent = await userRepository.get(student.userId);
+  if (_.isEmpty(userStudent.username)) {
+    throw new DomainError(`User student with ID ${student.userId} have not username !`);
+  }
+
+  const hashedPassword = await encryptionService.hashPassword(password);
+
+  return userRepository.updatePassword(student.userId, hashedPassword);
+};

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -4,6 +4,7 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 const Bookshelf = require('../bookshelf');
 const _ = require('lodash');
 const bluebird = require('bluebird');
+const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
 
@@ -69,5 +70,18 @@ module.exports = {
       .where({ userId, organizationId })
       .fetch()
       .then((student) => bookshelfToDomainConverter.buildDomainObject(BookshelfStudent, student));
+  },
+
+  get(studentId) {
+    return BookshelfStudent
+      .where({ id: studentId })
+      .fetch({ require: true })
+      .then((student) => bookshelfToDomainConverter.buildDomainObject(BookshelfStudent, student))
+      .catch((err) => {
+        if (err instanceof BookshelfStudent.NotFoundError) {
+          throw new NotFoundError(`Student not found for ID ${studentId}`);
+        }
+        throw err;
+      });
   }
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -227,11 +227,14 @@ module.exports = {
   updatePassword(id, hashedPassword) {
     return BookshelfUser
       .where({ id })
-      .save({ password: hashedPassword }, {
-        patch: true,
-        require: false
-      })
-      .then((bookshelfUser) => bookshelfUser.toDomainEntity());
+      .save({ password: hashedPassword }, { patch: true, method: 'update' })
+      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .catch((err) => {
+        if (err instanceof BookshelfUser.NoRowsUpdatedError) {
+          throw new UserNotFoundError(`User not found for ID ${id}`);
+        }
+        throw err;
+      });
   },
 
   async isPixMaster(id) {

--- a/api/lib/infrastructure/serializers/jsonapi/student-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(students) {
     return new Serializer('students', {
       attributes: [
-        'lastName', 'firstName', 'birthdate'
+        'lastName', 'firstName', 'birthdate', 'username'
       ],
     }).serialize(students);
   }

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -137,6 +137,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.OrganizationStudentAlreadyLinkedToUserError) {
     return new InfraErrors.ConflictError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToUpdateStudentPasswordError) {
+    return new InfraErrors.ForbiddenError(error.message);
+  }
 
   return new InfraErrors.InfrastructureError(error.message);
 }

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -128,7 +128,7 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = parseInt(request.params.id);
+  const organizationId = parseInt(request.params.id) || parseInt(request.payload.data.attributes['organization-id']);
 
   let belongsToScoOrganizationAndManageStudents;
   try {

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -746,19 +746,20 @@ describe('Acceptance | Application | organization-controller', () => {
 
   describe('GET /api/organizations/{id}/students', () => {
 
+    let user;
     let organization;
     let options;
 
     beforeEach(async () => {
-      const connectedUser = databaseBuilder.factory.buildUser();
+      user = databaseBuilder.factory.buildUser();
       organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: connectedUser.id });
+      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
       await databaseBuilder.commit();
 
       options = {
         method: 'GET',
         url: `/api/organizations/${organization.id}/students`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(connectedUser.id) },
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
     });
 
@@ -769,6 +770,7 @@ describe('Acceptance | Application | organization-controller', () => {
       beforeEach(async () => {
         student = databaseBuilder.factory.buildStudent({
           organizationId: organization.id,
+          userId: user.id
         });
 
         await databaseBuilder.commit();
@@ -783,6 +785,7 @@ describe('Acceptance | Application | organization-controller', () => {
                 'last-name': student.lastName,
                 'first-name': student.firstName,
                 'birthdate': student.birthdate,
+                'username': user.username
               },
               'id': student.id.toString(),
               'type': 'students'

--- a/api/tests/integration/application/student-dependent-users/index_test.js
+++ b/api/tests/integration/application/student-dependent-users/index_test.js
@@ -2,13 +2,16 @@ const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 
 const studentUserAssociationController = require('../../../../lib/application/student-dependent-users/student-dependent-user-controller');
 const moduleUnderTest = require('../../../../lib/application/student-dependent-users');
+const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 
 describe('Integration | Application | Route | student-dependent-users', () => {
 
   let httpTestServer;
 
   beforeEach(() => {
+    sinon.stub(securityController, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
     sinon.stub(studentUserAssociationController, 'createAndAssociateUserToStudent').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(studentUserAssociationController, 'updatePassword').callsFake((request, h) => h.response('ok').code(200));
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -36,6 +39,30 @@ describe('Integration | Application | Route | student-dependent-users', () => {
 
       // then
       expect(response.statusCode).to.equal(201);
+    });
+  });
+
+  describe('POST /api/student-dependent-users/password-update', () => {
+
+    it('should succeed', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/student-dependent-users/password-update';
+      const payload = {
+        data: {
+          attributes: {
+            'student-id': 1,
+            'organization-id': 3,
+            'password': 'P@ssw0rd'
+          }
+        }
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -3,7 +3,10 @@ const faker = require('faker');
 const bcrypt = require('bcrypt');
 const _ = require('lodash');
 
-const { AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError, OrganizationStudentAlreadyLinkedToUserError, NotFoundError, UserNotFoundError } = require('../../../../lib/domain/errors');
+const {
+  AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError, OrganizationStudentAlreadyLinkedToUserError,
+  NotFoundError, UserNotFoundError
+} = require('../../../../lib/domain/errors');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const User = require('../../../../lib/domain/models/User');
 const Membership = require('../../../../lib/domain/models/Membership');
@@ -461,6 +464,18 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       // then
       expect(updatedUser).to.be.an.instanceOf(User);
       expect(updatedUser.password).to.equal(newPassword);
+    });
+
+    it('should throw UserNotFoundError when user id not found', async () => {
+      // given
+      const wrongUserId = 0;
+      const newPassword = '1235Pix!';
+
+      // when
+      const error = await catchErr(userRepository.updatePassword)(wrongUserId, newPassword);
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
     });
   });
 

--- a/api/tests/integration/infrastructure/utils/error-manager_test.js
+++ b/api/tests/integration/infrastructure/utils/error-manager_test.js
@@ -372,6 +372,16 @@ describe('Integration | Utils | Error Manager', function() {
       expect(result.statusCode).to.equal(400);
     });
 
+    it('should return 403 on domain UserNotAuthorizedToUpdateStudentPasswordError', function() {
+      // given
+      const error = new DomainErrors.UserNotAuthorizedToUpdateStudentPasswordError();
+
+      // when
+      const result = send(hFake, error);
+
+      // then
+      expect(result.statusCode).to.equal(403);
+    });
   });
 
 });

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -20,8 +20,8 @@ class HttpTestServer {
     this.hapiServer.register(moduleUnderTest);
   }
 
-  request(method, url, payload) {
-    return this.hapiServer.inject({ method, url, payload });
+  request(method, url, payload, auth) {
+    return this.hapiServer.inject({ method, url, payload, auth });
   }
 }
 

--- a/api/tests/unit/application/preHandlers/user-existence-verification_test.js
+++ b/api/tests/unit/application/preHandlers/user-existence-verification_test.js
@@ -1,8 +1,8 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
-const BookshelfUser = require('../../../../lib/infrastructure/data/user');
 const userVerification = require('../../../../lib/application/preHandlers/user-existence-verification');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const errorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
+const { UserNotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Pre-handler | User Verification', () => {
 
@@ -45,7 +45,7 @@ describe('Unit | Pre-handler | User Verification', () => {
 
       it('should reply 404 status with a serialized error and takeOver the request', async () => {
         // given
-        userRepository.get.rejects(new BookshelfUser.NotFoundError());
+        userRepository.get.rejects(new UserNotFoundError());
         const serializedError = { serialized: 'error' };
         errorSerializer.serialize.returns(serializedError);
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -51,6 +51,10 @@ describe('Unit | Domain | Errors', () => {
     expect(errors.UserAlreadyLinkedToCandidateInSessionError).to.exist;
   });
 
+  it('should export a UserNotAuthorizedToUpdateStudentPassword', () => {
+    expect(errors.UserNotAuthorizedToUpdateStudentPasswordError).to.exist;
+  });
+
   describe('#UserNotFoundError', () => {
     it('should export a UserNotFoundError', () => {
       expect(errors.UserNotFoundError).to.exist;

--- a/api/tests/unit/domain/usecases/find-organization-students_test.js
+++ b/api/tests/unit/domain/usecases/find-organization-students_test.js
@@ -8,7 +8,7 @@ describe('Unit | UseCase | find-organization-students', () => {
     // given
     const organizationId = 1234;
     const studentRepositoryStub = { findByOrganizationId: sinon.stub() };
-    studentRepositoryStub.findByOrganizationId.resolves();
+    studentRepositoryStub.findByOrganizationId.resolves([]);
 
     // when
     await findOrganizationStudents({ organizationId, studentRepository: studentRepositoryStub });
@@ -28,6 +28,28 @@ describe('Unit | UseCase | find-organization-students', () => {
 
     // when
     const students = await findOrganizationStudents({ organizationId, studentRepository: studentRepositoryStub });
+
+    // then
+    expect(students).to.have.length(1);
+    expect(students[0]).to.be.an.instanceOf(Student);
+    expect(students).to.deep.equal(foundStudents);
+  });
+
+  it('should return the user\'s username if student userId is defined', async () => {
+    // given
+    const organizationId = 1234;
+
+    const foundUser = domainBuilder.buildUser();
+    const foundStudents = [domainBuilder.buildStudent({ organizationId, userId:  foundUser.id })];
+    const studentRepositoryStub = {
+      findByOrganizationId: sinon.stub().resolves(foundStudents)
+    };
+    const userRepositoryStub = {
+      get: sinon.stub().resolves(foundUser)
+    };
+
+    // when
+    const students = await findOrganizationStudents({ organizationId, studentRepository: studentRepositoryStub , userRepository: userRepositoryStub });
 
     // then
     expect(students).to.have.length(1);

--- a/api/tests/unit/domain/usecases/update-student-dependent-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-student-dependent-user-password_test.js
@@ -1,0 +1,160 @@
+const { sinon, expect, catchErr } = require('../../../test-helper');
+
+const {
+  UserNotAuthorizedToUpdateStudentPasswordError, UserNotFoundError, DomainError
+} = require('../../../../lib/domain/errors');
+
+const updateStudentDependentUserPassword = require('../../../../lib/domain/usecases/update-student-dependent-user-password');
+
+describe('Unit | UseCase | update-student-dependent-user-password', () => {
+
+  const userId = 1;
+  const organizationId = 1;
+  const studentId = 1;
+
+  const password = 'Pix12345';
+  const encryptedPassword = '@Pix12345@';
+
+  let encryptionService;
+  let userRepository;
+  let studentRepository;
+
+  let userMember;
+  let userStudent;
+  let student;
+
+  beforeEach(() => {
+    userMember = {
+      id: 1,
+      hasAccessToOrganization: sinon.stub().returns(true)
+    };
+    userStudent = {
+      username: 'first.last0112'
+    };
+
+    student = {
+      id: studentId,
+      userId: userMember.id,
+      organizationId
+    };
+
+    encryptionService = {
+      hashPassword: sinon.stub().resolves(encryptedPassword),
+    };
+    userRepository = {
+      get: sinon.stub().resolves(userStudent),
+      getWithMemberships: sinon.stub().resolves(userMember),
+      updatePassword: sinon.stub().resolves()
+    };
+    studentRepository = {
+      get: sinon.stub().resolves(student),
+    };
+  });
+
+  it('should get user by his id', async () => {
+    // when
+    await updateStudentDependentUserPassword({
+      userId, organizationId,
+      encryptionService,
+      userRepository, studentRepository });
+
+    // then
+    expect(userRepository.getWithMemberships).to.have.been.calledWith(userId);
+  });
+
+  it('should get student by his id', async () => {
+    // when
+    await updateStudentDependentUserPassword({
+      userId, organizationId, studentId, password,
+      encryptionService,
+      userRepository, studentRepository
+    });
+
+    // then
+    expect(studentRepository.get).to.have.been.calledWith(studentId);
+  });
+
+  it('should update user password with a hashed password', async () => {
+    // when
+    await updateStudentDependentUserPassword({
+      userId, organizationId, studentId, password,
+      encryptionService,
+      userRepository, studentRepository
+    });
+
+    // then
+    expect(encryptionService.hashPassword).to.have.been.calledWith(password);
+    expect(userRepository.updatePassword).to.have.been.calledWith(userMember.id, encryptedPassword);
+  });
+
+  describe('When the user member is not part of student organization', () => {
+
+    it('should return UserNotAuthorizedToUpdateStudentPasswordError', async () => {
+      // given
+      userMember.hasAccessToOrganization.returns(false);
+
+      // when
+      const error = await catchErr(updateStudentDependentUserPassword)({
+        userId, organizationId, studentId, password,
+        encryptionService,
+        userRepository, studentRepository
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToUpdateStudentPasswordError);
+    });
+  });
+
+  describe('When the student is not part of the organization', () => {
+
+    it('should return UserNotAuthorizedToUpdateStudentPasswordError', async () => {
+      // given
+      student.organizationId = 2;
+
+      // when
+      const error = await catchErr(updateStudentDependentUserPassword)({
+        userId, organizationId, studentId, password,
+        encryptionService,
+        userRepository, studentRepository
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToUpdateStudentPasswordError);
+    });
+  });
+
+  describe('When update user student\'s password is not possible', () => {
+
+    it('should return a UserNotFoundError when user student is not found', async () => {
+      // given
+      userRepository.get.rejects(new UserNotFoundError());
+
+      // when
+      const error = await catchErr(updateStudentDependentUserPassword)({
+        userId, organizationId, studentId, password,
+        encryptionService,
+        userRepository, studentRepository
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+
+    it('should return a DomainError when user student have not username', async () => {
+      // given
+      userStudent.username = null;
+
+      // when
+      const error = await catchErr(updateStudentDependentUserPassword)({
+        userId, organizationId, studentId, password,
+        encryptionService,
+        userRepository, studentRepository
+      });
+
+      // then
+      expect(error).to.be.instanceOf(DomainError);
+    });
+
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/student-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/student-serializer_test.js
@@ -1,0 +1,40 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/student-serializer');
+const Student = require('../../../../../lib/domain/models/Student');
+
+describe('Unit | Serializer | JSONAPI | student-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should convert a Student model object into JSON API data', () => {
+      // given
+      const student = new Student({
+        id: 5,
+        firstName: 'John',
+        lastName: 'Doe',
+        birthdate: '2020-01-01'
+      });
+
+      student.username = 'john.doe0101';
+
+      const expectedSerializedStudent = {
+        data: {
+          type: 'students',
+          id: '5',
+          attributes: {
+            'first-name': student.firstName,
+            'last-name': student.lastName,
+            'birthdate': student.birthdate,
+            'username': student.username,
+          }
+        }
+      };
+
+      // when
+      const json = serializer.serialize(student);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedStudent);
+    });
+  });
+});

--- a/api/tests/unit/interfaces/controllers/security-controller_test.js
+++ b/api/tests/unit/interfaces/controllers/security-controller_test.js
@@ -394,18 +394,45 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
             accessToken: 'valid.access.token',
             userId: 1234
           }
-        },
-        params: { id: 5678 } };
+        }
+      };
 
-      it('should authorize access to resource when the user is authenticated, belongs to SCO Organization and manages students', async () => {
-        // given
-        belongToScoOrganizationAndManageStudentsStub.resolves(true);
+      context('when organization id is in request params', () => {
 
-        // when
-        const response = await securityController.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+        request.params = { id: 5678 };
 
-        // then
-        expect(response.source).to.equal(true);
+        it('should authorize access to resource when the user is authenticated, belongs to SCO Organization and manages students', async () => {
+          // given
+          belongToScoOrganizationAndManageStudentsStub.resolves(true);
+
+          // when
+          const response = await securityController.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+
+          // then
+          expect(response.source).to.equal(true);
+        });
+      });
+
+      context('when organization id is in request payload', () => {
+
+        request.payload = {
+          data: {
+            attributes: {
+              organizationId: 5678
+            }
+          }
+        };
+
+        it('should authorize access to resource when the user is authenticated, belongs to SCO Organization and manages students', async () => {
+          // given
+          belongToScoOrganizationAndManageStudentsStub.resolves(true);
+
+          // when
+          const response = await securityController.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+
+          // then
+          expect(response.source).to.equal(true);
+        });
       });
     });
 

--- a/orga/app/adapters/student-dependent-user.js
+++ b/orga/app/adapters/student-dependent-user.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/student-dependent-users/password-update`;
+  },
+
+});

--- a/orga/app/components/password-reset-window.js
+++ b/orga/app/components/password-reset-window.js
@@ -1,0 +1,74 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+import isPasswordValid from '../utils/password-validator';
+
+const ERROR_PASSWORD_MESSAGE =
+  'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+
+export default Component.extend({
+
+  store: service(),
+  notifications: service('notifications'),
+
+  isLoading: false,
+
+  isPasswordVisible: false,
+  passwordInputType: computed('isPasswordVisible', function() {
+    return this.isPasswordVisible ? 'text' : 'password';
+  }),
+  student: null,
+  isShowingModal: null,
+  studentUser: null,
+
+  init() {
+    this._super(...arguments);
+    this.studentUser = this.store.createRecord('student-dependent-user', {
+      organizationId: this.student.organization.get('id'),
+      studentId: this.student.id,
+      password: null
+    });
+    this.set('validation', {
+      password: {
+        message: null
+      }
+    });
+  },
+
+  actions: {
+
+    async updatePassword() {
+      if (isPasswordValid(this.studentUser.password)) {
+        this.set('isLoading', true);
+        try {
+          await this.studentUser.save();
+          this.closePasswordReset();
+          this.get('notifications').sendSuccess('Mot de passe modifié !');
+        } catch (e) {
+          this.closePasswordReset();
+          this.get('notifications').sendError('Quelque chose s\'est mal passé. Veuillez réessayer.');
+        } finally {
+          this.set('isLoading', false);
+        }
+      }
+    },
+
+    togglePasswordVisibility() {
+      this.toggleProperty('isPasswordVisible');
+    },
+
+    validateInputPassword() {
+      const isInvalidInput = !isPasswordValid(this.studentUser.password);
+      const message = isInvalidInput ? ERROR_PASSWORD_MESSAGE : '';
+      this.set('validation.password.message', message);
+    },
+  },
+
+  closePasswordReset() {
+    this.set('studentUser', null);
+    this.set('validation', null);
+    this.set('isShowingModal', false);
+  },
+
+});

--- a/orga/app/components/pix-modal.js
+++ b/orga/app/components/pix-modal.js
@@ -1,0 +1,36 @@
+import { on } from '@ember/object/evented';
+import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
+import { EKMixin as EmberKeyboardMixin, keyUp } from 'ember-keyboard';
+
+export default ModalDialog.extend(EmberKeyboardMixin, {
+
+  translucentOverlay: true,
+  targetAttachment: 'none',
+  wrapperClass: 'centered-scrolling-wrapper',
+  overlayClass: 'centered-scrolling-overlay',
+  containerClass: 'centered-scrolling-container',
+
+  init() {
+    this._super(...arguments);
+    this.set('keyboardActivated', true);
+    this.set('wrapperClassNames', ['pix-modal-wrapper']);
+    this.set('overlayClassNames', ['pix-modal-overlay']);
+  },
+
+  didRender() {
+    this._super(...arguments);
+    document.querySelector('#modal-overlays').classList.add('active');
+    document.body.classList.add('centered-modal-showing');
+  },
+
+  willDestroyElement() {
+    document.querySelector('#modal-overlays').classList.remove('active');
+    document.body.classList.remove('centered-modal-showing');
+    this._super(...arguments);
+  },
+
+  closeOnEsc: on(keyUp('Escape'), function() {
+    this.onClose();
+  })
+
+});

--- a/orga/app/components/routes/authenticated/students/list-items.js
+++ b/orga/app/components/routes/authenticated/students/list-items.js
@@ -4,5 +4,20 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
 
   currentUser: service(),
+  student: null,
+  isShowingModal: false,
+
+  actions: {
+
+    openPasswordReset(student) {
+      this.set('student', student);
+      this.set('isShowingModal', true);
+    },
+
+    closePasswordReset() {
+      this.set('isShowingModal', false);
+    },
+
+  }
 
 });

--- a/orga/app/models/student-dependent-user.js
+++ b/orga/app/models/student-dependent-user.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  organizationId: DS.attr('number'),
+  studentId: DS.attr('number'),
+  password: DS.attr('string'),
+});

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -1,8 +1,12 @@
 import DS from 'ember-data';
+import { notEmpty } from '@ember/object/computed';
 
 export default DS.Model.extend({
   lastName: DS.attr('string'),
   firstName: DS.attr('string'),
   birthdate: DS.attr('date-only'),
   organization: DS.belongsTo('organization'),
+  username: DS.attr('string'),
+
+  hasUsername: notEmpty('username'),
 });

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -24,6 +24,7 @@
 @import "components/circle-chart";
 @import "components/current-organization";
 @import "components/pagination-control";
+@import "components/password-reset-modal";
 @import "components/progression-gauge";
 @import "components/register-form";
 @import "components/sidebar-menu";

--- a/orga/app/styles/components/password-reset-modal.scss
+++ b/orga/app/styles/components/password-reset-modal.scss
@@ -1,0 +1,58 @@
+.password-reset-modal {
+  @include device-is('desktop') {
+    width: 500px;
+  }
+}
+
+.password-reset-header {
+  padding-top: 10px;
+  text-align: left;
+  font-family: $roboto;
+  font-weight: 500;
+  align-items: baseline;
+
+  &__icon {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    left: auto;
+  }
+
+  &__title {
+    font-size: 1.75rem;
+    margin: 16px 0px 8px;
+    padding-left: 15px;
+  }
+
+  &__subtitle {
+    font-size: 1rem;
+    margin-bottom: 8px;
+    padding-left: 15px;
+  }
+}
+
+.password-reset-body {
+  background-color: $white;
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+  padding: 15px 15px 0px 15px;
+}
+
+.password-reset-body label {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: .05rem;
+}
+
+.password-reset-body .disabled {
+  background-color: $alto;
+}
+
+.password-reset-body .help {
+  text-transform: none;
+  font-weight: normal;
+  letter-spacing: normal;
+  font-size: 0.85rem;
+}
+

--- a/orga/app/templates/authenticated/students/list.hbs
+++ b/orga/app/templates/authenticated/students/list.hbs
@@ -1,8 +1,8 @@
 <div class="list-students-page">
 
   {{routes/authenticated/students/list-items
-  students=model
-  isLoading=isLoading
-  importStudents=(action 'importStudents')
+    students=model
+    isLoading=isLoading
+    importStudents=(action 'importStudents')
   }}
 </div>

--- a/orga/app/templates/components/password-reset-window.hbs
+++ b/orga/app/templates/components/password-reset-window.hbs
@@ -1,0 +1,68 @@
+{{#pix-modal containerClass="password-reset-modal" onClose=(action closePasswordReset) }}
+
+  <div class="pix-modal__container">
+
+    <div class="pix-modal-header">
+      <div class="password-reset-header__title">Réinitialisation du mot de passe</div>
+      <div class="password-reset-header__subtitle">L'élève saisit ici son nouveau mot de passe.</div>
+      <div class="icon-button password-reset-header__icon" {{ action closePasswordReset }}>
+        {{fa-icon 'times'}}
+      </div>
+    </div>
+
+    <div class="password-reset-body">
+      <form {{ action 'updatePassword' on='submit' }}>
+        <div class="input-container">
+          <label for="username" class="label">Identifiant de l'élève</label>
+          <Input
+            @id="username"
+            @name="username"
+            @type="text"
+            @class="input disabled"
+            @value={{student.username}}
+            @disabled="disabled"
+          />
+        </div>
+
+        <div class="input-container">
+          <label for="password" class="label">
+            Nouveau mot de passe<br>
+            <span class="help">
+              (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)
+            </span>
+          </label>
+          <div class="{{if validation.password.message 'alert-input alert-input--error'}}" role="alert">{{validation.password.message}}</div>
+          <div class="input-password {{if validation.password.message 'input-password--error'}}">
+            <Input
+              @id="update-password"
+              @name="password"
+              @type={{passwordInputType}}
+              @class="input"
+              @value={{studentUser.password}}
+              required="required"
+              @autocomplete="current-password"
+              @focusOut={{action 'validateInputPassword'}}
+            />
+            <button type="button" aria-label="rendre le mot de passe lisible" class="input-password__icon" {{action 'togglePasswordVisibility'}} >
+              {{#if isPasswordVisible}}
+                <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw input-password-icon__eye"}}</div>
+              {{else}}
+                <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="fa-fw input-password-icon__eye"}}</div>
+              {{/if}}
+            </button>
+          </div>
+        </div>
+
+        <div class="input-container">
+          {{#if isLoading}}
+            <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
+          {{else}}
+            <button type="submit" class="button">Modifier le mot de passe</button>
+          {{/if}}
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+{{/pix-modal}}

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -21,6 +21,7 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>Date de naissance</th>
+        <th>Mot de passe</th>
       </tr>
       </thead>
 
@@ -31,6 +32,14 @@
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
+            <td>
+              {{#if student.hasUsername}}
+                <button class="button button--with-icon-and-text button-edit-role"
+                        type="button" {{action 'openPasswordReset' student}}>
+                  Réinitialiser
+                </button>
+              {{/if}}
+            </td>
           </tr>
         {{/each}}
 
@@ -42,6 +51,10 @@
       <div class="table__empty content-text">En attente d'élèves</div>
     {{/unless}}
   </div>
+
+  {{#if isShowingModal}}
+    {{password-reset-window student=student isShowingModal=isShowingModal}}
+  {{/if}}
 </div>
 
 {{#if isLoading}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -194,4 +194,17 @@ export default function() {
   this.get('/campaign-participations/:id');
 
   this.get('/campaign-participation-results/:id');
+
+  this.post('/student-dependent-users/password-update', (schema, request) => {
+    const passwordForFailure = 'passwordFor01Failure';
+
+    const requestBody = JSON.parse(request.requestBody);
+    const { password } = requestBody.data.attributes;
+    if (password === passwordForFailure) {
+      return new Response(500, {}, { errors: [ { status: '500', detail: '' } ] });
+    }
+
+    return schema.users.find(1);
+  });
+
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14335,6 +14335,16 @@
         }
       }
     },
+    "ember-keyboard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-5.0.0.tgz",
+      "integrity": "sha512-ahWioA5ek1MU8JayyzowCiRQWRGXfqYTJPFOpxJsTDQmjpUm3HpQHVXmqZXy6wEPnRnhyngRpPbU5/K8cW0CMg==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+        "ember-cli-babel": "^7.4.1"
+      }
+    },
     "ember-load-initializers": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.0.tgz",

--- a/orga/package.json
+++ b/orga/package.json
@@ -60,6 +60,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-file-upload": "^2.7.1",
     "ember-freestyle": "^0.11.9",
+    "ember-keyboard": "^5.0.0",
     "ember-load-initializers": "^2.1.0",
     "ember-modal-dialog": "^3.0.0-beta.4",
     "ember-moment": "^8.0.0",

--- a/orga/tests/integration/components/password-reset-window-test.js
+++ b/orga/tests/integration/components/password-reset-window-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, render, triggerEvent } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
+import hbs from 'htmlbars-inline-precompile';
+
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+
+module('Integration | Component | password-reset-window', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let username;
+
+  hooks.beforeEach(function() {
+    const store = this.owner.lookup('service:store');
+    username = 'john.doe0112';
+    const student =
+      run(() => store.createRecord('student', {
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        birthdate: '2010-12-01',
+        username,
+        organization: run(() => store.createRecord('organization', {}))
+      }));
+    this.set('student', student);
+  });
+
+  module('Component rendering', function() {
+
+    test('should render component', async function(assert) {
+      // when
+      await render(hbs`{{password-reset-window student=student}}`);
+
+      // then
+      assert.dom('.pix-modal-overlay').exists();
+      assert.dom('#username').hasValue(username);
+    });
+
+    module('errors management', function() {
+
+      [' ', 'password', 'password1', 'Password'].forEach(function(wrongPassword) {
+
+        test(`it should display an error message on password field, when '${wrongPassword}' is typed and focused out`, async function(assert) {
+          // given
+          await render(hbs`{{password-reset-window student=student}}`);
+
+          // when
+          await fillIn('#update-password', wrongPassword);
+          await triggerEvent('#update-password', 'blur');
+
+          // then
+          assert.dom('.alert-input--error').hasText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
+          assert.dom('.input-password--error').exists();
+        });
+      });
+    });
+  });
+
+});

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -2,10 +2,26 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/students | list-items', function(hooks) {
   setupRenderingTest(hooks);
+
+  test('it should display the header names', async function(assert) {
+    // given
+    this.set('students', []);
+
+    // when
+    await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+
+    // then
+    assert.dom('.table thead tr th').exists({ count: 4 });
+    assert.dom('.table thead tr th:first-child').hasText('Nom');
+    assert.dom('.table thead tr th:nth-child(2)').hasText('Prénom');
+    assert.dom('.table thead tr th:nth-child(3)').hasText('Date de naissance');
+    assert.dom('.table thead tr th:last-child').hasText('Mot de passe');
+  });
 
   test('it should display a list of students', async function(assert) {
     // given
@@ -39,7 +55,71 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     // then
     assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
     assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
-    assert.dom('.table tbody tr:first-child td:last-child').hasText('01/02/2010');
+    assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/02/2010');
+  });
+
+  module('when student have a username', () => {
+
+    hooks.beforeEach(function() {
+      this.set('openPasswordResetSpy', () => {});
+    });
+
+    test('it should display the student\'s firstName, lastName and birthdate, and password update button', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const student =
+        run(() => store.createRecord('student', {
+          id: 1,
+          lastName: 'lastName',
+          firstName: 'firstName',
+          birthdate: new Date('2008-10-01'),
+          username: 'firstname.lastname0110'
+        }));
+
+      this.set('students', [student]);
+
+      // when
+      await render(hbs`{{routes/authenticated/students/list-items students=students openPasswordReset=openPasswordResetSpy}}`);
+
+      // then
+      assert.dom('.table tbody tr:first-child td:first-child').hasText('lastName');
+      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('firstName');
+      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/10/2008');
+      assert.dom('.table tbody tr:first-child td:last-child button').hasText('Réinitialiser');
+    });
+
+    test('it should not display password update button when student have not username', async function(assert) {
+      const store = this.owner.lookup('service:store');
+
+      const storedStudents = [];
+      [
+        {
+          id: 1,
+          firstName: 'Paul',
+          lastName: 'Durant',
+          birthdate: new Date('2008-10-01'),
+        },
+        {
+          id: 2,
+          firstName: 'Jackie',
+          lastName: 'Coogan',
+          birthdate: new Date('2004-10-26'),
+          username: 'jackie.coogan2610'
+        },
+      ].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
+
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`{{routes/authenticated/students/list-items students=students openPasswordReset=openPasswordResetSpy}}`);
+
+      // then
+      assert.dom('.table tbody tr:first-child td:last-child button').doesNotExist();
+      assert.dom('.table tbody tr:nth-child(2) td:last-child button').hasText('Réinitialiser');
+    });
+
   });
 
   module('when user is admin in organization', (hooks) => {


### PR DESCRIPTION
## :unicorn: Problème
La procédure de changement de mot de passe actuelle nécessite de posséder une adresse email. Cependant, les étudiants n'en possède pas forcément et, depuis la PF-966, il leur est permis de s'inscrire/se connecter via un nom d'utilisateur plutôt qu'une adresse email. Il nous faut donc un mécanisme permettant de changer de mot de passe pour ces étudiants. 

## :robot: Solution
Il a été décidé de permettre, depuis Pix Orga, à un membre de l'organisation SCO (un professeur) d'initier un changement de mot de passe de ses étudiants. Ces derniers, devront saisir leur nouveau mot de passe depuis l'ordinateur du professeur, garantissant ainsi l'identité de l'étudiant.
Cette nouvelle procédure ne s'adresse qu'aux étudiants dont le compte a été créé via nom d'utilisateur, les autres pouvant suivre la procédure de changement de mot de passes avec envoi d'email. 

## :rainbow: Remarques
Une solution plus complète est prévue mais par souci de temps, nous avons privilégié celle-ci qui pourra être disponible plus rapidement.   
