### PR TITLE
[BUGFIX] Mise à jour de la commande de création de release sentry-cli.

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -25,7 +25,7 @@ function push_commit_and_tag_to_remote_master {
 }
 
 function publish_release_on_sentry {
-    npx sentry-cli releases -o pix new -p pix-admin -p pix-api -p pix-app -p pix-orga -p pix-certif "v${PACKAGE_VERSION}"
+    npx sentry-cli releases -o pix new -p pix-api "v${PACKAGE_VERSION}"
     npx sentry-cli releases -o pix set-commits --commit "1024pix/pix@$( git rev-parse HEAD )" "v${PACKAGE_VERSION}"
     npx sentry-cli releases -o pix finalize "v${PACKAGE_VERSION}"
 }


### PR DESCRIPTION
## :unicorn: Problème
Le script de MEP échoue sur la commande de création de release sentry car des organisations ont été supprimées sur sentry. Ça ne bloque pas la MEP, voici l'erreur affichée :
```
error: API request failed
  caused by: sentry reported an error: request failure (http status: 400)
  Object({"projects": Array([String("Invalid project slugs")])})
```

## :robot: Solution
Ne pas les inclure dans la création de la release.