### PR TITLE
[FEATURE] Changer le design du bouton "Retour à la liste" sur la page certificat (PF-1051).

### DIFF
--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -90,26 +90,6 @@
   }
 }
 
-.scorecard-details-header {
-  &__return-button {
-    color: $black;
-    font-size: 1.3rem;
-    font-weight: $font-semi-bold;
-    letter-spacing: 0.03rem;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  &__return-button:hover {
-    text-decoration: none;
-    color: $black;
-
-    > .scorecard-details-header-return-button__icon {
-      background-color: $alto-grey;
-    }
-  }
-}
-
 .scorecard-details-content {
   &__left {
     display: flex;
@@ -208,12 +188,6 @@
     margin-left: 60px;
     text-transform: uppercase;
     color: $grayish-grey;
-  }
-}
-
-.scorecard-details-header-return-button {
-  &__icon {
-    margin-right: 8px;
   }
 }
 

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -187,4 +187,26 @@
   &--grey {
     color: $dove-gray;
   }
+
+  &__return-to {
+    color: $black;
+    font-size: 1.3rem;
+    font-weight: $font-semi-bold;
+    letter-spacing: 0.03rem;
+    display: inline-flex;
+    align-items: center;
+
+    .icon-button {
+      margin-right: 8px;
+    }
+
+    &:hover {
+      text-decoration: none;
+      color: $black;
+
+      .icon-button {
+        background-color: $alto-grey;
+      }
+    }
+  }
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -83,11 +83,8 @@
 
   &__error {
     color: $pure-orange;
-    font-size: 1.5rem;
-    padding: 4px 10px;
-
-    @include device-is('tablet') {
-      padding: 0;
-    }
+    font-size: 1.4rem;
+    padding: 16px 10px;
+    text-align: center;
   }
 }

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -6,9 +6,6 @@
   }
 }
 
-.user-certifications-page-get_link-to {
-  display: inline-block;
-  padding: 20px 0;
-  font-size: 1.5rem;
-  color: $pix-blue;
+.user-certifications-page-get__link-return-to {
+  padding-top: 14px;
 }

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -1,6 +1,6 @@
 <div class="scorecard-details__header">
-  <LinkTo @route="profile" class="scorecard-details-header__return-button">
-    <span class="icon-button scorecard-details-header-return-button__icon">
+  <LinkTo @route="profile" class="link__return-to">
+    <span class="icon-button">
       {{fa-icon 'arrow-left'}}
     </span>
     Retour Profil

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -1,6 +1,9 @@
 <div class="user-certifications-page-get__top-bar">
-  <LinkTo @route="user-certifications" class="user-certifications-page-get_link-to">
-    ‹‹ Retour à la liste
+  <LinkTo @route="user-certifications" class="link__return-to user-certifications-page-get__link-return-to">
+    <span class="icon-button">
+      {{fa-icon 'arrow-left'}}
+    </span>
+    Retour à la liste
   </LinkTo>
 </div>
 

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -57,7 +57,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
       await visitWithAbortedTransition(`/competences/${scorecardWithPoints.description}/details`);
 
       // when
-      await click('.scorecard-details-header__return-button');
+      await click('.link__return-to');
 
       // then
       expect(currentURL()).to.equal('/profil');

--- a/mon-pix/tests/acceptance/competences-results-test.js
+++ b/mon-pix/tests/acceptance/competences-results-test.js
@@ -42,8 +42,8 @@ describe('Acceptance | competences results', function() {
       await visitWithAbortedTransition(`/competences/${competenceId}/resultats/${assessmentId}`);
 
       // then
-      expect(find('.scorecard-details-header__return-button')).to.exist;
-      expect(find('.scorecard-details-header__return-button').getAttribute('href')).to.equal('/profil');
+      expect(find('.link__return-to')).to.exist;
+      expect(find('.link__return-to').getAttribute('href')).to.equal('/profil');
     });
 
     context('When user obtained 0 pix', async function() {


### PR DESCRIPTION
## :unicorn: Problème
- Les liens "retour vers une page" ne sont pas uniformisé sur l'application mon-pix. Ca n'aide pas l'utilisateur à se repérer et comprendre la logique du site.
- Les erreurs qui s'affichent lorsqu'on rentre un code de parcours ne sont pas super lisible (car il y a peu de marge entre le champ d'entrée et le bouton pour passer à la suite).

## :robot: Solution
- Uniformiser le bouton "Retour à la liste" (visible dans le détail d'une certification) avec le style du "Retour profil" (visible lorsqu'on clique sur un domaine).
**AVANT** 
<img width="345" alt="image" src="https://user-images.githubusercontent.com/38167520/75452422-9342e500-5972-11ea-946b-c8f16f8f690e.png">

**APRES** 
<img width="345" alt="image" src="https://user-images.githubusercontent.com/38167520/75452397-858d5f80-5972-11ea-8b47-d2c35984af48.png">

##
- Rajouter un espace lorsqu'un message d'erreur s'affiche lorsqu'on rentre un code de parcours.
**AVANT**
<img width="345" alt="image" src="https://user-images.githubusercontent.com/38167520/75452601-e5840600-5972-11ea-9995-1258978537bc.png">

**APRES** 
<img width="345" alt="image" src="https://user-images.githubusercontent.com/38167520/75452640-f3398b80-5972-11ea-8adf-73b98f2efeb3.png">


## :rainbow: Remarques
Le bouton "Commencer mon parcours" descend légèrement quand une erreur apparaît. 
C'est déjà le cas sur d'autres pages de l'application et ce comportement est souhaité.
