### PR TITLE
[TECH] Refacto serializers mirage sur mon-pix (PF-1038).

### DIFF
--- a/mon-pix/mirage/routes/get-campaign-participation.js
+++ b/mon-pix/mirage/routes/get-campaign-participation.js
@@ -11,5 +11,4 @@ export default function(schema, request) {
     return campaignParticipations;
   }
   return schema.campaignParticipations.all();
-
 }

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -1,5 +1,5 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['competenceResults'],
 });

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -1,5 +1,11 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
+  attrs: [
+    'totalSkillsCount',
+    'testedSkillsCount',
+    'validatedSkillsCount',
+    'isCompleted'
+  ],
   include: ['competenceResults'],
 });

--- a/mon-pix/mirage/serializers/campaign-participation.js
+++ b/mon-pix/mirage/serializers/campaign-participation.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['assessment', 'campaign'],
   links(campaignParticipation) {
     return {

--- a/mon-pix/mirage/serializers/campaign-participation.js
+++ b/mon-pix/mirage/serializers/campaign-participation.js
@@ -1,9 +1,21 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['assessment', 'campaign'],
+  attrs: [
+    'isShared',
+    'sharedAt',
+    'createdAt',
+    'participantExternalId',
+  ],
+  include: [
+    'campaign',
+    'user',
+  ],
   links(campaignParticipation) {
     return {
+      'assessment': {
+        related: `/api/assessments/${campaignParticipation.assessmentId}`
+      },
       'campaignParticipationResult': {
         related: `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`
       },

--- a/mon-pix/mirage/serializers/certification-course.js
+++ b/mon-pix/mirage/serializers/certification-course.js
@@ -1,5 +1,5 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['assessment'],
 });

--- a/mon-pix/mirage/serializers/certification-course.js
+++ b/mon-pix/mirage/serializers/certification-course.js
@@ -1,5 +1,16 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['assessment'],
+  attrs: [
+    'nbChallenges',
+    'examinerComment',
+    'hasSeenEndTestScreen',
+  ],
+  links(certificationCourse) {
+    return {
+      'assessment': {
+        related: `/api/assessments/${certificationCourse.assessmentId}`
+      }
+    };
+  }
 });

--- a/mon-pix/mirage/serializers/competence-evaluation.js
+++ b/mon-pix/mirage/serializers/competence-evaluation.js
@@ -1,6 +1,13 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
+  attrs: [
+    'createdAt',
+    'updatedAt',
+    'userId',
+    'competenceId',
+    'status'
+  ],
   include: ['assessment'],
   links(record) {
     return {

--- a/mon-pix/mirage/serializers/competence-evaluation.js
+++ b/mon-pix/mirage/serializers/competence-evaluation.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['assessment'],
   links(record) {
     return {

--- a/mon-pix/mirage/serializers/competence.js
+++ b/mon-pix/mirage/serializers/competence.js
@@ -1,5 +1,5 @@
-import BaseSerializer from './application';
+import ApplicationSerializer from './application';
 
-export default BaseSerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['area']
 });

--- a/mon-pix/mirage/serializers/competence.js
+++ b/mon-pix/mirage/serializers/competence.js
@@ -1,5 +1,0 @@
-import ApplicationSerializer from './application';
-
-export default ApplicationSerializer.extend({
-  include: ['area']
-});

--- a/mon-pix/mirage/serializers/scorecard.js
+++ b/mon-pix/mirage/serializers/scorecard.js
@@ -1,6 +1,6 @@
-import BaseSerializer from './application';
+import ApplicationSerializer from './application';
 
-export default BaseSerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['area'],
   links(record) {
     return {

--- a/mon-pix/mirage/serializers/scorecard.js
+++ b/mon-pix/mirage/serializers/scorecard.js
@@ -1,6 +1,17 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
+  attributes: [
+    'name',
+    'description',
+    'index',
+    'competenceId',
+    'earnedPix',
+    'level',
+    'pixScoreAheadOfNextLevel',
+    'status',
+    'remainingDaysBeforeReset',
+  ],
   include: ['area'],
   links(record) {
     return {

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -1,6 +1,6 @@
-import BaseSerializer from './application';
+import ApplicationSerializer from './application';
 
-export default BaseSerializer.extend({
+export default ApplicationSerializer.extend({
   include: ['competences', 'organizations'],
   links(user) {
     return {

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -1,20 +1,37 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
+  attributes: [
+    'firstName',
+    'lastName',
+    'email',
+    'username',
+    'cgu',
+    'pixOrgaTermsOfServiceAccepted',
+    'pixCertifTermsOfServiceAccepted',
+    'hasSeenAssessmentInstructions',
+  ],
   include: ['competences', 'organizations'],
   links(user) {
+    const userBaseUrl = `/api/users/${user.id}`;
     return {
       certificationProfile: {
-        related: `/api/users/${user.id}/certification-profile`,
+        related: `${userBaseUrl}/certification-profile`
       },
       pixScore: {
-        related: `/api/users/${user.id}/pixscore`
+        related: `${userBaseUrl}/pixscore`
       },
       scorecards: {
-        related: `/api/users/${user.id}/scorecards`
+        related: `${userBaseUrl}/scorecards`
       },
       campaignParticipations: {
-        related: `/api/users/${user.id}/campaign-participations`
+        related: `${userBaseUrl}/campaign-participations`
+      },
+      certificationCenterMemberships: {
+        related: `${userBaseUrl}/certification-center-memberships`
+      },
+      memberships: {
+        related: `${userBaseUrl}/memberships`
       }
     };
   }


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, il y a plusieurs façons de charger nos données mirage: en amont via des fixtures ou pendant les tests avec des factories. Ces données sont ensuite serialisés pour les convertir en JSON API.
Parfois même, on n'utilise ni fixture no factory: l'objet JSON API attendu est directement construit à la main.
Cela rend nos tests compliqués à modifier et debugger.

## :robot: Solution
Modifier notre manière d'utiliser mirage, pour coller davantage à la documentation ember-cli-mirage et uniformiser par rapport aux autres applis Pix.

Cette PR concerne le **refacto des serializers existants**.
D'autres PR suivront... ;)
