### PR TITLE
[TECH] Convertir les modèles PixApp en "Native JS".

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -27,6 +27,14 @@ module.exports = {
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',
     'ember/use-ember-data-rfc-395-imports': 'error',
+    'ember/order-in-models': ['error', {
+      order: [
+        'attribute',
+        'relationship',
+        'single-line-function',
+        'multi-line-function',
+      ]
+    }]
   },
   overrides: [
     // node files

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -22,9 +22,9 @@ module.exports = {
     browser: true
   },
   rules: {
-    'ember/avoid-leaking-state-in-ember-objects': 0,
-    'ember/no-restricted-resolver-tests': 0,
-    'ember/no-new-mixins': 0,
+    'ember/avoid-leaking-state-in-ember-objects': 'off',
+    'ember/no-new-mixins': 'off',
+    'ember/no-restricted-resolver-tests': 'off',
   },
   overrides: [
     // node files

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'ember/no-empty-attrs': 'error',
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',
+    'ember/use-ember-data-rfc-395-imports': 'error',
   },
   overrides: [
     // node files

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   rules: {
     'ember/avoid-leaking-state-in-ember-objects': 'off',
+    'ember/no-empty-attrs': 'error',
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',
   },

--- a/mon-pix/app/models/area.js
+++ b/mon-pix/app/models/area.js
@@ -1,10 +1,13 @@
-import Model, { hasMany, attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
-export default Model.extend({
-  name: attr('string'),
-  title: attr('string'),
-  competences: hasMany('competence'),
-  resultCompetences: hasMany('resultCompetence'),
-  code: attr('number'),
-  color: attr('string'),
-});
+export default class Area extends Model {
+  // attributes
+  @attr('string') name;
+  @attr('string') title;
+  @attr('number') code;
+  @attr('string') color;
+
+  // includes
+  @hasMany('competence') competences;
+  @hasMany('resultCompetence') resultCompetences;
+}

--- a/mon-pix/app/models/assessment-result.js
+++ b/mon-pix/app/models/assessment-result.js
@@ -1,7 +1,8 @@
 import Model, { belongsTo } from '@ember-data/model';
 
-export default Model.extend({
+export default class AssessmentResult extends Model {
 
-  assessment: belongsTo('assessment'),
+  // includes
+  @belongsTo('assessment') assessment;
 
-});
+}

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -1,49 +1,53 @@
-import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import { equal, or } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import ENV from 'mon-pix/config/environment';
 
-export default Model.extend({
+export default class Assessment extends Model {
 
   // attributes
-  codeCampaign: attr('string'),
-  estimatedLevel: attr('number'),
-  pixScore: attr('number'),
-  state: attr('string'),
-  title: attr('string'),
-  type: attr('string'),
-  certificationNumber: attr('string'),
-  participantExternalId: attr('string'),
-  competenceId: attr('string'),
+  @attr('string') certificationNumber;
+  @attr('string') codeCampaign;
+  @attr('number') estimatedLevel;
+  @attr('string') participantExternalId;
+  @attr('number') pixScore;
+  @attr('string') state;
+  @attr('string') title;
+  @attr('string') type;
 
   // includes
-  answers: hasMany('answer'),
-  course: belongsTo('course', { inverse: null }),
-  certificationCourse: belongsTo('certification-course'),
-  progression: belongsTo('progression', { inverse: null }),
-  result: belongsTo('assessment-result'),
+  @hasMany('answer') answers;
+  @belongsTo('certification-course') certificationCourse;
+  @belongsTo('course', { inverse: null }) course;
+  @belongsTo('progression', { inverse: null }) progression;
+  @belongsTo('assessment-result') result;
+
+  // relationships
+  @attr('string') competenceId;
 
   // methods
-  isCertification: equal('type', 'CERTIFICATION'),
-  isCompetenceEvaluation: equal('type', 'COMPETENCE_EVALUATION'),
-  isDemo: equal('type', 'DEMO'),
-  isPreview: equal('type', 'PREVIEW'),
-  isSmartPlacement: equal('type', 'SMART_PLACEMENT'),
-  isStarted: equal('state', 'started'),
-  isCompleted: equal('state', 'completed'),
-  isAborted: equal('state', 'aborted'),
+  @equal('type', 'CERTIFICATION') isCertification;
+  @equal('type', 'COMPETENCE_EVALUATION') isCompetenceEvaluation;
+  @equal('type', 'DEMO') isDemo;
+  @equal('type', 'PREVIEW') isPreview;
+  @equal('type', 'SMART_PLACEMENT') isSmartPlacement;
 
-  showProgressBar: or('isCompetenceEvaluation', 'isSmartPlacement', 'isDemo'),
-  showLevelup: or('isCompetenceEvaluation', 'isSmartPlacement'),
-  hasCheckpoints: or('isCompetenceEvaluation', 'isSmartPlacement'),
+  @equal('state', 'aborted') isAborted;
+  @equal('state', 'completed') isCompleted;
+  @equal('state', 'started') isStarted;
 
-  answersSinceLastCheckpoints: computed('answers.[]', function() {
+  @or('isCompetenceEvaluation', 'isSmartPlacement') hasCheckpoints;
+  @or('isCompetenceEvaluation', 'isSmartPlacement') showLevelup;
+  @or('isCompetenceEvaluation', 'isSmartPlacement', 'isDemo') showProgressBar;
+
+  @computed('answers.[]')
+  get answersSinceLastCheckpoints() {
     const answers = this.answers.toArray();
     const howManyAnswersSinceTheLastCheckpoint = answers.length % ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     const sliceAnswersFrom = (howManyAnswersSinceTheLastCheckpoint === 0)
       ? -ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS
       : -howManyAnswersSinceTheLastCheckpoint;
     return answers.slice(sliceAnswersFrom);
-  })
+  }
 
-});
+}

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -9,11 +9,14 @@ export default class Assessment extends Model {
   @attr('string') certificationNumber;
   @attr('string') codeCampaign;
   @attr('number') estimatedLevel;
-  @attr('string') participantExternalId;
   @attr('number') pixScore;
   @attr('string') state;
   @attr('string') title;
   @attr('string') type;
+
+  // references
+  @attr('string') competenceId;
+  @attr('string') participantExternalId;
 
   // includes
   @hasMany('answer') answers;
@@ -21,9 +24,6 @@ export default class Assessment extends Model {
   @belongsTo('course', { inverse: null }) course;
   @belongsTo('progression', { inverse: null }) progression;
   @belongsTo('assessment-result') result;
-
-  // relationships
-  @attr('string') competenceId;
 
   // methods
   @equal('type', 'CERTIFICATION') isCertification;

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -2,17 +2,23 @@ import Model, { attr, hasMany } from '@ember-data/model';
 import { mapBy, max } from '@ember/object/computed';
 import { computed } from '@ember/object';
 
-export default Model.extend({
+export default class CampaignParticipationResult extends Model {
 
-  totalSkillsCount: attr('number'),
-  testedSkillsCount: attr('number'),
-  validatedSkillsCount: attr('number'),
-  competenceResults: hasMany('competenceResult'),
+  // attributes
+  @attr('number') totalSkillsCount;
+  @attr('number') testedSkillsCount;
+  @attr('number') validatedSkillsCount;
 
-  totalSkillsCounts: mapBy('competenceResults', 'totalSkillsCount'),
-  maxTotalSkillsCountInCompetences: max('totalSkillsCounts'),
+  // includes
+  @hasMany('competenceResult') competenceResults;
 
-  masteryPercentage: computed('totalSkillsCount', 'validatedSkillsCount', function() {
+  // methods
+  @mapBy('competenceResults', 'totalSkillsCount') totalSkillsCounts;
+
+  @max('totalSkillsCounts') maxTotalSkillsCountInCompetences;
+
+  @computed('totalSkillsCount', 'validatedSkillsCount')
+  get masteryPercentage() {
     return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -1,11 +1,17 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-export default Model.extend({
-  isShared: attr('boolean'),
-  participantExternalId: attr('string'),
-  createdAt: attr('date'),
-  assessment: belongsTo('assessment'),
-  campaign: belongsTo('campaign'),
-  campaignParticipationResult: belongsTo('campaignParticipationResult'),
-  user: belongsTo('user'),
-});
+export default class CampaignParticipation extends Model {
+
+  // attributes
+  @attr('boolean') isShared;
+  @attr('date') createdAt;
+
+  // includes
+  @belongsTo('assessment') assessment;
+  @belongsTo('campaign') campaign;
+  @belongsTo('campaignParticipationResult') campaignParticipationResult;
+  @belongsTo('user') user;
+
+  // references
+  @attr('string') participantExternalId;
+}

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -6,12 +6,12 @@ export default class CampaignParticipation extends Model {
   @attr('boolean') isShared;
   @attr('date') createdAt;
 
+  // references
+  @attr('string') participantExternalId;
+
   // includes
   @belongsTo('assessment') assessment;
   @belongsTo('campaign') campaign;
   @belongsTo('campaignParticipationResult') campaignParticipationResult;
   @belongsTo('user') user;
-
-  // references
-  @attr('string') participantExternalId;
 }

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -1,18 +1,23 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  code: attr('string'),
-  idPixLabel: attr('string'),
-  title: attr('string'),
-  archivedAt: attr('date'),
-  organizationLogoUrl: attr('string'),
-  organizationName: attr('string'),
-  customLandingPageText: attr('string'),
-  isRestricted: attr('boolean'),
-  targetProfile: belongsTo('targetProfile'),
+export default class Campaign extends Model {
 
-  isArchived: computed('archivedAt', function() {
+  // attributes
+  @attr('string') code;
+  @attr('string') idPixLabel;
+  @attr('string') title;
+  @attr('date') archivedAt;
+  @attr('string') organizationLogoUrl;
+  @attr('string') organizationName;
+  @attr('string') customLandingPageText;
+  @attr('boolean') isRestricted;
+
+  // includes
+  @belongsTo('targetProfile') targetProfile;
+
+  @computed('archivedAt')
+  get isArchived() {
     return Boolean(this.archivedAt);
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/certification-candidate.js
+++ b/mon-pix/app/models/certification-candidate.js
@@ -1,8 +1,12 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  firstName: attr('string'),
-  lastName: attr('string'),
-  birthdate: attr('date-only'),
-  sessionId: attr('number'),
-});
+export default class CertificationCandidate extends Model {
+
+  // attributes
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('date-only') birthdate;
+
+  // references
+  @attr('number') sessionId;
+}

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -1,8 +1,14 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-export default Model.extend({
-  nbChallenges: attr('number'),
-  accessCode : attr('string'),
-  sessionId : attr('number'),
-  assessment: belongsTo('assessment'),
-});
+export default class CertificationCourse extends Model {
+
+  // attributes
+  @attr('string') accessCode;
+  @attr('number') nbChallenges;
+
+  // includes
+  @belongsTo('assessment') assessment;
+
+  // references
+  @attr('number') sessionId;
+}

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -6,9 +6,9 @@ export default class CertificationCourse extends Model {
   @attr('string') accessCode;
   @attr('number') nbChallenges;
 
-  // includes
-  @belongsTo('assessment') assessment;
-
   // references
   @attr('number') sessionId;
+
+  // includes
+  @belongsTo('assessment') assessment;
 }

--- a/mon-pix/app/models/certification-profile.js
+++ b/mon-pix/app/models/certification-profile.js
@@ -1,5 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  isCertifiable: attr('boolean'),
-});
+export default class CertificationProfile extends Model {
+
+  // attributes
+  @attr('boolean') isCertifiable;
+}

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -1,16 +1,20 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-export default Model.extend({
-  birthdate: attr('date-only'),
-  birthplace: attr('string'),
-  firstName: attr('string'),
-  lastName: attr('string'),
-  date: attr('date'),
-  certificationCenter: attr('string'),
-  isPublished: attr('boolean'),
-  pixScore: attr('number'),
-  status: attr('string'),
-  user: belongsTo('user'),
-  commentForCandidate: attr('string'),
-  resultCompetenceTree: belongsTo('resultCompetenceTree'),
-});
+export default class Certification extends Model {
+
+  // attributes
+  @attr('date-only') birthdate;
+  @attr('string') birthplace;
+  @attr('string') certificationCenter;
+  @attr('string') commentForCandidate;
+  @attr('date') date;
+  @attr('string') firstName;
+  @attr('boolean') isPublished;
+  @attr('string') lastName;
+  @attr('number') pixScore;
+  @attr('string') status;
+
+  // includes
+  @belongsTo('resultCompetenceTree') resultCompetenceTree;
+  @belongsTo('user') user;
+}

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -2,31 +2,40 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { notEmpty, equal, gt } from '@ember/object/computed';
 
-export default Model.extend({
+export default class Challenge extends Model {
 
-  instruction: attr('string'),
-  proposals: attr('string'),
-  timer: attr('number'),
-  illustrationUrl: attr('string'),
-  type: attr('string'),
-  embedUrl: attr('string'),
-  embedTitle: attr('string'),
-  embedHeight: attr('string'),
-  illustrationAlt: attr('string', { defaultValue: 'Illustration de l\'épreuve' }),
-  format: attr('string'),
+  // attributes
+  @attr('array') attachments;
+  @attr('string') embedUrl;
+  @attr('string') embedTitle;
+  @attr('string') embedHeight;
+  @attr('string') format;
+  @attr('string', {
+    defaultValue() { return 'Illustration de l\'épreuve'; }
+  }) illustrationAlt;
+  @attr('string') illustrationUrl;
+  @attr('string') instruction;
+  @attr('string') proposals;
+  @attr('number') timer;
+  @attr('string') type;
 
-  attachments: attr('array'),
-  answer: belongsTo('answer'),
+  // includes
+  @belongsTo('answer') answer;
 
-  hasValidEmbedDocument: computed('embedUrl', 'embedTitle', 'embedHeight', function() {
+  // methods
+  @computed('embedUrl', 'embedTitle', 'embedHeight')
+  get hasValidEmbedDocument() {
     const embedUrl = this.embedUrl;
     return !!embedUrl
       && !!this.embedTitle
       && !!this.embedHeight
       && embedUrl.toLowerCase().indexOf('https://') === 0; // fixes bug on IE: startsWith in not supported (PR #242)
-  }),
-  hasAttachment: notEmpty('attachments'),
-  hasSingleAttachment: equal('attachments.length', 1),
-  hasMultipleAttachments: gt('attachments.length', 1),
-  hasTimer: notEmpty('timer')
-});
+  }
+
+  @equal('attachments.length', 1) hasSingleAttachment;
+
+  @gt('attachments.length', 1) hasMultipleAttachments;
+
+  @notEmpty('attachments') hasAttachment;
+  @notEmpty('timer') hasTimer;
+}

--- a/mon-pix/app/models/competence-evaluation.js
+++ b/mon-pix/app/models/competence-evaluation.js
@@ -1,13 +1,18 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-export default Model.extend({
-  competenceId: attr('string'),
-  status: attr('string'),
-  createdAt: attr('date'),
-  updatedAt: attr('date'),
-  user: belongsTo('user'),
+export default class CompetenceEvaluation extends Model {
 
-  assessment: belongsTo('assessment'),
-  competence: belongsTo('competence'),
-  scorecard: belongsTo('scorecard', { async: false }),
-});
+  // attributes
+  @attr('string') status;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
+
+  // includes
+  @belongsTo('assessment') assessment;
+  @belongsTo('competence') competence
+  @belongsTo('scorecard', { async: false }) scorecard;
+  @belongsTo('user') user;
+
+  // references
+  @attr('string') competenceId;
+}

--- a/mon-pix/app/models/competence-evaluation.js
+++ b/mon-pix/app/models/competence-evaluation.js
@@ -7,12 +7,12 @@ export default class CompetenceEvaluation extends Model {
   @attr('date') createdAt;
   @attr('date') updatedAt;
 
+  // references
+  @attr('string') competenceId;
+
   // includes
   @belongsTo('assessment') assessment;
   @belongsTo('competence') competence
   @belongsTo('scorecard', { async: false }) scorecard;
   @belongsTo('user') user;
-
-  // references
-  @attr('string') competenceId;
 }

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -1,20 +1,26 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  name: attr('string'),
-  index: attr('string'),
-  areaColor: attr('string'),
-  totalSkillsCount: attr('number'),
-  testedSkillsCount: attr('number'),
-  validatedSkillsCount: attr('number'),
-  campaignParticipationResult: belongsTo('campaignParticipationResult'),
+export default class CompetenceResult extends Model {
 
-  totalSkillsCountPercentage: computed('totalSkillsCount', 'campaignParticipationResult', function() {
+  // attributes
+  @attr('string') areaColor;
+  @attr('string') name;
+  @attr('string') index;
+  @attr('number') totalSkillsCount;
+  @attr('number') testedSkillsCount;
+  @attr('number') validatedSkillsCount;
+
+  // includes
+  @belongsTo('campaignParticipationResult') campaignParticipationResult;
+
+  @computed('totalSkillsCount', 'campaignParticipationResult')
+  get totalSkillsCountPercentage() {
     return Math.round(this.totalSkillsCount * 100 / this.campaignParticipationResult.get('maxTotalSkillsCountInCompetences'));
-  }),
+  }
 
-  validatedSkillsPercentage: computed('validatedSkillsCount', 'totalSkillsCount', function() {
+  @computed('validatedSkillsCount', 'totalSkillsCount')
+  get validatedSkillsPercentage() {
     return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/competence.js
+++ b/mon-pix/app/models/competence.js
@@ -2,25 +2,33 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 import { alias, equal } from '@ember/object/computed';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  name: attr('string'),
-  area: belongsTo('area'),
-  user: belongsTo('user'),
-  index: attr('number'),
-  level: attr('number'),
-  description: attr('string'),
-  areaName: alias('area.name'),
-  courseId: attr('string'),
-  assessmentId: attr('string'),
-  status: attr('string'),
-  isRetryable: attr('boolean'),
-  daysBeforeNewAttempt: attr('number'),
+export default class Competence extends Model {
 
-  isAssessed: equal('status', 'assessed'),
-  isNotAssessed: equal('status', 'notAssessed'),
-  isBeingAssessed: equal('status', 'assessmentNotCompleted'),
+  // attributes
+  @attr('number') daysBeforeNewAttempt;
+  @attr('string') description;
+  @attr('number') index;
+  @attr('boolean') isRetryable;
+  @attr('number') level;
+  @attr('string') name;
+  @attr('string') status;
+  @alias('area.name') areaName;
 
-  isAssessableForTheFirstTime: computed('{isNotAssessed,courseId}', function() {
+  // includes
+  @belongsTo('area') area;
+  @belongsTo('user') user;
+
+  // references
+  @attr('string') assessmentId;
+  @attr('string') courseId;
+
+  // methods
+  @equal('status', 'assessed') isAssessed;
+  @equal('status', 'notAssessed') isNotAssessed;
+  @equal('status', 'assessmentNotCompleted') isBeingAssessed;
+
+  @computed('{isNotAssessed,courseId}')
+  get isAssessableForTheFirstTime() {
     return Boolean(this.isNotAssessed && this.courseId);
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/competence.js
+++ b/mon-pix/app/models/competence.js
@@ -14,13 +14,13 @@ export default class Competence extends Model {
   @attr('string') status;
   @alias('area.name') areaName;
 
-  // includes
-  @belongsTo('area') area;
-  @belongsTo('user') user;
-
   // references
   @attr('string') assessmentId;
   @attr('string') courseId;
+
+  // includes
+  @belongsTo('area') area;
+  @belongsTo('user') user;
 
   // methods
   @equal('status', 'assessed') isAssessed;

--- a/mon-pix/app/models/correction.js
+++ b/mon-pix/app/models/correction.js
@@ -1,17 +1,20 @@
 import Model, { hasMany, attr } from '@ember-data/model';
 import { and, empty } from '@ember/object/computed';
 
-export default Model.extend({
+export default class Correction extends Model {
 
-  solution: attr('string'),
-  hint: attr('string'),
-  tutorials: hasMany('tutorial', { inverse: null }),
-  learningMoreTutorials: hasMany('tutorial', { inverse: null }), // Traduction: TutoSavoirPlus
+  // attributes
+  @attr('string') solution;
+  @attr('string') hint;
 
-  hasNoHints: empty('hint'),
-  hasNoTutorials: empty('tutorials'),
-  hasNoLearningMoreTutorials: empty('learningMoreTutorials'),
+  // includes
+  @hasMany('tutorial', { inverse: null }) tutorials;
+  @hasMany('tutorial', { inverse: null }) learningMoreTutorials; // Traduction: TutoSavoirPlus
 
-  noHintsNorTutorialsAtAll: and('{hasNoHints,hasNoTutorials,hasNoLearningMoreTutorials}'),
+  // methods
+  @empty('hint') hasNoHints;
+  @empty('tutorials') hasNoTutorials;
+  @empty('learningMoreTutorials') hasNoLearningMoreTutorials;
 
-});
+  @and('{hasNoHints,hasNoTutorials,hasNoLearningMoreTutorials}') noHintsNorTutorialsAtAll;
+}

--- a/mon-pix/app/models/course.js
+++ b/mon-pix/app/models/course.js
@@ -1,16 +1,19 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
+export default class Course extends Model {
 
-  name: attr('string'),
-  description: attr('string'),
-  duration: attr('number'),
-  imageUrl: attr('string'),
-  nbChallenges: attr('number'),
-  type: attr('string'),
+  // attributes
+  @attr('string') description;
+  @attr('number') duration;
+  @attr('string') imageUrl;
+  @attr('string') name;
+  @attr('number') nbChallenges;
+  @attr('string') type;
 
-  isDemo: computed('type', function() {
+  // methods
+  @computed('type')
+  get isDemo() {
     return this.type === 'DEMO';
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/feedback.js
+++ b/mon-pix/app/models/feedback.js
@@ -1,9 +1,13 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
-export default Model.extend({
-  content: attr('string'),
-  category: attr('string'),
-  answer: attr('string'),
-  assessment: belongsTo('assessment'),
-  challenge: belongsTo('challenge')
-});
+export default class Feedback extends Model {
+
+  // attributes
+  @attr('string') answer;
+  @attr('string') category;
+  @attr('string') content;
+
+  // includes
+  @belongsTo('assessment') assessment;
+  @belongsTo('challenge') challenge;
+}

--- a/mon-pix/app/models/levelup.js
+++ b/mon-pix/app/models/levelup.js
@@ -1,6 +1,8 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  competenceName: attr(),
-  level: attr(),
-});
+export default class Levelup extends Model {
+
+  // attributes
+  @attr competenceName;
+  @attr level;
+}

--- a/mon-pix/app/models/levelup.js
+++ b/mon-pix/app/models/levelup.js
@@ -3,6 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class Levelup extends Model {
 
   // attributes
-  @attr competenceName;
-  @attr level;
+  @attr('string') competenceName;
+  @attr('number') level;
 }

--- a/mon-pix/app/models/organization.js
+++ b/mon-pix/app/models/organization.js
@@ -1,9 +1,13 @@
-import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
-export default Model.extend({
-  name: attr('string'),
-  type: attr('string'),
-  code: attr('string'),
-  user: belongsTo('user'),
-  snapshots: hasMany('snapshot')
-});
+export default class Organization extends Model {
+
+  // attributes
+  @attr('string') code;
+  @attr('string') name;
+  @attr('string') type;
+
+  // includes
+  @hasMany('snapshot') snapshots;
+  @belongsTo('user') user;
+}

--- a/mon-pix/app/models/password-reset-demand.js
+++ b/mon-pix/app/models/password-reset-demand.js
@@ -1,5 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  email: attr('string'),
-});
+export default class PasswordResetDemand extends Model {
+
+  // attributes
+  @attr('string') email;
+}

--- a/mon-pix/app/models/pix-score.js
+++ b/mon-pix/app/models/pix-score.js
@@ -1,5 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  value: attr('number')
-});
+export default class PixScore extends Model {
+
+  // attributes
+  @attr('number') value;
+}

--- a/mon-pix/app/models/progression.js
+++ b/mon-pix/app/models/progression.js
@@ -1,10 +1,14 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  completionRate: attr('number'),
+export default class Progression extends Model {
 
-  completionPercentage: computed('completionRate', function() {
+  // attributes
+  @attr('number') completionRate;
+
+  // methods
+  @computed('completionRate')
+  get completionPercentage() {
     return Math.round(this.completionRate * 100);
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/result-competence-tree.js
+++ b/mon-pix/app/models/result-competence-tree.js
@@ -1,5 +1,7 @@
 import Model, { hasMany } from '@ember-data/model';
 
-export default Model.extend({
-  areas: hasMany('area', { inverse: null }),
-});
+export default class ResultCompetenceTree extends Model {
+
+  // includes
+  @hasMany('area', { inverse: null }) areas;
+}

--- a/mon-pix/app/models/result-competence.js
+++ b/mon-pix/app/models/result-competence.js
@@ -1,8 +1,12 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
-export default Model.extend({
-  name: attr('string'),
-  area: belongsTo('area'),
-  index: attr('number'),
-  level: attr('number'),
-});
+export default class ResultCompetence extends Model {
+
+  // attributes
+  @attr('string') name;
+  @attr('number') index;
+  @attr('number') level;
+
+  // includes
+  @belongsTo('area') area;
+}

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -1,4 +1,4 @@
-import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { equal, and } from '@ember/object/computed';
 import { computed } from '@ember/object';
 
@@ -6,48 +6,59 @@ const NUMBER_OF_PIX_BY_LEVEL = 8;
 const MAX_DISPLAYED_PERCENTAGE = 95;
 const MAX_REACHABLE_LEVEL = 5;
 
-export default Model.extend({
-  name: attr('string'),
-  description: attr('string'),
-  index: attr('number'),
-  competenceId: attr('string'),
-  earnedPix: attr('number'),
-  level: attr('number'),
-  pixScoreAheadOfNextLevel: attr('number'),
-  status: attr('string'),
-  remainingDaysBeforeReset: attr('number'),
+export default class Scorecard extends Model {
+  @attr('string') description;
+  @attr('number') earnedPix;
+  @attr('number') index;
+  @attr('number') level;
+  @attr('string') name;
+  @attr('number') pixScoreAheadOfNextLevel;
+  @attr('number') remainingDaysBeforeReset;
+  @attr('string') status;
 
-  area: belongsTo('area'),
-  tutorials: hasMany('tutorial'),
+  // includes
+  @belongsTo('area') area;
+  @hasMany('tutorial') tutorials;
 
-  isFinished: equal('status', 'COMPLETED'),
-  isFinishedWithMaxLevel: and('isFinished', 'isMaxLevel'),
-  isStarted: equal('status', 'STARTED'),
-  isNotStarted: equal('status', 'NOT_STARTED'),
+  // relationships
+  @attr('string') competenceId;
 
-  percentageAheadOfNextLevel: computed('pixScoreAheadOfNextLevel', function() {
+  // methods
+  @and('isFinished', 'isMaxLevel') isFinishedWithMaxLevel;
+
+  @equal('status', 'COMPLETED') isFinished;
+  @equal('status', 'NOT_STARTED') isNotStarted;
+  @equal('status', 'STARTED') isStarted;
+
+  @computed('level')
+  get isMaxLevel() {
+    return this.level >= MAX_REACHABLE_LEVEL;
+  }
+
+  @computed('earnedPix')
+  get hasNotEarnAnything() {
+    return this.earnedPix === 0;
+  }
+
+  @computed('level')
+  get hasNotReachLevelOne() {
+    return this.level < 1;
+  }
+
+  @computed('level')
+  get hasReachAtLeastLevelOne() {
+    return this.level >= 1;
+  }
+
+  @computed('pixScoreAheadOfNextLevel')
+  get percentageAheadOfNextLevel() {
     const percentage = this.pixScoreAheadOfNextLevel / NUMBER_OF_PIX_BY_LEVEL * 100;
 
     return percentage >= MAX_DISPLAYED_PERCENTAGE ? MAX_DISPLAYED_PERCENTAGE : percentage;
-  }),
+  }
 
-  remainingPixToNextLevel: computed('pixScoreAheadOfNextLevel', function() {
+  @computed('pixScoreAheadOfNextLevel')
+  get remainingPixToNextLevel() {
     return NUMBER_OF_PIX_BY_LEVEL - this.pixScoreAheadOfNextLevel;
-  }),
-
-  isMaxLevel: computed('level', function() {
-    return this.level >= MAX_REACHABLE_LEVEL;
-  }),
-
-  hasNotEarnAnything: computed('earnedPix', function() {
-    return this.earnedPix === 0;
-  }),
-
-  hasNotReachLevelOne: computed('level', function() {
-    return this.level < 1;
-  }),
-
-  hasReachAtLeastLevelOne: computed('level', function() {
-    return this.level >= 1;
-  }),
-});
+  }
+}

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -16,12 +16,12 @@ export default class Scorecard extends Model {
   @attr('number') remainingDaysBeforeReset;
   @attr('string') status;
 
+  // references
+  @attr('string') competenceId;
+
   // includes
   @belongsTo('area') area;
   @hasMany('tutorial') tutorials;
-
-  // relationships
-  @attr('string') competenceId;
 
   // methods
   @and('isFinished', 'isMaxLevel') isFinishedWithMaxLevel;

--- a/mon-pix/app/models/snapshot.js
+++ b/mon-pix/app/models/snapshot.js
@@ -1,15 +1,22 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  testsFinished: attr('string'),
-  score: attr('number'),
-  createdAt: attr('date'),
-  organization: belongsTo('organization'),
-  user: belongsTo('user'),
-  studentCode: attr('string'),
-  campaignCode: attr('string'),
-  numberOfTestsFinished: computed('testsFinished', function() {
+export default class Snapshot extends Model {
+
+  // attributes
+  @attr('string') campaignCode;
+  @attr('date') createdAt;
+  @attr('number') score;
+  @attr('string') studentCode;
+  @attr('string') testsFinished;
+
+  // includes
+  @belongsTo('organization') organization;
+  @belongsTo('user') user;
+
+  // methods
+  @computed('testsFinished')
+  get numberOfTestsFinished() {
     return this.testsFinished || 0;
-  })
-});
+  }
+}

--- a/mon-pix/app/models/student-dependent-user.js
+++ b/mon-pix/app/models/student-dependent-user.js
@@ -1,12 +1,14 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  lastName: attr('string'),
-  firstName: attr('string'),
-  birthdate: attr('date-only'),
-  campaignCode: attr('string'),
-  email: attr('string'),
-  username: attr('string'),
-  password: attr('string'),
-  withUsername: attr('boolean'),
-});
+export default class StudentDependentUser extends Model {
+
+  // attributes
+  @attr('date-only') birthdate;
+  @attr('string') campaignCode;
+  @attr('string') email;
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') password;
+  @attr('string') username;
+  @attr('boolean') withUsername;
+}

--- a/mon-pix/app/models/student-user-association.js
+++ b/mon-pix/app/models/student-user-association.js
@@ -1,10 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  lastName: attr('string'),
-  firstName: attr('string'),
-  birthdate: attr('date-only'),
-  campaignCode: attr('string'),
-  username: attr('string'),
+export default class StudentUserAssociation extends Model {
 
-});
+  // attributes
+  @attr('date-only') birthdate;
+  @attr('string') campaignCode;
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') username;
+}

--- a/mon-pix/app/models/student.js
+++ b/mon-pix/app/models/student.js
@@ -1,8 +1,12 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
-export default Model.extend({
-  lastName: attr('string'),
-  firstName: attr('string'),
-  birthdate: attr('date-only'),
-  user: belongsTo('user')
-});
+export default class Student extends Model {
+
+  // attributes
+  @attr('date-only') birthdate;
+  @attr('string') firstName;
+  @attr('string') lastName;
+
+  // includes
+  @belongsTo('user') user;
+}

--- a/mon-pix/app/models/target-profile.js
+++ b/mon-pix/app/models/target-profile.js
@@ -1,5 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
-export default Model.extend({
-  name: attr('string'),
-});
+export default class TargetProfile extends Model {
+
+  // attributes
+  @attr('string') name;
+}

--- a/mon-pix/app/models/tutorial.js
+++ b/mon-pix/app/models/tutorial.js
@@ -1,15 +1,17 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
-export default Model.extend({
+export default class Tutorial extends Model {
 
-  duration: attr('string'),
-  format: attr('string'),
-  link: attr('string'),
-  source: attr('string'),
-  title: attr('string'),
-  tubeName: attr('string'),
-  tubePracticalTitle: attr('string'),
-  tubePracticalDescription: attr('string'),
-  scorecard: belongsTo('scorecard'),
+  // attributes
+  @attr('string') duration;
+  @attr('string') format;
+  @attr('string') link;
+  @attr('string') source;
+  @attr('string') title;
+  @attr('string') tubeName;
+  @attr('string') tubePracticalTitle;
+  @attr('string') tubePracticalDescription;
 
-});
+  // includes
+  @belongsTo('scorecard') scorecard;
+}

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -1,25 +1,31 @@
-import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 
-export default Model.extend({
-  firstName: attr('string'),
-  lastName: attr('string'),
-  email: attr('string'),
-  username: attr('string'),
-  password: attr('string'),
-  cgu: attr('boolean'),
-  hasSeenAssessmentInstructions: attr('boolean'),
-  recaptchaToken: attr('string'),
-  totalPixScore: attr('number'),
-  pixScore: belongsTo('pix-score'),
-  competences: hasMany('competence'),
-  organizations: hasMany('organization'),
-  certifications: hasMany('certification'),
-  campaignParticipations: hasMany('campaign-participation'),
-  scorecards: hasMany('scorecard'),
-  certificationProfile: belongsTo('certification-profile'),
+export default class User extends Model {
 
-  competenceAreas: computed('competences', function() {
+  // attributes
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') email;
+  @attr('string') username;
+  @attr('string') password;
+  @attr('boolean') cgu;
+  @attr('boolean') hasSeenAssessmentInstructions;
+  @attr('string') recaptchaToken;
+  @attr('number') totalPixScore;
+
+  // includes
+  @belongsTo('certification-profile') certificationProfile;
+  @belongsTo('pix-score') pixScore;
+  @hasMany('campaign-participation') campaignParticipations;
+  @hasMany('certification') certifications;
+  @hasMany('competence') competences;
+  @hasMany('organization') organizations;
+  @hasMany('scorecard') scorecards;
+
+  // methods
+  @computed('competences')
+  get competenceAreas() {
     return this.competences.then((competences) => {
       return competences.reduce((areas, competence) => {
         competence.get('area').then((competenceArea) => {
@@ -34,13 +40,15 @@ export default Model.extend({
         });
       }, []);
     });
-  }),
+  }
 
-  fullName: computed('firstName', 'lastName', function() {
+  @computed('firstName', 'lastName')
+  get fullName() {
     return `${this.firstName} ${ this.lastName}`;
-  }),
+  }
 
-  areasCode: computed('scorecards.@each.area', function() {
+  @computed('scorecards.@each.area')
+  get areasCode() {
     return this.scorecards.mapBy('area.code').uniq();
-  }),
-});
+  }
+}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -48,13 +48,13 @@ module.exports = function(environment) {
 
     // Set or update content security policies
     contentSecurityPolicy: {
-      'default-src': "'none'",
-      'script-src': "'self' www.google-analytics.com 'unsafe-inline' 'unsafe-eval' cdn.ravenjs.com",
-      'font-src': "'self' fonts.gstatic.com",
-      'connect-src': "'self' www.google-analytics.com",
-      'img-src': "'self'",
-      'style-src': "'self' fonts.googleapis.com",
-      'media-src': "'self'"
+      'default-src': '\'none\'',
+      'script-src': '\'self\' www.google-analytics.com \'unsafe-inline\' \'unsafe-eval\' cdn.ravenjs.com',
+      'font-src': '\'self\' fonts.gstatic.com',
+      'connect-src': '\'self\' www.google-analytics.com',
+      'img-src': '\'self\'',
+      'style-src': '\'self\' fonts.googleapis.com',
+      'media-src': '\'self\''
     },
 
     showdown: {

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
-  let app = new EmberApp(defaults, {
+  const app = new EmberApp(defaults, {
     // Add options here
     'ember-cli-babel': {
       includePolyfill: true

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -15904,14 +15904,14 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.7.2.tgz",
-      "integrity": "sha512-Ua7+xePz8m0BrqSHfYibkRXWQMMb5RBsH9ohZy2a7ri+s6+UQre9x3BxPpawCLZMzQzIG4vQh93YiVGCSv3XYA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.8.1.tgz",
+      "integrity": "sha512-74Whm5MHV+llWv0LA/4b4IaLQxMTj5Jc1zoK11gYEPQbPIAviTF4JsRuzPM/x7QMo5pQZyTdfGYF5zVMbgQ2RA==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",
         "ember-rfc176-data": "^0.3.12",
-        "snake-case": "^3.0.2"
+        "snake-case": "^3.0.3"
       }
     },
     "eslint-plugin-es": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -91,7 +91,7 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.7.2",
-    "eslint-plugin-ember": "^7.7.1",
+    "eslint-plugin-ember": "^7.8.1",
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember server",
-    "lint": "eslint app mirage tests",
+    "lint": "eslint ./*.js app config mirage tests",
     "lint:fix": "npm run lint -- --fix",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -90,7 +90,7 @@
     "ember-source": "~3.15.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
-    "eslint": "^6.7.2",
+    "eslint": "^6.8.0",
     "eslint-plugin-ember": "^7.8.1",
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Sur Mon Pix, la déclaration de nos modèles `ember-data` est dépassée depuis `Ember v3.15`.

## :robot: Solution
Aligner nos modèles avec les recommandations de la [documentation](https://guides.emberjs.com/v3.16.0/models/defining-models/).

## 📋 Reste à faire
- Mettre à jour `answer.js` -> a priori sera fait dans une autre PR qui traite convenablement les mixin

## 🌮 Take away
- Ajout de la règle eslint-plugin-ember [order-in-models](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-models.md) 
- Ajout de la règle eslint-plugin-ember [no-empty-attrs](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-empty-attrs.md) 
- Ajout de la règle eslint-plugin-ember [use-ember-data-rfc-395-imports](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/use-ember-data-rfc-395-imports.md) 
- Mise à jour de eslint et eslint-plugin-ember
- Une bonne pratique pour les futures PR de ce type est d'appliquer la règle eslint-plugin-ember que l'on souhaite appliquer et traiter les éléments un à un sur le modèle `1 eslint-plugin-ember rule = 1 PR`
- Voici la [liste](https://github.com/ember-cli/eslint-plugin-ember#-rules) des règles de linter disponible pour `eslint-plugin-ember`
- Il faut noter que toutes les règles de linter ne sont **pas (encore) disponibles** pour Octane. La [liste](https://github.com/ember-cli/eslint-plugin-ember/blob/master/lib/octane-rules.js) complète évolue et sera appliquée au fil du temps.
> 🚗 | octane | extends the recommended configuration by enabling octane rules. This ruleset is currently considered unstable and experimental ⚠️ as rules may be added and removed until the final ruleset is settled upon.


## 💊 Boy Scout Rule
- La commande `npm run lint` sur mon-pix ne traitait pas les fichiers .js et a été ajustée en conséquence
- Les règles qui étaient transgressée ont été corrigées
