### PR TITLE
[FEATURE] Autofocus les premiers champs de formulaire des deux écrans du tunnel de certification dans MonPix (PF-1117)

### DIFF
--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -86,7 +86,7 @@ export default Component.extend({
       const { value } = event.target;
 
       if (value.length === 2) {
-        document.getElementById('monthOfBirth').focus();
+        document.getElementById('certificationJoinerMonthOfBirth').focus();
       }
     },
 
@@ -94,7 +94,7 @@ export default Component.extend({
       const { value } = event.target;
 
       if (value.length === 2) {
-        document.getElementById('yearOfBirth').focus();
+        document.getElementById('certificationJoinerYearOfBirth').focus();
       }
     },
 

--- a/mon-pix/app/modifiers/autofocus.js
+++ b/mon-pix/app/modifiers/autofocus.js
@@ -1,0 +1,3 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => element.focus());

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -32,7 +32,7 @@
   align-items: center;
 }
 
-#session-code {
+#certificationStarterSessionCode {
   $space-between-dashes: 0.6ch;
   $nb-characters: 6;
   $total-width: $nb-characters * (1ch + $space-between-dashes);

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -7,7 +7,7 @@
     <form autocomplete="off">
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Numéro de session</label>
-          <Input @autofocus="autofocus" @type="text" @size="6" @value={{this.sessionId}} @id="certificationJoinerSessionId" />
+          <Input {{autofocus}} @type="text" @size="6" @value={{this.sessionId}} @id="certificationJoinerSessionId" />
         </div>
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Prénom</label>

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -7,15 +7,15 @@
     <form autocomplete="off">
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Numéro de session</label>
-          <Input @autofocus="autofocus" @type="text" @size="6" @value={{this.sessionId}} @id="sessionId" />
+          <Input @autofocus="autofocus" @type="text" @size="6" @value={{this.sessionId}} @id="certificationJoinerSessionId" />
         </div>
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Prénom</label>
-          <Input @type="text" @value={{this.firstName}} @id="firstName" />
+          <Input @type="text" @value={{this.firstName}} @id="certificationJoinerFirstName" />
         </div>
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Nom de naissance</label>
-          <Input @type="text" @value={{this.lastName}} @id="lastName" />
+          <Input @type="text" @value={{this.lastName}} @id="certificationJoinerLastName" />
         </div>
         <div class="certification-joiner__row">
             <label class="certification-joiner__label">Date de naissance</label>
@@ -24,7 +24,7 @@
                      @max="31"
                      @type="number"
                      @value={{this.dayOfBirth}} placeholder="JJ"
-                     @id="dayOfBirth"
+                     @id="certificationJoinerDayOfBirth"
                      @input={{action "handleDayInputChange"}}
                      @focus-in={{action "handleInputFocus"}} />
                 <div class="certification-joiner__divider"></div>
@@ -32,14 +32,14 @@
                      @max="12"
                      @type="number"
                      @value={{this.monthOfBirth}} placeholder="MM"
-                     @id="monthOfBirth"
+                     @id="certificationJoinerMonthOfBirth"
                      @input={{action "handleMonthInputChange"}}
                      @focus-in={{action "handleInputFocus"}} />
                 <div class="certification-joiner__divider"></div>
               <Input @min="1900"
                      @type="number"
                      @value={{this.yearOfBirth}} placeholder="AAAA"
-                     @id="yearOfBirth"
+                     @id="certificationJoinerYearOfBirth"
                      @focus-in={{action "handleInputFocus"}} />
             </div>
         </div>

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -6,7 +6,7 @@
     </p>
     <form autocomplete="off">
         <div class="certification-course-page__session-code-input">
-          <Input required={{true}} @id="certificationStarterSessionCode" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
+          <Input {{autofocus}} required={{true}} @id="certificationStarterSessionCode" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
           {{#if this.errorMessage}}
               <div class="certification-course-page__errors">{{this.errorMessage}}</div>
           {{/if}}

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -6,7 +6,7 @@
     </p>
     <form autocomplete="off">
         <div class="certification-course-page__session-code-input">
-          <Input required={{true}} @id="session-code" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
+          <Input required={{true}} @id="certificationStarterSessionCode" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
           {{#if this.errorMessage}}
               <div class="certification-course-page__errors">{{this.errorMessage}}</div>
           {{/if}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13865,6 +13865,42 @@
         }
       }
     },
+    "ember-modifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-1.0.3.tgz",
+      "integrity": "sha512-vWuFyvdkULUyasvEXxe5lcfuPZV/Uqe+b0IQ1yU+TY1RSJnFdVUu/CVHT8Bu4HUJInqzAihwPMTwty7fypzi5Q==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.11.1",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-modifier-manager-polyfill": "^1.2.0"
+      }
+    },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        }
+      }
+    },
     "ember-moment": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-8.0.0.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -80,6 +80,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-mocha": "^0.16.2",
     "ember-modal-dialog": "^2.4.4",
