### PR TITLE
[TECH] Nettoyage des index de la base de données (PF-728)

### DIFF
--- a/api/db/migrations/20160927153108_create_users.js
+++ b/api/db/migrations/20160927153108_create_users.js
@@ -15,17 +15,11 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20160929164549_create_assessments.js
+++ b/api/db/migrations/20160929164549_create_assessments.js
@@ -13,17 +13,11 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20160929172038_create_answers.js
+++ b/api/db/migrations/20160929172038_create_answers.js
@@ -14,17 +14,11 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20161221143039_create_scenarios.js
+++ b/api/db/migrations/20161221143039_create_scenarios.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'scenarios';
 
 exports.up = function(knex) {
-  
+
   function table(t) {
 
     t.increments().primary();
@@ -13,18 +13,12 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 
 };
 
 exports.down = function(knex) {
-  
+
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20170125155825_followers.js
+++ b/api/db/migrations/20170125155825_followers.js
@@ -11,17 +11,11 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20170207091544_create_feedbacks.js
+++ b/api/db/migrations/20170207091544_create_feedbacks.js
@@ -14,17 +14,11 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20170724181108_creating_organizations.js
+++ b/api/db/migrations/20170724181108_creating_organizations.js
@@ -11,10 +11,8 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable('organizations', table)
-    .then(() => {
-      console.log('organizations table is created!');
-    });};
+    .createTable('organizations', table);
+};
 
 exports.down = function(knex) {
   return knex.schema.dropTable('organizations');

--- a/api/db/migrations/20170818115953_snapshots.js
+++ b/api/db/migrations/20170818115953_snapshots.js
@@ -13,16 +13,10 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20170919181249_reset-password-demands.js
+++ b/api/db/migrations/20170919181249_reset-password-demands.js
@@ -12,16 +12,10 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20171023183134_skills.js
+++ b/api/db/migrations/20171023183134_skills.js
@@ -11,16 +11,10 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20171113101130_certification-courses.js
+++ b/api/db/migrations/20171113101130_certification-courses.js
@@ -8,16 +8,10 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20171113101244_certification-challenges.js
+++ b/api/db/migrations/20171113101244_certification-challenges.js
@@ -12,16 +12,10 @@ exports.up = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180109174844_create_mark_table.js
+++ b/api/db/migrations/20180109174844_create_mark_table.js
@@ -9,16 +9,10 @@ exports.up = (knex) => {
       t.text('area_code').notNull();
       t.text('competence_code').notNull();
       t.integer('assessmentId').unsigned().references('assessments.id');
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180131153634_create_sessions_table.js
+++ b/api/db/migrations/20180131153634_create_sessions_table.js
@@ -16,18 +16,12 @@ exports.up = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 
 };
 
 exports.down = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180212111049_delete_scenario_table.js
+++ b/api/db/migrations/20180212111049_delete_scenario_table.js
@@ -3,10 +3,7 @@ const TABLE_NAME = 'scenarios';
 exports.up = function(knex) {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };
 
 exports.down = function(knex) {
@@ -22,9 +19,6 @@ exports.down = function(knex) {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 
 };

--- a/api/db/migrations/20180405100236_move_status_from_certification_to_assessment.js
+++ b/api/db/migrations/20180405100236_move_status_from_certification_to_assessment.js
@@ -45,7 +45,6 @@ exports.up = function(knex) {
       return knex.schema.table(TABLE_NAME_CERTIFICATION, function(table) {
         table.dropColumn('status');
         table.dropColumn('rejectionReason');
-        console.log('Column Status moved from Certification to Assessments');
       });
     });
 };
@@ -76,8 +75,6 @@ exports.down = function(knex) {
   }).then(() => {
     return knex.schema.table(TABLE_NAME_ASSESSMENTS, function(table) {
       table.dropColumn('state');
-
-      console.log('Column Status moved from Assessments to Certifications');
     });
   });
 };

--- a/api/db/migrations/20180405100345_create_assessment_results_table.js
+++ b/api/db/migrations/20180405100345_create_assessment_results_table.js
@@ -15,16 +15,10 @@ exports.up = (knex) => {
       t.integer('juryId').unsigned().references('users.id');
       t.integer('assessmentId').unsigned().references('assessments.id');
       t.index('assessmentId');
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180405100530_link_marks_to_assessment_results.js
+++ b/api/db/migrations/20180405100530_link_marks_to_assessment_results.js
@@ -26,6 +26,5 @@ exports.up = function(knex) {
 exports.down = function(knex) {
   return knex.schema.table(TABLE_NAME_MARKS, function(table) {
     table.dropColumn('assessmentResultId');
-    console.log('Column assessmentResultId remove from Marks');
   });
 };

--- a/api/db/migrations/20180405100632_create_table_competences-marks.js
+++ b/api/db/migrations/20180405100632_create_table_competences-marks.js
@@ -11,16 +11,10 @@ exports.up = (knex) => {
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
       t.integer('assessmentResultId').unsigned().references('assessment-results.id');
       t.index('assessmentResultId');
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180405100655_migrate_old_marks_in_competence-marks.js
+++ b/api/db/migrations/20180405100655_migrate_old_marks_in_competence-marks.js
@@ -21,10 +21,7 @@ exports.up = function(knex) {
           });
       });
 
