### PR TITLE
Rendre les validateurs synchrones et s'assurer qu'ils jettent correctement leurs erreurs converties 4xx (PC-110)

### DIFF
--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -4,9 +4,9 @@ const campaignValidator = require('../validators/campaign-validator');
 const Campaign = require('../models/Campaign');
 const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
 
-module.exports = function createCampaign({ campaign, campaignRepository, userRepository, organizationService }) {
-  return campaignValidator.validate(campaign)
-    .then(() => _checkCreatorHasAccessToCampaignOrganization(campaign.creatorId, campaign.organizationId, userRepository))
+module.exports = async function createCampaign({ campaign, campaignRepository, userRepository, organizationService }) {
+  campaignValidator.validate(campaign);
+  return _checkCreatorHasAccessToCampaignOrganization(campaign.creatorId, campaign.organizationId, userRepository)
     .then(() => _checkOrganizationHasAccessToTargetProfile(campaign.targetProfileId, campaign.organizationId, organizationService))
     .then(() => campaignCodeGenerator.generate(campaignRepository))
     .then((generatedCampaignCode) => {

--- a/api/lib/domain/usecases/create-organization.js
+++ b/api/lib/domain/usecases/create-organization.js
@@ -2,7 +2,7 @@ const Organization = require('../models/Organization');
 const organizationCreationValidator = require('../validators/organization-creation-validator');
 const organizationService = require('../services/organization-service');
 
-module.exports = function createOrganization({
+module.exports = async function createOrganization({
   name,
   type,
   logoUrl,
@@ -10,9 +10,8 @@ module.exports = function createOrganization({
   provinceCode,
   organizationRepository,
 }) {
-
-  return organizationCreationValidator.validate({ name, type })
-    .then(() => organizationService.generateUniqueOrganizationCode({ organizationRepository }))
+  organizationCreationValidator.validate({ name, type });
+  return organizationService.generateUniqueOrganizationCode({ organizationRepository })
     .then((code) => new Organization({ name, type, code, logoUrl, externalId, provinceCode }))
     .then(organizationRepository.create);
 };

--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -45,13 +45,10 @@ const campaignValidationJoiSchema = Joi.object({
 module.exports = {
 
   validate(campaign) {
-
     const { error } = campaignValidationJoiSchema.validate(campaign, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
-    } else {
-      return Promise.resolve();
     }
+    return true;
   }
-
 };

--- a/api/lib/domain/validators/organization-creation-validator.js
+++ b/api/lib/domain/validators/organization-creation-validator.js
@@ -23,13 +23,10 @@ const organizationValidationJoiSchema = Joi.object({
 module.exports = {
 
   validate(organizationCreationParams) {
-
     const { error } = organizationValidationJoiSchema.validate(organizationCreationParams, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
-    } else {
-      return Promise.resolve();
     }
+    return true;
   }
-
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -43,10 +43,9 @@ const sessionValidationJoiSchema = Joi.object({
 module.exports = {
 
   validate(session) {
-
     const { error } = sessionValidationJoiSchema.validate(session, validationConfiguration);
     if (error) {
-      return Promise.reject(EntityValidationError.fromJoiErrors(error.details));
+      throw EntityValidationError.fromJoiErrors(error.details);
     }
   }
 };

--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -60,13 +60,10 @@ const userValidationJoiSchema = Joi.object({
 module.exports = {
 
   validate({ user, cguRequired = true }) {
-
     const { error } = userValidationJoiSchema.validate(user, { ...validationConfiguration, context: { cguRequired } });
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
-    } else {
-      return Promise.resolve();
     }
+    return true;
   }
-
 };

--- a/api/tests/unit/domain/usecases/create-and-associate-user-to-student_test.js
+++ b/api/tests/unit/domain/usecases/create-and-associate-user-to-student_test.js
@@ -83,7 +83,7 @@ describe('Unit | UseCase | create-and-associate-user-to-student', () => {
       encryptionService.hashPassword.resolves(encryptedPassword);
       userRepository.createAndAssociateUserToStudent.resolves(createdUser.id);
       userRepository.get.withArgs(createdUser.id).resolves(createdUser);
-      userValidator.validate.resolves();
+      userValidator.validate.returns();
     });
 
     context('When creation is with email', () => {
@@ -113,7 +113,7 @@ describe('Unit | UseCase | create-and-associate-user-to-student', () => {
               },
             ]
           });
-          userValidator.validate.rejects(expectedValidationError);
+          userValidator.validate.throws(expectedValidationError);
 
           // when
           const error = await catchErr(usecases.createAndAssociateUserToStudent)({

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -32,7 +32,7 @@ describe('Unit | UseCase | create-campaign', () => {
 
   it('should throw an EntityValidationError if campaign is not valid', () => {
     // given
-    campaignValidator.validate.rejects(new EntityValidationError({ invalidAttributes: [] }));
+    campaignValidator.validate.throws(new EntityValidationError({ invalidAttributes: [] }));
 
     // when
     const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
@@ -44,7 +44,7 @@ describe('Unit | UseCase | create-campaign', () => {
   it('should throw an error if user do not have an access to the campaign organization', () => {
     // given
     const organizationIdDifferentFromCampaign = 98437;
-    campaignValidator.validate.resolves();
+    campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(organizationIdDifferentFromCampaign);
 
     // when
@@ -56,7 +56,7 @@ describe('Unit | UseCase | create-campaign', () => {
 
   it('should generate a new code to the campaign', () => {
     // given
-    campaignValidator.validate.resolves();
+    campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
     campaignCodeGenerator.generate.resolves(availableCampaignCode);
     campaignRepository.save.resolves(savedCampaign);
@@ -73,7 +73,7 @@ describe('Unit | UseCase | create-campaign', () => {
 
   it('should save the campaign with name, userId, organizationId and generated code', () => {
     // given
-    campaignValidator.validate.resolves();
+    campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
     campaignCodeGenerator.generate.resolves(availableCampaignCode);
     campaignRepository.save.resolves(savedCampaign);
@@ -95,7 +95,7 @@ describe('Unit | UseCase | create-campaign', () => {
 
   it('should return the newly created campaign', () => {
     // given
-    campaignValidator.validate.resolves();
+    campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
     campaignCodeGenerator.generate.resolves(availableCampaignCode);
     campaignRepository.save.resolves(savedCampaign);

--- a/api/tests/unit/domain/usecases/create-organization_test.js
+++ b/api/tests/unit/domain/usecases/create-organization_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | create-organization', () => {
     let organizationRepository;
 
     beforeEach(() => {
-      organizationCreationValidator.validate.resolves(true);
+      organizationCreationValidator.validate.returns();
       organizationService.generateUniqueOrganizationCode.resolves(code);
 
       organizationRepository = { create: sinon.stub() };
@@ -65,7 +65,7 @@ describe('Unit | UseCase | create-organization', () => {
       const type = 'PRO';
       const organizationRepository = {};
 
-      organizationCreationValidator.validate.rejects(new EntityValidationError({}));
+      organizationCreationValidator.validate.throws(new EntityValidationError({}));
 
       // when
       const error = await catchErr(createOrganization)({ name, type, organizationRepository });

--- a/api/tests/unit/domain/validations/campaign-validator_test.js
+++ b/api/tests/unit/domain/validations/campaign-validator_test.js
@@ -26,24 +26,16 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
     context('when validation is successful', () => {
 
-      it('should resolve (with no value) when validation is successful', () => {
-        // when
-        const promise = campaignValidator.validate(campaign);
-
-        // then
-        return expect(promise).to.be.fulfilled;
+      it('should not throw any error', () => {
+        expect(campaignValidator.validate(campaign)).to.not.throw;
       });
 
       it('should resolve when idPixLabel is null', () => {
         // given
         campaign.idPixLabel = null;
 
-        // when
-        const promise = campaignValidator.validate(campaign);
-
-        // then
-        return expect(promise).to.be.fulfilled;
-
+        // when/then
+        expect(campaignValidator.validate(campaign)).to.not.throw;
       });
 
     });
@@ -52,7 +44,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
       context('on name attribute', () => {
 
-        it('should reject with error when name is missing', async () => {
+        it('should reject with error when name is missing', () => {
           // given
           const expectedError = {
             attribute: 'name',
@@ -62,8 +54,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
-
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
@@ -74,7 +66,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
       context('on creatorId attribute', () => {
 
-        it('should reject with error when creatorId is missing', async () => {
+        it('should reject with error when creatorId is missing', () => {
           // given
           const expectedError = {
             attribute: 'creatorId',
@@ -84,7 +76,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
 
           } catch (entityValidationErrors) {
             // then
@@ -96,7 +89,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
       context('on organizationId attribute', () => {
 
-        it('should reject with error when organizationId is missing', async () => {
+        it('should reject with error when organizationId is missing', () => {
           // given
           const expectedError = {
             attribute: 'organizationId',
@@ -106,7 +99,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
 
           } catch (entityValidationErrors) {
             // then
@@ -117,7 +111,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
       });
 
       context('on idPixLabel attribute', () => {
-        it('should reject with error when idPixLabel is an empty string', async () => {
+        it('should reject with error when idPixLabel is an empty string', () => {
           // given
           const expectedError = {
             attribute: 'idPixLabel',
@@ -127,7 +121,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
 
           } catch (entityValidationErrors) {
             // then
@@ -135,7 +130,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
           }
         });
 
-        it('should reject with error when idPixLabel length is under 3 characters', async () => {
+        it('should reject with error when idPixLabel length is under 3 characters', () => {
           // given
           const expectedError = {
             attribute: 'idPixLabel',
@@ -145,7 +140,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
 
           } catch (entityValidationErrors) {
             // then
@@ -157,7 +153,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
       context('on targetProfileId attribute', () => {
 
-        it('should reject with error when targetProfileId is missing', async () => {
+        it('should reject with error when targetProfileId is missing', () => {
           // given
           const expectedError = {
             attribute: 'targetProfileId',
@@ -167,7 +163,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
           try {
             // when
-            await campaignValidator.validate(campaign);
+            campaignValidator.validate(campaign);
+            expect.fail('should have thrown an error');
 
           } catch (entityValidationErrors) {
             // then
@@ -177,7 +174,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
       });
 
-      it('should reject with errors on all fields (but only once by field) when all fields are missing', async () => {
+      it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
         // given
         campaign.name = MISSING_VALUE;
         campaign.creatorId = MISSING_VALUE;
@@ -186,7 +183,8 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
 
         try {
           // when
-          await campaignValidator.validate(campaign);
+          campaignValidator.validate(campaign);
+          expect.fail('should have thrown an error');
 
         } catch (entityValidationErrors) {
           // then

--- a/api/tests/unit/domain/validations/organization-creation-validator_test.js
+++ b/api/tests/unit/domain/validations/organization-creation-validator_test.js
@@ -16,15 +16,12 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
     context('when validation is successful', () => {
 
-      it('should resolve (with no value) when validation is successful', () => {
+      it('should not throw any error', () => {
         // given
         const organizationCreationParams = { name: 'ACME', type: 'PRO' };
 
-        // when
-        const promise = organizationCreationValidator.validate(organizationCreationParams);
-
-        // then
-        return expect(promise).to.be.fulfilled;
+        // when/then
+        expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
       });
     });
 
@@ -32,7 +29,7 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
       context('on name attribute', () => {
 
-        it('should reject with error when name is missing', async () => {
+        it('should reject with error when name is missing', () => {
           // given
           const expectedError = {
             attribute: 'name',
@@ -42,8 +39,8 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
           try {
             // when
-            await organizationCreationValidator.validate(organizationCreationParams);
-
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
           } catch (errors) {
             // then
             _assertErrorMatchesWithExpectedOne(errors, expectedError);
@@ -54,7 +51,7 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
       context('on type attribute', () => {
 
-        it('should reject with error when type is missing', async () => {
+        it('should reject with error when type is missing', () => {
           // given
           const expectedError = [
             {
@@ -70,8 +67,8 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
           try {
             // when
-            await organizationCreationValidator.validate(organizationCreationParams);
-
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
           } catch (errors) {
             // then
             expect(errors.invalidAttributes).to.have.length(2);
@@ -79,7 +76,7 @@ describe('Unit | Domain | Validators | organization-validator', function() {
           }
         });
 
-        it('should reject with error when type value is not SUP, SCO or PRO', async () => {
+        it('should reject with error when type value is not SUP, SCO or PRO', () => {
           // given
           const expectedError = {
             attribute: 'type',
@@ -89,8 +86,8 @@ describe('Unit | Domain | Validators | organization-validator', function() {
 
           try {
             // when
-            await organizationCreationValidator.validate(organizationCreationParams);
-
+            organizationCreationValidator.validate(organizationCreationParams);
+            expect.fail('should have thrown an error');
           } catch (errors) {
             // then
             _assertErrorMatchesWithExpectedOne(errors, expectedError);
@@ -102,28 +99,25 @@ describe('Unit | Domain | Validators | organization-validator', function() {
           'SCO',
           'PRO'
         ].forEach((type) => {
-          it(`should accept ${type} as type`, function() {
+          it(`should not throw with ${type} as type`, function() {
             // given
             const organizationCreationParams = { name: 'ACME', type };
 
-            // when
-            const promise = organizationCreationValidator.validate(organizationCreationParams);
-
-            // then
-            return expect(promise).to.be.fulfilled;
+            // when/then
+            return expect(organizationCreationValidator.validate(organizationCreationParams)).to.not.throw;
           });
         });
 
       });
 
-      it('should reject with errors on all fields (but only once by field) when all fields are missing', async () => {
+      it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
         // given
         const organizationCreationParams = { name: MISSING_VALUE, type: MISSING_VALUE, };
 
         try {
           // when
-          await organizationCreationValidator.validate(organizationCreationParams);
-
+          organizationCreationValidator.validate(organizationCreationParams);
+          expect.fail('should have thrown an error');
         } catch (errors) {
           // then
           expect(errors.invalidAttributes).to.have.lengthOf(3);

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -21,9 +21,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
     context('when validation is successful', () => {
 
-      it('should resolve (with no value) when validation is successful', () => {
-        // when/then
-        return expect(() => sessionValidator.validate(session)).to.not.throw;
+      it('should not throw any error', () => {
+        expect(sessionValidator.validate(session)).to.not.throw;
       });
 
     });
@@ -32,7 +31,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
       context('on address attribute', () => {
 
-        it('should reject with error when address is missing', async () => {
+        it('should reject with error when address is missing', () => {
           // given
           const expectedErrors = [{
             attribute: 'address',
@@ -42,8 +41,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
@@ -64,8 +63,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
@@ -76,7 +75,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
       context('on date attribute', () => {
 
-        it('should reject with error when date is missing', async () => {
+        it('should reject with error when date is missing', () => {
           // given
           const expectedErrors = [{
             attribute: 'date',
@@ -86,8 +85,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
@@ -98,7 +97,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
       context('on time attribute', () => {
 
-        it('should reject with error when time is an empty string', async () => {
+        it('should reject with error when time is an empty string', () => {
           // given
           const expectedErrors = [{
             attribute: 'time',
@@ -108,15 +107,15 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
           }
         });
 
-        it('should reject with error when time ihas a format different than HH:MM', async () => {
+        it('should reject with error when time ihas a format different than HH:MM', () => {
           // given
           const expectedErrors = [{
             attribute: 'time',
@@ -126,8 +125,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
@@ -138,7 +137,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
       context('on examiner attribute', () => {
 
-        it('should reject with error when examiner is missing', async () => {
+        it('should reject with error when examiner is missing', () => {
           // given
           const expectedErrors = [{
             attribute: 'examiner',
@@ -148,8 +147,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           try {
             // when
-            await sessionValidator.validate(session);
-
+            sessionValidator.validate(session);
+            expect.fail('should have thrown an error');
           } catch (entityValidationErrors) {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);

--- a/api/tests/unit/domain/validations/user-validator_test.js
+++ b/api/tests/unit/domain/validations/user-validator_test.js
@@ -1,4 +1,4 @@
-const { expect, catchErr } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const userValidator = require('../../../../lib/domain/validators/user-validator');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
 const User = require('../../../../lib/domain/models/User');
@@ -31,18 +31,14 @@ describe('Unit | Domain | Validators | user-validator', function() {
 
       context('when validation is successful', () => {
 
-        it('should resolve (with no value) when validation is successful', () => {
-          // when
-          const promise = userValidator.validate({ user });
-
-          // then
-          return expect(promise).to.be.fulfilled;
+        it('should not throw any error', () => {
+          expect(userValidator.validate({ user })).to.not.throw;
         });
       });
 
       context('when user data validation fails', () => {
 
-        it('should reject with error when user is undefined', async () => {
+        it('should reject with error when user is undefined', () => {
           // given
           const expectedError = {
             attribute: undefined,
@@ -50,13 +46,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           };
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user: undefined });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user: undefined });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "first name" when first name is missing', async () => {
+        it('should reject with error on field "first name" when first name is missing', () => {
           // given
           const expectedError = {
             attribute: 'firstName',
@@ -65,13 +64,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.firstName = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "last name" when last name is missing', async () => {
+        it('should reject with error on field "last name" when last name is missing', () => {
           // given
           const expectedError = {
             attribute: 'lastName',
@@ -80,13 +82,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.lastName = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "password" when password is missing', async () => {
+        it('should reject with error on field "password" when password is missing', () => {
           // given
           const expectedError = {
             attribute: 'password',
@@ -95,13 +100,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.password = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "password" when password is invalid', async () => {
+        it('should reject with error on field "password" when password is invalid', () => {
           // given
           const expectedError = {
             attribute: 'password',
@@ -110,13 +118,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.password = 'invalid';
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "cgu" when cgu is false', async () => {
+        it('should reject with error on field "cgu" when cgu is false', () => {
           // given
           const expectedError = {
             attribute: 'cgu',
@@ -125,13 +136,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.cgu = 'false';
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "email" when email is missing', async () => {
+        it('should reject with error on field "email" when email is missing', () => {
           // given
           const expectedError = {
             attribute: 'email',
@@ -140,13 +154,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.email = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "email" when email is invalid', async () => {
+        it('should reject with error on field "email" when email is invalid', () => {
           // given
           const expectedError = {
             attribute: 'email',
@@ -155,13 +172,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.email = 'invalid_email';
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with errors on all fields (but only once by field) when all fields are missing', async () => {
+        it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
           // given
           user = {
             firstName: '',
@@ -171,10 +191,13 @@ describe('Unit | Domain | Validators | user-validator', function() {
           };
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user });
-
-          // then
-          expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(5);
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            expect(errors.invalidAttributes).to.have.lengthOf(5);
+          }
         });
       });
     });
@@ -194,18 +217,14 @@ describe('Unit | Domain | Validators | user-validator', function() {
 
       context('when validation is successful', () => {
 
-        it('should resolve (with no value) when validation is successful', () => {
-          // when
-          const promise = userValidator.validate({ user, cguRequired });
-
-          // then
-          return expect(promise).to.be.fulfilled;
+        it('should not throw any error', () => {
+          expect(userValidator.validate({ user, cguRequired })).to.not.throw;
         });
       });
 
       context('when user data validation fails', () => {
 
-        it('should reject with error when user is undefined', async () => {
+        it('should reject with error when user is undefined', () => {
           // given
           const expectedError = {
             attribute: undefined,
@@ -213,13 +232,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           };
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user: undefined, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user: undefined, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "first name" when first name is missing', async () => {
+        it('should reject with error on field "first name" when first name is missing', () => {
           // given
           const expectedError = {
             attribute: 'firstName',
@@ -228,13 +250,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.firstName = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "last name" when last name is missing', async () => {
+        it('should reject with error on field "last name" when last name is missing', () => {
           // given
           const expectedError = {
             attribute: 'lastName',
@@ -243,13 +268,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.lastName = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "password" when password is missing', async () => {
+        it('should reject with error on field "password" when password is missing', () => {
           // given
           const expectedError = {
             attribute: 'password',
@@ -258,13 +286,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.password = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "password" when password is invalid', async () => {
+        it('should reject with error on field "password" when password is invalid', () => {
           // given
           const expectedError = {
             attribute: 'password',
@@ -273,13 +304,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.password = 'invalid';
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with error on field "username" when username is missing', async () => {
+        it('should reject with error on field "username" when username is missing', () => {
           // given
           const expectedError = {
             attribute: 'username',
@@ -288,13 +322,16 @@ describe('Unit | Domain | Validators | user-validator', function() {
           user.username = MISSING_VALUE;
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
         });
 
-        it('should reject with errors on all fields (but only once by field) when all fields are missing', async () => {
+        it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
           // given
           user = {
             firstName: '',
@@ -304,10 +341,13 @@ describe('Unit | Domain | Validators | user-validator', function() {
           };
 
           // when
-          const entityValidationErrors = await catchErr(userValidator.validate)({ user, cguRequired });
-
-          // then
-          expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(4);
+          try {
+            userValidator.validate({ user, cguRequired });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            expect(errors.invalidAttributes).to.have.lengthOf(4);
+          }
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les validateurs ont des comportements hétérogènes + asynchrones dans certains cas (cas succès ou cas erreur, c'est pas constant). Du coup, une erreur qui devrait normalement être traitée et convertie correctement se retrouve perdue et convertie en erreur 500.

Exemple d'erreur occasionné :
https://sentry.io/organizations/pix/issues/1383959051/?project=1398749&query=is%3Aunresolved&statsPeriod=7d

## :robot: Solution
On remet ça à plat, maintenant les validateurs sont synchrones.

## :rainbow: Remarques
Revoir fonctionnellement : Création d'orga, création de session, création d'utilisateur système mail + username. Il faut tester la valid', donc malmener les champs, les inputs, les données