### PR TITLE
[TECH] Mise à jour de PixApp en Ember 3.13 (PF-1053).

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -1,16 +1,17 @@
 import DS from 'ember-data';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
-import { isPresent } from '@ember/utils';
+import { computed } from '@ember/object';
 import ENV from 'mon-pix/config/environment';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   host: ENV.APP.API_HOST,
   namespace: 'api',
 
-  authorize(xhr) {
-    const { access_token } = this.get('session.data.authenticated');
-    if (isPresent(access_token)) {
-      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`);
+  headers: computed('session.data.authenticated.access_token', function() {
+    const headers = {};
+    if (this.session.isAuthenticated) {
+      headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
-  }
+    return headers;
+  })
 });

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,6 +1,8 @@
-import { inject as service } from '@ember/service';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
+
 import Route from '@ember/routing/route';
+
+import { inject as service } from '@ember/service';
 
 export default Route.extend(ApplicationRouteMixin, {
 
@@ -26,17 +28,18 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   async sessionAuthenticated() {
+    const _super = this._super;
     await this._loadCurrentUser();
-
-    // Because ember-simple-auth does not support calling this._super() asynchronously,
-    // we have to do this hack to call the original "sessionAuthenticated"
-    ApplicationRouteMixin.mixins[0].properties.sessionAuthenticated.call(this);
+    _super.call(this, ...arguments);
   },
 
   // XXX: For override the sessionInvalidated from ApplicationRouteMixin to avoid the automatic redirection
-  sessionInvalidated() {},
+  sessionInvalidated() {
+    this.transitionTo('login');
+  },
 
   _loadCurrentUser() {
-    return this.currentUser.load();
+    return this.get('currentUser').load().catch(() => this.get('session').invalidate());
   }
+
 });

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -27,8 +27,7 @@ export default Route.extend({
     }
 
     if (this.hasUnauthorizedError(error)) {
-      return this.session.invalidate()
-        .then(() => this.transitionTo('login'));
+      return this.session.invalidate();
     }
   }
 

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -7,7 +7,7 @@ export default Route.extend(UnauthenticatedRouteMixin, {
   session: service(),
 
   actions: {
-    authenticate(login, password) {
+    async authenticate(login, password) {
       const scope = 'mon-pix';
       const trimedLogin = login ? login.trim() : '';
       return this.session.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -701,6 +701,23 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.8.3.tgz",
+      "integrity": "sha512-i3LuN8tPDqUCRFu3dkzF2r1Nx0jp4scxtm7JxtIqI9he9Vk20YD+/zshdzR9JLsoBMlJlNR82a62vQExNEVx/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
@@ -2374,9 +2391,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
+      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
       "dev": true
     },
     "astral-regex": {
@@ -11789,12 +11806,14 @@
       }
     },
     "ember-router-generator": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
-      "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-2.0.0.tgz",
+      "integrity": "sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==",
       "dev": true,
       "requires": {
-        "recast": "^0.11.3"
+        "@babel/parser": "^7.4.5",
+        "@babel/traverse": "^7.4.5",
+        "recast": "^0.18.1"
       }
     },
     "ember-simple-auth": {
@@ -11967,11 +11986,18 @@
       }
     },
     "ember-source": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.11.1.tgz",
-      "integrity": "sha512-FPHHHu/5FBbKQ3o1D2HXEIniBUVqG1N4vDB66BaP0ht2ZcO6EB3HMjGxVH8Ad3Of8QOcXtZrBfXDHZdIWLW4lQ==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.13.4.tgz",
+      "integrity": "sha512-JsH/3QQhGQZ6+KS8LdqeuQe6QoVWGCCjM08ccBh9LdPNz1TpyleNDt0PSvwTKZwOk1sm3mUvNwSfKoBw4Hj0Pw==",
       "dev": true,
       "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.4.4",
+        "@babel/plugin-transform-object-assign": "^7.2.0",
+        "@ember/edition-utils": "^1.1.1",
+        "babel-plugin-debug-macros": "^0.3.3",
+        "babel-plugin-filter-imports": "^3.0.0",
+        "broccoli-concat": "^3.7.3",
         "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^3.0.2",
         "chalk": "^2.4.2",
@@ -11982,10 +12008,11 @@
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-version-checker": "^3.1.3",
-        "ember-router-generator": "^1.2.3",
+        "ember-router-generator": "^2.0.0",
         "inflection": "^1.12.0",
         "jquery": "^3.4.1",
-        "resolve": "^1.10.1"
+        "resolve": "^1.11.1",
+        "silent-error": "^1.1.1"
       }
     },
     "ember-source-channel-url": {
@@ -18371,15 +18398,29 @@
       }
     },
     "recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.5.tgz",
+      "integrity": "sha512-sD1WJrpLQAkXGyQZyGzTM75WJvyAd98II5CHdK3IYbt/cZlU0UzCRVU11nUFNXX9fBVEt4E9ajkMjBlUlG+Oog==",
       "dev": true,
       "requires": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
+        "ast-types": "0.13.2",
+        "esprima": "~4.0.0",
+        "private": "^0.1.8",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "redeyed": {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11967,9 +11967,9 @@
       }
     },
     "ember-source": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.10.2.tgz",
-      "integrity": "sha512-7WRBikgS5riwO0DiBtKQDQhk80mqppMbghSAHXvfJAYpkGFxuH//MxjO1eRXP9xjzmdMhfDmixrMnNBtc5D6mA==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.11.1.tgz",
+      "integrity": "sha512-FPHHHu/5FBbKQ3o1D2HXEIniBUVqG1N4vDB66BaP0ht2ZcO6EB3HMjGxVH8Ad3Of8QOcXtZrBfXDHZdIWLW4lQ==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.2",
@@ -11984,8 +11984,8 @@
         "ember-cli-version-checker": "^3.1.3",
         "ember-router-generator": "^1.2.3",
         "inflection": "^1.12.0",
-        "jquery": "^3.3.1",
-        "resolve": "^1.10.0"
+        "jquery": "^3.4.1",
+        "resolve": "^1.10.1"
       }
     },
     "ember-source-channel-url": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -81,7 +81,7 @@
     "ember-resolver": "^6.0.0",
     "ember-responsive": "^3.0.5",
     "ember-route-action-helper": "^2.0.7",
-    "ember-simple-auth": "^2.1.0",
+    "ember-simple-auth": "^2.1.1",
     "ember-sinon": "^4.1.1",
     "ember-source": "~3.11.1",
     "ember-truth-helpers": "^2.1.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -83,7 +83,7 @@
     "ember-route-action-helper": "^2.0.7",
     "ember-simple-auth": "^2.1.0",
     "ember-sinon": "^4.1.1",
-    "ember-source": "~3.10.0",
+    "ember-source": "~3.11.1",
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.7.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -83,7 +83,7 @@
     "ember-route-action-helper": "^2.0.7",
     "ember-simple-auth": "^2.1.1",
     "ember-sinon": "^4.1.1",
-    "ember-source": "~3.11.1",
+    "ember-source": "~3.13.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.7.2",

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { it, describe } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import sinon from 'sinon';
 
 describe('Unit | Route | subscribers', function() {
   setupTest();
@@ -14,36 +13,26 @@ describe('Unit | Route | subscribers', function() {
     expect(applicationAdapter.namespace).to.equal('api');
   });
 
-  it('should add header with authentication token ', function() {
+  it('should add header with authentication token when the session is authenticated', function() {
     // Given
-    const xhr = {
-      setRequestHeader: sinon.stub()
-    };
     const access_token = '23456789';
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // When
-    applicationAdapter.set('session', { data: { authenticated: { access_token } } });
-    applicationAdapter.authorize(xhr);
+    applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
     // Then
-    sinon.assert.calledWith(xhr.setRequestHeader, 'Authorization', `Bearer ${access_token}`);
+    expect(applicationAdapter.headers['Authorization']).to.equal(`Bearer ${access_token}`);
   });
 
-  it('should not set Authorization header without token ', function() {
+  it('should not add header authentication token when the session is not authenticated', function() {
     // Given
-    const xhr = {
-      setRequestHeader: sinon.stub()
-    };
-    const access_token = '';
     const applicationAdapter = this.owner.lookup('adapter:application');
 
     // When
-    applicationAdapter.set('session', { data: { authenticated: { access_token } } });
-    applicationAdapter.authorize(xhr);
+    applicationAdapter.set('session', {});
 
     // Then
-    sinon.assert.notCalled (xhr.setRequestHeader);
+    expect(applicationAdapter.headers['Authorization']).to.be.undefined;
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
Pas à jour

## :robot: Solution
À jour grâce aux recommandations `ember-simple-auth` suivantes : 
- https://github.com/simplabs/ember-simple-auth#1994
- https://github.com/simplabs/ember-simple-auth/blob/master/guides/managing-current-user.md#loading-the-current-user

## 🤕 Erreur de mise à jour rencontrée
```bash
200) [Chrome 79.0] Acceptance | Error page should redirect to route /connexion when the api returned a 401 error
     expected '/mes-certifications' to equal '/connexion'

     AssertionError: expected '/mes-certifications' to equal '/connexion'
         at Context._callee$ (http://localhost:7357/assets/tests.js:3697:68)
         at tryCatch (http://localhost:7357/assets/vendor.js:11551:40)
         at Generator.invoke [as _invoke] (http://localhost:7357/assets/vendor.js:11777:22)
         at Generator.prototype.<computed> [as next] (http://localhost:7357/assets/vendor.js:11603:21)
         at asyncGeneratorStep (http://localhost:7357/assets/tests.js:3663:105)
         at _next (http://localhost:7357/assets/tests.js:3665:196)

Testem finished with non-zero exit code. Tests failed.
```

La trace remonterait dans `mon-pix/app/routes/error.js`
```js
if (this.hasUnauthorizedError(error)) {
	return this.session.invalidate()
		.then(() => this.transitionTo('login'));
}
```