### PR TITLE
[TECH] Mise à jour de hapi. 

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -203,19 +203,12 @@
       }
     },
     "@hapi/accept": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
-      "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
+      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/address": {
@@ -244,13 +237,6 @@
       "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
       "requires": {
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/boom": {
@@ -290,19 +276,12 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.2.tgz",
-      "integrity": "sha512-10XyXbpo0fAXmOf/Q4BCgsQrrTZuwa6/FcSnuKqD06sZz5yMCmJTD8VpmolEjEfwJqXtQBZHj9g/IYcmHk3nxQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
+      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/catbox": {
@@ -314,30 +293,6 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x",
         "@hapi/podium": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        },
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
       }
     },
     "@hapi/catbox-memory": {
@@ -347,19 +302,12 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/content": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
-      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
+      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
       "requires": {
         "@hapi/boom": "7.x.x"
       }
@@ -383,15 +331,15 @@
       "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/hapi": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
-      "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
+      "version": "18.4.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
+      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
       "requires": {
-        "@hapi/accept": "3.x.x",
-        "@hapi/ammo": "3.x.x",
+        "@hapi/accept": "^3.2.4",
+        "@hapi/ammo": "^3.1.2",
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
-        "@hapi/call": "5.x.x",
+        "@hapi/call": "^5.1.3",
         "@hapi/catbox": "10.x.x",
         "@hapi/catbox-memory": "4.x.x",
         "@hapi/heavy": "6.x.x",
@@ -402,15 +350,18 @@
         "@hapi/shot": "4.x.x",
         "@hapi/somever": "2.x.x",
         "@hapi/statehood": "6.x.x",
-        "@hapi/subtext": "6.x.x",
+        "@hapi/subtext": "^6.1.3",
         "@hapi/teamwork": "3.x.x",
         "@hapi/topo": "3.x.x"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+        "@hapi/ammo": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
+          "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
         },
         "@hapi/joi": {
           "version": "15.1.1",
@@ -433,30 +384,6 @@
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        },
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
       }
     },
     "@hapi/hoek": {
@@ -487,13 +414,6 @@
         "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/joi": {
@@ -530,13 +450,6 @@
       "requires": {
         "@hapi/hoek": "8.x.x",
         "mime-db": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/nigel": {
@@ -546,32 +459,18 @@
       "requires": {
         "@hapi/hoek": "8.x.x",
         "@hapi/vise": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/pez": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
-      "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
+      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
-        "@hapi/content": "4.x.x",
+        "@hapi/content": "^4.1.1",
         "@hapi/hoek": "8.x.x",
         "@hapi/nigel": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/pinpoint": {
@@ -586,30 +485,6 @@
       "requires": {
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        },
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
       }
     },
     "@hapi/shot": {
@@ -619,30 +494,6 @@
       "requires": {
         "@hapi/hoek": "8.x.x",
         "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        },
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
       }
     },
     "@hapi/somever": {
@@ -652,13 +503,6 @@
       "requires": {
         "@hapi/bounce": "1.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/statehood": {
@@ -673,51 +517,20 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
         "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        },
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
-      "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
+      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
-        "@hapi/content": "4.x.x",
+        "@hapi/content": "^4.1.1",
         "@hapi/file": "1.x.x",
         "@hapi/hoek": "8.x.x",
-        "@hapi/pez": "4.x.x",
+        "@hapi/pez": "^4.1.2",
         "@hapi/wreck": "15.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/teamwork": {
@@ -746,13 +559,6 @@
       "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
       "requires": {
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@hapi/vision": {
@@ -781,13 +587,6 @@
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
       }
     },
     "@passify/xml-encryption": {

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
   "main": "server.js",
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
-    "@hapi/hapi": "^18.4.0",
+    "@hapi/hapi": "^18.4.1",
     "@hapi/inert": "^5.2.2",
     "@hapi/joi": "^16.1.8",
     "@hapi/joi-date": "^2.0.1",


### PR DESCRIPTION
## :unicorn: Problème
`@hapi/hapi` (`18.4.0`) n'est pas à jour

## :robot: Solution
Passer le package `@hapi/hapi` en `18.4.1`
