### PR TITLE
[BUGFIX] Correction d'une erreur Redis au démarrage de l'API. 

### DIFF
--- a/api/lib/infrastructure/caches/RedisClient.js
+++ b/api/lib/infrastructure/caches/RedisClient.js
@@ -3,15 +3,7 @@ const Redlock = require('redlock');
 const { promisify } = require('util');
 const logger = require('../logger');
 
-const REDIS_CLIENT_OPTIONS = {
-  // To avoid a "thundering herd" effect on the Redis server when it comes back
-  // up after a crash or connection loss, which can cause Redis to use more
-  // memory (for client buffers) than the OS allows and get killed, causing
-  // more Redis queries to get backed up, do not store a backlog of Redis
-  // queries. Errors will be reported immediately if the Redis server is not
-  // available.
-  enable_offline_queue: false,
-};
+const REDIS_CLIENT_OPTIONS = {};
 
 module.exports = class RedisClient {
 


### PR DESCRIPTION
Cette PR est un fix de l'[erreur Sentry](https://sentry.io/organizations/pix/issues/1469577524/?project=1398749&query=is%3Aunresolved&statsPeriod=7d).

## :unicorn: Problème

Nous suspectons un problème de "connexion non encore établie" au démarrage d'un conteneur d'API qui reçoit des reuqêtes dès qu'il se met à écouter.

## :robot: Solution

Par le passé, nous avons désactivé l'option / feature "Offline Queue" de Redis qui générait beaucoup trop d'erreurs, du fait des trop nombreuses sollicitations de Redis (cf. PR #707). Depuis la PR #922 et l'amélioration de notre utilisation du cache et du fort diminution d'appels Redis, nous pouvons à nouveau activer ce mécanisme.