### PR TITLE
[FEATURE ] Ajouter un nouveau status de session de certif "PROCESSED" (PC-104)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/sessions/info/index.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/index.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { statusToDisplayName } from '../../../../../models/session';
 
 export default Controller.extend({
 
@@ -10,10 +8,6 @@ export default Controller.extend({
   notifications: service('notification-messages'),
 
   session: alias('model'),
-
-  sessionStatusLabel: computed('session.isFinalized', function() {
-    return this.session.isFinalized ? statusToDisplayName.finalized : statusToDisplayName.created;
-  }),
 
   actions: {
 

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,14 +1,15 @@
 import DS from 'ember-data';
 const { attr, hasMany, Model } = DS;
 import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
 import _ from 'lodash';
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const PROCESSED = 'processed';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [PROCESSED]: 'Traitée',
 };
 
 export default Model.extend({
@@ -22,8 +23,13 @@ export default Model.extend({
   accessCode: attr(),
   status: attr(),
   finalizedAt: attr(),
-  isFinalized: equal('status', 'finalized'),
   examinerGlobalComment: attr('string'),
+  displayStatus: computed('status', function() {
+    return statusToDisplayName[this.status];
+  }),
+  hasBeenFinalized: computed('status', function() {
+    return this.status === FINALIZED || this.status === PROCESSED;
+  }),
   certifications: hasMany('certification'),
   countExaminerComment : computed('certifications.[]', function() {
     return _.sumBy(

--- a/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/index.hbs
@@ -34,10 +34,10 @@
       </div>
       <div class='row'>
           <div class='col'>Statut :</div>
-          <div class='col' data-test-id='certifications-session-info__is-finalized'>{{sessionStatusLabel}}</div>
+          <div class='col' data-test-id='certifications-session-info__status'>{{session.displayStatus}}</div>
       </div>
 
-      {{#if session.isFinalized}}
+      {{#if session.hasBeenFinalized}}
       <div class='row'>
           <div class='col'>Date de finalisation :</div>
           <div class='col' data-test-id='certifications-session-info__finalized-at'>{{session.finalizationDate}}</div>
@@ -45,7 +45,7 @@
       {{/if}}
   </div>
 
-  {{#if session.isFinalized}}
+  {{#if session.hasBeenFinalized}}
   <div class="certifications-session-info__stats">
     <div class='row'>
         <div class='col'>Nombre de signalements :</div>

--- a/admin/tests/unit/models/session-test.js
+++ b/admin/tests/unit/models/session-test.js
@@ -1,14 +1,53 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { FINALIZED, CREATED, PROCESSED, statusToDisplayName } from 'pix-admin/models/session';
 
 module('Unit | Model | session', function(hooks) {
   setupTest(hooks);
-
   let store;
 
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
+  });
+
+  module('Given a status', function() {
+    let model1;
+    let model2;
+    let model3;
+
+    hooks.beforeEach(async function() {
+      model1 = run(() => store.createRecord('session', {
+        id: 123,
+        status: CREATED,
+      }));
+      model2 = run(() => store.createRecord('session', {
+        id: 1234,
+        status: FINALIZED,
+      }));
+      model3 = run(() => store.createRecord('session', {
+        id: 12345,
+        status: PROCESSED,
+      }));
+    });
+    
+    test('it should return the correct displayName', function(assert) {
+      assert.equal(model1.displayStatus, statusToDisplayName[CREATED]);
+      assert.equal(model2.displayStatus, statusToDisplayName[FINALIZED]);
+      assert.equal(model3.displayStatus, statusToDisplayName[PROCESSED]);
+    });
+
+    test('it should set hasBeenFinalized properly', function(assert) {
+      assert.equal(model1.hasBeenFinalized, false);
+      assert.equal(model2.hasBeenFinalized, true);
+      assert.equal(model3.hasBeenFinalized, true);
+    });
+  });
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const model = run(() => store.createRecord('session', {}));
+    assert.ok(model);
   });
 
   module('#countNotCheckedEndScreen', function() {
@@ -53,8 +92,6 @@ module('Unit | Model | session', function(hooks) {
       let sessionWithCertifications;
 
       hooks.beforeEach(async function() {
-        store = this.owner.lookup('service:store');
-
         sessionWithCertifications = run(() => {
           const certif1 = store.createRecord('certification', { hasSeenEndTestScreen: false });
           const certif2 = store.createRecord('certification', { hasSeenEndTestScreen: false });

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -1,9 +1,11 @@
 const CREATED = 'created';
 const FINALIZED = 'finalized';
+const PROCESSED = 'processed';
 
 const statuses = {
   CREATED,
   FINALIZED,
+  PROCESSED,
 };
 
 class Session {

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -8,9 +8,11 @@ const { Model, attr, belongsTo, hasMany } = DS;
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const PROCESSED = 'Traitée';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [PROCESSED]: 'Traitée',
 };
 
 export default class Session extends Model {

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -13,7 +13,7 @@ export default class AuthenticatedSessionsFinalizeRoute extends Route {
   }
 
   async afterModel(model, transition) {
-    if (model.isFinalized) {
+    if (model.hasBeenFinalized) {
       const { autoClear, clearDuration } = config.notifications;
       this.notifications.error('Cette session a déjà été finalisée.', { autoClear, clearDuration });
 

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -53,7 +53,7 @@
             Modifier
         </LinkTo>
       </div>
-      <div class="session-details-buttons session-details-buttons--push-right {{if this.session.isFinalized "button--disabled"}}">
+      <div class="session-details-buttons session-details-buttons--push-right {{if this.session.hasBeenFinalized "button--disabled"}}">
         <LinkTo @route="authenticated.sessions.finalize" @model={{this.session.id}} class="button button--regular button--link session-details-content__finalize-button push-right">
             Finaliser la session
         </LinkTo>
@@ -68,4 +68,3 @@
   </div>
 
 </div>
-

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -225,7 +225,7 @@ module('Acceptance | Session Details', function(hooks) {
         assert.equal(currentURL(), '/sessions/liste');
       });
 
-      module('when the session is not finalized', function() {
+      module('when the session has status started', function() {
 
         module('when the session has not CREATED', function() {
           test('it should not display the finalize button', async function(assert) {
@@ -253,35 +253,43 @@ module('Acceptance | Session Details', function(hooks) {
         });
       });
 
-      module('when the session is finalized', function() {
+      [
+        'finalized',
+        'processed',
+      ].forEach((status) => {
+        module(`when the session has status ${status}`, function() {
 
-        hooks.beforeEach(async function() {
-          const candidatesWithStartingCertif = server.createList('certification-candidate', 2, { isLinked: true });
-          sessionFinalized.update({ certificationCandidates: candidatesWithStartingCertif });
-        });
+          let session;
 
-        test('it should not redirect to finalize page on click on finalize button', async function(assert) {
-          // given
-          await visit(`/sessions/${sessionFinalized.id}`);
+          hooks.beforeEach(async function() {
+            session = server.create('session', { status });
+            const candidatesWithStartingCertif = server.createList('certification-candidate', 2, { isLinked: true });
+            session.update({ certificationCandidates: candidatesWithStartingCertif });
+          });
 
-          // when
-          await click('.session-details-content__finalize-button');
+          test('it should not redirect to finalize page on click on finalize button', async function(assert) {
+            // given
+            await visit(`/sessions/${session.id}`);
 
-          // then
-          assert.equal(currentURL(), `/sessions/${sessionFinalized.id}`);
-        });
+            // when
+            await click('.session-details-content__finalize-button');
 
-        test('it should throw an error on visiting /finalisation url', async function(assert) {
-          // given
-          await visit(`/sessions/${sessionFinalized.id}`);
-          const transitionError = new Error('TransitionAborted');
+            // then
+            assert.equal(currentURL(), `/sessions/${session.id}`);
+          });
 
-          // then
-          assert.rejects(
-            visit(`/sessions/${sessionFinalized.id}/finalisation`),
-            transitionError,
-            'error raised when visiting finalisation route'
-          );
+          test('it should throw an error on visiting /finalisation url', async function(assert) {
+            // given
+            await visit(`/sessions/${session.id}`);
+            const transitionError = new Error('TransitionAborted');
+
+            // then
+            assert.rejects(
+              visit(`/sessions/${session.id}/finalisation`),
+              transitionError,
+              'error raised when visiting finalisation route'
+            );
+          });
         });
       });
 

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -17,9 +17,34 @@ module('Unit | Model | session', function(hooks) {
       id: 1234,
       status: FINALIZED,
     }));
+    const model3 = run(() => store.createRecord('session', {
+      id: 12345,
+      status: 'processed',
+    }));
 
     assert.equal(model1.displayStatus, 'Créée');
     assert.equal(model2.displayStatus, 'Finalisée');
+    assert.equal(model3.displayStatus, 'Traitée');
+  });
+
+  test('it should set hasBeenFinalized properly', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model1 = run(() => store.createRecord('session', {
+      id: 1123,
+      status: 'started',
+    }));
+    const model2 = run(() => store.createRecord('session', {
+      id: 11234,
+      status: 'finalized',
+    }));
+    const model3 = run(() => store.createRecord('session', {
+      id: 112345,
+      status: 'processed',
+    }));
+
+    assert.equal(model1.hasBeenFinalized, false);
+    assert.equal(model2.hasBeenFinalized, true);
+    assert.equal(model3.hasBeenFinalized, true);
   });
 
   test('it should return the correct urlToUpload', function(assert) {


### PR DESCRIPTION
## ☕️: Contexte

Les sessions de certification ont 2 statuts: "CREATED" & "FINALIZED"

## :unicorn: Problème

Le pôle certif souhaite savoir quelles sessions ont été traitées (Les certifications sont toutes _VALIDATED_ ou _REJECTED_ puis publiées). Il manque un état des sessions après le statut _FINISHED_ pour lequel toutes les certifications d’une session sont publiées.
i.e. il n’y a plus d’action à effectuer sur la session, celle-ci peut être considérée comme terminée.

## :robot: Solution

Ajouter un statut _PROCESSED_  / "Résultats transmis par Pix"

## :rainbow: Remarques

- Ajout d'un script de mise à jour des données
- TODO verifier quand executer l'action (bouton _published_ globale et spécifique)
