### PR TITLE
[BUGFIX] Corrige le sous-titre de la page de finalization (PC-113)

### DIFF
--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -5,7 +5,8 @@
     </LinkTo>
     <h1 class="page-title">Finaliser la session {{this.session.id}}</h1>
   </div>
-  <div class="finalize__subtitle"> it should not redirect to finalize page on click on finalize button
+  <div class="finalize__subtitle">
+    Pour finaliser la session, complétez les trois étapes puis validez.
   </div>
 
   <SessionFinalizationStepContainer


### PR DESCRIPTION
## :unicorn: Problème

Un texte de test a remplacé un sous-titre sur la page de finalisation de session :

![image](https://user-images.githubusercontent.com/7529/73437599-ecf0c900-434c-11ea-9fb7-c33a84cebb84.png)


## :robot: Solution

Remettre le texte d'origine 😬

## :rainbow: Remarques

C'est très embarrassant 🤭