### PR TITLE
[TECH] Générer dynamiquement des variables d'environnement sur les RA.

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (environment) {
+module.exports = function(environment) {
   const ENV = {
     modulePrefix: 'pix-admin',
     environment,

--- a/api/scalingo.json
+++ b/api/scalingo.json
@@ -1,0 +1,9 @@
+{
+  "name": "Pix Review App",
+  "env": {
+    "PIXORGA_URL": {
+      "generator": "template",
+      "template": "https://pix-orga-review-pr%PR_NUMBER%"
+    }
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, pour créer un email d'invitation, certaines variables d'environnement sont utilisées par le service Sendinblue.
Toutes les valeurs de ces variables sont déjà déterminées dans pix-api-review.
**Sauf une : PIXORGA_URL**
Car elle doit correspondre à l'url de la RA de Pix-Orga (pix-orga-review-pr<PR_NUMBER>).

## ❓Question
Scalingo propose-t-il un moyen de générer dynamiquement des variables d'environnement ?
=> **OUI**

## :robot: Solution
* scalingo.json Schema
* Utiliser le Generator de type template
* cf. https://developers.scalingo.com/scalingo-json-schema/index