### PR TITLE
[FEATURE] Remplace le message d'erreur pour les comptes déjà créer (PF-989).

### DIFF
--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -101,7 +101,7 @@ export default Controller.extend({
         });
       }, (errorResponse) => {
         studentUserAssociation.unloadRecord();
-        this._setErrorMessageForAttemptNextAction(errorResponse)
+        this._setErrorMessageForAttemptNextAction(errorResponse);
         this.set('isLoading', false);
       });
     },

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -101,15 +101,7 @@ export default Controller.extend({
         });
       }, (errorResponse) => {
         studentUserAssociation.unloadRecord();
-        errorResponse.errors.forEach((error) => {
-          if (error.status === '409') {
-            return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
-          }
-          if (error.status === '404') {
-            return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
-          }
-          return this.set('errorMessage', error.detail);
-        });
+        this._setErrorMessageForAttemptNextAction(errorResponse)
         this.set('isLoading', false);
       });
     },
@@ -135,6 +127,18 @@ export default Controller.extend({
       this.set('yearOfBirth', value);
       this._validateInputYear(key, value);
     },
+  },
+
+  _setErrorMessageForAttemptNextAction(errorResponse) {
+    errorResponse.errors.forEach((error) => {
+      if (error.status === '409') {
+        return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
+      }
+      if (error.status === '404') {
+        return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+      }
+      return this.set('errorMessage', error.detail);
+    });
   },
 
   _executeFieldValidation(key, value, isValid) {

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -102,6 +102,9 @@ export default Controller.extend({
       }, (errorResponse) => {
         studentUserAssociation.unloadRecord();
         errorResponse.errors.forEach((error) => {
+          if (error.status === '409') {
+            return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
+          }
           if (error.status === '404') {
             return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
           }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -93,13 +93,4 @@
       width: 30%;
     }
   }
-
-  &__help-text {
-    color: $charcoal-grey;
-    font-family: $font-open-sans;
-    font-size: 1.4rem;
-    font-weight: $font-normal;
-    text-align: center;
-    margin-top: 26px;
-  }
 }

--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -64,9 +64,6 @@
           </button>
         {{/if}}
       </form>
-      <div class="join-restricted-campaign__help-text">
-        Ce n'est pas vous ?<br>Vérifiez que vous êtes bien connecté à votre ENT ou contactez votre enseignant.
-      </div>
     </div>
   </div>
 </div>

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -468,6 +468,20 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
       expect(controller.get('isLoading')).to.equal(false);
     });
 
+    it('should display a conflict error', async function() {
+      // given
+      studentUserAssociation.save.rejects({ errors: [{ status: '409' }] });
+
+      // when
+      await controller.actions.attemptNext.call(controller);
+
+      // then
+      sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+      expect(controller.get('errorMessage')).to.equal('Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
+      sinon.assert.notCalled(controller.transitionToRoute);
+      expect(controller.get('isLoading')).to.equal(false);
+    });
+
     it('should associate user with student and redirect to campaigns.start-or-resume after failing', async function() {
       // given
       studentUserAssociation.save

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -454,7 +454,7 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
       expect(controller.get('errorMessage')).to.equal(null);
     });
 
-    it('should display a general error', async function() {
+    it('should display a not found error', async function() {
       // given
       studentUserAssociation.save.rejects({ errors: [{ status: '404' }] });
 


### PR DESCRIPTION
## :unicorn: Problème
Le message à la fin du formulaire n'est plus approprié car tout le monde ne se connecte pas via un ENT.

Le message d'erreur en cas d'informations de reconciliation est trop générique.

## :robot: Solution
Suppression du message à la fin du formulaire.

Ajout d'un message d'erreur spécifique en cas d'informations déjà utilisées pour la réconciliation.
