### PR TITLE
[TECH] Gestion des commentaires examinateurs et globaux vides et blancs (PC-130)

### DIFF
--- a/api/lib/domain/models/CertificationReport.js
+++ b/api/lib/domain/models/CertificationReport.js
@@ -56,7 +56,5 @@ class CertificationReport {
   }
 }
 
-module.exports = {
-  CertificationReport,
-  NO_EXAMINER_COMMENT,
-};
+module.exports = CertificationReport;
+module.exports.NO_EXAMINER_COMMENT = NO_EXAMINER_COMMENT;

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -8,6 +8,8 @@ const statuses = {
   FINALIZED,
 };
 
+const NO_EXAMINER_GLOBAL_COMMENT = null;
+
 class Session {
   constructor({
     id,
@@ -56,3 +58,4 @@ class Session {
 
 module.exports = Session;
 module.exports.statuses = statuses;
+module.exports.NO_EXAMINER_GLOBAL_COMMENT = NO_EXAMINER_GLOBAL_COMMENT;

--- a/api/lib/infrastructure/repositories/certification-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-report-repository.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const Bookshelf = require('../bookshelf');
-const { CertificationReport } = require('../../domain/models/CertificationReport');
+const CertificationReport = require('../../domain/models/CertificationReport');
 
 const CertificationCourseBookshelf = require('../data/certification-course');
 const bookshelfToDomainConverter = require('../../infrastructure/utils/bookshelf-to-domain-converter');

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -1,8 +1,4 @@
 const { Serializer } = require('jsonapi-serializer');
-const CertificationCourse = require('../../../domain/models/CertificationCourse');
-
-const { WrongDateFormatError } = require('../../../domain/errors');
-const { isValidDate } = require('../../utils/date-utils');
 
 module.exports = {
 
@@ -31,26 +27,5 @@ module.exports = {
         }
       },
     }).serialize(certificationCourse);
-  },
-
-  deserialize(json) {
-    if (!isValidDate(json.data.attributes.birthdate, 'YYYY-MM-DD')) {
-      throw new WrongDateFormatError();
-    }
-
-    return new CertificationCourse({
-      id: json.data.id,
-      createdAt: json.data.attributes.createdAt,
-      updatedAt: json.data.attributes.updatedAt,
-      userId: json.data.attributes.userId,
-      completedAt: json.data.attributes.completedAt,
-      firstName: json.data.attributes.firstName,
-      lastName: json.data.attributes.lastName,
-      birthdate: json.data.attributes.birthdate,
-      birthplace: json.data.attributes.birthplace,
-      isV2Certification: json.data.attributes.isV2Certification,
-      examinerComment: json.data.attributes.examinerComment,
-      hasSeenEndTestScreen: json.data.attributes.hasSeenEndTestScreen,
-    });
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
-const { CertificationReport, NO_EXAMINER_COMMENT } = require('../../../domain/models/CertificationReport');
+const CertificationReport = require('../../../domain/models/CertificationReport');
 
 module.exports = {
   serialize(certificationReports) {
@@ -21,7 +21,7 @@ module.exports = {
     const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
     const deserializedReport = await deserializer.deserialize(jsonApiData);
     if (_.isEmpty(_.trim(deserializedReport.examinerComment))) {
-      deserializedReport.examinerComment = NO_EXAMINER_COMMENT;
+      deserializedReport.examinerComment = CertificationReport.NO_EXAMINER_COMMENT;
     }
     return new CertificationReport(deserializedReport);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
@@ -1,6 +1,9 @@
+const _ = require('lodash');
+
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 const { WrongDateFormatError } = require('../../../domain/errors');
+const { NO_EXAMINER_COMMENT } = require('../../../domain/models/CertificationReport');
 const { isValidDate } = require('../../utils/date-utils');
 
 module.exports = {
@@ -68,6 +71,9 @@ module.exports = {
           if (!isValidDate(birthdate, 'YYYY-MM-DD')) {
             return Promise.reject(new WrongDateFormatError());
           }
+        }
+        if (_.isEmpty(_.trim(certifications.examinerComment))) {
+          certifications.examinerComment = NO_EXAMINER_COMMENT;
         }
         return certifications;
       }));

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -88,7 +88,7 @@ module.exports = {
 
     const certificationCenterId = _.get(json.data, ['relationships', 'certification-center', 'data', 'id']);
 
-    return new Session({
+    const result = new Session({
       id: json.data.id,
       certificationCenter: attributes['certification-center'],
       certificationCenterId: certificationCenterId ? parseInt(certificationCenterId) : null,
@@ -101,5 +101,11 @@ module.exports = {
       description: attributes.description,
       examinerGlobalComment: attributes['examiner-global-comment'],
     });
+
+    if (_.isEmpty(_.trim(result.examinerGlobalComment))) {
+      result.examinerGlobalComment = Session.NO_EXAMINER_GLOBAL_COMMENT;
+    }
+
+    return result;
   }
 };

--- a/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-reports_test.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
+const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
 
 describe('Acceptance | Controller | session-controller-get-certification-reports', () => {
 

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { databaseBuilder, expect, catchErr } = require('../../../test-helper');
-const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
+const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
 const certificationReportRepository = require('../../../../lib/infrastructure/repositories/certification-report-repository');
 const { CertificationCourseUpdateError } = require('../../../../lib/domain/errors');
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -11,7 +11,7 @@ chai.use(require('sinon-chai'));
 // Other
 const _ = require('lodash');
 
-const EMPTY_BLANK_OR_NULL = ['', '\t \n', null];
+const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
 
 afterEach(function() {
   sinon.restore();
@@ -164,7 +164,7 @@ function compareDatabaseObject(evaluatedObject, expectedObject) {
 }
 
 module.exports = {
-  EMPTY_BLANK_OR_NULL,
+  EMPTY_BLANK_AND_NULL,
   airtableBuilder,
   expect,
   domainBuilder: require('./tooling/domain-builder/factory'),

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -11,6 +11,8 @@ chai.use(require('sinon-chai'));
 // Other
 const _ = require('lodash');
 
+const EMPTY_BLANK_OR_NULL = ['', '\t \n', null];
+
 afterEach(function() {
   sinon.restore();
   return databaseBuilder.clean();
@@ -162,6 +164,7 @@ function compareDatabaseObject(evaluatedObject, expectedObject) {
 }
 
 module.exports = {
+  EMPTY_BLANK_OR_NULL,
   airtableBuilder,
   expect,
   domainBuilder: require('./tooling/domain-builder/factory'),

--- a/api/tests/tooling/database-builder/factory/build-certification-report.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-report.js
@@ -1,6 +1,6 @@
 const faker = require('faker');
 const buildCertificationCourse = require('./build-certification-course');
-const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
+const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
 const _ = require('lodash');
 
 module.exports = function buildCertificationReport({

--- a/api/tests/tooling/domain-builder/factory/build-certification-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-report.js
@@ -1,5 +1,5 @@
 const faker = require('faker');
-const { CertificationReport } = require('../../../../lib/domain/models/CertificationReport');
+const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
 
 module.exports = function buildCertificationReport(
   {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -59,8 +59,6 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
       expect(deserializedCertificationCandidate.extraTimePercentage).to.equal(certificationCandidate.extraTimePercentage);
       expect(deserializedCertificationCandidate.externalId).to.equal(certificationCandidate.externalId);
       expect(deserializedCertificationCandidate.email).to.equal(certificationCandidate.email);
-      expect(deserializedCertificationCandidate.hasSeenEndTestScreen).to.equal(certificationCandidate.hasSeenEndTestScreen);
-      expect(deserializedCertificationCandidate.examinerComment).to.equal(certificationCandidate.examinerComment);
     });
 
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, domainBuilder, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-report-serializer');
 const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
 
@@ -45,31 +45,18 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
     });
   });
 
-  it('should return no examiner comment for an undefined examiner comment', async function() {
-    // when
-    delete jsonApiData.data.attributes['examiner-comment'];
-    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+  EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
+    it(`should return no examiner comment if comment is ${examinerComment}`, async function() {
+      // given
+      jsonApiData.data.attributes['examiner-comment'] = examinerComment;
 
-    // then
-    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
-  });
+      // when
+      const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
 
-  it('should return no examiner comment for an empty examiner comment', async function() {
-    // when
-    jsonApiData.data.attributes['examiner-comment'] = '';
-    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
+      // then
+      expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
+    });
 
-    // then
-    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
-  });
-
-  it('should return no examiner comment for a blank examiner comment', async function() {
-    // when
-    jsonApiData.data.attributes['examiner-comment'] = '\t \n';
-    const deserializedCertificationReport = await serializer.deserialize(jsonApiData);
-
-    // then
-    expect(deserializedCertificationReport.examinerComment).to.equal(NO_EXAMINER_COMMENT);
   });
 
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, domainBuilder, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
+const { expect, domainBuilder, EMPTY_BLANK_AND_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-report-serializer');
 const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
 
@@ -45,7 +45,7 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
     });
   });
 
-  EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
+  EMPTY_BLANK_AND_NULL.forEach(function(examinerComment) {
     it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
       // given
       jsonApiData.data.attributes['examiner-comment'] = examinerComment;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-report-serializer_test.js
@@ -46,7 +46,7 @@ describe('Unit | Serializer | JSONAPI | certification-report-serializer', functi
   });
 
   EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
-    it(`should return no examiner comment if comment is ${examinerComment}`, async function() {
+    it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
       // given
       jsonApiData.data.attributes['examiner-comment'] = examinerComment;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -57,7 +57,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
     });
 
     EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
-      it(`should return no examiner comment if comment is ${examinerComment}`, async function() {
+      it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
         // given
         jsonCertificationCourse.data.attributes['examiner-comment'] = examinerComment;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -1,55 +1,71 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, domainBuilder, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-serializer');
 const { WrongDateFormatError } = require('../../../../../lib/domain/errors');
+const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
 
 describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
 
   describe('#deserialize', function() {
+    let jsonCertificationCourse;
+    let certificationCourseObject;
 
-    const jsonCertificationCourse = {
-      data: {
-        type: 'certifications',
-        id: 1,
-        attributes: {
-          'first-name': 'Freezer',
-          'last-name': 'The all mighty',
-          'birthplace': 'Namek',
-          'birthdate': '1989-10-24',
-          'external-id': 'xenoverse2',
+    beforeEach(function() {
+      jsonCertificationCourse = {
+        data: {
+          type: 'certifications',
+          id: 1,
+          attributes: {
+            'first-name': 'Freezer',
+            'last-name': 'The all mighty',
+            'birthplace': 'Namek',
+            'birthdate': '1989-10-24',
+            'external-id': 'xenoverse2',
+          },
         },
-      },
-    };
+      };
 
-    const certificationCourseObject = {
-      id: 1,
-      firstName: 'Freezer',
-      lastName: 'The all mighty',
-      birthplace: 'Namek',
-      birthdate: '1989-10-24',
-      externalId: 'xenoverse2',
-    };
+      certificationCourseObject = {
+        id: 1,
+        firstName: 'Freezer',
+        lastName: 'The all mighty',
+        birthplace: 'Namek',
+        birthdate: '1989-10-24',
+        externalId: 'xenoverse2',
+        examinerComment: null,
+      };
+    });
 
-    it('should convert a JSON API data into a Certification Course object', function() {
+    it('should convert a JSON API data into a Certification Course object', async function() {
       // when
-      const certificationCourse = serializer.deserialize(jsonCertificationCourse);
+      const result = await serializer.deserialize(jsonCertificationCourse);
 
       // then
-
-      return certificationCourse.then((result) => {
-        expect(result).to.deep.equal(certificationCourseObject);
-      });
+      expect(result).to.deep.equal(certificationCourseObject);
     });
 
     it('should return an error if date is in wrong format', function() {
-      // when
+      // given
       jsonCertificationCourse.data.attributes.birthdate = '2015-32-12';
 
-      // given
+      // when
       const promise = serializer.deserialize(jsonCertificationCourse);
 
       // then
       return promise.catch(() => {
         expect(promise).to.be.rejectedWith(WrongDateFormatError);
+      });
+    });
+
+    EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
+      it(`should return no examiner comment if comment is ${examinerComment}`, async function() {
+        // given
+        jsonCertificationCourse.data.attributes['examiner-comment'] = examinerComment;
+
+        // when
+        const result = await serializer.deserialize(jsonCertificationCourse);
+
+        // then
+        expect(result.examinerComment).to.equal(NO_EXAMINER_COMMENT);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, domainBuilder, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
+const { expect, domainBuilder, EMPTY_BLANK_AND_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-serializer');
 const { WrongDateFormatError } = require('../../../../../lib/domain/errors');
 const { NO_EXAMINER_COMMENT } = require('../../../../../lib/domain/models/CertificationReport');
@@ -56,7 +56,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
       });
     });
 
-    EMPTY_BLANK_OR_NULL.forEach(function(examinerComment) {
+    EMPTY_BLANK_AND_NULL.forEach(function(examinerComment) {
       it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
         // given
         jsonCertificationCourse.data.attributes['examiner-comment'] = examinerComment;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../../test-helper');
+const { expect, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 
 const Session = require('../../../../../lib/domain/models/Session');
@@ -77,6 +77,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       // then
       expect(json).to.deep.equal(jsonApiSession);
     });
+
   });
 
   describe('#deserialize()', function() {
@@ -107,6 +108,19 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       expect(session.time).to.equal('14:30');
       expect(session.description).to.equal('');
       expect(session.examinerGlobalComment).to.equal('It was a fine session my dear');
+    });
+
+    EMPTY_BLANK_OR_NULL.forEach((examinerGlobalComment) => {
+      it(`should return no examiner comment if comment is ${examinerGlobalComment}`, () => {
+        // given
+        jsonApiSession.data.attributes['examiner-global-comment'] = examinerGlobalComment;
+
+        // when
+        const result = serializer.deserialize(jsonApiSession);
+
+        // then
+        expect(result.examinerGlobalComment).to.deep.equal(Session.NO_EXAMINER_GLOBAL_COMMENT);
+      });
     });
 
     context('when there is no certification center ID', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -111,7 +111,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
     });
 
     EMPTY_BLANK_OR_NULL.forEach((examinerGlobalComment) => {
-      it(`should return no examiner comment if comment is ${examinerGlobalComment}`, () => {
+      it(`should return no examiner comment if comment is "${examinerGlobalComment}"`, () => {
         // given
         jsonApiSession.data.attributes['examiner-global-comment'] = examinerGlobalComment;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, EMPTY_BLANK_OR_NULL } = require('../../../../test-helper');
+const { expect, EMPTY_BLANK_AND_NULL } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 
 const Session = require('../../../../../lib/domain/models/Session');
@@ -110,7 +110,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
       expect(session.examinerGlobalComment).to.equal('It was a fine session my dear');
     });
 
-    EMPTY_BLANK_OR_NULL.forEach((examinerGlobalComment) => {
+    EMPTY_BLANK_AND_NULL.forEach((examinerGlobalComment) => {
       it(`should return no examiner comment if comment is "${examinerGlobalComment}"`, () => {
         // given
         jsonApiSession.data.attributes['examiner-global-comment'] = examinerGlobalComment;

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -8,7 +8,7 @@ import config from '../../../config/environment';
 import { sumBy } from 'lodash';
 
 export default class AuthenticatedSessionsFinalizeController extends Controller {
-  
+
   @alias('model') session;
   @service notifications;
   @tracked isLoading;


### PR DESCRIPTION
## :unicorn: Problème

Suite au bug PC-129, on a détecté que permettre d'envoyer une chaîne vide dans le commentaire examinateur d'une certification causait une erreur de validation, et à cette occasion on s'est dit que traiter différemment une chaîne vide ou blanche (que des espaces) d'un `null` semble inutile et trompeur. On a donc implémenté un traitement commun de tout ces cas pour le commentaire examinateur des certification sur la page de finalisation de session.

Or il y a d'autres commentaires examinateurs. Il serait étrange qu'ils se comportent différemment.

## :robot: Solution

Par conséquent : ce ticket homogénéise les traitements de commentaires nuls, vides et blancs.
