### PR TITLE
[TECH] Amélioration de la gestion des types BIG_INTEGER dans PostgreSQL.

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -1,10 +1,23 @@
+const types = require('pg').types;
+
 /*
 By default, node-postgres casts a DATE value (PostgreSQL type) as a Date Object (JS type).
 But, when dealing with dates with no time (such as birthdate for example), we want to
 deal with a 'YYYY-MM-DD' string.
 */
-const types = require('pg').types;
 types.setTypeParser(types.builtins.DATE, (value) => value);
+
+/*
+The method Bookshelf.Model.count(), used with PostgreSQL, can sometimes returns a BIGINT.
+This is not the common case (maybe in several years).
+Even though, Bookshelf/Knex have decided to return String.
+We decided to parse the result of #count() method to force a resulting INTEGER.
+
+Links :
+- problem: https://github.com/bookshelf/bookshelf/issues/1275
+- solution: https://github.com/brianc/node-pg-types
+ */
+types.setTypeParser(types.builtins.INT8, (value) => parseInt(value));
 
 const _ = require('lodash');
 

--- a/api/lib/infrastructure/bookshelf.js
+++ b/api/lib/infrastructure/bookshelf.js
@@ -33,19 +33,4 @@ bookshelf.model = ((f) => (...args) => {
 
 bookshelf.plugin('pagination');
 
-// XXX a supprimer si Model.count() retourne un Integer
-// ref: https://github.com/bookshelf/bookshelf/issues/1275
-bookshelf.plugin((bookshelf) => {
-  const Model = bookshelf.Model;
-
-  const PatchedModel = Model.extend({
-    count(...options) {
-      const promise = Model.prototype.count.apply(this, options);
-      return promise.then((count) => parseInt(count, 10));
-    }
-  });
-
-  bookshelf.Model = PatchedModel;
-});
-
 module.exports = bookshelf;

--- a/api/lib/infrastructure/bookshelf.js
+++ b/api/lib/infrastructure/bookshelf.js
@@ -1,4 +1,3 @@
-const logger = require('./logger');
 const validator = require('validator');
 const _ = require('lodash');
 
@@ -33,11 +32,6 @@ bookshelf.model = ((f) => (...args) => {
 })(bookshelf.model);
 
 bookshelf.plugin('pagination');
-
-if (bookshelf.VERSION !== '0.12.1') {
-  logger.error('WARNING: nous avons patché la version 0.12.1 de Bookshelf. Risque de bug dans les versions à venir.');
-  logger.error('WARNING: supprimer le patch si `Model.count()` retourne un Integer sous PostgreSQL. Réréfence: https://github.com/bookshelf/bookshelf/issues/1275');
-}
 
 // XXX a supprimer si Model.count() retourne un Integer
 // ref: https://github.com/bookshelf/bookshelf/issues/1275

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -512,8 +512,8 @@ describe('Acceptance | Application | organization-controller', () => {
           const campaigns = response.result.data;
           expect(campaigns).to.have.lengthOf(1);
           const campaignReport = response.result.included[0].attributes;
-          expect(campaignReport['participations-count']).to.equal('1');
-          expect(campaignReport['shared-participations-count']).to.equal('1');
+          expect(campaignReport['participations-count']).to.equal(1);
+          expect(campaignReport['shared-participations-count']).to.equal(1);
         });
       });
     });

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -222,7 +222,7 @@ describe('Acceptance | Controller | saml-controller', () => {
 
         // then
         expect(secondVisitResponse.statusCode).to.equal(302);
-        expect(await knex('users').count('id as n')).to.deep.equal([{ n: '1' }]);
+        expect(await knex('users').count('id as n')).to.deep.equal([{ n: 1 }]);
       });
 
       it('should create another user for a different SAML ID', async () => {
@@ -243,7 +243,7 @@ describe('Acceptance | Controller | saml-controller', () => {
 
         // then
         expect(otherUserResponse.statusCode).to.equal(302);
-        expect(await knex('users').count('id as n')).to.deep.equal([{ n: '2' }]);
+        expect(await knex('users').count('id as n')).to.deep.equal([{ n: 2 }]);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -159,8 +159,8 @@ describe('Integration | Repository | Campaign', () => {
         expect(_.map(sortedCampaignsWithReports, 'id')).to.have.members([firstCampaignId, secondCampaignId]);
         expect(sortedCampaignsWithReports[0]).to.be.instanceOf(Campaign);
         expect(sortedCampaignsWithReports[0].campaignReport).to.be.instanceOf(CampaignReport);
-        expect(sortedCampaignsWithReports[0].campaignReport).to.deep.equal({ id: firstCampaignId, participationsCount: '3', sharedParticipationsCount: '1' });
-        expect(sortedCampaignsWithReports[1].campaignReport).to.deep.equal({ id: secondCampaignId, participationsCount: '2', sharedParticipationsCount: '2' });
+        expect(sortedCampaignsWithReports[0].campaignReport).to.deep.equal({ id: firstCampaignId, participationsCount: 3, sharedParticipationsCount: 1 });
+        expect(sortedCampaignsWithReports[1].campaignReport).to.deep.equal({ id: secondCampaignId, participationsCount: 2, sharedParticipationsCount: 2 });
       });
     });
 

--- a/orga/app/models/campaign-report.js
+++ b/orga/app/models/campaign-report.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  participationsCount: DS.attr(),
-  sharedParticipationsCount: DS.attr(),
+  participationsCount: DS.attr('number'),
+  sharedParticipationsCount: DS.attr('number'),
 });


### PR DESCRIPTION
## :unicorn: Problème
Il y a longtemps, nous avons développé un petit patch custom qui caste le résultat de la méthode `Bookshelf.Model.count()` de `String` à `Number`. Par défaut, la méthode `#count()` renvoie une `String` plutôt qu'un entier. Cela est lié au fait que PostgreSQL peut renvoyer un BIG_INTEGER plutôt qu'un INTEGER.

Par ailleurs, nous espérions à l'époque que le correctif serait intégré dans les versions futures de Bookshelf. Ce qui n'a pas été le cas. 

Quoiqu'il en soit, nous avions à l'époque mis un test avec un message de warning, portant sur la version de Bookshelf utilisée. Finalement, au cours de ces dernières semaines, nous avons monté la version de Bookshelf en faisant fi de ce warning. Tout semble se passer correctement. Nous n'avons plus besoin de ce test.

## :robot: Solution

1. Appliquer un meilleur patch au meilleur endroit (cf. détails dans les messages de commit).
2. Supprimer le test et le message d'alerte.
3. Définir le type `number` dans les propriétés des modèles côté front / Pix Orga

## :rainbow: Remarques

Pour les tests fonctionnels, il faut s'assurer que dans Pix Orga, tous les chiffres apparaissent correctement (pas de `NAN`).

Bonus : cette PR supprime un paquet de lignes d'alerte inutile dans les logs / DataDog 😎