### PR TITLE
[FEATURE] Pouvoir changer d'organisation courante dans Pix Orga (PO-237). 

### DIFF
--- a/api/db/migrations/20200303140224_add_columns_createdAt_and_updatedAt_to_user_orga_settings.js
+++ b/api/db/migrations/20200303140224_add_columns_createdAt_and_updatedAt_to_user_orga_settings.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'user-orga-settings';
+const CREATED_AT_COLUMN = 'createdAt';
+const UPDATED_AT_COLUMN = 'updatedAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(CREATED_AT_COLUMN).notNullable().defaultTo(knex.fn.now());
+    table.dateTime(UPDATED_AT_COLUMN).notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(UPDATED_AT_COLUMN);
+    table.dropColumn(CREATED_AT_COLUMN);
+  });
+};
+

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -31,7 +31,37 @@ exports.register = async function(server) {
         },
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Création des paramètres utilisateurs liées à Pix Orga\n' +
+          '- Création des paramètres utilisateurs liés à Pix Orga\n' +
+          '- L’id dans le payload doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user-orga-settings']
+      }
+
+    },
+    {
+      method: 'PATCH',
+      path: '/api/user-orga-settings/{id}',
+      config: {
+        handler: userOrgaSettingsController.update,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              relationships: {
+                organization: {
+                  data: {
+                    id: Joi.number().required(),
+                  }
+                }
+              }
+            }
+          })
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Mise à jour des paramètres utilisateurs liés à Pix Orga\n' +
           '- L’id dans le payload doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api', 'user-orga-settings']

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -18,7 +18,12 @@ module.exports = {
     return h.response(userOrgaSettingsSerializer.serialize(result)).created();
   },
 
-  update() {
-    // not yet implemented
+  async update(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+    const organizationId = request.payload.data.relationships.organization.data.id;
+
+    const result = await usecases.updateUserOrgaSettings({ userId: authenticatedUserId, organizationId });
+
+    return userOrgaSettingsSerializer.serialize(result);
   }
 };

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -16,5 +16,9 @@ module.exports = {
     const result = await usecases.createUserOrgaSettings({ userId, organizationId });
 
     return h.response(userOrgaSettingsSerializer.serialize(result)).created();
+  },
+
+  update() {
+    // not yet implemented
   }
 };

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -112,7 +112,7 @@ exports.register = async function(server) {
           '- Récupération des paramètres utilisateurs relatives à Pix Orga\n' +
           '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
-        tags: ['api', 'user', 'userOrgaSettings']
+        tags: ['api', 'user', 'user-orga-settings']
       }
     },
     {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -332,6 +332,12 @@ class UserOrgaSettingsCreationError extends DomainError {
   }
 }
 
