### PR TITLE
[BUGFIX] Probleme de validation des QROCM sous IE (PF-1055).

### DIFF
--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -20,7 +20,8 @@ const ChallengeItemQrocm = ChallengeItemGeneric.extend({
   // and moreover, is a much more robust solution when you need to test it properly.
   _getRawAnswerValue() {
     const result = {};
-    document.querySelectorAll('.challenge-proposals input').forEach((element)=> {
+    // XXX : forEach on NodeList returned by document.querySelectorAll is not supported by IE
+    _.forEach(document.querySelectorAll('.challenge-proposals input'), (element)=> {
       result[element.getAttribute('name')] = element.value;
     });
     return result;


### PR DESCRIPTION
## :unicorn: Problème
Sous IE 11, les utilisateurs ne pouvaient pas valider les épreuves QROCM.
Lors de la validation, un `document.querySelectorAll` récupérait la liste des input, et nous bouclions directement dessus avec un `forEach`.
Sous IE, il n'était pas possible de boucler directement sur le résultats du `querySelectorAll`

## :robot: Solution
Passer par une boucle for.

## :rainbow: Remarques
En lien avec la PR du commit 1f3692d qui supprimait jQuery.
Sous IE, on ne peut pas faire de `forEach` sur le retour de `document.querySelectorAll`, ce n'est pas supporté : https://developer.mozilla.org/fr/docs/Web/API/NodeList