### PR TITLE
[FEATURE] Tagger les résultats d'une session comme "envoyés au prescripteur" (PA-134)

### DIFF
--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -1,0 +1,22 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    const url = this._super(...arguments);
+    if (adapterOptions && adapterOptions.flagResultsAsSentToPrescriber)  {
+      delete adapterOptions.flagResultsAsSentToPrescriber;
+      return url + '/results-sent-to-prescriber';
+    }
+
+    return url;
+  },
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions.flagResultsAsSentToPrescriber) {
+      return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PUT');
+    }
+
+    return this._super(...arguments);
+  }
+});

--- a/admin/app/controllers/authenticated/certifications/sessions/info/index.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/index.js
@@ -32,5 +32,9 @@ export default Controller.extend({
         this.notifications.error(error);
       }
     },
+
+    async tagSessionAsSentToPrescriber() {
+      await this.session.save({ adapterOptions: { flagResultsAsSentToPrescriber: true } });
+    },
   },
 });

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -23,7 +23,7 @@ export default Model.extend({
   status: attr(),
   finalizedAt: attr(),
   isFinalized: equal('status', 'finalized'),
-  sentToPrescriberAt: attr(),
+  resultsSentToPrescriberAt: attr(),
   examinerGlobalComment: attr('string'),
   certifications: hasMany('certification'),
   countExaminerComment : computed('certifications.[]', function() {
@@ -52,7 +52,7 @@ export default Model.extend({
     return (new Date(this.finalizedAt)).toLocaleString('fr-FR');
   }),
 
-  sentToPrescriber() {
-    return this.store.adapterFor('session').sentToPrescriber(this);
-  }
+  resultsSentToPrescriberDate: computed('resultsSentToPrescriberAt', function() {
+    return (new Date(this.resultsSentToPrescriberAt)).toLocaleString('fr-FR');
+  }),
 });

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -23,6 +23,7 @@ export default Model.extend({
   status: attr(),
   finalizedAt: attr(),
   isFinalized: equal('status', 'finalized'),
+  sentToPrescriberAt: attr(),
   examinerGlobalComment: attr('string'),
   certifications: hasMany('certification'),
   countExaminerComment : computed('certifications.[]', function() {
@@ -50,4 +51,8 @@ export default Model.extend({
   finalizationDate: computed('finalizedAt', function() {
     return (new Date(this.finalizedAt)).toLocaleString('fr-FR');
   }),
+
+  sentToPrescriber() {
+    return this.store.adapterFor('session').sentToPrescriber(this);
+  }
 });

--- a/admin/app/styles/authenticated/certifications/sessions/info/index.scss
+++ b/admin/app/styles/authenticated/certifications/sessions/info/index.scss
@@ -3,10 +3,10 @@
   padding-bottom: 0px;
 
   .row--btn {
-    justify-content: flex-end;
+    margin: inherit;
 
     .btn {
-      margin-left: 20px;
+      margin-right: 20px;
     }
   }
 

--- a/admin/app/styles/authenticated/certifications/sessions/info/index.scss
+++ b/admin/app/styles/authenticated/certifications/sessions/info/index.scss
@@ -7,7 +7,12 @@
 
     .btn {
       margin-right: 20px;
+
+      &--right {
+        margin-left: auto;
+      }
     }
+
   }
 
   &__stats {

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -70,11 +70,11 @@
 
   <div class="certifications-session-info__actions">
     <div class='row row--btn'>
-        <button data-test-id="button-session-result-file-info" class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
+        <button class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
             Exporter les résultats
         </button>
 
-        <button data-test-id="button-before-jury-file" class="btn btn-primary" {{action "downloadBeforeJuryFile"}} type="button">
+        <button class="btn btn-primary" {{action "downloadBeforeJuryFile"}} type="button">
             Récupérer le fichier avant jury
         </button>
     </div>

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -42,6 +42,12 @@
           <div class='col'>Date de finalisation :</div>
           <div class='col' data-test-id='certifications-session-info__finalized-at'>{{session.finalizationDate}}</div>
       </div>
+      {{#if session.resultsSentToPrescriberAt}}
+      <div class='row'>
+          <div class='col'>Date d'envoi des résultats au prescripteur :</div>
+          <div class='col' data-test-id='certifications-session-info__sent-to-prescriber-at'>{{session.resultsSentToPrescriberDate}}</div>
+      </div>
+      {{/if}}
       {{/if}}
   </div>
 
@@ -70,13 +76,19 @@
 
   <div class="certifications-session-info__actions">
     <div class='row row--btn'>
-        <button class="btn btn-primary" {{action "downloadSessionResultFile"}} type="button">
-            Exporter les résultats
-        </button>
-
         <button class="btn btn-primary" {{action "downloadBeforeJuryFile"}} type="button">
             Récupérer le fichier avant jury
         </button>
+        
+        <button class="btn btn-primary btn--right" {{action "downloadSessionResultFile"}} type="button">
+            Exporter les résultats
+        </button>
+
+        {{#if (and session.isFinalized (not session.resultsSentToPrescriberAt))}}
+        <button class="btn btn-primary" {{action "tagSessionAsSentToPrescriber"}} type="button">
+          Résultats transmis au prescripteur
+        </button>
+        {{/if}}
     </div>
   </div>
 </div>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -43,6 +43,13 @@ export default function() {
   this.get('/sessions/:id/certifications', getCertificationsBySessionId);
   this.get('/admin/certifications/:id');
 
+  this.put('/sessions/:id/results-sent-to-prescriber', (schema, request) => {
+    const sessionId = request.params.id;
+    const session = schema.sessions.findBy({ id: sessionId });
+    session.update({ resultsSentToPrescriberAt: new Date() });
+    return session;
+  });
+
   this.put('/sessions/:id/certifications/attendance-sheet-analysis', upload(function() {
     return [
       { lastName: 'Lantier',

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -1,0 +1,77 @@
+import { module, test, only } from 'qunit';
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { FINALIZED, statusToDisplayName } from 'pix-admin/models/session';
+
+module('Acceptance | Session page', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    await authenticateSession({ userId: 1 });
+  });
+
+  module('Access', function() {
+
+    test('Session page should be accessible from /certification/sessions', async function(assert) {
+      // when
+      await visitSessionsPage();
+
+      // then
+      assert.equal(currentURL(), '/certifications/sessions');
+    });
+  });
+
+  module('Rendering', function(hooks) {
+
+    const STATUS_SECTION = 9;
+    const FINALISATION_DATE_SECTION = 10;
+    const SENT_TO_PRESCRIPTEUR_DATE_SECTION = 11;
+
+    hooks.beforeEach(async function() {
+      await visitSessionsPage();
+    });
+
+    test('Should not have a "Date de finalisation" section', async function(assert) {
+
+      const session = this.server.create('session');
+
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+      assert.dom('div.certifications-session-info__details').exists();
+      assert.dom('.row:nth-child(10) .col:nth-child(1)').doesNotExist();
+    });
+
+    only('Should have "Date de finalisation" and "Date d\'envoi au prescripteur" section', async function(assert) {
+
+      const finalizedDate = new Date('2019-03-10T01:03:04Z');
+      const session = this.server.create('session', { status: FINALIZED, finalizedAt: finalizedDate });
+      // when
+      await visit(`/certifications/sessions/${session.id}`);
+      assert.dom('div.certifications-session-info__details').exists();
+      assert.dom(`.row:nth-child(${STATUS_SECTION}) .col:nth-child(2)`).containsText(statusToDisplayName[FINALIZED]);
+      assert.dom(`.row:nth-child(${FINALISATION_DATE_SECTION}) .col:nth-child(2)`).containsText(finalizedDate.toLocaleString('fr-FR'));
+      assert.dom(`.row:nth-child(${SENT_TO_PRESCRIPTEUR_DATE_SECTION}) .col:nth-child(2)`).doesNotExist();
+    });
+
+    test('Should add "Date d\'envoi au prescripteur" section', async function(assert) {
+      const session = this.server.create('session', {
+        status: FINALIZED,
+        finalizedAt: new Date('2019-03-10T01:03:04Z'),
+      });
+        // when
+      await visit(`/certifications/sessions/${session.id}`);
+      await click('.certifications-session-info__actions button:nth-child(2)');
+        
+      assert.dom(`.row:nth-child(${SENT_TO_PRESCRIPTEUR_DATE_SECTION}) .col:nth-child(2)`).exists();
+    });
+
+  });
+
+  async function visitSessionsPage() {
+    return visit('/certifications/sessions');
+  }
+
+});

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | session', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:session');
+  });
+
+  module('#urlForUpdateRecord', () => {
+    test('should build update url from session id', async function(assert) {
+      // when
+      const options = { adapterOptions: { } };
+      const url = await adapter.urlForUpdateRecord(123, 'session', options);
+
+      assert.ok(url.endsWith('/sessions/123'));
+    });
+
+    test('should build specific url to results-sent-to-prescriber', async function(assert) {
+      // when
+      const options = { adapterOptions: { flagResultsAsSentToPrescriber: true } };
+      const url = await adapter.urlForUpdateRecord(123, 'session', options);
+
+      // then
+      assert.ok(url.endsWith('/sessions/123/results-sent-to-prescriber'));
+    });
+  });
+
+});

--- a/api/db/migrations/20200218114201_add_sendToPrescriber_column_in_session_table.js
+++ b/api/db/migrations/20200218114201_add_sendToPrescriber_column_in_session_table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'resultsSentToPrescriberAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -233,6 +233,7 @@ exports.register = async (server) => {
       }
     },
     {
+
       method: 'POST',
       path: '/api/sessions/{id}/candidate-participation',
       config: {
@@ -267,6 +268,23 @@ exports.register = async (server) => {
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
           '- Elle permet de lire et de retourner des données sur les certifications présentes dans le PV de session transmis en buffer',
+        ]
+      }
+    },
+    {
+      method: 'PUT',
+      path: '/api/sessions/{id}/results-sent-to-prescriber',
+      config: {
+        pre: [{
+          method: securityController.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.flagResultsAsSentToPrescriber,
+        tags: ['api', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de marquer le fait que les résultats de la session ont été envoyés au prescripteur,\n',
+          '- par le biais de la sauvegarde de la date courante.',
         ]
       }
     },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -140,6 +140,13 @@ module.exports = {
     const sessionId = request.params.id;
     const odsBuffer = request.payload.file;
     return usecases.analyzeAttendanceSheet({ sessionId, odsBuffer });
-  }
+  },
+
+  async flagResultsAsSentToPrescriber(request, h) {
+    const sessionId = request.params.id;
+    const { resultsFlaggedAsSent, session } = await usecases.flagSessionResultsAsSentToPrescriber({ sessionId });
+    const serializedSession = await sessionSerializer.serialize(session);
+    return resultsFlaggedAsSent ? h.response(serializedSession).created() : serializedSession;
+  },
 
 };

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const CREATED = 'created';
 const FINALIZED = 'finalized';
 
@@ -7,7 +9,6 @@ const statuses = {
 };
 
 class Session {
-
   constructor({
     id,
     // attributes
@@ -23,6 +24,7 @@ class Session {
     status,
     examinerGlobalComment,
     finalizedAt,
+    resultsSentToPrescriberAt,
     // includes
     certificationCandidates,
     // references
@@ -41,9 +43,14 @@ class Session {
     this.status = status;
     this.examinerGlobalComment = examinerGlobalComment;
     this.finalizedAt = finalizedAt;
+    this.resultsSentToPrescriberAt = resultsSentToPrescriberAt;
     // includes
     this.certificationCandidates = certificationCandidates;
     // references
+  }
+
+  areResultsFlaggedAsSent() {
+    return !_.isNil(this.resultsSentToPrescriberAt);
   }
 }
 

--- a/api/lib/domain/usecases/flag-session-results-as-sent-to-prescriber.js
+++ b/api/lib/domain/usecases/flag-session-results-as-sent-to-prescriber.js
@@ -1,0 +1,25 @@
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = async function flagSessionResultsAsSentToPrescriber({ sessionId, sessionRepository }) {
+  const integerSessionId = parseInt(sessionId);
+  const NOT_FOUND_SESSION = `La session ${sessionId} n'existe pas ou son accès est restreint lors du marquage d'envoi des résultats au prescripteur`;
+
+  if (!Number.isFinite(integerSessionId)) {
+    throw new NotFoundError(NOT_FOUND_SESSION);
+  }
+
+  let session;
+  try {
+    session = await sessionRepository.get(sessionId);
+  } catch (err) {
+    throw new NotFoundError(NOT_FOUND_SESSION);
+  }
+
+  if (!session.areResultsFlaggedAsSent()) {
+    session.resultsSentToPrescriberAt = new Date();
+    session = await sessionRepository.update(session);
+    return { resultsFlaggedAsSent: true, session };
+  }
+
+  return { resultsFlaggedAsSent: false, session };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -136,6 +136,7 @@ module.exports = injectDependencies({
   importStudentsFromSIECLE: require('./import-students-from-siecle'),
   linkUserToOrganizationStudentData: require('./link-user-to-organization-student-data'),
   linkUserToSessionCertificationCandidate: require('./link-user-to-session-certification-candidate'),
+  flagSessionResultsAsSentToPrescriber: require('./flag-session-results-as-sent-to-prescriber'),
   rememberUserHasSeenAssessmentInstructions: require('./remember-user-has-seen-assessment-instructions'),
   resetScorecard: require('./reset-scorecard'),
   retrieveCampaignInformation: require('./retrieve-campaign-information'),

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -29,20 +29,6 @@ module.exports = {
     return Boolean(session);
   },
 
-  getByAccessCode: async (accessCode) => {
-    try {
-      const sessionWithAccessCode = await BookshelfSession
-        .where({ accessCode })
-        .fetch({ require: true });
-      return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, sessionWithAccessCode);
-    } catch (err) {
-      if (err instanceof BookshelfSession.NotFoundError) {
-        throw new NotFoundError();
-      }
-      throw err;
-    }
-  },
-
   async get(idSession) {
     try {
       const session = await BookshelfSession

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -91,6 +91,7 @@ module.exports = {
       'description',
       'status',
       'examinerGlobalComment',
+      'resultsSentToPrescriberAt',
     ]);
 
     let updatedSession = await new BookshelfSession({ id: session.id })

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -25,6 +25,7 @@ module.exports = {
         'certificationReports',
         'examinerGlobalComment',
         'finalizedAt',
+        'resultsSentToPrescriberAt',
       ],
       certifications : {
         ref: 'id',

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -139,6 +139,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'status': statuses.CREATED,
             'examiner-global-comment': 'It was a fine session my dear',
             'finalized-at': null,
+            'results-sent-to-prescriber-at': null,
           },
           'relationships': {
             'certifications': {
@@ -172,6 +173,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
             'status': statuses.CREATED,
             'examiner-global-comment': 'It was a fine session my dear',
             'finalized-at': null,
+            'results-sent-to-prescriber-at': null,
           },
           'relationships': {
             'certifications': {

--- a/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
@@ -3,33 +3,27 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('PUT /api/sessions/:id/sent-to-prescriber', () => {
-
+describe('PUT /api/sessions/:id/results-sent-to-prescriber', () => {
   let server;
-  let options;
+  const options = { method: 'PUT' };
+  let userId;
 
   beforeEach(async () => {
     server = await createServer();
   });
 
-  context('User does not have the role PIX MASTER', () => {
+  context('when user does not have the role PIX MASTER', () => {
 
-    beforeEach(async () => {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
-      const headers = { 'authorization': `Bearer ${token}` };
-      options = {
-        method: 'PUT',
-        url: '/api/sessions/1/sent-to-prescriber',
-        headers,
-      };
-
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
       return databaseBuilder.commit();
     });
 
-    it('will shut me down ', async () => {
+    it('should return a 403 error code', async () => {
+      // given
+      options.url = '/api/sessions/any/results-sent-to-prescriber';
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+
       // when
       const response = await server.inject(options);
 
@@ -39,59 +33,113 @@ describe('PUT /api/sessions/:id/sent-to-prescriber', () => {
 
   });
 
-  context('User has role PixMaster', () => {
-    let sessionWithAlreadyADateId;
-    let sessionWithoutADateId;
+  context('when user has role PixMaster', () => {
 
-    beforeEach(async () => {
+    beforeEach(() => {
       // given
-      const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
-      sessionWithAlreadyADateId = databaseBuilder.factory.buildSession({ sentToPrescriberAt: new Date() }).id;
-      sessionWithoutADateId = databaseBuilder.factory.buildSession().id;
-
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
-      const headers = Object.assign({}, { 'authorization': `Bearer ${token}` });
-      options = {
-        method: 'PUT',
-        headers,
-      };
-
+      userId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
       return databaseBuilder.commit();
     });
 
-    it('should return an 404 status when the session doesn\'t exist', async () => {
-      // given
-      options.url = `/api/sessions/${sessionWithAlreadyADateId + sessionWithoutADateId}/sent-to-prescriber`;
+    context('when the session id has an invalid format', () => {
 
-      // when
-      const response = await server.inject(options);
+      it('should return a 404 error code', async () => {
+        // given
+        options.url = '/api/sessions/any/results-sent-to-prescriber';
 
-      // then
-      expect(response.statusCode).to.equal(404);
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
     });
 
-    it('should return an 201 status when the session sentToPrescriberAt already exists', async () => {
-      // given 
-      options.url = `/api/sessions/${sessionWithAlreadyADateId}/sent-to-prescriber`;
+    context('when the session id is a number', () => {
 
-      // when
-      const response = await server.inject(options);
+      context('when the session does not exist', () => {
 
-      // then
-      expect(response.statusCode).to.equal(201);
-    });
+        it('should return a 404 error code', async () => {
+          // given
+          options.url = '/api/sessions/1/results-sent-to-prescriber';
 
-    it('should return an 200 status when the session sentToPrescriberAt does not exist', async () => {
-      // given 
-      options.url = `/api/sessions/${sessionWithoutADateId}/sent-to-prescriber`;
+          // when
+          const response = await server.inject(options);
 
-      // when
-      const response = await server.inject(options);
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
 
-      // then
-      expect(response.statusCode).to.equal(200);
+      context('when the session exists', () => {
+        let sessionId;
+
+        context('when the session results were already flagged as sent to prescriber', () => {
+          const date = new Date();
+
+          beforeEach(() => {
+            // given
+            sessionId = databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: date }).id;
+            options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+            return databaseBuilder.commit();
+          });
+
+          it('should return a 200 status code', async () => {
+            // given
+            options.url = `/api/sessions/${sessionId}/results-sent-to-prescriber`;
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(200);
+          });
+
+          it('should return the serialized session with an untouched resultsSentToPrescriberAt date', async () => {
+            // given
+            options.url = `/api/sessions/${sessionId}/results-sent-to-prescriber`;
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.result.data.attributes['results-sent-to-prescriber-at']).to.deep.equal(date);
+          });
+        });
+
+        context('when the session results were not flagged as sent to prescriber', () => {
+
+          beforeEach(() => {
+            // given
+            sessionId = databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null }).id;
+            options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+            return databaseBuilder.commit();
+          });
+
+          it('should return a 201 status code', async () => {
+            // given
+            options.url = `/api/sessions/${sessionId}/results-sent-to-prescriber`;
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(201);
+          });
+
+          it('should return the serialized session with a defined resultsSentToPrescriberAt date', async () => {
+            // given
+            options.url = `/api/sessions/${sessionId}/results-sent-to-prescriber`;
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.result.data.attributes['results-sent-to-prescriber-at']).to.be.an.instanceOf(Date);
+          });
+        });
+      });
     });
   });
-
 });

--- a/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
@@ -1,0 +1,97 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('PUT /api/sessions/:id/sent-to-prescriber', () => {
+
+  let server;
+  let options;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  context('User does not have the role PIX MASTER', () => {
+
+    beforeEach(async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser();
+      const authHeader = generateValidRequestAuthorizationHeader(user.id);
+      const token = authHeader.replace('Bearer ', '');
+      const headers = { 'authorization': `Bearer ${token}` };
+      options = {
+        method: 'PUT',
+        url: '/api/sessions/1/sent-to-prescriber',
+        headers,
+      };
+
+      return databaseBuilder.commit();
+    });
+
+    it('will shut me down ', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+  });
+
+  context('User has role PixMaster', () => {
+    let sessionWithAlreadyADateId;
+    let sessionWithoutADateId;
+
+    beforeEach(async () => {
+      // given
+      const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+      sessionWithAlreadyADateId = databaseBuilder.factory.buildSession({ sentToPrescriberAt: new Date() }).id;
+      sessionWithoutADateId = databaseBuilder.factory.buildSession().id;
+
+      const authHeader = generateValidRequestAuthorizationHeader(user.id);
+      const token = authHeader.replace('Bearer ', '');
+      const headers = Object.assign({}, { 'authorization': `Bearer ${token}` });
+      options = {
+        method: 'PUT',
+        headers,
+      };
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return an 404 status when the session doesn\'t exist', async () => {
+      // given
+      options.url = `/api/sessions/${sessionWithAlreadyADateId + sessionWithoutADateId}/sent-to-prescriber`;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return an 201 status when the session sentToPrescriberAt already exists', async () => {
+      // given 
+      options.url = `/api/sessions/${sessionWithAlreadyADateId}/sent-to-prescriber`;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    it('should return an 200 status when the session sentToPrescriberAt does not exist', async () => {
+      // given 
+      options.url = `/api/sessions/${sessionWithoutADateId}/sent-to-prescriber`;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -121,49 +121,6 @@ describe('Integration | Repository | Session', function() {
     });
   });
 
-  describe('#getByAccessCode', () => {
-    let session;
-
-    beforeEach(() => {
-      session = {
-        certificationCenter: 'Paris',
-        address: 'Paris',
-        room: 'The lost room',
-        examiner: 'Bernard',
-        date: '2018-02-23',
-        time: '12:00',
-        description: 'The lost examen',
-        accessCode: 'ABC123'
-      };
-      databaseBuilder.factory.buildSession(session);
-
-      return databaseBuilder.commit();
-    });
-
-    it('should return the object by accessCode', async () => {
-      // given
-      const accessCode = 'ABC123';
-
-      // when
-      const actualSession = await sessionRepository.getByAccessCode(accessCode);
-
-      // then
-      expect(actualSession.description).to.be.equal(session.description);
-      expect(actualSession.accessCode).to.be.equal(session.accessCode);
-    });
-
-    it('should return a Not found error when no session was found', async () => {
-      // given
-      const accessCode = 'DEE123';
-
-      // when
-      const error = await catchErr(sessionRepository.getByAccessCode)(accessCode);
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
-  });
-
   describe('#get', () => {
     let session;
     let expectedSessionValues;

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -306,6 +306,7 @@ describe('Integration | Repository | Session', function() {
       session.examiner = 'New examiner';
       session.examinerGlobalComment = 'It was a fine session my dear';
       session.status = statuses.FINALIZED;
+      session.resultsSentToPrescriberAt = new Date('2018-02-15T15:00:34Z');
 
       // when
       const sessionSaved = await sessionRepository.update(session);
@@ -316,6 +317,7 @@ describe('Integration | Repository | Session', function() {
       expect(sessionSaved.examiner).to.equal('New examiner');
       expect(sessionSaved.examinerGlobalComment).to.equal('It was a fine session my dear');
       expect(sessionSaved.status).to.equal(statuses.FINALIZED);
+      expect(sessionSaved.resultsSentToPrescriberAt).to.deep.equal(new Date('2018-02-15T15:00:34Z'));
     });
 
     it('should not add row in table "sessions"', async () => {

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -20,6 +20,7 @@ module.exports = function buildSession({
   examinerGlobalComment = '',
   createdAt = faker.date.recent(),
   finalizedAt = null,
+  resultsSentToPrescriberAt = null,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -42,6 +43,7 @@ module.exports = function buildSession({
     examinerGlobalComment,
     createdAt,
     finalizedAt,
+    resultsSentToPrescriberAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -15,6 +15,7 @@ module.exports = function buildSession({
   time = '14:30',
   status = Session.statuses.CREATED,
   examinerGlobalComment = '',
+  resultsSentToPrescriberAt = null,
 } = {}) {
   return new Session({
     id,
@@ -29,5 +30,6 @@ module.exports = function buildSession({
     time,
     status,
     examinerGlobalComment,
+    resultsSentToPrescriberAt,
   });
 };

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -340,4 +340,22 @@ describe('Unit | Application | Sessions | Routes', () => {
       });
     });
   });
+
+  describe('PUT /api/sessions/{id}/results-sent-to-prescriber', () => {
+    let sessionId;
+
+    beforeEach(() => {
+      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      // given
+      sessionId = 3;
+
+      const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/results-sent-to-prescriber` });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -482,7 +482,7 @@ describe('Unit | Controller | sessionController', () => {
     });
   });
 
-  describe('#analyzeFromAttendanceSheet', () => {
+  describe('#analyzeAttendanceSheet', () => {
     const sessionId = 3;
 
     let request;
@@ -509,6 +509,56 @@ describe('Unit | Controller | sessionController', () => {
 
       // then
       expect(result).to.equal(analyzeResult);
+    });
+  });
+
+  describe('#flagResultsAsSentToPrescriber', () => {
+    const sessionId = 123;
+    const session = Symbol('session');
+    const serializedSession = Symbol('serializedSession');
+
+    beforeEach(() => {
+      request = {
+        params: {
+          id: sessionId,
+        },
+      };
+    });
+
+    context('when the session results were already flagged as sent', () => {
+
+      beforeEach(() => {
+        const usecaseResult = { resultsFlaggedAsSent: false, session };
+        sinon.stub(usecases, 'flagSessionResultsAsSentToPrescriber').withArgs({ sessionId }).resolves(usecaseResult);
+        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+      });
+
+      it('should return the serialized session with code 200', async () => {
+        // when
+        const response = await sessionController.flagResultsAsSentToPrescriber(request, hFake);
+
+        // then
+        expect(response).to.equal(serializedSession);
+      });
+
+    });
+
+    context('when the session results were not flagged as sent', () => {
+
+      beforeEach(() => {
+        const usecaseResult = { resultsFlaggedAsSent: true, session };
+        sinon.stub(usecases, 'flagSessionResultsAsSentToPrescriber').withArgs({ sessionId }).resolves(usecaseResult);
+        sinon.stub(sessionSerializer, 'serialize').withArgs(session).resolves(serializedSession);
+      });
+
+      it('should return the serialized session with code 201', async () => {
+        // when
+        const response = await sessionController.flagResultsAsSentToPrescriber(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+        expect(response.source).to.equal(serializedSession);
+      });
     });
   });
 

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -16,6 +16,7 @@ const SESSION_PROPS = [
   'status',
   'examinerGlobalComment',
   'finalizedAt',
+  'resultsSentToPrescriberAt',
   'certificationCandidates',
 ];
 
@@ -37,6 +38,7 @@ describe('Unit | Domain | Models | Session', () => {
       status: '',
       examinerGlobalComment: '',
       finalizedAt: '',
+      resultsSentToPrescriberAt: '',
       // includes
       certificationCandidates: [],
     });
@@ -48,5 +50,34 @@ describe('Unit | Domain | Models | Session', () => {
 
   it('should create a session with all the requires properties', () => {
     expect(_.keys(session)).to.have.deep.members(SESSION_PROPS);
+  });
+
+  context('#areResultsFlaggedAsSent', () => {
+    context('when session resultsSentToPrescriberAt timestamp is defined', () => {
+
+      it('should return true', () => {
+        // given
+        session.resultsSentToPrescriberAt = new Date();
+
+        // when
+        const areResultsFlaggedAsSent = session.areResultsFlaggedAsSent();
+
+        // then
+        expect(areResultsFlaggedAsSent).to.be.true;
+      });
+    });
+    context('when session resultsSentToPrescriberAt timestamp is falsy', () => {
+
+      it('should return false', () => {
+        // given
+        session.resultsSentToPrescriberAt = null;
+
+        // when
+        const areResultsFlaggedAsSent = session.areResultsFlaggedAsSent();
+
+        // then
+        expect(areResultsFlaggedAsSent).to.be.false;
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
@@ -1,0 +1,104 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const flagSessionResultsAsSentToPrescriber = require('../../../../lib/domain/usecases/flag-session-results-as-sent-to-prescriber');
+const Session = require('../../../../lib/domain/models/Session');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | set-date-of-sending-results-to-prescriber', () => {
+  let sessionId;
+  let sessionRepository;
+
+  beforeEach(() => {
+    sessionRepository = { get: sinon.stub(), update: sinon.stub() };
+  });
+
+  context('when session id is not a number', () => {
+
+    it('should throw a NotFound error', async () => {
+      // given
+      sessionId = 'notANumber';
+
+      // when
+      const error = await catchErr(flagSessionResultsAsSentToPrescriber)({ sessionId, sessionRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when session id is a number', () => {
+
+    beforeEach(() => {
+      sessionId = 1;
+    });
+
+    context('when session doesn\'t exist', () => {
+
+      it('should throw a NotFound error', async () => {
+        // given
+        sessionRepository.get.withArgs(sessionId).rejects();
+
+        // when
+        const error = await catchErr(flagSessionResultsAsSentToPrescriber)({ sessionId, sessionRepository });
+
+        // then
+        expect(sessionRepository.get).to.have.been.calledOnce;
+        expect(error).to.be.an.instanceOf(NotFoundError);
+      });
+    });
+
+    context('when session exists', () => {
+
+      context('when results are already flagged as sent', () => {
+        const alreadyFlaggedResultsAsSentSession = new Session({ resultsSentToPrescriberAt: new Date() });
+
+        it('should return a NON updated session with a flag to indicate that results has already been sent', async () => {
+          // given
+          sessionRepository.get.withArgs(sessionId).resolves(alreadyFlaggedResultsAsSentSession);
+
+          // when
+          const { resultsFlaggedAsSent, session } = await flagSessionResultsAsSentToPrescriber({ sessionId, sessionRepository });
+
+          // then
+          expect(resultsFlaggedAsSent).to.be.false;
+          expect(session).to.equal(alreadyFlaggedResultsAsSentSession);
+        });
+      });
+
+      context('when results are not flagged as sent yet', () => {
+        let notFlaggedSession;
+        const updatedSession = Symbol('updatedSession');
+
+        beforeEach(() => {
+          notFlaggedSession = new Session({ resultsSentToPrescriberAt: null });
+          sessionRepository.get.withArgs(sessionId).resolves(notFlaggedSession);
+        });
+
+        it('should return an updated session with a flag to indicate that the flagging has been done', async () => {
+          // given
+          sessionRepository.update.withArgs(notFlaggedSession).resolves(updatedSession);
+
+          // when
+          const { resultsFlaggedAsSent, session } = await flagSessionResultsAsSentToPrescriber({ sessionId, sessionRepository });
+
+          // then
+          expect(resultsFlaggedAsSent).to.be.true;
+          expect(session).to.equal(updatedSession);
+        });
+
+        it('should have set property resultsSentToPrescriberAt with now date', async () => {
+          // given
+          const now = new Date();
+          const clock = sinon.useFakeTimers(now);
+          sessionRepository.update.withArgs(notFlaggedSession).resolves(updatedSession);
+
+          // when
+          await flagSessionResultsAsSentToPrescriber({ sessionId, sessionRepository });
+          clock.restore();
+
+          // then
+          expect(notFlaggedSession.resultsSentToPrescriberAt).to.deep.equal(now);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -25,6 +25,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
           description: '',
           'examiner-global-comment': 'It was a fine session my dear',
           'finalized-at': new Date('2020-02-17T14:23:56Z'),
+          'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
         },
         relationships: {
           certifications: {
@@ -65,6 +66,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         status: statuses.STARTED,
         examinerGlobalComment: 'It was a fine session my dear',
         finalizedAt: new Date('2020-02-17T14:23:56Z'),
+        resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
       });
     });
 


### PR DESCRIPTION
## ☕️ Contexte
Le pôle certif* s'occupent de "traiter" les sessions* lorsque celles-ci sont "finalisées" (passées dans le temps). 
Traiter une session consiste à : 
- envoyer au prescripteur* les résultats de la session,
- diffuser / publier les résultats auprès des candidats (ils pourront les voir sur l'application pix en se connectant avec le compte avec lequel ils ont passé leur certification). 

Aujourd'hui ce traitement des sessions se faire sur un google sheet par le pôle certif.

*pôle certif = Anne-C, Pablo, Josselin de chez Pix
*session = un jour donné, examen encadré par un surveillant, de quelques minutes sur l'application pix (contenu des questions adapté à chaque candidat)
*prescripteur = organisation qui a demandé que son public passe une session de certification

## :unicorn: Problème
Plus le pôle certif a de session à traiter, plus il devient compliqué de tenir à jour leur avancement en jonglant entre les informations présentent sur pix admin et sur leur google sheet. 
Il aimeraient pouvoir savoir pour quelles sessions ils ont déjà envoyé les résultats facilement dans l'application pix admin.


## :robot: Solution
Ajouter un bouton dans pix admin sur la page de détail d'une session qui permet de "tagger" le fait que les résultats, pour cette session, ont été envoyés au prescripteur.

## :rainbow: Remarques
A terme il est souhaité que le pôle certif n'utilise plus leur google sheet et qu'ils puissent tenir à jour l'avancement de leur travail directement sur l'application pix admin.