### PR TITLE
[FEATURE] Distinguer les compétences non évaluées de celles échouées dans le fichier de résultats pour prescripteur (PA-160)

### DIFF
--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -88,8 +88,10 @@ function _buildSessionExportFileData(session) {
 
     const certificationIndexedCompetences = certification.indexedCompetences;
     competenceIndexes.forEach((competence) => {
-      if (!certificationIndexedCompetences[competence] || certificationIndexedCompetences[competence].level === 0 || certificationIndexedCompetences[competence].level === -1) {
+      if (!certificationIndexedCompetences[competence]) {
         rowItem[competence] = '-';
+      } else if (certificationIndexedCompetences[competence].level === 0 || certificationIndexedCompetences[competence].level === -1) {
+        rowItem[competence] = '0';
       } else {
         rowItem[competence] = certificationIndexedCompetences[competence].level;
       }

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -134,11 +134,11 @@ module('Unit | Service | session-info-service', function(hooks) {
       // then
       assert.equal(fileSaverStub.getContent(), '\uFEFF' +
         '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-        '"1";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"2";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"3";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"4";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"5";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";555;"Certification center";"20/07/2018"\n' +
+        '"1";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
+        '"2";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
+        '"3";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
+        '"4";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
+        '"5";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
         '');
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Des plaintes ont été remontées depuis les prescripteurs vers le pôle certif.
Comme on le sait, à l'issue d'un arbitrage d'une session de certification, le pôle certif génère, via PixAdmin, un fichier csv à destination du ou des prescripteurs de la session de certification qui contient les résultats.
Les résultats sont présentés comme suit : dans le fichier, nous avons une ligne par certification passée. Au sein d'une ligne, des colonnes contenant diverses informations sur la certif (identité du candidat par ex, etc), mais aussi le détail du niveau certifié par compétence du candidat.
En l'état, que la compétence soit échouée ou carrément pas du tout évaluée, elle est marquée avec un tiret : -
Or, les prescripteurs souhaiteraient avoir la distinction entre une compétence non-évaluée et une compétence échouée.

## :robot: Solution
On avait un gros if avec 3 opérandes pour mettre le tiret.
On divise ce if en deux avec d'abord :
- Si la compétence n'a pas été évaluée, on met un tiret
- Si la compétence a été échouée, on met un 0

## :rainbow: Remarques