-    }).then(() => knex.schema.dropTable(TABLE_NAME_MARKS))
-    .then(() => {
-      console.log(`${TABLE_NAME_MARKS} table was dropped!`);
-    });
+    }).then(() => knex.schema.dropTable(TABLE_NAME_MARKS));
 };
 
 exports.down = function(knex) {

--- a/api/db/migrations/20180620161732_create_campaigns.js
+++ b/api/db/migrations/20180620161732_create_campaigns.js
@@ -9,16 +9,10 @@ exports.up = (knex) => {
       t.integer('organizationId').unsigned().references('organizations.id').index();
       t.integer('creatorId').unsigned().references('users.id');
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180711173105_create_knowledge-elements.js
+++ b/api/db/migrations/20180711173105_create_knowledge-elements.js
@@ -12,16 +12,10 @@ exports.up = (knex) => {
       table.integer('answerId').unsigned().references('answers.id').index();
       table.integer('assessmentId').unsigned().references('assessments.id').index();
       table.string('skillId').index();
-    })
-    .then(() => {
-      console.log(`${KNOWLEDGE_ELEMENTS_TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(KNOWLEDGE_ELEMENTS_TABLE_NAME)
-    .then(() => {
-      console.log(`${KNOWLEDGE_ELEMENTS_TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(KNOWLEDGE_ELEMENTS_TABLE_NAME);
 };

--- a/api/db/migrations/20180730120109_create_campaign_participations_table.js
+++ b/api/db/migrations/20180730120109_create_campaign_participations_table.js
@@ -7,16 +7,10 @@ exports.up = (knex) => {
       t.integer('campaignId').unsigned().references('campaigns.id').index();
       t.integer('assessmentId').unsigned().references('assessments.id').index();
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20180731102046_create_target_profiles_table.js
+++ b/api/db/migrations/20180731102046_create_target_profiles_table.js
@@ -12,18 +12,12 @@ exports.up = function(knex) {
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
     })
     .then(() => {
-      console.log(`${TABLE_NAME_TARGET_PROFILES} table is created!`);
-    })
-    .then(() => {
       return knex.schema
         .createTable(TABLE_NAME_TARGET_PROFILES_SKILLS, (t) => {
           t.increments().primary();
           t.integer('targetProfileId').unsigned().references('target-profiles.id').index();
           t.string('skillId').notNullable();
         });
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME_TARGET_PROFILES_SKILLS} table is created!`);
     })
     .then(() => {
       return knex.schema.table(TABLE_NAME_CAMPAIGNS, function(table) {
@@ -40,12 +34,6 @@ exports.down = function(knex) {
       return knex.schema.dropTable(TABLE_NAME_TARGET_PROFILES_SKILLS);
     })
     .then(() => {
-      console.log(`${TABLE_NAME_TARGET_PROFILES_SKILLS} table was dropped!`);
-    })
-    .then(() => {
       return knex.schema.dropTable(TABLE_NAME_TARGET_PROFILES);
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME_TARGET_PROFILES} table was dropped!`);
     });
 };

--- a/api/db/migrations/20181001172308_create_target_profile_shares.js
+++ b/api/db/migrations/20181001172308_create_target_profile_shares.js
@@ -7,16 +7,10 @@ exports.up = (knex) => {
       t.integer('targetProfileId').unsigned().references('target-profiles.id').index();
       t.integer('organizationId').unsigned().references('organizations.id').index();
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20181017163633_delete-followers.js
+++ b/api/db/migrations/20181017163633_delete-followers.js
@@ -3,10 +3,7 @@ const TABLE_NAME = 'followers';
 exports.up = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };
 
 exports.down = (knex) => {
@@ -20,9 +17,6 @@ exports.down = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 

--- a/api/db/migrations/20190115155237_create_certification_center_table.js
+++ b/api/db/migrations/20190115155237_create_certification_center_table.js
@@ -6,16 +6,10 @@ exports.up = (knex) => {
       t.increments().primary();
       t.string('name').notNullable();
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20190206150018_delete_skills_table.js
+++ b/api/db/migrations/20190206150018_delete_skills_table.js
@@ -3,10 +3,7 @@ const TABLE_NAME = 'skills';
 exports.up = (knex) => {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };
 
 exports.down = (knex) => {
@@ -21,9 +18,6 @@ exports.down = (knex) => {
   }
 
   return knex.schema
-    .createTable(TABLE_NAME, table)
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
-    });
+    .createTable(TABLE_NAME, table);
 };
 

--- a/api/db/migrations/20190405155259_create_competence_evaluations_table.js
+++ b/api/db/migrations/20190405155259_create_competence_evaluations_table.js
@@ -9,16 +9,10 @@ exports.up = (knex) => {
       t.string('competenceId').index();
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
       t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = (knex) => {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20190729162546_create_table_students.js
+++ b/api/db/migrations/20190729162546_create_table_students.js
@@ -11,17 +11,11 @@ exports.up = function(knex) {
       t.date('birthdate').notNullable();
       t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
       t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = function(knex) {
 
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20190910165023_create_organization_invitations_table.js
+++ b/api/db/migrations/20190910165023_create_organization_invitations_table.js
@@ -9,16 +9,10 @@ exports.up = function(knex) {
       table.string('status').notNullable();
       table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
       table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
-    })
-    .then(() => {
-      console.log(`${TABLE_NAME} table is created!`);
     });
 };
 
 exports.down = function(knex) {
   return knex.schema
-    .dropTable(TABLE_NAME)
-    .then(() => {
-      console.log(`${TABLE_NAME} table was dropped!`);
-    });
+    .dropTable(TABLE_NAME);
 };

--- a/api/db/migrations/20200212135345_fix_indexes_on_table_campaign-participations.js
+++ b/api/db/migrations/20200212135345_fix_indexes_on_table_campaign-participations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'campaign-participations';
+const CAMPAIGNID_COLUMN = 'campaignId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(CAMPAIGNID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(CAMPAIGNID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212135819_fix_indexes_on_table_certification-candidates.js
+++ b/api/db/migrations/20200212135819_fix_indexes_on_table_certification-candidates.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-candidates';
+const SESSIONID_COLUMN = 'sessionId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(SESSIONID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(SESSIONID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212140202_fix_indexes_on_table_certification-center-memberships.js
+++ b/api/db/migrations/20200212140202_fix_indexes_on_table_certification-center-memberships.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'certification-center-memberships';
+const USERID_COLUMN = 'userId';
+const CERTIFICATIONCENTERID_COLUMN = 'certificationCenterId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(USERID_COLUMN);
+    table.dropIndex(CERTIFICATIONCENTERID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(USERID_COLUMN);
+    table.index(CERTIFICATIONCENTERID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212140810_fix_indexes_on_table_competence-evaluations.js
+++ b/api/db/migrations/20200212140810_fix_indexes_on_table_competence-evaluations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'competence-evaluations';
+const COMPETENCEID_COLUMN = 'competenceId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(COMPETENCEID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(COMPETENCEID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212141121_fix_indexes_on_table_knowledge-elements.js
+++ b/api/db/migrations/20200212141121_fix_indexes_on_table_knowledge-elements.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'knowledge-elements';
+const SKILLID_COLUMN = 'skillId';
+const ANSWERID_COLUMN = 'answerId';
+const ASSESSMENTID_COLUMN = 'assessmentId';
+const COMPETENCEID_COLUMN = 'competenceId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(SKILLID_COLUMN);
+    table.dropIndex(ANSWERID_COLUMN);
+    table.dropIndex(ASSESSMENTID_COLUMN);
+    table.dropIndex(COMPETENCEID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(SKILLID_COLUMN);
+    table.index(ANSWERID_COLUMN);
+    table.index(ASSESSMENTID_COLUMN);
+    table.index(COMPETENCEID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
+++ b/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'memberships';
+const USERID_COLUMN = 'userId';
+const ORGANIZATIONID_COLUMN = 'organizationId';
+const OLD_INDEX_USERID = 'organizations_accesses_userid_index';
+const OLD_INDEX_ORGANIZATIONID = 'organizations_accesses_organizationid_index';
+
+exports.up = async function(knex) {
+  await knex.raw(`DROP INDEX IF EXISTS ${OLD_INDEX_USERID}`);
+  await knex.raw(`DROP INDEX IF EXISTS ${OLD_INDEX_ORGANIZATIONID}`);
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(ORGANIZATIONID_COLUMN);
+  });
+};
+
+exports.down = async function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(ORGANIZATIONID_COLUMN);
+    table.index(USERID_COLUMN, OLD_INDEX_USERID);
+    table.index(ORGANIZATIONID_COLUMN, OLD_INDEX_ORGANIZATIONID);
+  });
+};

--- a/api/db/migrations/20200212141646_fix_indexes_on_table_organizations.js
+++ b/api/db/migrations/20200212141646_fix_indexes_on_table_organizations.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'organizations';
+const USERID_COLUMN = 'userId';
+const PROVINCECODE_COLUMN = 'provinceCode';
+const EXTERNALID_COLUMN = 'externalId';
+const CODE_COLUMN = 'code';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(USERID_COLUMN);
+    table.dropIndex(PROVINCECODE_COLUMN);
+    table.dropIndex(EXTERNALID_COLUMN);
+    table.index(CODE_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(USERID_COLUMN);
+    table.index(PROVINCECODE_COLUMN);
+    table.index(EXTERNALID_COLUMN);
+    table.dropIndex(CODE_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212142949_fix_indexes_on_table_sessions.js
+++ b/api/db/migrations/20200212142949_fix_indexes_on_table_sessions.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const ACCESSCODE_COLUMN = 'accessCode';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(ACCESSCODE_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(ACCESSCODE_COLUMN);
+  });
+};

--- a/api/db/migrations/20200212143352_fix_indexes_on_table_students.js
+++ b/api/db/migrations/20200212143352_fix_indexes_on_table_students.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'students';
+const USERID_COLUMN = 'userId';
+const ORGANIZATIONID_COLUMN = 'organizationId';
+const NATIONALSTUDENTID_COLUMN = 'nationalStudentId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(NATIONALSTUDENTID_COLUMN);
+    table.dropIndex(ORGANIZATIONID_COLUMN);
+    table.dropIndex(USERID_COLUMN);
+    table.dropUnique([NATIONALSTUDENTID_COLUMN, ORGANIZATIONID_COLUMN]);
+    table.unique([ORGANIZATIONID_COLUMN, NATIONALSTUDENTID_COLUMN]);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(NATIONALSTUDENTID_COLUMN);
+    table.index(ORGANIZATIONID_COLUMN);
+    table.index(USERID_COLUMN);
+    table.unique([NATIONALSTUDENTID_COLUMN, ORGANIZATIONID_COLUMN]);
+    table.dropUnique([ORGANIZATIONID_COLUMN, NATIONALSTUDENTID_COLUMN]);
+  });
+};

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -73,13 +73,6 @@ module.exports = {
       .then(_toDomain);
   },
 
