### PR TITLE
[TECH] Les tests de MonPix sur CircleCI se déclenchaient 3 fois complètement en parallèle

### DIFF
--- a/mon-pix/tests/test-helper.js
+++ b/mon-pix/tests/test-helper.js
@@ -2,10 +2,7 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { mocha } from 'mocha';
-import { start } from 'ember-mocha';
-import loadEmberExam from 'ember-exam/test-support/load';
-
-loadEmberExam();
+import start from 'ember-exam/test-support/start';
 
 mocha.setup({
   // If a test is randomly killed by the timeout duration,


### PR DESCRIPTION
## :unicorn: Problème
Les tests de monPix sur CircleCI se déclenchent 3 fois en parallèle, ce qui prend en moyenne 4 min 30 !!
C'est une régression, car avant, il y avait en effet 3 containers qui passaient les tests, mais ils se divisaient le travail !

## :robot: Solution
Régression introduite par une mise à jour de ember-exam, avec un breaking change pas pris en compte lors de la montée de version (my bad :japanese_ogre: )

https://github.com/ember-cli/ember-exam/blob/master/CHANGELOG.md#v300--2019-04-08

## :rainbow: Remarques