### PR TITLE
Move e2e_tests (longest job) to top to reduce overall build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ workflows:
                 - gh-pages
                 - /release-.*/
 
+      - e2e_test:
+          requires:
+            - checkout
+
       - api_build_and_test:
           requires:
             - checkout
@@ -50,10 +54,6 @@ workflows:
             - checkout
 
       - admin_build_and_test:
-          requires:
-            - checkout
-
-      - e2e_test:
           requires:
             - checkout
 


### PR DESCRIPTION
## :unicorn: Problème
Bien que les jobs soient parallélisés on ne peut lancer que 2 jobs à la fois.

## :robot: Solution
Lancer le job le plus long en premier.

## :rainbow: Remarques
