### PR TITLE
[BSR] Ajuster le style du bouton réinitialiser des embed (PF-1061).

### DIFF
--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -19,8 +19,8 @@
   </div>
 </div>
 
-<div class="link link--grey embed__reboot">
-  <div class="embed-reboot__content" {{action "rebootSimulator"}}>
+<div class="embed__reboot">
+  <div class="link link--grey embed-reboot__content" {{action "rebootSimulator"}}>
     <Fa-Icon @icon="redo-alt"></Fa-Icon>
     <div class="embed-reboot-content__text"> Réinitialiser </div>
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Il était possible de mettre le bouton de Réinitialisation en surbrillance en pointant la ligne.

## :robot: Solution
Mettre le bouton de Réinitialisation en surbrillance en pointant le texte.