### PR TITLE
[TECH] Résolution du test "flaky" (qui échoue aléatoirement) sur la CI - api

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -31,7 +31,7 @@ const _databaseName = knex.client.database();
 
 const _dbSpecificQueries = {
   listTablesQuery: 'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?',
-  emptyTableQuery: 'TRUNCATE TABLE ?? CASCADE;'
+  emptyTableQuery: 'TRUNCATE ',
 };
 
 async function listAllTableNames() {
@@ -52,11 +52,10 @@ async function emptyAllTables() {
     'pix_roles'
   );
 
+  const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 
   const query = _dbSpecificQueries.emptyTableQuery;
-  for (const tableName of tablesToDelete) {
-    await knex.raw(query, [tableName]);
-  }
+  return knex.raw(`${query}${tables}`);
 }
 
 async function listTablesByDependencyOrderDesc() {

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -27,19 +27,16 @@ const { environment } = require('../lib/config');
 const knexConfig = knexConfigs[environment];
 const knex = require('knex')(knexConfig);
 
-const _clientName = knex.schema.client.config.client;
 const _databaseName = knex.client.database();
 
 const _dbSpecificQueries = {
-  postgresql: {
-    listTablesQuery: 'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?',
-    truncateTableQuery: 'TRUNCATE TABLE ?? CASCADE;'
-  },
+  listTablesQuery: 'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?',
+  emptyTableQuery: 'TRUNCATE TABLE ?? CASCADE;'
 };
 
 async function listAllTableNames() {
   const bindings = [_databaseName];
-  const query = _dbSpecificQueries[_clientName].listTablesQuery;
+  const query = _dbSpecificQueries.listTablesQuery;
 
   const resultSet = await knex.raw(query, bindings);
 
@@ -55,8 +52,8 @@ async function emptyAllTables() {
     'pix_roles'
   );
 
-  const query = _dbSpecificQueries[_clientName].truncateTableQuery;
 
+  const query = _dbSpecificQueries.emptyTableQuery;
   for (const tableName of tablesToDelete) {
     await knex.raw(query, [tableName]);
   }

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -14,9 +14,9 @@ module.exports = class DatabaseBuilder {
 
   async commit() {
     if (this.isFirstCommit) {
+      this.isFirstCommit = false;
       await knexDatabaseConnection.emptyAllTables();
       await this._initTablesOrderedByDependencyWithDirtinessMap();
-      this.isFirstCommit = false;
     }
     const trx = await this.knex.transaction();
     for (const objectToInsert of this.databaseBuffer.objectsToInsert) {


### PR DESCRIPTION
## :unicorn: Problème
Il arrive de plus en plus fréquemment que le job CircleCI `api_build_and_test` échoue de manière aléatoire.

## 👀 Analyse
La difficulté de l'analyse est que ce n'est pas toujours le même test qui échoue, qu'il n'échoue pas systématiquement, et qu'il n'est jamais reproduit en local.

Par chance, j'ai rencontré le problème en local, un jour où mon ordinateur était en fonctionnement dégradé (car batterie faible).

J'ai donc supposé que l'erreur est bien due à un test qui prend trop de temps et dépasse le timeout par défaut de `mocha`, qui est de 2 secondes.

Fort de cette supposition, je me suis lancé dans une investigation plus poussée en commençant par chercher à reproduire le test en échec de manière systématique.
Pour cela, j'ai lancé les tests en spécifiant un timeout de plus en plus petit jusqu'à faire échouer le test.

```
npm run test:api -- --timeout 500
```

La valeur de 500ms m'a donné la sortie suivante :
```js
1) Acceptance | Controller | answer-controller
       GET /api/answers?challengeId=Y&assessmentId=Z
         when the assessment has an userId (is not a demo or preview)
           "before each" hook for "should return 200 HTTP status code":
     Error: Timeout of 500ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/GUL/Documents/Missions/gip pix/pix/api/tests/acceptance/application/answers/answer-controller-find_test.js)
      at listOnTimeout (internal/timers.js:531:17)
      at processTimers (internal/timers.js:475:7)`
```

Bingo ! Je reproduis désormais le test en échec de manière systématique.

Le problème se situe donc dans un `before each` dont le code est le suivant : 
```js
      beforeEach(async () => {
        server = await createServer();
        userId = databaseBuilder.factory.buildUser().id;
        const assessment = databaseBuilder.factory.buildAssessment({ userId, type: 'COMPETENCE_EVALUATION' });
        answer = databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id, value: '1.2', result: 'ok', challengeId });
        await databaseBuilder.commit();
        options = {
          method: 'GET',
          url: `/api/answers?challenge=${challengeId}&assessment=${assessment.id}`,
          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
        };
      });
```

J'ai donc ajouté un `.only` et mesuré le temps d'exécution de chaque fonction.
(J'ai utilisé les fonctions standard node [console.time](https://developer.mozilla.org/fr/docs/Web/API/Console/time) et [console.timeEnd](https://developer.mozilla.org/fr/docs/Web/API/Console/timeEnd))

Les mesures ont montré que `await databaseBuilder.commit();` est la fonction qui prend le plus de temps.

Comme le montre son code ci-dessous, cette fonction a un comportement différent lors du premier appel :
```js
async commit() {
    if (this.isFirstCommit) {
      await knexDatabaseConnection.emptyAllTables();
      await this._initTablesOrderedByDependencyWithDirtinessMap();
      this.isFirstCommit = false;
    }
    const trx = await this.knex.transaction();
    for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
      await trx(objectToInsert.tableName).insert(objectToInsert.values);
      this._setTableAsDirty(objectToInsert.tableName);
    }
    this.databaseBuffer.objectsToInsert = [];
    this.databaseBuffer.tablesToDelete = this._selectDirtyTables();
    await trx.commit();
  }
```

Cela explique pourquoi ce n'est pas toujours le même test qui échoue, car l'ordre des tests n'est pas déterministe : c'est donc le `beforeEach` du premier test d'acceptance de la suite de test qui peut échoué en timeout.

J'ai utilisé le même procédé pour trouver quelle fonction prend le plus de temps.
C'est la fonction `await knexDatabaseConnection.emptyAllTables();` dont voici le code :
```js
async function emptyAllTables() {
  const tableNames = await listAllTableNames();
  const tablesToDelete = _.without(tableNames,
    'knex_migrations',
    'knex_migrations_lock',
    'pix_roles'
  );

  const query = _dbSpecificQueries[_clientName].truncateTableQuery;

  for (const tableName of tablesToDelete) {
    await knex.raw(query, [tableName]);
  }
}
```

Cette fonction prend plus de 700ms pour s'exécuter.
```js
knexDatabaseConnection.emptyAllTables: 718.492ms
```

On voit qu'on boucle sur l'ensemble des tables de la base pour vider chacune des tables.
Plusieurs solutions sont envisageables.
Le choix de solution est expliqué dans le paragraphe suivant.

## :robot: Solution
~~1- Ne pas vider la base de données sur la CI.~~
~~Comme la base de données est recréée à chaque lancement de la CI, il n'est pas nécessaire de la vider.~~
~~On ajoute donc un contrôle pour ne pas vider la base sur la CI.~~
➡️ Cette analyse est fausse, je n'ai pas eu le temps de creuser, mais tous les tests d'acceptance échouent sur la CI dans ce cas.

1- Réduire le temps d'exécution de la fonction de vidage de la base de données
La requête `TRUNCATE TABLE <table_name> CASCADE;` est exécutée pour chaque table de la base de données.
Le `CASCADE` n'est pas nécessaire car le nettoyage de la base de données prend déjà soin de supprimer les enregistrements dans le bon ordre.
En modifiant les N requêtes par une seule requête comme suit
```sql
TRUNCATE <table_name1> <table_name2> .... <table_nameN>;
```
Le temps d'exécution est désormais le suivant :
```js
knexDatabaseConnection.emptyAllTables: 168.884ms
```

~~2- Augmenter le timeout du test de la fonction qui vide la base de données
Vider la base de données prenant du temps (parfois plus de 2 secondes), on fixe un timeout arbitraire de 5 secondes spécifiquement à ce test uniquement.~~
➡️ Plus nécessaire avec la réduction du temps d'exécution (cf point 1 ci-dessus).

## :rainbow: Remarques
Pas de gain de performance sur l'exécution des tests en eux-mêmes, mais un gros gain dans le process de tous les devs, qui ne devront plus relancer des builds en échec 👍 
