### PR TITLE
[BUGFIX] Lors de l'inscription, vérification de la non présence de l'email en base avec insensibilité à la casse (PF-1077).

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -77,7 +77,7 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
     qb.whereRaw('LOWER("lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
   if (email) {
-    qb.whereRaw('LOWER("email") LIKE ?', `%${email.toLowerCase()}%`);
+    qb.whereRaw('email LIKE ?', `%${email.toLowerCase()}%`);
   }
 }
 
@@ -94,7 +94,7 @@ module.exports = {
   // TODO use _toDomain()
   findByEmail(email) {
     return BookshelfUser
-      .where({ email })
+      .where({ email: email.toLowerCase() })
       .fetch({ require: true })
       .then((bookshelfUser) => {
         return bookshelfUser.toDomainEntity();
@@ -109,7 +109,7 @@ module.exports = {
 
   getByUsernameOrEmailWithRoles(username) {
     return BookshelfUser
-      .query((qb) => { qb.whereRaw('LOWER("email") LIKE ?', `${username.toLowerCase()}`).orWhere({ 'username': username }); })
+      .query((qb) => qb.where({ email: username.toLowerCase() }).orWhere({ 'username': username }))
       .fetch({
         withRelated: [
           'memberships',
@@ -216,7 +216,7 @@ module.exports = {
 
   isUserExistingByEmail(email) {
     return BookshelfUser
-      .where({ email })
+      .where({ email: email.toLowerCase() })
       .fetch({ require: true })
       .then(() => true)
       .catch(() => {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -203,7 +203,7 @@ module.exports = {
 
   isEmailAvailable(email) {
     return BookshelfUser
-      .where({ email })
+      .where({ email: email.toLowerCase() })
       .fetch()
       .then((user) => {
         if (user) {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -74,7 +74,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       it('should handle a rejection, when user id is not found', async () => {
         // given
-        const emailThatDoesNotExist = 10093;
+        const emailThatDoesNotExist = '10093';
 
         // when
         const result = await catchErr(userRepository.findByEmail)(emailThatDoesNotExist);
@@ -86,6 +86,17 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       it('should return a domain user when found', async () => {
         // when
         const user = await userRepository.findByEmail(userInDb.email);
+
+        // then
+        expect(user.email).to.equal(userInDb.email);
+      });
+
+      it('should return a domain user when email case insensitive found', async () => {
+        // given
+        const uppercaseEmailAlreadyInDb = userInDb.email.toUpperCase();
+
+        // when
+        const user = await userRepository.findByEmail(uppercaseEmailAlreadyInDb);
 
         // then
         expect(user.email).to.equal(userInDb.email);
@@ -181,6 +192,20 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         expect(user.email).to.equal(expectedUser.email);
         expect(user.password).to.equal(expectedUser.password);
         expect(user.cgu).to.equal(expectedUser.cgu);
+      });
+
+      it('should return user informations for the given email (case insensitive)', async () => {
+        // given
+        const expectedUser = new User(userInDB);
+        const uppercaseEmailAlreadyInDb = userInDB.email.toUpperCase();
+
+        // when
+        const user = await userRepository.getByUsernameOrEmailWithRoles(uppercaseEmailAlreadyInDb);
+
+        // then
+        expect(user).to.be.an.instanceof(User);
+        expect(user.id).to.equal(expectedUser.id);
+        expect(user.email).to.equal(expectedUser.email);
       });
 
       it('should return user informations for the given username', async () => {
@@ -446,10 +471,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     it('should reject an AlreadyRegisteredEmailError when email case insensitive already exists', async () => {
       // given
-      const capitalEmailAlreadyInDb = userInDb.email.toUpperCase();
+      const uppercaseEmailAlreadyInDb = userInDb.email.toUpperCase();
 
       // when
-      const result = await catchErr(userRepository.isEmailAvailable)(capitalEmailAlreadyInDb);
+      const result = await catchErr(userRepository.isEmailAvailable)(uppercaseEmailAlreadyInDb);
 
       // then
       expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
@@ -501,6 +526,17 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     it('should return true when the user exists by email', async () => {
       const userExists = await userRepository.isUserExistingByEmail(email);
+      expect(userExists).to.be.true;
+    });
+
+    it('should return true when the user exists by email (case insensitive)', async () => {
+      // given
+      const uppercaseEmailAlreadyInDb = email.toUpperCase();
+
+      // when
+      const userExists = await userRepository.isUserExistingByEmail(uppercaseEmailAlreadyInDb);
+
+      // then
       expect(userExists).to.be.true;
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -443,6 +443,17 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       // then
       expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
     });
+
+    it('should reject an AlreadyRegisteredEmailError when email case insensitive already exists', async () => {
+      // given
+      const capitalEmailAlreadyInDb = userInDb.email.toUpperCase();
+
+      // when
+      const result = await catchErr(userRepository.isEmailAvailable)(capitalEmailAlreadyInDb);
+
+      // then
+      expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);
+    });
   });
 
   describe('#updatePassword', () => {


### PR DESCRIPTION
## :unicorn: Problème

1 - sur la double mire, faire la pré-réconciliation (First Last 10/10/2010)
2 - Choisir une inscription par email
3 - Remplir l'email avec un email déjà en base mais en majuscule (Userpix1@example.net)
2 - Remplir le champ mot de passe avec un mot de passe valide
3 - Valider

Constater qu'il y a une erreur 500. Côté utilisateur il ne se passe rien, donc l'utilisateur réessaie, donc on a des 500 en pagaille.

## :robot: Solution
Checker l'email non sensible à la casse.
