### PR TITLE
[FEATURE] Ajoute la colonne "Créé par" dans la liste des campagnes (PO-308).

### DIFF
--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -16,10 +16,11 @@ class Campaign {
     targetProfile,
     campaignReport,
     campaignCollectiveResult,
+    creator,
     // references
-    creatorId,
     organizationId,
-    targetProfileId
+    targetProfileId,
+    creatorId
   } = {}) {
     this.id = id;
     // attributes
@@ -36,10 +37,11 @@ class Campaign {
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;
     this.campaignCollectiveResult = campaignCollectiveResult;
+    this.creator = creator;
     // references
-    this.creatorId = creatorId;
     this.organizationId = organizationId;
     this.targetProfileId = targetProfileId;
+    this.creatorId = creatorId;
   }
 }
 

--- a/api/lib/infrastructure/data/campaign.js
+++ b/api/lib/infrastructure/data/campaign.js
@@ -18,4 +18,8 @@ module.exports = Bookshelf.model('Campaign', {
   targetProfile: function() {
     return this.belongsTo('TargetProfile', 'targetProfileId');
   },
+
+  creator: function() {
+    return this.belongsTo('User', 'creatorId');
+  },
 });

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -30,7 +30,7 @@ function _fromBookshelfCampaignWithReportDataToDomain(campaignWithReportData) {
     'name',
     'code',
     'organizationId',
-    'creatorId',
+    'creator',
     'createdAt',
     'targetProfileId',
     'customLandingPageText',
@@ -107,7 +107,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted']);
+    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator']);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);
@@ -135,7 +135,8 @@ module.exports = {
       })
       .fetchPage({
         page: page.number,
-        pageSize: page.size
+        pageSize: page.size,
+        withRelated: ['creator']
       })
       .then(({ models, pagination }) => {
         const campaignsWithReports = models.map(_fromBookshelfCampaignWithReportDataToDomain);

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -6,9 +6,13 @@ const Campaign = require('../../../domain/models/Campaign');
 module.exports = {
 
   serialize(campaigns, meta, { tokenForCampaignResults, ignoreCampaignReportRelationshipData = true } = {}) {
-
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted'],
+      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator'],
+      typeForAttribute(attribute) {
+        if (attribute === 'creator') {
+          return 'users';
+        }
+      },
       transform: (record) => {
         const campaign = Object.assign({}, record);
         campaign.tokenForCampaignResults = tokenForCampaignResults;
@@ -28,6 +32,12 @@ module.exports = {
             return `/api/campaigns/${parent.id}/campaign-report`;
           }
         }
+      },
+      creator: {
+        ref: 'id',
+        type: 'users',
+        attributes: ['lastName', 'firstName'],
+        included: true,
       },
       campaignCollectiveResult: {
         ref: 'id',

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -42,7 +42,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       expect(response.result.errors[0].detail).to.equal(`Campaign with code ${fakeCamapignCode} not found`);
     });
 
-    it('should return an InternalError if there is no organization link to the code', async () => {
+    it('should return an NotFoundError if there is no organization link to the code', async () => {
       // given
       const options = {
         method: 'GET',

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -460,9 +460,9 @@ describe('Acceptance | Application | organization-controller', () => {
       organizationId = databaseBuilder.factory.buildOrganization({}).id;
       otherOrganizationId = databaseBuilder.factory.buildOrganization({}).id;
       campaignsData = _.map([
-        { name: 'Quand Peigne numba one', code: 'ATDGRK343', organizationId, },
-        { name: 'Quand Peigne numba two', code: 'KFCTSU984', organizationId, },
-        { name: 'Quand Peigne otha orga', code: 'CPFTQX735', organizationId: otherOrganizationId, },
+        { name: 'Quand Peigne numba one', code: 'ATDGRK343', organizationId },
+        { name: 'Quand Peigne numba two', code: 'KFCTSU984', organizationId },
+        { name: 'Quand Peigne otha orga', code: 'CPFTQX735', organizationId: otherOrganizationId },
       ], (camp) => {
         const builtCampaign = databaseBuilder.factory.buildCampaign(camp);
         return { name: camp.name, code: camp.code, id: builtCampaign.id };
@@ -507,6 +507,23 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(campaigns).to.have.lengthOf(2);
         expect(_.map(campaigns, 'attributes.name')).to.have.members([campaignsData[0].name, campaignsData[1].name]);
         expect(_.map(campaigns, 'attributes.code')).to.have.members([campaignsData[0].code, campaignsData[1].code]);
+      });
+
+      it('should return campaigns with its creator', async () => {
+        // given
+        organizationId = databaseBuilder.factory.buildOrganization({}).id;
+        const creatorId = databaseBuilder.factory.buildUser({ firstName: 'Daenerys', lastName: 'Targaryen' }).id;
+        databaseBuilder.factory.buildCampaign({ organizationId, creatorId });
+        await databaseBuilder.commit();
+        options.url = `/api/organizations/${organizationId}/campaigns`;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.included[1].attributes['first-name']).to.equal('Daenerys');
+        expect(response.result.included[1].attributes['last-name']).to.equal('Targaryen');
       });
 
       it('should return 200 status code with the campaignReports with the campaigns', async () => {

--- a/api/tests/tooling/domain-builder/factory/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign.js
@@ -1,6 +1,7 @@
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const faker = require('faker');
 const buildTargetProfile = require('./build-target-profile');
+const buildUser = require('./build-user');
 
 module.exports = function buildCampaign(
   {
@@ -12,6 +13,7 @@ module.exports = function buildCampaign(
     customLandingPageText = faker.lorem.text(),
     createdAt = faker.date.recent(),
     creatorId = faker.random.number(2),
+    creator = buildUser({ id: creatorId }),
     organizationId = faker.random.number(2),
     targetProfileId = faker.random.number(2),
     targetProfile = buildTargetProfile({ id: targetProfileId }),
@@ -25,8 +27,9 @@ module.exports = function buildCampaign(
     title,
     idPixLabel,
     customLandingPageText,
-    createdAt,
     creatorId,
+    createdAt,
+    creator,
     organizationId,
     targetProfileId,
     targetProfile,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           title: 'Parcours recherche internet',
           customLandingPageText: 'Parcours concernant la recherche internet',
           createdAt: new Date('2018-02-06T14:12:44Z'),
-          creatorId: 3453,
+          creator: { id: 3453, firstName: 'Daenerys', lastName: 'Targaryen' },
           organizationId: 10293,
           organizationLogoUrl: 'some logo',
           organizationName: 'College Victor Hugo',
@@ -51,6 +51,12 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
                   type: 'targetProfiles'
                 }
               },
+              'creator': {
+                data: {
+                  id: '3453',
+                  type: 'users',
+                }
+              },
               'campaign-report': {
                 'links': {
                   'related': '/api/campaigns/5/campaign-report'
@@ -70,6 +76,14 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               },
               id: '123',
               type: 'targetProfiles'
+            },
+            {
+              id: '3453',
+              type: 'users',
+              attributes: {
+                'first-name': 'Daenerys',
+                'last-name': 'Targaryen',
+              }
             }
           ],
           meta
@@ -96,7 +110,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           title: 'Parcours recherche internet',
           customLandingPageText: 'Parcours concernant la recherche internet',
           createdAt: new Date('2018-02-06T14:12:44Z'),
-          creatorId: 3453,
+          creator: { id: 3453, firstName: 'Daenerys', lastName: 'Targaryen' },
           organizationId: 10293,
           organizationLogoUrl: 'some logo',
           organizationName: 'College Victor Hugo',
@@ -126,6 +140,12 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
                 data: {
                   id: '123',
                   type: 'targetProfiles'
+                }
+              },
+              'creator': {
+                data: {
+                  id: '3453',
+                  type: 'users',
                 }
               },
               'campaign-report': {
@@ -159,6 +179,14 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               },
               id: '5',
               type: 'campaignReports'
+            },
+            {
+              id: '3453',
+              type: 'users',
+              attributes: {
+                'first-name': 'Daenerys',
+                'last-name': 'Targaryen',
+              }
             }
           ],
           meta

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -30,6 +30,8 @@ when(`je saisis ma date de naissance {int}-{int}-{int}`, (dayOfBirth, monthOfBir
 
 then(`je vois la liste des campagnes`, () => {
   cy.get('.campaign-list table tbody tr').should('have.lengthOf', 2);
+  cy.get('.campaign-list table thead').contains('Créé par');
+  cy.get('.campaign-list table tbody tr td:nth-child(2)').contains(/(.+)/);
 });
 
 when(`je recherche une campagne avec le nom {string}`, (campaignSearchName) => {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   code: DS.attr('string'),
   title: DS.attr('string'),
   createdAt: DS.attr('date'),
+  creator: DS.belongsTo('user'),
   idPixLabel: DS.attr('string'),
   customLandingPageText: DS.attr('string'),
   // TODO remove organizationId and work only with the relationship

--- a/orga/app/models/user.js
+++ b/orga/app/models/user.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 
 export default DS.Model.extend({
 
@@ -8,5 +9,9 @@ export default DS.Model.extend({
   password: DS.attr('string'),
   cgu: DS.attr('boolean'),
   pixOrgaTermsOfServiceAccepted: DS.attr('boolean'),
-  memberships: DS.hasMany('membership')
+  memberships: DS.hasMany('membership'),
+
+  fullName: computed('firstName', 'lastName', function() {
+    return `${this.get('firstName')} ${this.get('lastName')}`;
+  })
 });

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -43,7 +43,7 @@ tr {
 
 td, th {
   text-align: left;
-  padding-left: 30px;
+  padding-left: 24px;
 }
 
 .table__column {
@@ -55,6 +55,12 @@ td, th {
 
   &--wide {
     width: 25%;
+  }
+
+  &--truncated {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -10,32 +10,35 @@
     <div class="table content-text content-text--small">
       <table>
         <thead>
-        <tr>
-          <th>Parcours</th>
-          <th>Créé le</th>
-          <th>Participants</th>
-          <th>Résultats reçus</th>
-        </tr>
-        <tr>
-          <th>
-            {{search-input
-              inputName="campaignName"
-              class="input table__input"
-              value=campaignName
-              placeholder="Nom du parcours"
-              keyUp=(action triggerFiltering 'name' campaignName)
-            }}
-          </th>
-          <th></th>
-          <th></th>
-          <th></th>
-        </tr>
+          <tr>
+            <th class="table__column table__column--wide">Parcours</th>
+            <th class="table__column">Créé par</th>
+            <th class="table__column table__column--small">Créé le</th>
+            <th class="table__column table__column--small">Participants</th>
+            <th class="table__column table__column--small">Résultats reçus</th>
+          </tr>
+          <tr>
+            <th>
+              {{search-input
+                inputName="campaignName"
+                class="input table__input"
+                value=campaignName
+                placeholder="Nom du parcours"
+                keyUp=(action triggerFiltering 'name' campaignName)
+              }}
+            </th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+          </tr>
         </thead>
 
         <tbody>
         {{#each campaigns as |campaign|}}
           <tr onclick={{action goToCampaignPage campaign.id}} class="tr--clickable">
             <td>{{campaign.name}}</td>
+            <td class="table__column--truncated">{{campaign.creator.fullName}}</td>
             <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
             <td>{{campaign.campaignReport.participationsCount}}</td>
             <td>{{campaign.campaignReport.sharedParticipationsCount}}</td>

--- a/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
@@ -57,6 +57,45 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
     assert.dom('.campaign-list .table tbody tr:first-child td:first-child').hasText('campagne 1');
   });
 
+  test('it should display the creator of the campaigns', async function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const user1 = run(() => store.createRecord('user', {
+      id: 1,
+      firstName: 'Jean-Michel',
+      lastName: 'Jarre',
+    }));
+    const user2 = run(() => store.createRecord('user', {
+      id: 2,
+      firstName: 'Mathilde',
+      lastName: 'Bonnin de La Bonninière de Beaumont',
+    }));
+    const campaign1 = run(() => store.createRecord('campaign', {
+      id: 1,
+      name: 'campagne 1',
+      creator: user1,
+      code: 'AAAAAA111',
+    }));
+    const campaign2 = run(() => store.createRecord('campaign', {
+      id: 2,
+      name: 'campagne 1',
+      creator: user2,
+      code: 'BBBBBB222'
+    }));
+    const campaigns = [campaign1, campaign2];
+    campaigns.meta = {
+      rowCount: 2
+    };
+    this.set('campaigns', campaigns);
+
+    // when
+    await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
+
+    // then
+    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(2)').hasText('Jean-Michel Jarre');
+    assert.dom('.campaign-list .table tbody tr:last-child td:nth-child(2)').hasText('Mathilde Bonnin de La Bonninière de Beaumont');
+  });
+
   test('it must display the creation date of the campaigns', async function(assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -82,7 +121,7 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
     await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
 
     // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(2)').hasText('02/02/2020');
+    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(3)').hasText('02/02/2020');
   });
 
   test('it should display the participations count', async function(assert) {
@@ -111,7 +150,7 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
     await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
 
     // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(3)').hasText('10');
+    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(4)').hasText('10');
   });
 
   test('it should display the shared participations count', async function(assert) {
@@ -140,6 +179,6 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
     await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
 
     // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(4)').hasText('4');
+    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(5)').hasText('4');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs de PIX Orga ont besoin de savoir qui est le créateur d'une campagne.

## :robot: Solution
Nous avons ajouté une colonne "Créé par" dans la liste des campagnes.

## :rainbow: Remarques
On est pas satisfait du beforeEach de la suite de "save" qui utilise la fonction `buildCampaign` du domain pour créer les données à insérer en base.

Nous sommes preneur de vos suggestions.
