### PR TITLE
[EXPEDIT] Bug d'affichage du "Nombre d'écran de FDT non renseignés" quand une seule certif pour une session

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -26,7 +26,7 @@ export default Model.extend({
   countNotCheckedEndScreen : computed('certifications.[]', function() {
     return _.sumBy(
       this.certifications.toArray(),
-      (certif) => !certif.hasSeenEndTestScreen
+      (certif) => Number(!certif.hasSeenEndTestScreen)
     );
   }),
   countNonValidatedCertifications : computed('certifications.[]', function() {

--- a/admin/tests/unit/models/session-test.js
+++ b/admin/tests/unit/models/session-test.js
@@ -5,10 +5,75 @@ import { run } from '@ember/runloop';
 module('Unit | Model | session', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('session', {}));
-    assert.ok(model);
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
   });
+
+  module('#countNotCheckedEndScreen', function() {
+
+    module('when there is only one certification', function() {
+      let sessionWithOneUncheckedEndScreen;
+      let sessionWithOneCheckedEndScreen;
+
+      hooks.beforeEach(async function() {
+        store = this.owner.lookup('service:store');
+
+        sessionWithOneUncheckedEndScreen = run(() => {
+          const certif = store.createRecord('certification', { hasSeenEndTestScreen: false });
+          return store.createRecord('session', { certifications: [certif] });
+        });
+
+        sessionWithOneCheckedEndScreen = run(() => {
+          const certif = store.createRecord('certification', { hasSeenEndTestScreen: true });
+          return store.createRecord('session', { certifications: [certif] });
+        });
+      });
+
+      test('it should have one certification', function(assert) {
+        const certifsChecked = sessionWithOneUncheckedEndScreen.get('certifications');
+        const certifsUnchecked = sessionWithOneCheckedEndScreen.get('certifications');
+        assert.equal(certifsChecked.length, 1);
+        assert.equal(certifsUnchecked.length, 1);
+      });
+
+      test('it should count 1 unchecked box if only one box (unchecked)', function(assert) {
+        const countNotCheckedEndScreen = sessionWithOneUncheckedEndScreen.get('countNotCheckedEndScreen');
+        assert.equal(countNotCheckedEndScreen, 1);
+      });
+
+      test('it should count 0 unchecked box if only one box (checked)', function(assert) {
+        const countNotCheckedEndScreen = sessionWithOneCheckedEndScreen.get('countNotCheckedEndScreen');
+        assert.equal(countNotCheckedEndScreen, 0);
+      });
+    });
+
+    module('when there are multiple certifications', function() {
+      let sessionWithCertifications;
+
+      hooks.beforeEach(async function() {
+        store = this.owner.lookup('service:store');
+
+        sessionWithCertifications = run(() => {
+          const certif1 = store.createRecord('certification', { hasSeenEndTestScreen: false });
+          const certif2 = store.createRecord('certification', { hasSeenEndTestScreen: false });
+          const certif3 = store.createRecord('certification', { hasSeenEndTestScreen: true });
+          return store.createRecord('session', { certifications: [ certif1, certif2, certif3 ] });
+        });
+      });
+
+      test('it should have 3 certifications', function(assert) {
+        const certifications = sessionWithCertifications.get('certifications');
+        assert.equal(certifications.length, 3);
+      });
+
+      test('it should count 2 unchecked box if two box (unchecked)', function(assert) {
+        const countNotCheckedEndScreen = sessionWithCertifications.get('countNotCheckedEndScreen');
+        assert.equal(countNotCheckedEndScreen, 2);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, dans la page de détail d'une session pour la ligne "Nombre d'écrans de fin de test non renseigné", lorsqu'on a qu'une seule certification il est affiché "true" ou "false" (au lieu de 0 ou 1).

## :robot: Solution
En fait le sumBy de lodash ne cast pas lorsqu'il n'y a qu'un élément dans la collection. 
On cast donc nous même le booleen en nombre. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_
