### PR TITLE
[EXPEDITE][BUGFIX] Les écrans de fin de test issus de l'analyse du PV de session dans PixAdmin ne sont pas pris en compte (PA-158)

### DIFF
--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -59,7 +59,7 @@ export default Model.extend({
         this.set(attribute, certificationInReport[attribute].trim());
       }
     });
-
-    this.set('hasSeenEndTestScreen', this.hasSeenEndTestScreen && certificationInReport.hasSeenEndTestScreen);
+    
+    this.set('hasSeenEndTestScreen', certificationInReport.hasSeenEndTestScreen);
   },
 });


### PR DESCRIPTION
## :unicorn: Problème
Un petit cafouillage lors du merge de la https://github.com/1024pix/pix/pull/1057. 
Les écrans de fin de test n'étaient plus pris en compte lors de l'analyse du PV de session dans PixAdmin

## :robot: Solution
On en tient compte !

## :rainbow: Remarques
