### PR TITLE
[BUGFIX] Ne pas générer d'erreurs 500 lorsque la route /campaign/id est appelée avec un id non valide (PO-251).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   getById(request) {
-    const campaignId = parseInt(request.params.id);
+    const campaignId = request.params.id;
     const options = queryParamsUtils.extractParameters(request.query);
     const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
     return usecases.getCampaign({ campaignId, options })

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,3 +1,10 @@
+const { NotFoundError } = require('../../domain/errors');
+
 module.exports = function getCampaign({ campaignId, options, campaignRepository }) {
-  return campaignRepository.get(campaignId, options);
+  const integerCampaignId = parseInt(campaignId);
+  if (!Number.isFinite(integerCampaignId)) {
+    throw new NotFoundError(`Campaign not found for ID ${campaignId}`);
+  }
+
+  return campaignRepository.get(integerCampaignId, options);
 };

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -8,7 +8,7 @@ describe('Integration | Application | Route | campaignRouter', () => {
   beforeEach(() => {
     sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getCsvResults').callsFake((request, h) => h.response('ok').code(201));
-    sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
 
     server = Hapi.server();
@@ -58,19 +58,18 @@ describe('Integration | Application | Route | campaignRouter', () => {
 
   describe('GET /api/campaigns/{id}', () => {
 
-    it('should exist', function() {
+    it('should return a 200', function() {
       // when
       const promise = server.inject({
         method: 'GET',
-        url: '/api/campaigns/FAKE_ID',
+        url: '/api/campaigns/1',
       });
 
       // then
       return promise.then((res) => {
-        expect(res.statusCode).to.equal(201);
+        expect(res.statusCode).to.equal(200);
       });
     });
-
   });
 
   describe('PATCH /api/campaigns/{id}', () => {

--- a/orga/app/routes/authenticated/campaigns/details.js
+++ b/orga/app/routes/authenticated/campaigns/details.js
@@ -3,7 +3,10 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model(params) {
-    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile' });
+    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile' })
+      .catch((error) => {
+        return this.send('error', error, this.replaceWith('not-found', params.campaign_id));
+      });
   },
 
   afterModel(model) {

--- a/orga/tests/unit/routes/authenticated/campaigns/details-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/details-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/campaigns/details', function(hooks) {
+  setupTest(hooks);
+
+  let route, params;
+  let findRecordStub;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/campaigns/details');
+    params = { campaign_id: 'liste' };
+
+    findRecordStub = sinon.stub();
+    const storeStub = Service.create({
+      findRecord: findRecordStub
+    });
+    route.set('store', storeStub);
+  });
+
+  test('should redirect to not-found page', async function(assert) {
+    // given
+    findRecordStub.rejects({ errors: [{ status: '400' }] });
+
+    // then
+    const expectedRedirection = 'not-found';
+    route.replaceWith = (redirection) => {
+      assert.equal(
+        redirection,
+        expectedRedirection,
+        `expect transition to ${expectedRedirection}, got ${redirection}`
+      );
+    };
+
+    // when
+    await route.model(params);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On a des erreurs 500 qui sont générées parce que les utilisateurs demandent côté front la page `/campagnes/liste`. Cette page n'existe plus, mais il se trouve que ça match le template `/campagnes/id`, et donc le front va chercher la campagne d'id `liste`. En arrivant côté back, on fait un `parseInt(id)`, on se retrouve donc avec un `NaN`. Ce qui échoue en base en jetant une 500.

## :robot: Solution
- Côté back, empêcher d'aller plus loin avec un check côté domain sur le type de l'ID. Le `GET /campaign/liste` ressort donc avec une 404 Not Found.

- Côté front, catcher l'erreur après le findRecord, et rediriger vers la page `Not Found`.

## :rainbow: Remarques
Il se trouve qu'actuellement la page `Not Found` redirige vers la page par défaut. Niveau UX, ce n'est pas forcément le meilleur comportement. Néanmoins, ce n'est pas à cette PR de modifier cela.
