### PR TITLE
[POC] Auto-validation des embed (PF-793).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -12,6 +12,8 @@ const ChallengeItemGeneric = Component.extend({
 
   isValidateButtonEnabled: true,
   isSkipButtonEnabled: true,
+  hideInput: false,
+  hideInputHandler: null,
 
   _elapsedTime: null,
   _timer: null,
@@ -26,6 +28,8 @@ const ChallengeItemGeneric = Component.extend({
 
   didUpdateAttrs() {
     this._super(...arguments);
+    this.set('hideInput', false);
+
     if (!this._isUserAwareThatChallengeIsTimed) {
       this.set('hasUserConfirmWarning', false);
       this.set('hasChallengeTimer', this.hasTimerDefined());
@@ -36,6 +40,15 @@ const ChallengeItemGeneric = Component.extend({
     this._super(...arguments);
     const timer = this._timer;
     cancel(timer);
+  },
+
+  didInsertElement: function() {
+    this.hideInputHandler = this._hideInput.bind(this);
+    window.addEventListener('message',  this.hideInputHandler);
+  },
+
+  didDestroyElement: function() {
+    window.removeEventListener('message', this.hideInputHandler);
   },
 
   hasUserConfirmWarning: computed('challenge', function() {
@@ -52,6 +65,12 @@ const ChallengeItemGeneric = Component.extend({
 
   hasTimerDefined() {
     return _.isInteger(this.challenge.timer);
+  },
+
+  _hideInput: function(event) {
+    if (event.data === 'hideInput') {
+      this.set('hideInput', true);
+    }
   },
 
   _getTimeout() {

--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -11,6 +11,7 @@ export default class QrocProposal extends Component {
   proposals = null;
   answerValue = null;
   answerChanged = null; // action
+  postMessageHandler = null;
 
   @computed('proposals')
   get _blocks() {
@@ -22,12 +23,25 @@ export default class QrocProposal extends Component {
     const answer = this.answerValue || '';
     return answer.indexOf('#ABAND#') > -1 ? '' : answer;
   }
+  _setAnswerValue(event) {
+    this.set('answerValue', event.data) ;
+  }
+
+  didUpdateAttrs() {
+    this.set('userAnswer', '');
+  }
 
   didInsertElement() {
+    this.postMessageHandler = this._setAnswerValue.bind(this);
+    window.addEventListener('message', this.postMessageHandler);
 
     this.$('input').keydown(() => {
       this.answerChanged();
     });
+  }
+
+  didDestroyElement() {
+    window.removeEventListener('message',this.postMessageHandler);
   }
 
   willRender() {

--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -24,7 +24,9 @@ export default class QrocProposal extends Component {
     return answer.indexOf('#ABAND#') > -1 ? '' : answer;
   }
   _setAnswerValue(event) {
-    this.set('answerValue', event.data) ;
+    if (event.data !== 'hideInput' && typeof event.data === 'string') {
+      this.set('userAnswer', event.data);
+    }
   }
 
   didUpdateAttrs() {

--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -87,3 +87,7 @@ form .challenge-response-locked {
     }
   }
 }
+
+.input-hidden {
+  display: none;
+}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -7,8 +7,7 @@
 {{#unless hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
-
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}} {{if hideInput 'input-hidden'}}">
       <div class="challenge-proposals">
         <QrocProposal @answer={{answer}} @format={{challenge.format}} @proposals={{challenge.proposals}} @answerValue={{answer.value}} @answerChanged={{action "answerChanged"}} />
       </div>
@@ -27,7 +26,6 @@
         {{/if}}
       {{/if}}
     </div>
-
     {{#if errorMessage}}
       <div class="alert alert-danger" role="alert">
         {{errorMessage}}


### PR DESCRIPTION
## :unicorn: Problème
On veut que l'utilisateur n'ai plus a reporter le mot magique dans le champ input. 

## :robot: Solution
Permettre à l'iframe de l'embed de communiquer a pix-app le mot qui valide le challenge.

## :rainbow: Remarques
A tester avec l'épreuve : rec7zwiiwWzlAfTS1
