### PR TITLE
[FEATURE] Afficher les méthodes de connexion des élèves (PO-320)

### DIFF
--- a/api/lib/domain/usecases/find-organization-students.js
+++ b/api/lib/domain/usecases/find-organization-students.js
@@ -3,7 +3,8 @@ module.exports = async function findOrganizationStudents({ organizationId, stude
   const students = await studentRepository.findByOrganizationId({ organizationId });
 
   for (const student of students) {
-    if (student.userId) {
+    const isUserReconcilied = student.userId;
+    if (isUserReconcilied) {
       const user = await userRepository.get(student.userId);
       student.username = user.username;
     }

--- a/api/lib/domain/usecases/find-organization-students.js
+++ b/api/lib/domain/usecases/find-organization-students.js
@@ -7,6 +7,8 @@ module.exports = async function findOrganizationStudents({ organizationId, stude
     if (isUserReconcilied) {
       const user = await userRepository.get(student.userId);
       student.username = user.username;
+      student.email = user.email;
+      student.isAuthenticatedFromGAR = (user.samlId) ? true : false;
     }
   }
 

--- a/api/lib/infrastructure/serializers/jsonapi/student-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(students) {
     return new Serializer('students', {
       attributes: [
-        'lastName', 'firstName', 'birthdate', 'username'
+        'lastName', 'firstName', 'birthdate', 'username', 'email', 'isAuthenticatedFromGAR',
       ],
     }).serialize(students);
   }

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -735,7 +735,7 @@ describe('Acceptance | Application | organization-controller', () => {
     let options;
 
     beforeEach(async () => {
-      user = databaseBuilder.factory.buildUser();
+      user = databaseBuilder.factory.buildUser({ samlId: '234' });
       organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
       await databaseBuilder.commit();
@@ -769,7 +769,9 @@ describe('Acceptance | Application | organization-controller', () => {
                 'last-name': student.lastName,
                 'first-name': student.firstName,
                 'birthdate': student.birthdate,
-                'username': user.username
+                'username': user.username,
+                'email': user.email,
+                'is-authenticated-from-gar': true,
               },
               'id': student.id.toString(),
               'type': 'students'

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -13,6 +13,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     sinon.stub(securityController, 'checkUserIsAdminInScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
     sinon.stub(securityController, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(securityController, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
+    sinon.stub(securityController, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
 
     sinon.stub(organizationController, 'create').returns('ok');
     sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
@@ -20,6 +21,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     sinon.stub(organizationController, 'importStudentsFromSIECLE').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
     sinon.stub(organizationController, 'findPendingInvitations').returns('ok');
+    sinon.stub(organizationController, 'findStudents').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -124,6 +126,22 @@ describe('Integration | Application | Organizations | Routes', () => {
       // then
       expect(response.statusCode).to.equal(200);
       expect(organizationController.findPendingInvitations).to.have.been.calledOnce;
+    });
+  });
+
+  describe('GET /api/organizations/:id/students', () => {
+
+    it('should call the organization controller to return students', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/organizations/:id/students';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(organizationController.findStudents).to.have.been.calledOnce;
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-organization-students_test.js
+++ b/api/tests/unit/domain/usecases/find-organization-students_test.js
@@ -3,14 +3,14 @@ const findOrganizationStudents = require('../../../../lib/domain/usecases/find-o
 
 describe('Unit | UseCase | find-organization-students', () => {
 
-  // given
-  const organizationId = 'organization id';
-  const userId = 'user id';
+  // Given
+  const organizationId = 1;
+  const userId = 2;
   const username = 'username';
   const user = { username };
 
-  const studentNotYetReconcilied = { id: 'non reconcilied' };
-  const studentReconcilied = { id: 'reconcilied', userId };
+  const studentNotYetReconcilied = { id: 3 };
+  const studentReconcilied = { id: 4, userId };
   const studentReconciliedWithUserInformations = { ...studentReconcilied, ...{ username }  };
 
   let res;
@@ -18,12 +18,12 @@ describe('Unit | UseCase | find-organization-students', () => {
   const userRepository = { get: sinon.stub().withArgs(userId).returns(user) };
   const studentRepository = { findByOrganizationId: sinon.stub().withArgs({ organizationId }).returns(students) };
 
-  beforeEach(async function() {
-    // when
+  // When
+  before(async function() {
     res = await findOrganizationStudents({ organizationId, studentRepository, userRepository });
   });
 
-  // THEN.... :)
+  // Then
   it('should fetch students matching organization', function() {
     expect(studentRepository.findByOrganizationId).to.have.been.calledWithExactly({ organizationId });
   });
@@ -32,7 +32,11 @@ describe('Unit | UseCase | find-organization-students', () => {
     expect(userRepository.get).to.have.been.calledWithExactly(studentReconcilied.userId);
   });
 
-  it('should return students', function() {
+  it('should not fetch the user if the student is not reconcilied', function() {
+    expect(userRepository.get).to.have.been.calledOnce;
+  });
+
+  it('should return reconcilied and not reconcilied students', function() {
     expect(res).to.deep.equal([studentNotYetReconcilied, studentReconciliedWithUserInformations ]);
   });
 

--- a/api/tests/unit/domain/usecases/find-organization-students_test.js
+++ b/api/tests/unit/domain/usecases/find-organization-students_test.js
@@ -7,14 +7,17 @@ describe('Unit | UseCase | find-organization-students', () => {
   const organizationId = 1;
   const userId = 2;
   const username = 'username';
-  const user = { username };
+  const email = 'email@example.net';
+  const samlId = 'samlId';
+  const isAuthenticatedFromGAR = true;
+  const user = { username, email , samlId };
 
   const studentNotYetReconcilied = { id: 3 };
   const studentReconcilied = { id: 4, userId };
-  const studentReconciliedWithUserInformations = { ...studentReconcilied, ...{ username }  };
+  const expectedReconciliedStudentFromGAR = { ...studentReconcilied, ...{ username, email, isAuthenticatedFromGAR } };
 
   let res;
-  const students = [studentNotYetReconcilied, studentReconcilied ];
+  const students = [studentNotYetReconcilied, studentReconcilied, ];
   const userRepository = { get: sinon.stub().withArgs(userId).returns(user) };
   const studentRepository = { findByOrganizationId: sinon.stub().withArgs({ organizationId }).returns(students) };
 
@@ -28,16 +31,35 @@ describe('Unit | UseCase | find-organization-students', () => {
     expect(studentRepository.findByOrganizationId).to.have.been.calledWithExactly({ organizationId });
   });
 
-  it('should fetch the user if the student is reconcilied', function() {
-    expect(userRepository.get).to.have.been.calledWithExactly(studentReconcilied.userId);
-  });
-
-  it('should not fetch the user if the student is not reconcilied', function() {
-    expect(userRepository.get).to.have.been.calledOnce;
-  });
-
   it('should return reconcilied and not reconcilied students', function() {
-    expect(res).to.deep.equal([studentNotYetReconcilied, studentReconciliedWithUserInformations ]);
+    expect(res).to.deep.equal([studentNotYetReconcilied, studentReconcilied]);
+  });
+
+  context('The student is reconcilied', () => {
+
+    it('should fetch the user if the student is reconcilied', function() {
+      expect(userRepository.get).to.have.been.calledWithExactly(studentReconcilied.userId);
+    });
+
+    it('should add user{username} to student if authenticated by username', function() {
+      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+    });
+
+    it('should add user{email} to student if authenticated by email', function() {
+      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+    });
+
+    it('should add user{isAuthenticatedFromGAR} to student if authenticated from GAR', function() {
+      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+    });
+
+  });
+
+  context('The student is not reconcilied yet', () => {
+
+    it('should not fetch the user if the student is not reconcilied', function() {
+      expect(userRepository.get).to.have.been.calledOnce;
+    });
   });
 
 });

--- a/api/tests/unit/domain/usecases/find-organization-students_test.js
+++ b/api/tests/unit/domain/usecases/find-organization-students_test.js
@@ -3,7 +3,6 @@ const findOrganizationStudents = require('../../../../lib/domain/usecases/find-o
 
 describe('Unit | UseCase | find-organization-students', () => {
 
-  // Given
   const organizationId = 1;
   const userId = 2;
   const username = 'username';
@@ -16,23 +15,21 @@ describe('Unit | UseCase | find-organization-students', () => {
   const studentReconcilied = { id: 4, userId };
   const expectedReconciliedStudentFromGAR = { ...studentReconcilied, ...{ username, email, isAuthenticatedFromGAR } };
 
-  let res;
+  let foundOrganizationStudents;
   const students = [studentNotYetReconcilied, studentReconcilied, ];
   const userRepository = { get: sinon.stub().withArgs(userId).returns(user) };
   const studentRepository = { findByOrganizationId: sinon.stub().withArgs({ organizationId }).returns(students) };
 
-  // When
   before(async function() {
-    res = await findOrganizationStudents({ organizationId, studentRepository, userRepository });
+    foundOrganizationStudents = await findOrganizationStudents({ organizationId, studentRepository, userRepository });
   });
 
-  // Then
   it('should fetch students matching organization', function() {
     expect(studentRepository.findByOrganizationId).to.have.been.calledWithExactly({ organizationId });
   });
 
   it('should return reconcilied and not reconcilied students', function() {
-    expect(res).to.deep.equal([studentNotYetReconcilied, studentReconcilied]);
+    expect(foundOrganizationStudents).to.deep.equal([studentNotYetReconcilied, studentReconcilied]);
   });
 
   context('The student is reconcilied', () => {
@@ -42,15 +39,15 @@ describe('Unit | UseCase | find-organization-students', () => {
     });
 
     it('should add user{username} to student if authenticated by username', function() {
-      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+      expect(foundOrganizationStudents).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
     });
 
     it('should add user{email} to student if authenticated by email', function() {
-      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+      expect(foundOrganizationStudents).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
     });
 
     it('should add user{isAuthenticatedFromGAR} to student if authenticated from GAR', function() {
-      expect(res).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
+      expect(foundOrganizationStudents).to.deep.equal([studentNotYetReconcilied, expectedReconciliedStudentFromGAR]);
     });
 
   });

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -1,5 +1,21 @@
 import DS from 'ember-data';
 import { notEmpty } from '@ember/object/computed';
+import { computed } from '@ember/object';
+
+const StudentAuthMethod = {
+  studentNotReconcilied: {
+    message: '-',
+  },
+  hasEmail: {
+    message: 'Adresse e-mail'
+  },
+  isAuthenticatedFromGar: {
+    message: 'Mediacentre'
+  },
+  hasUsername: {
+    message: 'Identifiant'
+  },
+};
 
 export default DS.Model.extend({
   lastName: DS.attr('string'),
@@ -7,6 +23,23 @@ export default DS.Model.extend({
   birthdate: DS.attr('date-only'),
   organization: DS.belongsTo('organization'),
   username: DS.attr('string'),
-
+  email: DS.attr('string'),
+  isAuthenticatedFromGar: DS.attr('boolean'),
   hasUsername: notEmpty('username'),
+  hasEmail: notEmpty('email'),
+  authenticationMethods : computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar', function() {
+
+    const SPACING_CHARACTER = ' ';
+    let message = '';
+    const props = ['hasEmail', 'hasUsername', 'isAuthenticatedFromGar'];
+
+    props.forEach((prop) => {
+      if (this[prop]) {
+        message = message.concat(StudentAuthMethod[prop].message, SPACING_CHARACTER);
+      }
+    });
+
+    return message ?  message.trim() : StudentAuthMethod['studentNotReconcilied'].message;
+
+  }),
 });

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -2,9 +2,11 @@ import DS from 'ember-data';
 import { notEmpty } from '@ember/object/computed';
 import { computed } from '@ember/object';
 
+const dash = '\u2013';
+
 const StudentAuthMethod = {
   studentNotReconcilied: {
-    message: '-',
+    message: dash,
   },
   hasEmail: {
     message: 'Adresse e-mail'
@@ -29,7 +31,7 @@ export default DS.Model.extend({
   hasEmail: notEmpty('email'),
   authenticationMethods : computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar', function() {
 
-    const SPACING_CHARACTER = ' ';
+    const SPACING_CHARACTER = '\n';
     let message = '';
     const props = ['hasEmail', 'hasUsername', 'isAuthenticatedFromGar'];
 

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -13,4 +13,8 @@
     margin-top: 20px;
     margin-left: auto;
   }
+
+  .authentication-methods {
+    white-space: pre;
+  }
 }

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -17,6 +17,7 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>Date de naissance</th>
+        <th>Connecté avec</th>
         <th>Mot de passe</th>
       </tr>
       </thead>
@@ -28,6 +29,7 @@
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
+            <td>{{student.authenticationMethods}}</td>
             <td>
               {{#if student.hasUsername}}
                 <button class="button button--with-icon-and-text button-edit-role"

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -29,7 +29,7 @@
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td>{{student.authenticationMethods}}</td>
+            <td class="authentication-methods">{{student.authenticationMethods}}</td>
             <td>
               {{#if student.hasUsername}}
                 <button class="button button--with-icon-and-text button-edit-role"

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -102,7 +102,20 @@ module('Acceptance | Student List', function(hooks) {
         await visit('/eleves');
 
         // then
+        assert.dom('.table thead th').exists({ count: 5 });
         assert.dom('.table tbody tr').exists({ count: 6 });
+      });
+
+      test('it should display headers labels', async function(assert) {
+        // when
+        await visit('/eleves');
+
+        // then
+        assert.dom('.table thead th:nth-child(1)').hasText('Nom');
+        assert.dom('.table thead th:nth-child(2)').hasText('Prénom');
+        assert.dom('.table thead th:nth-child(3)').hasText('Date de naissance');
+        assert.dom('.table thead th:nth-child(4)').hasText('Connecté avec');
+        assert.dom('.table thead th:nth-child(5)').hasText('Mot de passe');
       });
 
       module('when student have a username', async function() {

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -16,10 +16,11 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
 
     // then
-    assert.dom('.table thead tr th').exists({ count: 4 });
+    assert.dom('.table thead tr th').exists({ count: 5 });
     assert.dom('.table thead tr th:first-child').hasText('Nom');
     assert.dom('.table thead tr th:nth-child(2)').hasText('Prénom');
     assert.dom('.table thead tr th:nth-child(3)').hasText('Date de naissance');
+    assert.dom('.table thead tr th:nth-child(4)').hasText('Connecté avec');
     assert.dom('.table thead tr th:last-child').hasText('Mot de passe');
   });
 
@@ -43,7 +44,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
   test('it should display the firstName, lastName and birthdate of student', async function(assert) {
     // given
     const students = [
-      { lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },
+      { lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') ,  },
       { lastName: 'L\'asticot', firstName: 'Gogo', birthdate: new Date('2010-05-10') },
     ];
 
@@ -58,6 +59,64 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/02/2010');
   });
 
+  module('it should display the authentication method', ()=> {
+
+    test('it should display - not reconcilied', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const storedStudents = [];
+      [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          birthdate: '2010-01-01',
+        },
+      ].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
+
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+
+      // then
+      assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
+      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
+      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/01/2010');
+      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText('-');
+    });
+    test('it should display Identifiant when identified by username', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const storedStudents = [];
+      [
+        {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          birthdate: '2010-01-01',
+          username: 'blueivy.carter0701',
+          isAuthenticatedFromGar: false,
+        },
+      ].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
+
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+
+      // then
+      assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
+      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
+      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/01/2010');
+      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText('Identifiant');
+    });
+
+  });
   module('when student have a username', () => {
 
     test('it should display the student\'s firstName, lastName and birthdate, and password update button', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -61,9 +61,10 @@ module('Integration | Component | routes/authenticated/students | list-items', f
 
   module('it should display the authentication method', ()=> {
 
-    test('it should display - not reconcilied', async function(assert) {
+    test('it should display dash when not reconcilied', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
+      const dash = '\u2013';
 
       const storedStudents = [];
       [
@@ -85,7 +86,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
       assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
       assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/01/2010');
-      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText('-');
+      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText(dash);
     });
     test('it should display Identifiant when identified by username', async function(assert) {
       // given

--- a/orga/tests/unit/models/student-test.js
+++ b/orga/tests/unit/models/student-test.js
@@ -18,15 +18,16 @@ module('Unit | Model | student', function(hooks) {
   module('#authenticationMethods', function() {
 
     module('when not reconcilied', function() {
-      test('it should return -', function(assert) {
+      test('it should return dash', function(assert) {
         // given
+        const dash = '\u2013';
         const store = this.owner.lookup('service:store');
         const student = { lastName: 'Last', firstName: 'First', birthdate: '2010-10-10' };
         const model = run(() => store.createRecord('student', student));
 
         // when
         // then
-        assert.equal(model.authenticationMethods, '-');
+        assert.equal(model.authenticationMethods, dash);
       });
     });
 
@@ -84,6 +85,7 @@ module('Unit | Model | student', function(hooks) {
 
         test('it should return 2 aggregated methods, excluding GAR', function(assert) {
           // given
+          const SPACING_CHARACTER = '\n';
           const store = this.owner.lookup('service:store');
           const student = {
             lastName: 'Carter',
@@ -97,7 +99,7 @@ module('Unit | Model | student', function(hooks) {
 
           // when
           // then
-          assert.equal(model.authenticationMethods, 'Adresse e-mail Identifiant');
+          assert.equal(model.authenticationMethods, 'Adresse e-mail' + SPACING_CHARACTER + 'Identifiant');
         });
       });
 

--- a/orga/tests/unit/models/student-test.js
+++ b/orga/tests/unit/models/student-test.js
@@ -5,7 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Model | student', function(hooks) {
 
   setupTest(hooks);
-
   test('it exists', function(assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -15,6 +14,94 @@ module('Unit | Model | student', function(hooks) {
 
     // then
     assert.ok(model);
+  });
+  module('#authenticationMethods', function() {
+
+    module('when not reconcilied', function() {
+      test('it should return -', function(assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const student = { lastName: 'Last', firstName: 'First', birthdate: '2010-10-10' };
+        const model = run(() => store.createRecord('student', student));
+
+        // when
+        // then
+        assert.equal(model.authenticationMethods, '-');
+      });
+    });
+
+    module('when reconcilied', function() {
+
+      module('single authentication method', function() {
+        test('it should return Identifiant when identified by username', function(assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const student = {
+            lastName: 'Carter',
+            firstName: 'Blue Ivy',
+            birthdate: '2012-01-07',
+            username: 'blueivy.carter0701',
+          };
+          const model = run(() => store.createRecord('student', student));
+
+          // when
+          // then
+          assert.equal(model.authenticationMethods, 'Identifiant');
+        });
+        test('it should return Adresse e-mail when identified by email', function(assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const student = {
+            lastName: 'De Cambridge',
+            firstName: 'George',
+            birthdate: '2013-07-22',
+            email: 'georges.decambridge@example.net'
+          };
+          const model = run(() => store.createRecord('student', student));
+
+          // when
+          // then
+          assert.equal(model.authenticationMethods, 'Adresse e-mail');
+        });
+        test('it should return Mediacentre when identified from GAR', function(assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const student = {
+            lastName: 'De Cambridge',
+            firstName: 'George',
+            birthdate: '2013-07-22',
+            isAuthenticatedFromGar: true
+          };
+          const model = run(() => store.createRecord('student', student));
+
+          // when
+          // then
+          assert.equal(model.authenticationMethods, 'Mediacentre');
+        });
+      });
+
+      module('multiple authentication method', function() {
+
+        test('it should return 2 aggregated methods, excluding GAR', function(assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const student = {
+            lastName: 'Carter',
+            firstName: 'Blue Ivy',
+            birthdate: '2012-01-07',
+            username: 'blueivy.carter0701',
+            email: 'carter.blueivy@example.net',
+            isAuthenticatedFromGar: false,
+          };
+          const model = run(() => store.createRecord('student', student));
+
+          // when
+          // then
+          assert.equal(model.authenticationMethods, 'Adresse e-mail Identifiant');
+        });
+      });
+
+    });
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Les enseignants ne savent pas si les élèves se sont réconciliés avec leur compte GAR, leur adresse email ou leur identifiant. Ils sont donc très limités pour les aider à se connecter une fois la première connexion est faite. On veut donc leur donner davantage d'infos pour les aider.

## :robot: Solution

Afficher la méthode de connexion pour chaque élève. Pour préparer l'arrivée de la réinitialisation, l'email complet sera exposé par l'API : GET /organizations/{id}/students.

## :rainbow: Remarques
Cette feature inclus un enrichissement de cas de test sur le use-case utilisé par la route.
