### PR TITLE
[TECH] Suppression de la dépendance sib-api-v3-sdk de la racine.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2316,14 +2316,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
-    "sib-api-v3-sdk": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/sib-api-v3-sdk/-/sib-api-v3-sdk-7.1.4.tgz",
-      "integrity": "sha512-a37TUVl59DW1A6TO1++cCv7Kp7a97oDlBJPR1GKEm/M7PXDww1PQHJorA5BwYmVYu+SF6Vbac8QdWbzroHqvjg==",
-      "requires": {
-        "superagent": "3.7.0"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "axios": "^0.19.0",
     "eslint-plugin-ember": "^7.6.0",
     "moment": "^2.24.0",
-    "npm-run-all": "^4.1.5",
-    "sib-api-v3-sdk": "^7.1.4"
+    "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Il n'est plus possible d'exécuter `npm ci` à la racine.

## :robot: Solution
Suppression de la dépendance `sib-api-v3-sdk` qui n'a pas lieu d'être présente dans le package.json de la racine.