### PR TITLE
[FEATURE] Ajout d'un bouton pour rafraîchir le cache de données pédagogiques dans Pix Admin (PA-139).

### DIFF
--- a/admin/app/adapters/learning-content-cache.js
+++ b/admin/app/adapters/learning-content-cache.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  refreshCacheEntries() {
+    const url = `${this.host}/${this.namespace}/cache`;
+    return this.ajax(url, 'PATCH');
+  }
+
+});

--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -8,7 +8,6 @@ export default Controller.extend({
 
   session: service(),
   sessionInfoService: service(),
-  store: service(),
   notifications: service('notification-messages'),
 
   displayConfirm: false,

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -1,10 +1,23 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
 
+  isLoading: false,
+
+  notifications: service('notification-messages'),
+
   actions: {
-    refreshLearningContent() {
-      console.log('TODO refreshLearningContent');
+    async refreshLearningContent() {
+      this.set('isLoading', true);
+      try {
+        await this.store.adapterFor('learning-content-cache').refreshCacheEntries();
+        this.notifications.success('Le cache a été rechargé avec succès.');
+      } catch (err) {
+        this.notifications.error('Une erreur est survenue.');
+      } finally {
+        this.set('isLoading', false);
+      }
     }
   }
 });

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  actions: {
+    refreshLearningContent() {
+      console.log('TODO refreshLearningContent');
+    }
+  }
+});

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -46,6 +46,7 @@ Router.map(function() {
     this.route('users', function() {
       this.route('list');
     });
+    this.route('tools');
   });
 });
 

