### PR TITLE
[A11Y] Ajouter des labels aux QROCm (PF-957)

### DIFF
--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -15,10 +15,10 @@ export default Component.extend({
     return proposalsAsBlocks(this.proposals);
   }),
 
-  didInsertElement: function() {
-    this.$('input').keydown(() => {
+  actions: {
+    onInputChange: function() {
       this.answerChanged();
-    });
+    }
   }
 
 });

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -12,7 +12,11 @@ export default Component.extend({
   format: null,
 
   _blocks: computed('proposals', function() {
-    return proposalsAsBlocks(this.proposals);
+    return proposalsAsBlocks(this.proposals)
+      .map((block) => {
+        block.showText = block.text && !block.ariaLabel && !block.input;
+        return block;
+      });
   }),
 
   actions: {

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -17,7 +17,7 @@
                 id="{{block.text}}"
                 value={{property-of answersValue block.input}}
                 disabled={{answer}}
-                aria-label={{if block.ariaLabel block.ariaLabel false}}
+                aria-label={{block.ariaLabel}}
                 onkeydown={{action 'onInputChange'}}>
       </textarea>
     {{else if (eq format 'phrase')}}
@@ -32,7 +32,7 @@
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
              disabled={{answer}}
-             aria-label={{if block.ariaLabel block.ariaLabel false}}
+             aria-label={{block.ariaLabel}}
              onkeydown={{action 'onInputChange'}}>
     {{else}}
       {{#if block.text}}
@@ -47,7 +47,7 @@
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
              disabled={{answer}}
-             aria-label={{if block.ariaLabel block.ariaLabel false}}
+             aria-label={{block.ariaLabel}}
              onkeydown={{action 'onInputChange'}}>
     {{/if}}
 

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,6 +1,6 @@
 {{#each _blocks as |block|}}
 
-  {{#if (and block.text (not block.ariaLabel) (not block.input))}}
+  {{#if block.showText}}
     <span>{{block.text}}</span>
   {{/if}}
 

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -16,7 +16,7 @@
                 autocomplete="off"
                 id="{{block.text}}"
                 value={{property-of answersValue block.input}}
-                disabled={{if answer true}}
+                disabled={{answer}}
                 aria-label={{if block.ariaLabel block.ariaLabel false}}>
       </textarea>
     {{else if (eq format 'phrase')}}
@@ -30,7 +30,7 @@
              autocomplete="off"
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
-             disabled={{if answer true}}
+             disabled={{answer}}
              aria-label={{if block.ariaLabel block.ariaLabel false}}>
     {{else}}
       {{#if block.text}}
@@ -44,7 +44,7 @@
              autocomplete="off"
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
-             disabled={{if answer true}}
+             disabled={{answer}}
              aria-label={{if block.ariaLabel block.ariaLabel false}}>
     {{/if}}
 

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,14 +1,14 @@
 {{#each _blocks as |block|}}
 
-  {{#if block.text}}
-    <label for="{{block.text}}">{{block.text}}</label>
+  {{#if (and block.text (not block.ariaLabel) (not block.input))}}
+    <div>{{block.text}}</div>
   {{/if}}
 
   {{#if block.input}}
     {{#if (eq format 'paragraphe')}}
+      <label for="{{block.text}}">{{block.text}}</label>
       <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
                 rows="5"
-                for="qrocm_input"
                 name={{block.input}}
                 placeholder={{block.placeholder}}
                 autocomplete="off"
@@ -17,9 +17,9 @@
                 disabled={{if answer true}}>
       </textarea>
     {{else if (eq format 'phrase')}}
+      <label for="{{block.text}}">{{block.text}}</label>
       <input class="challenge-response__proposal challenge-response__proposal--sentence"
              type="text"
-             for="qrocm_input"
              name={{block.input}}
              placeholder={{block.placeholder}}
              autocomplete="off"
@@ -27,16 +27,19 @@
              value={{property-of answersValue block.input}}
              disabled={{if answer true}}>
     {{else}}
+      {{#if block.text}}
+        <label for="{{block.text}}">{{block.text}}</label>
+      {{/if}}
       <input class="challenge-response__proposal"
              size="{{get-qroc-input-size format}}"
              type="text"
-             for="qrocm_input"
              name={{block.input}}
              placeholder={{block.placeholder}}
              autocomplete="off"
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
-             disabled={{if answer true}}>
+             disabled={{if answer true}}
+             aria-label={{if block.ariaLabel block.ariaLabel false}}>
     {{/if}}
 
   {{/if}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -6,7 +6,9 @@
 
   {{#if block.input}}
     {{#if (eq format 'paragraphe')}}
-      <label for="{{block.text}}">{{block.text}}</label>
+      {{#if block.text}}
+        <label for="{{block.text}}">{{block.text}}</label>
+      {{/if}}
       <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
                 rows="5"
                 name={{block.input}}
@@ -14,10 +16,13 @@
                 autocomplete="off"
                 id="{{block.text}}"
                 value={{property-of answersValue block.input}}
-                disabled={{if answer true}}>
+                disabled={{if answer true}}
+                aria-label={{if block.ariaLabel block.ariaLabel false}}>
       </textarea>
     {{else if (eq format 'phrase')}}
-      <label for="{{block.text}}">{{block.text}}</label>
+      {{#if block.text}}
+        <label for="{{block.text}}">{{block.text}}</label>
+      {{/if}}
       <input class="challenge-response__proposal challenge-response__proposal--sentence"
              type="text"
              name={{block.input}}
@@ -25,7 +30,8 @@
              autocomplete="off"
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
-             disabled={{if answer true}}>
+             disabled={{if answer true}}
+             aria-label={{if block.ariaLabel block.ariaLabel false}}>
     {{else}}
       {{#if block.text}}
         <label for="{{block.text}}">{{block.text}}</label>

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -17,7 +17,8 @@
                 id="{{block.text}}"
                 value={{property-of answersValue block.input}}
                 disabled={{answer}}
-                aria-label={{if block.ariaLabel block.ariaLabel false}}>
+                aria-label={{if block.ariaLabel block.ariaLabel false}}
+                onkeydown={{action 'onInputChange'}}>
       </textarea>
     {{else if (eq format 'phrase')}}
       {{#if block.text}}
@@ -31,7 +32,8 @@
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
              disabled={{answer}}
-             aria-label={{if block.ariaLabel block.ariaLabel false}}>
+             aria-label={{if block.ariaLabel block.ariaLabel false}}
+             onkeydown={{action 'onInputChange'}}>
     {{else}}
       {{#if block.text}}
         <label for="{{block.text}}">{{block.text}}</label>
@@ -45,7 +47,8 @@
              id="{{block.text}}"
              value={{property-of answersValue block.input}}
              disabled={{answer}}
-             aria-label={{if block.ariaLabel block.ariaLabel false}}>
+             aria-label={{if block.ariaLabel block.ariaLabel false}}
+             onkeydown={{action 'onInputChange'}}>
     {{/if}}
 
   {{/if}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,7 +1,7 @@
 {{#each _blocks as |block|}}
 
   {{#if (and block.text (not block.ariaLabel) (not block.input))}}
-    <div>{{block.text}}</div>
+    <span>{{block.text}}</span>
   {{/if}}
 
   {{#if block.input}}

--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -95,17 +95,17 @@ class ResponseBlock {
   }
 
   attachLabel({ isInputField, ariaLabelNeeded, prevBlockText, questionIdx }) {
-    if (isInputField
-        && !ariaLabelNeeded
+    if (!isInputField) {
+      return false;
+    }
+    if (!ariaLabelNeeded
         && this._hasPrevBlockText(prevBlockText)) {
       this._text = prevBlockText;
-      return true;
     }
-    else if (isInputField) {
+    else {
       this._ariaLabel = 'Réponse ' + questionIdx;
-      return true;
     }
-    return false;
+    return true;
   }
 
   _hasPrevBlockText(prevBlockText) {

--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -54,7 +54,7 @@ function isAriaLabelNeededForInputs(lines) {
 }
 
 function buildLineFrom(blocks, ariaLabelNeeded, challengeResponseTemplate) {
-  let prevBlockText = '';
+  let previousBlockText = '';
   for (let blockIdx = 0; blockIdx < blocks.length; blockIdx += 1) {
     const { isInput, block } = parseInput((isInput || false), blocks[blockIdx]);
     if (!block) {
@@ -68,9 +68,9 @@ function buildLineFrom(blocks, ariaLabelNeeded, challengeResponseTemplate) {
     const didAttachedLabel = block.attachLabel({
       isInputField,
       ariaLabelNeeded,
-      prevBlockText,
+      previousBlockText,
       questionIdx: challengeResponseTemplate.inputCount });
-    prevBlockText = didAttachedLabel ? '' : block.text;
+    previousBlockText = didAttachedLabel ? '' : block.text;
 
     const canAddBlockToTemplate = ariaLabelNeeded || isInputField || isLastElement(blockIdx, blocks);
     challengeResponseTemplate.add({ canAddBlockToTemplate, block: block.get() });
@@ -94,13 +94,13 @@ class ResponseBlock {
     }
   }
 
-  attachLabel({ isInputField, ariaLabelNeeded, prevBlockText, questionIdx }) {
+  attachLabel({ isInputField, ariaLabelNeeded, previousBlockText, questionIdx }) {
     if (!isInputField) {
       return false;
     }
     if (!ariaLabelNeeded
-        && this._hasPrevBlockText(prevBlockText)) {
-      this._text = prevBlockText;
+        && this._hasPreviousBlockText(previousBlockText)) {
+      this._text = previousBlockText;
     }
     else {
       this._ariaLabel = 'Réponse ' + questionIdx;
@@ -108,8 +108,8 @@ class ResponseBlock {
     return true;
   }
 
-  _hasPrevBlockText(prevBlockText) {
-    return !(prevBlockText.trim().length === 1 && prevBlockText[0] === '-');
+  _hasPreviousBlockText(previousBlockText) {
+    return !(previousBlockText.trim().length === 1 && previousBlockText[0] === '-');
   }
 
   get input() {

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
-import { find, render } from '@ember/test-helpers';
+import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROCm proposal', function() {
@@ -85,6 +85,80 @@ describe('Integration | Component | QROCm proposal', function() {
 
           // then
           expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('off');
+        });
+      });
+    });
+
+    [
+      { proposals: '${input}', expectedAriaLabel: ['Réponse 1'] },
+      { proposals: '${rep1}, ${rep2} ${rep3}', expectedAriaLabel: ['Réponse 1', 'Réponse 2', 'Réponse 3'] },
+      { proposals: 'Réponses :↵${rep1}\n${rep2}', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
+      { proposals: 'Vidéo : ${video#.ex1} ${video2#.ex2}\nImage : ${image} ${image2}', expectedAriaLabel: ['Réponse 1', 'Réponse 2', 'Réponse 3', 'Réponse 4'] },
+      { proposals: 'Le protocole ${https} assure que la communication entre l\'ordinateur d\'Adèle et le serveur de la banque est ${sécurisée}.', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
+      { proposals: '- ${NumA} Il classe les pages trouvées pour les présenter\n- ${NumB} Il sélectionne  les pages correspondant aux mots', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
+    ].forEach((data) => {
+      describe(`Component aria-label accessibility when proposal is ${data.proposals}`, function() {
+        beforeEach(async function() {
+          // given
+          this.set('proposals', data.proposals);
+          this.set('answerValue', '');
+          this.set('format', 'phrase');
+
+          // when
+          await render(hbs`{{qrocm-proposal proposals=proposals format=format answerValue=answerValue}}`);
+        });
+
+        it('should have an aria-label', async function() {
+          // then
+          expect(findAll('.challenge-response__proposal').length).to.be.above(0);
+          findAll('.challenge-response__proposal').forEach((element, index) => {
+            expect(element.getAttribute('aria-label')).to.equal(data.expectedAriaLabel[index]);
+          });
+        });
+
+        it('should not have a label', async function() {
+          // then
+          expect(find('label')).to.be.null;
+        });
+      });
+    });
+
+    [
+      { proposals: 'texte : ${rep1}\nautre texte : ${rep2}', expectedLabel: ['texte :', 'autre texte :'] },
+    ].forEach((data) => {
+      describe(`Component label accessibility when proposal is ${data.proposals}`, function() {
+
+        beforeEach(async function() {
+          // given
+          this.set('proposals', data.proposals);
+          this.set('answerValue', '');
+          this.set('format', 'phrase');
+
+          // when
+          await render(hbs`{{qrocm-proposal proposals=proposals format=format answerValue=answerValue}}`);
+        });
+
+        it('should have a label', async function() {
+          // then
+          expect(findAll('label').length).to.be.above(0);
+          findAll('label').forEach((element, index) => {
+            expect(element.textContent).to.equal(data.expectedLabel[index]);
+          });
+        });
+
+        it('should not have an aria-label', async function() {
+          // then
+          expect(find('.challenge-response__proposal').getAttribute('aria-label')).to.be.null;
+        });
+
+        it('should connect the label with the input', async function() {
+          // then
+          expect(findAll('.challenge-response__proposal').length).to.be.above(0);
+          expect(findAll('.challenge-response__proposal').length).to.equal(findAll('label').length);
+          findAll('.challenge-response__proposal').forEach((element, index) => {
+            const expectedInputId = findAll('.challenge-response__proposal')[index].getAttribute('id');
+            expect(findAll('label')[index].getAttribute('for')).to.equal(expectedInputId);
+          });
         });
       });
     });

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -98,6 +98,9 @@ describe('Integration | Component | QROCm proposal', function() {
       { proposals: '- ${NumA} Il classe les pages trouvées pour les présenter\n- ${NumB} Il sélectionne  les pages correspondant aux mots', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
     ].forEach((data) => {
       describe(`Component aria-label accessibility when proposal is ${data.proposals}`, function() {
+
+        let allInputElements;
+
         beforeEach(async function() {
           // given
           this.set('proposals', data.proposals);
@@ -106,12 +109,15 @@ describe('Integration | Component | QROCm proposal', function() {
 
           // when
           await render(hbs`{{qrocm-proposal proposals=proposals format=format answerValue=answerValue}}`);
+
+          //then
+          allInputElements = findAll('.challenge-response__proposal');
         });
 
         it('should have an aria-label', async function() {
           // then
-          expect(findAll('.challenge-response__proposal').length).to.be.above(0);
-          findAll('.challenge-response__proposal').forEach((element, index) => {
+          expect(allInputElements.length).to.be.equal(data.expectedAriaLabel.length);
+          allInputElements.forEach((element, index) => {
             expect(element.getAttribute('aria-label')).to.equal(data.expectedAriaLabel[index]);
           });
         });
@@ -128,6 +134,8 @@ describe('Integration | Component | QROCm proposal', function() {
     ].forEach((data) => {
       describe(`Component label accessibility when proposal is ${data.proposals}`, function() {
 
+        let allLabelElements, allInputElements;
+
         beforeEach(async function() {
           // given
           this.set('proposals', data.proposals);
@@ -136,12 +144,17 @@ describe('Integration | Component | QROCm proposal', function() {
 
           // when
           await render(hbs`{{qrocm-proposal proposals=proposals format=format answerValue=answerValue}}`);
+
+          //then
+          allLabelElements = findAll('label');
+          allInputElements = findAll('.challenge-response__proposal');
         });
 
         it('should have a label', async function() {
           // then
-          expect(findAll('label').length).to.be.above(0);
-          findAll('label').forEach((element, index) => {
+          expect(allLabelElements.length).to.be.equal(allInputElements.length);
+          expect(allLabelElements.length).to.be.equal(data.expectedLabel.length);
+          allLabelElements.forEach((element, index) => {
             expect(element.textContent).to.equal(data.expectedLabel[index]);
           });
         });
@@ -153,12 +166,10 @@ describe('Integration | Component | QROCm proposal', function() {
 
         it('should connect the label with the input', async function() {
           // then
-          expect(findAll('.challenge-response__proposal').length).to.be.above(0);
-          expect(findAll('.challenge-response__proposal').length).to.equal(findAll('label').length);
-          findAll('.challenge-response__proposal').forEach((element, index) => {
-            const expectedInputId = findAll('.challenge-response__proposal')[index].getAttribute('id');
-            expect(findAll('label')[index].getAttribute('for')).to.equal(expectedInputId);
-          });
+          expect(allInputElements.length).to.equal(allLabelElements.length);
+          const allInputElementsId = allInputElements.map((inputElement) => inputElement.getAttribute('id'));
+          const allLabelElementsFor = allLabelElements.map((labelElement) => labelElement.getAttribute('for'));
+          expect(allInputElementsId).to.deep.equal(allLabelElementsFor);
         });
       });
     });

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -6,35 +6,35 @@ describe('Unit | Utility | proposals as blocks', function() {
 
   const testData = [
     { data: '', expected: [] },
-    { data: 'Text', expected: [{ text: 'Text', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: 'Text', expected: [{ text: 'Text', input: undefined, placeholder: undefined, ariaLabel: null }] },
     { data: '${qroc}', expected: [{ input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' }] },
     { data: 'Test: ${test}', expected: [
-      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: '' }] },
+      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null }] },
     { data: 'Test: ${test} (kilometres)', expected: [
-      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: '' },
-      { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null },
+      { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: null }] },
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [
         { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' },
-        { input: undefined, text: ',' , placeholder: undefined, ariaLabel: '' },
+        { input: undefined, text: ',' , placeholder: undefined, ariaLabel: null },
         { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 2' },
         { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 3' }]
     },
     { data: '${plop#var}', expected: [{ input: 'plop', placeholder: 'var', text: undefined, ariaLabel: 'Réponse 1' }] },
     { data: 'line1\nline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
       { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }] },
     { data: 'line1\r\nline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
       { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }] },
     { data: '- ${plop}', expected: [
-      { text: '-', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { text: '-', input: undefined, placeholder: undefined, ariaLabel: null },
       { text: undefined, input: 'plop', placeholder: undefined, ariaLabel: 'Réponse 1' }] },
     { data: '- line ${plop}', expected: [
-      { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: '' }] },
+      { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: null }] },
   ];
 
   testData.forEach(({ data, expected }) => {

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -6,20 +6,39 @@ describe('Unit | Utility | proposals as blocks', function() {
 
   const testData = [
     { data: '', expected: [] },
-    { data: 'Text', expected: [{ text: 'Text' }] },
-    { data: 'Text test plop', expected: [{ text: 'Text test plop' }] },
-    { data: '${qroc}', expected: [{ input: 'qroc' }] },
-    { data: 'Test: ${test}', expected: [{ text: 'Test:' }, { input: 'test' }] },
-    { data: 'Test: ${test} (kilometres)', expected: [{ text: 'Test:' }, { input: 'test' }, { text: '(kilometres)' }] },
+    { data: 'Text', expected: [{ text: 'Text', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: 'Text test plop', expected: [{ text: 'Text test plop', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: '${qroc}', expected: [{ input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' }] },
+    { data: 'Test: ${test}', expected: [
+      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: '' }] },
+    { data: 'Test: ${test} (kilometres)', expected: [
+      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: '' },
+      { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: '' }] },
     {
       data: '${plop}, ${plop} ${plop}',
-      expected: [{ input: 'plop' }, { text: ',' }, { input: 'plop' }, { input: 'plop' }]
+      expected: [
+        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' },
+        { input: undefined, text: ',' , placeholder: undefined, ariaLabel: '' },
+        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 2' },
+        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 3' }]
     },
-    { data: '${plop#var}', expected: [{ input: 'plop', placeholder: 'var' }] },
-    { data: 'line1\nline2', expected: [{ text: 'line1' }, { breakline: true }, { text: 'line2' }] },
-    { data: 'line1\r\nline2', expected: [{ text: 'line1' }, { breakline: true }, { text: 'line2' }] },
-    { data: 'line1\n\rline2', expected: [{ text: 'line1' }, { breakline: true }, { text: 'line2' }] },
-    { data: 'line1\n\nline2', expected: [{ text: 'line1' }, { breakline: true }, { text: 'line2' }] }
+    { data: '${plop#var}', expected: [{ input: 'plop', placeholder: 'var', text: undefined, ariaLabel: 'Réponse 1' }] },
+    { data: 'line1\nline2', expected: [
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { breakline: true },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: 'line1\r\nline2', expected: [
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { breakline: true },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: 'line1\n\rline2', expected: [
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { breakline: true },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
+    { data: 'line1\n\nline2', expected: [
+      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { breakline: true },
+      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] }
   ];
 
   testData.forEach(({ data, expected }) => {

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -7,7 +7,6 @@ describe('Unit | Utility | proposals as blocks', function() {
   const testData = [
     { data: '', expected: [] },
     { data: 'Text', expected: [{ text: 'Text', input: undefined, placeholder: undefined, ariaLabel: '' }] },
-    { data: 'Text test plop', expected: [{ text: 'Text test plop', input: undefined, placeholder: undefined, ariaLabel: '' }] },
     { data: '${qroc}', expected: [{ input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' }] },
     { data: 'Test: ${test}', expected: [
       { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: '' }] },
@@ -31,14 +30,11 @@ describe('Unit | Utility | proposals as blocks', function() {
       { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
       { breakline: true },
       { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
-    { data: 'line1\n\rline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
-      { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] },
-    { data: 'line1\n\nline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: '' },
-      { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: '' }] }
+    { data: '- ${plop}', expected: [
+      { text: '-', input: undefined, placeholder: undefined, ariaLabel: '' },
+      { text: undefined, input: 'plop', placeholder: undefined, ariaLabel: 'Réponse 1' }] },
+    { data: '- line ${plop}', expected: [
+      { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: '' }] },
   ];
 
   testData.forEach(({ data, expected }) => {

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -5,36 +5,79 @@ import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 describe('Unit | Utility | proposals as blocks', function() {
 
   const testData = [
-    { data: '', expected: [] },
-    { data: 'Text', expected: [{ text: 'Text', input: undefined, placeholder: undefined, ariaLabel: null }] },
-    { data: '${qroc}', expected: [{ input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' }] },
-    { data: 'Test: ${test}', expected: [
-      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null }] },
-    { data: 'Test: ${test} (kilometres)', expected: [
-      { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null },
-      { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: null }] },
+    {
+      data: '',
+      expected: []
+    },
+    {
+      data: 'Text',
+      expected: [
+        { text: 'Text', input: undefined, placeholder: undefined, ariaLabel: null }
+      ]
+    },
+    {
+      data: '${qroc}',
+      expected: [
+        { input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' }
+      ]
+    },
+    {
+      data: 'Test: ${test}',
+      expected: [
+        { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null }
+      ]
+    },
+    {
+      data: 'Test: ${test} (kilometres)',
+      expected: [
+        { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null },
+        { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: null }
+      ]
+    },
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [
         { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' },
         { input: undefined, text: ',' , placeholder: undefined, ariaLabel: null },
         { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 2' },
-        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 3' }]
+        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 3' }
+      ]
     },
-    { data: '${plop#var}', expected: [{ input: 'plop', placeholder: 'var', text: undefined, ariaLabel: 'Réponse 1' }] },
-    { data: 'line1\nline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
-      { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }] },
-    { data: 'line1\r\nline2', expected: [
-      { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
-      { breakline: true },
-      { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }] },
-    { data: '- ${plop}', expected: [
-      { text: '-', input: undefined, placeholder: undefined, ariaLabel: null },
-      { text: undefined, input: 'plop', placeholder: undefined, ariaLabel: 'Réponse 1' }] },
-    { data: '- line ${plop}', expected: [
-      { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: null }] },
+    {
+      data: '${plop#var}',
+      expected: [
+        { input: 'plop', placeholder: 'var', text: undefined, ariaLabel: 'Réponse 1' }
+      ]
+    },
+    {
+      data: 'line1\nline2',
+      expected: [
+        { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
+        { breakline: true },
+        { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }
+      ]
+    },
+    {
+      data: 'line1\r\nline2',
+      expected: [
+        { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
+        { breakline: true },
+        { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null }
+      ]
+    },
+    {
+      data: '- ${plop}',
+      expected: [
+        { text: '-', input: undefined, placeholder: undefined, ariaLabel: null },
+        { text: undefined, input: 'plop', placeholder: undefined, ariaLabel: 'Réponse 1' }
+      ]
+    },
+    {
+      data: '- line ${plop}',
+      expected: [
+        { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: null }
+      ]
+    },
   ];
 
   testData.forEach(({ data, expected }) => {


### PR DESCRIPTION
## :unicorn: Problème
Les champs des QROCm ne sont pas accessibles et par conséquent, ne peuvent pas être lus par des screen-readers utilisés par les aveugles ou mal-voyants.

## :robot: Solution
Attribuer aux inputs/textarea des QROCm un `label` ou `aria-label`.

## :rainbow: Remarques
Il existe plusieurs formats de QROCm (je ne pense pas avoir tout listé, donc il y a des potentiels bugs d'affichage pour les autres types):
- des textes à trous (challengeId: [recDdegyiMfqln0dr](https://app-pr1001.review.pix.fr/assessments/102067/challenges/recDdegyiMfqln0dr))
- des listes d'inputs (challengeId: [rec5uBBZC9FyAfIs7](https://app-pr1001.review.pix.fr/assessments/102067/challenges/rec5uBBZC9FyAfIs7))
- des listes de texte + input (challengeId: [recj0g7zZF5LTxij5](https://app-pr1001.review.pix.fr/assessments/102067/challenges/recj0g7zZF5LTxij5))
- des listes de texte + plusieurs input (challengeId: [recyNr3bZvwZNY3Is](https://app-pr1001.review.pix.fr/assessments/102067/challenges/recyNr3bZvwZNY3Is))
- des listes de input + texte (challengeId: [recQJAn2fX140kvPR](https://app-pr1001.review.pix.fr/assessments/102067/challenges/recQJAn2fX140kvPR))

## :cyclone: Difficultés rencontrées
Actuellement nous recevons de l'api un format similaire à `Le protocole ${https} assure que la communication entre l'ordinateur d'Adèle` (il s'agit dans cet exemple d'un text à trou), où après un parse, `${https}` sera remplacé par un champ input.
Or il existe plusieurs types de QROCm. Les labels sont gérés différemment en fonction de cela.
