### PR TITLE
[BUGFIX] Pouvoir remettre à zéro une compétence après l'avoir terminé (PF-872).

### DIFF
--- a/mon-pix/app/models/competence-evaluation.js
+++ b/mon-pix/app/models/competence-evaluation.js
@@ -11,5 +11,5 @@ export default Model.extend({
 
   assessment: belongsTo('assessment'),
   competence: belongsTo('competence'),
-  scorecard: belongsTo('scorecard'),
+  scorecard: belongsTo('scorecard', { async: false }),
 });

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -316,6 +316,45 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           expect(findAll('.scorecard-details-content-right-score-container__pix-earned .score-value')).to.have.lengthOf(0);
           expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
         });
+
+        it('should reset competence when user clicks on reset from results page', async () => {
+          // given
+          server.create('scorecard', {
+            id: '1_1',
+            name,
+            description,
+            earnedPix,
+            level,
+            pixScoreAheadOfNextLevel,
+            area,
+            status,
+            remainingDaysBeforeReset,
+            competenceId: 1,
+          });
+          server.create('assessment', {
+            id: 2,
+            type: 'COMPETENCE_EVALUATION',
+            state: 'completed',
+          });
+
+          server.create('competence-evaluation', {
+            id: 1,
+            assessmentId: 2,
+            competenceId: 1,
+            userId: 1,
+          });
+          await visitWithAbortedTransition('/competences/1/resultats/2');
+          await click('.scorecard-details__reset-button');
+
+          // when
+          await click('.button--red');
+
+          // then
+          expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);
+          expect(findAll('.scorecard-details-content-right-score-container__pix-earned .score-value')).to.have.lengthOf(0);
+          expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
+        });
+
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on arrivait sur la page de résultats d'une compétence, et qu'on pouvait remettre à zéro, le bouton remise à zéro ne fonctionnait pas.

## :robot: Solution
- Ajout de `{ async : false }` dans le `BelongsTo` de la `competenceEvaluation` vers sa `scorecard`.
- Dans ce bug, le `scorecard.save()` ne fonctionnait pas, car le scorecard était un proxy et ne pouvait pas appeler sa méthode save.
- Pour éviter cela, l'ajout du async à false

## :rainbow: Remarques
Doc : `async: A boolean value used to explicitly declare this to be an async relationship. The default is true.`


