### PR TITLE
[FEATURE] Ajouter une date de finalisation lorsqu'un utilisateur PixCertif finalise une session (PC-111)

### DIFF
--- a/api/db/migrations/20200129155649_add_column_finalizedAt_to_sessions.js
+++ b/api/db/migrations/20200129155649_add_column_finalizedAt_to_sessions.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'finalizedAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/sessions-builder.js
+++ b/api/db/seeds/data/sessions-builder.js
@@ -52,6 +52,7 @@ module.exports = function sessionsBuilder({ databaseBuilder }) {
     status: 'finalized',
     certificationCenterId: 1,
     examinerGlobalComment: 'Le Lorem Ipsum est simplement du faux texte employé dans la composition et la mise en page avant impression. Le Lorem Ipsum est le faux texte standard de l\'imprimerie depuis les années 1500, quand un imprimeur anonyme assembla ensemble des morceaux de texte pour réaliser un livre spécimen de polices de texte. Il n\'a pas fait que survivre cinq siècles, mais s\'est aussi adapté à la bureautique informatique, sans que son contenu n\'en soit modifié.',
+    finalizedAt: new Date('2018-06-15T15:00:34Z'),
   });
 
   databaseBuilder.factory.buildSession({

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -23,5 +23,6 @@ module.exports = async function finalizeSession({
     id: sessionId,
     status: statuses.FINALIZED,
     examinerGlobalComment,
+    finalizedAt: new Date(),
   });
 };

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -19,7 +19,7 @@ module.exports = async function finalizeSession({
 
   await certificationReportRepository.finalizeAll(certificationReports);
 
-  return sessionRepository.updateStatusAndExaminerGlobalComment({
+  return sessionRepository.finalize({
     id: sessionId,
     status: statuses.FINALIZED,
     examinerGlobalComment,

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -133,14 +133,9 @@ module.exports = {
     return Boolean(session);
   },
 
-  async finalize(session) {
-    const sessionDataToUpdate = _.pick(session, [
-      'status',
-      'examinerGlobalComment',
-    ]);
-
-    let updatedSession = await new BookshelfSession({ id: session.id })
-      .save(sessionDataToUpdate, { patch: true });
+  async finalize({ id, status, examinerGlobalComment }) {
+    let updatedSession = await new BookshelfSession({ id })
+      .save({ id, status, examinerGlobalComment }, { patch: true });
     updatedSession = await updatedSession.refresh();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, updatedSession);
   },

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -133,9 +133,9 @@ module.exports = {
     return Boolean(session);
   },
 
-  async finalize({ id, status, examinerGlobalComment }) {
+  async finalize({ id, status, examinerGlobalComment, finalizedAt }) {
     let updatedSession = await new BookshelfSession({ id })
-      .save({ id, status, examinerGlobalComment }, { patch: true });
+      .save({ id, status, examinerGlobalComment, finalizedAt }, { patch: true });
     updatedSession = await updatedSession.refresh();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, updatedSession);
   },

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -133,7 +133,7 @@ module.exports = {
     return Boolean(session);
   },
 
-  async updateStatusAndExaminerGlobalComment(session) {
+  async finalize(session) {
     const sessionDataToUpdate = _.pick(session, [
       'status',
       'examinerGlobalComment',

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -498,21 +498,19 @@ describe('Integration | Repository | Session', function() {
   });
 
   describe('#finalize', () => {
-    let session;
+    let id;
+    let status = 'started';
+    let examinerGlobalComment = '';
 
     beforeEach(() => {
-      const bookshelfSession = databaseBuilder.factory.buildSession({
-        id: 1,
-        status: Session.statuses.STARTED,
-      });
-      session = domainBuilder.buildSession(bookshelfSession);
+      id = databaseBuilder.factory.buildSession({ status: Session.statuses.STARTED }).id;
 
       return databaseBuilder.commit();
     });
 
     it('should return a Session domain object', async () => {
       // when
-      const sessionSaved = await sessionRepository.finalize(session);
+      const sessionSaved = await sessionRepository.finalize({ id, status, examinerGlobalComment });
 
       // then
       expect(sessionSaved).to.be.an.instanceof(Session);
@@ -520,16 +518,16 @@ describe('Integration | Repository | Session', function() {
 
     it('should update model in database', async () => {
       // given
-      session.examinerGlobalComment = 'It was a fine session my dear';
-      session.status = Session.statuses.FINALIZED;
+      examinerGlobalComment = 'It was a fine session my dear';
+      status = Session.statuses.FINALIZED;
 
       // when
-      const sessionSaved = await sessionRepository.finalize(session);
+      const sessionSaved = await sessionRepository.finalize({ id, status, examinerGlobalComment });
 
       // then
-      expect(sessionSaved.id).to.deep.equal(session.id);
-      expect(sessionSaved.examinerGlobalComment).to.deep.equal('It was a fine session my dear');
-      expect(sessionSaved.status).to.deep.equal(Session.statuses.FINALIZED);
+      expect(sessionSaved.id).to.deep.equal(id);
+      expect(sessionSaved.examinerGlobalComment).to.deep.equal(examinerGlobalComment);
+      expect(sessionSaved.status).to.deep.equal(status);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -497,7 +497,7 @@ describe('Integration | Repository | Session', function() {
 
   });
 
-  describe('#updateStatusAndExaminerGlobalComment', () => {
+  describe('#finalize', () => {
     let session;
 
     beforeEach(() => {
@@ -512,7 +512,7 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a Session domain object', async () => {
       // when
-      const sessionSaved = await sessionRepository.updateStatusAndExaminerGlobalComment(session);
+      const sessionSaved = await sessionRepository.finalize(session);
 
       // then
       expect(sessionSaved).to.be.an.instanceof(Session);
@@ -524,7 +524,7 @@ describe('Integration | Repository | Session', function() {
       session.status = Session.statuses.FINALIZED;
 
       // when
-      const sessionSaved = await sessionRepository.updateStatusAndExaminerGlobalComment(session);
+      const sessionSaved = await sessionRepository.finalize(session);
 
       // then
       expect(sessionSaved.id).to.deep.equal(session.id);

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -501,6 +501,7 @@ describe('Integration | Repository | Session', function() {
     let id;
     let status = 'started';
     let examinerGlobalComment = '';
+    const finalizedAt = new Date('2017-09-01T12:14:33Z');
 
     beforeEach(() => {
       id = databaseBuilder.factory.buildSession({ status: Session.statuses.STARTED }).id;
@@ -510,10 +511,13 @@ describe('Integration | Repository | Session', function() {
 
     it('should return a Session domain object', async () => {
       // when
-      const sessionSaved = await sessionRepository.finalize({ id, status, examinerGlobalComment });
+      const sessionSaved = await sessionRepository.finalize({ id, status, examinerGlobalComment, finalizedAt });
 
       // then
       expect(sessionSaved).to.be.an.instanceof(Session);
+      expect(sessionSaved.id).to.deep.equal(id);
+      expect(sessionSaved.examinerGlobalComment).to.deep.equal(examinerGlobalComment);
+      expect(sessionSaved.status).to.deep.equal(status);
     });
 
     it('should update model in database', async () => {
@@ -522,12 +526,13 @@ describe('Integration | Repository | Session', function() {
       status = Session.statuses.FINALIZED;
 
       // when
-      const sessionSaved = await sessionRepository.finalize({ id, status, examinerGlobalComment });
+      await sessionRepository.finalize({ id, status, examinerGlobalComment, finalizedAt });
 
       // then
-      expect(sessionSaved.id).to.deep.equal(id);
-      expect(sessionSaved.examinerGlobalComment).to.deep.equal(examinerGlobalComment);
-      expect(sessionSaved.status).to.deep.equal(status);
+      const sessions = await knex('sessions').where({ id });
+      expect(sessions[0].status).to.equal(status);
+      expect(sessions[0].examinerGlobalComment).to.equal(examinerGlobalComment);
+      expect(sessions[0].finalizedAt).to.deep.equal(finalizedAt);
     });
   });
 });

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -7,18 +7,19 @@ const moment = require ('moment');
 
 module.exports = function buildSession({
   id,
-  certificationCenter = faker.company.companyName(),
-  certificationCenterId,
   accessCode = faker.random.alphaNumeric(9),
   address = faker.address.streetAddress(),
-  room = faker.random.alphaNumeric(9),
-  examiner = faker.name.findName(),
+  certificationCenter = faker.company.companyName(),
+  certificationCenterId,
   date = moment(faker.date.recent()).format('YYYY-MM-DD'),
-  time = faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0'),
   description = faker.random.words(),
-  createdAt = faker.date.recent(),
+  examiner = faker.name.findName(),
+  room = faker.random.alphaNumeric(9),
+  time = faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0'),
   status = Session.statuses.STARTED,
   examinerGlobalComment = '',
+  createdAt = faker.date.recent(),
+  finalizedAt = null,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -28,18 +29,19 @@ module.exports = function buildSession({
   }
   const values = {
     id,
-    certificationCenter,
-    certificationCenterId,
     accessCode,
     address,
-    room,
-    examiner,
+    certificationCenter,
+    certificationCenterId,
     date,
-    time,
     description,
-    createdAt,
+    examiner,
+    room,
+    time,
     status,
     examinerGlobalComment,
+    createdAt,
+    finalizedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -4,16 +4,17 @@ const Session = require('../../../../lib/domain/models/Session');
 
 module.exports = function buildSession({
   id = faker.random.number(),
-  certificationCenter = faker.company.companyName(),
-  certificationCenterId,
   accessCode = faker.random.alphaNumeric(9),
   address = faker.address.streetAddress(),
-  room = '28D',
-  examiner = faker.name.findName(),
+  certificationCenter = faker.company.companyName(),
+  certificationCenterId,
   date = moment(faker.date.recent()).format('YYYY-MM-DD'),
+  description = faker.random.words(),
+  examiner = faker.name.findName(),
+  room = '28D',
   time = '14:30',
   status = Session.statuses.STARTED,
-  description = faker.random.words(),
+  examinerGlobalComment = '',
 } = {}) {
   return new Session({
     id,
@@ -26,6 +27,7 @@ module.exports = function buildSession({
     examiner,
     room,
     time,
-    status
+    status,
+    examinerGlobalComment,
   });
 };

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -48,7 +48,7 @@ describe('Unit | UseCase | create-session', () => {
           userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
         });
 
-        it('should throw an Forbidden error', async () => {
+        it('should throw a Forbidden error', async () => {
           // when
           const error = await catchErr(createSession)({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
 

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -7,6 +7,7 @@ const {
 
 const finalizeSession = require('../../../../lib/domain/usecases/finalize-session');
 const { SessionAlreadyFinalizedError, InvalidCertificationReportForFinalization } = require('../../../../lib/domain/errors');
+const { statuses } = require('../../../../lib/domain/models/Session');
 
 describe('Unit | UseCase | finalize-session', () => {
 
@@ -76,7 +77,11 @@ describe('Unit | UseCase | finalize-session', () => {
     });
 
     context('When the certificationReports are valid', () => {
+      const now = new Date('2019-01-01T05:06:07Z');
+      let clock;
+
       beforeEach(() => {
+        clock = sinon.useFakeTimers(now);
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
           hasSeenEndTestScreen: false,
@@ -86,14 +91,19 @@ describe('Unit | UseCase | finalize-session', () => {
         certificationReportRepository.finalizeAll.withArgs(certificationReports).resolves();
         sessionRepository.finalize.withArgs({
           id: sessionId,
-          status: 'finalized',
+          status: statuses.FINALIZED,
           examinerGlobalComment,
+          finalizedAt: now,
         }).resolves(updatedSession);
       });
 
-      it('should return the updated session', async () => {
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('should finalize session with expected arguments', async () => {
         // when
-        const res = await finalizeSession({
+        await finalizeSession({
           sessionId,
           examinerGlobalComment,
           sessionRepository,
@@ -102,7 +112,12 @@ describe('Unit | UseCase | finalize-session', () => {
         });
 
         // then
-        expect(res).to.deep.equal(updatedSession);
+        expect(sessionRepository.finalize.calledWithExactly({
+          id: sessionId,
+          status: statuses.FINALIZED,
+          examinerGlobalComment,
+          finalizedAt: now,
+        })).to.be.true;
       });
     });
 

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | finalize-session', () => {
     updatedSession = Symbol('updated session');
     examinerGlobalComment = 'It was a fine session my dear.';
     sessionRepository = {
-      updateStatusAndExaminerGlobalComment: sinon.stub(),
+      finalize: sinon.stub(),
       isFinalized: sinon.stub(),
     };
     certificationReportRepository = {
@@ -84,7 +84,7 @@ describe('Unit | UseCase | finalize-session', () => {
         certificationReports = [validReportForFinalization];
         sessionRepository.isFinalized.withArgs(sessionId).resolves(false);
         certificationReportRepository.finalizeAll.withArgs(certificationReports).resolves();
-        sessionRepository.updateStatusAndExaminerGlobalComment.withArgs({
+        sessionRepository.finalize.withArgs({
           id: sessionId,
           status: 'finalized',
           examinerGlobalComment,


### PR DESCRIPTION
## :unicorn: Problème
Le pôle Certif, afin de traiter les sessions dans un ordre juste, souhaite pouvoir obtenir un ordre de finalisation de session, par le biais dans un premier temps de metabase.

## :robot: Solution
Ajouter une date de finalisation de session à la table session lors de la finalisation de celle-ci dans PixCertif.

## :rainbow: Remarques
