### PR TITLE
[FEATURE] Ajout d'un filtre sur le status lors de l'affichage de la liste des campagnes (PO-314).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -57,6 +57,10 @@ module.exports = {
     const organizationId = parseInt(request.params.id);
     const options = queryParamsUtils.extractParameters(request.query);
 
+    if (options.filter.status === 'archived') {
+      options.filter.ongoing = false;
+      delete options.filter.status;
+    }
     const { models: campaigns, pagination } = await usecases.findPaginatedFilteredOrganizationCampaigns({ organizationId, filter: options.filter, page: options.page });
     return campaignSerializer.serialize(campaigns, pagination, { ignoreCampaignReportRelationshipData : false });
   },

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -72,9 +72,14 @@ function _countCampaignParticipations(qb) {
   );
 }
 
-function _setSearchFiltersForQueryBuilder(qb, { name }) {
+function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true }) {
   if (name) {
     qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+  }
+  if (ongoing) {
+    qb.whereNull('campaigns.archivedAt');
+  } else {
+    qb.whereNotNull('campaigns.archivedAt');
   }
 }
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -352,12 +352,15 @@ describe('Acceptance | Application | organization-controller', () => {
       campaignsData = _.map([
         { name: 'Quand Peigne numba one', code: 'ATDGRK343', organizationId },
         { name: 'Quand Peigne numba two', code: 'KFCTSU984', organizationId },
+        { name: 'Quand Peigne numba three', code: 'ABC180ELO', organizationId, archivedAt: new Date('2000-01-01T10:00:00Z') },
+        { name: 'Quand Peigne numba four', code: 'ABC180LEO', organizationId, archivedAt: new Date('2000-02-01T10:00:00Z') },
         { name: 'Quand Peigne otha orga', code: 'CPFTQX735', organizationId: otherOrganizationId },
       ], (camp) => {
         const builtCampaign = databaseBuilder.factory.buildCampaign(camp);
         return { name: camp.name, code: camp.code, id: builtCampaign.id };
+
       });
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[2].id, isShared: true });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[4].id, isShared: true });
       await databaseBuilder.commit();
 
       options = {
@@ -414,6 +417,21 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.result.included[1].attributes['first-name']).to.equal('Daenerys');
         expect(response.result.included[1].attributes['last-name']).to.equal('Targaryen');
+      });
+
+      it('should return archived campaigns', async () => {
+        // given
+        options.url = `/api/organizations/${organizationId}/campaigns?page[number]=1&page[size]=2&filter[status]=archived`;
+        const expectedMetaData = { page: 1, pageSize: 2, rowCount: 2, pageCount: 1 };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.meta).to.deep.equal(expectedMetaData);
+        expect(response.result.data).to.have.lengthOf(2);
+        expect(response.result.data[0].type).to.equal('campaigns');
       });
 
       it('should return 200 status code with the campaignReports with the campaigns', async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -226,6 +226,28 @@ describe('Integration | Repository | Campaign', () => {
         expect(_.map(campaignsWithReports, 'id')).to.deep.equal([campaignBInTheFutureId, campaignAInThePresentId, campaignBInThePastId]);
       });
 
+      context('when some campaigns are archived', async () => {
+
+        it('should be able to retrieve only campaigns that are archived', async () => {
+          // given
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: new Date('2010-07-30T09:35:45Z') });
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: new Date('2010-07-30T09:35:45Z') });
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: null });
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: null });
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: null });
+          filter.ongoing = false;
+
+          await databaseBuilder.commit();
+          // when
+          const { models: archivedCampaigns } = await campaignRepository.findPaginatedFilteredByOrganizationIdWithCampaignReports({ organizationId, filter, page });
+
+          // then
+          expect(archivedCampaigns).to.have.lengthOf(2);
+          expect(archivedCampaigns[0].archivedAt).is.not.null;
+        });
+      });
+
       context('when campaigns have participants', async () => {
 
         it('should return the campaigns of the given organization id with campaignReports', async () => {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -312,7 +312,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       // given
       request.query = {};
       const expectedResponse = { data: serializedCampaigns, meta: {} };
-      queryParamsUtils.extractParameters.withArgs({}).returns({});
+      queryParamsUtils.extractParameters.withArgs({}).returns({ filter: {} });
       usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: {}, pagination: {} });
       campaignSerializer.serialize.returns(expectedResponse);
 
@@ -329,7 +329,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       const expectedResults = [campaign];
       const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
       const expectedConfig = { ignoreCampaignReportRelationshipData: false };
-      queryParamsUtils.extractParameters.withArgs({}).returns({});
+      queryParamsUtils.extractParameters.withArgs({}).returns({ filter: {} });
       usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: expectedResults, pagination: expectedPagination });
 
       // when