-  findByChallenge(challengeId) {
-    return BookshelfAnswer
-      .where({ challengeId })
-      .fetchAll()
-      .then((answers) => answers.models.map(_toDomain));
-  },
-
   findChallengeIdsFromAnswerIds(answerIds) {
     return Bookshelf.knex('answers')
       .distinct('challengeId')

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -32,14 +32,6 @@ module.exports = {
       .then(_toDomain);
   },
 
-  findByAssessmentId(assessmentId) {
-    return BookshelfKnowledgeElement
-      .where({ assessmentId })
-      .fetchAll()
-      .then(_toDomain)
-      .then(_dropResetKnowledgeElements);
-  },
-
   findUniqByUserId({ userId, limitDate }) {
     return BookshelfKnowledgeElement
       .query((qb) => {

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -85,38 +85,6 @@ describe('Integration | Repository | AnswerRepository', () => {
     });
   });
 
-  describe('#findByChallenge', () => {
-
-    beforeEach(() => {
-      _.each([
-        { value: '1,2', challengeId, assessmentId, }, // nominal case
-        { value: '1', challengeId, assessmentId: otherAssessmentId, }, // same challenge different assessment
-        { value: '1,2,3', challengeId: otherChallengeId, assessmentId: otherAssessmentId, }, //different challenge different assessment
-      ], (answer) => (databaseBuilder.factory.buildAnswer(answer)));
-      return databaseBuilder.commit();
-    });
-
-    it('should find all answers by challenge id', () => {
-      // when
-      const promise = AnswerRepository.findByChallenge('challenge_1234');
-
-      // then
-      return promise.then((foundAnswers) => {
-
-        expect(foundAnswers).to.exist;
-
-        expect(foundAnswers).to.have.length.of(2);
-
-        const values = _.map(foundAnswers, 'value');
-        expect(values).to.include.members(['1', '1,2']);
-
-        const challengeIds = _.map(foundAnswers, 'challengeId');
-        expect(challengeIds).to.include(challengeId);
-        expect(challengeIds).to.not.include(otherChallengeId);
-      });
-    });
-  });
-
   describe('#findChallengeIdsFromAnswerIds', () => {
     it('should return a list of corresponding challenge ids', async () => {
       // given

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -68,45 +68,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     });
   });
 
-  describe('#findByAssessmentId', () => {
-
-    let knowledgeElementsWanted;
-    let assessmentId;
-
-    beforeEach(async () => {
-      // given
-      assessmentId = databaseBuilder.factory.buildAssessment().id;
-      const assessmentIdOther = databaseBuilder.factory.buildAssessment().id;
-      const answer1Id = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
-      const answer2Id = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
-      const answer3Id = databaseBuilder.factory.buildAnswer({ assessmentId: assessmentIdOther }).id;
-
-      knowledgeElementsWanted = [
-        databaseBuilder.factory.buildKnowledgeElement({
-          assessmentId,
-          answerId: answer1Id,
-        }),
-        databaseBuilder.factory.buildKnowledgeElement({
-          assessmentId,
-          answerId: answer2Id,
-        })
-      ];
-      databaseBuilder.factory.buildKnowledgeElement({
-        assessmentId: assessmentIdOther,
-        answerId: answer3Id
-      });
-      await databaseBuilder.commit();
-    });
-
-    it('should find the knowledge elements associated with a given assessment', async () => {
-      // when
-      const knowledgeElementsFound = await KnowledgeElementRepository.findByAssessmentId(assessmentId);
-
-      expect(knowledgeElementsFound).have.lengthOf(2);
-      expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
-    });
-  });
-
   describe('#findUniqByUserId', () => {
 
     const today = new Date('2018-08-01T12:34:56Z');


### PR DESCRIPTION
# Étude et actions sur les index dans la base de données
## TL;DR
Voici un tableau résumant l'ensemble des ajouts/suppressions/modifications des index par table de la base de données :

TABLE / INDEX | Ajout | Suppression | Modification
------------ | ------------- | ------------- | -------------
`ANSWERS` | - | 2 | -
`CAMPAIGN-PARTICIPATIONS` | - | 1 | -
`CERTIFICATION-CANDIDATES` | - | 1 | -
`CERTIFICATION-CENTER-MEMBERSHIPS` | - | 2 | -
`COMPETENCE-EVALUATIONS` | - | 1 | -
`KNOWLEDGE-ELEMENTS` | - | 4 | -
`MEMBERSHIPS` | - | 2 | -
`ORGANIZATIONS` | 1 | 3 | -
`SESSIONS` | 1 | - | -
`STUDENTS` | - | 3 | 1
**_TOTAL_** | 2 | 18 | 1

## Introduction
Il existe une multitude d'axes de réflexion lorsqu'on souhaite améliorer les performances d'une base de données. La plupart d'entre eux nécessitent des connaissances avancées sur le fonctionnement d'une base de données, que seul un expert en SGBD peut détenir. En revanche, l'indexation **DOIT** être le travail des développeurs (et c'est complètement à leur portée) :

> l’information la plus importante pour une bonne indexation ne se situe ni au niveau de la configuration du système de stockage ni dans la configuration du matériel, mais plutôt au niveau de l'application : « comment l'application cherche ses données ». Cette information n'est pas facilement accessible aux administrateurs de bases de données ou aux consultants externes. Il est parfois nécessaire de récupérer cette information en surveillant l'application. Par contre, les développeurs ont cette information facilement. 
> 
> Markus Winand  
> 
> Livre: SQL Performance Explained: Everything Developers Need to Know about SQL Performance

### *Mais pourquoi c’est grave d’avoir des index inefficaces/inutiles ?* 
Les index constituent des redondances de données. Ce sont des copies d'enregistrements de tables, classées de sorte à pouvoir, dans le cadre de formulation de requête spécifique, retrouver rapidement un enregistrement.

Qui dit copie dit devoir maintenir la cohérence des données. Donc l’ensemble des copies doit être mis à jour à chaque insertion, mise à jour ou suppression dans la base de données. Cela peut devenir très coûteux et prendre beaucoup de place (en espace ET en temps) si c’est fait à la va-vite.

Illustration de l’impact du nombre d’index sur la durée d’exécution d’une requête d'insertion :
![index_time_consuming (1)](https://user-images.githubusercontent.com/48727874/74648907-d2a55080-517e-11ea-9702-7542405346d8.jpg)

### *Objectifs de l'étude*
* Identification des index en doublon
* Identification + décision sur les des index inutilisés
* Identification d'index à ajouter

## Préparation
### Les bases de données
* La base de données de production va être consultée **EN LECTURE SEULE**. Scalingo a activé le module **_pg_stat_statement_** sur l'addon PostgreSQL, ce qui veut dire que des statistiques sont enregistrées dans la table en permanence (et ça va nous être bien utile !)
* La base de données de réplication de la production va nous servir de terrain de jeu de test des index
### Les requêtes
Voici la liste des requêtes qui vont nous être utiles lors de cette étude. A chaque fois je vous présente un extrait du résultat de la requête.

**_Liste simple des index existants dans la base de données :_** 
```
SELECT tablename, indexname, indexdef
FROM pg_indexes
WHERE schemaname = 'public'
ORDER BY tablename, indexname
```
![extract_index_list](https://user-images.githubusercontent.com/48727874/74649521-08970480-5180-11ea-9973-ec1bdfbea23c.png)


**_Liste des X requêtes les plus lentes en moyenne exécutées dans la base de données (on exclut les requête appelées moins de 100 fois) :_**
```
SELECT (total_time / 1000 / 60) as total_in_minutes, (total_time/calls) as avg_in_millisecs, query 
FROM pg_stat_statements 
WHERE calls > 100
ORDER BY avg_in_millisecs DESC 
LIMIT X;
```
![extract_time_queries](https://user-images.githubusercontent.com/48727874/74649680-53188100-5180-11ea-9f44-dc89ecc94faa.png)


**_Informations sur les index par table, leur taille respective, la taille de la table à laquelle ils appartiennent et le taux d’utilisation de ces index :_**
```
SELECT
    t.tablename,
    indexname,
    c.reltuples AS num_rows,
    pg_size_pretty(pg_relation_size(quote_ident(t.schemaname)::text || '.' || quote_ident(t.tablename)::text)) AS table_size,
    pg_size_pretty(pg_relation_size(quote_ident(t.schemaname)::text || '.' || quote_ident(indexrelname)::text)) AS index_size,
    CASE WHEN indisunique THEN 'Y'
        ELSE 'N'
    END AS UNIQUE,
    number_of_scans,
    tuples_read,
    tuples_fetched
FROM pg_tables t
LEFT OUTER JOIN pg_class c ON t.tablename = c.relname
LEFT OUTER JOIN (
    SELECT
        c.relname AS ctablename,
        ipg.relname AS indexname,
        x.indnatts AS number_of_columns,
        idx_scan AS number_of_scans,
        idx_tup_read AS tuples_read,
        idx_tup_fetch AS tuples_fetched,
        indexrelname,
        indisunique,
        schemaname
    FROM pg_index x
    JOIN pg_class c ON c.oid = x.indrelid
    JOIN pg_class ipg ON ipg.oid = x.indexrelid
    JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid
) AS foo ON t.tablename = foo.ctablename AND t.schemaname = foo.schemaname
WHERE t.schemaname NOT IN ('pg_catalog', 'information_schema')
ORDER BY tablename,number_of_scans;
```
![extract_full_info](https://user-images.githubusercontent.com/48727874/74649869-bc988f80-5180-11ea-9cd0-0b28aab966fa.png)


**_Consulter le plan d’exécution d’une requête : ATTENTION, L’AJOUT D’ANALYZE EXÉCUTE VRAIMENT LA REQUÊTE, GARE AUX INSERT/UPDATE/DELETE, à faire sur le base de réplication_**
`EXPLAIN [ANALYZE] <INSERT_QUERY>`
![extract_explain](https://user-images.githubusercontent.com/48727874/74650036-1bf69f80-5181-11ea-8628-15f7ab0a37d4.png)

## Identifier les index en doublon
### Méthodologie
1. Identifier un doublon
2. Vérifier le ou lesquels vient/viennent d'une migration (ou pas)
3. Corriger le doublon
  - Dans le cas où un des deux est issu d’une migration, conserver celui de la migration et supprimer l’autre
  - Dans le cas où aucun des deux n’est issu d’une migration, supprimer les deux index et créer une migration pour le créer en un seul exemplaire “officiellement”
  - Dans le cas où les deux sont issus d’une migration, en choisir un (selon le critère d’uniformisation de nommage par exemple) à supprimer
**_NOTE :_** Si l'index à supprimer vient d'une migration, faire une migration pour le supprimer, sinon le supprimer directement dans la base de données.

**Code pour créer et supprimer des index**
```
# JAVASCRIPT
// Cas de suppression d'un index
await knex.schema.table(TABLE_NAME, function(table) {
    table.dropIndex(COLUMN_NAME);
});
// Cas de suppression d'un index composite
await knex.schema.table(TABLE_NAME, function(table) {
  table.dropIndex([COL_A, COL_B]);
});

// Cas de création d'un index
await knex.schema.table(TABLE_NAME, function(table) {
  table.index(COLUMN_NAME);
});
// Cas de création d'un index composite
await knex.schema.table(TABLE_NAME, function(table) {
  table.index([COL_A, COL_B]);
});

# SQL
DROP INDEX <index_name>;
```
### Résultats
Un doublon identifié dans la table `answers`
![dup_answers](https://user-images.githubusercontent.com/48727874/74650540-41d07400-5182-11ea-9b6b-fff78e5fefb0.png)

**_ACTION :_** Supprimer _index_answers_assessmentid_ en base de données directement, car cet index n'a pas été crée via migration.

## Relecture et correction de l'existant
### Méthodologie 
Le moteur qui exécute une requête a plusieurs raisons de décider d'utiliser un index ou pas. Nous allons nous concentrer sur les deux raisons les plus "simples" :
* Les clauses `WHERE`
* Les jointures

Pour chaque index, nous allons identifier si, effectivement, la colonne indexée est bien mentionnée dans une clause `WHERE` ou dans une jointure. Et si c'est le cas, nous allons consulter ses statistiques d'usage voir si c'est cohérent.
Pour consulter les requêtes mentionnant la colonne recherchée, deux sources d'informations :
* Les repositories
* La requête donnée plus haut qui permet de lister les requêtes exécutées dans la base de données dans l'ordre de temps d'exécution moyen. En mettant une limite élevée, on peut presque obtenir l'ensemble des requêtes exécutées dans la base

**_Note :_** Lors de la création d'une table, un index est automatiquement crée sur la colonne de clé primaire. Nous allons volontairement ignorer ce genre d'index pour chaque table dans cette étude.

Nous allons essayer de faire une lecture croisée de l'ensemble de ces informations :
1. Dans le cas d'un index à la fois peu ou pas utilisé, mais aussi portant sur une colonne laquelle ne semble pas apparaître dans les clauses `WHERE` ou `JOIN`, on peut le supprimer.
2. Dans le cas d’un index peu utilisé mais sur une colonne pour laquelle cela pourrait être bénéfique, alors il s’agit peut-être de plusieurs index qui se télescopent entre eux. Plus généralement, on va chercher à éviter la redondance d’index. Voici un exemple d’index redondants :
```
// Single index
CREATE INDEX colA_index ON public.mytable USING btree ("colA")
// Composite index
CREATE INDEX colA_colB_index ON public.mytable USING btree ("colA","colB")
```
Ici, le premier index est clairement redondant et pas nécessaire. Dans le cas de requêtes où la colonne **colA** apparaît dans une clause `WHERE` SANS la **colB**, l’index composite va être choisi à l’exécution.

**_ATTENTION_** : si l’index composite avait été le suivant :

`CREATE INDEX colB_colA_index ON public.mytable USING btree ("colB","colA")`

les choses auraient été un peu différentes. En effet, l’ordre des colonnes dans la déclaration d’index composite est très important. Un tel index ne pourrait être utilisé dans une requête pour laquelle la colonne **colA** apparaît dans une clause `WHERE` SANS la **colB**.

Les index composites sont donc à déterminer avec intelligence !

Pour chaque index remplacé par un autre, s’assurer que ce dernier est utilisé dans le plan d’exécution. Pour cela, on peut faire les commandes à la main dans la base de réplication (au pire, c’est revenu le lendemain comme avant ;p).

## Résultats
### Table ANSWERS
![index_answers](https://user-images.githubusercontent.com/48727874/74659510-c4622f00-5194-11ea-8bd5-b9d6a540d616.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `assessmentId`
* `challengeId AND assessmentId`
**_Constat n°1 :_**   il existe des requêtes avec une clause `WHERE` portant sur le `challengeId`, pourquoi l’index sur cette colonne n’est-il jamais utilisé ?
La réponse est ici :
![why_answers](https://user-images.githubusercontent.com/48727874/74659692-173be680-5195-11ea-9b0d-83589cc77c07.png)
Pour cette requête, l’index portant sur la colonne `assessmentId` est utilisé, car il est le plus discriminant. Puis, le moteur estime ne pas avoir besoin d’utiliser l’index sur la colonne `challengeId`, car le reste des résultats est suffisamment petit. Et quand on y pense, ça a du sens. Pour un _assessment_ donné, il n’existe, dans les faits, pas plus d’une centaine de réponses.
**_ACTION :_** Supprimer l'index sur la colonne `challengeId`
### Table ASSESSMENT-RESULTS
Rien à signaler, il n’existe qu’un index sur la colonne `assessmentId` qui est largement utilisé. Donc on le laisse là où il est !
### Table ASSESSMENTS
J'ai besoin d'aide pour cette table, j'ai l'impression qu'il y a encore pas mal de code v1 qui traîne et ça m'empêche de tirer les bonnes conclusions. On peut reporter le traitement de cette table à plus tard.
### Table CAMPAIGN-PARTICIPATIONS
![index_campparti](https://user-images.githubusercontent.com/48727874/74660255-12c3fd80-5196-11ea-8b0b-15c2cef2c86f.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `userId`
* `campaignId`
**_Constat n°1 :_**   On détecte une redondance dans les index. Typiquement, les index _campaign_participations_campaignid_index_ et _campaign_participations_campaignid_userid_unique_ servent tous les deux sur des requêtes où la colonne `campaignId` se trouve dans des clauses `WHERE` ou des jointures.
**_ACTION :_** On peut supprimer l’index portant seulement sur la colonne `campaignId`, car l’index composite sur `campaignId` et `userId` va le remplacer sans problème.
### Table CAMPAIGNS
![index_camp](https://user-images.githubusercontent.com/48727874/74660397-5a4a8980-5196-11ea-99f9-af87ac182e04.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `code`
* `organizationId`
* `targetProfileId`
Rien à signaler.
### Table CERTIFICATION-CANDIDATES
![index_ccand](https://user-images.githubusercontent.com/48727874/74660482-81a15680-5196-11ea-9699-e5d5187c8709.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `sessionId AND userId`
* `sessionId AND LOWER(firstName) AND LOWER(lastName) AND birthdate`
* `userId`
**_Constat n°1 :_**   On détecte une redondance dans les index. Typiquement, les index _certification_candidate_sessionid_index_ et _certification_candidate_sessionid_userid_unique_ servent tous les deux sur des requêtes où la colonne `sessionId` se trouve dans des clauses `WHERE` ou des jointures.
**_Constat n°2 :_**   On pourrait se dire qu’il serait possible d’améliorer les performances sur les requêtes avec un `WHERE` contenant `sessionId AND LOWER(firstName) AND LOWER(lastName) AND birthdate` en ajoutant un index sur `LOWER(firstName)` par exemple. Il y a fort à parier que dans les faits, cet index risque de ne jamais être utilisé. En effet, chercher la liste des candidats avec comme critère l’id de la session est suffisamment discriminant.
**_ACTION :_** On peut supprimer l’index portant seulement sur la colonne `sessionId`, car l’index composite sur `sessionId` et `userId` va le remplacer sans problème.
### Table CERTIFICATION-CENTER-MEMBERSHIPS
![index_ccenmem](https://user-images.githubusercontent.com/48727874/74660692-eeb4ec00-5196-11ea-9358-8c22185e1b4f.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `userId`
* `userId AND certificationCenterId`
**_Constat n°1 :_**   On détecte une redondance dans les index. Typiquement, les index _certification_center_memberships_userid_index_ et _certification_center_memberships_userid_certificationcenterid_unique_ servent tous les deux sur des requêtes où la colonne `userId` se trouve dans des clauses `WHERE` ou des jointures
**_Constat n°2 :_**   L’index sur la colonne `certificationCenterId` est très peu utilisé car il n’existe pas de requête dont le prédicat contient cette colonne (sauf avec `userId`, mais on a déjà un index dessus)
**_ACTION :_** On peut supprimer l’index portant seulement sur la colonne `userId`, car l’index composite sur `userId` et `certificationCenterId` va le remplacer sans problème. On peut également supprimer l’index portant sur la colonne `certificationCenterId` car il est inutile (pour le moment !).
### Table CERTIFICATION-CENTERS
RIen à signaler, il n’existe aucun index sur cette table, et elle n’en a pas besoin
### Table CERTIFICATION-CHALLENGES
Rien à signaler, il n’existe qu’un index sur la colonne `courseId` qui est largement utilisé. Donc on le laisse là où il est !
### Table CERTIFICATION-COURSES
![index_ccourse](https://user-images.githubusercontent.com/48727874/74661005-73a00580-5197-11ea-9b9d-012a4b170a3e.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `sessionId`
* `userId`
* `sessionId AND userId`
Rien à signaler
### Table COMPETENCE-EVALUATIONS
![index_compeval](https://user-images.githubusercontent.com/48727874/74661095-95998800-5197-11ea-992d-52ce00a28d13.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `assessmentId`
* `userId`
* `userId AND competenceId`
**_Constat n°1 :_**  On détecte un index non utilisé, _competence_evaluations_competenceid_index_. Pas étonnant pour deux raisons :
* La colonne concernée par l’index n’est pas une colonne impliqué seule dans une requête. On voit que cette colonne, `competenceId`, est par contre présente dans des requête en compagnie de la colonne `userId`. De toute évidence, c’est l’index sur la colonne `userId` qui est utilisé.
* La colonne `competenceId` n’est de toute façon pas suffisamment discriminante. Rappelons-nous qu’il n’existe que 16 compétences dans **Pix**, donc il est fort probable que le moteur estime l’efficacité de cet index proche de nulle.
**_ACTION :_** On peut supprimer l’index portant seulement sur la colonne `competenceId`
### Table COMPETENCE-MARKS
Rien à signaler, il n’existe qu’un index sur la colonne `assessmentResultId` qui est largement utilisé. Donc on le laisse là où il est !
### Table FEEDBACKS
TODO
### Table KNOWLEDGE-ELEMENTS
![index_knoel](https://user-images.githubusercontent.com/48727874/74661319-00e35a00-5198-11ea-80d4-26a57d85917f.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `userId`
* `userId AND createdAt`
* `userId AND skillId`
* `userId AND competenceId`
* `assessmentId` (méthode de répo jamais utilisée dans le code)
**_Constat n°1 :_** On détecte trois index non utilisés (ou très très peu), _knowledge_elements_skillid_index_,  _knowledge_elements_answerid_index_ et _knowledge_elements_competenceid_index_. Celui sur la colonne `answerId`, c’est simplement qu’il n’existe de toute façon aucune requête ayant besoin d’une recherche sur cette colonne. Quant à la colonne `skillId`, cela s’explique par la puissance de discrimination de cet index. Dans la requête où les colonnes `skillId` et `userId` sont sollicités, le moteur choisit d’utiliser l’index sur `userId` qui est très discriminant, et le reste des lignes à parcourir est suffisamment petit pour ne pas avoir à se servir de l’index sur `skillId`. Même explication pour l’index sur la colonne `competenceId`.
**_Constat n°2 :_** On détecte un index “périmé” grâce au code. En effet, la méthode de repository utilisant la colonne `assessmentId` dans la clause `WHERE` n’est plus utilisée.
**_ACTION :_** On peut supprimer les index portant sur les colonnes `skillId`, `answerId`, `competenceId` et `assessmentId`.
### Table MEMBERSHIPS  (@lisequesnel on pourrait renommer cette table dans pas longtemps ? :( )
![index_member](https://user-images.githubusercontent.com/48727874/74661513-66374b00-5198-11ea-92f6-415c64e271bd.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `organizationId`
* `userId`
* `organizationId AND userId`
**_Constat n°1 :_** On détecte une redondance dans les index. Typiquement, les index _organizations_accesses_userId_index_ et _memberships_userid_organizationid_unique_ servent tous les deux sur des requêtes où la colonne `userId` se trouve dans des clauses `WHERE` ou des jointures.
**_ACTION :_** On peut supprimer l’index portant seulement sur la colonne `userId`, car l’index composite sur `userId` et `organizationId` va le remplacer sans problème.
### Table ORGANIZATION-INVITATIONS
Rien à signaler, il n’existe qu’un index sur la colonne `organizationId` qui est largement utilisé. Donc on le laisse là où il est !
### Table ORGANIZATIONS
![index_orga](https://user-images.githubusercontent.com/48727874/74661783-ec539180-5198-11ea-9405-2ed280202273.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `LOWER(name) LIKE`
* `code`
* `userId` (pour la vérif d'autorisation pour l'export snapshot)
* `externalId` (méthode de répo jamais utilisée dans le code)
**_Constat n°1 :_** On remarque que désormais AUCUN des index existants sur la table n’est pertinent. La fonctionnalité d’export des snapshots pour laquelle est nécessaire la vérification d’autorisation à l’aide de la colonne `userId` n’a pas un usage qui justifie la création d’un tel index (il suffit de voir les statistiques d’utilisation de ce dernier). L’index sur la colonne `externalId` est désormais “périmé” puisque la méthode de répository qui l’utilise n’est, elle, plus utilisée. Il s’agit peut-être de la même explication pour l’index portant sur la colonne `provinceCode`, en tout cas désormais il n’existe aucune requête dans le code qui sollicite cet index, car la colonne est inexistante en clause WHERE ou jointure.
**_Constat n°2 :_** Il existe deux colonnes utilisées dans les clauses de recherche qui malheureusement ne bénéficient pas d’index. C’est peut-être le moment de tester et de voir si il est pertinent d’en ajouter un !
1. **Index sur la colonne code**
Requête :
![req_code_orga](https://user-images.githubusercontent.com/48727874/74662032-6dab2400-5199-11ea-957f-7fc9260e1ceb.png)
Plan actuel :
![req_query_orga_avant](https://user-images.githubusercontent.com/48727874/74662039-71d74180-5199-11ea-959c-f5bff22a2bd1.png)
Seq Scan signifie que la recherche a parcouru l’ensemble des enregistrements de la table l’un après l’autre jusqu'à trouver l’enregistrement recherché. Dans le pire des cas, on fait autant de lectures que d’enregistrements dans la table. On cherche particulièrement à éviter les Seq Scan ! 

Mise en place de l’index + APRES :
```
CREATE INDEX organization_temp_code_idx ON organizations (code);
// Remarque : pas d'index sur un LOWER() de la colonne, il semblerait que,
// dans le code, ce soit toujours en majuscules
```
![req_query_orga_apres_code](https://user-images.githubusercontent.com/48727874/74662046-74399b80-5199-11ea-9bca-448c25d7a173.png)

On peut donc constater une réduction proche de 100% du temps d’exécution de la requête.

1. **Index sur la colonne name**
On peut d’ores et déjà renoncer à implémenter des index “classiques” sur cette colonne, car si l’on regarde le code, cette colonne est recherchée de la manière suivante :

`LOWER("name") LIKE '%MaRecherche%';`

Le problème ici n’est pas tant la mise en minuscules (il suffit de créer un index non pas sur `name` mais sur `LOWER(name)` ), mais la partie `LIKE`. On remarque qu’on utilise des caractères Joker, et plus spécifiquement un dès le début. Ce caractère en tout début de filtre empêche complètement l’usage d’index.
Pour aller plus loin, on pourrait faire un tour du côté du module **pg_trgm** (sûrement après cette étude, car on fait beaucoup (trop) de recherches par filtre avec joker en premier caractère chez **_Pix_** ! )
**_ACTION :_** Suppression des 3 index sur les colonnes `userId`, `provinceCode` et `externalId`, puis ajout d’un index sur la colonne `code`.
### Table PIX_ROLES
Rien à signaler, la table est toute petite !
### Table RESET-PASSWORD-DEMANDS
![index_repasdem](https://user-images.githubusercontent.com/48727874/74662355-12c5fc80-519a-11ea-93d9-bf2f59d5bdcb.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `email`
* `temporaryKey and used=false`
* `email AND temporaryKey AND used=false`
Rien à signaler.
### Table SESSIONS
![index_session](https://user-images.githubusercontent.com/48727874/74662473-456ff500-519a-11ea-9b04-b0000502a0a9.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `certificationCenterId`
* `accessCode`
**_Constat n°1 :_** Un index sur la colonne `accessCode` pourrait peut-être servir.
1. **Index sur la colonne accessCode**
Requête :
![req_sessions](https://user-images.githubusercontent.com/48727874/74662590-82d48280-519a-11ea-9eaa-9251d61621c8.png)
Plan actuel :
![req_session_avant](https://user-images.githubusercontent.com/48727874/74662592-849e4600-519a-11ea-8d3e-9701f1f8d304.png)
Seq Scan signifie que la recherche a parcouru l’ensemble des enregistrements de la table l’un après l’autre jusqu'à trouver l’enregistrement recherché. Dans le pire des cas, on fait autant de lectures que d’enregistrements dans la table. On cherche particulièrement à éviter les Seq Scan ! 

Mise en place de l’index + APRES :
`CREATE INDEX sessions_temp_accesscode_idx ON sessions ("accessCode");`
![req_session_apres](https://user-images.githubusercontent.com/48727874/74662616-8ec04480-519a-11ea-9880-f6b0ccfdb859.png)
On peut donc constater une réduction proche de 100% du temps d’exécution de la requête.
**_ACTION :_** On peut ajouter un index sur la colonne `accessCode`, en prenant garde de :
* S’assurer que la casse soit toujours la même dans la base de données, et qu’on utilise une variable avec la casse déjà appropriée OU
* Si l’on fait subir à notre colonne une transformation dans la requête : `WHERE LOWER(“accessCode”) = $1`, alors il faut créer un index sur la colonne transformée : `CREATE INDEX sessions_temp_accesscode_idx ON sessions (LOWER("accessCode"));`
### Table SNAPSHOTS
TODO
### Table STUDENTS
![index_students](https://user-images.githubusercontent.com/48727874/74663161-90d6d300-519b-11ea-8923-c01b4d3b0031.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `organizationId`
* `organizationId AND birthdate`
* `organizationId AND nationalStudentId`
* `organizationId AND userId`
* `id AND userId IS NULL`
**_Constat n°1 :_** Un index non utilisé (à juste titre), celui portant sur la colonne `nationalStudentId`.
**_Constat n°2 :_** Beaucoup de requêtes contiennent la colonne `organizationId` dans leur clause de recherche. A ce titre, il semble nécessaire d’avoir un index sur cette colonne. Par contre, cette colonne est présente dans 3 index différents. Il y a donc une redondance. Attention toutefois, certaines de ces redondances sont nécessaires car elles renforcent aussi la contrainte d’unicité de la paire de colonnes (les index suffixés par unique). On peut par contre se passer du single index sur la colonne, et éventuellement changer l’index unique sur (`nationalStudentId`, `organizationId`) en (`organizationId`, `nationalStudentId`). En déplaçant la colonne `organizationId` le plus à gauche de l’index, on s’assurer de sa disponibilité pour les autres requêtes.
**_ACTION :_** Suppression de 3 index sur les colonnes `nationalStudentId`, `userId` et `organizationId`, puis inversement de l’index composite unique `nationalStudentId/organizationId`
### Table TARGET-PROFILE-SHARES
![index_targprosh](https://user-images.githubusercontent.com/48727874/74663552-4570f480-519c-11ea-9079-1d088e91d4bd.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `organizationId`
* `targetProfileId`
Rien à signaler
### Table TARGET-PROFILES
Rien à signaler, la table est toute petite !
### Table TARGET-PROFILES_SKILLS
Rien à signaler, il n’existe qu’un index sur la colonne `targetProfileId` qui est largement utilisé. Donc on le laisse là où il est !
### Table USERS
![index_user](https://user-images.githubusercontent.com/48727874/74663727-9d0f6000-519c-11ea-853a-52265baddfbf.png)
Colonnes dans les clauses `WHERE` et `JOIN` :
* `LOWER(email) LIKE or username`  (réparé en `email or username` depuis https://github.com/1024pix/pix/pull/1045)
* `hasSeenAssessmentInstructions AND updatedAt`  (à ignorer, rare)
* `pixOrgaTermsOfServiceAccepted AND updatedAt`  (à ignorer, rare)
* `pixCertifTermsOfServiceAccepted AND updatedAt`  (à ignorer, rare)
* `LOWER(email) LIKE`  (réparé en `email` or username depuis https://github.com/1024pix/pix/pull/1045)
* `LOWER(lastName) LIKE`
* `email`
* `samlId`
* `LOWER(lastName) LIKE AND LOWER(lastName) LIKE`
Le morceau barré n'est plus à jour depuis https://github.com/1024pix/pix/pull/1045, mais je laisse quand même l'étude pour l'apprentissage :
~~**_Constat n°1 :_** Il existe beaucoup de requêtes dont le prédicat est la colonne `email`. En revanche, on remarque également que ce prédicat n’est pas recherché toujours selon la même casse. cela empêche l’index existant sur cette colonne d'être utilisé tout le temps. Exemple :~~
![outdated_users](https://user-images.githubusercontent.com/48727874/74664188-887f9780-519d-11ea-9939-bf728655ca95.png)
~~Le moteur fait un _Seq Scan_ et ne peut pas utiliser l’index existant sur la colonne `email`. C’est à cause du `LOWER()`. Pour résoudre le problème, il y a deux solutions :
* Changer la requête pour ne pas rechercher sur `LOWER(email)` mais `email`
* Changer l’index et indexer sur `LOWER(email)`, et en contrepartie on modifie toutes les requêtes pour rechercher uniquement sur `LOWER(email)`
**_ACTION :_** Décider de quel index choisir pour la colonne `email`, et homogénéiser en conséquence les requêtes portant sur cette colonne.~~
**_Note :_** La problématique des requêtes portant sur les colonnes `firstName` ou `lastName` par exemple a volontairement été ignorée, mais il faudra s’en occuper plus tard. En fait, il s’agit des requêtes émises à la demande de **PixAdmin** et contient des `LIKE` avec des caractères joker en début de recherche. On pourrait envisager de revoir la stratégie de recherche afin d’améliorer les performances.
### Table USERS_PIX_ROLES
Rien à signaler, la table est toute petite !