### PR TITLE
[BUGFIX] Appliquer la pagination par défaut lorsque la page 0 est demandée (PO-342).

### DIFF
--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -21,7 +21,7 @@ function _extractPage(query) {
   const regex = /page\[([a-zA-Z]*)]/;
   const params = _extractObjectParameter(query, regex);
 
-  return _convertToInt(params);
+  return _convertObjectValueToInt(params);
 }
 
 function _extractObjectParameter(query, regex) {
@@ -38,6 +38,6 @@ function _extractArrayParameter(query, parameterName) {
   return query[parameterName] ? query[parameterName].split(',') : [];
 }
 
-function _convertToInt(params) {
-  return _.mapValues(params, (value) => parseInt(value));
+function _convertObjectValueToInt(params) {
+  return _.mapValues(params, _.toInteger);
 }

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -19,7 +19,9 @@ function _extractFilter(query) {
 
 function _extractPage(query) {
   const regex = /page\[([a-zA-Z]*)]/;
-  return _extractObjectParameter(query, regex);
+  const params = _extractObjectParameter(query, regex);
+
+  return _convertToInt(params);
 }
 
 function _extractObjectParameter(query, regex) {
@@ -34,4 +36,8 @@ function _extractObjectParameter(query, regex) {
 
 function _extractArrayParameter(query, parameterName) {
   return query[parameterName] ? query[parameterName].split(',') : [];
+}
+
+function _convertToInt(params) {
+  return _.mapValues(params, (value) => parseInt(value));
 }

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -8,10 +8,10 @@ describe('Unit | Utils | Query Params Utils', function() {
     it('should extract multiple parameters from request Object', function() {
       // given
       const query = {
-        'filter[courseId]': 26,
-        'filter[userId]': 1,
-        'page[number]': 1,
-        'page[size]': 200,
+        'filter[courseId]': '26',
+        'filter[userId]': '1',
+        'page[number]': '1',
+        'page[size]': '200',
         sort: '-createdAt,id',
         include: 'user,organization',
       };
@@ -22,8 +22,8 @@ describe('Unit | Utils | Query Params Utils', function() {
       // then
       expect(result).to.deep.equal({
         filter: {
-          courseId: 26,
-          userId: 1,
+          courseId: '26',
+          userId: '1',
         },
         page: {
           number: 1,


### PR DESCRIPTION
## :unicorn: Problème
Quand l'utilisateur saisie la page 0 il y a une erreur 500 et l'utilisateur a une page blanche

## :robot: Solution
Parser en INT les paramètres de la page

## :rainbow: Remarques
Il y a une méthode ensureIntWithDefault qui applique la pagination par défaut quand la pagination n'est pas valide.  Elle se base sur un !number et en lui passant "0" il ne détecte pas que c'est une mauvaise pagination

https://github.com/bookshelf/bookshelf/blob/e7d81f5401ca2ec0695d5817cdf9f3d709f6b353/lib/helpers.js#L10