### PR TITLE
[TECH] Supprimer Bootstrap.js de mon-pix. 

### DIFF
--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -5,27 +5,27 @@ const contentReference = {
   ok: {
     icon: 'check-circle',
     color: 'green',
-    tooltip: 'Réponse correcte'
+    title: 'Réponse correcte'
   },
   ko: {
     icon: 'times-circle',
     color: 'red',
-    tooltip: 'Réponse incorrecte'
+    title: 'Réponse incorrecte'
   },
   aband: {
     icon: 'times-circle',
     color: 'grey',
-    tooltip: 'Sans réponse'
+    title: 'Sans réponse'
   },
   partially: {
     icon: 'check-circle',
     color: 'orange',
-    tooltip: 'Réponse partielle'
+    title: 'Réponse partielle'
   },
   timedout: {
     icon: 'times-circle',
     color: 'red',
-    tooltip: 'Temps dépassé'
+    title: 'Temps dépassé'
   }
 };
 
@@ -40,7 +40,7 @@ export default Component.extend({
   }),
 
   resultTooltip: computed('resultItem', function() {
-    return this.resultItem ? this.resultItem.tooltip : null;
+    return this.resultItem ? this.resultItem.title : null;
   }),
 
   validationImplementedForChallengeType: computed('answer.challenge.type', function() {
@@ -52,16 +52,5 @@ export default Component.extend({
   textLength: computed('', function() {
     return window.innerWidth <= 767 ? 60 : 110;
   }),
-
-  didRender() {
-    this._super(...arguments);
-
-    const tooltipElement = this.$('[data-toggle="tooltip"]');
-    const tooltipValue = this.resultTooltip;
-
-    if (tooltipValue) {
-      tooltipElement.tooltip({ title: tooltipValue });
-    }
-  },
 
 });

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -82,34 +82,4 @@
   &--grey {
     color: $dove-gray;
   }
-
-  /* Forces bootstrap's default by including bootstrap props into .assessment-results container */
-  .tooltip-inner {
-    padding-top: 13px;
-    width: auto;
-    padding-left: 16px;
-    padding-right: 16px;
-    height: 48px;
-    background-color: $mercury-grey;
-    color: $charcoal-grey;
-    font-size: 1.4rem;
-    box-shadow: 2px 2px 2px 0 rgba(0, 0, 0, 0.2);
-    border: solid 1px $white;
-  }
-
-  .tooltip.top .tooltip-arrow {
-    border-top-color: $mercury-grey;
-  }
-
-  .tooltip.in {
-    opacity: 1;
-    transition: opacity .75s ease;
-  }
-
-  .tooltip.top .tooltip-arrow {
-    bottom: -4px;
-    left: 50%;
-    margin-left: -13px;
-    border-width: 10px 13px 0;
-  }
 }

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -30,36 +30,6 @@
   box-shadow: 0 7px 14px 0 rgba(12, 22, 58, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.1);
 }
 