+class UserNotMemberOfOrganizationError extends DomainError {
+  constructor(message = 'L\'utilisateur n\'est pas membre de l\'organisation.') {
+    super(message);
+  }
+}
+
 class FileValidationError extends DomainError {
   constructor(message = 'Erreur, fichier non valide.') {
     super(message);
@@ -509,6 +515,7 @@ module.exports = {
   UserNotAuthorizedToUpdateResourceError,
   UserNotAuthorizedToUpdateStudentPasswordError,
   UserNotFoundError,
-  UserOrgaSettingsCreationError,
   WrongDateFormatError,
+  UserOrgaSettingsCreationError,
+  UserNotMemberOfOrganizationError,
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -155,5 +155,6 @@ module.exports = injectDependencies({
   updateOrganizationInformation: require('./update-organization-information'),
   updateSession: require('./update-session'),
   updateStudentDependentUserPassword: require('./update-student-dependent-user-password'),
-  updateUserPassword: require('./update-user-password'),
+  updateUserOrgaSettings: require('./update-user-orga-settings'),
+  updateUserPassword: require('./update-user-password')
 });

--- a/api/lib/domain/usecases/update-user-orga-settings.js
+++ b/api/lib/domain/usecases/update-user-orga-settings.js
@@ -1,0 +1,17 @@
+const { UserNotMemberOfOrganizationError } = require('../errors');
+const _ = require('lodash');
+
+module.exports = async function updateUserOrgaSettings(
+  { userId,
+    organizationId,
+    userOrgaSettingsRepository,
+    membershipRepository
+  }) {
+  const memberships = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId });
+
+  if (_.isEmpty(memberships)) {
+    throw new UserNotMemberOfOrganizationError(`L'utilisateur ${userId} n'est pas membre de l'organisation ${organizationId}.`);
+  }
+
+  return userOrgaSettingsRepository.update(userId, organizationId);
+};

--- a/api/lib/infrastructure/data/user-orga-settings.js
+++ b/api/lib/infrastructure/data/user-orga-settings.js
@@ -6,6 +6,7 @@ require('./organization');
 module.exports = Bookshelf.model('UserOrgaSettings', {
 
   tableName: 'user-orga-settings',
+  hasTimestamps: ['createdAt', 'updatedAt'],
 
   user() {
     return this.belongsTo('User', 'userId');

--- a/api/lib/infrastructure/repositories/user-orga-settings-repository.js
+++ b/api/lib/infrastructure/repositories/user-orga-settings-repository.js
@@ -16,5 +16,13 @@ module.exports = {
         }
         throw err;
       });
+  },
+
+  update(userId, organizationId) {
+    return BookshelfUserOrgaSettings
+      .where({ userId })
+      .save({ currentOrganizationId: organizationId }, { patch: true, method: 'update' })
+      .then((bookshelfUserOrgaSettings) => bookshelfUserOrgaSettings.refresh({ withRelated: ['user', 'currentOrganization'] }))
+      .then((userOrgaSettings) => bookshelfToDomainConverter.buildDomainObject(BookshelfUserOrgaSettings, userOrgaSettings));
   }
 };

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -152,6 +152,9 @@ function _mapToInfrastructureError(error) {
   if (error instanceof DomainErrors.UserOrgaSettingsCreationError) {
     return new InfraErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotMemberOfOrganizationError) {
+    return new InfraErrors.UnprocessableEntityError(error.message);
+  }
 
   return new InfraErrors.InfrastructureError(error.message);
 }

--- a/api/tests/acceptance/application/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings-controller_test.js
@@ -115,4 +115,77 @@ describe('Acceptance | Controller | user-orga-settings-controller', () => {
       });
     });
   });
