### PR TITLE
[TECH] Ajout de la variable d'environnement POSTGRES_HOST_AUTH_METHOD au docker-compose.yml pour réparer postgres (PF-1107).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:12.14.0
-      - image: postgres:10-alpine
+      - image: postgres:11.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -191,7 +191,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node12.14.0-chrome79-ff71
-      - image: postgres:10-alpine
+      - image: postgres:11.7-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:10-alpine
+    image: postgres:11.7-alpine
     ports:
       - "5432:5432"
     environment:
@@ -10,6 +10,6 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
-    image: redis
+    image: redis:5.0.7-alpine
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_DB: pix
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
     image: redis


### PR DESCRIPTION
## :unicorn: Problème
L'image docker a été mise à jour rendant les scripts de migrations inopérant: 
https://github.com/docker-library/postgres/issues/681

## :robot: Solution
Il faut rajouter une variable dans le docker-compose.yml

