### PR TITLE
[BUGFIX] Empécher de pouvoir accéder à Pix Orga sans valider les CGU (PO-347).

### DIFF
--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -1,5 +1,17 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
 
 export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: service(),
+
+  model() {
+    return this.currentUser.organization;
+  },
+
+  afterModel() {
+    if (!this.currentUser.user.pixOrgaTermsOfServiceAccepted) {
+      return this.transitionTo('authenticated.terms-of-service');
+    }
+  }
 });

--- a/orga/tests/acceptance/campaign-collective-result-test.js
+++ b/orga/tests/acceptance/campaign-collective-result-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -15,9 +15,12 @@ module('Acceptance | Campaign Collective Result', function(hooks) {
 
   hooks.beforeEach(async () => {
     server.logging = true;
-    user = createUserWithMembership();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     await authenticateSession({
       user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
     });
     const campaignReport = server.create('campaign-report', { sharedParticipationCount: 3 });
     const campaignCollectiveResult = server.create('campaign-collective-result', 'withCompetenceCollectiveResults');

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -25,7 +25,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
     let user;
 
     hooks.beforeEach(async function() {
-      user = createUserWithMembership();
+      user = createUserWithMembershipAndTermsOfServiceAccepted();
       availableTargetProfiles = server.createList('target-profile', 2);
       await authenticateSession({
         user_id: user.id,

--- a/orga/tests/acceptance/campaign-details-test.js
+++ b/orga/tests/acceptance/campaign-details-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { currentURL, visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -30,7 +30,7 @@ module('Acceptance | Campaign Details', function(hooks) {
   module('When user is logged in', function(hooks) {
 
     hooks.beforeEach(async () => {
-      user = createUserWithMembership();
+      user = createUserWithMembershipAndTermsOfServiceAccepted();
 
       await authenticateSession({
         user_id: user.id,

--- a/orga/tests/acceptance/campaign-list-test.js
+++ b/orga/tests/acceptance/campaign-list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { currentURL, visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -27,7 +27,7 @@ module('Acceptance | Campaign List', function(hooks) {
   module('When user is logged in', function(hooks) {
 
     hooks.beforeEach(async () => {
-      user = createUserWithMembership();
+      user = createUserWithMembershipAndTermsOfServiceAccepted();
 
       await authenticateSession({
         user_id: user.id,

--- a/orga/tests/acceptance/campaign-participants-details-test.js
+++ b/orga/tests/acceptance/campaign-participants-details-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -14,15 +14,18 @@ module('Acceptance | Campaign Participants Details', function(hooks) {
   let user;
 
   hooks.beforeEach(async () => {
-    user = createUserWithMembership();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     await authenticateSession({
       user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
     });
     const campaignCollectiveResult = server.create('campaign-collective-result', 'withCompetenceCollectiveResults');
     server.create('campaign', { id: 1, campaignCollectiveResult });
 
-    server.create('user', { id: 1, firstName: 'Jack', lastName: 'Doe' });
-    server.create('campaign-participation', { campaignId: 1, userId: 1 });
+    const participant = server.create('user', { firstName: 'Jack', lastName: 'Doe' });
+    server.create('campaign-participation', { campaignId: 1, userId: participant.id });
   });
 
   test('it should display user details', async function(assert) {

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit, click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -17,9 +17,12 @@ module('Acceptance | Campaign Participants', function(hooks) {
   const pageSize = 10;
   const rowCount = 50;
   hooks.beforeEach(async () => {
-    user = createUserWithMembership();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     await authenticateSession({
       user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
     });
     server.create('campaign', { id: 1 });
     server.createList('campaign-participation', rowCount, { campaignId: 1 });

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -12,8 +12,13 @@ module('Acceptance | Campaign Update', function(hooks) {
 
   test('it should allow to update a campaign and redirect to the newly updated campaign', async function(assert) {
     // given
-    const user = createUserWithMembership();
-    await authenticateSession({ user_id: user.id });
+    const user = createUserWithMembershipAndTermsOfServiceAccepted();
+    await authenticateSession({
+      user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
+    });
     const campaign = server.create('campaign', { id: 1 });
     const newTitle = 'New title';
     const newText = 'New text';

--- a/orga/tests/acceptance/participant-results-test.js
+++ b/orga/tests/acceptance/participant-results-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembership } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -14,9 +14,12 @@ module('Acceptance | Campaign Details Participants', function(hooks) {
   let user;
 
   hooks.beforeEach(async () => {
-    user = createUserWithMembership();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     await authenticateSession({
       user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
     });
     server.create('campaign', { id: 1 });
     server.createList('campaign-participation', 2, { campaignId: 1 });

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -86,6 +86,14 @@ module('Acceptance | terms-of-service', function(hooks) {
       // then
       assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still authenticated');
     });
+
+    test('it should not be possible to visit another page if cgu are not accepted', async function(assert) {
+      // when
+      await visit('/campagnes');
+
+      // then
+      assert.equal(currentURL(), '/cgu');
+    });
   });
 
   module('When user has already accepted terms of service', function(hooks) {


### PR DESCRIPTION
## :unicorn: Problème
Il est possible pour un utilisateur de ne pas accepter les CGUs de Pix Orga.
Pour cela, il lui suffit d'aller sur Pix Orga et lorsqu'on lui propose de valider les CGU, il peut changer d'url en ajoutant /campagnes par exemple et il a accès à la plateforme.

![Feb-21-2020 16-00-29](https://user-images.githubusercontent.com/26384707/75045345-66e71e80-54c3-11ea-97b0-2777e1e02919.gif)


## :robot: Solution
Dans l'`afterModel` d'`authenticated` vérifier si l'utilisateur a bien validé les CGU sinon le renvoyer sur la page en question.

![cgu-pix-orga-new](https://user-images.githubusercontent.com/26384707/75045353-6cdcff80-54c3-11ea-9453-2dcbf34bc46c.gif)


## :taco: Remarque
On peut voir que beaucoup de tests, on été changé cela est du au fait que les tests utilisaient un user qui n'acceptait pas les CGU