-/* Forces bootstrap's default by including bootstrap props into .assessment-results container */
-.assessment-results .tooltip-inner {
-  padding-top: 13px;
-  width: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 48px;
-  background-color: $mercury-grey;
-  color: $charcoal-grey;
-  font-size: 14px;
-  box-shadow: 2px 2px 2px 0 rgba(0, 0, 0, 0.2);
-  border: solid 1px $white;
-}
-
-.assessment-results .tooltip.top .tooltip-arrow {
-  border-top-color: $mercury-grey;
-}
-
-.assessment-results .tooltip.in {
-  opacity: 1;
-  transition: opacity 1s ease;
-}
-
-.assessment-results .tooltip.top .tooltip-arrow {
-  bottom: -4px;
-  left: 50%;
-  margin-left: -13px;
-  border-width: 10px 13px 0;
-}
-
 /* XXX : See https://github.com/sgmap/pix/issues/211 */
 .assessment-results [data-lines="2"] + div .tooltip-inner {
   padding-top: 3px;

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -10,9 +10,9 @@
 
     <div class="pix-modal-header comparison-window-header">
       <div class="comparison-window__title">
-        <div data-toggle="tooltip" data-placement="top" title="{{resultItem.tooltip}}">
+        <div title="{{resultItem.tooltip}}">
           <img class="comparison-window__result-icon comparison-window__result-icon--{{resultItem.status}}"
-               src={{resultItemIcon}} alt="">
+               src={{resultItemIcon}} alt={{resultItem.tooltip}}>
         </div>
       </div>
       <div class="comparison-window__title-text">{{resultItem.title}}</div>

--- a/mon-pix/app/templates/components/result-item.hbs
+++ b/mon-pix/app/templates/components/result-item.hbs
@@ -1,7 +1,5 @@
-<div class="result-item__icon">
-  <div data-toggle="tooltip" data-placement="top" title="{{resultItem.tooltip}}">
-    {{fa-icon resultItem.icon class=(concat 'result-item__icon--' resultItem.color)}}
-  </div>
+<div class="result-item__icon" title="{{resultItem.title}}">
+  {{fa-icon resultItem.icon class=(concat 'result-item__icon--' resultItem.color)}}
 </div>
 
 <div class="result-item__instruction">

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -23,7 +23,6 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  app.import('node_modules/bootstrap/dist/js/bootstrap.js');
   app.import('node_modules/bootstrap/dist/css/bootstrap.css');
 
   return app.toTree();

--- a/mon-pix/tests/acceptance/course-ending-screen-test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen-test.js
@@ -30,10 +30,6 @@ describe('Acceptance | Course ending screen', function() {
     expect(findAll('.result-item')[3].textContent).to.contain('Un QROCM est une question ouverte');
   });
 
-  it('should provide a valid answer when the user answered wrongly', function() {
-    expect(findAll('div[data-toggle="tooltip"]')[0].getAttribute('data-original-title')).to.equal('Réponse incorrecte');
-  });
-
   it('should display the course name', function() {
     expect(find('.assessment-banner__title').textContent).to.contain('First Course');
   });

--- a/mon-pix/tests/integration/components/result-item-campaign-test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign-test.js
@@ -81,40 +81,6 @@ describe('Integration | Component | result item', function() {
       expect(find('.result-item__correction-button').textContent.trim()).to.deep.equal('Réponses et tutos');
     });
 
-    it('should render tooltip for the answer', async function() {
-      // given
-      this.set('answer', answer);
-
-      // when
-      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
-
-      // then
-      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
-    });
-
-    it('should not render a tooltip when the answer is being retrieved', async function() {
-      // given
-      this.set('answer', null);
-
-      // when
-      await render(hbs`{{result-item answer=answer}}`);
-
-      // then
-      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title')).to.not.exist;
-    });
-
-    it('should update the tooltip when the answer is eventually retrieved', async function() {
-      // given
-      this.set('answer', null);
-      await render(hbs`{{result-item answer=answer openAnswerDetails=(action openComparisonWindow)}}`);
-
-      // when
-      this.set('answer', answer);
-
-      // then
-      expect(find('div[data-toggle="tooltip"]').getAttribute('data-original-title').trim()).to.equal('Réponse incorrecte');
-    });
-
     it('should render tooltip with an image', async function() {
       // given
       this.set('answer', answer);

--- a/mon-pix/tests/unit/components/result-item-test.js
+++ b/mon-pix/tests/unit/components/result-item-test.js
@@ -57,7 +57,7 @@ describe('Unit | Component | result-item-component', function() {
       component.set('answer', answerWithOkResult);
 
       // then
-      expect(component.get('resultItem.tooltip')).to.equal('Réponse correcte');
+      expect(component.get('resultItem.title')).to.equal('Réponse correcte');
       expect(component.get('resultItem.color')).to.equal('green');
       expect(component.get('resultItem.icon')).to.equal('check-circle');
     });
@@ -70,7 +70,7 @@ describe('Unit | Component | result-item-component', function() {
       component.set('answer', answerWithKoResult);
 
       // then
-      expect(component.get('resultItem.tooltip')).to.equal('Réponse incorrecte');
+      expect(component.get('resultItem.title')).to.equal('Réponse incorrecte');
       expect(component.get('resultItem.color')).to.equal('red');
       expect(component.get('resultItem.icon')).to.equal('times-circle');
     });
@@ -83,7 +83,7 @@ describe('Unit | Component | result-item-component', function() {
       component.set('answer', answerWithTimedoutResult);
 
       // then
-      expect(component.get('resultItem.tooltip')).to.equal('Temps dépassé');
+      expect(component.get('resultItem.title')).to.equal('Temps dépassé');
       expect(component.get('resultItem.color')).to.equal('red');
       expect(component.get('resultItem.icon')).to.equal('times-circle');
     });
@@ -96,7 +96,7 @@ describe('Unit | Component | result-item-component', function() {
       component.set('answer', answerWithPartiallyResult);
 
       // then
-      expect(component.get('resultItem.tooltip')).to.equal('Réponse partielle');
+      expect(component.get('resultItem.title')).to.equal('Réponse partielle');
       expect(component.get('resultItem.color')).to.equal('orange');
       expect(component.get('resultItem.icon')).to.equal('check-circle');
     });
@@ -109,7 +109,7 @@ describe('Unit | Component | result-item-component', function() {
       component.set('answer', answerWithAbandResult);
 
       // then
-      expect(component.get('resultItem.tooltip')).to.equal('Sans réponse');
+      expect(component.get('resultItem.title')).to.equal('Sans réponse');
       expect(component.get('resultItem.color')).to.equal('grey');
       expect(component.get('resultItem.icon')).to.equal('times-circle');
     });


### PR DESCRIPTION
## :unicorn: Problème
On charge bootstrap et on ne s'en sert pas ou très peu. 

## :robot: Solution
Supprimer cette dépendance.

## :rainbow: Remarques
Les modals n'utilisent pas Bootstrap. Pas grand chose d'ailleurs, si ce n'est les tooltips sur la `comparison-window` qui font crasher la page, on les remplace par les **infobulles** du browser. 