### PR TITLE
[FEATURE] Gestion des caractères à risque lors des exports CSV dans Pix Orga - nom des acquis (PO-332).

### DIFF
--- a/api/lib/domain/services/csv-service.js
+++ b/api/lib/domain/services/csv-service.js
@@ -1,0 +1,14 @@
+module.exports = {
+
+  sanitize(data) {
+    const specialCharacters = ['@', '-', '+', '='];
+    let result = data;
+
+    if (typeof result === 'string' && specialCharacters.includes(result[0])) {
+      result = '\'' + result;
+    }
+
+    return result;
+  }
+
+};

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -3,6 +3,7 @@ const moment = require('moment');
 const bluebird = require('bluebird');
 
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignWithoutOrganizationError } = require('../errors');
+const csvService = require('../services/csv-service');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   if (_.isNil(organizationId)) {
@@ -45,7 +46,7 @@ function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
     { title: 'Nom du Participant', property: 'participantLastName' },
     { title: 'Prénom du Participant', property: 'participantFirstName' },
 
-    ...(idPixLabel ? [ { title: idPixLabel, property: 'participantExternalId' } ] : []),
+    ...(idPixLabel ? [ { title: csvService.sanitize(idPixLabel), property: 'participantExternalId' } ] : []),
 
     { title: '% de progression', property: 'percentageProgression' },
     { title: 'Date de début', property: 'createdAt' },
@@ -65,7 +66,7 @@ function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
       { title: `Acquis maitrisés du domaine ${area.title}`, property: `area_${area.id}_validatedSkillCount` },
     ])),
 
