### PR TITLE
[BUGFIX] Eviter de sauvegarder les réponses sans leurs KE (PF-1116).

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -136,6 +136,10 @@ class Assessment {
     return this.type === types.COMPETENCE_EVALUATION;
   }
 
+  hasKnowledgeElements() {
+    return this.isCompetenceEvaluation() || this.isSmartPlacement();
+  }
+
   isCertifiable() {
     return this.getLastAssessmentResult().level >= 1;
   }

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -19,7 +19,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
     competenceRepository,
     competenceEvaluationRepository,
     skillRepository,
-    smartPlacementAssessmentRepository,
+    targetProfileRepository,
     knowledgeElementRepository,
   } = {}) {
   const assessment = await assessmentRepository.get(answer.assessmentId);
@@ -50,30 +50,23 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   }
 
   const answerSaved = await answerRepository.save(correctedAnswer);
-  let savedKnowledgeElements = [];
-  if (assessment.isCompetenceEvaluation()) {
-    savedKnowledgeElements = await _saveKnowledgeElementsForCompetenceEvaluation({
+  let knowledgeElements = [];
+  if (assessment.isCompetenceEvaluation() || assessment.isSmartPlacement()) {
+    const knowledgeElementsFromAnswer = await _getKnowledgeElements({
       assessment,
       answer: answerSaved,
       challenge,
-      competenceEvaluationRepository,
       skillRepository,
+      targetProfileRepository,
       knowledgeElementRepository
     });
-  }
-
-  if (assessment.isSmartPlacement()) {
-    savedKnowledgeElements = await _saveKnowledgeElementsForSmartPlacement({
-      answer: answerSaved,
-      challenge,
-      smartPlacementAssessmentRepository,
-      knowledgeElementRepository,
-    });
+    knowledgeElements = await Promise.all(knowledgeElementsFromAnswer.map((knowledgeElement) =>
+      knowledgeElementRepository.save(knowledgeElement)));
   }
   answerSaved.levelup = {};
 
   if (correctedAnswer.result.isOK() && (assessment.isCompetenceEvaluation() || assessment.isSmartPlacement())) {
-    const sumPixEarned = _.sumBy(savedKnowledgeElements, 'earnedPix');
+    const sumPixEarned = _.sumBy(knowledgeElements, 'earnedPix');
     const totalPix = scorecardBeforeAnswer.exactlyEarnedPix + sumPixEarned;
     const userLevel = Math.min(constants.MAX_REACHABLE_LEVEL, _.floor(totalPix / constants.PIX_COUNT_BY_LEVEL));
 
@@ -93,56 +86,29 @@ function _evaluateAnswer(challenge, answer) {
   return examiner.evaluate(answer);
 }
 
-async function _saveKnowledgeElementsForSmartPlacement({ answer, challenge, smartPlacementAssessmentRepository, knowledgeElementRepository }) {
-
-  const smartPlacementAssessment = await smartPlacementAssessmentRepository.get(answer.assessmentId);
-
-  return _saveKnowledgeElements({
-    userId: smartPlacementAssessment.userId,
-    targetSkills: smartPlacementAssessment.targetProfile.skills,
-    knowledgeElements: smartPlacementAssessment.knowledgeElements,
-    answer,
-    challenge,
-    knowledgeElementRepository,
-  });
-}
-
-async function _saveKnowledgeElementsForCompetenceEvaluation({ assessment, answer, challenge, competenceEvaluationRepository, skillRepository, knowledgeElementRepository }) {
-
-  const competenceEvaluation = await competenceEvaluationRepository.getByAssessmentId(assessment.id);
-  const [targetSkills, knowledgeElements] = await Promise.all([
-    skillRepository.findByCompetenceId(competenceEvaluation.competenceId),
-    knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId })]
-  );
-
-  return _saveKnowledgeElements({
-    userId: assessment.userId,
-    targetSkills,
-    knowledgeElements,
-    answer,
-    challenge,
-    knowledgeElementRepository,
-  });
-}
-
-function _saveKnowledgeElements({ userId, targetSkills, knowledgeElements, answer, challenge, knowledgeElementRepository }) {
-
-  const knowledgeElementsToCreate = KnowledgeElement.createKnowledgeElementsForAnswer({
+async function _getKnowledgeElements({ assessment, answer, challenge, skillRepository, targetProfileRepository, knowledgeElementRepository }) {
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
+  let targetSkills;
+  if (assessment.isCompetenceEvaluation()) {
+    targetSkills = await skillRepository.findByCompetenceId(assessment.competenceId);
+  }
+  if (assessment.isSmartPlacement()) {
+    const targetProfile = await targetProfileRepository.getByCampaignId(assessment.campaignParticipation.campaignId);
+    targetSkills = targetProfile.skills;
+  }
+  return KnowledgeElement.createKnowledgeElementsForAnswer({
     answer,
     challenge,
     previouslyFailedSkills: _getSkillsFilteredByStatus(knowledgeElements, targetSkills, KnowledgeElement.StatusType.INVALIDATED),
     previouslyValidatedSkills: _getSkillsFilteredByStatus(knowledgeElements, targetSkills, KnowledgeElement.StatusType.VALIDATED),
     targetSkills,
-    userId
+    userId: assessment.userId,
   });
-
-  return Promise.all(knowledgeElementsToCreate.map((knowledgeElement) =>
-    knowledgeElementRepository.save(knowledgeElement)));
 }
 
 function _getSkillsFilteredByStatus(knowledgeElements, targetSkills, status) {
   return knowledgeElements
     .filter((knowledgeElement) => knowledgeElement.status === status)
     .map((knowledgeElement) => knowledgeElement.skillId)
-    .map((skillId) => targetSkills.find((skill) => skill.id === skillId));
+    .filter((skillId) => targetSkills.find((skill) => skill.id === skillId));
 }

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -2,9 +2,12 @@ const fp = require('lodash/fp');
 const Answer = require('../../domain/models/Answer');
 const answerStatusDatabaseAdapter = require('../adapters/answer-status-database-adapter');
 const BookshelfAnswer = require('../data/answer');
+const BookshelfKnowledgeElement = require('../data/knowledge-element');
+
 const Bookshelf = require('../bookshelf');
 const { NotFoundError } = require('../../domain/errors');
 const jsYaml = require('js-yaml');
+const _ = require('lodash');
 
 function _adaptModelToDb(answer) {
   return {
@@ -93,4 +96,18 @@ module.exports = {
       .save(null, { require: true, method: 'insert' });
     return _toDomain(newAnswer);
   },
+
+  async saveWithKnowledgeElements(answer, knowledgeElements) {
+    const answerForDB = _adaptModelToDb(answer);
+    const newAnswer = await new BookshelfAnswer(answerForDB)
+      .save(null, { require: true, method: 'insert' });
+    const answerSaved = _toDomain(newAnswer);
+
+    knowledgeElements.map((knowledgeElement) => knowledgeElement.answerId = answerSaved.id);
+    await Promise.all(knowledgeElements.map(async (knowledgeElement) => {
+      const knowledgeElementBookshelf = await new BookshelfKnowledgeElement(_.omit(knowledgeElement, ['id', 'createdAt']));
+      await knowledgeElementBookshelf.save();
+    }));
+    return answerSaved;
+  }
 };

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -90,13 +90,6 @@ module.exports = {
       .then((answers) => answers.models.map(_toDomain));
   },
 
-  async save(answer) {
-    const answerForDB = _adaptModelToDb(answer);
-    const newAnswer = await new BookshelfAnswer(answerForDB)
-      .save(null, { require: true, method: 'insert' });
-    return _toDomain(newAnswer);
-  },
-
   async saveWithKnowledgeElements(answer, knowledgeElements) {
     const answerForDB = _adaptModelToDb(answer);
 

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -93,13 +93,13 @@ module.exports = {
   async saveWithKnowledgeElements(answer, knowledgeElements) {
     const answerForDB = _adaptModelToDb(answer);
 
-    return Bookshelf.transaction(async (t) => {
+    return Bookshelf.transaction(async (transacting) => {
       const answerSaved = await new BookshelfAnswer(answerForDB)
-        .save(null, { require: true, method: 'insert', transacting: t });
+        .save(null, { require: true, method: 'insert', transacting });
       knowledgeElements.map((knowledgeElement) => knowledgeElement.answerId = answerSaved.id);
       await Promise.all(knowledgeElements.map(async (knowledgeElement) => {
         const knowledgeElementBookshelf = await new BookshelfKnowledgeElement(_.omit(knowledgeElement, ['id', 'createdAt']));
-        await knowledgeElementBookshelf.save(null, { transacting: t });
+        await knowledgeElementBookshelf.save(null, { transacting });
       }));
 
       return _toDomain(answerSaved);

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -19,7 +19,9 @@ describe('Acceptance | Controller | answer-controller-save', () => {
     const challengeId = 'a_challenge_id';
 
     beforeEach(async () => {
-      const assessment = databaseBuilder.factory.buildAssessment();
+      const assessment = databaseBuilder.factory.buildAssessment({
+        type: 'COMPETENCE_EVALUATION'
+      });
       insertedAssessmentId = assessment.id;
       userId = assessment.userId;
 

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -260,52 +260,6 @@ describe('Integration | Repository | AnswerRepository', () => {
     });
   });
 
-  describe('#save', () => {
-
-    let answer;
-    let savedAnswer;
-
-    beforeEach(async () => {
-      // XXX resultDetails is by default null which is saved as "null\n" in db.
-      // To avoid problems in test it is fixed to another string.
-      answer = domainBuilder.buildAnswer({ assessmentId, resultDetails: 'some random detail' });
-      answer.id = undefined;
-
-      // when
-      savedAnswer = await AnswerRepository.save(answer);
-    });
-
-    afterEach(() => {
-      return knex('answers').delete();
-    });
-
-    it('should save the answer in db', () => {
-      // then
-      // id, createdAt, and updatedAt are not present
-      const expectedRawAnswerWithoutIdNorDates = {
-        value: answer.value,
-        result: answerStatusDatabaseAdapter.toSQLString(answer.result),
-        assessmentId: answer.assessmentId,
-        challengeId: answer.challengeId,
-        timeout: answer.timeout,
-        elapsedTime: answer.elapsedTime,
-        resultDetails: `${answer.resultDetails}\n`, // XXX text fields are saved with a \n at the end
-      };
-      return knex('answers').first()
-        .then((answer) => _.omit(answer, ['id', 'createdAt', 'updatedAt']))
-        .then((answerWithoutIdNorDates) => {
-          return expect(answerWithoutIdNorDates).to.deep.equal(expectedRawAnswerWithoutIdNorDates);
-        });
-    });
-
-    it('should return a domain object with the id', () => {
-      expect(savedAnswer.id).to.not.equal(undefined);
-      expect(savedAnswer).to.be.an.instanceOf(Answer);
-      // XXX text fields are saved with a \n at the end, so the test fails for that reason
-      expect(_.omit(savedAnswer, ['id', 'resultDetails'])).to.deep.equal(_.omit(answer, ['id', 'resultDetails']));
-    });
-  });
-
   describe('#saveWithKnowledgeElements', () => {
 
     let answer, firstKnowledgeElement, secondeKnowledgeElements;

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, knex, domainBuilder, databaseBuilder, sinon, catchErr } = require('../../../test-helper');
+const { expect, knex, domainBuilder, databaseBuilder, sinon, catchErr, compareDatabaseObject } = require('../../../test-helper');
 const Answer = require('../../../../lib/domain/models/Answer');
 const answerStatusDatabaseAdapter = require('../../../../lib/infrastructure/adapters/answer-status-database-adapter');
 const BookshelfKnowledgeElement = require('../../../../lib/infrastructure/data/knowledge-element');
@@ -277,7 +277,7 @@ describe('Integration | Repository | AnswerRepository', () => {
       await knex('answers').delete();
     });
 
-    context('when the database work correctly', () => {
+    context('when the database works correctly', () => {
 
       beforeEach(async () => {
         // when
@@ -296,15 +296,15 @@ describe('Integration | Repository | AnswerRepository', () => {
           resultDetails: `${answer.resultDetails}\n`,
         };
         const answerInDB = await knex('answers').first();
-        return expect(_.omit(answerInDB, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(expectedRawAnswerWithoutIdNorDates);
+        return compareDatabaseObject(answerInDB, expectedRawAnswerWithoutIdNorDates);
       });
 
       it('should save knowledge elements', async () => {
         const knowledgeElementsInDB = await knex('knowledge-elements').where({ answerId: savedAnswer.id }).orderBy('id');
 
         expect(knowledgeElementsInDB).to.length(2);
-        expect(_.omit(knowledgeElementsInDB[0], ['id', 'createdAt', 'answerId'])).to.deep.equal(_.omit(firstKnowledgeElement, ['id', 'createdAt', 'answerId']));
-        expect(_.omit(knowledgeElementsInDB[1], ['id', 'createdAt', 'answerId'])).to.deep.equal(_.omit(secondeKnowledgeElements, ['id', 'createdAt', 'answerId']));
+        compareDatabaseObject(knowledgeElementsInDB[0], firstKnowledgeElement);
+        compareDatabaseObject(knowledgeElementsInDB[1], secondeKnowledgeElements);
 
       });
 
@@ -315,7 +315,7 @@ describe('Integration | Repository | AnswerRepository', () => {
         expect(_.omit(savedAnswer, ['id', 'resultDetails'])).to.deep.equal(_.omit(answer, ['id', 'resultDetails']));
       });
     });
-    context('when the database do not work correctly', () => {
+    context('when the database do not works correctly', () => {
       it('should not save the answer nor knowledge-elements', async () => {
         // given
         sinon.stub(BookshelfKnowledgeElement.prototype, 'save').rejects();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -156,6 +156,11 @@ function catchErr(promiseFn, ctx) {
   };
 }
 
+function compareDatabaseObject(evaluatedObject, expectedObject) {
+  return expect(_.omit(evaluatedObject, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(_.omit(expectedObject, ['id', 'createdAt', 'updatedAt']));
+
+}
+
 module.exports = {
   airtableBuilder,
   expect,
@@ -173,5 +178,6 @@ module.exports = {
   streamToPromise,
   catchErr,
   testErr: new Error('Fake Error'),
-  testInfraNotFoundErr: new infraErrors.NotFoundError('Fake infra NotFoundError')
+  testInfraNotFoundErr: new infraErrors.NotFoundError('Fake infra NotFoundError'),
+  compareDatabaseObject
 };

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -360,6 +360,41 @@ describe('Unit | Domain | Models | Assessment', () => {
     });
   });
 
+  describe('#hasKnowledgeElements', () => {
+
+    it('should return true when the assessment is a CompetenceEvaluation', () => {
+      // given
+      const assessment = domainBuilder.buildAssessment({ type: Assessment.types.COMPETENCE_EVALUATION });
+
+      // when/then
+      expect(assessment.hasKnowledgeElements()).to.be.true;
+    });
+
+    it('should return true when the assessment is a Smart Placement', () => {
+      // given
+      const assessment = domainBuilder.buildAssessment({ type: Assessment.types.SMARTPLACEMENT });
+
+      // when/then
+      expect(assessment.hasKnowledgeElements()).to.be.true;
+    });
+
+    it('should return false when the assessment is not a CompetenceEvaluation nor SmartPlacement', () => {
+      // given
+      const assessment = domainBuilder.buildAssessment({ type: Assessment.types.CERTIFICATION });
+
+      // when/then
+      expect(assessment.hasKnowledgeElements()).to.be.false;
+    });
+
+    it('should return false when the assessment has no type', () => {
+      // given
+      const assessment = domainBuilder.buildAssessment({ type: null });
+
+      // when/then
+      expect(assessment.hasKnowledgeElements()).to.be.false;
+    });
+  });
+
   describe('#isCertifiable', () => {
 
     it('should return true when the last assessment has a level > 0', () => {

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -369,8 +369,10 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         });
 
         // then
+        const answerCreated = domainBuilder.buildAnswer(savedAnswer);
+        answerCreated.id = undefined;
         const expectedArgument = {
-          answer: savedAnswer,
+          answer: answerCreated,
           challenge: challenge,
           previouslyFailedSkills: [],
           previouslyValidatedSkills: [],

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -22,8 +22,8 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
   };
   const assessmentRepository = { get: () => undefined };
   const challengeRepository = { get: () => undefined };
-  const competenceEvaluationRepository = { getByAssessmentId: () => undefined };
-  const smartPlacementAssessmentRepository = { get: () => undefined };
+  const competenceEvaluationRepository = {  };
+  const targetProfileRepository = { getByCampaignId: () => undefined };
   const skillRepository = { findByCompetenceId: () => undefined };
   const scorecardService = { computeScorecard: () => undefined };
   const knowledgeElementRepository = {
@@ -36,9 +36,8 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     sinon.stub(answerRepository, 'save');
     sinon.stub(assessmentRepository, 'get');
     sinon.stub(challengeRepository, 'get');
-    sinon.stub(competenceEvaluationRepository, 'getByAssessmentId');
     sinon.stub(skillRepository, 'findByCompetenceId');
-    sinon.stub(smartPlacementAssessmentRepository, 'get');
+    sinon.stub(targetProfileRepository, 'getByCampaignId');
     sinon.stub(scorecardService, 'computeScorecard');
     sinon.stub(knowledgeElementRepository, 'save');
     sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
@@ -72,7 +71,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         answerRepository,
         assessmentRepository,
         challengeRepository,
-        smartPlacementAssessmentRepository,
+        targetProfileRepository,
         knowledgeElementRepository,
         scorecardService,
       });
@@ -98,7 +97,6 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
 
     context('and assessment is a COMPETENCE_EVALUATION', () => {
 
-      let competenceEvaluation;
       let knowledgeElement;
       let firstCreatedKnowledgeElement;
       let secondCreatedKnowledgeElement;
@@ -108,17 +106,15 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
       beforeEach(() => {
         // given
         assessment.type = Assessment.types.COMPETENCE_EVALUATION;
+        assessment.competenceId = 'recABCD';
         assessmentRepository.get.resolves(assessment);
-
-        competenceEvaluation = domainBuilder.buildCompetenceEvaluation();
         knowledgeElement = domainBuilder.buildKnowledgeElement();
         firstCreatedKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 2 });
         secondCreatedKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 1 });
         skills = domainBuilder.buildSkillCollection();
 
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 22, exactlyEarnedPix: 22 });
-        competenceEvaluationRepository.getByAssessmentId.withArgs(assessment.id).resolves(competenceEvaluation);
-        skillRepository.findByCompetenceId.withArgs(competenceEvaluation.competenceId).resolves(skills);
+        skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
         knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([knowledgeElement]);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([
           firstCreatedKnowledgeElement, secondCreatedKnowledgeElement,
@@ -126,7 +122,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         knowledgeElementRepository.save
           .onFirstCall().resolves(firstCreatedKnowledgeElement)
           .onSecondCall().resolves(secondCreatedKnowledgeElement);
-        smartPlacementAssessmentRepository.get.rejects(new NotFoundError());
+        targetProfileRepository.getByCampaignId.rejects(new NotFoundError());
         scorecardService.computeScorecard.resolves(scorecard);
       });
 
@@ -140,7 +136,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -159,14 +155,13 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
 
         // then
-        expect(competenceEvaluationRepository.getByAssessmentId).to.have.been.calledWith(assessment.id);
-        expect(skillRepository.findByCompetenceId).to.have.been.calledWith(competenceEvaluation.competenceId);
+        expect(skillRepository.findByCompetenceId).to.have.been.calledWith(assessment.competenceId);
         expect(knowledgeElementRepository.findUniqByUserId).to.have.been.calledWith({ userId: assessment.userId });
       });
 
@@ -180,7 +175,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -203,7 +198,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -231,7 +226,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -258,7 +253,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -270,21 +265,25 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     });
 
     context('and assessment is a SMART_PLACEMENT', () => {
-      let smartPlacementAssessment;
       let firstKnowledgeElement;
       let secondKnowledgeElement;
-      let scorecard;
+      let scorecard, knowledgeElement, targetProfile;
 
       beforeEach(() => {
         // given
         assessment.type = Assessment.types.SMARTPLACEMENT;
+        assessment.campaignParticipation = domainBuilder.buildCampaignParticipation();
         assessmentRepository.get.resolves(assessment);
 
-        smartPlacementAssessment = domainBuilder.buildSmartPlacementAssessment();
         firstKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 2 });
         secondKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 1.8 });
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 20, exactlyEarnedPix: 20.2 });
-        smartPlacementAssessmentRepository.get.resolves(smartPlacementAssessment);
+        targetProfile = domainBuilder.buildTargetProfile();
+
+        knowledgeElement = domainBuilder.buildKnowledgeElement();
+        knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([knowledgeElement]);
+
+        targetProfileRepository.getByCampaignId.resolves(targetProfile);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([
           firstKnowledgeElement, secondKnowledgeElement,
         ]);
@@ -304,7 +303,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -314,7 +313,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         expect(answerRepository.save).to.have.been.calledWith(expectedArgument);
       });
 
-      it('should call the smart placement assessment repository to try and get the assessment', async () => {
+      it('should call the target profile repository to find target skills', async () => {
         // when
         await correctAnswerThenUpdateAssessment({
           answer,
@@ -324,14 +323,14 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
 
         // then
-        const expectedArgument = answer.assessmentId;
-        expect(smartPlacementAssessmentRepository.get).to.have.been.calledWith(expectedArgument);
+        const expectedArgument = assessment.campaignParticipation.campaignId;
+        expect(targetProfileRepository.getByCampaignId).to.have.been.calledWith(expectedArgument);
       });
 
       it('should call the challenge repository to get the answer challenge', async () => {
@@ -344,7 +343,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -364,7 +363,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -373,10 +372,10 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         const expectedArgument = {
           answer: savedAnswer,
           challenge: challenge,
-          previouslyFailedSkills: smartPlacementAssessment.getFailedSkills(),
-          previouslyValidatedSkills: smartPlacementAssessment.getValidatedSkills(),
-          targetSkills: smartPlacementAssessment.targetProfile.skills,
-          userId: smartPlacementAssessment.userId
+          previouslyFailedSkills: [],
+          previouslyValidatedSkills: [],
+          targetSkills: targetProfile.skills,
+          userId: assessment.userId
         };
         expect(KnowledgeElement.createKnowledgeElementsForAnswer).to.have.been.calledWith(expectedArgument);
       });
@@ -391,7 +390,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -414,7 +413,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -438,7 +437,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -466,7 +465,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -493,7 +492,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
             challengeRepository,
             competenceEvaluationRepository,
             skillRepository,
-            smartPlacementAssessmentRepository,
+            targetProfileRepository,
             knowledgeElementRepository,
             scorecardService,
           });
@@ -553,7 +552,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -576,7 +575,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -596,7 +595,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -616,7 +615,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });
@@ -635,7 +634,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           challengeRepository,
           competenceEvaluationRepository,
           skillRepository,
-          smartPlacementAssessmentRepository,
+          targetProfileRepository,
           knowledgeElementRepository,
           scorecardService,
         });


### PR DESCRIPTION
## :unicorn: Problème
Quand la base de données a des difficultés, on se retrouvait dans le problème suivant : 
- Un utilisateur répond à une question
- Une entrée est enregistré dans la table Answers, mais les KnowledgeElements ne sont pas enregistrés
- Quand on cherche la prochaine question, l'algo ne considère donc pas les acquis précédemment vue, et repose le même acquis, et le même challenge
- L'utilisateur revoit la même épreuve marqué "déjà répondu" et donc on ne réenregistre rien
- Ça boucle : donc l'utilisateur est bloqué sur une épreuve déjà répondu

## :robot: Solution
Pour cela, on utilise les transactions de Bookshelf. Pour faciliter cela, il y a eu plusieurs refacto du usecase pour sauvegarder l'Answer et les KnowledgeElements au même endroit.
Une méthode a été ajouté pour sauvegarder les deux dans le repository de Answer.

## :rainbow: Remarques
Suppression de l'ancienne methode de sauvegarde d'Answer, mais pas du KnowledgeElement qui est utilisé lors de la remise à zéro.