+
+  describe('PATCH /api/user-orga-settings/{id}', () => {
+
+    let expectedOrganizationId;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      const actualOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      expectedOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId: actualOrganizationId, organizationRole: 'MEMBER' });
+      databaseBuilder.factory.buildMembership({ userId, organizationId: expectedOrganizationId, organizationRole: 'MEMBER' });
+      databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: actualOrganizationId });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'PATCH',
+        url: '/api/user-orga-settings/{id}',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: expectedOrganizationId,
+                  type: 'organizations'
+                }
+              }
+            }
+          }
+        }
+      };
+    });
+
+    describe('Resource access management', () => {
+
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+    });
+
+    describe('Success case', () => {
+
+      it('should update and return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('Error case', () => {
+
+      it('should respond with a 422 HTTP status code - if user is not member of organization', async () => {
+        // given
+        options.payload.data.relationships.organization.data.id = 12345;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -3,15 +3,22 @@ const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings
 const BookshelfUserOrgaSettings = require('../../../../lib/infrastructure/data/user-orga-settings');
 const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
 const { UserOrgaSettingsCreationError } = require('../../../../lib/domain/errors');
+const _ = require('lodash');
 
 describe('Integration | Repository | UserOrgaSettings', function() {
 
-  let userId;
-  let organizationId;
+  const USER_OMITTED_PROPERTIES = ['campaignParticipations', 'certificationCenterMemberships', 'knowledgeElements',
+    'memberships', 'pixRoles', 'pixScore', 'samlId', 'scorecards', 'userOrgaSettings'];
+
+  const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares',
+    'createdAt', 'updatedAt'];
+
+  let user;
+  let organization;
 
   beforeEach(async () => {
-    userId = databaseBuilder.factory.buildUser().id;
-    organizationId = databaseBuilder.factory.buildOrganization().id;
+    user = databaseBuilder.factory.buildUser();
+    organization = databaseBuilder.factory.buildOrganization();
     await databaseBuilder.commit();
   });
 
@@ -23,7 +30,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
 
     it('should return an UserOrgaSettings domain object', async () => {
       // when
-      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(userId, organizationId);
+      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(user.id, organization.id);
 
       // then
       expect(userOrgaSettingsSaved).to.be.an.instanceof(UserOrgaSettings);
@@ -34,7 +41,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
       const nbBeforeCreation = await BookshelfUserOrgaSettings.count();
 
       // when
-      await userOrgaSettingsRepository.create(userId, organizationId);
+      await userOrgaSettingsRepository.create(user.id, organization.id);
 
       // then
       const nbAfterCreation = await BookshelfUserOrgaSettings.count();
@@ -43,25 +50,46 @@ describe('Integration | Repository | UserOrgaSettings', function() {
 
     it('should save model properties', async () => {
       // when
-      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(userId, organizationId);
+      const userOrgaSettingsSaved = await userOrgaSettingsRepository.create(user.id, organization.id);
 
       // then
       expect(userOrgaSettingsSaved.id).to.not.be.undefined;
-      expect(userOrgaSettingsSaved.user.id).to.equal(userId);
-      expect(userOrgaSettingsSaved.currentOrganization.id).to.equal(organizationId);
+      expect(_.omit(userOrgaSettingsSaved.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.omit(userOrgaSettingsSaved.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(organization, ORGANIZATION_OMITTED_PROPERTIES));
     });
 
     it('should throw a UserOrgaSettingsCreationError when userOrgaSettings already exist', async () => {
       // given
-      databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
+      databaseBuilder.factory.buildUserOrgaSettings({ userId: user.id, currentOrganizationId: organization.id });
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(userOrgaSettingsRepository.create)(userId, organizationId);
+      const error = await catchErr(userOrgaSettingsRepository.create)(user.id, organization.id);
 
       // then
       expect(error).to.be.instanceOf(UserOrgaSettingsCreationError);
     });
   });
 
+  describe('#update', () => {
+
+    let userOrgaSettingsId;
+    let expectedOrganization;
+
+    beforeEach(async () => {
+      userOrgaSettingsId = databaseBuilder.factory.buildUserOrgaSettings({ userId: user.id, currentOrganizationId: organization.id }).id;
+      expectedOrganization = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+    });
+
+    it('should return the updated userOrgaSettings', async () => {
+      // when
+      const updatedUserOrgaSettings = await userOrgaSettingsRepository.update(user.id, expectedOrganization.id);
+
+      // then
+      expect(updatedUserOrgaSettings.id).to.deep.equal(userOrgaSettingsId);
+      expect(_.omit(updatedUserOrgaSettings.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.omit(updatedUserOrgaSettings.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(expectedOrganization, ORGANIZATION_OMITTED_PROPERTIES));
+    });
+  });
 });

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -9,6 +9,7 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
   beforeEach(() => {
     sinon.stub(userOrgaSettingsController, 'create').returns('ok');
+    sinon.stub(userOrgaSettingsController, 'update').returns('ok');
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -87,4 +88,73 @@ describe('Unit | Router | user-orga-settings-router', () => {
 
   });
 
+  describe('PATCH /api/user-orga-settings/{id}', () => {
+
+    let method;
+    let url;
+    let payload;
+
+    beforeEach(() => {
+      method = 'PATCH';
+      url = '/api/user-orga-settings/{id}';
+      payload = {
+        data: {
+          relationships: {
+            organization: {
+              data: {
+                id: 1,
+                type: 'organizations'
+              }
+            }
+          }
+        }
+      };
+    });
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    describe('Payload schema validation', () => {
+
+      it('should be mandatory', async () => {
+        // given
+        payload = undefined;
+
+        // when
+        const result = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should contain relationships.organization.data.id', async () => {
+        // given
+        payload.data.relationships.organization.data.id = undefined;
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should contain relationships.organization.data.id as number', async () => {
+        // given
+        payload.data.relationships.organization.data = { id: 'test' };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+    });
+
+  });
 });

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -92,4 +92,76 @@ describe('Unit | Controller | user-orga-settings-controller', () => {
       });
     });
   });
+
+  describe('#update', () => {
+
+    const userId = 7;
+    const organizationId = 2;
+    const request = {
+      auth: { credentials: { userId } },
+      payload: {
+        data: {
+          relationships: {
+            organization: {
+              data: {
+                id: organizationId,
+                type: 'organizations'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const serializedUseOrgaSettings = {
+      data: {
+        type: 'user-orga-settings',
+        id: 1,
+        attributes: {},
+        relationships: {
+          organization: {
+            data: {
+              type: 'organizations',
+              id: organizationId,
+            },
+          },
+          user: {
+            data: {
+              type: 'users',
+              id: userId,
+            },
+          },
+        },
+      },
+    };
+
+    let expectedUserOrgaSettings;
+    let response;
+
+    beforeEach(async () => {
+      sinon.stub(usecases, 'updateUserOrgaSettings');
+      sinon.stub(userOrgaSettingsSerializer, 'serialize');
+
+      expectedUserOrgaSettings = { id: 1, user: { id: userId }, organization: { id: organizationId } };
+      usecases.updateUserOrgaSettings.resolves(expectedUserOrgaSettings);
+      userOrgaSettingsSerializer.serialize.resolves(serializedUseOrgaSettings);
+
+      response = await userOrgaSettingsController.update(request);
+    });
+
+    it('should call the usecase to update the userOrgaSetting', async () => {
+      // then
+      expect(usecases.updateUserOrgaSettings).to.have.been.calledWith({ userId, organizationId });
+    });
+
+    it('should serialize the userOrgaSettings', () => {
+      // then
+      expect(userOrgaSettingsSerializer.serialize).to.have.been.calledWith(expectedUserOrgaSettings);
+    });
+
+    it('should return the serialized userOrgaSettings', () => {
+      // then
+      expect(response).to.deep.equal(serializedUseOrgaSettings);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/update-user-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/update-user-orga-settings_test.js
@@ -1,0 +1,39 @@
+const updateUserOrgaSettings = require('../../../../lib/domain/usecases/update-user-orga-settings');
+const { expect, catchErr, sinon } = require('../../../test-helper');
+const { UserNotMemberOfOrganizationError } = require('../../../../lib/domain/errors');
+const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+
+describe('Unit | UseCase | update-user-orga-settings', () => {
+
+  const userId = 1;
+  const organizationId = 3;
+
+  beforeEach(() => {
+    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    sinon.stub(userOrgaSettingsRepository, 'update');
+  });
+
+  it('should update the user orga settings', async () => {
+    // given
+    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
+
+    // when
+    await updateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+
+    // then
+    expect(userOrgaSettingsRepository.update).to.have.been.calledWithExactly(userId, organizationId);
+  });
+
+  it('should throw a UserNotMemberOfOrganizationError if user is not member of the organization', async () => {
+    // given
+    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([]);
+
+    // when
+    const error = await catchErr(updateUserOrgaSettings)({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+
+    // then
+    expect(error).to.be.an.instanceof(UserNotMemberOfOrganizationError);
+    expect(error.message).to.equal(`L'utilisateur ${userId} n'est pas membre de l'organisation ${organizationId}.`);
+  });
+});

--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -4,6 +4,8 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
 
+  classNames: ['logged-user-container'],
+
   currentUser: service(),
   store: service(),
   router: service(),

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -13,7 +13,7 @@ export default Controller.extend({
   campaignName: null,
 
   hasNoCampaign: empty('model'),
-  displayNoCampaignPanel: computed('name,hasNoCampaign', function() {
+  displayNoCampaignPanel: computed('name', 'hasNoCampaign', function() {
     return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status);
   }),
   isArchived: computed('status', function() {

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -15,6 +15,7 @@ export default Service.extend({
         const userOrgaSettings = await user.get('userOrgaSettings');
 
         this.set('user', user);
+        this.set('memberships', userMemberships);
 
         if (userOrgaSettings) {
           const organization = await userOrgaSettings.get('organization');

--- a/orga/app/styles/components/user-logged-menu.scss
+++ b/orga/app/styles/components/user-logged-menu.scss
@@ -1,3 +1,7 @@
+.logged-user-container{
+  position: relative;
+}
+
 .logged-user-summary {
   letter-spacing: 0.03125rem;
   text-align: right;
@@ -42,8 +46,8 @@
   box-shadow: $box-shadow-user-logged-menu;
   overflow: hidden;
   position: absolute;
-  right: 30px;
-  top: 60px;
+  right: 0;
+  top: 49px;
   width: 400px;
 
   &-item {

--- a/orga/app/templates/components/user-logged-menu.hbs
+++ b/orga/app/templates/components/user-logged-menu.hbs
@@ -15,6 +15,14 @@
 {{#if isMenuOpen}}
   {{#click-outside onClickOutside=(action 'closeMenu')}}
     <div class="logged-user-menu">
+      {{#each eligibleOrganizations as |organization|}}
+        <div class="logged-user-menu-item" title="{{organization.name}}" onclick={{action 'onOrganizationChange' organization}}>
+          <span class="logged-user-menu-item__organization-name">{{organization.name}}</span>
+          {{#if organization.externalId}}
+            <span class="logged-user-menu-item__organization-externalId">({{organization.externalId}})</span>
+          {{/if}}
+        </div>
+      {{/each}}
       {{#link-to 'logout' class="link logged-user-menu-item logged-user-menu-item__last"}}
         {{fa-icon "power-off" class="logged-user-menu-item__icon"}}
         Se déconnecter

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -219,4 +219,14 @@ export default function() {
     return schema.userOrgaSettings.create({ user, organization });
   });
 
+  this.patch('/user-orga-settings/:id', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+    const userOrgaSettingsId = request.params.id;
+    const organizationId = requestBody.data.relationships.organization.data.id;
+
+    const userOrgaSettings = schema.userOrgaSettings.find(userOrgaSettingsId);
+    const organization = schema.organizations.find(organizationId);
+    return userOrgaSettings.update({ organization });
+  });
+
 }

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { click, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import {
+  createUserWithMembershipAndTermsOfServiceAccepted,
+  createUserWithMultipleMemberships
+} from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Switch Organization', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When connected user is linked to only one organization', function(hooks) {
+
+    hooks.beforeEach(async function() {
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      await authenticateSession({
+        user_id: user.id,
+        access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+        expires_in: 3600,
+        token_type: 'Bearer token type',
+      });
+      await visit('/');
+    });
+
+    test('should display the main organization name and externalId in summary', function(assert) {
+      assert.dom('.logged-user-summary__organization').hasText('BRO & Evil Associates (EXTBRO)');
+    });
+
+    test('should have no organization in menu', async function(assert) {
+      await click('.logged-user-summary__link');
+
+      assert.dom('.logged-user-menu-item__organization-name').doesNotExist();
+    });
+
+  });
+
+  module('When connected user is linked to multiples organizations', function(hooks) {
+
+    hooks.beforeEach(async function() {
+      const user = createUserWithMultipleMemberships();
+      await authenticateSession({
+        user_id: user.id,
+        access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+        expires_in: 3600,
+        token_type: 'Bearer token type',
+      });
+      await visit('/');
+    });
+
+    test('should have an organization in menu', async function(assert) {
+      await click('.logged-user-summary__link');
+
+      assert.dom('.logged-user-menu-item__organization-name').exists();
+      assert.dom('.logged-user-menu-item__organization-name').hasText('My Heaven Company');
+      assert.dom('.logged-user-menu-item__organization-externalId').hasText('(HEAVEN)');
+    });
+
+    module('When user click on an organization', function() {
+
+      test('should change main organization in summary', async function(assert) {
+        await click('.logged-user-summary__link');
+        await click('.logged-user-menu-item');
+
+        assert.dom('.logged-user-summary__organization').hasText('My Heaven Company (HEAVEN)');
+      });
+
+      test('should have the old main organization in the menu', async function(assert) {
+        await click('.logged-user-summary__link');
+        await click('.logged-user-menu-item');
+
+        assert.dom('.logged-user-menu-item__organization-name').exists();
+        assert.dom('.logged-user-menu-item__organization-name').hasText('BRO & Evil Associates');
+        assert.dom('.logged-user-menu-item__organization-externalId').hasText('(EXTBRO)');
+      });
+    });
+  });
+});

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -50,6 +50,35 @@ export function createUserMembershipWithRole(organizationRole) {
   return user;
 }
 
+export function createUserWithMultipleMemberships() {
+  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': true });
+
+  const firstOrganization = server.create('organization', {
+    name: 'BRO & Evil Associates',
+    externalId: 'EXTBRO'
+  });
+
+  const secondOrganization = server.create('organization', {
+    name: 'My Heaven Company',
+    externalId: 'HEAVEN'
+  });
+
+  const firstMembership = server.create('membership', {
+    organizationId: firstOrganization.id,
+    userId: user.id
+  });
+
+  const secondMembership = server.create('membership', {
+    organizationId: secondOrganization.id,
+    userId: user.id
+  });
+
+  user.memberships = [firstMembership, secondMembership];
+  user.userOrgaSettings =   server.create('user-orga-setting', { organization: firstOrganization, user });
+
+  return user;
+}
+
 export function createAdminMembershipWithNbMembers(countMembers) {
 
   const organization = server.create('organization', {

--- a/orga/tests/integration/components/user-logged-menu-test.js
+++ b/orga/tests/integration/components/user-logged-menu-test.js
@@ -72,4 +72,20 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     assert.dom('.logged-user-menu').exists();
     assert.dom('.logged-user-menu-item__last').hasText('Se déconnecter');
   });
+
+  test('should display the organizations name and externalId when menu is open', async function(assert) {
+    // when
+    const organization1 = { id: 2, name: 'Organization 2', externalId: 'EXT2' };
+    const organization2 = { id: 3, name: 'Organization 3', externalId: 'EXT3' };
+    this.set('organizations', [organization1, organization2]);
+    await render(hbs`{{user-logged-menu eligibleOrganizations=organizations}}`);
+    await click('.logged-user-summary__link');
+
+    // then
+    assert.dom('.logged-user-menu').exists();
+    assert.dom('.logged-user-menu > div:nth-child(1) > span.logged-user-menu-item__organization-name').hasText(organization1.name);
+    assert.dom('.logged-user-menu > div:nth-child(1) > span.logged-user-menu-item__organization-externalId').hasText(`(${organization1.externalId})`);
+    assert.dom('.logged-user-menu > div:nth-child(2) > span.logged-user-menu-item__organization-name').hasText(organization2.name);
+    assert.dom('.logged-user-menu > div:nth-child(2) > span.logged-user-menu-item__organization-externalId').hasText(`(${organization2.externalId})`);
+  });
 });

--- a/orga/tests/unit/components/user-logged-menu-test.js
+++ b/orga/tests/unit/components/user-logged-menu-test.js
@@ -16,7 +16,7 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       // then
       assert.equal(component.get('isMenuOpen'), false);
     });
-    
+
     test('should return true, when user details is clicked', function(assert) {
       // when
       component.send('toggleUserMenu');
@@ -30,6 +30,34 @@ module('Unit | Component | user-logged-menu', (hooks) => {
       component.send('toggleUserMenu');
       // then
       assert.equal(component.get('isMenuOpen'), false);
+    });
+  });
+
+  module('organizationNameAndExternalId', () => {
+
+    test('should return the organization name if the externalId is not defined', (assert) => {
+      // given
+      const expectedOrganizationName = 'expectedOrganizationName';
+      const currentUser = { organization: { name: expectedOrganizationName } };
+      component.set('currentUser', currentUser);
+
+      // when
+      const computedOrganizationName = component.get('organizationNameAndExternalId');
+      // then
+      assert.equal(computedOrganizationName, expectedOrganizationName);
+    });
+
+    test('should return the organization name and externalId if the externalId is defined', (assert) => {
+      // given
+      const expectedOrganizationName = 'expectedOrganizationName';
+      const expectedExternalId = 'expectedExternalId';
+      const currentUser = { organization: { name: expectedOrganizationName, externalId: expectedExternalId } };
+      component.set('currentUser', currentUser);
+
+      // when
+      const computedOrganizationName = component.get('organizationNameAndExternalId');
+      // then
+      assert.equal(computedOrganizationName, `${expectedOrganizationName} (${expectedExternalId})`);
     });
   });
 });

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -35,6 +35,34 @@ module('Unit | Service | current-user', function(hooks) {
       assert.equal(currentUser.user, connectedUser);
     });
 
+    test('should load the memberships', async function(assert) {
+      // Given
+      const connectedUserId = 1;
+      const firstOrganization = Object.create({ id: 9 });
+      const secondOrganization = Object.create({ id: 10 });
+      const memberships = [Object.create({ organization: firstOrganization }), Object.create({ organization: secondOrganization })];
+      const connectedUser = Object.create({
+        id: connectedUserId,
+        memberships
+      });
+      const storeStub = Service.create({
+        queryRecord: () => resolve(connectedUser)
+      });
+      const sessionStub = Service.create({
+        isAuthenticated: true,
+        data: { authenticated: { user_id: connectedUserId } }
+      });
+      const currentUser = this.owner.lookup('service:currentUser');
+      currentUser.set('store', storeStub);
+      currentUser.set('session', sessionStub);
+
+      // When
+      await currentUser.load();
+
+      // Then
+      assert.equal(currentUser.memberships, memberships);
+    });
+
     test('should load the organization', async function(assert) {
       // Given
       const connectedUserId = 1;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans Pix Orga, un utilisateur appartenant à plusieurs organisations n'a pas les moyens de se connecter à une organisation différente de son organisation courante. 

## :robot: Solution
Ajout de la liste des organisations dans le menu utilisateur et de la possibilité de sélectionner une nouvelle organisation courante. 

## :rainbow: Remarques
La dernière organisation sélectionnée devient la nouvelle organisation courante.
