### PR TITLE
[FEATURE] Ajout date finalisation sur la page de détail d'une session (PA-145)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -14,8 +14,9 @@ export default Model.extend({
   description: attr(),
   accessCode: attr(),
   status: attr(),
+  finalizedAt: attr(),
   isFinalized: equal('status', 'finalized'),
-  examinerGlobalComment: attr(),
+  examinerGlobalComment: attr('string'),
   certifications: hasMany('certification'),
   countExaminerComment : computed('certifications.[]', function() {
     return _.sumBy(
@@ -37,5 +38,9 @@ export default Model.extend({
   }),
   hasExaminerGlobalComment : computed('examinerGlobalComment', function() {
     return this.examinerGlobalComment && this.examinerGlobalComment.trim().length > 0;
+  }),
+
+  finalizationDate: computed('finalizedAt', function() {
+    return (new Date(this.finalizedAt)).toLocaleString('fr-FR');
   }),
 });

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -36,6 +36,13 @@
           <div class='col'>Statut :</div>
           <div class='col' data-test-id='certifications-session-info__is-finalized'>{{if session.isFinalized 'Finalisée' 'Prête'}}</div>
       </div>
+
+      {{#if session.isFinalized}}
+      <div class='row'>
+          <div class='col'>Date de finalisation :</div>
+          <div class='col' data-test-id='certifications-session-info__finalized-at'>{{session.finalizationDate}}</div>
+      </div>
+      {{/if}}
   </div>
 
   {{#if session.isFinalized}}

--- a/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/sessions/certifications-session-info-test.js
@@ -77,6 +77,19 @@ module('Integration | Component | certifications-session-info', function(hooks) 
       assert.dom('[data-test-id="certifications-session-info__is-finalized"]').hasText('Finalisée');
     });
 
+    test('it renders the finalization date in correct format', async function(assert) {
+      // given
+      const now = new Date();
+      sessionData.finalizedAt = now;
+      session = this.server.create('session', sessionData);
+
+      // when
+      await visit(`/certifications/sessions/${sessionId}`);
+
+      // then
+      assert.dom('[data-test-id="certifications-session-info__finalized-at"]').hasText(now.toLocaleString('fr-FR'));
+    });
+
     test('it renders the examinerGlobalComment if any', async function(assert) {
       // given
       sessionData.status = 'finalized';

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -19,6 +19,7 @@ class Session {
     time,
     status,
     examinerGlobalComment,
+    finalizedAt,
     // includes
     certificationCandidates,
     // references
@@ -36,6 +37,7 @@ class Session {
     this.time = time;
     this.status = status;
     this.examinerGlobalComment = examinerGlobalComment;
+    this.finalizedAt = finalizedAt;
     // includes
     this.certificationCandidates = certificationCandidates;
     // references

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -24,6 +24,7 @@ module.exports = {
         'certificationCandidates',
         'certificationReports',
         'examinerGlobalComment',
+        'finalizedAt',
       ],
       certifications : {
         ref: 'id',

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -137,6 +137,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'time': '14:30:00',
             'status': 'started',
             'examiner-global-comment': 'It was a fine session my dear',
+            'finalized-at': null,
           },
           'relationships': {
             'certifications': {
@@ -169,6 +170,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'time': '14:30:00',
             'status': 'started',
             'examiner-global-comment': 'It was a fine session my dear',
+            'finalized-at': null,
           },
           'relationships': {
             'certifications': {

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -14,8 +14,9 @@ const SESSION_PROPS = [
   'room',
   'time',
   'status',
-  'certificationCandidates',
   'examinerGlobalComment',
+  'finalizedAt',
+  'certificationCandidates',
 ];
 
 describe('Unit | Domain | Models | Session', () => {
@@ -35,6 +36,7 @@ describe('Unit | Domain | Models | Session', () => {
       time: '',
       status: '',
       examinerGlobalComment: '',
+      finalizedAt: '',
       // includes
       certificationCandidates: [],
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -22,7 +22,8 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
           time: '14:30',
           status: 'created',
           description: '',
-          'examiner-global-comment': 'It was a fine session my dear'
+          'examiner-global-comment': 'It was a fine session my dear',
+          'finalized-at': new Date('2020-02-17T14:23:56Z'),
         },
         relationships: {
           certifications: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -5,20 +5,6 @@ const Session = require('../../../../../lib/domain/models/Session');
 
 describe('Unit | Serializer | JSONAPI | session-serializer', function() {
 
-  const modelSession = new Session({
-    id: 12,
-    certificationCenter: 'Université de dressage de loutres',
-    address: 'Nice',
-    room: '28D',
-    examiner: 'Antoine Toutvenant',
-    date: '2017-01-20',
-    time: '14:30',
-    description: '',
-    accessCode: '',
-    status: 'created',
-    examinerGlobalComment: 'It was a fine session my dear',
-  });
-
   let jsonApiSession;
 
   beforeEach(function() {
@@ -60,6 +46,25 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
   });
 
   describe('#serialize()', function() {
+
+    let modelSession;
+
+    beforeEach(function() {
+      modelSession = new Session({
+        id: 12,
+        certificationCenter: 'Université de dressage de loutres',
+        address: 'Nice',
+        room: '28D',
+        examiner: 'Antoine Toutvenant',
+        date: '2017-01-20',
+        time: '14:30',
+        description: '',
+        accessCode: '',
+        status: 'created',
+        examinerGlobalComment: 'It was a fine session my dear',
+        finalizedAt: new Date('2020-02-17T14:23:56Z'),
+      });
+    });
 
     it('should convert a Session model object into JSON API data', function() {
       // when


### PR DESCRIPTION
## ☕️  Contexte
Le pôle certif* s'occupent de "traiter" les sessions lorsque celles-ci sont finalisées. C'est à dire:
- que les sessions se sont déroulées (passées dans le temps),
- et que le CDC ont noté les signalements et ont validé avoir vu, ou non, les fin de tests sur les écrans des candidats (l'action "finaliser la session" est faite sur l'appli certif). 

*pôle certif = Anne-C, Pablo, Josselin de chez Pix
*CDC = centre de certification

## :unicorn: Problème
Pour savoir quelles sont les sessions dont le pôle certif doit s'occuper, ils aimeraient avoir accès à plusieurs informations, dont la date de finalisation de la session.

## :robot: Solution
Afficher la date de finalisation de la session dans Pix admin sur la page de détail de la session choisie.
![image](https://user-images.githubusercontent.com/38167520/74660654-d3e27780-5196-11ea-9965-0e8e858a00eb.png)


## :rainbow: Remarques
La date de finalisation ne s'affiche que pour les sessions au status "finalisé". 
