### PR TITLE
[EXPEDITE][BUGFIX] Finalisation de session en échec dans un cas particulier (PC-129)

### DIFF
--- a/api/lib/domain/models/CertificationReport.js
+++ b/api/lib/domain/models/CertificationReport.js
@@ -2,6 +2,8 @@ const Joi = require('@hapi/joi');
 
 const { InvalidCertificationReportForFinalization } = require('../errors');
 
+const NO_EXAMINER_COMMENT = null;
+
 const certificationReportSchemaForFinalization = Joi.object({
   id: Joi.string().optional(),
   firstName: Joi.string().optional(),
@@ -54,4 +56,7 @@ class CertificationReport {
   }
 }
 
-module.exports = CertificationReport;
+module.exports = {
+  CertificationReport,
+  NO_EXAMINER_COMMENT,
+};

--- a/api/lib/infrastructure/repositories/certification-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-report-repository.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const Bookshelf = require('../bookshelf');
-const CertificationReport = require('../../domain/models/CertificationReport');
+const { CertificationReport } = require('../../domain/models/CertificationReport');
 
 const CertificationCourseBookshelf = require('../data/certification-course');
 const bookshelfToDomainConverter = require('../../infrastructure/utils/bookshelf-to-domain-converter');

--- a/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
-const CertificationReport = require('../../../domain/models/CertificationReport');
+const { CertificationReport, NO_EXAMINER_COMMENT } = require('../../../domain/models/CertificationReport');
 
 module.exports = {
   serialize(certificationReports) {
@@ -21,7 +21,7 @@ module.exports = {
     const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
     const deserializedReport = await deserializer.deserialize(jsonApiData);
     if (_.isEmpty(_.trim(deserializedReport.examinerComment))) {
-      deserializedReport.examinerComment = null;
+      deserializedReport.examinerComment = NO_EXAMINER_COMMENT;
     }
     return new CertificationReport(deserializedReport);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 const CertificationReport = require('../../../domain/models/CertificationReport');
@@ -18,6 +20,9 @@ module.exports = {
   async deserialize(jsonApiData) {
     const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
     const deserializedReport = await deserializer.deserialize(jsonApiData);
+    if (_.isEmpty(_.trim(deserializedReport.examinerComment))) {
+      deserializedReport.examinerComment = null;
+    }
     return new CertificationReport(deserializedReport);
   },
 };

--- a/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
 
 describe('Acceptance | Controller | session-controller-get-certification-reports', () => {
 

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { databaseBuilder, expect, catchErr } = require('../../../test-helper');
-const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
 const certificationReportRepository = require('../../../../lib/infrastructure/repositories/certification-report-repository');
 const { CertificationCourseUpdateError } = require('../../../../lib/domain/errors');
 

--- a/api/tests/tooling/database-builder/factory/build-certification-report.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-report.js
@@ -1,6 +1,6 @@
 const faker = require('faker');
 const buildCertificationCourse = require('./build-certification-course');
-const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
 const _ = require('lodash');
 
 module.exports = function buildCertificationReport({

--- a/api/tests/tooling/domain-builder/factory/build-certification-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-report.js
@@ -1,5 +1,5 @@
 const faker = require('faker');
-const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
 
 module.exports = function buildCertificationReport(
   {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -44,4 +44,31 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
     });
   });
 
+  it('should return a null for an undefined examiner comment', async function() {
+    // when
+    delete jsonApiData.data.attributes['examiner-comment'];
+    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+
+    // then
+    expect(deserializedCertificationReport.examinerComment).to.be.null;
+  });
+
+  it('should return a null for an empty examiner comment (empty => none)', async function() {
+    // when
+    jsonApiData.data.attributes['examiner-comment'] = '';
+    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+
+    // then
+    expect(deserializedCertificationReport.examinerComment).to.be.null;
+  });
+
+  it('should return a null for an all spaces examiner comment (" " => none)', async function() {
+    // when
+    jsonApiData.data.attributes['examiner-comment'] = '\t ';
+    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+
+    // then
+    expect(deserializedCertificationReport.examinerComment).to.be.null;
+  });
+
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-report-serializer');
+const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
 
 describe('Unit | Serializer | JSONAPI | certification-report-serializer', function() {
 
@@ -44,31 +45,31 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
     });
   });
 
-  it('should return a null for an undefined examiner comment', async function() {
+  it('should return no examiner comment for an undefined examiner comment', async function() {
     // when
     delete jsonApiData.data.attributes['examiner-comment'];
     const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
 
     // then
-    expect(deserializedCertificationReport.examinerComment).to.be.null;
+    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
   });
 
-  it('should return a null for an empty examiner comment (empty => none)', async function() {
+  it('should return no examiner comment for an empty examiner comment', async function() {
     // when
     jsonApiData.data.attributes['examiner-comment'] = '';
     const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
 
     // then
-    expect(deserializedCertificationReport.examinerComment).to.be.null;
+    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
   });
 
-  it('should return a null for an all spaces examiner comment (" " => none)', async function() {
+  it('should return no examiner comment for a blank examiner comment', async function() {
     // when
-    jsonApiData.data.attributes['examiner-comment'] = '\t ';
+    jsonApiData.data.attributes['examiner-comment'] = '\t \n';
     const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
 
     // then
-    expect(deserializedCertificationReport.examinerComment).to.be.null;
+    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
   });
 
 });

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -2,29 +2,6 @@ import ApplicationAdapter from './application';
 
 export default class SessionAdapter extends ApplicationAdapter {
 
-  finalize(model) {
-    const url = `${this.buildURL('session', model.id)}/finalization`;
-
-    // Here we try to respect the JSON-API format
-    // so the API knows how to handle this payload
-    return this.ajax(url, 'PUT', {
-      data: {
-        data: {
-          attributes: {
-            'examiner-global-comment': model.get('examinerGlobalComment'),
-          },
-          included: model.get('certificationReports')
-            .filter((certificationReport) => certificationReport.hasDirtyAttributes)
-            .map((certificationReport) => ({
-              type: 'certification-reports',
-              id: certificationReport.get('id'),
-              attributes: certificationReport.toJSON(),
-            })),
-        },
-      },
-    });
-  }
-
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);
     if (adapterOptions && adapterOptions.finalization)  {

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -24,4 +24,37 @@ export default class SessionAdapter extends ApplicationAdapter {
       },
     });
   }
+
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    const url = super.urlForUpdateRecord(...arguments);
+    if (adapterOptions && adapterOptions.finalization)  {
+      delete adapterOptions.finalization;
+      return url + '/finalization';
+    }
+
+    return url;
+  }
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions && snapshot.adapterOptions.finalization) {
+      const model = snapshot.record;
+      const data = {
+        data: {
+          attributes: {
+            'examiner-global-comment': model.get('examinerGlobalComment'),
+          },
+          included: model.get('certificationReports')
+            .filter((certificationReport) => certificationReport.hasDirtyAttributes)
+            .map((certificationReport) => ({
+              type: 'certification-reports',
+              id: certificationReport.get('id'),
+              attributes: certificationReport.toJSON(),
+            })),
+        },
+      };
+      return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PUT', { data });
+    }
+
+    return super.updateRecord(...arguments);
+  }
 }

--- a/certif/app/components/session-finalization-examiner-global-comment-step.hbs
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.hbs
@@ -7,11 +7,11 @@
       {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
     </div>
   </div>
-  <textarea
-    id="examiner-global-comment"
+  <Textarea
+    @id="examiner-global-comment"
     class="session-finalization-examiner-global-comment-step__textarea"
-    value={{@session.examinerGlobalComment}}
+    @value={{@session.examinerGlobalComment}}
     {{on 'input' @updateExaminerGlobalComment}}
-    maxlength={{@examinerGlobalCommentMaxLength}}
+    @maxlength={{@examinerGlobalCommentMaxLength}}
   />
 </div>

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -47,9 +47,8 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
   @action
   async finalizeSession() {
     this.isLoading = true;
-
     try {
-      await this.session.finalize();
+      await this.session.save({ adapterOptions: { finalization: true } });
       this.showSuccessNotification('Les informations de la session ont été transmises avec succès.');
     } catch (err) {
       (err.errors && err.errors[0] && err.errors[0].status === '400')

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
@@ -64,7 +65,7 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
   updateExaminerGlobalComment(event) {
     const inputText = event.target.value;
     if (inputText.length <= this.examinerGlobalCommentMaxLength) {
-      this.session.examinerGlobalComment = inputText;
+      this.session.examinerGlobalComment = this._convertStringToNullIfEmpty(inputText);
     }
   }
 
@@ -72,7 +73,7 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
   updateCertificationReportExaminerComment(certificationReport, event) {
     const inputText = event.target.value;
     if (inputText.length <= this.examinerCommentMaxLength) {
-      certificationReport.examinerComment = inputText;
+      certificationReport.examinerComment = this._convertStringToNullIfEmpty(inputText);
     }
   }
 
@@ -98,5 +99,9 @@ export default class AuthenticatedSessionsFinalizeController extends Controller 
   @action
   closeModal() {
     this.showConfirmModal = false;
+  }
+
+  _convertStringToNullIfEmpty(str) {
+    return _.isEmpty(_.trim(str)) ? null : str;
   }
 }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -49,8 +49,4 @@ export default class Session extends Model {
   get displayStatus() {
     return statusToDisplayName[this.status];
   }
-
-  finalize() {
-    return this.store.adapterFor('session').finalize(this);
-  }
 }

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -82,7 +82,7 @@ module('Acceptance | Session Finalization', function(hooks) {
       });
 
       test('it checks the hasSeenEndTestScreen checkbox', async function(assert) {
-        const certificationReport = await checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
+        const certificationReport = await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
 
         assert.equal(certificationReport.hasSeenEndTestScreen, true);
       });
@@ -161,7 +161,7 @@ module('Acceptance | Session Finalization', function(hooks) {
             
       module('when confirm modal is open with one checked option', function(hooks) {
         hooks.beforeEach(async function(assert) {
-          await checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
+          await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
           return click('[data-test-id="finalize__button"]');
         });
               
@@ -175,7 +175,7 @@ module('Acceptance | Session Finalization', function(hooks) {
   });
 });
 
-async function checkFirstHasSeenEndTestScreenOption(finalizeController, assert) {
+async function _checkFirstHasSeenEndTestScreenOption(finalizeController, assert) {
   const certificationReports = finalizeController.model.certificationReports.toArray();
   const certificationReport = certificationReports[0];
   const id = certificationReport.certificationCourseId;

--- a/certif/tests/unit/adapters/session-test.js
+++ b/certif/tests/unit/adapters/session-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | session', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:session');
+  });
+
+  module('#urlForUpdateRecord', () => {
+    test('should build update url from session id', async function(assert) {
+      // when
+      const options = { adapterOptions: { } };
+      const url = await adapter.urlForUpdateRecord(123, 'session', options);
+
+      assert.ok(url.endsWith('/sessions/123'));
+    });
+
+    test('should build specific url to finalization', async function(assert) {
+      // when
+      const options = { adapterOptions: { finalization: true } };
+      const url = await adapter.urlForUpdateRecord(123, 'session', options);
+
+      // then
+      assert.ok(url.endsWith('/sessions/123/finalization'));
+    });
+  });
+
+});

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/sessions/details', function(hooks) {
+  setupTest(hooks);
+
+  module('#computed certificationCandidatesCount()', function() {
+    test('should return a string the the candidate count if more than 0 candidate', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = { certificationCandidates: ['candidate1', 'candidate2'] };
+
+      // when
+      const actualStrCertificationCandidatesCount = controller.certificationCandidatesCount;
+
+      // then
+      assert.equal(actualStrCertificationCandidatesCount, `(${controller.model.certificationCandidates.length})`);
+    });
+
+    test('should return an empty string when there are no certification candidates in the session', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = { certificationCandidates: [] };
+
+      // when
+      const actualStrCertificationCandidatesCount = controller.certificationCandidatesCount;
+
+      // then
+      assert.equal(actualStrCertificationCandidatesCount, '');
+    });
+  });
+});

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -7,102 +7,263 @@ const FINALIZE_PATH = 'authenticated/sessions/finalize';
 module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    assert.ok(controller);
