### PR TITLE
[TECH] Utilisation de mots-clés français dans les tests Cypress

### DIFF
--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -62,3 +62,16 @@ ou
 ```
 npm run cy:run:local
 ```
+
+#### Écrire des tests Cypress
+
+On utilise
+[cypress-cucumber-preprocessor](https://github.com/TheBrainFamily/cypress-cucumber-preprocessor)
+pour pouvoir écrire les tests sous la forme de scénarios Cucumber (en langage
+"Gherkin").
+
+Pour connaître la liste des mots-clés utilisables, exécuter la commande :
+
+```
+npx cucumber-js --i18n-keywords fr
+```

--- a/high-level-tests/e2e/cypress/integration/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/campaign-management.feature
@@ -1,17 +1,18 @@
-Feature: Gestion des Campagnes
+#language: fr
+Fonctionnalité: Gestion des Campagnes
 
-  Background:
-    Given les données de test sont chargées
+  Contexte:
+    Étant donné que les données de test sont chargées
 
-  Scenario: Je me connecte à Pix Orga
-    Given je vais sur Pix Orga
-    When je me connecte avec le compte "daenerys.targaryen@pix.fr"
-    Then je suis redirigé vers le compte Orga de "Daenerys Targaryen"
+  Scénario: Je me connecte à Pix Orga
+    Étant donné que je vais sur Pix Orga
+    Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Alors je suis redirigé vers le compte Orga de "Daenerys Targaryen"
 
-  Scenario: Je consulte le détail d'une campagne
-    Given je suis connecté à Pix Orga
-    Then je vois la liste des campagnes
-    When je recherche une campagne avec le nom "néra"
-    Then la liste est filtrée
-    When je clique sur la campagne "Campagne de la Néra"
-    Then je vois le détail de la campagne "Campagne de la Néra"
+  Scénario: Je consulte le détail d'une campagne
+    Étant donné que je suis connecté à Pix Orga
+    Alors je vois la liste des campagnes
+    Lorsque je recherche une campagne avec le nom "néra"
+    Alors la liste est filtrée
+    Lorsque je clique sur la campagne "Campagne de la Néra"
+    Alors je vois le détail de la campagne "Campagne de la Néra"

--- a/high-level-tests/e2e/cypress/integration/campaign.feature
+++ b/high-level-tests/e2e/cypress/integration/campaign.feature
@@ -1,50 +1,51 @@
-Feature: Campagne
+#language: fr
+Fonctionnalité: Campagne
 
-  Background:
-    Given les données de test sont chargées
+  Contexte:
+    Étant donné que les données de test sont chargées
 
-  Scenario: Je rejoins mon parcours prescrit
-    Given je vais sur Pix
-    And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    When je vais sur la page d'accès à une campagne
-    And je saisis "NERA" dans le champ
-    When je clique sur "Commencer mon parcours"
-    Then je vois la page de "presentation" de la campagne
-    When je clique sur "Je commence"
-    Then je vois la page de "didacticiel" de la campagne
+  Scénario: Je rejoins mon parcours prescrit
+    Étant donné que je vais sur Pix
+    Et je suis connecté à Pix en tant que "Daenerys Targaryen"
+    Lorsque je vais sur la page d'accès à une campagne
+    Et je saisis "NERA" dans le champ
+    Lorsque je clique sur "Commencer mon parcours"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
+    Alors je vois la page de "didacticiel" de la campagne
 
-  Scenario: Je rejoins mon parcours prescrit via l'URL sans être connecté
-    Given je vais sur Pix
-    When je vais sur la campagne "WALL" avec l'identifiant "1er bataillon"
-    Then je vois la page de "presentation" de la campagne
-    When je clique sur "Je commence"
-    And je clique sur "connectez-vous à votre compte"
-    And je me connecte avec le compte "daenerys.targaryen@pix.fr"
-    Then je vois la page de "didacticiel" de la campagne
+  Scénario: Je rejoins mon parcours prescrit via l'URL sans être connecté
+    Étant donné que je vais sur Pix
+    Lorsque je vais sur la campagne "WALL" avec l'identifiant "1er bataillon"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
+    Et je clique sur "connectez-vous à votre compte"
+    Et je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Alors je vois la page de "didacticiel" de la campagne
 
-  Scenario: Je rejoins mon parcours prescrit restreint
-    Given je vais sur Pix
-    And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    And je vais sur la page d'accès à une campagne
-    When je saisis "WINTER" dans le champ
-    And je clique sur "Commencer mon parcours"
-    Then je vois la page de "rejoindre" de la campagne
-    When je saisis mon prénom "Daenerys"
-    When je saisis mon nom "Targaryen"
-    When je saisis ma date de naissance 23-10-1986
-    And je clique sur "C'est parti !"
-    Then je vois la page de "presentation" de la campagne
-    When je clique sur "Je commence"
-    Then je vois la page de "didacticiel" de la campagne
+  Scénario: Je rejoins mon parcours prescrit restreint
+    Étant donné que je vais sur Pix
+    Et je suis connecté à Pix en tant que "Daenerys Targaryen"
+    Et je vais sur la page d'accès à une campagne
+    Lorsque je saisis "WINTER" dans le champ
+    Et je clique sur "Commencer mon parcours"
+    Alors je vois la page de "rejoindre" de la campagne
+    Lorsque je saisis mon prénom "Daenerys"
+    Lorsque je saisis mon nom "Targaryen"
+    Lorsque je saisis ma date de naissance 23-10-1986
+    Et je clique sur "C'est parti !"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
+    Alors je vois la page de "didacticiel" de la campagne
 
-  Scenario: Je rejoins mon parcours prescrit restreint en étant connecté via un organisme externe
-    Given je vais sur Pix via un organisme externe
-    And je vais sur la page d'accès à une campagne
-    When je saisis "WINTER" dans le champ
-    And je clique sur "Commencer mon parcours"
-    Then je vois la page de "rejoindre" de la campagne
-    When je saisis ma date de naissance 23-10-1986
-    And je clique sur "C'est parti !"
-    Then je vois la page de "presentation" de la campagne
-    When je clique sur "Je commence"
-    Then je vois la page de "didacticiel" de la campagne
+  Scénario: Je rejoins mon parcours prescrit restreint en étant connecté via un organisme externe
+    Étant donné que je vais sur Pix via un organisme externe
+    Et je vais sur la page d'accès à une campagne
+    Lorsque je saisis "WINTER" dans le champ
+    Et je clique sur "Commencer mon parcours"
+    Alors je vois la page de "rejoindre" de la campagne
+    Lorsque je saisis ma date de naissance 23-10-1986
+    Et je clique sur "C'est parti !"
+    Alors je vois la page de "presentation" de la campagne
+    Lorsque je clique sur "Je commence"
+    Alors je vois la page de "didacticiel" de la campagne

--- a/high-level-tests/e2e/cypress/integration/demo.feature
+++ b/high-level-tests/e2e/cypress/integration/demo.feature
@@ -1,19 +1,20 @@
-Feature: Demo
+#language: fr
+Fonctionnalité: Demo
 
-  Scenario: Je lance une démo
-    Given je vais sur Pix
-    When je lance le course "rec5UecGJn0kr2odZ"
-    Then je suis redirigé vers une page d'épreuve
-    And le titre sur l'épreuve est "Démo essentiels"
-    When l'épreuve contient le texte "Combien font 2 + 2 ?"
-    And je clique sur "Je passe"
-    And l'épreuve contient le texte "Quel mot est synonyme de"
-    And je choisis la réponse "radio_3"
-    And je clique sur "Je valide"
-    And l'épreuve contient le texte "quel est le verbe ?"
-    And je saisis "manger" dans le champ
-    And je clique sur "Je valide"
-    Then je vois la page de résultats
-    And j'ai passé à "Combien font 2 + 2 ?"
-    And j'ai mal répondu à "Quel mot est synonyme de"
-    And j'ai bien répondu à "quel est le verbe ?"
+  Scénario: Je lance une démo
+    Étant donné que je vais sur Pix
+    Lorsque je lance le course "rec5UecGJn0kr2odZ"
+    Alors je suis redirigé vers une page d'épreuve
+    Et le titre sur l'épreuve est "Démo essentiels"
+    Lorsque l'épreuve contient le texte "Combien font 2 + 2 ?"
+    Et je clique sur "Je passe"
+    Et l'épreuve contient le texte "Quel mot est synonyme de"
+    Et je choisis la réponse "radio_3"
+    Et je clique sur "Je valide"
+    Et l'épreuve contient le texte "quel est le verbe ?"
+    Et je saisis "manger" dans le champ
+    Et je clique sur "Je valide"
+    Alors je vois la page de résultats
+    Et j'ai passé à "Combien font 2 + 2 ?"
+    Et j'ai mal répondu à "Quel mot est synonyme de"
+    Et j'ai bien répondu à "quel est le verbe ?"

--- a/high-level-tests/e2e/cypress/integration/login-logout.feature
+++ b/high-level-tests/e2e/cypress/integration/login-logout.feature
@@ -1,32 +1,33 @@
-Feature: Connexion
+#language: fr
+Fonctionnalité: Connexion
 
-  Background:
-    Given tous les comptes sont créés
+  Contexte:
+    Étant donné que tous les comptes sont créés
 
-  Scenario: Je me connecte puis je me déconnecte en fin de session
-    Given je vais sur Pix
-    When je me connecte avec le compte "daenerys.targaryen@pix.fr"
-    Then je suis redirigé vers le profil de "Daenerys"
-    When je me déconnecte
-    Then je suis redirigé vers la page "/connexion"
+  Scénario: Je me connecte puis je me déconnecte en fin de session
+    Étant donné que je vais sur Pix
+    Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque je me déconnecte
+    Alors je suis redirigé vers la page "/connexion"
 
-  Scenario: Je suis connecté et ma session expire puis je rejoins une nouvelle page
-    Given je vais sur Pix
-    When je suis connecté avec un compte dont le token expire bientôt
-    Then je suis redirigé vers le profil de "Daenerys"
-    When j'attends 3000 ms
-    And je vais sur la page "/mes-certifications"
-    Then je suis redirigé vers la page "/connexion"
+  Scénario: Je suis connecté et ma session expire puis je rejoins une nouvelle page
+    Étant donné que je vais sur Pix
+    Lorsque je suis connecté avec un compte dont le token expire bientôt
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque j'attends 3000 ms
+    Et je vais sur la page "/mes-certifications"
+    Alors je suis redirigé vers la page "/connexion"
 
-  Scenario: Je me connecte via un organisme externe puis je me déconnecte
-    When je vais sur Pix via un organisme externe
-    Then je suis redirigé vers le profil de "Daenerys"
-    When je me déconnecte
-    Then je suis redirigé vers la page "/nonconnecte"
+  Scénario: Je me connecte via un organisme externe puis je me déconnecte
+    Lorsque je vais sur Pix via un organisme externe
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque je me déconnecte
+    Alors je suis redirigé vers la page "/nonconnecte"
 
-  Scenario: Je me connecte via un organisme externe alors qu'il y a une personne déjà connectée puis je me déconnecte
-    Given je suis connecté à Pix en tant que "John Snow"
-    When je vais sur Pix via un organisme externe
-    Then je suis redirigé vers le profil de "Daenerys"
-    When je me déconnecte
-    Then je suis redirigé vers la page "/nonconnecte"
+  Scénario: Je me connecte via un organisme externe alors qu'il y a une personne déjà connectée puis je me déconnecte
+    Étant donné que je suis connecté à Pix en tant que "John Snow"
+    Lorsque je vais sur Pix via un organisme externe
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque je me déconnecte
+    Alors je suis redirigé vers la page "/nonconnecte"

--- a/high-level-tests/e2e/cypress/integration/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/page-title.feature
@@ -1,19 +1,20 @@
-Feature: Titre des pages
+#language: fr
+Fonctionnalité: Titre des pages
 
-  Scenario: j'accède à la page de connexion
-    When je vais sur la page de connexion
-    Then je vois le titre de la page "Connexion | Pix"
+  Scénario: j'accède à la page de connexion
+    Lorsque je vais sur la page de connexion
+    Alors je vois le titre de la page "Connexion | Pix"
 
-  Scenario: j'accède à la page profil
-    Given tous les comptes sont créés
-    And je vais sur Pix
-    And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    When j'accède à mon profil
-    Then je vois le titre de la page "Votre profil | Pix"
+  Scénario: j'accède à la page profil
+    Étant donné que tous les comptes sont créés
+    Et je vais sur Pix
+    Et je suis connecté à Pix en tant que "Daenerys Targaryen"
+    Lorsque j'accède à mon profil
+    Alors je vois le titre de la page "Votre profil | Pix"
 
-  Scenario: j'accède à la page compétence
-    Given tous les comptes sont créés
-    And je vais sur Pix
-    And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    When je vais sur la compétence "recH9MjIzN54zXlwr"
-    Then je vois le titre de la page "Compétence | Mathématiques | Pix"
+  Scénario: j'accède à la page compétence
+    Étant donné que tous les comptes sont créés
+    Et je vais sur Pix
+    Et je suis connecté à Pix en tant que "Daenerys Targaryen"
+    Lorsque je vais sur la compétence "recH9MjIzN54zXlwr"
+    Alors je vois le titre de la page "Compétence | Mathématiques | Pix"

--- a/high-level-tests/e2e/cypress/integration/preview.feature
+++ b/high-level-tests/e2e/cypress/integration/preview.feature
@@ -1,12 +1,13 @@
-Feature: Preview
+#language: fr
+Fonctionnalité: Preview
 
-  Background:
-    Given les données de test sont chargées
+  Contexte:
+    Étant donné que les données de test sont chargées
 
-  Scenario: Je peux voir la prévisualisation d'une question
-    Given je vais sur Pix
-    And je suis connecté à Pix en tant qu'administrateur
-    When je lance la preview du challenge "recc3QU4nKAk4byGv"
-    Then je suis redirigé vers une page d'épreuve
-    Then l'épreuve contient le texte "Quelle est la capitale de la Lettonie ?"
+  Scénario: Je peux voir la prévisualisation d'une question
+    Étant donné que je vais sur Pix
+    Et je suis connecté à Pix en tant qu'administrateur
+    Lorsque je lance la preview du challenge "recc3QU4nKAk4byGv"
+    Alors je suis redirigé vers une page d'épreuve
+    Alors l'épreuve contient le texte "Quelle est la capitale de la Lettonie ?"
 

--- a/high-level-tests/e2e/cypress/integration/profile.feature
+++ b/high-level-tests/e2e/cypress/integration/profile.feature
@@ -1,11 +1,12 @@
-Feature: Profil
+#language: fr
+Fonctionnalité: Profil
 
-  Background:
-    Given les données de test sont chargées
+  Contexte:
+    Étant donné que les données de test sont chargées
 
-  Scenario: J'accède à la page de détails d'une compétence
-    Given je vais sur Pix
-    And je suis connecté à Pix en tant que "Daenerys Targaryen"
-    When j'accède à mon profil
-    And je clique sur le rond de niveau de la compétence "Géographie"
-    Then je vois la page de détails de la compétence "Géographie"
+  Scénario: J'accède à la page de détails d'une compétence
+    Étant donné que je vais sur Pix
+    Et je suis connecté à Pix en tant que "Daenerys Targaryen"
+    Lorsque j'accède à mon profil
+    Et je clique sur le rond de niveau de la compétence "Géographie"
+    Alors je vois la page de détails de la compétence "Géographie"

--- a/high-level-tests/e2e/cypress/integration/signup.feature
+++ b/high-level-tests/e2e/cypress/integration/signup.feature
@@ -1,6 +1,7 @@
-Feature: Inscription
+#language: fr
+Fonctionnalité: Inscription
 
-  Scenario: Je m'inscris
-    Given je vais sur l'inscription de Pix
-    When je m'inscris avec le prénom "Michel", le nom "Jacqueson", le mail "mj@example.net" et le mot de passe "Pix_example1"
-    Then je suis redirigé vers le profil de "Michel"
+  Scénario: Je m'inscris
+    Étant donné que je vais sur l'inscription de Pix
+    Lorsque je m'inscris avec le prénom "Michel", le nom "Jacqueson", le mail "mj@example.net" et le mot de passe "Pix_example1"
+    Alors je suis redirigé vers le profil de "Michel"


### PR DESCRIPTION
## :unicorn: Problème

Les tests Cypress sont écrits en français mais les mots-clés anglais (`Given`, `When`, `Then`…) sont utilisés ce qui est désagréable à la lecture.

## :robot: Solution

On utilise la possibilité offerte par [cypress-cucumber-preprocessor](https://github.com/TheBrainFamily/cypress-cucumber-preprocessor) d'utiliser des mots-clés dans une autre langue que l'anglais.

Cette PR ajoute aussi dans le `README.md` la commande à lancer pour connaître les mots-clés disponibles.

## :rainbow: Remarques

Cette commande a été utilisée pour automatiser le processus :

```
gsed -i -e $'s/Feature:/#language: fr\\\nFonctionnalité:/' \
  -e 's/Background:/Contexte:/' \
  -e 's/Scenario:/Scénario:/' \
  -e 's/Given /Étant donné que /' \
  -e 's/And /Et /' \
  -e 's/When /Lorsque /' \
  -e 's/Then /Alors /' \$
  ./cypress/integration/*.feature
```

Noter que le style pourrait dans certains cas être amélioré en utilisant `Et que` plutôt que `Et`, ou encore `Quand` à la place de `Lorsque`…