### PR TITLE
[STYLE] Align pages title styles (PF-1020)

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -18,6 +18,7 @@
 @import 'globals/buttons';
 @import 'globals/tables';
 @import 'globals/text';
+@import 'globals/titles';
 /* components */
 @import 'components/background-banner';
 @import 'components/assessment-banner';

--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -18,19 +18,15 @@
 }
 
 .certification-not-certifiable__title {
-  font-family: $font-open-sans;
-  font-weight: $font-bold;
   text-align: center;
-  font-size: 36px;
-  line-height: 42px;
 }
 
 .certification-not-certifiable__text {
   font-family: $font-open-sans;
-  text-align: left;
-  font-size: 20px;
-  line-height: 24px;
-  margin-top: 58px;
+  text-align: center;
+  font-size: 1.6rem;
+  line-height: 27px;
+  margin-top: 0;
 
   @include device-is('desktop') {
     max-width: 850px;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -123,17 +123,10 @@
 
 // Text styles
 .rounded-panel-title {
-  font-weight: $font-light;
-  font-family: $font-open-sans;
-  color: $black;
-  font-size: 2.6rem;
-  line-height: 3.4rem;
   text-align: center;
 
   @include device-is('tablet') {
     display: block;
-    font-size: 3.2rem;
-    line-height: 4.5rem;
     text-align: left;
   }
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -118,7 +118,7 @@
     flex-grow: 1;
     padding: 0 30px 30px 30px;
     max-width: 100%;
-    
+
     @include device-is('desktop') {
       max-width: 68%;
       padding: 0 30px;
@@ -166,8 +166,6 @@
 
   &__name {
     margin: 15px 0;
-    font-size: 3.6rem;
-    line-height: 3.8rem;
   }
 
   &__description {

--- a/mon-pix/app/styles/globals/_titles.scss
+++ b/mon-pix/app/styles/globals/_titles.scss
@@ -1,0 +1,13 @@
+h3 {
+  font-size: 2.6rem;
+  color: $black;
+  font-family: $font-open-sans;
+  font-weight: $font-light;
+  letter-spacing: 0.15px;
+  line-height: 3.4rem;
+
+  @include device-is('tablet') {
+    font-size: 3.2rem;
+    line-height: 54px;
+  }
+}

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -10,11 +10,7 @@
 
   &__title {
     text-align: center;
-    color: $nero;
     margin-bottom: 42px;
-    @include device-is('tablet') {
-      font-size: 4.2rem;
-    }
   }
 
   &__instruction {

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -6,9 +6,9 @@
       <div class="background-banner"></div>
 
       <div class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
-        <h1 class="fill-in-campaign-code__title rounded-panel-title">
+        <h3 class="fill-in-campaign-code__title rounded-panel-title">
           Vous souhaitez participer<br>à un parcours de test
-        </h1>
+        </h3>
 
         <div class="fill-in-campaign-code__instruction">Saisissez le code du parcours</div>
         <form class="fill-in-campaign-code__form" autocomplete="off">

--- a/mon-pix/app/templates/components/certification-not-certifiable.hbs
+++ b/mon-pix/app/templates/components/certification-not-certifiable.hbs
@@ -1,7 +1,7 @@
 <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner certification-not-certifiable__panel">
-  <h2 class="certification-not-certifiable__title">
+  <h3 class="certification-not-certifiable__title">
       Votre profil n'est pas encore certifiable.
-  </h2>
+  </h3>
   <p class="certification-not-certifiable__text">
       Pour faire certifier votre profil, vous devez avoir obtenu un niveau supérieur à 0 dans 5 compétences minimum.
   </p>

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -5,9 +5,9 @@
 
     <div class="rounded-panel-header-with-components">
       <div class="rounded-panel-header__left-wrapper">
-        <h1 class="rounded-panel-header-text__content rounded-panel-title">
+        <h3 class="rounded-panel-header-text__content rounded-panel-title">
           Vous avez 16 compétences à tester.<br>On se concentre et c'est partix&nbsp;!
-        </h1>
+        </h3>
       </div>
       <div class="rounded-panel-header__right-wrapper">
         <HexagonScore @pixScore={{@model.pixScore.value}} />

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -12,9 +12,9 @@
     <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{scorecard.area.color}}">
       {{scorecard.area.title}}
     </div>
-    <div class="scorecard-details-content-left__name">
+    <h3 class="scorecard-details-content-left__name">
       {{scorecard.name}}
-    </div>
+    </h3>
     <div class="scorecard-details-content-left__description">
       {{scorecard.description}}
     </div>


### PR DESCRIPTION
## :unicorn: Problème
Les titres sur les pages /profil, /campagnes et /certification ont des titres de style différent.

edit: le titre de la page `competences.details` est aussi concerné

## :robot: Solution
Cette PR uniformise les styles de ces titres.

## :rainbow: Remarques
Vu avec @QuentinChapelain-ui : les titres sont en `<h3>` car ce ne sont pas les gros titres / textes que l'on s'attendrait à voir en `<h1>`
