### PR TITLE
[Tech] Se prémunir d'une attaque de type "Airtable formula injection"

### DIFF
--- a/api/lib/application/cache/index.js
+++ b/api/lib/application/cache/index.js
@@ -1,3 +1,4 @@
+const Joi = require('@hapi/joi');
 const securityController = require('../../interfaces/controllers/security-controller');
 const CacheController = require('./cache-controller');
 
@@ -11,6 +12,11 @@ exports.register = async function(server) {
           method: securityController.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster'
         }],
+        validate: {
+          params: Joi.object({
+            cachekey: Joi.string().regex(/^(.)+_rec[a-zA-Z0-9]+/).required()
+          })
+        },
         handler: CacheController.refreshCacheEntry,
         tags: ['api', 'cache'],
         notes: [

--- a/api/tests/acceptance/application/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache-controller_test.js
@@ -16,12 +16,30 @@ describe('Acceptance | Controller | cache-controller', () => {
     beforeEach(() => {
       options = {
         method: 'DELETE',
-        url: '/api/cache/cache-test-key',
+        url: '/api/cache',
         headers: {}
       };
     });
 
+    describe('Airtable Formula injection protection', () => {
+      it('should respond with a 400 - bad request - if cacheKey is not in the form of "ABCD_recXXXX"', async () => {
+        // given
+        const pixMasterUserId = 1234;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(pixMasterUserId);
+        options.url = '/api/cache/SomeBadFormattedKey';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
     describe('Resource access management', () => {
+      beforeEach(() => {
+        options.url = '/api/cache/Epreuves_recABCD';
+      });
 
       it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
         // given
@@ -36,8 +54,8 @@ describe('Acceptance | Controller | cache-controller', () => {
 
       it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', async () => {
         // given
-        const nonPixMAsterUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMAsterUserId);
+        const nonPixMasterUserId = 9999;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
 
         // when
         const response = await server.inject(options);

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -28,7 +28,7 @@ describe('Unit | Router | cache-router', () => {
       // given
       const options = {
         method: 'DELETE',
-        url: '/api/cache/test-cache-key'
+        url: '/api/cache/Table_recXYZ1234'
       };
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Comme vu par @jonathanperret dans la PR #1074, l'API ne fait pas de contrôle sur le format des clés de cache et utilise le paramètre d'entrée directement dans l'appel de l'API Airtable.
Il existe donc une faille potentielle par laquelle une personne pourrait injecter une formule Airtable comme identifiant, entraînant un comportement non maitrisé.
C'est le même type qu'une attaque par injection SQL mais avec une formule Airtable. (https://fr.wikipedia.org/wiki/Injection_SQL)

## :robot: Solution
Valider le format de la clé du cache en entrée de l'API.

## :rainbow: Remarques
Pas de validation fonctionnelle sur la review app.
Il faudra s'assurer en intégration que Pix editor arrive toujours à mettre à jour le cache pour une épreuve donnée.
