### PR TITLE
[BUGFIX] L'initialisation du statut de la session à leur création ne fonctionnait pas (PC-112)

### DIFF
--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const { ForbiddenAccess } = require('../errors');
 const sessionValidator = require('../validators/session-validator');
 const sessionCodeService = require('../services/session-code-service');
+const { statuses } = require('../models/Session');
 
 module.exports = async function createSession({ userId, session, certificationCenterRepository, sessionRepository, userRepository }) {
   sessionValidator.validate(session);
@@ -16,5 +17,6 @@ module.exports = async function createSession({ userId, session, certificationCe
   sessionWithCode.accessCode = await sessionCodeService.getNewSessionCode();
   const certificationCenter = await certificationCenterRepository.get(certificationCenterId);
   sessionWithCode.certificationCenter = certificationCenter.name;
+  sessionWithCode.status = statuses.STARTED;
   return sessionRepository.save(sessionWithCode);
 };

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -1,32 +1,20 @@
 const _ = require('lodash');
 const { ForbiddenAccess } = require('../errors');
 const sessionValidator = require('../validators/session-validator');
-
 const sessionCodeService = require('../services/session-code-service');
-
-async function _createSessionAsNormalUser(userId, certificationCenterId, session, certificationCenterRepository, sessionRepository, userRepository) {
-  const userWithCertifCenters = await userRepository.getWithCertificationCenterMemberships(userId);
-
-  if (userWithCertifCenters.hasAccessToCertificationCenter(certificationCenterId)) {
-    return _setCertifCenterNameInSessionAndSave(session, certificationCenterId, certificationCenterRepository, sessionRepository);
-  }
-  throw new ForbiddenAccess('User is not a member of the certification center');
-}
-
-function _setCertifCenterNameInSessionAndSave(session, certificationCenterId, certificationCenterRepository, sessionRepository) {
-  return certificationCenterRepository.get(certificationCenterId)
-    .then((certificationCenter) => session.certificationCenter = certificationCenter.name)
-    .then(() => sessionRepository.save(session));
-}
 
 module.exports = async function createSession({ userId, session, certificationCenterRepository, sessionRepository, userRepository }) {
   sessionValidator.validate(session);
 
+  const certificationCenterId = session.certificationCenterId;
+  const userWithCertifCenters = await userRepository.getWithCertificationCenterMemberships(userId);
+  if (!userWithCertifCenters.hasAccessToCertificationCenter(certificationCenterId)) {
+    throw new ForbiddenAccess('L\'utilisateur n\'est pas membre du centre de certification dans lequel il souhaite créer une session');
+  }
+
   const sessionWithCode = _.clone(session);
-  const sessionCode = await sessionCodeService.getNewSessionCode();
-  sessionWithCode.accessCode = sessionCode;
-
-  const certificationCenterId = sessionWithCode.certificationCenterId;
-
-  return _createSessionAsNormalUser(userId, certificationCenterId, sessionWithCode, certificationCenterRepository, sessionRepository, userRepository);
+  sessionWithCode.accessCode = await sessionCodeService.getNewSessionCode();
+  const certificationCenter = await certificationCenterRepository.get(certificationCenterId);
+  sessionWithCode.certificationCenter = certificationCenter.name;
+  return sessionRepository.save(sessionWithCode);
 };

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -3,6 +3,7 @@ const { expect, sinon, catchErr } = require('../../../test-helper');
 const createSession = require('../../../../lib/domain/usecases/create-session');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
+const { statuses } = require('../../../../lib/domain/models/Session');
 const { ForbiddenAccess } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-session', () => {
@@ -71,7 +72,7 @@ describe('Unit | UseCase | create-session', () => {
           await createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
 
           // then
-          expect(sessionRepository.save.calledWithExactly({ certificationCenterId, certificationCenter: certificationCenterName, accessCode })).to.be.true;
+          expect(sessionRepository.save.calledWithExactly({ certificationCenterId, certificationCenter: certificationCenterName, accessCode, status: statuses.STARTED })).to.be.true;
         });
       });
     });

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -1,155 +1,80 @@
-const { expect, sinon, domainBuilder, testErr } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 
 const createSession = require('../../../../lib/domain/usecases/create-session');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
