### PR TITLE
[FEATURE] Afficher si l'organisation SCO gère des élèves (PA-140)

### DIFF
--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -1,9 +1,17 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
 
-  // Public props
   organization: null,
+
+  isOrganizationSCO: computed('organization.type', function() {
+    return this.organization.type === 'SCO';
+  }),
+
+  isManagingStudents: computed('organization.isManagingStudents', function() {
+    return this.organization.isManagingStudents ? 'Oui' : 'Non';
+  }),
 
   actions: {
     updateLogo(file) {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -10,6 +10,7 @@ export default Model.extend({
   logoUrl: attr(),
   externalId: attr(),
   provinceCode: attr(),
+  isManagingStudents: attr(),
 
   // Relationships
   memberships: hasMany('membership'),

--- a/admin/app/templates/components/organization-information-section.hbs
+++ b/admin/app/templates/components/organization-information-section.hbs
@@ -25,6 +25,9 @@
         {{#if organization.provinceCode}}
           Département : <span class="organization__provinceCode">{{organization.provinceCode}}</span><br>
         {{/if}}
+        {{#if isOrganizationSCO}}
+          Gère des élèves : <span class="organization__isManagingStudents">{{isManagingStudents}}</span>
+        {{/if}}
       </p>
     </div>
   </div>

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -2,13 +2,60 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | organization-information-section', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`{{organization-information-section}}`);
+    const organization = EmberObject.create({ type: 'SUP', isManagingStudents: false });
+
+    this.set('organization', organization);
+    await render(hbs`{{organization-information-section organization=organization}}`);
 
     assert.dom('.organization__information').exists();
+  });
+
+  module('When organization is SCO', function(hooks) {
+
+    let organization;
+
+    hooks.beforeEach(function() {
+      organization = EmberObject.create({ type: 'SCO', isManagingStudents: true });
+    });
+
+    test('it should display if it is managing students', async function(assert) {
+      this.set('organization', organization);
+      await render(hbs`{{organization-information-section organization=organization}}`);
+
+      assert.dom('.organization__isManagingStudents').exists();
+    });
+
+    test('it should display "Oui" if it is managing students', async function(assert) {
+      this.set('organization', organization);
+      await render(hbs`{{organization-information-section organization=organization}}`);
+
+      assert.dom('.organization__isManagingStudents').hasText('Oui');
+    });
+
+    test('it should display "Non" if managing students is false', async function(assert) {
+      organization.isManagingStudents = false;
+      this.set('organization', organization);
+      await render(hbs`{{organization-information-section organization=organization}}`);
+
+      assert.dom('.organization__isManagingStudents').hasText('Non');
+    });
+  });
+
+  module('When organization is not SCO', function() {
+
+    test('it should not display if it is managing students', async function(assert) {
+      const organization = EmberObject.create({ type: 'PRO', isManagingStudents: false });
+
+      this.set('organization', organization);
+      await render(hbs`{{organization-information-section organization=organization}}`);
+
+      assert.dom('.organization__isManagingStudents').doesNotExist();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Bien qu'il soit possible de gérer les organisations SCO depuis Pix Admin, il n'existe pas de moyen de savoir si une organisation SCO gère ou non des élèves.  

## :robot: Solution
Ajout de l'information de la gestion d'élèves pour les organisations SCO dans la page de détail d'une organisation.