### PR TITLE
[TECH] Supprimer les logs non utiles

### DIFF
--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -2,13 +2,10 @@ const DomainErrors = require('../../domain/errors');
 const InfraErrors = require('../errors');
 const JSONAPI = require('../../interfaces/jsonapi');
 const errorSerializer = require('../serializers/jsonapi/error-serializer');
-const logger = require('../logger');
 
 module.exports = { send };
 
 function send(h, error) {
-  logger.error(error);
-
   if (error instanceof DomainErrors.EntityValidationError) {
     return h.response(JSONAPI.unprocessableEntityError(error.invalidAttributes)).code(422);
   }

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -1,4 +1,3 @@
-const logger = require('../../infrastructure/logger');
 const tokenService = require('../../domain/services/token-service');
 const checkUserIsAuthenticatedUseCase = require('../../application/usecases/checkUserIsAuthenticated');
 const checkUserHasRolePixMasterUseCase = require('../../application/usecases/checkUserHasRolePixMaster');
@@ -51,10 +50,7 @@ function checkUserIsAuthenticated(request, h) {
       }
       return _replyWithAuthenticationError(h);
     })
-    .catch((err) => {
-      logger.error(err);
-      return _replyWithAuthenticationError(h);
-    });
+    .catch(() => _replyWithAuthenticationError(h));
 }
 
 function checkUserHasRolePixMaster(request, h) {
@@ -71,10 +67,7 @@ function checkUserHasRolePixMaster(request, h) {
       }
       return _replyWithAuthorizationError(h);
     })
-    .catch((err) => {
-      logger.error(err);
-      return _replyWithAuthorizationError(h);
-    });
+    .catch(() => _replyWithAuthorizationError(h));
 }
 
 function checkRequestedUserIsAuthenticatedUser(request, h) {
@@ -105,10 +98,7 @@ function checkUserIsAdminInOrganization(request, h) {
       }
       return _replyWithAuthorizationError(h);
     })
-    .catch((err) => {
-      logger.error(err);
-      return _replyWithAuthorizationError(h);
-    });
+    .catch(() => _replyWithAuthorizationError(h));
 }
 
 async function checkUserIsAdminInOrganizationOrHasRolePixMaster(request, h) {
@@ -144,7 +134,6 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   try {
     belongsToScoOrganizationAndManageStudents = await checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
   } catch (err) {
-    logger.error(err);
     return _replyWithAuthorizationError(h);
   }
 

--- a/api/tests/integration/infrastructure/utils/error-manager_test.js
+++ b/api/tests/integration/infrastructure/utils/error-manager_test.js
@@ -1,29 +1,11 @@
-const { sinon, expect, hFake } = require('../../../test-helper');
+const { expect, hFake } = require('../../../test-helper');
 const { send } = require('../../../../lib/infrastructure/utils/error-manager');
 const DomainErrors = require('../../../../lib/domain/errors');
 const InfraErrors = require('../../../../lib/infrastructure/errors');
-const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Integration | Utils | Error Manager', function() {
 
-  let loggerStub;
-
-  beforeEach(() => {
-    loggerStub = sinon.stub(logger, 'error').returns();
-  });
-
   describe('#send', function() {
-
-    it('should log the error', function() {
-      // given
-      const error = new Error();
-
-      // when
-      send(hFake, error);
-
-      // then
-      sinon.assert.calledOnce(loggerStub);
-    });
 
     it('should return 422 on EntityValidationError', function() {
       // given


### PR DESCRIPTION
## :unicorn: Problème

Environ 60 % des lignes de logs de datadogs remontés par le filtre `Error` ne sont pas intéressantes et ne correspondent pas à des erreurs.

Elles apparaissent ici suite à un `logger.error()` qui soit n'est pas justifié, soit au mieux fait doublon avec les access logs.

## :robot: Solution

Supprimer les `logger.error()` inutiles.

## :rainbow: Remarques

- InfrastructureErrors are already in access logs
- Domain errors are part of normal workflow