### PR TITLE
[FEATURE] Garantir la sélection de l'organisation par défaut dans Pix Orga (PO-344).

### DIFF
--- a/api/db/migrations/20200220145135_create_user_orga_settings.js
+++ b/api/db/migrations/20200220145135_create_user_orga_settings.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'user-orga-settings';
+
+exports.up = (knex) => {
+
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('id').primary();
+    t.bigInteger('userId').references('users.id').index();
+    t.bigInteger('currentOrganizationId').references('organizations.id');
+    t.unique(['userId']);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/migrations/20200220145419_migrate_first_organization_join_to_user_orga_settings.js
+++ b/api/db/migrations/20200220145419_migrate_first_organization_join_to_user_orga_settings.js
@@ -1,0 +1,40 @@
+const { batch } = require('../batchTreatment');
+
+const TABLE_NAME_USER_ORGA_SETTINGS = 'user-orga-settings';
+const TABLE_NAME_MEMBERSHIPS = 'memberships';
+
+exports.up = function(knex) {
+  const subQuery = knex(TABLE_NAME_MEMBERSHIPS).min('id').groupBy('userId');
+
+  return knex(TABLE_NAME_MEMBERSHIPS)
+    .select('userId', 'organizationId')
+    .whereIn('id', subQuery)
+    .then((memberships) => {
+
+      return batch(knex, memberships, (membership) => {
+        return knex(TABLE_NAME_USER_ORGA_SETTINGS)
+          .insert({
+            userId: membership.userId,
+            currentOrganizationId: membership.organizationId
+          });
+      });
+    });
+};
+
+exports.down = function(knex) {
+  const subQuery = knex(TABLE_NAME_MEMBERSHIPS).min('id').groupBy('userId');
+
+  return knex(TABLE_NAME_MEMBERSHIPS)
+    .select('userId', 'organizationId')
+    .whereIn('id', subQuery)
+    .then((memberships) => {
+
+      return batch(knex, memberships, (membership) => {
+        return knex(TABLE_NAME_USER_ORGA_SETTINGS)
+          .delete({
+            userId: membership.userId,
+            currentOrganizationId: membership.organizationId
+          });
+      });
+    });
+};

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -1,0 +1,43 @@
+const Joi = require('@hapi/joi');
+const userOrgaSettingsController = require('./user-orga-settings-controller');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/user-orga-settings',
+      config: {
+        handler: userOrgaSettingsController.create,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              relationships: {
+                organization: {
+                  data: {
+                    id: Joi.number().required(),
+                  }
+                },
+                user: {
+                  data: {
+                    id: Joi.number().required()
+                  }
+                }
+              }
+            }
+          })
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Création des paramètres utilisateurs liées à Pix Orga\n' +
+          '- L’id dans le payload doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user-orga-settings']
+      }
+    }
+  ]);
+};
+
+exports.name = 'user-orga-settings-api';

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -1,0 +1,20 @@
+const userOrgaSettingsSerializer = require('../../infrastructure/serializers/jsonapi/user-orga-settings-serializer');
+const { UserNotAuthorizedToCreateResourceError } = require('../../domain/errors');
+const usecases = require('../../domain/usecases');
+
+module.exports = {
+
+  async create(request, h) {
+    const authenticatedUserId = request.auth.credentials.userId;
+    const userId = request.payload.data.relationships.user.data.id;
+    const organizationId = request.payload.data.relationships.organization.data.id;
+
+    if (authenticatedUserId !== userId) {
+      throw new UserNotAuthorizedToCreateResourceError();
+    }
+
+    const result = await usecases.createUserOrgaSettings({ userId, organizationId });
+
+    return h.response(userOrgaSettingsSerializer.serialize(result)).created();
+  }
+};

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -99,6 +99,23 @@ exports.register = async function(server) {
       }
     },
     {
+      method: 'GET',
+      path: '/api/users/{id}/user-orga-settings',
+      config: {
+        pre: [{
+          method: securityController.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser'
+        }],
+        handler: userController.getUserOrgaSettings,
+        notes : [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération des paramètres utilisateurs relatives à Pix Orga\n' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user', 'userOrgaSettings']
+      }
+    },
+    {
       method: 'PATCH',
       path: '/api/users/{id}/password-update',
       config: {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -2,6 +2,7 @@ const campaignParticipationSerializer = require('../../infrastructure/serializer
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const certificationProfileSerializer = require('../../infrastructure/serializers/jsonapi/certification-profile-serializer');
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
+const userOrgaSettingsSerializer = require('../../infrastructure/serializers/jsonapi/user-orga-settings-serializer');
 const pixScoreSerializer = require('../../infrastructure/serializers/jsonapi/pix-score-serializer');
 const scorecardSerializer = require('../../infrastructure/serializers/jsonapi/scorecard-serializer');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
@@ -128,4 +129,11 @@ module.exports = {
     return usecases.resetScorecard({ userId: authenticatedUserId, competenceId })
       .then(scorecardSerializer.serialize);
   },
+
+  getUserOrgaSettings(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+
+    return usecases.getUserWithOrgaSettings({ userId: authenticatedUserId })
+      .then((user) => userOrgaSettingsSerializer.serialize(user.userOrgaSettings));
+  }
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -320,6 +320,12 @@ class OrganizationStudentAlreadyLinkedToUserError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToCreateResourceError extends DomainError {
+  constructor(message = 'Cet utilisateur n\'est pas autorisé à créer la ressource.') {
+    super(message);
+  }
+}
+
 class FileValidationError extends DomainError {
   constructor(message = 'Erreur, fichier non valide.') {
     super(message);
@@ -490,6 +496,7 @@ module.exports = {
   UserNotAuthorizedToAccessEntity,
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,
+  UserNotAuthorizedToCreateResourceError,
   UserNotAuthorizedToGetCampaignResultsError,
   UserNotAuthorizedToGetCertificationCoursesError,
   UserNotAuthorizedToUpdateCampaignError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -326,6 +326,12 @@ class UserNotAuthorizedToCreateResourceError extends DomainError {
   }
 }
 
+class UserOrgaSettingsCreationError extends DomainError {
+  constructor(message = 'Erreur lors de la création des paramètres utilisateur relatifs à Pix Orga.') {
+    super(message);
+  }
+}
+
 class FileValidationError extends DomainError {
   constructor(message = 'Erreur, fichier non valide.') {
     super(message);
@@ -503,5 +509,6 @@ module.exports = {
   UserNotAuthorizedToUpdateResourceError,
   UserNotAuthorizedToUpdateStudentPasswordError,
   UserNotFoundError,
+  UserOrgaSettingsCreationError,
   WrongDateFormatError,
 };

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -23,6 +23,7 @@ class User {
     pixScore,
     scorecards = [],
     campaignParticipations = [],
+    userOrgaSettings
     // references
   } = {}) {
     this.id = id;
@@ -45,6 +46,7 @@ class User {
     this.certificationCenterMemberships = certificationCenterMemberships;
     this.scorecards = scorecards;
     this.campaignParticipations = campaignParticipations;
+    this.userOrgaSettings = userOrgaSettings;
     // references
   }
 

--- a/api/lib/domain/models/UserOrgaSettings.js
+++ b/api/lib/domain/models/UserOrgaSettings.js
@@ -1,0 +1,17 @@
+class UserOrgaSettings {
+
+  constructor({
+    id,
+    // includes
+    currentOrganization,
+    user,
+  } = {}) {
+    this.id = id;
+    // includes
+    this.currentOrganization = currentOrganization;
+    this.user = user;
+  }
+
+}
+
+module.exports = UserOrgaSettings;

--- a/api/lib/domain/usecases/create-user-orga-settings.js
+++ b/api/lib/domain/usecases/create-user-orga-settings.js
@@ -1,0 +1,6 @@
+module.exports = async function createUserOrgaSettings({
+  userOrgaSettings
+}) {
+
+  return userOrgaSettings;
+};

--- a/api/lib/domain/usecases/create-user-orga-settings.js
+++ b/api/lib/domain/usecases/create-user-orga-settings.js
@@ -1,6 +1,13 @@
 module.exports = async function createUserOrgaSettings({
-  userOrgaSettings
+  organizationId,
+  userId,
+  userRepository,
+  organizationRepository,
+  userOrgaSettingsRepository
 }) {
 
-  return userOrgaSettings;
+  await userRepository.get(userId);
+  await organizationRepository.get(organizationId);
+
+  return userOrgaSettingsRepository.create(userId, organizationId);
 };

--- a/api/lib/domain/usecases/get-user-with-orga-settings.js
+++ b/api/lib/domain/usecases/get-user-with-orga-settings.js
@@ -1,0 +1,3 @@
+module.exports = async function getUserWithOrgaSettings({ userId, userRepository }) {
+  return userRepository.getWithOrgaSettings(userId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -132,6 +132,7 @@ module.exports = injectDependencies({
   getUserPixScore: require('./get-user-pix-score'),
   getUserScorecards: require('./get-user-scorecards'),
   getUserWithMemberships: require('./get-user-with-memberships'),
+  getUserWithOrgaSettings: require('./get-user-with-orga-settings'),
   importCertificationCandidatesFromAttendanceSheet: require('./import-certification-candidates-from-attendance-sheet'),
   importStudentsFromSIECLE: require('./import-students-from-siecle'),
   linkUserToOrganizationStudentData: require('./link-user-to-organization-student-data'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -79,6 +79,7 @@ module.exports = injectDependencies({
   createOrganizationInvitations: require('./create-organization-invitations'),
   createSession: require('./create-session'),
   createUser: require('./create-user'),
+  createUserOrgaSettings: require('./create-user-orga-settings'),
   deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
   finalizeSession: require('./finalize-session'),
   findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -49,6 +49,7 @@ const dependencies = {
   tokenService: require('../../domain/services/token-service'),
   tubeRepository: require('../../infrastructure/repositories/tube-repository'),
   tutorialRepository: require('../../infrastructure/repositories/tutorial-repository'),
+  userOrgaSettingsRepository: require('../../infrastructure/repositories/user-orga-settings-repository'),
   userReconciliationService: require('../services/user-reconciliation-service'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   userService: require('../../domain/services/user-service'),

--- a/api/lib/infrastructure/data/user-orga-settings.js
+++ b/api/lib/infrastructure/data/user-orga-settings.js
@@ -1,0 +1,18 @@
+const Bookshelf = require('../bookshelf');
+
+require('./user');
+require('./organization');
+
+module.exports = Bookshelf.model('UserOrgaSettings', {
+
+  tableName: 'user-orga-settings',
+
+  user() {
+    return this.belongsTo('User', 'userId');
+  },
+
+  currentOrganization() {
+    return this.belongsTo('Organization', 'currentOrganizationId');
+  },
+
+});

--- a/api/lib/infrastructure/data/user.js
+++ b/api/lib/infrastructure/data/user.js
@@ -9,6 +9,7 @@ require('./organization');
 require('./knowledge-element');
 require('./membership');
 require('./certification-center-membership');
+require('./user-orga-settings');
 
 module.exports = Bookshelf.model('User', {
   tableName: 'users',
@@ -39,6 +40,10 @@ module.exports = Bookshelf.model('User', {
 
   certificationCenterMemberships() {
     return this.hasMany('CertificationCenterMembership', 'userId');
+  },
+
+  userOrgaSettings() {
+    return this.hasOne('UserOrgaSettings', 'userId', 'id');
   },
 
   toDomainEntity() {

--- a/api/lib/infrastructure/repositories/user-orga-settings-repository.js
+++ b/api/lib/infrastructure/repositories/user-orga-settings-repository.js
@@ -1,0 +1,20 @@
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const BookshelfUserOrgaSettings = require('../data/user-orga-settings');
+const bookshelfUtils = require('../utils/bookshelf-utils');
+const { UserOrgaSettingsCreationError } = require('../../domain/errors');
+
+module.exports = {
+
+  create(userId, currentOrganizationId) {
+    return new BookshelfUserOrgaSettings({ userId, currentOrganizationId })
+      .save()
+      .then((bookshelfUserOrgaSettings) => bookshelfUserOrgaSettings.load(['user', 'currentOrganization']))
+      .then((userOrgaSettings) => bookshelfToDomainConverter.buildDomainObject(BookshelfUserOrgaSettings, userOrgaSettings))
+      .catch((err) => {
+        if (bookshelfUtils.isUniqConstraintViolated(err)) {
+          throw new UserOrgaSettingsCreationError(err.message);
+        }
+        throw err;
+      });
+  }
+};

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -147,7 +147,7 @@ module.exports = {
   get(userId) {
     return BookshelfUser
       .where({ id: userId })
-      .fetch({ require: true })
+      .fetch({ require: true, withRelated: ['userOrgaSettings'] })
       .then((user) => bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user))
       .catch((err) => {
         if (err instanceof BookshelfUser.NotFoundError) {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -5,6 +5,7 @@ const { AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError, Organizatio
 const User = require('../../domain/models/User');
 const PixRole = require('../../domain/models/PixRole');
 const Membership = require('../../domain/models/Membership');
+const UserOrgaSettings = require('../../domain/models/UserOrgaSettings');
 const CertificationCenter = require('../../domain/models/CertificationCenter');
 const CertificationCenterMembership = require('../../domain/models/CertificationCenterMembership');
 const Organization = require('../../domain/models/Organization');
@@ -41,6 +42,21 @@ function _toMembershipsDomain(membershipsBookshelf) {
   });
 }
 
+function _toUserOrgaSettingsDomain(userOrgaSettingsBookshelf) {
+  const { id, code, name, type, isManagingStudents, externalId } = userOrgaSettingsBookshelf.related('currentOrganization').attributes;
+  return new UserOrgaSettings({
+    id: userOrgaSettingsBookshelf.get('id'),
+    currentOrganization: new Organization({
+      id,
+      code,
+      name,
+      type,
+      isManagingStudents: Boolean(isManagingStudents),
+      externalId
+    }),
+  });
+}
+
 function _toPixRolesDomain(pixRolesBookshelf) {
   return pixRolesBookshelf.map((pixRoleBookshelf) => {
     return new PixRole({
@@ -65,6 +81,7 @@ function _toDomain(userBookshelf) {
     certificationCenterMemberships: _toCertificationCenterMembershipsDomain(userBookshelf.related('certificationCenterMemberships')),
     pixRoles: _toPixRolesDomain(userBookshelf.related('pixRoles')),
     hasSeenAssessmentInstructions: Boolean(userBookshelf.get('hasSeenAssessmentInstructions')),
+    userOrgaSettings: _toUserOrgaSettingsDomain(userBookshelf.related('userOrgaSettings'))
   });
 }
 
@@ -86,7 +103,7 @@ function _adaptModelToDb(user) {
   return _.omit(user, [
     'id', 'campaignParticipations', 'pixRoles', 'memberships',
     'certificationCenterMemberships', 'pixScore', 'knowledgeElements',
-    'scorecards',
+    'scorecards', 'userOrgaSettings'
   ]);
 }
 
@@ -185,6 +202,23 @@ module.exports = {
           throw new UserNotFoundError(`User not found for ID ${userId}`);
         }
         throw err;
+      });
+  },
+
+  getWithOrgaSettings(userId) {
+    return BookshelfUser
+      .where({ id: userId })
+      .fetch({
+        withRelated: [
+          'userOrgaSettings',
+          'userOrgaSettings.currentOrganization',
+        ]
+      })
+      .then((foundUser) => {
+        if (foundUser === null) {
+          return Promise.reject(new UserNotFoundError(`User not found for ID ${userId}`));
+        }
+        return _toDomain(foundUser);
       });
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
@@ -1,0 +1,79 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(userOrgaSettings) {
+    return new Serializer('user-orga-settings', {
+      transform(record) {
+        record.organization = record.currentOrganization;
+
+        // we add a 'campaigns' attr to the organization so that the serializer
+        // can see there is a 'campaigns' attribute and add the relationship link.
+        if (record.organization) {
+          record.organization.campaigns = [];
+          record.organization.targetProfiles = [];
+          record.organization.memberships = [];
+          record.organization.students = [];
+          record.organization.organizationInvitations = [];
+        }
+        return record;
+      },
+      attributes: ['organization', 'user'],
+      organization: {
+        ref: 'id',
+        included: true,
+        attributes: ['code', 'name', 'type', 'isManagingStudents', 'externalId', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+        campaigns: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/campaigns`;
+            }
+          }
+        },
+        targetProfiles: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/target-profiles`;
+            }
+          }
+        },
+        memberships: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/memberships`;
+            }
+          }
+        },
+        students: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/students`;
+            }
+          }
+        },
+        organizationInvitations: {
+          ref: 'id',
+          ignoreRelationshipData: true,
+          relationshipLinks: {
+            related: function(record, current, parent) {
+              return `/api/organizations/${parent.id}/invitations`;
+            }
+          }
+        },
+      },
+      user: {
+        ref: 'id',
+        included: true,
+        attributes: ['firstName', 'lastName', 'email']
+      }
+    }).serialize(userOrgaSettings);
+  }
+};

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -8,6 +8,9 @@ module.exports = {
       transform: (untouchedUser) => {
         const user = Object.assign({}, untouchedUser);
         user.certificationProfile = undefined;
+        if (!user.userOrgaSettings) {
+          delete user.userOrgaSettings;
+        }
         return user;
       },
       attributes: [
@@ -15,6 +18,7 @@ module.exports = {
         'pixCertifTermsOfServiceAccepted', 'memberships',
         'certificationCenterMemberships', 'pixScore', 'scorecards',
         'campaignParticipations', 'hasSeenAssessmentInstructions', 'certificationProfile',
+        'userOrgaSettings'
       ],
       memberships: {
         ref: 'id',
@@ -67,6 +71,15 @@ module.exports = {
         relationshipLinks: {
           related: function(record, current, parent) {
             return `/api/users/${parent.id}/certification-profile`;
+          }
+        }
+      },
+      userOrgaSettings: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/users/${parent.id}/user-orga-settings`;
           }
         }
       },

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -149,6 +149,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToCreateResourceError) {
     return new InfraErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserOrgaSettingsCreationError) {
+    return new InfraErrors.BadRequestError(error.message);
+  }
 
   return new InfraErrors.InfrastructureError(error.message);
 }

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -146,6 +146,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToUpdateStudentPasswordError) {
     return new InfraErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToCreateResourceError) {
+    return new InfraErrors.ForbiddenError(error.message);
+  }
 
   return new InfraErrors.InfrastructureError(error.message);
 }

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -19,6 +19,7 @@ module.exports = [
   require('./application/memberships'),
   require('./application/metrics'),
   require('./application/organization-invitations'),
+  require('./application/user-orga-settings'),
   require('./application/organizations'),
   require('./application/passwords'),
   require('./application/progressions'),

--- a/api/tests/acceptance/application/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings-controller_test.js
@@ -1,0 +1,118 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');
+const createServer = require('../../../server');
+
+describe('Acceptance | Controller | user-orga-settings-controller', () => {
+
+  let userId;
+  let options;
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  afterEach(async () => {
+    await knex('user-orga-settings').delete();
+  });
+
+  describe('POST /api/user-orga-settings', () => {
+
+    let organizationId;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'POST',
+        url: '/api/user-orga-settings',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: organizationId,
+                  type: 'organizations'
+                }
+              },
+              user: {
+                data: {
+                  id: userId,
+                  type: 'users'
+                }
+              }
+            }
+          }
+        }
+      };
+    });
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should respond with a 403 if payload user is not the same as authenticated user', async () => {
+        // given
+        const otherUserId = 9999;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('Success case', () => {
+
+      it('should update and return 201 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+
+    describe('Error case', () => {
+
+      it('should respond with a 400 HTTP status code - if there is no organization id ', async () => {
+        // given
+        options.payload.data.relationships.organization.data = {
+          id: undefined
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should respond with a 400 HTTP status code - if organization id is not a number', async () => {
+        // given
+        options.payload.data.relationships.organization.data = {
+          id: 'test'
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -1,0 +1,67 @@
+const { catchErr, expect, knex, databaseBuilder } = require('../../../test-helper');
+const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
+const BookshelfUserOrgaSettings = require('../../../../lib/infrastructure/data/user-orga-settings');
+const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
+const { UserOrgaSettingsCreationError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | UserOrgaSettings', function() {
+
+  let userId;
+  let organizationId;
+
+  beforeEach(async () => {
+    userId = databaseBuilder.factory.buildUser().id;
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('user-orga-settings').delete();
+  });
+
+  describe('#create', () => {
+
+    it('should return an UserOrgaSettings domain object', async () => {
+      // when
+      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(userId, organizationId);
+
+      // then
+      expect(userOrgaSettingsSaved).to.be.an.instanceof(UserOrgaSettings);
+    });
+
+    it('should add a row in the table "user-orga-settings"', async () => {
+      // given
+      const nbBeforeCreation = await BookshelfUserOrgaSettings.count();
+
+      // when
+      await userOrgaSettingsRepository.create(userId, organizationId);
+
+      // then
+      const nbAfterCreation = await BookshelfUserOrgaSettings.count();
+      expect(nbAfterCreation).to.equal(nbBeforeCreation + 1);
+    });
+
+    it('should save model properties', async () => {
+      // when
+      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(userId, organizationId);
+
+      // then
+      expect(userOrgaSettingsSaved.id).to.not.be.undefined;
+      expect(userOrgaSettingsSaved.user.id).to.equal(userId);
+      expect(userOrgaSettingsSaved.currentOrganization.id).to.equal(organizationId);
+    });
+
+    it('should throw a UserOrgaSettingsCreationError when userOrgaSettings already exist', async () => {
+      // given
+      databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(userOrgaSettingsRepository.create)(userId, organizationId);
+
+      // then
+      expect(error).to.be.instanceOf(UserOrgaSettingsCreationError);
+    });
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -10,6 +10,7 @@ const {
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const User = require('../../../../lib/domain/models/User');
 const Membership = require('../../../../lib/domain/models/Membership');
+const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
 const CertificationCenter = require('../../../../lib/domain/models/CertificationCenter');
 const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
 const Organization = require('../../../../lib/domain/models/Organization');
@@ -28,6 +29,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
   let userInDB;
   let organizationInDB, organizationRoleInDB;
   let membershipInDB;
+  let userOrgaSettingsInDB;
   let certificationCenterInDB, certificationCenterMembershipInDB;
 
   function _insertUserWithOrganizationsAndCertificationCenterAccesses() {
@@ -44,6 +46,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       userId: userInDB.id,
       organizationRole: organizationRoleInDB,
       organizationId: organizationInDB.id
+    });
+
+    userOrgaSettingsInDB = databaseBuilder.factory.buildUserOrgaSettings({
+      userId: userInDB.id,
+      currentOrganizationId: organizationInDB.id
     });
 
     certificationCenterInDB = databaseBuilder.factory.buildCertificationCenter();
@@ -387,6 +394,62 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // when
         const result = await catchErr(userRepository.getWithCertificationCenterMemberships)(unknownUserId);
+
+        // then
+        expect(result).to.be.instanceOf(UserNotFoundError);
+      });
+    });
+
+    describe('#getWithOrgaSettings', () => {
+
+      beforeEach(async () => {
+        await _insertUserWithOrganizationsAndCertificationCenterAccesses();
+      });
+
+      it('should return user for the given id', async () => {
+        // given
+        const expectedUser = new User(userInDB);
+
+        // when
+        const user = await userRepository.getWithOrgaSettings(userInDB.id);
+
+        // then
+        expect(user).to.be.an.instanceof(User);
+        expect(user.id).to.equal(expectedUser.id);
+        expect(user.firstName).to.equal(expectedUser.firstName);
+        expect(user.lastName).to.equal(expectedUser.lastName);
+        expect(user.email).to.equal(expectedUser.email);
+        expect(user.password).to.equal(expectedUser.password);
+        expect(user.cgu).to.equal(expectedUser.cgu);
+      });
+
+      it('should return user-orga-settings associated to the user', async () => {
+        // when
+        const user = await userRepository.getWithOrgaSettings(userInDB.id);
+
+        // then
+        expect(user.userOrgaSettings).to.be.an('Object');
+
+        const userOrgaSettings = user.userOrgaSettings;
+        expect(userOrgaSettings).to.be.an.instanceof(UserOrgaSettings);
+        expect(userOrgaSettings.id).to.equal(userOrgaSettingsInDB.id);
+
+        const associatedOrganization = userOrgaSettings.currentOrganization;
+        expect(associatedOrganization).to.be.an.instanceof(Organization);
+        expect(associatedOrganization.id).to.equal(organizationInDB.id);
+        expect(associatedOrganization.code).to.equal(organizationInDB.code);
+        expect(associatedOrganization.name).to.equal(organizationInDB.name);
+        expect(associatedOrganization.type).to.equal(organizationInDB.type);
+
+        expect(userOrgaSettings.organizationRole).to.equal(userOrgaSettings.organizationRole);
+      });
+
+      it('should reject with a UserNotFound error when no user was found with the given id', async () => {
+        // given
+        const unknownUserId = 666;
+
+        // when
+        const result = await catchErr(userRepository.getWithOrgaSettings)(unknownUserId);
 
         // then
         expect(result).to.be.instanceOf(UserNotFoundError);

--- a/api/tests/tooling/database-builder/factory/build-user-orga-settings.js
+++ b/api/tests/tooling/database-builder/factory/build-user-orga-settings.js
@@ -1,0 +1,25 @@
+const databaseBuffer = require('../database-buffer');
+const buildUser = require('./build-user');
+const buildOrganization = require('./build-organization');
+const _ = require('lodash');
+
+module.exports = function buildUserOrgaSettings(
+  {
+    id,
+    currentOrganizationId,
+    userId,
+  } = {}) {
+
+  userId = _.isUndefined(userId) ? buildUser().id : userId;
+  currentOrganizationId = _.isUndefined(currentOrganizationId) ? buildOrganization().id : currentOrganizationId;
+
+  const values = {
+    id,
+    currentOrganizationId,
+    userId
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'user-orga-settings',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -24,5 +24,6 @@ module.exports = {
   buildTargetProfileSkill: require('./build-target-profile-skill'),
   buildTargetProfileShare: require('./build-target-profile-share'),
   buildUser: require('./build-user'),
+  buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserPixRole: require('./build-user-pix-role'),
 };

--- a/api/tests/tooling/domain-builder/factory/build-user-orga-settings.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-orga-settings.js
@@ -1,0 +1,42 @@
+const faker = require('faker');
+const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
+const Organization = require('../../../../lib/domain/models/Organization');
+const User = require('../../../../lib/domain/models/User');
+
+/*
+ * /!\ We can not use standard entity builders because of bidirectional relationships (a.k.a. cyclic dependencies)
+ */
+
+function _buildUser() {
+  return new User({
+    id: faker.random.number(),
+    firstName: 'Jean',
+    lastName: 'Dupont',
+    email: 'jean.dupont@example.net'
+  });
+}
+
+function _buildOrganization() {
+  return new Organization({
+    id: faker.random.number(),
+    name: 'ACME',
+    type: 'PRO',
+    code: 'ABCD12',
+    externalId: 'EXTID',
+    isManagingStudents: false,
+  });
+}
+
+module.exports = function buildUserOrgaSettings(
+  {
+    id = faker.random.number(),
+    currentOrganization = _buildOrganization(),
+    user = _buildUser(),
+  } = {}) {
+
+  const userOrgaSettings = new UserOrgaSettings({ id, currentOrganization, user });
+
+  userOrgaSettings.user.userOrgaSettings = userOrgaSettings;
+
+  return userOrgaSettings;
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -48,6 +48,7 @@ module.exports = {
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
   buildUser: require('./build-user'),
+  buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserScorecard: require('./build-user-scorecard'),
   buildValidation: require('./build-validation'),
   buildValidator: require('./build-validator'),

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -1,0 +1,90 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const userOrgaSettingsController = require('../../../../lib/application/user-orga-settings/user-orga-settings-controller');
+
+const moduleUnderTest = require('../../../../lib/application/user-orga-settings');
+
+describe('Unit | Router | user-orga-settings-router', () => {
+
+  let httpTestServer;
+
+  beforeEach(() => {
+    sinon.stub(userOrgaSettingsController, 'create').returns('ok');
+    httpTestServer = new HttpTestServer(moduleUnderTest);
+  });
+
+  describe('POST /api/user-orga-settings', () => {
+
+    let method;
+    let url;
+    let payload;
+
+    beforeEach(() => {
+      method = 'POST';
+      url = '/api/user-orga-settings';
+      payload = {
+        data: {
+          relationships: {
+            organization: {
+              data: {
+                id: 1,
+                type: 'organizations'
+              }
+            },
+            user: {
+              data: {
+                id: 1,
+                type: 'users'
+              }
+            }
+          }
+        }
+      };
+    });
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    describe('Payload schema validation', () => {
+
+      it('should have a payload', async () => {
+        // given
+        payload = undefined;
+
+        // when
+        const result = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should have an organization id in relationship in payload', async () => {
+        // given
+        payload.data.relationships.organization.data.id = undefined;
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should have a user id in relationship in payload', async () => {
+        // given
+        payload.data.relationships.user.data.id = undefined;
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+  });
+
+});

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -1,0 +1,95 @@
+const { sinon, expect, hFake, catchErr } = require('../../../test-helper');
+
+const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
+const User = require('../../../../lib/domain/models/User');
+const Organization = require('../../../../lib/domain/models/Organization');
+
+const { UserNotAuthorizedToCreateResourceError } = require('../../../../lib/domain/errors');
+
+const userOrgaSettingsController = require('../../../../lib/application/user-orga-settings/user-orga-settings-controller');
+
+const usecases = require('../../../../lib/domain/usecases');
+
+const userOrgaSettingsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer');
+
+describe('Unit | Controller | user-orga-settings-controller', () => {
+
+  describe('#create', () => {
+    const userId = 123;
+    const organizationId = 234;
+
+    const userOrgaSettings = new UserOrgaSettings({ user: new User({ id: userId }), organization: new Organization({ id: organizationId }) });
+
+    let request;
+
+    beforeEach(() => {
+      request = {
+        auth: { credentials: { userId } },
+        payload: {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: organizationId,
+                  type: 'organizations'
+                }
+              },
+              user: {
+                data: {
+                  id: userId,
+                  type: 'users'
+                }
+              }
+            },
+          },
+        },
+      };
+
+      sinon.stub(userOrgaSettingsSerializer, 'serialize');
+      sinon.stub(usecases, 'createUserOrgaSettings');
+    });
+
+    describe('when request is valid', () => {
+
+      beforeEach(() => {
+        usecases.createUserOrgaSettings.resolves(userOrgaSettings);
+      });
+
+      it('should return a serialized user and a 201 status code', async () => {
+        // given
+        const expectedSerializedUserOrgaSettings = { message: 'serialized user' };
+        userOrgaSettingsSerializer.serialize.returns(expectedSerializedUserOrgaSettings);
+
+        // when
+        const response = await userOrgaSettingsController.create(request, hFake);
+
+        // then
+        expect(userOrgaSettingsSerializer.serialize).to.have.been.calledWith(userOrgaSettings);
+        expect(response.source).to.deep.equal(expectedSerializedUserOrgaSettings);
+        expect(response.statusCode).to.equal(201);
+      });
+
+      it('should call the user orga settings creation usecase', async () => {
+        // when
+        await userOrgaSettingsController.create(request, hFake);
+
+        // then
+        expect(usecases.createUserOrgaSettings).to.have.been.calledWith({ userId, organizationId });
+      });
+    });
+
+    describe('when request in not valid', function() {
+
+      it('should throw a UserNotAuthorizedToCreateResourceError when payload user and connected user are not the same', async () => {
+        // given
+        request.auth.credentials.userId = 321;
+
+        // when
+        const error = await catchErr(userOrgaSettingsController.create)(request, hFake);
+
+        // then
+        expect(error).to.be.instanceof(UserNotAuthorizedToCreateResourceError);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -255,4 +255,26 @@ describe('Unit | Router | user-router', () => {
       });
     });
   });
+
+  describe('GET /api/users/{id}/user-orga-settings', function() {
+    beforeEach(() => {
+      sinon.stub(userController, 'getUserOrgaSettings').returns('ok');
+      sinon.stub(securityController, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
+      startServer();
+    });
+
+    it('should exist', () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/users/12/user-orga-settings',
+      };
+
+      // when
+      return server.inject(options).then(() => {
+        // then
+        sinon.assert.calledOnce(userController.getUserOrgaSettings);
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -16,6 +16,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const membershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/membership-serializer');
+const userOrgaSettingsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer');
 const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
 const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
@@ -266,6 +267,38 @@ describe('Unit | Controller | user-controller', () => {
 
       // when
       const response = await userController.getMemberships(request, hFake);
+
+      // then
+      expect(response).to.deep.equal({});
+    });
+  });
+
+  describe('#getUserOrgaSettings', () => {
+    const userId = '1';
+
+    const request = {
+      auth: {
+        credentials: {
+          userId: userId
+        }
+      },
+      params: {
+        id: userId
+      }
+    };
+
+    beforeEach(() => {
+      sinon.stub(userOrgaSettingsSerializer, 'serialize');
+      sinon.stub(usecases, 'getUserWithOrgaSettings');
+    });
+
+    it('should return serialized UserOrgaSettings', async function() {
+      // given
+      usecases.getUserWithOrgaSettings.withArgs({ userId }).resolves({ userOrgaSettings: {}  });
+      userOrgaSettingsSerializer.serialize.withArgs({}).returns({});
+
+      // when
+      const response = await userController.getUserOrgaSettings(request, hFake);
 
       // then
       expect(response).to.deep.equal({});

--- a/api/tests/unit/domain/usecases/create-user-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/create-user-orga-settings_test.js
@@ -1,0 +1,79 @@
+const { domainBuilder, expect, sinon, catchErr } = require('../../../test-helper');
+const { createUserOrgaSettings } = require('../../../../lib/domain/usecases');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
+const {  NotFoundError, UserNotFoundError, UserOrgaSettingsCreationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | create-user-orga-settings', () => {
+
+  let user;
+  let organization;
+  let userOrgaSettings;
+  let getUserStub;
+  let getOrganizationStub;
+  let createUserOrgaSettingsStub;
+
+  beforeEach(() => {
+    organization = domainBuilder.buildOrganization();
+    user = domainBuilder.buildUser();
+    userOrgaSettings = domainBuilder.buildUserOrgaSettings({ organization, user });
+
+    getUserStub = sinon.stub(userRepository, 'get');
+    getOrganizationStub = sinon.stub(organizationRepository, 'get');
+    createUserOrgaSettingsStub = sinon.stub(userOrgaSettingsRepository, 'create');
+  });
+
+  context('Green cases', () => {
+    it('should create user-orga-settings', async () => {
+      // given
+      getUserStub.resolves();
+      getOrganizationStub.resolves();
+      createUserOrgaSettingsStub.resolves(userOrgaSettings);
+
+      // when
+      const result = await createUserOrgaSettings({ userOrgaSettings });
+
+      // then
+      expect(userRepository.get).to.be.calledOnce;
+      expect(organizationRepository.get).to.be.calledOnce;
+      expect(result.id).to.exist;
+    });
+  });
+
+  context('Red cases', () => {
+
+    it('should throw an error when user not found', async () => {
+      // given
+      getUserStub.rejects(new UserNotFoundError());
+
+      // when
+      const error = await catchErr(createUserOrgaSettings)({ userOrgaSettings });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+
+    it('should throw an error when organization not found', async () => {
+      // given
+      getOrganizationStub.rejects(new NotFoundError());
+
+      // when
+      const error = await catchErr(createUserOrgaSettings)({ userOrgaSettings });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should throw an error when organization user information already exist', async () => {
+      // given
+      createUserOrgaSettingsStub.rejects(new UserOrgaSettingsCreationError());
+
+      // when
+      const error = await catchErr(createUserOrgaSettings)({ userOrgaSettings });
+
+      // then
+      expect(error).to.be.instanceOf(UserOrgaSettingsCreationError);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-user-with-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/get-user-with-orga-settings_test.js
@@ -1,0 +1,29 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const getUserWithOrgaSettings = require('../../../../lib/domain/usecases/get-user-with-orga-settings');
+const User = require('../../../../lib/domain/models/User');
+
+describe('Unit | UseCase | get-user-with-orga-settings', () => {
+
+  let userRepository;
+
+  beforeEach(() => {
+    userRepository = { getWithOrgaSettings: sinon.stub() };
+  });
+
+  it('should return a User with its Memberships', async () => {
+    // given
+    const fetchedUser = domainBuilder.buildUser();
+    userRepository.getWithOrgaSettings.resolves(fetchedUser);
+
+    // when
+    const result = await getUserWithOrgaSettings({
+      userId: fetchedUser.id,
+      userRepository,
+    });
+
+    // then
+    expect(result).to.be.an.instanceOf(User);
+    expect(result).to.equal(fetchedUser);
+    expect(userRepository.getWithOrgaSettings).to.have.been.calledOnce;
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
@@ -1,0 +1,135 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer');
+const UserOrgaSettings = require('../../../../../lib/domain/models/UserOrgaSettings');
+
+describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should convert a UserOrgaSettings model object into JSON API data', () => {
+      // given
+      const userOrgaSettings = new UserOrgaSettings({
+        id: 5,
+        currentOrganization: {
+          id: 10293,
+          name: 'The name of the organization',
+          type: 'SUP',
+          code: 'WASABI666',
+          externalId: 'EXTID'
+        },
+      });
+
+      const expectedSerializedUserOrgaSettings = {
+        data: {
+          type: 'user-orga-settings',
+          id: '5',
+          attributes: {},
+          relationships: {
+            organization: {
+              data:
+                {
+                  type: 'organizations', id: '10293'
+                },
+            },
+            user: {
+              'data': null
+            }
+          }
+        },
+        included: [{
+          type: 'organizations',
+          id: '10293',
+          attributes: {
+            name: 'The name of the organization',
+            type: 'SUP',
+            code: 'WASABI666',
+            'external-id': 'EXTID'
+          },
+          relationships: {
+            campaigns: {
+              links: {
+                related: '/api/organizations/10293/campaigns'
+              }
+            },
+            'target-profiles': {
+              links: {
+                related: '/api/organizations/10293/target-profiles'
+              }
+            },
+            memberships: {
+              links: {
+                related: '/api/organizations/10293/memberships'
+              }
+            },
+            students: {
+              links: {
+                related: '/api/organizations/10293/students'
+              }
+            },
+            'organization-invitations': {
+              links: {
+                related: '/api/organizations/10293/invitations',
+              },
+            },
+          }
+        }]
+      };
+
+      // when
+      const json = serializer.serialize(userOrgaSettings);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedUserOrgaSettings);
+    });
+
+    it('should include "organization"', () => {
+      // given
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
+
+      // when
+      const json = serializer.serialize(userOrgaSettings);
+
+      // then
+      expect(json.data.relationships.organization.data.type).to.equal('organizations');
+      expect(json.data.relationships.organization.data.id).to.equal(`${userOrgaSettings.organization.id}`);
+      expect(json.included[0].type).to.equal('organizations');
+      expect(json.included[0].attributes).to.deep.equal({
+        'name': 'ACME',
+        'type': 'PRO',
+        'code': 'ABCD12',
+        'external-id': 'EXTID',
+        'is-managing-students': false
+      });
+    });
+
+    it('should include "user"', () => {
+      // given
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
+
+      // when
+      const json = serializer.serialize(userOrgaSettings);
+
+      // then
+      expect(json.data.relationships.user.data.type).to.equal('users');
+      expect(json.data.relationships.user.data.id).to.equal(`${userOrgaSettings.user.id}`);
+      expect(json.included[1].type).to.equal('users');
+      expect(json.included[1].attributes).to.deep.equal({
+        'first-name': 'Jean',
+        'last-name': 'Dupont',
+        'email': 'jean.dupont@example.net',
+      });
+    });
+
+    it('should not force the add of campaigns and target profiles relation links if the UserOrgaSettings does not contain organization data', () => {
+      // given
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
+      userOrgaSettings.currentOrganization = null;
+
+      // when
+      const json = serializer.serialize(userOrgaSettings);
+
+      // then
+      expect(json.data.relationships.organization.data).to.be.null;
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -22,72 +22,154 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
 
   describe('#serialize', () => {
 
-    it('should serialize excluding password', () => {
-      // given
-      const modelObject = new User({
-        id: '234567',
-        firstName: 'Luke',
-        lastName: 'Skywalker',
-        email: 'lskywalker@deathstar.empire',
-        username: 'luke.skywalker1234',
-        cgu: true,
-        pixOrgaTermsOfServiceAccepted: false,
-        pixCertifTermsOfServiceAccepted: false,
-        hasSeenAssessmentInstructions: false,
-        password: '',
-      });
+    describe('when user has no userOrgaSettings', () => {
 
-      // when
-      const json = serializer.serialize(modelObject);
-
-      // then
-      expect(json).to.be.deep.equal({
-        data: {
-          attributes: {
-            'first-name': 'Luke',
-            'last-name': 'Skywalker',
-            'email': 'lskywalker@deathstar.empire',
-            'username': 'luke.skywalker1234',
-            'cgu': true,
-            'pix-orga-terms-of-service-accepted': false,
-            'pix-certif-terms-of-service-accepted': false,
-            'has-seen-assessment-instructions': false,
-          },
+      it('should serialize excluding password', () => {
+        // given
+        const modelObject = new User({
           id: '234567',
-          type: 'users',
-          relationships: {
-            memberships: {
-              links: {
-                related: '/api/users/234567/memberships'
-              }
+          firstName: 'Luke',
+          lastName: 'Skywalker',
+          email: 'lskywalker@deathstar.empire',
+          username: 'luke.skywalker1234',
+          cgu: true,
+          pixOrgaTermsOfServiceAccepted: false,
+          pixCertifTermsOfServiceAccepted: false,
+          hasSeenAssessmentInstructions: false,
+          password: '',
+        });
+
+        // when
+        const json = serializer.serialize(modelObject);
+
+        // then
+        expect(json).to.be.deep.equal({
+          data: {
+            attributes: {
+              'first-name': 'Luke',
+              'last-name': 'Skywalker',
+              'email': 'lskywalker@deathstar.empire',
+              'username': 'luke.skywalker1234',
+              'cgu': true,
+              'pix-orga-terms-of-service-accepted': false,
+              'pix-certif-terms-of-service-accepted': false,
+              'has-seen-assessment-instructions': false,
             },
-            'certification-center-memberships': {
-              links: {
-                related: '/api/users/234567/certification-center-memberships'
-              }
-            },
-            'pix-score': {
-              links: {
-                related: '/api/users/234567/pixscore'
-              }
-            },
-            scorecards: {
-              links: {
-                related: '/api/users/234567/scorecards'
-              }
-            },
-            'campaign-participations': {
-              links: {
-                related: '/api/users/234567/campaign-participations'
-              }
-            },
-            'certification-profile': {
-              links: {
-                related: '/api/users/234567/certification-profile'
+            id: '234567',
+            type: 'users',
+            relationships: {
+              memberships: {
+                links: {
+                  related: '/api/users/234567/memberships'
+                }
+              },
+              'certification-center-memberships': {
+                links: {
+                  related: '/api/users/234567/certification-center-memberships'
+                }
+              },
+              'pix-score': {
+                links: {
+                  related: '/api/users/234567/pixscore'
+                }
+              },
+              scorecards: {
+                links: {
+                  related: '/api/users/234567/scorecards'
+                }
+              },
+              'campaign-participations': {
+                links: {
+                  related: '/api/users/234567/campaign-participations'
+                }
+              },
+              'certification-profile': {
+                links: {
+                  related: '/api/users/234567/certification-profile'
+                }
               }
             }
           }
-        }
+        });
+      });
+    });
+
+    describe('when user has an userOrgaSettings', () => {
+
+      it('should serialize excluding password', () => {
+        // given
+        const modelObject = new User({
+          id: '234567',
+          firstName: 'Luke',
+          lastName: 'Skywalker',
+          email: 'lskywalker@deathstar.empire',
+          username: 'luke.skywalker1234',
+          cgu: true,
+          pixOrgaTermsOfServiceAccepted: false,
+          pixCertifTermsOfServiceAccepted: false,
+          hasSeenAssessmentInstructions: false,
+          password: '',
+        });
+
+        modelObject.userOrgaSettings = {};
+
+        // when
+        const json = serializer.serialize(modelObject);
+
+        // then
+        expect(json).to.be.deep.equal({
+          data: {
+            attributes: {
+              'first-name': 'Luke',
+              'last-name': 'Skywalker',
+              'email': 'lskywalker@deathstar.empire',
+              'username': 'luke.skywalker1234',
+              'cgu': true,
+              'pix-orga-terms-of-service-accepted': false,
+              'pix-certif-terms-of-service-accepted': false,
+              'has-seen-assessment-instructions': false,
+            },
+            id: '234567',
+            type: 'users',
+            relationships: {
+              memberships: {
+                links: {
+                  related: '/api/users/234567/memberships'
+                }
+              },
+              'certification-center-memberships': {
+                links: {
+                  related: '/api/users/234567/certification-center-memberships'
+                }
+              },
+              'user-orga-settings': {
+                links: {
+                  related: '/api/users/234567/user-orga-settings'
+                }
+              },
+              'pix-score': {
+                links: {
+                  related: '/api/users/234567/pixscore'
+                }
+              },
+              scorecards: {
+                links: {
+                  related: '/api/users/234567/scorecards'
+                }
+              },
+              'campaign-participations': {
+                links: {
+                  related: '/api/users/234567/campaign-participations'
+                }
+              },
+              'certification-profile': {
+                links: {
+                  related: '/api/users/234567/certification-profile'
+                }
+              }
+            }
+          }
+        });
       });
     });
   });

--- a/high-level-tests/e2e/cypress/fixtures/user-orga-settings.json
+++ b/high-level-tests/e2e/cypress/fixtures/user-orga-settings.json
@@ -1,0 +1,10 @@
+[
+  {
+    "userId": 1,
+    "currentOrganizationId": 1
+  },
+  {
+    "userId": 3 ,
+    "currentOrganizationId": 2
+  }
+]

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -2,6 +2,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'users');
   cy.task('db:fixture', 'organizations');
   cy.task('db:fixture', 'memberships');
+  cy.task('db:fixture', 'user-orga-settings');
   cy.task('db:fixture', 'target-profiles');
   cy.task('db:fixture', 'target-profiles_skills');
   cy.task('db:fixture', 'campaigns');

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -13,11 +13,14 @@ export default Controller.extend({
 
       const userOrgaSettings = await user.userOrgaSettings;
       if (!userOrgaSettings) {
-        const organization = this.currentUser.organization;
-        this.store.createRecord('user-orga-setting', { user, organization }).save();
+        const userMemberships = await this.currentUser.user.memberships;
+        const membership = await userMemberships.firstObject;
+        const organization = await membership.organization;
+        await this.store.createRecord('user-orga-setting', { user, organization }).save();
+        await this.currentUser.load();
       }
 
-      return this.replaceRoute('');
+      this.replaceRoute('');
     }
   }
 });

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -4,11 +4,20 @@ import { inject as service } from '@ember/service';
 export default Controller.extend({
 
   currentUser: service(),
+  store: service(),
 
   actions: {
     async submit() {
-      await this.currentUser.user.save({ adapterOptions: { acceptPixOrgaTermsOfService: true } });
-      this.replaceRoute('');
+      const user = this.currentUser.user;
+      await user.save({ adapterOptions: { acceptPixOrgaTermsOfService: true } });
+
+      const userOrgaSettings = await user.userOrgaSettings;
+      if (!userOrgaSettings) {
+        const organization = this.currentUser.organization;
+        this.store.createRecord('user-orga-setting', { user, organization }).save();
+      }
+
+      return this.replaceRoute('');
     }
   }
 });

--- a/orga/app/models/user-orga-setting.js
+++ b/orga/app/models/user-orga-setting.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  user: DS.belongsTo('user'),
+  organization: DS.belongsTo('organization')
+});

--- a/orga/app/models/user.js
+++ b/orga/app/models/user.js
@@ -10,6 +10,7 @@ export default DS.Model.extend({
   cgu: DS.attr('boolean'),
   pixOrgaTermsOfServiceAccepted: DS.attr('boolean'),
   memberships: DS.hasMany('membership'),
+  userOrgaSettings: DS.belongsTo('user-orga-setting'),
 
   fullName: computed('firstName', 'lastName', function() {
     return `${this.get('firstName')} ${this.get('lastName')}`;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -14,22 +14,17 @@ export default Service.extend({
         const userMemberships = await user.get('memberships');
         const userOrgaSettings = await user.get('userOrgaSettings');
 
-        let organization;
-        let userMembership;
-        if (userOrgaSettings) {
-          organization = await userOrgaSettings.get('organization');
-          userMembership = await this._getMembershipByOrganizationId(userMemberships.toArray(), organization.id);
-        } else {
-          userMembership = await userMemberships.get('firstObject');
-          organization = await userMembership.organization;
-        }
-        const isAdminInOrganization = userMembership.isAdmin;
-        const canAccessStudentsPage = organization.isSco && organization.isManagingStudents;
-
         this.set('user', user);
-        this.set('organization', organization);
-        this.set('isAdminInOrganization', isAdminInOrganization);
-        this.set('canAccessStudentsPage', canAccessStudentsPage);
+
+        if (userOrgaSettings) {
+          const organization = await userOrgaSettings.get('organization');
+          const userMembership = await this._getMembershipByOrganizationId(userMemberships.toArray(), organization.id);
+          const isAdminInOrganization = userMembership.isAdmin;
+          const canAccessStudentsPage = organization.isSco && organization.isManagingStudents;
+          this.set('organization', organization);
+          this.set('isAdminInOrganization', isAdminInOrganization);
+          this.set('canAccessStudentsPage', canAccessStudentsPage);
+        }
       } catch (error) {
         if (_.get(error, 'errors[0].code') === 401) {
           return this.session.invalidate();

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -208,4 +208,15 @@ export default function() {
     return schema.users.find(1);
   });
 
+  this.post('/user-orga-settings', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+    const userId = requestBody.data.relationships.user.data.id;
+    const organizationId = requestBody.data.relationships.organization.data.id;
+
+    const user = schema.users.find(userId);
+    const organization = schema.organizations.find(organizationId);
+
+    return schema.userOrgaSettings.create({ user, organization });
+  });
+
 }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -45,7 +45,7 @@ export default function() {
 
   this.patch('/users/:id/pix-orga-terms-of-service-acceptance', (schema, request) => {
     const user = schema.users.find(request.params.id);
-    user.pixOrgaTermsOfServiceAccepted = true;
+    user.update({ pixOrgaTermsOfServiceAccepted: true });
     return user;
   });
 

--- a/orga/mirage/serializers/user-orga-setting.js
+++ b/orga/mirage/serializers/user-orga-setting.js
@@ -1,0 +1,7 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+const relationshipsToInclude = ['organization'];
+
+export default JSONAPISerializer.extend({
+  include: relationshipsToInclude
+});

--- a/orga/mirage/serializers/user.js
+++ b/orga/mirage/serializers/user.js
@@ -1,6 +1,11 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
+const relationshipsToInclude = ['userOrgaSettings'];
+
 export default JSONAPISerializer.extend({
+
+  include: relationshipsToInclude,
+
   links(user) {
     return {
       'memberships': {

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -100,15 +100,34 @@ module('Acceptance | terms-of-service', function(hooks) {
 
     module('When user has no user-orga-settings', () => {
 
-      test('it should create the user-orga-settings', async (assert) => {
+      test('it should create the user-orga-settings', async function(assert) {
         // given
         await visit('/cgu');
+        const previousSettingsCount = server.schema.userOrgaSettings.all().length;
 
         // when
         await click('button[type=submit]');
 
         // then
-        assert.ok(user.userOrgaSettings);
+        const actualSettingsCount = server.schema.userOrgaSettings.all().length;
+        assert.equal(actualSettingsCount, previousSettingsCount + 1);
+      });
+
+      test('it should reload the currentUser service', async function(assert) {
+        const currentUser = this.owner.lookup('service:currentUser');
+
+        // given
+        await visit('/cgu');
+        const previousOrganization = currentUser.organization;
+
+        // when
+        await click('button[type=submit]');
+
+        // then
+        const actualOrganization = currentUser.organization;
+        assert.notOk(previousOrganization);
+        const firstOrganization = currentUser.user.memberships.firstObject.organization;
+        assert.equal(actualOrganization.id, firstOrganization.get('id'));
       });
     });
   });

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -97,6 +97,20 @@ module('Acceptance | terms-of-service', function(hooks) {
       // then
       assert.equal(currentURL(), '/cgu');
     });
+
+    module('When user has no user-orga-settings', () => {
+
+      test('it should create the user-orga-settings', async (assert) => {
+        // given
+        await visit('/cgu');
+
+        // when
+        await click('button[type=submit]');
+
+        // then
+        assert.ok(user.userOrgaSettings);
+      });
+    });
   });
 
   module('When user has already accepted terms of service', function(hooks) {

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -10,10 +10,7 @@ export function createUserWithMembership() {
     userId: user.id
   });
 
-  const userOrgaSettings = server.create('user-orga-setting', { user, organization });
-
   user.memberships = [memberships];
-  user.userOrgaSettings = userOrgaSettings;
   return user;
 }
 
@@ -30,6 +27,7 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
     userId: user.id
   });
 
+  user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
   user.memberships = [memberships];
   return user;
 }
@@ -47,6 +45,7 @@ export function createUserMembershipWithRole(organizationRole) {
     organizationRole,
   });
 
+  user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
   user.memberships = [memberships];
   return user;
 }
@@ -70,6 +69,7 @@ export function createAdminMembershipWithNbMembers(countMembers) {
     organizationRole: 'ADMIN',
   });
 
+  admin.userOrgaSettings = server.create('user-orga-setting', { user: admin, organization });
   admin.memberships[0] = adminMemberships;
 
   for (let i = 1; i < countMembers; i++) {
@@ -80,6 +80,8 @@ export function createAdminMembershipWithNbMembers(countMembers) {
       email: 'harry@cover.com',
       'pixOrgaTermsOfServiceAccepted': true
     });
+
+    user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
 
     admin.memberships[i] = server.create('membership', {
       userId: user.id,
@@ -105,6 +107,7 @@ export function createUserManagingStudents(role = 'MEMBER') {
     organizationRole: role
   });
 
+  user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
   user.memberships = [memberships];
   return user;
 }

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -10,7 +10,10 @@ export function createUserWithMembership() {
     userId: user.id
   });
 
+  const userOrgaSettings = server.create('user-orga-setting', { user, organization });
+
   user.memberships = [memberships];
+  user.userOrgaSettings = userOrgaSettings;
   return user;
 }
 

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -15,7 +15,7 @@ module('Unit | Service | current-user', function(hooks) {
       const connectedUserId = 1;
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [{ organization: [] }]
+        memberships: [{ organization: [] }],
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -41,7 +41,8 @@ module('Unit | Service | current-user', function(hooks) {
       const organization = Object.create({ id: 9 });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [{ organization }]
+        memberships: [Object.create({ organization })],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -68,7 +69,8 @@ module('Unit | Service | current-user', function(hooks) {
       const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [membership]
+        memberships: [membership],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -95,7 +97,8 @@ module('Unit | Service | current-user', function(hooks) {
       const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'MEMBER', isAdmin: false });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [membership]
+        memberships: [membership],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -122,7 +125,8 @@ module('Unit | Service | current-user', function(hooks) {
       const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [membership]
+        memberships: [membership],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -149,7 +153,8 @@ module('Unit | Service | current-user', function(hooks) {
       const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [membership]
+        memberships: [membership],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)
@@ -176,7 +181,8 @@ module('Unit | Service | current-user', function(hooks) {
       const membership = Object.create({ userId: connectedUserId, organization, organizationRole: 'ADMIN', isAdmin: true });
       const connectedUser = Object.create({
         id: connectedUserId,
-        memberships: [membership]
+        memberships: [membership],
+        userOrgaSettings: Object.create({ organization })
       });
       const storeStub = Service.create({
         queryRecord: () => resolve(connectedUser)


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu’un utilisateur est associé à plusieurs organisations, la première organisation renvoyée par l’api est sélectionnée par défaut. Néanmoins, aucune règle de tri n’a été établi ce qui rend la sélection de cette organisation par défaut aléatoire. 

## :robot: Solution
Afin de répondre à ce problème et afin de faciliter le changement d'organisation "par défaut" (fonctionnalité qui arrivera sous peu), il a été décidé de stocker dans une table de paramétrage relative à l'application Pix Orga, l'organisation "principale" des utilisateurs.

## :rainbow: Remarques
Ce ticket comprend notamment:
- La création d'une table de paramétrage afin de stocker l'orgnisation sélectionnée par défaut
- La création d'un script de migration afin de définir une organisation par défaut pour les utilisateurs existants
- La création d'une entrée dans cette table lors de la validation des CGU dans le cas où elle n'existerait pas encore
- L'utilisation de la valeur de l'organisation courante dans Pix Orga
