### PR TITLE
[BUGFIX] Fix sumBy when list contain 1 value (pc-117)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -26,7 +26,7 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
   get uncheckedHasSeenEndTestScreenCount() {
     return sumBy(
       this.session.certificationReports.toArray(),
-      (reports) => !reports.hasSeenEndTestScreen
+      (reports) => Number(!reports.hasSeenEndTestScreen)
     );
   }
 

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -30,6 +30,10 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
     );
   }
 
+  get hasUncheckedHasSeenEndTestScreen() {
+    return this.uncheckedHasSeenEndTestScreenCount > 0;
+  }
+
   showErrorNotification(message) {
     const { autoClear, clearDuration } = config.notifications;
     this.notifications.error(message, { autoClear, clearDuration });

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -63,7 +63,9 @@
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="app-modal-body__attention">Vous êtes sur le point de finaliser cette session.</div>
         <div class="app-modal-body__warning">
-          <p class="app-modal-body__contextual"> La case "Écran de fin du test vu" n'est pas cochée pour {{ this.uncheckedHasSeenEndTestScreenCount }} candidats</p>
+          {{#if this.hasUncheckedHasSeenEndTestScreen}}
+          <p class="app-modal-body__contextual"> La case "Écran de fin du test vu" n'est pas cochée pour {{ this.uncheckedHasSeenEndTestScreenCount }} candidat(s)</p>
+          {{/if}}
           <p>Attention : il ne vous sera plus possible de modifier ces informations par la suite.</p>
         </div>
       </div>

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -121,7 +121,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         });
         
         test('it should display the number of unchecked options (all)', async function(assert) {
-          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidats');
+          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidat(s)');
         });
         
         test('it should close the modal on cancel button click', async function(assert) {
@@ -166,7 +166,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         });
               
         test('it should display the number of unchecked options (one)', async function(assert) {
-          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidats');
+          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
         });
       });
 

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -67,4 +67,42 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     // then
     assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 1);
   });
+
+  test('it should be false if no unchecked certification reports', function(assert) {
+
+    // given
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    const sessions = ArrayProxy.create({
+      certificationReports: [
+        { hasSeenEndTestScreen: true },
+        { hasSeenEndTestScreen: true },
+      ]
+    });
+    controller.set('model', sessions);
+
+    // when
+    const hasUncheckedHasSeenEndTestScreen = controller.get('hasUncheckedHasSeenEndTestScreen');
+
+    // then
+    assert.equal(hasUncheckedHasSeenEndTestScreen, false);
+  });
+
+  test('it should be true if at least one unchecked certification reports', function(assert) {
+
+    // given
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    const sessions = ArrayProxy.create({
+      certificationReports: [
+        { hasSeenEndTestScreen: false },
+        { hasSeenEndTestScreen: true },
+      ]
+    });
+    controller.set('model', sessions);
+
+    // when
+    const hasUncheckedHasSeenEndTestScreen = controller.get('hasUncheckedHasSeenEndTestScreen');
+
+    // then
+    assert.equal(hasUncheckedHasSeenEndTestScreen, true);
+  });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -49,4 +49,22 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     // then
     assert.equal(uncheckedHasSeenEndTestScreenCount, 3);
   });
+
+  test('it should count 1 unchecked box if only one box (unchecked)', function(assert) {
+
+    // given
+    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+    const sessions = ArrayProxy.create({
+      certificationReports: [
+        { hasSeenEndTestScreen: false },
+      ]
+    });
+    controller.set('model', sessions);
+
+    // when
+    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+
+    // then
+    assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 1);
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le message contextuel de la popin *finalize* affiche `true` au lieu de `1` lorsque la liste ne contient qu'un seul élément

## :robot: Solution
Il faut forcer le cast du boolean en number `Number(true)`

## :rainbow: Remarques
mettre le “s” du mot “candidats” entre () => candidat(s)
ne PAS afficher la phrase qui indique le nombre de FDT non cochées si ce nombre est = 0