### PR TITLE
[FEATURE] Mettre à jour les labels pour la finalisation de session (PC-114)

### DIFF
--- a/certif/app/components/session-finalization-formbuilder-link-step.hbs
+++ b/certif/app/components/session-finalization-formbuilder-link-step.hbs
@@ -1,6 +1,6 @@
 <div class="session-finalization-formbuilder-link-step">
   <div class="session-finalization-formbuilder-link-step__text">
-    Pour transmettre le PV de session sur 123formbuilder, suivez ce lien
+    Pour transmettre le PV de session scanné, suivez ce lien
   </div>
   <div class="session-finalization-formbuilder-link-step__link">
     <a href={{this.formBuilderLinkUrl}} target="_blank" rel="noopener noreferrer" >

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -5,7 +5,7 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>N° de certification</th>
-        <th>Signalement (facultatif)</th>
+        <th>Signalement (à renseigner le cas échéant)</th>
         <th>
           <div class="session-finalization-reports-informations-step__row">
             <div class="session-finalization-reports-informations-step__checker" {{on 'click' (fn @toggleAllCertificationReportsHasSeenEndTestScreen this.hasCheckedSomething)}}>

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -1,12 +1,13 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import config from '../../../config/environment';
+import { sumBy } from 'lodash';
 
 export default class AuthenticatedSessionsFinalizeController extends Controller {
-
+  
   @alias('model') session;
   @service notifications;
   @tracked isLoading;
@@ -19,6 +20,14 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
     this.showConfirmModal = false;
     this.examinerGlobalCommentMaxLength = 500;
     this.examinerCommentMaxLength = 500;
+  }
+
+  @computed('session.certificationReports.@each.hasSeenEndTestScreen')
+  get uncheckedHasSeenEndTestScreenCount() {
+    return sumBy(
+      this.session.certificationReports.toArray(),
+      (reports) => !reports.hasSeenEndTestScreen
+    );
   }
 
   showErrorNotification(message) {

--- a/certif/app/styles/components/finalize.scss
+++ b/certif/app/styles/components/finalize.scss
@@ -19,14 +19,25 @@
 .app-modal-body{
 
   &__attention {
-    color: #000;
+    color: $black;
     font-weight: 500;
     font-size: 1.2rem;
   }
 
   &__warning{
-    color: #39393A;
+    color: $gun-powder;
     font-weight: 300;
     font-size: 1em;
+  }
+
+  &__contextual{
+    border: 2px solid $alto;
+    background-color: $alto;
+    border-radius: 4px;
+    padding: 10px 0;
+    font-size: 1rem;
+    font-weight: bold;
+    color: $nero;
+    outline: 0;
   }
 }

--- a/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
@@ -5,16 +5,17 @@
   &__header-container{
     color: $grey;
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
   }
 
   &__label {
     flex: 1;
-    margin-bottom: 14px;
     line-height: 22px;
   }
 
   &__characters-information {
+    flex: 1;
     min-width: max-content;
     font-size: 0.85rem;
     align-self: flex-end;

--- a/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
@@ -10,12 +10,12 @@
   }
 
   &__label {
-    flex: 1;
+    flex: 1 0 auto;
     line-height: 22px;
   }
 
   &__characters-information {
-    flex: 1;
+    flex: 1 0 auto;
     min-width: max-content;
     font-size: 0.85rem;
     align-self: flex-end;

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -24,7 +24,7 @@
 
   <SessionFinalizationStepContainer
           @number="2"
-          @title="Transmettre le PV de session"
+          @title="Transmettre le PV de session scanné et autres documents éventuels"
           @icon="/icons/session-finalization-send.svg"
           @iconAlt="">
       <SessionFinalizationFormbuilderLinkStep/>

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -63,6 +63,7 @@
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="app-modal-body__attention">Vous êtes sur le point de finaliser cette session.</div>
         <div class="app-modal-body__warning">
+          <p class="app-modal-body__contextual"> La case "Écran de fin du test vu" n'est pas cochée pour {{ this.uncheckedHasSeenEndTestScreenCount }} candidats</p>
           <p>Attention : il ne vous sera plus possible de modifier ces informations par la suite.</p>
         </div>
       </div>

--- a/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
+++ b/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
@@ -9,6 +9,6 @@ module('Integration | Component | session-finalization-formbuilder-link-step', f
   test('it renders', async function(assert) {
     await render(hbs`<SessionFinalizationFormbuilderLinkStep />`);
 
-    assert.equal(this.element.textContent.trim().replace(/\s+/g, ' '), 'Pour transmettre le PV de session sur 123formbuilder, suivez ce lien Formulaire 123formbuilder');
+    assert.equal(this.element.textContent.trim().replace(/\s+/g, ' '), 'Pour transmettre le PV de session scanné, suivez ce lien Formulaire 123formbuilder');
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ArrayProxy from '@ember/array/proxy';
+
+const FINALIZE_PATH = 'authenticated/sessions/finalize';
+
+module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    assert.ok(controller);
+  });
+
+  test('it should count no unchecked box if no report', function(assert) {
+
+    // given
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    const sessions = ArrayProxy.create({
+      certificationReports: []
+    });
+    controller.set('model', sessions);
+
+    // when
+    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+
+    // then
+    assert.equal(uncheckedHasSeenEndTestScreenCount, 0);
+  });
+
+  test('it should count unchecked boxes', function(assert) {
+
+    // given
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    const sessions = ArrayProxy.create({
+      certificationReports: [
+        { hasSeenEndTestScreen: true },
+        { hasSeenEndTestScreen: false },
+        { hasSeenEndTestScreen: false },
+        { hasSeenEndTestScreen: false },
+        { hasSeenEndTestScreen: true },
+      ]
+    });
+    controller.set('model', sessions);
+
+    // when
+    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+
+    // then
+    assert.equal(uncheckedHasSeenEndTestScreenCount, 3);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Sur la page de finalisation de session, des labels ne sont pas à jour.
Le label _commentaire_ passe à la ligne différemment selon le nombre de caractère en commentaire.

## :robot: Solution

Mettre à jour les labels.
Ne pas aligner le label _commentaire_ avec le champs du nombre de caractère insérés.

## :rainbow: Remarques
On a 2 px de décalage au niveaux des commentaires 😱
