### PR TITLE
[TECH] Déplacement vers le backend de la fonctionnalité d'export des résultats de session en CSV (PA-138)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -248,6 +248,19 @@ exports.register = async (server) => {
         ]
       }
     },
+    {
+      method: 'GET',
+      path: '/api/sessions/{id}/csv-results',
+      config: {
+        auth: false,
+        handler: sessionController.getCsvResults,
+        tags: ['api', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Cette route permet de télécharger le csv de résultats destinés aux prescripteurs',
+        ]
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -135,8 +135,15 @@ module.exports = {
     return usecases.analyzeAttendanceSheet({ sessionId, odsBuffer });
   },
 
-  async getCsvResults() {
-    return null;
+  async getCsvResults(request, h) {
+    const sessionId = request.params.id;
+    const token = request.query.accessToken;
+    const userId = tokenService.extractUserId(token);
+    const { csvFilename, csvContent } = await usecases.generateSessionCsvResults({ sessionId, userId });
+
+    return h.response(csvContent)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', `attachment; filename=${csvFilename}`);
   },
 
 };

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -133,6 +133,10 @@ module.exports = {
     const odsBuffer = request.payload.file;
 
     return usecases.analyzeAttendanceSheet({ sessionId, odsBuffer });
-  }
+  },
+
+  async getCsvResults() {
+    return null;
+  },
 
 };

--- a/api/lib/domain/usecases/generate-session-csv-results.js
+++ b/api/lib/domain/usecases/generate-session-csv-results.js
@@ -1,0 +1,6 @@
+module.exports = async function generateSessionCsvResults({
+  sessionId,
+  userId,
+}) {
+  return { sessionId, userId };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -99,6 +99,7 @@ module.exports = injectDependencies({
   findSmartPlacementAssessments: require('./find-smart-placement-assessments'),
   findSnapshots: require('./find-snapshots'),
   findTutorials: require('./find-tutorials'),
+  generateSessionCsvResults: require('./generate-session-csv-results'),
   getAnswer: require('./get-answer'),
   getAssessment: require('./get-assessment'),
   getAttendanceSheet: require('./get-attendance-sheet'),

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -287,4 +287,18 @@ describe('Unit | Application | Sessions | Routes', () => {
       });
     });
   });
+
+  describe('GET /api/sessions/{id}/csv-results', () => {
+
+    beforeEach(() => {
+      sinon.stub(sessionController, 'getCsvResults').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/csv-results' });
+
+      expect(res.statusCode).to.equal(200);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le code côté PixAdmin contient beaucoup de logique métier qu'il serait préférable de reporter côté API. Avoir des fonctionnalités côté front nous contraint à récupérer beaucoup de données (complexes et mises dans des modèles un peu fourre-tout). Dans notre cas, il s'agit de l'export en CSV des résultats d'une session à destination des prescripteurs.

## :robot: Solution
Créer une route GET /api/sessions/:id/csv-results pour télécharger le fichier csv contenant les résultats d'une session à destination des prescripteurs.

## :rainbow: Remarques
