### PR TITLE
[BUGFIX] La vérification de l'existence d'une invitation n'est plus sensible à la casse pour l'email (PO-329)

### DIFF
--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -68,7 +68,9 @@ module.exports = {
 
   findOnePendingByOrganizationIdAndEmail({ organizationId, email }) {
     return BookshelfOrganizationInvitation
-      .where({ organizationId, email, status: 'pending' })
+      .query((qb) =>
+        qb.where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
+          .whereRaw('LOWER("email") = ?', `${email.toLowerCase()}`))
       .fetch({ required: false })
       .then(_toDomain);
   },

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -159,20 +159,35 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
 
   describe('#findOnePendingByOrganizationIdAndEmail', () => {
 
-    it('should retrieve one pending organization-invitation with given organizationId and email', async () => {
+    let organizationInvitation;
+
+    beforeEach(async () => {
       // given
       databaseBuilder.factory.buildOrganizationInvitation({
         status: OrganizationInvitation.StatusType.ACCEPTED,
       });
-      const organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+      organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
         status: OrganizationInvitation.StatusType.PENDING,
       });
-      const { organizationId, email } = organizationInvitation;
-
       await databaseBuilder.commit();
+    });
+
+    it('should retrieve one pending organization-invitation with given organizationId and email', async () => {
+      const { organizationId, email } = organizationInvitation;
 
       // when
       const foundOrganizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
+
+      // then
+      expect(_.omit(foundOrganizationInvitation, 'organizationName')).to.deep.equal(organizationInvitation);
+    });
+
+    it('should retrieve one pending organization-invitation with given organizationId and case-insensitive email', async () => {
+      const { organizationId, email } = organizationInvitation;
+
+      const upperEmail = email.toUpperCase();
+      // when
+      const foundOrganizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email: upperEmail });
 
       // then
       expect(_.omit(foundOrganizationInvitation, 'organizationName')).to.deep.equal(organizationInvitation);


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création d'une invitation à rejoindre une organisation, une vérification est effectuée au préalable afin de vérifier qu'il n'existe pas déjà une demande existante pour l'adresse email que l'on souhaite inviter. Cette vérification de l'adresse email est sensible à la casse et il arrive parfois que les utilisateurs créent des demandes d'invitations avec des emails contenant des majuscules pour des emails déjà invités.  

## :robot: Solution
Rendre cette vérification de l'email insensible à la casse.