-    ...(_.map(skills, (skill) => ({ title: `${skill.name}`, property: `skill_${skill.id}` }))),
+    ...(_.map(skills, (skill) => ({ title: csvService.sanitize(skill.name), property: `skill_${skill.id}` }))),
   ];
 }
 

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -177,7 +177,26 @@ describe('Acceptance | API | Campaign Controller', () => {
         url
       };
 
-      const expectedCsv = `\uFEFF"Nom de l'organisation";"ID Campagne";"Nom de la campagne";"Nom du Profil Cible";"Nom du Participant";"Prénom du Participant";"${campaign.idPixLabel}";"% de progression";"Date de début";"Partage (O/N)";"Date du partage";"% maitrise de l'ensemble des acquis du profil";"% de maitrise des acquis de la compétence Liberticide";"Nombre d'acquis du profil cible dans la compétence Liberticide";"Acquis maitrisés dans la compétence Liberticide";"% de maitrise des acquis du domaine Information et données";"Nombre d'acquis du profil cible du domaine Information et données";"Acquis maitrisés du domaine Information et données";"@accesDonnées1"\n` +
+      const expectedCsv = '\uFEFF"Nom de l\'organisation";' +
+        '"ID Campagne";' +
+        '"Nom de la campagne";' +
+        '"Nom du Profil Cible";' +
+        '"Nom du Participant";' +
+        '"Prénom du Participant";' +
+        `"${campaign.idPixLabel}";` +
+        '"% de progression";' +
+        '"Date de début";' +
+        '"Partage (O/N)";' +
+        '"Date du partage";' +
+        '"% maitrise de l\'ensemble des acquis du profil";' +
+        '"% de maitrise des acquis de la compétence Liberticide";' +
+        '"Nombre d\'acquis du profil cible dans la compétence Liberticide";' +
+        '"Acquis maitrisés dans la compétence Liberticide";' +
+        '"% de maitrise des acquis du domaine Information et données";' +
+        '"Nombre d\'acquis du profil cible du domaine Information et données";' +
+        '"Acquis maitrisés du domaine Information et données";' +
+        '"\'@accesDonnées1"' +
+        '\n' +
         `"${organization.name}";${campaign.id};"${campaign.name}";"${targetProfile.name}";"${user.lastName}";"${user.firstName}";"${externalId}";0;${participationStartDate};"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"\n`;
 
       // when

--- a/api/tests/unit/domain/services/csv-service_test.js
+++ b/api/tests/unit/domain/services/csv-service_test.js
@@ -1,0 +1,100 @@
+const { expect } = require('../../../test-helper');
+const service = require('../../../../lib/domain/services/csv-service');
+
+describe('Unit | Service | csv-service', function() {
+
+  describe('#sanitize', () => {
+
+    context('when the string is clean', () => {
+
+      it('should return the string when string is empty', () => {
+        // given
+        const emptyString = '';
+
+        // when
+        const sanitizedString = service.sanitize(emptyString);
+
+        // then
+        expect(sanitizedString).to.equal(emptyString);
+      });
+
+      it('should return the string when it doesn\'t start with an illegal character', () => {
+        // given
+        const expectedString = 'clean string';
+
+        // when
+        const sanitizedString = service.sanitize(expectedString);
+
+        // then
+        expect(sanitizedString).to.equal(expectedString);
+      });
+
+    });
+
+    context('when the string starts with an illegal character', () => {
+
+      it('should sanitize when starts with @', () => {
+        // given
+        const uncleanString = '@unclean string';
+        const expectedString = '\'@unclean string';
+
+        // when
+        const sanitizedString = service.sanitize(uncleanString);
+
+        // then
+        expect(sanitizedString).to.equal(expectedString);
+      });
+
+      it('should sanitize when starts with -', () => {
+        // given
+        const uncleanString = '-unclean string';
+        const expectedString = '\'-unclean string';
+
+        // when
+        const sanitizedString = service.sanitize(uncleanString);
+
+        // then
+        expect(sanitizedString).to.equal(expectedString);
+      });
+
+      it('should sanitize when starts with =', () => {
+        // given
+        const uncleanString = '=unclean string';
+        const expectedString = '\'=unclean string';
+
+        // when
+        const sanitizedString = service.sanitize(uncleanString);
+
+        // then
+        expect(sanitizedString).to.equal(expectedString);
+      });
+
+      it('should sanitize when starts with +', () => {
+        // given
+        const uncleanString = '+unclean string';
+        const expectedString = '\'+unclean string';
+
+        // when
+        const sanitizedString = service.sanitize(uncleanString);
+
+        // then
+        expect(sanitizedString).to.equal(expectedString);
+      });
+    });
+
+    context('when the value is not a string', () => {
+
+      it('should return the same value', () => {
+        // given
+        const originalValue = new Date();
+
+        // when
+        const result = service.sanitize(originalValue);
+
+        // then
+        expect(result).to.equal(originalValue);
+      });
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -12,9 +12,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
     const user = domainBuilder.buildUser();
     const organization = user.memberships[0].organization;
-    const listSkills = domainBuilder.buildSkillCollection({ name: 'web', minLevel: 1, maxLevel: 5 });
+    const listSkills = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
     listSkills.forEach((skill) => { skill.competenceId = 'recCompetence1'; });
-    const listSkillsNotInTargetProfile = domainBuilder.buildSkillCollection({ name: 'url', minLevel: 1, maxLevel: 2 });
+    const listSkillsNotInTargetProfile = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
     const [skillWeb1, skillWeb2, skillWeb3, skillWeb4, skillWeb5] = listSkills;
     const [skillUrl1, skillUrl2] = listSkillsNotInTargetProfile;
     const knowledgeElements = [
@@ -141,11 +141,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
         '"% de maitrise des acquis du domaine Domain 1";' +
         '"Nombre d\'acquis du profil cible du domaine Domain 1";' +
         '"Acquis maitrisés du domaine Domain 1";' +
-        '"web1";' +
-        '"web2";' +
-        '"web3";' +
-        '"web4";' +
-        '"web5"\n';
+        '"\'@web1";' +
+        '"\'@web2";' +
+        '"\'@web3";' +
+        '"\'@web4";' +
+        '"\'@web5"\n';
       findResultDataByCampaignIdStub.resolves([]);
 
       // when
@@ -336,11 +336,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           '"% de maitrise des acquis du domaine Domain 1";' +
           '"Nombre d\'acquis du profil cible du domaine Domain 1";' +
           '"Acquis maitrisés du domaine Domain 1";' +
-          '"web1";' +
-          '"web2";' +
-          '"web3";' +
-          '"web4";' +
-          '"web5"';
+          '"\'@web1";' +
+          '"\'@web2";' +
+          '"\'@web3";' +
+          '"\'@web4";' +
+          '"\'@web5"';
 
         // when
         startWritingCampaignResultsToStream({


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'export csv des résultats d'une campagne, si le nom des acquis commence par un '@' il sera mal retranscrit dans un tableur.

## :robot: Solution
Echapper les chaines de caractères commençant par les symboles =, -, +, ou @
avec le caractère " **'** "