### PR TITLE
[FEATURE] Ecriture du script pour mettre à jour la colonne marquant la date d'envoi des résultats au prescripteur dans la table SESSIONS (PA-146)

### DIFF
--- a/api/scripts/20200219_pa_146_update_results_sent_to_prescriber_at.js
+++ b/api/scripts/20200219_pa_146_update_results_sent_to_prescriber_at.js
@@ -1,0 +1,36 @@
+const { knex } = require('../db/knex-database-connection');
+
+/**
+ * Utilisation
+ * ===========
+ *
+ * ``node 20200219_pa_146_update_results_sent_to_prescriber_at_test.js``
+ */
+
+function updateResultsSentToPrescribedDate(prescribedAtDatetime = new Date()) {
+  const updateRequest = `
+    update sessions
+    set "resultsSentToPrescriberAt" = ?
+    where exists
+    (
+          select 1
+          from "certification-courses" as cc1
+          where sessions.id = cc1."sessionId"
+          and cc1."isPublished" is true
+        
+    )
+
+  `;
+  return knex.raw(updateRequest, prescribedAtDatetime);
+}
+
+if (require.main === module) {
+  updateResultsSentToPrescribedDate()
+    .then(() => console.log('Sessions\' resultsSentToPrescriberAt field updated.'))
+    .catch(console.error)
+    .finally(() => process.exit(0));
+}
+
+module.exports = {
+  updateResultsSentToPrescribedDate,
+};

--- a/api/scripts/20200219_pa_146_update_results_sent_to_prescriber_at.js
+++ b/api/scripts/20200219_pa_146_update_results_sent_to_prescriber_at.js
@@ -19,6 +19,7 @@ function updateResultsSentToPrescribedDate(prescribedAtDatetime = new Date()) {
           and cc1."isPublished" is true
         
     )
