### PR TITLE
[BUGFIX] Corriger le design de la double mire de connexion (PF-1069).

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -53,6 +53,7 @@
 @import 'components/navbar-header';
 @import 'components/navbar-mobile-header';
 @import 'components/no-certification-panel';
+@import 'components/panel';
 @import 'components/password-reset-demand-form';
 @import 'components/pix-logo';
 @import 'components/progress-bar';

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -54,7 +54,7 @@
     min-width: 0px;
 
     &:hover {
-      border: 2px solid $dogder-blue;
+      border: 2px solid $dodger-blue;
     }
   }
 

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -42,7 +42,7 @@
   width: 100%;
 
   &:hover {
-    border: 2px solid $dogder-blue;
+    border: 2px solid $dodger-blue;
   }
 
   @include device-is('desktop') {

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -4,7 +4,7 @@
   &__user-info {
     display: flex;
     flex-direction: column;
-    background-color: $dogder-blue;
+    background-color: $dodger-blue;
   }
 
   &__navigation {
@@ -68,8 +68,8 @@
     font-family: $font-roboto;
 
     &.active {
-      color: $dogder-blue;
-      border-left: 5px solid $dogder-blue;
+      color: $dodger-blue;
+      border-left: 5px solid $dodger-blue;
       padding-left: 27px;
     }
 
@@ -79,7 +79,7 @@
     }
 
     &:hover {
-      color: $dogder-blue;
+      color: $dodger-blue;
       text-decoration: none;
     }
   }

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -31,8 +31,8 @@
 
     &.active {
       text-decoration: none;
-      color: $dogder-blue;
-      border-bottom: 2px solid $dogder-blue;
+      color: $dodger-blue;
+      border-bottom: 2px solid $dodger-blue;
     }
 
     &:focus {
@@ -43,7 +43,7 @@
     &:hover {
       text-decoration: none;
       cursor: pointer;
-      color: $dogder-blue;
+      color: $dodger-blue;
     }
   }
 }

--- a/mon-pix/app/styles/components/_panel.scss
+++ b/mon-pix/app/styles/components/_panel.scss
@@ -1,0 +1,24 @@
+.panel {
+  border-radius: 4px;
+  border: none;
+  box-shadow: 0 1px 1px 0 rgba(12, 22, 58, 0.1), 0 2px 5px 0 rgba(0, 0, 0, 0.1);
+  background-color: white;
+
+  &--strong-shadow {
+    box-shadow: 0 6px 12px 0 rgba(12, 22, 58, 0.1), 0 2px 5px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  &--link {
+    text-decoration: none;
+    border: solid 2px white;
+    color: $nero;
+    outline: none;
+    cursor: pointer;
+
+    &:hover, &:active, &:focus {
+      border-color: $dodger-blue;
+      transition: border-color 1s ease;
+      box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.05);
+    }
+  }
+}

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -17,10 +17,10 @@
 
   &:hover {
     text-decoration: none;
-    color: $dogder-blue;
+    color: $dodger-blue;
 
     > .caret {
-      border-color: $dogder-blue transparent transparent transparent;
+      border-color: $dodger-blue transparent transparent transparent;
     }
   }
 }

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -24,7 +24,7 @@ $black: #000000;
 
 $periwinkle-blue: #c3d0ff;
 $jordy-blue: #8D9EF7;
-$dogder-blue: #388AFF;
+$dodger-blue: #388AFF;
 $pix-blue: #3d68ff;
 $pix-blue-hover: #3257D9;
 $pix-grey: #585F75;
@@ -71,7 +71,7 @@ $butterfly-bush-dark: #5E2563;
 /*
   Gradients
  */
-$pix-blue-to-purple-gradient: linear-gradient(to right, $dogder-blue, $purple);
+$pix-blue-to-purple-gradient: linear-gradient(to right, $dodger-blue, $purple);
 $pix-emerald-to-emerald-dark-gradient: linear-gradient(to right, $emerald, $emerald-dark);
 $pix-emerald-to-emerald-dark-gradient-bottom-to-top: linear-gradient(to top, $emerald, $emerald-dark);
 $pix-yellow-to-orange-gradient: linear-gradient(180deg, $bright-yellow 0%, $pizazz-orange 100%);


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix APP, la double mire de connexion apparaît comme suit : 
<img width="1567" alt="Screenshot 2020-02-03 at 11 04 27" src="https://user-images.githubusercontent.com/46371288/73644175-225f2480-4675-11ea-8779-087a3cb2c82e.png">

## :robot: Solution
Ajouter la classe `panels` qui manquait à Pix APP pour retrouver le design suivant attendu : 
<img width="1574" alt="Screenshot 2020-02-03 at 11 03 50" src="https://user-images.githubusercontent.com/46371288/73644317-6d793780-4675-11ea-9cfc-2d46c91323e8.png">

## 🕵 Cause possible de la régression (sans vérification approfondie)
L'absence de la classe panels dans Pix APP a probablement créé une dépendance à Bootstrap qui vient d'être supprimé de l'application, d'où la régression.

## 🤔 Consolider les fondations pour l'avenir
Quel test pourrait-on ajouter pour couvrir ce cas d'erreur ? 
Un test de classe ne nous aurait pas averti du problème et un test sur la couleur aurait créé une dépendance au css. 
Les tests automatisés de non-régression visuelle (dans une approche différente de Cypress ou avec Cypress) sont peut-être intéressant.

## 💯 Pour tester 
Il faut être déconnecté puis saisir l'URL suivante :
https://app-pr1027.review.pix.fr/campagnes/AZERTY456/identification