-const Session = require('../../../../lib/domain/models/Session');
 const { ForbiddenAccess } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-session', () => {
 
   describe('#save', () => {
+    const userId = 'userId';
+    const certificationCenterId = 'certificationCenterId';
+    const certificationCenterName = 'certificationCenterName';
+    const certificationCenter = { id: certificationCenterId, name: certificationCenterName };
+    const sessionToSave = { certificationCenterId };
+    const certificationCenterRepository = { get: sinon.stub() };
+    const sessionRepository = { save: sinon.stub() };
+    const userRepository = { getWithCertificationCenterMemberships: sinon.stub() };
+    const userWithMemberships = { hasAccessToCertificationCenter: sinon.stub() };
+    const accessCode = Symbol('accessCode');
 
-    let certificationCenter, certificationCenterId, certificationCenterName, expectedSavedSession, sessionWithCodeAndName,
-      sessionAccessCode, sessionId, sessionToSave, userId;
-
-    let certificationCenterRepository, sessionRepository, userRepository;
-
-    beforeEach(() => {
-      userId = 473820;
-      sessionAccessCode = 'SHC542';
-      sessionId = 'PIX666';
-      certificationCenterId = '5';
-      certificationCenterName = 'Pass Ta Certif';
-
-      certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, name: certificationCenterName });
-      sessionToSave = domainBuilder.buildSession({ id: sessionId, certificationCenterId, certificationCenter: null, accessCode: null });
-      expectedSavedSession = domainBuilder.buildSession();
-
-      sessionWithCodeAndName = new Session({ ...sessionToSave });
-      sessionWithCodeAndName.certificationCenter = certificationCenterName;
-      sessionWithCodeAndName.accessCode = sessionAccessCode;
-
-      certificationCenterRepository = { get: sinon.stub() };
-      sessionRepository = { save: sinon.stub() };
-      userRepository = { getWithCertificationCenterMemberships: sinon.stub() };
-      sinon.stub(sessionValidator, 'validate');
-      sinon.stub(sessionCodeService, 'getNewSessionCode');
-    });
-
-    it('should forward the error if the session is not valid', () => {
-      // given
-      sessionValidator.validate.withArgs(sessionToSave).throws();
-
-      // when
-      const promise = createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
-
-      // then
-      return expect(promise).to.be.rejected;
-    });
-
-    context('when the session is valid', () => {
+    context('when session is not valid', () => {
 
       beforeEach(() => {
-        sessionValidator.validate.withArgs(sessionToSave).returns();
-        sessionCodeService.getNewSessionCode.resolves(sessionAccessCode);
+        sinon.stub(sessionValidator, 'validate').throws();
       });
 
-      it('should forward the error if an error occurs while retrieving the user', () => {
-        // given
-        userRepository.getWithCertificationCenterMemberships.withArgs(userId).rejects(testErr);
-
-        // when
+      it('should throw an error', () => {
         const promise = createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
 
         // then
-        return promise.catch((err) => {
-          expect(err).to.deep.equal(testErr);
-        });
+        expect(promise).to.be.rejected;
+        expect(sessionValidator.validate.calledWithExactly(sessionToSave));
+      });
+    });
+
+    context('when session is valid', () => {
+
+      beforeEach(() => {
+        sinon.stub(sessionValidator, 'validate').returns();
       });
 
-      context('and the user has not access to the sessions certification center', () => {
-
-        it('should throw an error', () => {
-          // given
-          const userWithNoCertifCenterMemberships = domainBuilder.buildUser({ certificationCenterMemberships: [] });
-
-          userRepository.getWithCertificationCenterMemberships.withArgs(userId).resolves(userWithNoCertifCenterMemberships);
-
-          // when
-          const promise = createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
-
-          // then
-          return expect(promise).to.have.been.rejectedWith(ForbiddenAccess);
-        });
-
-      });
-
-      context('and the user has access to the sessions certification center', () => {
+      context('when user has no certification center membership', () => {
 
         beforeEach(() => {
-          const userWithMembershipToCertificationCenter = domainBuilder.buildUser({
-            certificationCenterMemberships: [{ certificationCenter: { id: certificationCenterId } }]
-          });
-          userRepository.getWithCertificationCenterMemberships.withArgs(userId).resolves(userWithMembershipToCertificationCenter);
+          userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(false);
+          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
         });
 
-        it('should add an accessCode and add the certif center name to the session in order not to break pixAdmin' +
-            'and user certifications details, and save the new session', async () => {
-          // given
+        it('should throw an Forbidden error', async () => {
+          // when
+          const error = await catchErr(createSession)({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
+
+          // then
+          expect(error).to.be.instanceOf(ForbiddenAccess);
+        });
+      });
+
+      context('when user has certification center membership', () => {
+
+        beforeEach(() => {
+          userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
+          userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
+          sinon.stub(sessionCodeService, 'getNewSessionCode').resolves(accessCode);
           certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
           sessionRepository.save.resolves();
+        });
 
+        it('should save the session with appropriate arguments', async () => {
           // when
           await createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
 
           // then
-          expect(sessionRepository.save).to.have.been.calledWithExactly(sessionWithCodeAndName);
+          expect(sessionRepository.save.calledWithExactly({ certificationCenterId, certificationCenter: certificationCenterName, accessCode })).to.be.true;
         });
-
-        it('should return the saved session', async () => {
-          // given
-          certificationCenterRepository.get.resolves(certificationCenter);
-          sessionRepository.save.withArgs(sessionWithCodeAndName).resolves(expectedSavedSession);
-
-          // when
-          const savedSession = await createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
-
-          // then
-          expect(savedSession).to.deep.equal(expectedSavedSession);
-        });
-
-        it('should forward the error if an error occurs while retrieveing the certification center', () => {
-          // given
-          certificationCenterRepository.get.withArgs(certificationCenterId).rejects(testErr);
-
-          // when
-          const promise = createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
-
-          // then
-          return promise.catch((err) => {
-            expect(err).to.deep.equal(testErr);
-          });
-        });
-
-        it('should forward the error if an error occurs while saving the session', () => {
-          // given
-          certificationCenterRepository.get.resolves(certificationCenter);
-          sessionRepository.save.withArgs(sessionWithCodeAndName).rejects(testErr);
-
-          // when
-          const promise = createSession({ userId, session: sessionToSave, certificationCenterRepository, sessionRepository, userRepository });
-
-          // then
-          return promise.catch((err) => {
-            expect(err).to.deep.equal(testErr);
-          });
-        });
-
       });
-
     });
-
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
La colonne status de la table Sessions a pour default value le status STARTED.
Malheureusement, bookshelfJS ne tient pas compte de ce paramétrage :( Du coup les sessions créées étaient initialisées au statut NULL.

## :robot: Solution
Fixer le statut à la création.

## :rainbow: Remarques