+    "ember-modifier": "^1.0.3",
     "ember-moment": "^8.0.0",
     "ember-page-title": "^5.2.0",
     "ember-resolver": "^7.0.0",

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -67,11 +67,11 @@ describe('Acceptance | Certification | Start Course', function() {
             await visitWithAbortedTransition('/certifications');
 
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -84,12 +84,12 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when no candidate with given info has been registered in the given session', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'PasInscrite');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'PasInscrite');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -102,12 +102,12 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when several candidates with given info are found in the given session', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'PlusieursMatchs');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'PlusieursMatchs');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -120,12 +120,12 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when user has already been linked to another candidate in the session', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'UtilisateurLiéAutre');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'UtilisateurLiéAutre');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -138,12 +138,12 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when candidate has already been linked to another user in the session', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'CandidatLiéAutre');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'CandidatLiéAutre');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -164,12 +164,12 @@ describe('Acceptance | Certification | Start Course', function() {
               birthdate: '1990-01-04',
             });
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'CandidatLiéUtilisateur');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'CandidatLiéUtilisateur');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -182,12 +182,12 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when user is successfuly linked to the candidate', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'Bravo');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'Bravo');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
           });
 
@@ -200,14 +200,14 @@ describe('Acceptance | Certification | Start Course', function() {
         context('when user enter a correct code session', function() {
           beforeEach(async function() {
             // when
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'Bravo');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'Bravo');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
-            await fillIn('#session-code', 'ABCD12');
+            await fillIn('#certificationStarterSessionCode', 'ABCD12');
             await click('.certification-course-page__submit_button');
           });
 
@@ -245,14 +245,14 @@ describe('Acceptance | Certification | Start Course', function() {
 
           it('should be redirected on the second challenge of an assessment', async function() {
             // given
-            await fillIn('#sessionId', '1');
-            await fillIn('#firstName', 'Laura');
-            await fillIn('#lastName', 'Bravo');
-            await fillIn('#dayOfBirth', '04');
-            await fillIn('#monthOfBirth', '01');
-            await fillIn('#yearOfBirth', '1990');
+            await fillIn('#certificationJoinerSessionId', '1');
+            await fillIn('#certificationJoinerFirstName', 'Laura');
+            await fillIn('#certificationJoinerLastName', 'Bravo');
+            await fillIn('#certificationJoinerDayOfBirth', '04');
+            await fillIn('#certificationJoinerMonthOfBirth', '01');
+            await fillIn('#certificationJoinerYearOfBirth', '1990');
             await click('.certification-joiner__attempt-next-btn');
-            await fillIn('#session-code', '10ue1');
+            await fillIn('#certificationStarterSessionCode', '10ue1');
             await click('.certification-course-page__submit_button');
 
             await click('.challenge-actions__action-skip');


### PR DESCRIPTION
## :unicorn: Problème
Le premier écran du tunnel de certification dans MonPix possède un autofocus sur le premier champ du formulaire. En revanche, le deuxième écran (celui du code d'accès), n'en a pas, et c'est bien dommage !

## :robot: Solution
Le truc c'est que la propriété autofocus des input n'est prise en compte que lors du premier rendu de toute la fenêtre (à un refresh par exemple). Dans le cadre du tunnel de certification ( - et plus généralement dans toutes nos applis, puisque SPA), on rend l'ensemble qu'une seule fois, puis on rend individuellement les components en fonction du besoin. Donc, en cas de remplacement d'un component par un autre par exemple, la propriété n'est pas prise en compte.
En suivant les conseils de la doc ember, on ajoute donc un _modifier_ pour pouvoir facilement définir l'autofocus sur l'élément de notre choix dans un template donné. :
Doc : https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_calling-methods-on-first-render

## :rainbow: Remarques