--- a/admin/app/routes/authenticated/certifications/single/info.js
+++ b/admin/app/routes/authenticated/certifications/single/info.js
@@ -2,8 +2,7 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model(params) {
-    const store = this.store;
-    return store.findRecord('certification', params.certification_id);
+    return this.store.findRecord('certification', params.certification_id);
   },
   setupController(controller, model) {
     this._super(controller, model);

--- a/admin/app/routes/authenticated/tools.js
+++ b/admin/app/routes/authenticated/tools.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({});

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -11,6 +11,7 @@
 @import 'misc/page';
 @import 'misc/button';
 @import 'misc/form';
+@import 'misc/callout';
 @import 'misc/power-select';
 @import 'misc/tables';
 @import 'misc/utils';

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import 'authenticated/certifications/sessions/info/list';
 @import 'authenticated/certifications/sessions/info/index';
 @import 'authenticated/certifications/sessions-list';
+@import 'authenticated/tools';
 /* components */
 @import 'components/menu-bar';
 @import 'components/organization-list';

--- a/admin/app/styles/authenticated.scss
+++ b/admin/app/styles/authenticated.scss
@@ -24,7 +24,7 @@ body > div.ember-view {
 
       .app-logo__link {
         color: #FFFFFF;
-        background-color: $blue-pix;
+        background-color: $pix-blue;
         display: block;
         line-height: $app-header-height;
         width: 100%;

--- a/admin/app/styles/authenticated/tools.scss
+++ b/admin/app/styles/authenticated/tools.scss
@@ -1,0 +1,3 @@
+.btn-refresh-cache {
+  width: 180px;
+}

--- a/admin/app/styles/misc/button.scss
+++ b/admin/app/styles/misc/button.scss
@@ -20,8 +20,30 @@
   line-height: 28px;
 }
 
+.btn-primary {
+  text-align: center;
+  border-radius: 5px;
+  background-color: $pix-blue;
+  color: $white;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  transition: background-color 0.2s ease;
+
+  &:hover, &:active, &:focus {
+    background-color: $pix-blue-hover;
+  }
+}
+
 .btn-group {
   .btn {
     min-width: 43.5px;
   }
 }
+
+.loader-in-button {
+  display: flex;
+  background: url('/images/loader-white.svg') no-repeat center;
+  background-size: 50px;
+}
+

--- a/admin/app/styles/misc/callout.scss
+++ b/admin/app/styles/misc/callout.scss
@@ -1,0 +1,42 @@
+.callout {
+  position: relative;
+  margin: 0 0 1rem 0;
+  padding: 1rem;
+  border: 1px solid rgba(10, 10, 10, 0.25);
+  border-radius: 0;
+
+  &.secondary {
+    color: #383d41;
+    background-color: #e2e3e5;
+    border-color: #d6d8db;
+  }
+
+  &.primary {
+    color: #004085;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+  }
+
+  &.info {
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
+  }
+
+  &.success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+  }
+
+  &.warning {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;  }
+
+  &.alert {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+  }
+}

--- a/admin/app/styles/misc/palette.scss
+++ b/admin/app/styles/misc/palette.scss
@@ -1,3 +1,5 @@
-$blue-pix: #3d68ff;
+$white: #ffffff;
 $grey-body: #ebeef0;
 $grey-border: #ced4da;
+$pix-blue: #3d68ff;
+$pix-blue-hover: #3257D9;

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -12,6 +12,3 @@
     {{organization-list organizations=model}}
   </section>
 </main>
-
-
-

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -10,9 +10,15 @@
       <header class="page-section__header">
         <h2 class="page-section__title">Référentiel</h2>
       </header>
-      <div class="member-list">
+      <div>
+        <p>Le référentiel de données pédagogique est mis à jour automatiquement quotidiennement (vers 6h00).</p>
+        <p>Parfois, il peut s’avérer utile ou nécessaire de forcer le rechargement du référentiel.</p>
+        <p>Ex : apparition d’une régression sur la plateforme (Pix API, Pix Editor, etc.)</p>
+        <div class="callout alert"><strong>Attention !</strong> Le rechargement du référentiel est une opération risquée. Il est recommandé de ne l’effectuer qu’en cas de force majeur, accompagné d’un développeur.</div>
+        <div class="callout info">Durée de l’opération : <strong>≈1mn</strong>.</div>
         {{#if isLoading}}
-          <button type="submit" class="btn btn-primary btn-refresh-cache"><span class="loader-in-button">&nbsp;</span></button>
+          <button type="submit" class="btn btn-primary btn-refresh-cache"><span class="loader-in-button">&nbsp;</span>
+          </button>
         {{else}}
           <button class="btn btn-primary btn-refresh-cache" onclick={{action "refreshLearningContent"}}>
             {{fa-icon "sync"}} Recharger le cache

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -1,0 +1,21 @@
+<div class="page">
+  <header class="page-header">
+    <div class="page-title">Outils</div>
+    <div class="page-actions">
+    </div>
+  </header>
+
+  <main class="page-body">
+    <section class="page-section">
+      <header class="page-section__header">
+        <h2 class="page-section__title">Référentiel</h2>
+      </header>
+      <div class="member-list">
+        <button class="btn btn-outline-default" onclick={{action "refreshLearningContent"}}>
+          {{fa-icon "sync"}} Recharger le cache de données pédagogiques
+        </button>
+      </div>
+    </section>
+  </main>
+
+</div>

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -6,14 +6,18 @@
   </header>
 
   <main class="page-body">
-    <section class="page-section">
+    <section class="page-section learning-content">
       <header class="page-section__header">
         <h2 class="page-section__title">Référentiel</h2>
       </header>
       <div class="member-list">
-        <button class="btn btn-outline-default" onclick={{action "refreshLearningContent"}}>
-          {{fa-icon "sync"}} Recharger le cache de données pédagogiques
-        </button>
+        {{#if isLoading}}
+          <button type="submit" class="btn btn-primary btn-refresh-cache"><span class="loader-in-button">&nbsp;</span></button>
+        {{else}}
+          <button class="btn btn-primary btn-refresh-cache" onclick={{action "refreshLearningContent"}}>
+            {{fa-icon "sync"}} Recharger le cache
+          </button>
+        {{/if}}
       </div>
     </section>
   </main>

--- a/admin/app/templates/components/menu-bar.hbs
+++ b/admin/app/templates/components/menu-bar.hbs
@@ -20,6 +20,12 @@
       {{/link-to}}
     </li>
     <li class="menu-bar__entry">
+      {{#link-to "authenticated.tools" class="menu-bar__link menu-bar__link--tools"}}
+        {{fa-icon "tools"}}
+        {{#bs-tooltip placement="right"}}Outils{{/bs-tooltip}}
+      {{/link-to}}
+    </li>
+    <li class="menu-bar__entry">
       {{#link-to "logout" class="menu-bar__link menu-bar__link--logout"}}
         {{fa-icon "power-off"}}
         {{#bs-tooltip placement="right"}}Se déconnecter{{/bs-tooltip}}

--- a/admin/public/images/loader-white.svg
+++ b/admin/public/images/loader-white.svg
@@ -1,0 +1,14 @@
+<svg class="lds-message" width="64px"  height="64px"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+  <g transform="translate(25 50)" class="">
+  <circle cx="0" cy="0" r="6" fill="#ffffff" transform="scale(0.999738 0.999738)" class="">
+    <animateTransform attributeName="transform" type="scale" begin="-0.3333333333333333s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite" class=""></animateTransform>
+  </circle>
+</g><g transform="translate(45 50)" class="">
+  <circle cx="0" cy="0" r="6" fill="#ffffff" transform="scale(0.718862 0.718862)" class="">
+    <animateTransform attributeName="transform" type="scale" begin="-0.16666666666666666s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite" class=""></animateTransform>
+  </circle>
+</g><g transform="translate(65 50)" class="">
+  <circle cx="0" cy="0" r="6" fill="#ffffff" transform="scale(0.256735 0.256735)" class="">
+    <animateTransform attributeName="transform" type="scale" begin="0s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite" class=""></animateTransform>
+  </circle>
+</g></svg>

--- a/admin/tests/acceptance/tools-page-test.js
+++ b/admin/tests/acceptance/tools-page-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | tools page', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    await authenticateSession({ userId: 1 });
+  });
+
+  module('Access', function() {
+
+    test('Tools page should be accessible from /tools', async function(assert) {
+      // when
+      await visit('/tools');
+
+      // then
+      assert.equal(currentURL(), '/tools');
+    });
+  });
+
+  module('Rendering', function(hooks) {
+
+    hooks.beforeEach(async function() {
+      await visit('/tools');
+    });
+
+    test('Should content "Learning content" section', async function(assert) {
+      assert.dom('section.learning-content').exists();
+      assert.dom('button.btn-refresh-cache').exists();
+    });
+  });
+
+});

--- a/admin/tests/integration/components/menu-bar-test.js
+++ b/admin/tests/integration/components/menu-bar-test.js
@@ -29,4 +29,12 @@ module('Integration | Component | menu-bar', function(hooks) {
     // then
     assert.dom('a.menu-bar__link--certifications').exists();
   });
+
+  test('should contain link to "tools" management page', async function(assert) {
+    // when
+    await render(hbs`{{menu-bar}}`);
+
+    // then
+    assert.dom('a.menu-bar__link--tools').exists();
+  });
 });

--- a/admin/tests/unit/adapters/learning-content-cache-test.js
+++ b/admin/tests/unit/adapters/learning-content-cache-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | learning content cache', function(hooks) {
+
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:learning-content-cache');
+    sinon.stub(adapter, 'ajax');
+  });
+
+  hooks.afterEach(function() {
+    adapter.ajax.restore();
+  });
+
+  test('it should make AJAX call "PATCH /api/cache" in order to refresh learning content cache', async function(assert) {
+    // given
+    adapter.ajax.resolves();
+
+    // when
+    await adapter.refreshCacheEntries();
+
+    // then
+    sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/cache', 'PATCH');
+    assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/tools-test.js
+++ b/admin/tests/unit/controllers/authenticated/tools-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/tools', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const controller = this.owner.lookup('controller:authenticated/tools');
+    assert.ok(controller);
+  });
+});

--- a/admin/tests/unit/routes/authenticated/tools-test.js
+++ b/admin/tests/unit/routes/authenticated/tools-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authenticated/tools', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:authenticated/tools');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Le (cache du) référentiel de données pédagogique est mis à jour automatiquement quotidiennement (vers 6h00).

Parfois, il peut être utile ou nécessaire de forcer une mise à jour.

La procédure actuelle est trop manuelle, donc trop compliquée, trop longue, trop pas MD10.

## :robot: Solution

L'objet de cette PR est d'ajouter, dans Pix Admin, un **bouton de rafraîchissement du cache**, dans une page dédiée à l'outillage _back-office_.

![image](https://user-images.githubusercontent.com/265963/73474316-95734d00-438e-11ea-8deb-ba2dd90bf79a.png)

## 🧞‍♂️ Remarques 

Le endpoint de rechargement du cache est de type _mutation_ (c'est une action avec effets de bord sur le système et non pas une ressource) et n'est pas très Ember Data / JSONAPI _friendly_.

J'ai tenté dans un premier temps de passer sans Amber Data, juste avec Ember Fetch, mais je me suis pris : 
- 1 erreur CORS pour le verbe `PATCH`
- de devoir gérer les headers de requêtes (dommage, surtout quand on utilise déjà Ember Simple Auth)

Finalement, sur les bons conseils de @Radioreve, je me suis basé sur [cet article](https://emberigniter.com/non-standard-rest-actions-ember-data/) pour implémenter une solution basée sur Ember Data / Ember Simple Auth qui marche à peu de frais et plutôt élégante.

Par rapport à la solution proposée : 
- je n'utilise pas de Model Ember Data (dans ce contexte, le cache est un bloc d'informations indissociables)
- je n'utilise pas l'addon `ember-api-actions` qui ne me servait pas


Dernière remarque : j'ai cherché partout où et comment est ajouté la méthode `ajax` à la classe `EmberData.Adapter`. En vain. Je crois avoir compris qu'il s'agit d'un wrapper au-dessus de la méthode jQuery `$.ajax`. Mais je ne sais pas où se fait la magie. Ce n'ets porutant pas faute d'avoir écumé et chercher dans Ember et Ember Data !