### PR TITLE
[BUGFIX] Deux QROCs qui se suivent avec un même input conservent la réponse précédente

### DIFF
--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -25,5 +25,9 @@ export default Component.extend({
     this.$('input').keydown(() => {
       this.answerChanged();
     });
+  },
+
+  willRender: function() {
+    this.notifyPropertyChange('proposals');
   }
 });


### PR DESCRIPTION
## :unicorn: Problème
Le champ de réponse d'une question est pré-rempli avec la réponse entrée à la question précédente.
Ce comportement intervient uniquement lorsque deux QROCs consécutives ont exactement les mêmes `proposals`.
Ceci est entrainé par le fait que l'attribut `proposals` étant le même, Ember ne re-compute pas la variable `blocks` dont on se sert pour configurer l'input.

## :robot: Solution
Forcer un re-compute de la variable `blocks` à chaque affichage du composant.

## :rainbow: Remarques
Pour tester, utiliser le test statique : `/courses/recvHSPnmfGsmmfsg`.
