### PR TITLE
[BUGFIX] Fix style du titre de la page résultats d'une campagne

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -103,16 +103,8 @@
 .skill-review-result {
   &__abstract {
     text-align: center;
-    font-size: 2.8rem;
-    line-height: 38px;
     text-transform: none;
-    color: $tundora-grey;
     margin-bottom: 10px;
-
-    @include device-is('tablet') {
-      font-size: 4.2rem;
-      line-height: 48px;
-    }
   }
 
   &__badge {

--- a/mon-pix/app/templates/campaigns/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/skill-review.hbs
@@ -19,13 +19,13 @@
     {{/if}}
 
     {{#if (not @model.campaignParticipation.campaign.isArchived )}}
-      <h1 class="rounded-panel-title skill-review-result__abstract">
+      <h3 class="rounded-panel-title skill-review-result__abstract">
         Vous maîtrisez
         <span class="skill-review-result-abstract__percentage">
           {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
         </span>
         <br> des compétences testées.
-      </h1>
+      </h3>
       <div class="skill-review-result__share-container">
         {{#if model.campaignParticipation.isShared}}
           <p class="skill-review-share__thanks">Merci, vos résultats ont bien été envoyés !</p>


### PR DESCRIPTION
## :unicorn: Problème
Suite à la PR #1082, les titres de certaines pages ont été alignés sur leur style.
Il manque la prise en compte de la page de résultats d'une campagne.

## :robot: Solution
Aligner le titre des résultats d'une campagne.
