### PR TITLE
[BUGFIX] Les résultat Pix+ ne doivent pas apparaître dans les résultats de certification (PF-1098)

### DIFF
--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -19,17 +19,18 @@ function list() {
     });
 }
 
-function listWithCompetences() {
-  return Promise.all([list(), competenceRepository.list()])
+async function listWithPixCompetencesOnly() {
+  const areas = await Promise.all([list(), competenceRepository.listPixCompetencesOnly()])
     .then(([areas, competences]) => {
       areas.forEach((area) => {
         area.competences = _.filter(competences, { area: { id: area.id } });
       });
       return areas;
     });
+  return _.filter(areas, ({ competences }) => !_.isEmpty(competences));
 }
 
 module.exports = {
   list,
-  listWithCompetences,
+  listWithPixCompetencesOnly,
 };

--- a/api/lib/infrastructure/repositories/competence-tree-repository.js
+++ b/api/lib/infrastructure/repositories/competence-tree-repository.js
@@ -4,7 +4,7 @@ const CompetenceTree = require('../../domain/models/CompetenceTree');
 module.exports = {
 
   get() {
-    return areaRepository.listWithCompetences()
+    return areaRepository.listWithPixCompetencesOnly()
       .then((areas) => new CompetenceTree({ areas }));
   },
 };

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -275,11 +275,11 @@ describe('Acceptance | API | Certifications', () => {
 
     it('should return unauthorized 403 HTTP status code when user is not owner of the certification', () => {
       // given
-      const NOT_authenticatedUserID = authenticatedUserID + 1;
+      const unauthenticatedUserId = authenticatedUserID + 1;
       options = {
         method: 'GET',
         url: `/api/certifications/${certificationCourse.id}`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(NOT_authenticatedUserID) },
+        headers: { authorization: generateValidRequestAuthorizationHeader(unauthenticatedUserId) },
       };
 
       // when

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -1,7 +1,11 @@
 const {
-  expect, generateValidRequestAuthorizationHeader, knex,
-  insertUserWithRolePixMaster, insertUserWithStandardRole,
-  airtableBuilder, databaseBuilder
+  knex,
+  expect,
+  airtableBuilder,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithStandardRole,
+  insertUserWithRolePixMaster,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -1,9 +1,11 @@
 const {
-  expect, generateValidRequestAuthorizationHeader,
-  insertUserWithRolePixMaster, insertUserWithStandardRole, knex, nock,
+  expect, generateValidRequestAuthorizationHeader, knex,
+  insertUserWithRolePixMaster, insertUserWithStandardRole,
+  airtableBuilder, databaseBuilder
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { map } = require('lodash');
 
 describe('Acceptance | API | Certifications', () => {
 
@@ -16,62 +18,32 @@ describe('Acceptance | API | Certifications', () => {
   describe('GET /api/certifications', () => {
 
     let options;
-    let certificationId;
     const authenticatedUserID = 1234;
 
-    const session = {
-      certificationCenter: 'Université du Pix',
-      address: '1 rue de l\'educ',
-      room: 'Salle Benjamin Marteau',
-      examiner: '',
-      date: '2018-08-14',
-      time: '11:00',
-      description: '',
-      accessCode: 'PIX123',
-    };
+    let session, certificationCourse, assessment, assessmentResult;
 
-    const certificationCourse = {
-      userId: authenticatedUserID,
-      completedAt: new Date('2018-02-15T15:15:52Z'),
-      isPublished: true,
-      firstName: 'Bro',
-      lastName: 'Ther',
-      birthdate: '1993-12-08',
-      birthplace: 'Asnières IZI',
-    };
-
-    const assessment = {
-      userId: authenticatedUserID,
-      type: Assessment.types.CERTIFICATION,
-      state: 'completed',
-    };
-
-    const assessmentResult = {
-      level: 1,
-      pixScore: 23,
-      emitter: 'PIX-ALGO',
-      status: 'rejected',
-    };
-
-    beforeEach(() => {
-      return insertUserWithRolePixMaster()
-        .then(() => knex('sessions').insert(session).returning('id'))
-        .then(([id]) => certificationCourse.sessionId = id)
-        .then(() => knex('certification-courses').insert(certificationCourse).returning('id'))
-        .then(([id]) => {
-          certificationId = id;
-          assessment.courseId = id;
-        })
-        .then(() => knex('assessments').insert(assessment).returning('id'))
-        .then(([id]) => assessmentResult.assessmentId = id)
-        .then(() => knex('assessment-results').insert(assessmentResult));
+    beforeEach(async function() {
+      await insertUserWithRolePixMaster();
+      session = databaseBuilder.factory.buildSession();
+      certificationCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, userId: authenticatedUserID });
+      assessment = databaseBuilder.factory.buildAssessment({
+        userId: authenticatedUserID,
+        courseId: certificationCourse.id,
+        type: Assessment.types.CERTIFICATION,
+        state: 'completed',
+      });
+      assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessment.id,
+        level: 1,
+        pixScore: 23,
+        emitter: 'PIX-ALGO',
+        status: 'rejected',
+      });
+      await databaseBuilder.commit();
     });
 
-    afterEach(async () => {
-      await knex('assessment-results').delete();
-      await knex('assessments').delete();
-      await knex('certification-courses').delete();
-      return knex('sessions').delete();
+    afterEach(() => {
+      return databaseBuilder.clean();
     });
 
     it('should return 200 HTTP status code', () => {
@@ -89,18 +61,18 @@ describe('Acceptance | API | Certifications', () => {
         expect(response.result.data).to.deep.equal([
           {
             type: 'certifications',
-            id: certificationId.toString(),
+            id: `${certificationCourse.id}`,
             attributes: {
-              'birthdate': '1993-12-08',
-              'birthplace': 'Asnières IZI',
-              'certification-center': 'Université du Pix',
-              'comment-for-candidate': null,
-              'date': new Date('2018-02-15T15:15:52Z'),
-              'first-name': 'Bro',
-              'is-published': true,
-              'last-name': 'Ther',
-              'pix-score': 23,
-              'status': 'rejected',
+              'birthdate': certificationCourse.birthdate,
+              'birthplace': certificationCourse.birthplace,
+              'certification-center': session.certificationCenter,
+              'comment-for-candidate': assessmentResult.commentForCandidate,
+              'date': certificationCourse.completedAt,
+              'first-name': certificationCourse.firstName,
+              'is-published': certificationCourse.isPublished,
+              'last-name': certificationCourse.lastName,
+              'pix-score': assessmentResult.pixScore,
+              'status': assessmentResult.status,
             },
             relationships: {
               'result-competence-tree': {
@@ -134,278 +106,81 @@ describe('Acceptance | API | Certifications', () => {
     let options;
 
     const JOHN_USERID = 1234;
-    const JOHN_CERTIFICATION_ID = 2;
 
-    const session = {
-      id: 1,
-      certificationCenter: 'Université du Pix',
-      address: '137 avenue de Bercy',
-      room: 'La grande',
-      examiner: 'Serge le Mala',
-      date: '1989-10-24',
-      time: '21:30',
-      accessCode: 'ABCD12',
-    };
-    const john_certificationCourse = {
-      id: JOHN_CERTIFICATION_ID,
-      userId: JOHN_USERID,
-      firstName: 'John',
-      lastName: 'Doe',
-      birthplace: 'Earth',
-      birthdate: '1989-10-24',
-      completedAt: new Date('2003-02-01T01:02:03Z'),
-      sessionId: session.id,
-      isPublished: false,
-    };
-    const john_completedAssessment = {
-      id: 1000,
-      courseId: JOHN_CERTIFICATION_ID,
-      userId: JOHN_USERID,
-      type: Assessment.types.CERTIFICATION,
-      state: 'completed',
-    };
-    const assessmentResult = {
-      id: 45,
-      level: 1,
-      pixScore: 23,
-      emitter: 'PIX-ALGO',
-      status: 'rejected',
-      assessmentId: john_completedAssessment.id,
-    };
-    const competenceMark = {
-      level: 3,
-      score: 23,
-      'area_code': '1',
-      'competence_code': '1.1',
-      assessmentResultId: assessmentResult.id,
-    };
+    let session, johnCertificationCourse, john_completedAssessment, assessmentResult;
 
     before(() => {
-      nock.cleanAll();
+      const area = airtableBuilder.factory.buildArea();
+      airtableBuilder.mockList({ tableName: 'Domaines' })
+        .returns([area])
+        .activate();
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Competences')
-        .query(true)
-        .times(2)
-        .reply(200, {
-          records: [
-            {
-              'id': 'recsvLz0W2ShyfD63',
-              'fields': {
-                'id persistant': 'recsvLz0W2ShyfD63',
-                'Domaine (id persistant)': [
-                  'recvoGdo7z2z7pXWa',
-                ],
-                'Epreuves': [
-                  'rec02tVrimXNkgaLD',
-                  'rec0gm0GFue3PQB3k',
-                  'rec0hoSlSwCeNNLkq',
-                  'rec2FcZ4jsPuY1QYt',
-                  'rec39bDMnaVw3MyMR',
-                  'rec3FMoD8h9USTktb',
-                  'rec3P7fvPSpFkIFLV',
-                ],
-                'Sous-domaine': '1.1',
-                'Titre': 'Mener une recherche et une veille d’information',
-                'Acquis (identifiants)': [
-                  'recV11ibSCXvaUzZd',
-                  'recD01ptfJy7c4Sex',
-                  'recfO8994EvSQV9Ip',
-                  'recDMMeHSZRCjqo5x',
-                  'reci0phtJi0lvqW9j',
-                  'recUQSpjuDvwqKMst',
-                  'recxqogrKZ9p8b1u8',
-                  'recRV35kIeqUQj8cI',
-                  'rec50NXHkatsRkjVQ',
-                ],
-                'Référence': '1.1 Mener une recherche et une veille d’information',
-                'Tests Record ID': [
-                  'recNPB7dTNt5krlMA',
-                ],
-                'Acquis': [
-                  '@url2',
-                  '@url5',
-                  '@utiliserserv6',
-                  '@rechinfo1',
-                  '@eval2',
-                  '@publi4',
-                  '@modèleEco2',
-                  '@utiliserserv1',
-                ],
-                'Record ID': 'recsvLz0W2ShyfD63',
-                'Domaine Titre': [
-                  'Information et données',
-                ],
-                'Domaine Code': [
-                  '1',
-                ],
-              },
-              'createdTime': '2017-06-13T13:53:17.000Z',
-            },
-            {
-              'id': 'recNv8qhaY887jQb2',
-              'fields': {
-                'id persistant': 'recNv8qhaY887jQb2',
-                'Domaine (id persistant)': [
-                  'recvoGdo7z2z7pXWa',
-                ],
-                'Epreuves': [
-                  'rec02tVrimXNkgaLD',
-                  'rec0gm0GFue3PQB3k',
-                  'rec0hoSlSwCeNNLkq',
-                  'rec2FcZ4jsPuY1QYt',
-                  'rec39bDMnaVw3MyMR',
-                  'rec3FMoD8h9USTktb',
-                  'rec3P7fvPSpFkIFLV',
-                ],
-                'Sous-domaine': '1.2',
-                'Titre': 'Gérer des données',
-                'Acquis (identifiants)': [
-                  'recV11ibSCXvaUzZd',
-                  'recD01ptfJy7c4Sex',
-                  'recfO8994EvSQV9Ip',
-                  'recDMMeHSZRCjqo5x',
-                  'reci0phtJi0lvqW9j',
-                  'recUQSpjuDvwqKMst',
-                  'recxqogrKZ9p8b1u8',
-                  'recRV35kIeqUQj8cI',
-                  'rec50NXHkatsRkjVQ',
-                ],
-                'Référence': '1.2 Gérer des données',
-                'Tests Record ID': [
-                  'recNPB7dTNt5krlMA',
-                ],
-                'Acquis': [
-                  '@url2',
-                  '@url5',
-                  '@utiliserserv6',
-                  '@rechinfo1',
-                  '@eval2',
-                  '@publi4',
-                  '@modèleEco2',
-                  '@utiliserserv1',
-                ],
-                'Record ID': 'recNv8qhaY887jQb2',
-                'Domaine Titre': [
-                  'Information et données',
-                ],
-                'Domaine Code': [
-                  '1',
-                ],
-              },
-              'createdTime': '2017-06-13T13:53:17.000Z',
-            },
-            {
-              'id': 'recIkYm646lrGvLNT',
-              'fields': {
-                'id persistant': 'recIkYm646lrGvLNT',
-                'Domaine (id persistant)': [
-                  'recvoGdo7z2z7pXWa',
-                ],
-                'Epreuves': [
-                  'rec02tVrimXNkgaLD',
-                  'rec0gm0GFue3PQB3k',
-                  'rec0hoSlSwCeNNLkq',
-                  'rec2FcZ4jsPuY1QYt',
-                  'rec39bDMnaVw3MyMR',
-                  'rec3FMoD8h9USTktb',
-                  'rec3P7fvPSpFkIFLV',
-                ],
-                'Sous-domaine': '1.3',
-                'Titre': 'Traiter des données',
-                'Acquis (identifiants)': [
-                  'recV11ibSCXvaUzZd',
-                  'recD01ptfJy7c4Sex',
-                  'recfO8994EvSQV9Ip',
-                  'recDMMeHSZRCjqo5x',
-                  'reci0phtJi0lvqW9j',
-                  'recUQSpjuDvwqKMst',
-                  'recxqogrKZ9p8b1u8',
-                  'recRV35kIeqUQj8cI',
-                  'rec50NXHkatsRkjVQ',
-                ],
-                'Référence': '1.3 Traiter des données',
-                'Tests Record ID': [
-                  'recNPB7dTNt5krlMA',
-                ],
-                'Acquis': [
-                  '@url2',
-                  '@url5',
-                  '@utiliserserv6',
-                  '@rechinfo1',
-                  '@eval2',
-                  '@publi4',
-                  '@modèleEco2',
-                  '@utiliserserv1',
-                ],
-                'Record ID': 'recIkYm646lrGvLNT',
-                'Domaine Titre': [
-                  'Information et données',
-                ],
-                'Domaine Code': [
-                  '1',
-                ],
-              },
-              'createdTime': '2017-06-13T13:53:17.000Z',
-            }] });
+      const epreuves = [
+        'rec02tVrimXNkgaLD',
+        'rec0gm0GFue3PQB3k',
+        'rec0hoSlSwCeNNLkq',
+        'rec2FcZ4jsPuY1QYt',
+        'rec39bDMnaVw3MyMR',
+        'rec3FMoD8h9USTktb',
+        'rec3P7fvPSpFkIFLV',
+      ];
+      const competences = map([{
+        id: 'recsvLz0W2ShyfD63',
+        epreuves,
+        sousDomaine: '1.1',
+        titre: 'Mener une recherche et une veille d’information',
+      }, {
+        id: 'recNv8qhaY887jQb2',
+        epreuves,
+        sousDomaine: '1.2',
+        titre: 'Gérer des données',
+      }, {
+        id: 'recIkYm646lrGvLNT',
+        epreuves,
+        sousDomaine: '1.3',
+        titre: 'Traiter des données',
+      }], (competence) => airtableBuilder.factory.buildCompetence(competence));
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Domaines')
-        .query(true)
-        .times(2)
-        .reply(200, {
-          'records': [
-            {
-              'id': 'recvoGdo7z2z7pXWa',
-              'fields': {
-                'id persistant': 'recvoGdo7z2z7pXWa',
-                'Competences (identifiants) (id persistant)': [
-                  'recsvLz0W2ShyfD63',
-                  'recNv8qhaY887jQb2',
-                  'recIkYm646lrGvLNT',
-                ],
-                'Code': '1',
-                'Titre': 'Information et données',
-                'Nom': '1. Information et données',
-                'Competences (nom complet)': [
-                  '1.1 Mener une recherche et une veille d’information',
-                  '1.3 Traiter des données',
-                  '1.2 Gérer des données',
-                ],
-              },
-              'createdTime': '2017-06-13T13:15:26.000Z',
-            },
-          ],
-        });
+      airtableBuilder.mockList({ tableName: 'Competences' })
+        .returns(competences)
+        .activate();
     });
 
-    after(() => {
-      nock.cleanAll();
+    beforeEach(async () => {
+      session = databaseBuilder.factory.buildSession();
+      await insertUserWithRolePixMaster();
+      await insertUserWithStandardRole();
+      johnCertificationCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, userId: JOHN_USERID });
+      john_completedAssessment = databaseBuilder.factory.buildAssessment({
+        userId: JOHN_USERID,
+        courseId: johnCertificationCourse.id,
+        type: Assessment.types.CERTIFICATION,
+        state: 'completed',
+      });
+      assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: john_completedAssessment.id,
+        level: 1,
+        pixScore: 23,
+        emitter: 'PIX-ALGO',
+        status: 'rejected',
+      });
+      databaseBuilder.factory.buildCompetenceMark({
+        level: 3,
+        score: 23,
+        area_code: '1',
+        competence_code: '1.1',
+        assessmentResultId: assessmentResult.id,
+      });
+      await databaseBuilder.commit();
     });
 
-    beforeEach(() => {
-      return knex('sessions').insert(session)
-        .then(insertUserWithRolePixMaster)
-        .then(insertUserWithStandardRole)
-        .then(() => knex('certification-courses').insert(john_certificationCourse))
-        .then(() => knex('assessments').insert(john_completedAssessment))
-        .then(() => knex('assessment-results').insert(assessmentResult))
-        .then(() => knex('competence-marks').insert(competenceMark));
-    });
-
-    afterEach(async () => {
-      await knex('competence-marks').delete();
-      await knex('assessment-results').delete();
-      await knex('assessments').delete();
-      await knex('certification-courses').delete();
-      return knex('sessions').delete();
-    });
+    afterEach(() => databaseBuilder.clean());
 
     it('should return 200 HTTP status code and the certification with the result competence tree included', () => {
       // given
       options = {
         method: 'GET',
-        url: `/api/certifications/${JOHN_CERTIFICATION_ID}`,
+        url: `/api/certifications/${johnCertificationCourse.id}`,
         headers: { authorization: generateValidRequestAuthorizationHeader(JOHN_USERID) },
       };
 
@@ -416,22 +191,22 @@ describe('Acceptance | API | Certifications', () => {
       const expectedBody = {
         'data': {
           'attributes': {
-            'birthdate': '1989-10-24',
-            'birthplace': 'Earth',
-            'certification-center': 'Université du Pix',
-            'comment-for-candidate': null,
-            'date': new Date('2003-02-01T01:02:03Z'),
-            'first-name': 'John',
-            'is-published': false,
-            'last-name': 'Doe',
-            'pix-score': 23,
-            'status': 'rejected',
+            'birthdate': johnCertificationCourse.birthdate,
+            'birthplace': johnCertificationCourse.birthplace,
+            'certification-center': session.certificationCenter,
+            'comment-for-candidate': assessmentResult.commentForCandidate,
+            'date': johnCertificationCourse.completedAt,
+            'first-name': johnCertificationCourse.firstName,
+            'is-published': johnCertificationCourse.isPublished,
+            'last-name': johnCertificationCourse.lastName,
+            'pix-score': assessmentResult.pixScore,
+            'status': assessmentResult.status,
           },
-          'id': '2',
+          'id': `${johnCertificationCourse.id}`,
           'relationships': {
             'result-competence-tree': {
               'data': {
-                'id': '2-45',
+                'id': `${johnCertificationCourse.id}-${assessmentResult.id}`,
                 'type': 'result-competence-trees',
               },
             },
@@ -498,9 +273,9 @@ describe('Acceptance | API | Certifications', () => {
           },
           {
             'attributes': {
-              'id': '2-45',
+              'id': `${johnCertificationCourse.id}-${assessmentResult.id}`,
             },
-            'id': '2-45',
+            'id': `${johnCertificationCourse.id}-${assessmentResult.id}`,
             'relationships': {
               'areas': {
                 'data': [
@@ -527,7 +302,7 @@ describe('Acceptance | API | Certifications', () => {
       const NOT_JOHN_USERID = JOHN_USERID + 1;
       options = {
         method: 'GET',
-        url: `/api/certifications/${JOHN_CERTIFICATION_ID}`,
+        url: `/api/certifications/${johnCertificationCourse.id}`,
         headers: { authorization: generateValidRequestAuthorizationHeader(NOT_JOHN_USERID) },
       };
 
@@ -541,74 +316,44 @@ describe('Acceptance | API | Certifications', () => {
   });
 
   describe('PATCH /api/certifications/:id', () => {
-
     let options;
 
     const JOHN_USERID = 1234;
     const JOHN_CERTIFICATION_ID = 2;
 
-    const john_certificationCourse = {
-      id: JOHN_CERTIFICATION_ID,
-      userId: JOHN_USERID,
-      firstName: 'John',
-      lastName: 'Doe',
-      birthplace: 'Earth',
-      birthdate: '1991-10-24',
-      completedAt: new Date('2003-01-02T01:02:03Z'),
-      sessionId: 1,
-      isPublished: false,
-    };
-    const john_completedAssessment = {
-      id: 1,
-      courseId: JOHN_CERTIFICATION_ID,
-      userId: JOHN_USERID,
-      type: Assessment.types.CERTIFICATION,
-      state: 'completed',
-    };
-    const assessmentResult = {
-      assessmentId: 1,
-      level: 1,
-      pixScore: 23,
-      emitter: 'PIX-ALGO',
-      status: 'rejected',
-    };
-    const session = {
-      id: 1,
-      certificationCenter: 'Université du Pix',
-      address: '137 avenue de Bercy',
-      room: 'La grande',
-      examiner: 'Serge le Mala',
-      date: '1989-10-24',
-      time: '21:30',
-      accessCode: 'ABCD12',
-    };
+    let session, johnCertificationCourse, john_completedAssessment, assessmentResult;
 
-    beforeEach(() => {
-      return knex('sessions').insert(session).returning('id')
-        .then(insertUserWithRolePixMaster)
-        .then(insertUserWithStandardRole)
-        .then(() => knex('certification-courses').insert(john_certificationCourse))
-        .then(() => knex('assessments').insert(john_completedAssessment))
-        .then(() => knex('assessment-results').insert(assessmentResult));
-    });
-
-    afterEach(async () => {
-      await knex('assessment-results').delete();
-      await knex('assessments').delete();
-      await knex('certification-courses').delete();
-      return knex('sessions').delete();
+    beforeEach(async () => {
+      session = databaseBuilder.factory.buildSession();
+      await insertUserWithRolePixMaster();
+      await insertUserWithStandardRole();
+      johnCertificationCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, userId: JOHN_USERID });
+      john_completedAssessment = databaseBuilder.factory.buildAssessment({
+        userId: JOHN_USERID,
+        courseId: johnCertificationCourse.id,
+        type: Assessment.types.CERTIFICATION,
+        state: 'completed',
+      });
+      assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: john_completedAssessment.id,
+        level: 1,
+        pixScore: 23,
+        emitter: 'PIX-ALGO',
+        status: 'rejected',
+      });
+      await databaseBuilder.commit();
     });
 
     it('should return 200 HTTP status code and the updated certification', () => {
       // given
       options = {
         method: 'PATCH',
-        url: `/api/certifications/${JOHN_CERTIFICATION_ID}`,
+        url: `/api/certifications/${johnCertificationCourse.id}`,
         headers: { authorization: generateValidRequestAuthorizationHeader() },
         payload: {
           data: {
             type: 'certifications',
-            id: JOHN_CERTIFICATION_ID,
+            id: johnCertificationCourse.id,
             attributes: {
               'is-published': true,
             },
@@ -625,18 +370,18 @@ describe('Acceptance | API | Certifications', () => {
           expect(response.statusCode).to.equal(200);
           expect(response.result.data).to.deep.equal({
             type: 'certifications',
-            id: JOHN_CERTIFICATION_ID.toString(),
+            id: `${johnCertificationCourse.id}`,
             attributes: {
-              'birthdate': '1991-10-24',
-              'birthplace': 'Earth',
-              'certification-center': 'Université du Pix',
-              'comment-for-candidate': null,
-              'date': new Date('2003-01-02T01:02:03Z'),
-              'first-name': 'John',
+              'birthdate': johnCertificationCourse.birthdate,
+              'birthplace': johnCertificationCourse.birthplace,
+              'certification-center': session.certificationCenter,
+              'comment-for-candidate': assessmentResult.commentForCandidate,
+              'date': johnCertificationCourse.completedAt,
+              'first-name': johnCertificationCourse.firstName,
               'is-published': true,
-              'last-name': 'Doe',
-              'pix-score': 23,
-              'status': 'rejected',
+              'last-name': johnCertificationCourse.lastName,
+              'pix-score': assessmentResult.pixScore,
+              'status': assessmentResult.status,
             },
             relationships: {
               'result-competence-tree': {
@@ -645,8 +390,8 @@ describe('Acceptance | API | Certifications', () => {
             },
           });
         })
-        .then(() => knex('certification-courses').where('id', JOHN_CERTIFICATION_ID))
-        .then((foundCertification) => expect(foundCertification[0].isPublished == true).to.be.true);
+        .then(() => knex('certification-courses').where('id', johnCertificationCourse.id))
+        .then((foundCertification) => expect(foundCertification[0].isPublished).to.be.true);
     });
 
     it('should return unauthorized 403 HTTP status code when user is not pixMaster', () => {
@@ -670,8 +415,8 @@ describe('Acceptance | API | Certifications', () => {
       // then
       return promise
         .then((response) => expect(response.statusCode).to.equal(403))
-        .then(() => knex('certification-courses').where('id', JOHN_CERTIFICATION_ID))
-        .then((certifications) => expect(certifications[0].isPublished == true).to.be.false);
+        .then(() => knex('certification-courses').where('id', johnCertificationCourse.id))
+        .then((certifications) => expect(certifications[0].isPublished).to.be.false);
     });
   });
 

--- a/api/tests/unit/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/area-repository_test.js
@@ -70,18 +70,24 @@ describe('Unit | Repository | area-repository', function() {
     });
   });
 
-  describe('#listWithCompetences', () => {
+  describe('#listWithPixCompetencesOnly', () => {
     const competence1 = domainBuilder.buildCompetence({
-        area: { id: 'recDomaine1' }
-      }), competence2 = domainBuilder.buildCompetence({
-        area: { id: 'recDomaine2' }
-      });
+      area: { id: 'recDomaine1' }
+    });
+    const competence2 = domainBuilder.buildCompetence({
+      area: { id: 'recDomaine2' }
+    });
+    const nonPixCompetence = domainBuilder.buildCompetence({
+      area: { id: 'recDomaine3' },
+      origin: 'Other'
+    });
 
     beforeEach(() => {
-      sinon.stub(competenceRepository, 'list');
-      competenceRepository.list.resolves([
+      sinon.stub(competenceRepository, 'listPixCompetencesOnly');
+      competenceRepository.listPixCompetencesOnly.resolves([
         competence1,
         competence2,
+        nonPixCompetence,
       ]);
     });
 
@@ -111,7 +117,7 @@ describe('Unit | Repository | area-repository', function() {
       ];
 
       // when
-      const fetchedAreas = areaRepository.listWithCompetences();
+      const fetchedAreas = areaRepository.listWithPixCompetencesOnly();
 
       // then
       return fetchedAreas.then((areas) => {

--- a/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/competence-tree-repository_test.js
@@ -6,7 +6,7 @@ const CompetenceTree = require('../../../../lib/domain/models/CompetenceTree');
 describe('Unit | Repository | competence-tree-repository', () => {
 
   beforeEach(() => {
-    sinon.stub(areaRepository, 'listWithCompetences');
+    sinon.stub(areaRepository, 'listWithPixCompetencesOnly');
   });
 
   describe('#get', () => {
@@ -31,7 +31,7 @@ describe('Unit | Repository | competence-tree-repository', () => {
         ],
       };
 
-      areaRepository.listWithCompetences.resolves([area]);
+      areaRepository.listWithPixCompetencesOnly.resolves([area]);
 
       const expectedTree = {
         id: 1,


### PR DESCRIPTION
## :unicorn: Problème
Quand des compétences / domaines non-Pix (Pix+) existent dans le référentiel, elles ne sont pas certifiables.
Actuellement, le problème est que ces compétences sont affichées dans les résultats de certification.

## :robot: Solution
Filtrer les compétences / domaines affichées dans les résultats de certification qui ne sont pas Pix.

## :rainbow: Remarques
En faisant la modification, les tests de `certification-controller` échouaient.
En essayant de comprendre pourquoi, j'ai constaté que les tests n'utilisaient pas les `builders` rendant la lecture et la compréhension des tests.
J'ai donc commencé par un refacto de `certification-controller_test`.