+    and "resultsSentToPrescriberAt" is null
 
   `;
   return knex.raw(updateRequest, prescribedAtDatetime);

--- a/api/tests/acceptance/scripts/20200219_pa_146_update_sent_to_prescriber_at_test.js
+++ b/api/tests/acceptance/scripts/20200219_pa_146_update_sent_to_prescriber_at_test.js
@@ -1,0 +1,97 @@
+const { expect, knex, databaseBuilder } = require('../../test-helper');
+
+const { updateResultsSentToPrescribedDate } = require('../../../scripts/20200219_pa_146_update_results_sent_to_prescriber_at');
+
+describe('Acceptance | Scripts | 20200219_pa_146_update_results_sent_to_prescriber_at_test.js', () => {
+  let sessionWithoutCourse;
+  let sessionWithAllPublishedCourses;
+  let sessionWithNonePublishedCourses;
+  let sessionWithoutAllPublishedCourses;
+
+  beforeEach(async () => {
+    // given
+    sessionWithoutCourse = _createSession();
+
+    sessionWithAllPublishedCourses = _createSession();
+    _createPublishedCertificationCourses(sessionWithAllPublishedCourses);
+
+    sessionWithoutAllPublishedCourses = _createSession();
+    _createPublishedCertificationCourses(sessionWithoutAllPublishedCourses);
+    _createUnpublishedCertificationCourses(sessionWithoutAllPublishedCourses);
+    sessionWithNonePublishedCourses = _createSession();
+    _createUnpublishedCertificationCourses(sessionWithNonePublishedCourses);
+
+    await databaseBuilder.commit();
+  });
+
+  describe('Session without certification course', () => {
+
+    it('does not set resultsSentToPrescriberAt value', async () => {
+      // when
+      await updateResultsSentToPrescribedDate();
+      // then
+      const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithoutCourse.id });
+      expect(sessionAfterUpdate.resultsSentToPrescriberAt).to.be.null;
+    });
+  });
+
+  describe('Session with certification courses', () => {
+    context('all published', () => {
+      it('does set resultsSentToPrescriberAt value', async () => {
+        // when
+        await updateResultsSentToPrescribedDate();
+        // then
+        const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithAllPublishedCourses.id });
+        expect(sessionAfterUpdate.resultsSentToPrescriberAt).not.to.be.null;
+      });
+    });
+
+    context('not all published', () => {
+      it('does set resultsSentToPrescriberAt value (considered published)', async () => {
+        // when
+        await updateResultsSentToPrescribedDate();
+        // then
+        const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithoutAllPublishedCourses.id });
+        expect(sessionAfterUpdate.resultsSentToPrescriberAt).not.to.be.null;
+      });
+    });
+
+    context('none published', () => {
+      it('does not set resultsSentToPrescriberAt value', async () => {
+        // when
+        await updateResultsSentToPrescribedDate();
+        // then
+        const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithNonePublishedCourses.id });
+        expect(sessionAfterUpdate.resultsSentToPrescriberAt).to.be.null;
+      });
+    });
+  });
+});
+
+function _createSession() {
+  return databaseBuilder.factory.buildSession();
+}
+
+function _createPublishedCertificationCourses(session) {
+  databaseBuilder.factory.buildCertificationCourse({
+    sessionId: session.id,
+    isPublished: true,
+  });
+
+  databaseBuilder.factory.buildCertificationCourse({
+    sessionId: session.id,
+    isPublished: true,
+  });
+}
+
+function _createUnpublishedCertificationCourses(session) {
+  databaseBuilder.factory.buildCertificationCourse({
+    sessionId: session.id,
+    isPublished: false,
+  });
+
+  databaseBuilder.factory.buildCertificationCourse({
+    sessionId: session.id,
+    isPublished: false,
+  });
+}

--- a/api/tests/acceptance/scripts/20200219_pa_146_update_sent_to_prescriber_at_test.js
+++ b/api/tests/acceptance/scripts/20200219_pa_146_update_sent_to_prescriber_at_test.js
@@ -7,6 +7,7 @@ describe('Acceptance | Scripts | 20200219_pa_146_update_results_sent_to_prescrib
   let sessionWithAllPublishedCourses;
   let sessionWithNonePublishedCourses;
   let sessionWithoutAllPublishedCourses;
+  let sessionWithAllPublishedCoursesAndDefinedResultsSentToPrescriberAt;
 
   beforeEach(async () => {
     // given
@@ -20,6 +21,9 @@ describe('Acceptance | Scripts | 20200219_pa_146_update_results_sent_to_prescrib
     _createUnpublishedCertificationCourses(sessionWithoutAllPublishedCourses);
     sessionWithNonePublishedCourses = _createSession();
     _createUnpublishedCertificationCourses(sessionWithNonePublishedCourses);
+
+    sessionWithAllPublishedCoursesAndDefinedResultsSentToPrescriberAt = _createSession({ resultsSentToPrescriberAt: new Date() });
+    _createPublishedCertificationCourses(sessionWithAllPublishedCoursesAndDefinedResultsSentToPrescriberAt);
 
     await databaseBuilder.commit();
   });
@@ -43,6 +47,15 @@ describe('Acceptance | Scripts | 20200219_pa_146_update_results_sent_to_prescrib
         // then
         const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithAllPublishedCourses.id });
         expect(sessionAfterUpdate.resultsSentToPrescriberAt).not.to.be.null;
+      });
+
+      it('does not update resultsSentToPrescriberAt value', async () => {
+        // when
+        await updateResultsSentToPrescribedDate();
+        // then
+        const [sessionAfterUpdate] = await knex('sessions').where({ id: sessionWithAllPublishedCoursesAndDefinedResultsSentToPrescriberAt.id });
+        expect(sessionAfterUpdate.resultsSentToPrescriberAt.toString())
+          .to.equal(sessionWithAllPublishedCoursesAndDefinedResultsSentToPrescriberAt.resultsSentToPrescriberAt.toString());
       });
     });
 
@@ -68,8 +81,8 @@ describe('Acceptance | Scripts | 20200219_pa_146_update_results_sent_to_prescrib
   });
 });
 
-function _createSession() {
-  return databaseBuilder.factory.buildSession();
+function _createSession(session) {
+  return databaseBuilder.factory.buildSession(session);
 }
 
 function _createPublishedCertificationCourses(session) {


### PR DESCRIPTION
## :unicorn: Problème
Par défaut, toutes les sessions vont être taguées comme “non diffusées” dans le cadre de l’implémentation du tag, alors que les sessions anciennes ont en principe déjà été diffusées au prescripteur.

## :robot: Solution
Conditions pour le champ:
- Toutes les sessions ayant au moins une certification publiée !

https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1227292673/2020-03-02+Comment+choisir+les+sessions+la+colonne+resultsSentAt+doit+tre+mise+jour+lors+de+la+migration+d+di+e

## :rainbow: Remarques
Requête lancée en Prod le 02/03/2020 vers 15h15. Nombre de sessions mises à jour  : 4276.
Rectification sur 23 d'entre elles d'après la liste fournie par le pôle certif.
Date inscrite dans la colonne : 02/03/2020 à minuit (UTC + 0)
