### PR TITLE
[BUGFIX] L'identifiant ne doit pas se vider après avoir tenté de s'inscrire avec adresse email existante (PF-1074).

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -37,8 +37,10 @@ export default Component.extend({
   passwordInputType: computed('isPasswordVisible', function() {
     return this.isPasswordVisible ? 'text' : 'password';
   }),
+
   username: '',
   email: '',
+  password: '',
 
   firstName: '',
   lastName: '',
@@ -57,10 +59,10 @@ export default Component.extend({
       || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
   }),
 
-  isCreationFormNotValid: computed('studentDependentUser.{email,username,password}', function() {
-    const isPasswordNotValid = !isPasswordValid(this.get('studentDependentUser.password'));
-    const isUsernameNotValid = !isStringValid(this.get('studentDependentUser.username'));
-    const isEmailNotValid = !isEmailValid(this.get('studentDependentUser.email'));
+  isCreationFormNotValid: computed('email,username,password', function() {
+    const isPasswordNotValid = !isPasswordValid(this.get('password'));
+    const isUsernameNotValid = !isStringValid(this.get('username'));
+    const isEmailNotValid = !isEmailValid(this.get('email'));
     if (this.loginWithUsername) {
       return isUsernameNotValid || isPasswordNotValid;
     }
@@ -145,7 +147,7 @@ export default Component.extend({
             lastName: this.lastName,
             email: '',
             username: this.username,
-            password: '',
+            password: this.password,
           });
         }, (errorResponse) => {
           this.studentUserAssociation.unloadRecord();
@@ -165,10 +167,12 @@ export default Component.extend({
     async register() {
       this.set('isLoading', true);
       try {
-        this.set('email', this.get('studentDependentUser.email'));
+        this.set('studentDependentUser.password', this.password);
         if (this.loginWithUsername) {
+          this.set('studentDependentUser.username', this.get('username'));
           this.set('studentDependentUser.email', undefined);
         } else {
+          this.set('studentDependentUser.email', this.get('email'));
           this.set('studentDependentUser.username', undefined);
         }
         await this.studentDependentUser.save({
@@ -180,8 +184,6 @@ export default Component.extend({
           }
         });
       } catch (error) {
-        this.set('studentDependentUser.email', this.email);
-        this.set('studentDependentUser.username', this.username);
         this.set('isLoading', false);
         return this._updateInputsStatus();
       }

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -38,6 +38,7 @@ export default Component.extend({
     return this.isPasswordVisible ? 'text' : 'password';
   }),
   username: '',
+  email: '',
 
   firstName: '',
   lastName: '',
@@ -164,6 +165,7 @@ export default Component.extend({
     async register() {
       this.set('isLoading', true);
       try {
+        this.set('email', this.get('studentDependentUser.email'));
         if (this.loginWithUsername) {
           this.set('studentDependentUser.email', undefined);
         } else {
@@ -178,6 +180,8 @@ export default Component.extend({
           }
         });
       } catch (error) {
+        this.set('studentDependentUser.email', this.email);
+        this.set('studentDependentUser.username', this.username);
         this.set('isLoading', false);
         return this._updateInputsStatus();
       }

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -147,7 +147,7 @@ export default Component.extend({
             lastName: this.lastName,
             email: '',
             username: this.username,
-            password: this.password,
+            password: '',
           });
         }, (errorResponse) => {
           this.studentUserAssociation.unloadRecord();

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -59,7 +59,7 @@ export default Component.extend({
       || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
   }),
 
-  isCreationFormNotValid: computed('email,username,password', function() {
+  isCreationFormNotValid: computed('email','username','password', function() {
     const isPasswordNotValid = !isPasswordValid(this.get('password'));
     const isUsernameNotValid = !isStringValid(this.get('username'));
     const isEmailNotValid = !isEmailValid(this.get('email'));

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -79,8 +79,8 @@
         <div id="register-username-container">
           <FormTextfield @label="Mon identifiant"
                          @textfieldName="username"
-                         @inputBindingValue={{this.studentDependentUser.username}}
-                         @onValidate={{action "triggerInputStringValidation" "username" this.studentDependentUser.username}}
+                         @inputBindingValue={{this.username}}
+                         @onValidate={{action "triggerInputStringValidation" "username" this.username}}
                          @validationStatus={{this.validation.username.status}}
                          @validationMessage={{this.validation.username.message}}
                          @disabled={{true}}
@@ -91,8 +91,8 @@
           <FormTextfield @label="Adresse e-mail"
                          @help="(ex: nom@exemple.fr)"
                          @textfieldName="email"
-                         @inputBindingValue={{this.studentDependentUser.email}}
-                         @onValidate={{action "triggerInputEmailValidation" "email" this.studentDependentUser.email}}
+                         @inputBindingValue={{this.email}}
+                         @onValidate={{action "triggerInputEmailValidation" "email" this.email}}
                          @validationStatus={{this.validation.email.status}}
                          @validationMessage={{this.validation.email.message}}
                          @require={{true}} />
@@ -102,8 +102,8 @@
       <FormTextfield @label="Mot de passe"
                      @help="(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)"
                      @textfieldName="password"
-                     @inputBindingValue={{this.studentDependentUser.password}}
-                     @onValidate={{action "triggerInputPasswordValidation" "password" this.studentDependentUser.password}}
+                     @inputBindingValue={{this.password}}
+                     @onValidate={{action "triggerInputPasswordValidation" "password" this.password}}
                      @validationStatus={{this.validation.password.status}}
                      @validationMessage={{this.validation.password.message}}
                      @require={{true}} />

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -76,6 +76,24 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
           context('When campaign is restricted', function() {
             const campaignCode = 'AZERTY4';
 
+            context('When the student has an account but is not reconcilied', function() {
+
+              it('should redirect to reconciliation page', async function() {
+
+                // given
+                await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
+
+                // when
+                await click('#login-button');
+                await fillIn('#login', prescritUser.email);
+                await fillIn('#password', prescritUser.password);
+                await click('#submit-connexion');
+
+                // then
+                expect(currentURL()).to.equal(`/campagnes/${campaignCode}/rejoindre`);
+              });
+            });
+
             it('should redirect to login-or-register page', async function() {
               // when
               await visitWithAbortedTransition(`/campagnes/${campaignCode}`);

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -20,8 +20,8 @@ function _buildCampaignParticipation(schema) {
   return schema.campaignParticipations.create({ assessment });
 }
 
-function _overrideResponseApi(status, stub) {
-  return new Response(status,{ 'content-type': 'application/json; charset=utf-8' }, stub);
+function _overrideApiResponse(status, responseBody) {
+  return new Response(status,{ 'content-type': 'application/json; charset=utf-8' }, responseBody);
 }
 
 describe('Acceptance | Campaigns | Start Campaigns', function() {
@@ -145,12 +145,12 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }
                 };
 
-                return _overrideResponseApi(200,studentFoundWithUsernameGenerated);
+                return _overrideApiResponse(200,studentFoundWithUsernameGenerated);
               });
 
               this.server.post('student-dependent-users', () => {
 
-                const stubErrorInvalidDataEmailAlreadyExist = {
+                const emailAlreadyExistResponse = {
                   'errors': [{
                     'status': '422',
                     'title': 'Invalid data attribute "email"',
@@ -159,7 +159,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }]
                 };
 
-                return _overrideResponseApi(422,stubErrorInvalidDataEmailAlreadyExist);
+                return _overrideApiResponse(422,emailAlreadyExistResponse);
               });
 
               await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
@@ -172,7 +172,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
               await fillIn('#yearOfBirth', '2000');
 
               await click('#submit-search');
-              //switch to email login mode
+              //go to email-based authentication window
               await click('.pix-toggle__off');
 
               await fillIn('#email', 'JeanPrescrit.Campagne@example.net');
@@ -185,7 +185,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
               expect(find('#email').value).to.equal('JeanPrescrit.Campagne@example.net');
               expect(find('#password').value).to.equal('pix123');
 
-              //switch to username login mode
+              //go to username-based authentication window
               await click('.pix-toggle__off');
               expect(find('#username').value).to.equal('first.last1010');
               expect(find('#password').value).to.equal('pix123');

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -88,8 +88,6 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
               // given
               await visitWithAbortedTransition(`/campagnes/${campaignCode}`);
 
-              expect(currentURL()).to.equal('/campagnes/AZERTY4/identification');
-
               // when
               await fillIn('#firstName', 'JeanPrescrit');
               await fillIn('#lastName', 'Campagne');

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -5,6 +5,7 @@ import {
   authenticateByEmail,
   authenticateByGAR,
 } from '../helpers/authentification';
+import  overrideApiResponse  from '../helpers/mirage';
 import {
   startCampaignByCode,
   startCampaignByCodeAndExternalId
@@ -13,15 +14,10 @@ import visitWithAbortedTransition from '../helpers/visit';
 import defaultScenario from '../../mirage/scenarios/default';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { Response } from 'ember-cli-mirage';
 
 function _buildCampaignParticipation(schema) {
   const assessment = schema.assessments.create({});
   return schema.campaignParticipations.create({ assessment });
-}
-
-function _overrideApiResponse(status, responseBody) {
-  return new Response(status,{ 'content-type': 'application/json; charset=utf-8' }, responseBody);
 }
 
 describe('Acceptance | Campaigns | Start Campaigns', function() {
@@ -145,7 +141,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }
                 };
 
-                return _overrideApiResponse(200,studentFoundWithUsernameGenerated);
+                return overrideApiResponse(200,studentFoundWithUsernameGenerated);
               });
 
               this.server.post('student-dependent-users', () => {
@@ -159,7 +155,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }]
                 };
 
-                return _overrideApiResponse(422,emailAlreadyExistResponse);
+                return overrideApiResponse(422,emailAlreadyExistResponse);
               });
 
               await visitWithAbortedTransition(`/campagnes/${campaignCode}`);

--- a/mon-pix/tests/acceptance/start-campaigns-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-test.js
@@ -141,7 +141,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }
                 };
 
-                return overrideApiResponse(200,studentFoundWithUsernameGenerated);
+                return overrideApiResponse(200, studentFoundWithUsernameGenerated);
               });
 
               this.server.post('student-dependent-users', () => {
@@ -155,7 +155,7 @@ describe('Acceptance | Campaigns | Start Campaigns', function() {
                   }]
                 };
 
-                return overrideApiResponse(422,emailAlreadyExistResponse);
+                return overrideApiResponse(422, emailAlreadyExistResponse);
               });
 
               await visitWithAbortedTransition(`/campagnes/${campaignCode}`);

--- a/mon-pix/tests/helpers/mirage.js
+++ b/mon-pix/tests/helpers/mirage.js
@@ -1,5 +1,5 @@
 import { Response } from 'ember-cli-mirage';
 
 export default function overrideApiResponse(status, responseBody) {
-  return new Response(status,{ 'content-type': 'application/json; charset=utf-8' }, responseBody);
+  return new Response(status, { 'content-type': 'application/json; charset=utf-8' }, responseBody);
 }

--- a/mon-pix/tests/helpers/mirage.js
+++ b/mon-pix/tests/helpers/mirage.js
@@ -1,0 +1,5 @@
+import { Response } from 'ember-cli-mirage';
+
+export default function overrideApiResponse(status, responseBody) {
+  return new Response(status,{ 'content-type': 'application/json; charset=utf-8' }, responseBody);
+}


### PR DESCRIPTION
## :unicorn: Problème
_Scénario pour reproduire :
1 - Sur la double mire, faire la pré-réconciliation (First Last 10/10/2010)
2 - Choisir e-mail sur le toggle
3 - Remplir avec un email déjà existant (userpix1@example.net) et un mot de passe valide
4 - Valider (un message d'erreur s'affiche, logique)
5 - Cliquer sur identifiant sur le toggle
6 - Constater le problème que l'identifiant "first.last1010" a disparu_

## :robot: Solution
_ Remplacer le binding de l'input username par la propriété username qui ne réinitialise pas . 
Contrairement à celle du modele student user association qui subi un reset lors du changement de mode de connexion._

![image](https://user-images.githubusercontent.com/10045497/74756699-4164d580-5275-11ea-9649-faabe7cb9e18.png)