+  module('#computed uncheckedHasSeenEndTestScreenCount', function() {
+
+    test('it should count no unchecked box if no report', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = ArrayProxy.create({
+        certificationReports: []
+      });
+      controller.model = sessions;
+
+      // when
+      const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
+
+      // then
+      assert.equal(uncheckedHasSeenEndTestScreenCount, 0);
+    });
+
+    test('it should count unchecked boxes', function(assert) {
+
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = ArrayProxy.create({
+        certificationReports: [
+          { hasSeenEndTestScreen: true },
+          { hasSeenEndTestScreen: false },
+          { hasSeenEndTestScreen: false },
+          { hasSeenEndTestScreen: false },
+          { hasSeenEndTestScreen: true },
+        ]
+      });
+      controller.model = sessions;
+
+      // when
+      const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
+
+      // then
+      assert.equal(uncheckedHasSeenEndTestScreenCount, 3);
+    });
+
+    test('it should count 1 unchecked box if only one box (unchecked)', function(assert) {
+
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = ArrayProxy.create({
+        certificationReports: [
+          { hasSeenEndTestScreen: false },
+        ]
+      });
+      controller.model = sessions;
+
+      // when
+      const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
+
+      // then
+      assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 1);
+    });
   });
 
-  test('it should count no unchecked box if no report', function(assert) {
+  module('#computed hasUncheckedHasSeenEndTestScreen', function() {
 
-    // given
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    const sessions = ArrayProxy.create({
-      certificationReports: []
+    test('it should be false if no unchecked certification reports', function(assert) {
+
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = ArrayProxy.create({
+        certificationReports: [
+          { hasSeenEndTestScreen: true },
+          { hasSeenEndTestScreen: true },
+        ]
+      });
+      controller.model = sessions;
+
+      // when
+      const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
+
+      // then
+      assert.equal(hasUncheckedHasSeenEndTestScreen, false);
     });
-    controller.set('model', sessions);
 
-    // when
-    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+    test('it should be true if at least one unchecked certification reports', function(assert) {
 
-    // then
-    assert.equal(uncheckedHasSeenEndTestScreenCount, 0);
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = ArrayProxy.create({
+        certificationReports: [
+          { hasSeenEndTestScreen: false },
+          { hasSeenEndTestScreen: true },
+        ]
+      });
+      controller.model = sessions;
+
+      // when
+      const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
+
+      // then
+      assert.equal(hasUncheckedHasSeenEndTestScreen, true);
+    });
   });
 
-  test('it should count unchecked boxes', function(assert) {
+  module('#action updateExaminerGlobalComment', function() {
 
-    // given
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    const sessions = ArrayProxy.create({
-      certificationReports: [
-        { hasSeenEndTestScreen: true },
-        { hasSeenEndTestScreen: false },
-        { hasSeenEndTestScreen: false },
-        { hasSeenEndTestScreen: false },
-        { hasSeenEndTestScreen: true },
-      ]
+    test('it should left session examiner global comment untouched if input value exceeds max size', function(assert) {
+      // given
+      const initialValue = null;
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const session = { examinerGlobalComment: initialValue };
+      controller.model = session;
+      controller.examinerGlobalCommentMaxLength = 5;
+
+      // when
+      controller.send('updateExaminerGlobalComment', { target: { value: 'MoreThan5Characters' } });
+
+      // then
+      assert.equal(session.examinerGlobalComment, initialValue);
     });
-    controller.set('model', sessions);
 
-    // when
-    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+    test('it should update session examiner global comment if input value is not exceeding max size', function(assert) {
+      // given
+      const initialValue = null;
+      const newValue = 'hello';
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const session = { examinerGlobalComment: initialValue };
+      controller.model = session;
 
-    // then
-    assert.equal(uncheckedHasSeenEndTestScreenCount, 3);
+      // when
+      controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
+
+      // then
+      assert.equal(session.examinerGlobalComment, newValue);
+    });
+
+    test('it should update session examiner global comment to null if trimmed input value is still empty', function(assert) {
+      // given
+      const initialValue = 'initialValue';
+      const newValue = '  ';
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const session = { examinerGlobalComment: initialValue };
+      controller.model = session;
+
+      // when
+      controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
+
+      // then
+      assert.equal(session.examinerGlobalComment, null);
+    });
   });
 
-  test('it should count 1 unchecked box if only one box (unchecked)', function(assert) {
+  module('#action updateCertificationReportExaminerComment', function() {
 
-    // given
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    const sessions = ArrayProxy.create({
-      certificationReports: [
-        { hasSeenEndTestScreen: false },
-      ]
+    test('it should left certif examiner comment untouched if input value exceeds max size', function(assert) {
+      // given
+      const initialValue = null;
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const certifReport = { examinerComment: initialValue };
+      controller.examinerCommentMaxLength = 5;
+
+      // when
+      controller.send('updateCertificationReportExaminerComment', certifReport, { target: { value: 'MoreThan5Characters' } });
+
+      // then
+      assert.equal(certifReport.examinerComment, initialValue);
     });
-    controller.set('model', sessions);
 
-    // when
-    const uncheckedHasSeenEndTestScreenCount = controller.get('uncheckedHasSeenEndTestScreenCount');
+    test('it should update certif examiner comment if input value is not exceeding max size', function(assert) {
+      // given
+      const initialValue = null;
+      const newValue = 'hello';
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const certifReport = { examinerComment: initialValue };
 
-    // then
-    assert.strictEqual(uncheckedHasSeenEndTestScreenCount, 1);
+      // when
+      controller.send('updateCertificationReportExaminerComment', certifReport, { target: { value: newValue } });
+
+      // then
+      assert.equal(certifReport.examinerComment, newValue);
+    });
+
+    test('it should update certif examiner comment to null if trimmed input value is still empty', function(assert) {
+      // given
+      const initialValue = 'initialValue';
+      const newValue = '  ';
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const certifReport = { examinerComment: initialValue };
+
+      // when
+      controller.send('updateCertificationReportExaminerComment', certifReport, { target: { value: newValue } });
+
+      // then
+      assert.equal(certifReport.examinerComment, null);
+    });
   });
 
-  test('it should be false if no unchecked certification reports', function(assert) {
+  module('#action toggleCertificationReportHasSeenEndTestScreen', function() {
 
-    // given
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    const sessions = ArrayProxy.create({
-      certificationReports: [
-        { hasSeenEndTestScreen: true },
-        { hasSeenEndTestScreen: true },
-      ]
+    test('it should toggle the hasSeenEndTestScreen attribute of the certif parameter', function(assert) {
+      // given
+      const initialValue = true;
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const certifReport = { hasSeenEndTestScreen: initialValue };
+
+      // when
+      controller.send('toggleCertificationReportHasSeenEndTestScreen', certifReport);
+
+      // then
+      assert.equal(certifReport.hasSeenEndTestScreen, !initialValue);
     });
-    controller.set('model', sessions);
-
-    // when
-    const hasUncheckedHasSeenEndTestScreen = controller.get('hasUncheckedHasSeenEndTestScreen');
-
-    // then
-    assert.equal(hasUncheckedHasSeenEndTestScreen, false);
   });
 
-  test('it should be true if at least one unchecked certification reports', function(assert) {
+  module('#action toggleAllCertificationReportsHasSeenEndTestScreen', function() {
 
-    // given
-    const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-    const sessions = ArrayProxy.create({
-      certificationReports: [
-        { hasSeenEndTestScreen: false },
-        { hasSeenEndTestScreen: true },
-      ]
+    test('it should toggle the hasSeenEndTestScreen attribute of all the certifs in session to false depending on if some were checked', function(assert) {
+      // given
+      const someWereChecked = true;
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+      const sessions = {
+        certificationReports: [
+          { hasSeenEndTestScreen: false },
+          { hasSeenEndTestScreen: true },
+        ]
+      };
+      controller.model = sessions;
+
+      // when
+      controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
+
+      // then
+      sessions.certificationReports.forEach((certif) => {
+        assert.equal(certif.hasSeenEndTestScreen, !someWereChecked);
+      });
     });
-    controller.set('model', sessions);
+  });
 
-    // when
-    const hasUncheckedHasSeenEndTestScreen = controller.get('hasUncheckedHasSeenEndTestScreen');
+  module('#action openModal', function() {
 
-    // then
-    assert.equal(hasUncheckedHasSeenEndTestScreen, true);
+    test('it should set flag showConfirmModal to true', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+
+      // when
+      controller.send('openModal');
+
+      // then
+      assert.equal(controller.showConfirmModal, true);
+    });
+  });
+
+  module('#action close', function() {
+
+    test('it should set flag showConfirmModal to false', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+
+      // when
+      controller.send('closeModal');
+
+      // then
+      assert.equal(controller.showConfirmModal, false);
+    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -5,41 +5,37 @@ import ArrayProxy from '@ember/array/proxy';
 module('Unit | Controller | authenticated/sessions/list', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:authenticated/sessions/list');
-    assert.ok(controller);
-  });
+  module('#computed hasSession', function() {
 
-  test('it should know when there is no sessions', function(assert) {
+    test('it should know when there is no sessions', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/list');
+      const sessions = ArrayProxy.create({
+        content: []
+      });
+      controller.model = sessions;
 
-    // given
-    const controller = this.owner.lookup('controller:authenticated/sessions/list');
-    const sessions = ArrayProxy.create({
-      content: []
+      // when
+      const hasSession = controller.hasSession;
+
+      // then
+      assert.equal(hasSession, false);
     });
-    controller.set('model', sessions);
 
-    // when
-    const hasSession = controller.get('hasSession');
+    test('it should know when there are sessions', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/list');
+      const session1 = { id: 1, date: new Date('2018-08-07T14:00:44Z') };
+      const sessions = ArrayProxy.create({
+        content: [session1]
+      });
+      controller.model = sessions;
 
-    // then
-    assert.equal(hasSession, false);
-  });
+      // when
+      const hasSession = controller.hasSession;
 
-  test('it should know when there are sessions', function(assert) {
-
-    // given
-    const controller = this.owner.lookup('controller:authenticated/sessions/list');
-    const session1 = { id: 1, date: new Date('2018-08-07T14:00:44Z') };
-    const sessions = ArrayProxy.create({
-      content: [session1]
+      // then
+      assert.equal(hasSession, true);
     });
-    controller.set('model', sessions);
-
-    // when
-    const hasSession = controller.get('hasSession');
-
-    // then
-    assert.equal(hasSession, true);
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/new-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/new-test.js
@@ -2,17 +2,17 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/update', function(hooks) {
+module('Unit | Controller | authenticated/sessions/new', function(hooks) {
   setupTest(hooks);
 
-  module('#action updateSession', function(hooks) {
+  module('#action createSession', function(hooks) {
     let controller;
     let event;
     const sessionId = 'sessionId';
     const session = { id: sessionId };
 
     hooks.beforeEach(function() {
-      controller = this.owner.lookup('controller:authenticated/sessions/update');
+      controller = this.owner.lookup('controller:authenticated/sessions/new');
       event = { preventDefault: sinon.stub() };
       controller.transitionToRoute = sinon.stub();
       session.save = sinon.stub().resolves();
@@ -21,7 +21,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
 
     test('it should call preventDefault on event passed in action', async function(assert) {
       // when
-      await controller.send('updateSession', event);
+      await controller.send('createSession', event);
 
       // then
       assert.ok(event.preventDefault.calledOnce);
@@ -29,7 +29,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
 
     test('it should call save on the session model', async function(assert) {
       // when
-      await controller.send('updateSession', event);
+      await controller.send('createSession', event);
 
       // then
       assert.ok(session.save.calledOnce);
@@ -37,7 +37,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
 
     test('it should transition to correct route with the session id', async function(assert) {
       // when
-      await controller.send('updateSession', event);
+      await controller.send('createSession', event);
 
       // then
       assert.ok(controller.transitionToRoute.calledWith('authenticated.sessions.details', sessionId));
@@ -50,17 +50,17 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     const session = { id: sessionId };
 
     hooks.beforeEach(function() {
-      controller = this.owner.lookup('controller:authenticated/sessions/update');
+      controller = this.owner.lookup('controller:authenticated/sessions/new');
       controller.transitionToRoute = sinon.stub();
       controller.model = session;
     });
 
-    test('it should transition to correct cancel route with the session id', async function(assert) {
+    test('it should transition to correct cancel list route', async function(assert) {
       // when
       await controller.send('cancel');
 
       // then
-      assert.ok(controller.transitionToRoute.calledWith('authenticated.sessions.details', sessionId));
+      assert.ok(controller.transitionToRoute.calledWith('authenticated.sessions.list'));
     });
   });
 
@@ -69,7 +69,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     const session = { date: '' };
 
     hooks.beforeEach(function() {
-      controller = this.owner.lookup('controller:authenticated/sessions/update');
+      controller = this.owner.lookup('controller:authenticated/sessions/new');
       controller.model = session;
     });
 
@@ -88,7 +88,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     const session = { time: '' };
 
     hooks.beforeEach(function() {
-      controller = this.owner.lookup('controller:authenticated/sessions/update');
+      controller = this.owner.lookup('controller:authenticated/sessions/new');
       controller.model = session;
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Comment reproduire le bug :
- Accéder à la page de finalisation de session avec au moins une certification
- Cliquer dans le champ signalement d'une certification (sans rien écrire dedans)
- Finaliser la session -> échec
Dans le cas reproduit au dessus, le payload envoyé à l'API contient, pour l'attribut `examinerComment` de la certification pour laquelle on a cliqué dans le champ, la valeur '' (chaîne vide). Or, la validation JOI des données de la certification côté API interdit une chaîne vide pour cet attribut (mais tolère `null` et `undefined`)

## :robot: Solution
- Front et Back, convertir les chaînes vides en `null` (à l'envoi et à la désérialization)
Cette PR contient également :
- Une réécriture de l'action de finalisation côté front qui soit plus _Ember-like_
- Ajout de tests unitaires de controllers manquants côté front.

## :rainbow: Remarques