--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -47,8 +47,8 @@ then(`je suis redirigé vers le compte Orga de {string}`, (fullName) => {
   cy.get('.logged-user-summary__name').should((userName) => {
     expect(userName.text()).to.contains(fullName);
   });
-  cy.get('.page-title').should((title) => {
-    expect(title.text()).to.contains('Campagnes');
+  cy.get('.list-campaigns-page').should((list) => {
+    expect(list).to.exist;
   });
 });
 

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -5,7 +5,7 @@ import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
 
 export default Controller.extend({
-  queryParams: ['pageNumber', 'pageSize', 'name'],
+  queryParams: ['pageNumber', 'pageSize', 'name', 'status'],
   pageNumber: 1,
   pageSize: 25,
   name: null,
@@ -14,9 +14,11 @@ export default Controller.extend({
 
   hasNoCampaign: empty('model'),
   displayNoCampaignPanel: computed('name,hasNoCampaign', function() {
-    return this.hasNoCampaign && isEmpty(this.name);
+    return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status);
   }),
-
+  isArchived: computed('status', function() {
+    return this.status === 'archived';
+  }),
   setFieldName() {
     this.set(this.searchFilter.fieldName, this.searchFilter.value);
   },
@@ -26,7 +28,9 @@ export default Controller.extend({
       this.set('searchFilter', { fieldName, value });
       debounce(this, this.setFieldName, 500);
     },
-
+    updateCampaignStatus(newStatus) {
+      this.set('status', newStatus);
+    },
     goToCampaignPage(campaignId) {
       this.transitionToRoute('authenticated.campaigns.details', campaignId);
     }

--- a/orga/app/routes/authenticated/campaigns/list.js
+++ b/orga/app/routes/authenticated/campaigns/list.js
@@ -13,6 +13,9 @@ export default Route.extend({
     name: {
       refreshModel: true
     },
+    status: {
+      refreshModel: true
+    },
   },
 
   currentUser: service(),
@@ -22,6 +25,7 @@ export default Route.extend({
       filter: {
         organizationId: this.currentUser.organization.id,
         name: params.name,
+        status: params.status,
       },
       page: {
         number: params.pageNumber,

--- a/orga/app/styles/pages/authenticated/campaigns/list.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/list.scss
@@ -5,11 +5,44 @@
 
   &__header-page {
     display: flex;
-    margin: 1em;
+    margin: 1em 0 2.4em;
+    align-items: flex-end;
   }
 
   &__create-campaign-button {
     margin-top: 20px;
     margin-left: auto;
+  }
+
+  &__campaigns-status {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__tab {
+    text-transform: uppercase;
+    color: $comet;
+    background: transparent;
+    padding: 6px 8px;
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+    margin-right: 10px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    outline: none;
+    font-family: $roboto;
+    border-radius: 4px;
+    &:hover {
+      background: $alto;
+      opacity: .8;
+    }
+    &--active {
+      background: $alto;
+      &:hover {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -2,9 +2,18 @@
   {{#if displayNoCampaignPanel}}
     {{routes/authenticated/campaigns/no-campaign-panel}}
   {{else}}
+    <div class="list-campaigns-page__header-page">
+      <ul role="tablist" class="list-campaigns-page__campaigns-status" aria-label="Filtre des campagnes par statut">
+        <li role="tab" type="submit" class="list-campaigns-page__tab {{unless isArchived  'list-campaigns-page__tab--active' }}" aria-selected="{{ not isArchived }}" {{ action 'updateCampaignStatus' null }}>Actives</li>
+        <li role="tab" type="submit" class="list-campaigns-page__tab {{if isArchived 'list-campaigns-page__tab--active' }}" aria-selected="{{ isArchived }}" {{ action 'updateCampaignStatus' 'archived' }}>Archivées</li>
+      </ul>
+      <div role="tabpanel" class="list-campaigns-page__create-campaign-button">
+        {{#link-to 'authenticated.campaigns.new' class="button button--link"}}Créer une campagne{{/link-to}}
+      </div>
+    </div>
     {{routes/authenticated/campaigns/list-items
       campaigns=model
-      name=name
+      campaignName=name
       triggerFiltering=(action 'triggerFiltering')
       goToCampaignPage=(action 'goToCampaignPage')}}
   {{/if}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -1,11 +1,4 @@
-<div class="list-campaigns-page__header-page">
-  <h1 class="page__title page-title">Campagnes</h1>
-  <div class="list-campaigns-page__create-campaign-button">
-    {{#link-to 'authenticated.campaigns.new' class="button button--link"}}Créer une campagne{{/link-to}}
-  </div>
-</div>
-
-<div class="campaign-list">
+<div class="campaign-list" role="tabpanel">
   <div class="panel">
     <div class="table content-text content-text--small">
       <table>

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -23,7 +23,7 @@ module.exports = function(environment) {
     },
 
     googleFonts: [
-      'Roboto:300,400,700,900', // main font
+      'Roboto:300,400,500,700,900', // main font
       'Open+Sans:300,600',
     ],
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -61,4 +61,29 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       assert.equal(displayNoCampaignPanel, false);
     });
   });
+
+  module('isArchived', function() {
+    module('when status is archived', function() {
+      test('it should returns true', function(assert) {
+        const controller = this.owner.lookup('controller:authenticated/campaigns/list');
+        controller.set('status', 'archived');
+
+        const isArchived = controller.get('isArchived');
+
+        assert.equal(isArchived, true);
+      });
+    });
+
+    module('when status is not archived', function() {
+      test('it should returns false', function(assert) {
+        const controller = this.owner.lookup('controller:authenticated/campaigns/list');
+        controller.set('status', null);
+
+        const isArchived = controller.get('isArchived');
+
+        assert.equal(isArchived, false);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## 😋 : Problème
Actuellement, les utilisateurs de pix orga ont la possibilité d'archiver leur campagnes, mais ce nouveau statut n'est pas présent dans l'affichage de la liste, ce qui encombre l'interface.

## 🍰 : Solution
Rajout d'un filtre permettant de choisir les campagnes qui sont archivées de celles qui sont en cours de façon mutuellement exclusive.

