### PR TITLE
[BUGFIX] Changement de texte pour l'info-bulle des 1024 pix.

### DIFF
--- a/mon-pix/app/templates/components/hexagon-score.hbs
+++ b/mon-pix/app/templates/components/hexagon-score.hbs
@@ -5,8 +5,8 @@
     <div class="hexagon-score-content__pix-total">1024 <Fa-Icon @icon="info-circle"/></div>
   </div>
     <div class="hexagon-score__information hexagon-score-information__text {{this.displayHelp}}">
-        <span class="hexagon-score-information__text--strong">Pourquoi 1024 Pix ?</span>
+        <span class="hexagon-score-information__text--strong">Pourquoi 1024 pix ?</span>
         <span class="hexagon-score-information__close" {{action 'hideHelp'}}><Fa-Icon @icon="times"/></span>
-        <br><br>C’est le score maximum atteignable dès que le niveau 8 des compétences sera disponible.
-        <span class="hexagon-score-information__text--strong">Le score maximum à ce jour est 640 Pix</span> car les compétences sont pour l’instant limitées au niveau 5.</div>
+        <br><br>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.
+        Aujourd’hui, <span class="hexagon-score-information__text--strong">le maximum est de 640 pix</span>, correspondant au niveau 5.</div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le texte pour l'info bulle a été modifié

## :robot: Solution
Le modifier

## :rainbow: Remarques
Quand on parle du nombre de pix, il faut mettre un p minuscule.