### PR TITLE
[FEATURE] Pix+ - Ajout et prise en compte de l'origine (Pix ou hors Pix) des compétences (PF-1047)

### DIFF
--- a/api/lib/domain/models/Competence.js
+++ b/api/lib/domain/models/Competence.js
@@ -7,6 +7,7 @@ class Competence {
     name,
     index,
     description,
+    origin,
     // includes
     skills = [],
     // references
@@ -18,6 +19,7 @@ class Competence {
     this.name = name;
     this.index = index;
     this.description = description;
+    this.origin = origin;
     this.level = -1;
     // includes
     this.skills = skills; // TODO remplacer par un vrai tableau de SKills

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -100,7 +100,7 @@ function _createUserCompetencesV1({ allCompetences, allAdaptativeCourses, userLa
 async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1(certificationProfile) {
   const certificationProfileToFill = _.clone(certificationProfile);
   const [allCompetences, allAdaptativeCourses] = await Promise.all([
-    competenceRepository.list(),
+    competenceRepository.listPixCompetencesOnly(),
     courseRepository.getAdaptiveCourses()
   ]);
   const userLastAssessments = await assessmentRepository
@@ -131,7 +131,7 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
 
 async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2(certificationProfile) {
   const certificationProfileToFill = _.clone(certificationProfile);
-  const allCompetences = await competenceRepository.list();
+  const allCompetences = await competenceRepository.listPixCompetencesOnly();
 
   const knowledgeElementsByCompetence = await knowledgeElementRepository
     .findUniqByUserIdGroupedByCompetenceId({ userId: certificationProfile.userId, limitDate: certificationProfile.profileDate });

--- a/api/lib/domain/usecases/get-user-scorecards.js
+++ b/api/lib/domain/usecases/get-user-scorecards.js
@@ -4,7 +4,7 @@ const Scorecard = require('../models/Scorecard');
 module.exports = async function getUserScorecards({ userId, knowledgeElementRepository, competenceRepository, competenceEvaluationRepository }) {
   const [knowledgeElementsGroupedByCompetenceId, competencesWithArea, competenceEvaluations] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId }),
-    competenceRepository.list(),
+    competenceRepository.listPixCompetencesOnly(),
     competenceEvaluationRepository.findByUserId(userId),
   ]);
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -12,7 +12,8 @@ module.exports = datasource.extend({
     'Description',
     'Domaine',
     'Tests',
-    'Acquis (via Tubes)'
+    'Acquis (via Tubes)',
+    'Origine',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -24,6 +25,7 @@ module.exports = datasource.extend({
       areaId: airtableRecord.get('Domaine') ? airtableRecord.get('Domaine')[0] : '',
       courseId: airtableRecord.get('Tests') ? airtableRecord.get('Tests')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes)') || [],
+      origin: airtableRecord.get('Origine') || 'Pix',
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -25,7 +25,7 @@ module.exports = datasource.extend({
       areaId: airtableRecord.get('Domaine') ? airtableRecord.get('Domaine')[0] : '',
       courseId: airtableRecord.get('Tests') ? airtableRecord.get('Tests')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes)') || [],
-      origin: airtableRecord.get('Origine') || 'Pix',
+      origin: airtableRecord.get('Origine'),
     };
   },
 

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -5,6 +5,8 @@ const areaDatasource = require('../datasources/airtable/area-datasource');
 const Area = require('../../domain/models/Area');
 const { NotFoundError } = require('../../domain/errors');
 
+const PixOriginName = 'Pix';
+
 function _toDomain(competenceData, areaDatas) {
   const areaData = competenceData.areaId && _.find(areaDatas, { id: competenceData.areaId });
   return new Competence({
@@ -31,8 +33,9 @@ module.exports = {
   },
 
   listPixCompetencesOnly() {
+
     return _list().then((competences) =>
-      competences.filter((competence) => competence.origin === 'Pix')
+      competences.filter((competence) => competence.origin === PixOriginName)
     );
   },
 

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -12,6 +12,7 @@ function _toDomain(competenceData, areaDatas) {
     name: competenceData.name,
     index: competenceData.index,
     description: competenceData.description,
+    origin: competenceData.origin,
     courseId: competenceData.courseId,
     skills: competenceData.skillIds,
     area: areaData && new Area({
@@ -26,13 +27,13 @@ function _toDomain(competenceData, areaDatas) {
 module.exports = {
 
   list() {
-    return Promise.all([competenceDatasource.list(), areaDatasource.list()])
-      .then(([competenceDatas, areaDatas]) => {
-        return _.sortBy(
-          competenceDatas.map((competenceData) => _toDomain(competenceData, areaDatas)),
-          'index'
-        );
-      });
+    return _list();
+  },
+
+  listPixCompetencesOnly() {
+    return _list().then((competences) =>
+      competences.filter((competence) => competence.origin === 'Pix')
+    );
   },
 
   get(id) {
@@ -50,3 +51,13 @@ module.exports = {
       });
   }
 };
+
+function _list() {
+  return Promise.all([competenceDatasource.list(), areaDatasource.list()])
+    .then(([competenceDatas, areaDatas]) => {
+      return _.sortBy(
+        competenceDatas.map((competenceData) => _toDomain(competenceData, areaDatas)),
+        'index'
+      );
+    });
+}

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -93,7 +93,7 @@ describe('Integration | Service | User Service | #getCertificationProfile', func
       challengeRecordWithoutSkills,
       oldChallengeWithAlreadyValidatedSkill
     ]);
-    sinon.stub(competenceRepository, 'list').resolves([
+    sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves([
       competenceFlipper,
       competenceDauphin
     ]);
@@ -148,7 +148,7 @@ describe('Integration | Service | User Service | #getCertificationProfile', func
         await userService.getCertificationProfile({ userId, isV2Certification: false });
 
         // then
-        sinon.assert.calledOnce(competenceRepository.list);
+        sinon.assert.calledOnce(competenceRepository.listPixCompetencesOnly);
       });
 
       it('should return the appropriate challenge IDS depending on answers', async () => {

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -63,6 +63,7 @@ module.exports = function buildCompetence({
     '1',
   ],
   createdTime = '2017-06-13T13:53:17.000Z',
+  origin = 'Pix',
 } = {}) {
 
   return {
@@ -82,6 +83,7 @@ module.exports = function buildCompetence({
       'Record ID': recordID,
       'Domaine Titre': domaineTitre,
       'Domaine Code': domaineCode,
+      'Origine': origin,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
@@ -5,6 +5,7 @@ module.exports = function buildCompetenceAirtableDataObject({
   areaId = 'recvoGdo7z2z7pXWa',
   courseId = 'recNPB7dTNt5krlMA',
   description = 'Some description',
+  origin = 'Pix',
   skillIds = [
     'recV11ibSCXvaUzZd',
     'recD01ptfJy7c4Sex',
@@ -24,6 +25,7 @@ module.exports = function buildCompetenceAirtableDataObject({
     index,
     areaId,
     courseId,
+    origin,
     skillIds,
     description,
   };

--- a/api/tests/tooling/domain-builder/factory/build-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence.js
@@ -13,6 +13,7 @@ module.exports = function buildCompetence({
   // relationships
   area = buildArea(),
   skills = [],
+  origin = 'Pix',
 } = {}) {
 
   return new Competence({
@@ -22,6 +23,7 @@ module.exports = function buildCompetence({
     index,
     courseId,
     description,
+    origin,
     // relationships
     area,
     skills,

--- a/api/tests/tooling/fixtures/infrastructure/competenceRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/competenceRawAirTableFixture.js
@@ -59,6 +59,7 @@ module.exports = function competenceRawAirTableFixture() {
       'Acquis Of Level 6': 4,
       'Acquis Of Level 7': 0,
       'Acquis Of Level 8': 0,
+      'Origine': 'Pix',
     },
     'createdTime': '2017-06-13T13:53:17.000Z',
   });

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
   const scorecard = { id: 'foo' };
 
   beforeEach(() => {
-    competenceRepository = { list: sinon.stub() };
+    competenceRepository = { listPixCompetencesOnly: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserIdGroupedByCompetenceId: sinon.stub() };
     competenceEvaluationRepository = { findByUserId: sinon.stub() };
     sinon.stub(Scorecard, 'buildFrom').returns(scorecard);
@@ -35,7 +35,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
 
       it('should resolve', () => {
         // given
-        competenceRepository.list.resolves([]);
+        competenceRepository.listPixCompetencesOnly.resolves([]);
         knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId.resolves({});
         competenceEvaluationRepository.findByUserId.resolves([]);
 
@@ -64,7 +64,7 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           domainBuilder.buildCompetence({ id: 2 }),
           domainBuilder.buildCompetence({ id: 3 })
         ];
-        competenceRepository.list.resolves(competenceList);
+        competenceRepository.listPixCompetencesOnly.resolves(competenceList);
 
         const assessmentFinishedOfCompetence1 = domainBuilder.buildAssessment({
           type: 'COMPETENCE_EVALUATION',

--- a/api/tests/unit/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-repository_test.js
@@ -23,6 +23,7 @@ describe('Unit | Repository | competence-repository', () => {
     description: 'Competence description 1',
     areaId: 'recArea',
     courseId: 'recCourse1',
+    origin: 'Pix',
     skillIds: ['recSkill1', 'recSkill2'],
   };
 
@@ -32,13 +33,25 @@ describe('Unit | Repository | competence-repository', () => {
     index: '1.2',
     description: 'Competence description 2',
     areaId: 'recArea',
+    origin: 'Pix',
+    courseId: 'recCourse2',
+    skillIds: [],
+  };
+
+  const nonPixCompetenceData = {
+    id: 'recNonPixCompetence',
+    name: 'NonPixCompetenceName',
+    index: '4.1',
+    description: 'Non Pix Competence description',
+    areaId: 'recArea',
+    origin: 'Autre que Pix',
     courseId: 'recCourse2',
     skillIds: [],
   };
 
   beforeEach(() => {
     sinon.stub(areaDatasource, 'list').resolves([areaData]);
-    sinon.stub(competenceDatasource, 'list').resolves([competenceData2, competenceData1]);
+    sinon.stub(competenceDatasource, 'list').resolves([competenceData2, competenceData1, nonPixCompetenceData]);
     sinon.stub(competenceDatasource, 'get').withArgs('recCompetence1').resolves(competenceData1);
   });
 
@@ -47,6 +60,23 @@ describe('Unit | Repository | competence-repository', () => {
     it('should return domain Competence objects sorted by index', () => {
       // when
       const fetchedCompetences = competenceRepository.list();
+
+      // then
+      return fetchedCompetences.then((competences) => {
+        expect(competences).to.have.lengthOf(3);
+        expect(competences[0]).to.be.an.instanceOf(Competence);
+        expect(competences[0].index).to.equal('1.1');
+        expect(competences[1].index).to.equal('1.2');
+        expect(competences[2].index).to.equal('4.1');
+      });
+    });
+  });
+
+  describe('#listPixCompetencesOnly', () => {
+
+    it('should return Pix only domain Competence objects sorted by index', () => {
+      // when
+      const fetchedCompetences = competenceRepository.listPixCompetencesOnly();
 
       // then
       return fetchedCompetences.then((competences) => {
@@ -71,6 +101,7 @@ describe('Unit | Repository | competence-repository', () => {
         name: 'Mener une recherche d’information',
         description: 'Competence description 1',
         courseId: 'recCourse1',
+        origin: 'Pix',
         skills: ['recSkill1', 'recSkill2'],
         area: new Area({
           id: 'recArea',
@@ -98,6 +129,7 @@ describe('Unit | Repository | competence-repository', () => {
         index: '1.1',
         name: 'Mener une recherche d’information',
         courseId: 'recCourse',
+        origin: 'Pix',
         skills: ['recSkill1', 'recSkill2'],
         area: new Area({
           id: 'recArea',

--- a/docs/Calcul-Airtable.md
+++ b/docs/Calcul-Airtable.md
@@ -1,0 +1,63 @@
+# Calcul des Pix dans Airtable
+
+# Règle de calcul des Pix
+
+Rappel de la règle de calcul :
+
+1.  On ne considère dans la suite que les Acquis :
+    1.  Ayant le champ **Status** à **actif** ;
+    2.  Associé à au moins une épreuve ayant le champ **Statut** à **validé**, **validé sans test** ou **pré-validé**.
+    3.  Associé à une Compétence dont le champ **Origine** est **Pix**
+2.  Pour chaque Acquis :
+    1.  On compte le nombre d'acquis :
+        1.  de la même compétence ;
+        2.  et de même niveau.
+    2.  On divise 8 par ce nombre pour obtenir la valeur en Pix ; si le résultat est supérieur à 4 la valeur est limitée à 4.
+
+# Ajouter les champs de calcul des Pix
+
+Rappel : la hiérarchie d'objets concernée est la suivante :
+
+*   Chaque Compétence :
+    *   contient des Tubes…
+        *   qui contiennent des Acquis…
+            *   qui contiennent des Epreuves.
+
+L'idée est de construire en remontant la liste des niveaux des acquis jusqu'à leur compétence, puis de la redescendre jusqu'à chaque acquis qui peut ensuite déterminer combien d'acquis dans sa compétence ont le même niveau que lui.
+
+Sont ajoutés les champs suivants, dans l'ordre où ils sont évalués :
+
+*   **Epreuves**.**IsValidated** qui vaut 1 si l'épreuve est considérée "validée" (règle 1.b), et 0 sinon ;
+    *   Field type : Formula
+    *   Formule : <span style="color: rgb(0,146,29);">IF(OR({Statut}="validé", {Statut}="validé sans test", {Statut}="pré-validé"), 1,0)</span>
+    *   Exemple de résultat : 1
+*   **Acquis**.**LevelIfActive** qui vaut le niveau (**Level**) de l'acquis si le **Status** est **actif** (règle 1.a) et qu'il existe une épreuve validée (règle 1.b), sinon une chaîne vide ;
+    *   Pour savoir s'il existe une épreuve validée, ce champ est un _rollup_ du champ **IsValidated** des épreuves associées à l'acquis ; en faisant la somme des **IsValidated** on sait s'il existe ou non une épreuve validée; 
+    *   Field type : Rollup
+    *   Formule : <span style="color: rgb(0,146,29);">IF(AND(SUM(values) > 0, Status="actif"), Level, "")</span>
+    *   Exemple de résultat : 3
+*   **Tubes**.**AcquisLevels** qui calcule la concaténation des **LevelIfActive** des **Acquis** contenus dans le tube ;
+    *   Field type : Rollup 
+    *   Formule : <span style="color: rgb(0,146,29);">CONCATENATE(values)</span>
+    *   Exemple de résultat : 1245
+*   **Acquis**.**Origin** qui recopie le champ **Origine** de la compétence sur chacun de ses Tubes ;
+    *   Field type : Lookup
+    *   Exemple de résultat : "Pix"
+*   **Competences**.**AcquisLevels** qui fait à son tour la concaténation des **AcquisLevels** remontés sur les **Tubes** ;
+    *   Field type : Rollup
+    *   Formule : <span style="color: rgb(0,146,29);">CONCATENATE(values)</span>
+    *   Exemple de résultat : 1544352134513675445363453124351241234
+*   **Tubes**.**CompetenceAcquisLevels** qui recopie le champ **AcquisLevels** de la compétence sur chacun de ses Tubes ;
+    *   Field type : Lookup 
+    *   Exemple de résultat : 1544352134513675445363453124351241234
+*   **Acquis**.**PixValue** qui récupère le **CompetenceAcquisLevels** de son Tube et dispose donc de la liste complète des niveaux d'acquis présents dans sa compétence, et l'utilise pour calculer sa valeur en Pix :
+    *   Si l'acquis n'est pas actif au sens de la règle 1, sa valeur est simplement mise à zéro ; 
+    *   Si l'acquis n'est pas d'origine Pix, sa valeur est simplement mise à zéro ; 
+    *   Sinon, on doit déterminer dans la chaîne des niveaux le nombre d'occurrences du niveau de l'acquis considéré. Comme Airtable ne fournit pas de fonction donnant directement ce nombre, on calcule la différence entre la longueur de la chaîne originale (ex. 12434132), et cette même chaîne dans laquelle on aurait remplacé notre niveau (ex. 2) par une chaîne vide (ex. 143413), ce qui donne bien le nombre d'occurrences du niveau dans la compétence ;
+    *   Il ne reste qu'à diviser 8 par ce nombre et limiter à 4 le résultat ;
+    *   Field type : Rollup
+    *   Formule : <span style="color: rgb(0,146,29);">IF(LevelIfActive > 0, MIN(4, 8/(LEN(CONCATENATE(values)) - LEN(SUBSTITUTE( CONCATENATE(values),LevelIfActive,"")))), 0)</span>
+    *   Noter que même si à la base on a une simple copie d'une valeur de l'enregistrement **Tube** lié, ce qui correspond plutôt à un **lookup** on utilise ici un champ de type **rollup** pour pouvoir appliquer une formule. Du coup on est obligé de faire un **CONCATENATE(values)** pour obtenir la valeur de **CompetenceAcquisLevels** ;
+    *   Il est utile de changer le formatage par défaut du champ pour afficher quelques décimales ;
+    *   Exemple de résultat : 1.333
+

--- a/docs/adr/0006-ajout-du-support-de-sendinblue-pour-le-mailing.md
+++ b/docs/adr/0006-ajout-du-support-de-sendinblue-pour-le-mailing.md
@@ -10,7 +10,7 @@ Accepted
 
 Les DANE et académies ont tendance à bloquer les providers commerciaux et filtrent les messages avec un mécanisme de whitelisting d'IP.
 
-Par ailleurs, nous avons été plusieurs fois rencontrés des difficultés avec MailJet (API limit, communication, support), en particulier lors de moments ou phases critiques.
+Par ailleurs, nous avons plusieurs fois rencontrés des difficultés avec MailJet (API limit, communication, support), en particulier lors de moments ou phases critiques.
 
 Sans compter que MailJet a été racheté par MailGun, entreprise américaine. **MailJet est donc désormais soumis au CLOUD Act.**
 

--- a/docs/adr/0006-calcul-des-pix.md
+++ b/docs/adr/0006-calcul-des-pix.md
@@ -1,0 +1,29 @@
+# 5. Calcul des pix
+
+Date : 2020-01-22
+
+## État
+
+Draft
+
+## Contexte
+
+Le référentiel des Acquis et Compétences est actuellement stocké et géré dans Airtable.  
+
+À chaque Acquis est associé une valeur en `pix`.  Cette valeur est la résultante d'un calcul expliqué dans la [documentation](../Calcul-Airtable.md). 
+
+Dans le cadre de Pix+, des Acquis hors Compétences numériques sont ajoutés. Ces Acquis ne doivent pas influencer le nombre de `pix` gagné par l'utilisateur.  
+ 
+## Décision
+
+Le calcul pourrait être déplacée dans le datasource côté `API`, ce qui aurait pour conséquences de documenter et sécuriser le calcul via des tests unitaires.  
+Toutefois, il est décidé que l'effort que cela représente versus les gains apportés est trop important.  
+Nous décidons donc de faire évoluer le calcul dans Airtable.
+
+## Conséquences
+
+La formule de calcul ainsi que la documentation sont mises à jour.
+
+### Architecture
+
+D'un point de vue architecture logicielle, aucune évolution n'est nécessaire.

--- a/docs/adr/0007-calcul-des-pix.md
+++ b/docs/adr/0007-calcul-des-pix.md
@@ -1,10 +1,10 @@
-# 5. Calcul des pix
+# 7. Calcul des pix
 
 Date : 2020-01-22
 
 ## État
 
-Draft
+Accepted
 
 ## Contexte
 


### PR DESCRIPTION
## :unicorn: Problème
Avec Pix+, Pix sera utilisé pour évaluer des acquis/compétences hors numérique.
Ces compétences ne doivent pas influencer le nombre de pix des utilisateurs.
Ces compétences ne doivent pas apparaître comme des cartes de score sur l'accueil de mon-pix.
Ces compétences ne sont pas certifiables.

## :robot: Solution
Un attribut `Origin` est ajouté sur chaque compétence.
Cet attribut vaut `Pix` pour les compétences numériques.
Le champ `Pix Value` de chaque `Acquis` dans le référentiel est modifié pour valoir `0` si l'acquis n'est pas liée à une compétence numérique (identifiée par l'attribut `origine = "Pix"`)
 
## :rainbow: Remarques
Avec la modification du calcul de la colonne de `Pix Value` dans Airtable, cette PR ajoute une page de documentation sur les différents calculs actuels.
