### PR TITLE
BUGFIX: Réparation de la mise à jour du cache Airtable d'un élément unique

### DIFF
--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -11,7 +11,7 @@ async function getRecord(tableName, recordId) {
   logger.info({ tableName, recordId }, 'Querying Airtable');
   const allRecords = await _airtableClient()
     .table(tableName)
-    .select({ filterByFormula: `{id persistant}=${recordId}` })
+    .select({ filterByFormula: `{id persistant}="${recordId}"` })
     .all();
   return _.first(allRecords);
 }

--- a/api/tests/tooling/airtable-builder/airtable-mock-route.js
+++ b/api/tests/tooling/airtable-builder/airtable-mock-route.js
@@ -54,7 +54,7 @@ function generateUrlForRouteType({ routeType, tableName, returnBody }) {
     throw new Error('get route should have a return object with an id a its root');
   }
 
-  const query = routeType === ROUTE_TYPE.GET && { filterByFormula: `{id persistant}=${returnBodyId}` };
+  const query = routeType === ROUTE_TYPE.GET && { filterByFormula: `{id persistant}="${returnBodyId}"` };
   return { url, query };
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Depuis pix editor, lors de la MAJ du cache d'un challenge donnée, l'API Airtable prend une erreur 422.
Après investigation, la requête est mal formatée : la valeur de l'id doit être mis entre quotes (") sinon Airtable le considère comme un nom de champ.

## :robot: Solution
Mettre la valeur de l'id entre quotes lors de l'appel.

## :rainbow: Remarques
A passer rapidement, car les preview de challenges de pix editor ne fonctionne pas.