### PR TITLE
[FEATURE] Script pour rattacher les administrateurs des organisations aux centres de certification correspondants (PF-952).

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,6 +1,8 @@
 'use strict';
 const faker = require('faker');
+
 const DatabaseBuilder = require('../../tests/tooling/database-builder/database-builder');
+
 const answersBuilder = require('./data/answers-builder');
 const assessmentsBuilder = require('./data/assessments-builder');
 const campaignParticipationsBuilder = require('./data/campaign-participations-builder');

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -4,6 +4,7 @@ class CertificationCenter {
     id,
     // attributes
     name,
+    externalId,
     createdAt,
     // includes
     // references
@@ -11,6 +12,7 @@ class CertificationCenter {
     this.id = id;
     // attributes
     this.name = name;
+    this.externalId = externalId;
     this.createdAt = createdAt;
     // includes
     // references

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -9,6 +9,7 @@ function _toDomain(bookshelfCertificationCenter) {
   return new CertificationCenter(_.pick(dbCertificationCenter, [
     'id',
     'name',
+    'externalId',
     'createdAt',
   ]));
 }

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const _ = require('lodash');
+
+const { checkCsvExtensionFile, parseCsvWithHeader } = require('./helpers/csvHelpers');
+
+const { NotFoundError } = require('../lib/domain/errors');
+const Membership = require('../lib/domain/models/Membership');
+
+const Bookshelf = require('../lib/infrastructure/bookshelf');
+const bookshelfToDomainConverter = require('../lib/infrastructure/utils/bookshelf-to-domain-converter');
+const BookshelfCertificationCenter = require('../lib/infrastructure/data/certification-center');
+const BookshelfMembership = require('../lib/infrastructure/data/membership');
+
+function getCertificationCenterByExternalId(externalId) {
+  return BookshelfCertificationCenter
+    .where({ externalId })
+    .fetch({ require: true })
+    .then((certificationCenter) => bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationCenter, certificationCenter))
+    .catch((err) => {
+      if (err instanceof BookshelfCertificationCenter.NotFoundError) {
+        throw new NotFoundError(`CertificationCenter not found for External ID ${externalId}`);
+      }
+      throw err;
+    });
+}
+
+async function getAdminMembershipsByOrganizationExternalId(externalId) {
+  return BookshelfMembership
+    .query((qb) => {
+      qb.innerJoin('organizations', 'memberships.organizationId', 'organizations.id');
+      qb.where('organizationRole', Membership.roles.ADMIN);
+      qb.where('organizations.externalId', '=' , externalId);
+    })
+    .fetchAll({ require: true })
+    .then((memberships) => {
+      const data = memberships.models.map((model) => model.attributes);
+      return data;
+    })
+    .catch((err) => {
+      if (err instanceof BookshelfMembership.NotFoundError) {
+        throw new NotFoundError(`Organization not found for External ID ${externalId}`);
+      }
+      throw err;
+    });
+}
+
+function buildCertificationCenterMemberships({ certificationCenterId, memberships }) {
+  return memberships.map((membership) => {
+    return { certificationCenterId, userId: membership.userId };
+  });
+}
+
+async function fetchCertificationCenterMembershipsByExternalId(externalId) {
+  const { id: certificationCenterId } = await getCertificationCenterByExternalId(externalId);
+  const memberships = await getAdminMembershipsByOrganizationExternalId(externalId);
+
+  return buildCertificationCenterMemberships({ certificationCenterId, memberships });
+}
+
+function prepareDataForInsert(rawExternalIds) {
+  return Promise.all(_.map(rawExternalIds, ({ externalId }) => {
+    return fetchCertificationCenterMembershipsByExternalId(externalId);
+  }))
+    .then((certificationCenterMemberships) => {
+      return _.union(...certificationCenterMemberships);
+    });
+}
+
+async function createCertificationCenterMemberships(certificationCenterMemberships) {
+  return Bookshelf.knex.batchInsert('certification-center-memberships', certificationCenterMemberships);
+}
+
+async function main() {
+  console.log('Starting creating Certification Center memberships with a list of ExternalIds.');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Check csv extension file... ');
+    checkCsvExtensionFile(filePath);
+    console.log('ok');
+
+    console.log('Reading and parsing csv data file... ');
+    const csvData = parseCsvWithHeader(filePath);
+    console.log('ok');
+
+    console.log('Data preparation before insertion into the database...');
+    const certificationCenterMemberships = await prepareDataForInsert(csvData);
+    console.log('ok');
+
+    console.log('Creating Certification Center Memberships into database...');
+    await createCertificationCenterMemberships(certificationCenterMemberships);
+    console.log('\nDone.');
+
+  } catch (error) {
+    console.error('\n', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  getCertificationCenterByExternalId,
+  getAdminMembershipsByOrganizationExternalId,
+  buildCertificationCenterMemberships,
+  fetchCertificationCenterMembershipsByExternalId,
+  prepareDataForInsert,
+  createCertificationCenterMemberships
+};

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -7,7 +7,9 @@ const _ = require('lodash');
 describe('Integration | Repository | Certification Center', () => {
 
   describe('#get', () => {
+
     context('the certification is found', () => {
+
       beforeEach(async () => {
         databaseBuilder.factory.buildCertificationCenter({
           id: 1,
@@ -15,19 +17,23 @@ describe('Integration | Repository | Certification Center', () => {
           createdAt: new Date('2018-01-01T05:43:10Z'),
         });
         databaseBuilder.factory.buildCertificationCenter({ id: 2 });
+
         await databaseBuilder.commit();
       });
+
       it('should return the certification of the given id with the right properties', async () => {
         // when
         const certificationCenter = await certificationCenterRepository.get(1);
         // then
         expect(certificationCenter.id).to.equal(1);
         expect(certificationCenter.name).to.equal('certificationCenterName');
-        expect(certificationCenter.createdAt).to.deep.equal(new Date('2018-01-01T05:43:10Z')),
-        expect(certificationCenter).to.have.all.keys(['id', 'name', 'createdAt']);
+        expect(certificationCenter.createdAt).to.deep.equal(new Date('2018-01-01T05:43:10Z'));
+        expect(certificationCenter).to.have.all.keys(['id', 'name', 'externalId', 'createdAt']);
       });
     });
+
     context('the certification center could not be found', () => {
+
       it('should throw a NotFound error', () => {
         // when
         const nonExistentId = 1;
@@ -39,9 +45,11 @@ describe('Integration | Repository | Certification Center', () => {
   });
 
   describe('#save', () => {
+
     afterEach(() => {
       return knex('certification-centers').delete();
     });
+
     it('should save the given certification center', async () => {
       // given
       const certificationCenter = new CertificationCenter({ name: 'CertificationCenterName' });
@@ -55,19 +63,24 @@ describe('Integration | Repository | Certification Center', () => {
   });
 
   describe('#find', () => {
+
     context('there are no certification centers', () => {
+
       it('should not return any result', async () => {
         // when
         const certificationCenters = await certificationCenterRepository.find();
         // then
         expect(certificationCenters).to.have.lengthOf(0);
       });
+
     });
     context('there are some certification centers', async () => {
+
       beforeEach(() => {
         _.times(5, databaseBuilder.factory.buildCertificationCenter);
         return databaseBuilder.commit();
       });
+
       it('should return all the certification centers', async () => {
         // when
         const certificationCenters = await certificationCenterRepository.find();

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -1,0 +1,163 @@
+const _ = require('lodash');
+
+const { expect, databaseBuilder, knex } = require('../../test-helper');
+
+const Membership = require('../../../lib/domain/models/Membership');
+const BookshelfCertificationCenterMembership = require('../../../lib/infrastructure/data/certification-center-membership');
+
+const {
+  getCertificationCenterByExternalId, getAdminMembershipsByOrganizationExternalId,
+  fetchCertificationCenterMembershipsByExternalId,
+  prepareDataForInsert,
+  createCertificationCenterMemberships
+} = require('../../../scripts/create-certification-center-memberships-from-organization-admins');
+
+describe('Integration | Scripts | create-certification-center-memberships-from-organization-admins.js', () => {
+
+  const externalId1 = '1234567A';
+  const externalId2 = '7654321B';
+
+  let organizationId1;
+  let organizationId2;
+  let certificationCenterId1;
+  let certificationCenterId2;
+
+  let adminUserId1a;
+  let adminUserId1b;
+  let adminUserId2a;
+  let adminUserId2b;
+
+  beforeEach(async () => {
+    organizationId1 = databaseBuilder.factory.buildOrganization({
+      externalId: externalId1
+    }).id;
+    organizationId2 = databaseBuilder.factory.buildOrganization({
+      externalId: externalId2
+    }).id;
+
+    adminUserId1a = databaseBuilder.factory.buildUser().id;
+    adminUserId1b = databaseBuilder.factory.buildUser().id;
+    const userId1 = databaseBuilder.factory.buildUser().id;
+
+    adminUserId2a = databaseBuilder.factory.buildUser().id;
+    adminUserId2b = databaseBuilder.factory.buildUser().id;
+    const userId2 = databaseBuilder.factory.buildUser().id;
+
+    _.each([
+      { userId: adminUserId1a, organizationId: organizationId1, organizationRole: Membership.roles.ADMIN },
+      { userId: adminUserId1b, organizationId: organizationId1, organizationRole: Membership.roles.ADMIN },
+      { userId: userId1, organizationId: organizationId1, organizationRole: Membership.roles.MEMBER },
+
+      { userId: adminUserId2a, organizationId: organizationId2, organizationRole: Membership.roles.ADMIN },
+      { userId: adminUserId2b, organizationId: organizationId2, organizationRole: Membership.roles.ADMIN },
+      { userId: userId2, organizationId: organizationId2, organizationRole: Membership.roles.MEMBER },
+
+    ], (membership) => (databaseBuilder.factory.buildMembership(membership)));
+
+    certificationCenterId1 = databaseBuilder.factory.buildCertificationCenter({
+      externalId: externalId1
+    }).id;
+    certificationCenterId2 = databaseBuilder.factory.buildCertificationCenter({
+      externalId: externalId2
+    }).id;
+
+    await databaseBuilder.commit();
+  });
+
+  describe('#getCertificationCenterByExternalId', () => {
+
+    it('should get certification center by externalId', async () => {
+      // when
+      const certificationCenter = await getCertificationCenterByExternalId(externalId1);
+
+      // then
+      expect(certificationCenter.externalId).to.equal(externalId1);
+    });
+  });
+
+  describe('#getAdminMembershipsByOrganizationExternalId', () => {
+
+    it('should get admin memberships by organization externalId', async () => {
+      // given
+      const expectedUserIds = [{ userId: adminUserId1a }, { userId: adminUserId1b }];
+
+      // when
+      const memberships = await getAdminMembershipsByOrganizationExternalId(externalId1);
+
+      // then
+      const userIds = memberships.map((membership) => _.pick(membership, 'userId'));
+      expect(userIds).to.deep.have.members(expectedUserIds);
+    });
+  });
+
+  describe('#fetchCertificationCenterMembershipsByExternalId', () => {
+
+    it('should fetch list of certification center memberships by externalId', async () => {
+      // given
+      const expectedCertificationCenterMemberships = [
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1a },
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1b },
+      ];
+
+      // when
+      const result = await fetchCertificationCenterMembershipsByExternalId(externalId1);
+
+      // then
+      expect(result).to.deep.have.members(expectedCertificationCenterMemberships);
+    });
+  });
+
+  describe('#prepareDataForInsert', () => {
+
+    it('should create a list of certification center memberships to insert from a list of externalIds', async () => {
+      // given
+      const expectedCertificationCenterMemberships = [
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1a },
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1b },
+
+        { certificationCenterId: certificationCenterId2, userId: adminUserId2a },
+        { certificationCenterId: certificationCenterId2, userId: adminUserId2b },
+      ];
+
+      // when
+      const result = await prepareDataForInsert([
+        { externalId: externalId1 },
+        { externalId: externalId2 },
+      ]);
+
+      // then
+      expect(result).to.deep.have.members(expectedCertificationCenterMemberships);
+    });
+  });
+
+  describe('#createCertificationCenterMemberships', () => {
+
+    const getNumberOfCertificationCenterMemberships = () => {
+      return BookshelfCertificationCenterMembership.count()
+        .then((number) => parseInt(number, 10));
+    };
+
+    afterEach(async () => {
+      await knex('certification-center-memberships').delete();
+    });
+
+    it('should insert 4 certification center memberships', async () => {
+      // given
+      const certificationCenterMemberships = [
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1a },
+        { certificationCenterId: certificationCenterId1, userId: adminUserId1b },
+        { certificationCenterId: certificationCenterId2, userId: adminUserId2a },
+        { certificationCenterId: certificationCenterId2, userId: adminUserId2b },
+      ];
+      const numberBefore = await getNumberOfCertificationCenterMemberships();
+
+      // when
+      await createCertificationCenterMemberships(certificationCenterMemberships);
+      const numberAfter = await getNumberOfCertificationCenterMemberships();
+
+      // then
+      expect(numberAfter - numberBefore).to.equal(4);
+    });
+  });
+
+});

--- a/api/tests/tooling/database-builder/factory/build-certification-center.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-center.js
@@ -4,12 +4,14 @@ const databaseBuffer = require('../database-buffer');
 module.exports = function buildCertificationCenter({
   id,
   name = faker.company.companyName(),
+  externalId = faker.random.alphaNumeric(8).toUpperCase(),
   createdAt = faker.date.recent(),
 } = {}) {
 
   const values = {
     id,
     name,
+    externalId,
     createdAt,
   };
   return databaseBuffer.pushInsertable({

--- a/api/tests/unit/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/unit/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -1,0 +1,27 @@
+const { expect } = require('../../test-helper');
+
+const { buildCertificationCenterMemberships } = require('../../../scripts/create-certification-center-memberships-from-organization-admins');
+
+describe('Unit | Scripts | create-certification-center-memberships-from-organization-admins.js', () => {
+
+  describe('#buildCertificationCenterMemberships', () => {
+
+    it('should build the list of certification center memberships', () => {
+      // given
+      const memberships = [{ userId: 1 }, { userId: 5 }];
+      const certificationCenterId = 100;
+
+      const expectedCertificationCenterMemberships = [
+        { certificationCenterId, userId: 1 },
+        { certificationCenterId, userId: 5 }
+      ];
+
+      // when
+      const result = buildCertificationCenterMemberships({ certificationCenterId, memberships });
+
+      // then
+      expect(result).to.deep.equal(expectedCertificationCenterMemberships);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Via un script, à partir d'un fichier csv contenant une liste d'ExternalIds, rattacher les administrateurs des organisations aux centres de certifications correspondants.

## :robot: Solution
1. Identifier les memberships des organisations (identifié avec leur externalId) qui sont administrateurs.
2. Identifier les centres de certifications (identifiés par leur externalId).
3. Effectuer les correspondances et créer les certificationCenterMemberships en base de données. 