### PR TITLE
[BUGFIX] Correction de style sur les épreuves avec téléchargement (PF-1048).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -64,26 +64,11 @@
 }
 
 .challenge-statement__help-icon {
-  width: 18px;
-  height: 18px;
-  line-height: 18px;
-  color: $white;
   display: inline-block;
-  background: $pix-blue;
-  border-radius: 50%;
   margin: 0 5px;
   cursor: pointer;
+  color: $pix-blue;
   position: relative;
-  text-align: center;
-  vertical-align: middle;
-}
-
-.challenge-statement__help-icon:after {
-  content: "i";
-  position: absolute;
-  font-size: 12px;
-  font-weight: $font-heavy;
-  left: 8px;
 }
 
 .challenge-statement__help-tooltip {

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -3,9 +3,10 @@
   border-radius: 5px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.05);
   margin-bottom: 30px;
-  overflow: hidden;
+  padding-bottom: 2px;
 
   &--strong {
+    padding-bottom: 30px;
     border-radius: 10px;
     box-shadow: 0 50px 54px -40px rgba(0, 0, 0, 0.4), 0 7px 14px 0 rgba(12, 22, 58, 0.1);
   }

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -26,6 +26,7 @@
       <p class="challenge-statement__text">
         <span class="challenge-statement__text-content">Choisissez le type de fichier que vous voulez utiliser</span>
       <div class="challenge-statement__help-icon">
+        <Fa-Icon @icon="info-circle"/>
         <div class="challenge-statement__help-tooltip">
           <span class="challenge-statement__help-text">Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.</span>
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves qui proposent de télécharger un fichier : 
- Les radio button et l'icone info était décalé
- Le tooltip de l'info n'était pas visible (passait sous la barre de progression) si le texte était court

## :robot: Solution
- Supprimer le overflow:hidden
- Recaler le radio button et l'icone

## :rainbow: Remarques
Pour tester, trouver une épreuve avec un téléchargement et supprimer dans le DOM le texte de l'épreuve.