### PR TITLE
[BUGFIX] Requêter le détail d'une compétence avec un mauvais identifiant provoque désormais une erreur 404 plutôt que 500.

### DIFF
--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -1,8 +1,8 @@
+const _ = require('lodash');
 const Assessment = require('./Assessment');
 const CompetenceEvaluation = require('./CompetenceEvaluation');
 const KnowledgeElement = require('./KnowledgeElement');
 const constants = require('../constants');
-const _ = require('lodash');
 
 const statuses = {
   NOT_STARTED: 'NOT_STARTED',

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -17,10 +17,7 @@ module.exports = async function startOrResumeCompetenceEvaluation({ competenceId
 };
 
 function _checkCompetenceExists(competenceId, competenceRepository) {
-  return competenceRepository.get(competenceId)
-    .catch(() => {
-      throw new NotFoundError('La compétence demandée n\'existe pas');
-    });
+  return competenceRepository.get(competenceId);
 }
 
 async function _resumeCompetenceEvaluation({ userId, competenceId, assessmentRepository, competenceEvaluationRepository }) {

--- a/api/tests/acceptance/application/competence-evaluation-controller_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller_test.js
@@ -26,27 +26,29 @@ describe('Acceptance | API | Competence Evaluations', () => {
     };
 
     context('When user is authenticated', () => {
-      context('and competence exists', () => {
-        beforeEach(async () => {
-          const airtableCompetence = airtableBuilder.factory.buildCompetence({
-            id: competenceId,
-          });
-          airtableBuilder
-            .mockList({ tableName: 'Competences' })
-            .returns([airtableCompetence])
-            .activate();
-          airtableBuilder
-            .mockList({ tableName: 'Domaines' })
-            .returns({})
-            .activate();
-        });
 
-        afterEach(async () => {
-          airtableBuilder.cleanAll();
-          await knex('competence-evaluations').delete();
-          await knex('assessments').delete();
-          return cache.flushAll();
+      beforeEach(async () => {
+        const airtableCompetence = airtableBuilder.factory.buildCompetence({
+          id: competenceId,
         });
+        airtableBuilder
+          .mockList({ tableName: 'Competences' })
+          .returns([airtableCompetence])
+          .activate();
+        airtableBuilder
+          .mockList({ tableName: 'Domaines' })
+          .returns({})
+          .activate();
+      });
+
+      afterEach(async () => {
+        airtableBuilder.cleanAll();
+        await knex('competence-evaluations').delete();
+        await knex('assessments').delete();
+        return cache.flushAll();
+      });
+
+      context('and competence exists', () => {
 
         it('should return 201 and the competence evaluation when it has been successfully created', async () => {
           // when
@@ -74,36 +76,34 @@ describe('Acceptance | API | Competence Evaluations', () => {
           expect(response.result.data.attributes['assessment-id']).to.be.not.null;
         });
       });
+
       context('and competence does not exists', () => {
-        it('should return 404 error', () => {
+
+        it('should return 404 error', async () => {
           // given
           options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
           options.payload.competenceId = 'WRONG_ID';
 
           // when
-          const promise = server.inject(options);
+          const response = await server.inject(options);
 
           // then
-          return promise.then((response) => {
-            expect(response.statusCode).to.equal(404);
-          });
+          expect(response.statusCode).to.equal(404);
         });
       });
     });
 
     context('When user is not authenticated', () => {
-      beforeEach(async () => {
-        options.headers.authorization = null;
-      });
 
-      it('should return 401 error', () => {
+      it('should return 401 error', async () => {
+        // given
+        options.headers.authorization = null;
+
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
   });

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -1,7 +1,7 @@
+const moment = require('moment');
 const { expect, sinon } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
-const moment = require('moment');
 const constants = require('../../../../lib/domain/constants');
 
 describe('Unit | Domain | Models | Scorecard', () => {
@@ -33,7 +33,10 @@ describe('Unit | Domain | Models | Scorecard', () => {
           status: 'started',
           assessment: { state: 'started' },
         };
-        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, { earnedPix: 3.6, createdAt: new Date() }];
+        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, {
+          earnedPix: 3.6,
+          createdAt: new Date()
+        }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
         // when
         actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
@@ -93,7 +96,10 @@ describe('Unit | Domain | Models | Scorecard', () => {
       beforeEach(() => {
         // given
         competenceEvaluation = undefined;
-        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, { earnedPix: 3.6, createdAt: new Date() }];
+        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, {
+          earnedPix: 3.6,
+          createdAt: new Date()
+        }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
         //when
         actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
@@ -122,7 +128,10 @@ describe('Unit | Domain | Models | Scorecard', () => {
     context('when the competence evaluation has been reset and some knowledgeElements exist', () => {
       beforeEach(() => {
         // given
-        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, { earnedPix: 3.6, createdAt: new Date() }];
+        const knowledgeElements = [{ earnedPix: 5.5, createdAt: new Date() }, {
+          earnedPix: 3.6,
+          createdAt: new Date()
+        }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
         competenceEvaluation = { status: 'reset' };
 
@@ -179,13 +188,25 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
       it('should have the same number of pix if blockReachablePixAndLevel is false', () => {
         //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: false });
+        actualScorecard = Scorecard.buildFrom({
+          userId,
+          knowledgeElements,
+          competenceEvaluation,
+          competence,
+          blockReachablePixAndLevel: false
+        });
         // then
         expect(actualScorecard.earnedPix).to.equal(120);
       });
       it('should have the number of pix blocked if blockReachablePixAndLevel is true', () => {
         //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: true });
+        actualScorecard = Scorecard.buildFrom({
+          userId,
+          knowledgeElements,
+          competenceEvaluation,
+          competence,
+          blockReachablePixAndLevel: true
+        });
         // then
         expect(actualScorecard.earnedPix).to.equal(constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
       });
@@ -240,4 +261,22 @@ describe('Unit | Domain | Models | Scorecard', () => {
       });
     });
   });
+
+  describe('#parseId', () => {
+
+    it('should return a JSON object with parsed user ID and competence ID', () => {
+      // given
+      const id = '1234_recABC1234';
+
+      // when
+      const result = Scorecard.parseId(id);
+
+      // then
+      expect(result).to.deep.equal({
+        userId: 1234,
+        competenceId: 'recABC1234'
+      });
+    });
+  });
+
 });

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -32,23 +32,29 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
   });
 
   context('When the competence does not exist', () => {
-    beforeEach(() => {
-      competenceRepository.get.withArgs(competenceId).rejects();
-    });
-    it('should throw a Not Found Error', async () => {
+
+    it('should bubble the domain NotFoundError', async () => {
+      // given
+      const notFoundError = new NotFoundError('La compétence demandée n’existe pas');
+      competenceRepository.get.withArgs(competenceId).rejects(notFoundError);
+
       // when
       const err = await catchErr(usecases.startOrResumeCompetenceEvaluation)({
         competenceId, userId, competenceEvaluationRepository, assessmentRepository, competenceRepository
       });
+
       // then
-      expect(err).to.be.instanceOf(NotFoundError);
+      expect(err).to.deep.equal(notFoundError);
     });
   });
+
   context('When the competence could not be retrieved', () => {
+
     beforeEach(() => {
       competenceRepository.get.withArgs(competenceId).resolves();
       competenceEvaluationRepository.getByCompetenceIdAndUserId.rejects(new Error);
     });
+
     it('should forward the error', async () => {
       // when
       const err = await catchErr(usecases.startOrResumeCompetenceEvaluation)({


### PR DESCRIPTION
Cette PR fixe [l'erreur Sentry suivante](https://sentry.io/organizations/pix/issues/1459640624).

## :unicorn: Problème

Certaines anciennes versions de Pix App requêtaient mal le service pour récupérer le détail du résultat d'une compétence : `/api/scorecards/:user_competence_id`. 

Ainsi, l'API subit des appels tels que : `/api/scorecards/1234_1234_recAbcd`, qui lèvent des erreurs 500.

Il nous paraît plus judicieux de renvoyer une 404.

## :robot: Solution

Afin de pallier au problème, nous traitons l'erreur `NotFoundError` non plus au niveau de l'exploitant (ici, le service) mais plus bas / directement au niveau du repository, qui porte alors la responsabilité de convertir une erreur technique `infrastructure.datasources.airtable.AirtableResourceNotFound` en erreur du domaine `domain.NotFoundError`.

## :rainbow: Remarques

Au passage, cette PR remplace quelques promise-based tests en  async/await dans les fichiers touchés #BSR.

Pas de conséquence fonctionnelle côté utilisateur, qui continueront de voir la "page Oups" d'erreur si elle survient. En revanche, ça fera des évènements en moins dans Sentry ^^ ! 