### PR TITLE
[FEATURE] Agrandir la zone de click de la carte compétence (PF-1011)

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -83,8 +83,8 @@
   }
 
   .competence-card:hover .competence-card__footer {
-    transition-delay: 0.15s;
-    bottom: 22px;
+    bottom: 0px;
+    height: 70px;
   }
 
   .competence-card__button:hover .competence-card-button__label {

--- a/mon-pix/app/templates/components/competence-card-desktop.hbs
+++ b/mon-pix/app/templates/components/competence-card-desktop.hbs
@@ -1,4 +1,5 @@
 <article class="competence-card">
+  <LinkTo @route="competences.details" @model={{scorecard.competenceId}}>
     <header class="competence-card__header">
       <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
       <span class="competence-card__area-name">{{scorecard.area.title}}</span>
@@ -7,16 +8,14 @@
 
     <div class="competence-card__body">
       {{#if scorecard.isFinishedWithMaxLevel}}
-        <LinkTo @route="competences.details" @model={{scorecard.competenceId}}>
-          <div class="competence-card__congrats competence-card__congrats--with-magnification">
-            <div class="competence-card__level competence-card__level--congrats">
-              <span class="score-label competence-card__score-label--congrats">Niveau</span>
-              <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{displayedLevel}}</span>
-            </div>
+        <div class="competence-card__congrats competence-card__congrats--with-magnification">
+          <div class="competence-card__level competence-card__level--congrats">
+            <span class="score-label competence-card__score-label--congrats">Niveau</span>
+            <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{displayedLevel}}</span>
           </div>
-        </LinkTo>
+        </div>
       {{else}}
-        <LinkTo @route="competences.details" @model={{scorecard.competenceId}} class="competence-card__link">
+        <div class="competence-card__link">
           <CircleChart @value={{scorecard.percentageAheadOfNextLevel}} @sliceColor={{scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
             <div class="competence-card__level">
               <span class="score-label">Niveau</span>
@@ -24,9 +23,10 @@
               <span class="competence-card__score-details">détail</span>
             </div>
           </CircleChart>
-        </LinkTo>
+        </div>
       {{/if}}
     </div>
+  </LinkTo>
 
   {{#if scorecard.isFinishedWithMaxLevel}}
     <footer class="competence-card__congrats-message">


### PR DESCRIPTION
## :unicorn: Problème
Pour accéder aux détails d'une compétence, il fallait cliquer exactement sur le cercle de la carte compétence: ce qui n'est pas intuitif car toute la carte réagit dès que on la survole.

## :robot: Solution
Agrandir la zone de click pour pouvoir cliquer sur toute la zone avant le bouton "commencer" ou "reprendre".
