### PR TITLE
[FEATURE] Afficher un message d'information dans Pix Orga lorsqu'un utilisateur clique sur une invitation déjà acceptée (PO-276)

### DIFF
--- a/orga/app/controllers/login.js
+++ b/orga/app/controllers/login.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['hasInvitationError']
+});

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -7,7 +7,12 @@ export default Route.extend(UnauthenticatedRouteMixin, {
     return this.store.queryRecord('organization-invitation', {
       invitationId: params.invitationId,
       code: params.code
-    }).catch(() => {
+    }).catch((errorResponse) => {
+      errorResponse.errors.forEach((error) => {
+        if (error.status === '421') {
+          this.replaceWith('login', { queryParams: { hasInvitationError: true } });
+        }
+      });
       this.replaceWith('login');
     });
   }

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -1,5 +1,5 @@
 .login-form {
-  max-width: 360px;
+  max-width: 400px;
 
   &__information {
     max-width: 360px;
@@ -8,10 +8,25 @@
 
   &__error-message {
     margin-bottom: 10px;
+    font-size: 0.875rem;
   }
 
   &__forgotten-password {
     font-size: 0.875rem;
+    text-align: center;
+  }
+
+  &__button {
+    font-weight: 600;
+  }
+
+  &__invitation-error {
+    background: $pure-orange;
+    border-radius: 3px;
+    color: $white;
+    font-size: 0.875rem;
+    margin: 10px 0 16px 0;
+    padding: 9px;
     text-align: center;
   }
 }

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -1,5 +1,6 @@
 // Colors
 $vermilion: #FF4B00;
+$pure-orange: #f45c00;
 $vermilion-light: #FFDBCC;
 $orange-peel: #FF9400;
 $amber: #ffbe00;

--- a/orga/app/templates/components/routes/login-form.hbs
+++ b/orga/app/templates/components/routes/login-form.hbs
@@ -3,6 +3,12 @@
     pour rejoindre l'espace organisation.
   </div>
 
+  {{#if hasInvitationError}}
+      <div class="login-form__invitation-error">
+        Cette invitation a déjà été acceptée. Connectez-vous ou contactez l’administrateur de votre espace Pix Orga.
+      </div>
+  {{/if}}
+
   {{#if isErrorMessagePresent}}
     <div id="login-form-error-message" class="login-form__error-message error-message">L'adresse e-mail et/ou le mot
       de passe saisis sont incorrects.
@@ -48,7 +54,7 @@
       {{#if isLoading}}
         <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button type="submit" class="button">Je me connecte</button>
+        <button type="submit" class="button button--medium-weight">Je me connecte</button>
       {{/if}}
     </div>
 

--- a/orga/app/templates/components/routes/login-form.hbs
+++ b/orga/app/templates/components/routes/login-form.hbs
@@ -54,7 +54,7 @@
       {{#if isLoading}}
         <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button type="submit" class="button button--medium-weight">Je me connecte</button>
+        <button type="submit" class="button login-form__button">Je me connecte</button>
       {{/if}}
     </div>
 

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -2,6 +2,6 @@
   <div class="panel login-page__panel">
     <img src="/pix-orga.svg" alt="logo de Pix Orga">
     <h1 class="form-title">Déjà utilisateur Pix ?</h1>
-    {{routes/login-form isWithInvitation=false}}
+    {{routes/login-form isWithInvitation=false hasInvitationError=hasInvitationError}}
   </div>
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -91,8 +91,11 @@ export default function() {
       return new Response(400, {}, { errors: [ { status: '400', detail: '' } ] });
     }
 
-    const organizationInvitation = schema.organizationInvitations.findBy({ id: organizationInvitationId, code: organizationInvitationCode, status: 'pending' });
+    const organizationInvitation = schema.organizationInvitations.findBy({ id: organizationInvitationId, code: organizationInvitationCode });
     if (!organizationInvitation) {
+      return new Response(404, {}, { errors: [ { status: '404', detail: '' } ] });
+    }
+    if (organizationInvitation.status === 'accepted') {
       return new Response(421, {}, { errors: [ { status: '421', detail: '' } ] });
     }
 

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -53,8 +53,10 @@ module('Acceptance | join', function(hooks) {
       await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
 
       // then
-      assert.equal(currentURL(), '/connexion');
+      assert.equal(currentURL(), '/connexion?hasInvitationError=true');
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+      assert.dom('.login-form__invitation-error').exists();
+      assert.dom('.login-form__invitation-error').hasText('Cette invitation a déjà été acceptée. Connectez-vous ou contactez l’administrateur de votre espace Pix Orga.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur clique sur un lien d'invitation à rejoindre Pix Orga et que cette invitation a déjà été acceptée, il est redirigé sur la page de connexion sans aucune information. 

## :robot: Solution
Ajouter un message d'information sur la page de connexion dans le cas où l'invitation a déjà été acceptée afin de l'informer de la situation.