### PR TITLE
[TECH] Démocratisation du code HTTP 404 quand il est impossible de récupérer une ressource : routes answers (PF-1131)

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -16,7 +16,7 @@ module.exports = {
 
   async get(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const answerId = parseInt(request.params.id);
+    const answerId = request.params.id;
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);

--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -41,9 +41,10 @@ module.exports = {
 
   async getCorrection(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
+    const answerId = request.params.id;
 
     const correction = await usecases.getCorrectionForAnswer({
-      answerId: parseInt(request.params.id),
+      answerId,
       userId
     });
 

--- a/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
@@ -1,7 +1,3 @@
-const {
-  ForbiddenAccess
-} = require('../errors');
-
 module.exports = async function findAnswerByChallengeAndAssessment(
   {
     challengeId,
@@ -10,12 +6,14 @@ module.exports = async function findAnswerByChallengeAndAssessment(
     answerRepository,
     assessmentRepository,
   } = {}) {
-  const assessment = await assessmentRepository.get(assessmentId);
-  if (assessment.userId !== userId) {
-    throw new ForbiddenAccess('User is not allowed to see this assessment.');
+  const integerAssessmentId = parseInt(assessmentId);
+  if (!Number.isFinite(integerAssessmentId)) {
+    return null;
   }
 
-  const answer = await answerRepository.findByChallengeAndAssessment({ challengeId, assessmentId });
-
-  return answer;
+  const assessment = await assessmentRepository.get(assessmentId);
+  if (assessment.userId !== userId) {
+    return null;
+  }
+  return answerRepository.findByChallengeAndAssessment({ challengeId, assessmentId: integerAssessmentId });
 };

--- a/api/lib/domain/usecases/get-answer.js
+++ b/api/lib/domain/usecases/get-answer.js
@@ -1,5 +1,5 @@
 const {
-  ForbiddenAccess
+  NotFoundError,
 } = require('../errors');
 
 module.exports = async function getAnswer(
@@ -9,11 +9,14 @@ module.exports = async function getAnswer(
     answerRepository,
     assessmentRepository,
   } = {}) {
-
-  const answer = await answerRepository.get(answerId);
+  const integerAnswerId = parseInt(answerId);
+  if (!Number.isFinite(integerAnswerId)) {
+    throw new NotFoundError(`Not found answer for ID ${answerId}`);
+  }
+  const answer = await answerRepository.get(integerAnswerId);
   const assessment = await assessmentRepository.get(answer.assessmentId);
   if (assessment.userId !== userId) {
-    throw new ForbiddenAccess('User is not allowed to get this answer.');
+    throw new NotFoundError(`Not found answer for ID ${integerAnswerId}`);
   }
   return answer;
 };

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -1,7 +1,7 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | answer-controller', () => {
+describe('Acceptance | Controller | answer-controller-find', () => {
 
   describe('GET /api/answers?challengeId=Y&assessmentId=Z', () => {
 
@@ -11,7 +11,39 @@ describe('Acceptance | Controller | answer-controller', () => {
     let answer;
     const challengeId = 'recLt9uwa2dR3IYpi';
 
+    context('when the assessmentid passed in query param is not an integer', () => {
+
+      beforeEach(async () => {
+        server = await createServer();
+        userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        options = {
+          method: 'GET',
+          url: `/api/answers?challenge=${challengeId}&assessment=salut`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return no answer', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.result.data).to.be.null;
+      });
+
+    });
+
     context('when the assessment has an userId (is not a demo or preview)', () => {
+
       beforeEach(async () => {
         server = await createServer();
         userId = databaseBuilder.factory.buildUser().id;
@@ -25,44 +57,40 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 200 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return application/json', () => {
+      it('should return application/json', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          const contentType = response.headers['content-type'];
-          expect(contentType).to.contain('application/json');
-        });
+        const contentType = response.headers['content-type'];
+        expect(contentType).to.contain('application/json');
       });
 
-      it('should return required answer', () => {
+      it('should return required answer', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          const answerReceived = response.result.data;
-          expect(answerReceived.id).to.equal(answer.id.toString());
-          expect(answerReceived.attributes.value.toString()).to.equal(answer.value.toString());
-          expect(answerReceived.attributes.result.toString()).to.equal(answer.result.toString());
-          expect(answerReceived.relationships.assessment.data.id.toString()).to.equal(answer.assessmentId.toString());
-          expect(answerReceived.relationships.challenge.data.id.toString()).to.equal(answer.challengeId.toString());
-        });
+        const answerReceived = response.result.data;
+        expect(answerReceived.id).to.equal(answer.id.toString());
+        expect(answerReceived.attributes.value.toString()).to.equal(answer.value.toString());
+        expect(answerReceived.attributes.result.toString()).to.equal(answer.result.toString());
+        expect(answerReceived.relationships.assessment.data.id.toString()).to.equal(answer.assessmentId.toString());
+        expect(answerReceived.relationships.challenge.data.id.toString()).to.equal(answer.challengeId.toString());
       });
 
     });
+    
     context('when the assessment has an userId but the user is not the relevant user', () => {
+      
       beforeEach(async () => {
         server = await createServer();
         userId = databaseBuilder.factory.buildUser().id;
@@ -76,18 +104,25 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 403 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
-        });
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return no answer', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.result.data).to.be.null;
       });
     });
 
     context('when the assessment is demo and there is no userId', () => {
+      
       beforeEach(async () => {
         server = await createServer();
         const assessment = databaseBuilder.factory.buildAssessment({ userId: null, type: 'DEMO' });
@@ -99,14 +134,12 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 200 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
     });
   });

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -110,7 +110,7 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       expect(response.result).to.deep.equal(expectedBody);
     });
 
-    it('should return 403 when user does not has access to this answer', async () => {
+    it('should return 404 when user does not has access to this answer', async () => {
       // given
       const options = {
         method: 'GET',
@@ -122,7 +122,22 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(403);
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return 404 when the answer id provided is not an integer', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/answers/coucou/correction',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
     });
   });
 });

--- a/api/tests/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get_test.js
@@ -1,7 +1,7 @@
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | answer-controller', () => {
+describe('Acceptance | Controller | answer-controller-get', () => {
 
   describe('GET /api/answers/:id', () => {
 
@@ -24,43 +24,58 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 200 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return application/json', () => {
+      it('should return application/json', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          const contentType = response.headers['content-type'];
-          expect(contentType).to.contain('application/json');
-        });
+        const contentType = response.headers['content-type'];
+        expect(contentType).to.contain('application/json');
       });
 
-      it('should return required answer', () => {
+      it('should return required answer', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          const answerReceived = response.result.data;
-          expect(answerReceived.id).to.equal(answer.id.toString());
-          expect(answerReceived.attributes.value.toString()).to.equal(answer.value.toString());
-          expect(answerReceived.attributes.result.toString()).to.equal(answer.result.toString());
-          expect(answerReceived.relationships.assessment.data.id.toString()).to.equal(answer.assessmentId.toString());
-          expect(answerReceived.relationships.challenge.data.id.toString()).to.equal(answer.challengeId.toString());
-        });
+        const answerReceived = response.result.data;
+        expect(answerReceived.id).to.equal(answer.id.toString());
+        expect(answerReceived.attributes.value.toString()).to.equal(answer.value.toString());
+        expect(answerReceived.attributes.result.toString()).to.equal(answer.result.toString());
+        expect(answerReceived.relationships.assessment.data.id.toString()).to.equal(answer.assessmentId.toString());
+        expect(answerReceived.relationships.challenge.data.id.toString()).to.equal(answer.challengeId.toString());
       });
-
     });
+
+    context('when the id of the answer is not an integer', () => {
+      beforeEach(async () => {
+        server = await createServer();
+        userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        options = {
+          method: 'GET',
+          url: '/api/answers/salut',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId + 1) },
+        };
+      });
+
+      it('should return 404 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
     context('when the assessment has an userId but the user is not the relevant user', () => {
       beforeEach(async () => {
         server = await createServer();
@@ -75,13 +90,13 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 403 HTTP status code', () => {
+      it('should return 404 HTTP status code', () => {
         // when
         const promise = server.inject(options);
 
         // given
         return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
+          expect(response.statusCode).to.equal(404);
         });
       });
     });
@@ -98,14 +113,12 @@ describe('Acceptance | Controller | answer-controller', () => {
         };
       });
 
-      it('should return 200 HTTP status code', () => {
+      it('should return 200 HTTP status code', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // given
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
     });
   });

--- a/api/tests/acceptance/application/answers/answer-controller-update_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-update_test.js
@@ -1,7 +1,7 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | answer-controller', () => {
+describe('Acceptance | Controller | answer-controller-update', () => {
 
   describe('PATCH /api/answers/:id', () => {
 

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -31,12 +31,12 @@ describe('Integration | Repository | AnswerRepository', () => {
 
     context('when there are no answers', () => {
 
-      it('should reject an error if nothing is found', () => {
+      it('should reject an error if nothing is found', async () => {
         // when
-        const promise = AnswerRepository.get(100);
+        const error = await catchErr(AnswerRepository.get)(100);
 
         // then
-        return expect(promise).to.be.rejectedWith(NotFoundError);
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
 
@@ -48,15 +48,13 @@ describe('Integration | Repository | AnswerRepository', () => {
         return databaseBuilder.commit();
       });
 
-      it('should retrieve an answer from its id', () => {
+      it('should retrieve an answer from its id', async () => {
         // when
-        const promise = AnswerRepository.get(answerId);
+        const foundAnswer = await AnswerRepository.get(answerId);
 
         // then
-        return promise.then((foundAnswer) => {
-          expect(foundAnswer).to.be.an.instanceof(Answer);
-          expect(foundAnswer.id).to.equal(answerId);
-        });
+        expect(foundAnswer).to.be.an.instanceof(Answer);
+        expect(foundAnswer.id).to.equal(answerId);
       });
     });
   });
@@ -72,19 +70,17 @@ describe('Integration | Repository | AnswerRepository', () => {
       return databaseBuilder.commit();
     });
 
-    it('should find the answer by challenge and assessment and return its in an object', () => {
+    it('should find the answer by challenge and assessment and return its in an object', async () => {
       // when
-      const promise = AnswerRepository.findByChallengeAndAssessment({
+      const foundAnswers = await AnswerRepository.findByChallengeAndAssessment({
         challengeId,
         assessmentId
       });
 
       // then
-      return promise.then((foundAnswers) => {
-        expect(foundAnswers).to.exist;
-        expect(foundAnswers).to.be.an.instanceOf(Answer);
-        expect(foundAnswers.value).to.equal('answer value');
-      });
+      expect(foundAnswers).to.exist;
+      expect(foundAnswers).to.be.an.instanceOf(Answer);
+      expect(foundAnswers.value).to.equal('answer value');
     });
   });
 
@@ -177,27 +173,23 @@ describe('Integration | Repository | AnswerRepository', () => {
       return databaseBuilder.commit();
     });
 
-    it('should resolves answers with assessment id provided', () => {
+    it('should resolves answers with assessment id provided', async () => {
       // when
-      const promise = AnswerRepository.findByAssessment(assessmentId);
+      const answers = await AnswerRepository.findByAssessment(assessmentId);
 
       // then
-      return promise.then((answers) => {
-        expect(answers.length).to.be.equal(2);
-        expect(answers[0].assessmentId).to.be.equal(assessmentId);
-        expect(answers[1].assessmentId).to.be.equal(assessmentId);
-      });
+      expect(answers.length).to.be.equal(2);
+      expect(answers[0].assessmentId).to.be.equal(assessmentId);
+      expect(answers[1].assessmentId).to.be.equal(assessmentId);
     });
 
-    it('should return answers as domain objects', () => {
+    it('should return answers as domain objects', async () => {
       // when
-      const promise = AnswerRepository.findByAssessment(assessmentId);
+      const answers = await AnswerRepository.findByAssessment(assessmentId);
 
       // then
-      return promise.then((answers) => {
-        expect(answers[0]).to.be.instanceof(Answer);
-        expect(answers[1]).to.be.instanceof(Answer);
-      });
+      expect(answers[0]).to.be.instanceof(Answer);
+      expect(answers[1]).to.be.instanceof(Answer);
     });
   });
 
@@ -214,16 +206,14 @@ describe('Integration | Repository | AnswerRepository', () => {
       return databaseBuilder.commit();
     });
 
-    it('should resolves the last answers with assessment id provided', () => {
+    it('should resolves the last answers with assessment id provided', async () => {
       // when
-      const promise = AnswerRepository.findLastByAssessment(assessmentId);
+      const answer = await AnswerRepository.findLastByAssessment(assessmentId);
 
       // then
-      return promise.then((answer) => {
-        expect(answer).to.be.instanceof(Answer);
-        expect(answer.assessmentId).to.be.equal(assessmentId);
-        expect(answer.id).to.be.equal(expectedAnswerId);
-      });
+      expect(answer).to.be.instanceof(Answer);
+      expect(answer.assessmentId).to.be.equal(assessmentId);
+      expect(answer.id).to.be.equal(expectedAnswerId);
     });
   });
 
@@ -238,25 +228,23 @@ describe('Integration | Repository | AnswerRepository', () => {
       return databaseBuilder.commit();
     });
 
-    it('should retrieve answers with ok status from assessment id provided', () => {
+    it('should retrieve answers with ok status from assessment id provided', async () => {
       // given
       const expectedStatus = {
         status: 'ok'
       };
 
       // when
-      const promise = AnswerRepository.findCorrectAnswersByAssessmentId(assessmentId);
+      const answers = await AnswerRepository.findCorrectAnswersByAssessmentId(assessmentId);
 
       // then
-      return promise.then((answers) => {
-        expect(answers).to.exist;
-        expect(answers).to.have.length.of(1);
+      expect(answers).to.exist;
+      expect(answers).to.have.length.of(1);
 
-        const foundAnswer = answers[0];
+      const foundAnswer = answers[0];
 
-        expect(foundAnswer.assessmentId).to.be.equal(assessmentId);
-        expect(foundAnswer.result).to.deep.equal(expectedStatus);
-      });
+      expect(foundAnswer.assessmentId).to.be.equal(assessmentId);
+      expect(foundAnswer.result).to.deep.equal(expectedStatus);
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-answer-by-challenge-and-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-answer-by-challenge-and-assessment_test.js
@@ -1,11 +1,10 @@
 const { expect, sinon } = require('../../../test-helper');
 const findAnswerByChallengeAndAssessment = require('../../../../lib/domain/usecases/find-answer-by-challenge-and-assessment');
-const { ForbiddenAccess } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
 
   const challengeId = 'recChallenge';
-  const assessmentId = 'assessmentId';
+  const assessmentId = 123;
   const answerId = 'answerId';
   const userId = 'userId';
   let answerRepository, assessmentRepository;
@@ -17,7 +16,7 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
       challengeId
     };
     const assessment = {
-      id: challengeId,
+      id: assessmentId,
       userId: userId,
     };
 
@@ -33,27 +32,34 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
     assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
   });
 
-  context('when user asked for answer is the user of the assessment', () => {
-    it('should get the answer', () => {
-
+  context('when the assessmentid passed is not an integer', () => {
+    it('should get the answer', async () => {
       // when
-      const result = findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId, answerRepository, assessmentRepository });
+      const result = await findAnswerByChallengeAndAssessment({ challengeId, assessmentId: 'salut', userId, answerRepository, assessmentRepository });
 
       // then
-      return result.then((resultAnswer) => {
-        expect(resultAnswer.id).to.equal(answerId);
-      });
+      return expect(result).to.be.null;
+    });
+  });
+
+  context('when user asked for answer is the user of the assessment', () => {
+    it('should get the answer', async () => {
+
+      // when
+      const resultAnswer = await findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId, answerRepository, assessmentRepository });
+
+      // then
+      expect(resultAnswer.id).to.equal(answerId);
     });
   });
 
   context('when user asked for answer is not the user of the assessment', () => {
-    it('should throw a Forbidden Access error', () => {
-
+    it('should return null', async () => {
       // when
-      const result = findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId: userId + 1 , answerRepository, assessmentRepository });
+      const result = await findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId: userId + 1 , answerRepository, assessmentRepository });
 
       // then
-      return expect(result).to.be.rejectedWith(ForbiddenAccess);
+      return expect(result).to.be.null;
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-answer_test.js
@@ -1,12 +1,13 @@
 const { expect, sinon } = require('../../../test-helper');
 const getAnswer = require('../../../../lib/domain/usecases/get-answer');
-const { ForbiddenAccess } = require('../../../../lib/domain/errors');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-answer', () => {
 
   const answerId = 1;
   const userId = 'userId';
-  let answerRepository, assessmentRepository;
+  let answerRepository;
+  let assessmentRepository;
 
   beforeEach(() => {
     const answer = {
@@ -44,13 +45,24 @@ describe('Unit | UseCase | get-answer', () => {
   });
 
   context('when user asked for answer is not the user of the assessment', () => {
-    it('should throw a Forbidden Access error', () => {
+    it('should throw a Not Found error', () => {
 
       // when
       const result = getAnswer({ answerId, userId: userId + 1 , answerRepository, assessmentRepository });
 
       // then
-      return expect(result).to.be.rejectedWith(ForbiddenAccess);
+      return expect(result).to.be.rejectedWith(NotFoundError);
+    });
+  });
+
+  context('when the answer id provided is not an integer', () => {
+    it('should throw a Not Found error', () => {
+
+      // when
+      const result = getAnswer({ answerId: 'salut', userId: userId + 1 , answerRepository, assessmentRepository });
+
+      // then
+      return expect(result).to.be.rejectedWith(NotFoundError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Là où tout a commencé.... https://github.com/1024pix/pix/pull/1062
Suite aux discussions amenées par ce ticket, il semblerait qu'une convention puisse s'en dégager.
Dans la base de code côté API, jusqu'à présent, nous jetions un code statut HTTP en accord avec l'erreur rencontrée pendant le traitement de la requête. Par exemple, si un utilisateur demande une ressource pour laquelle il n'est pas le propriétaire, on jette habituellement 403. Si une erreur se produit pendant la validation des paramètres d'entrée c'est 401, si la ressource n'est pas trouvée c'est 404, etc...
Or, on s'aperçoit que cette stratégie permet à un utilisateur mal-intentionné de crawler des informations utiles sur les ressources. Exemple :  en tant qu'utilisateur cherchant à obtenir des informations sur les données, je teste des requêtes du style` GET /api/answers/<id>`.
J'obtiens des 404 en boucle, jusqu'à obtenir une 403. Je peux donc en conclure que la ressource existe bien....

## :robot: Solution
Nous souhaitons rester opaque sur l'avancée du traitement des requêtes de la catégorie de la récupération de ressources identifiées. NOUS NE PARLONS PAS ICI D'INSERTION OU DE MISE 0 JOUR, SEULEMENT DE LECTURE.
On peut suggérer la convention suivante :
**_Dans le cas de lecture d'une ressource identifiée, on s'efforce de toujours jeter 404 afin de ne pas livrer trop d'informations. Dans le cas particulier d'une lecture de type find (à savoir où le résultat peut-être vide), nous renverrons 200 assorti d'un payload vide._**

Dans cette PR, nous appliquons cette convention dans un premier temps pour les routes `/api/answers/...`

## :rainbow: Remarques
Au fil de la revue, vous apercevrez sur votre droite un toilettage async/await sur certains fichiers.