### PR TITLE
[FEATURE] Gestion des caractères à risque dans l'export des résultats de campagne (PO-351).

### DIFF
--- a/api/lib/domain/services/csv-service.js
+++ b/api/lib/domain/services/csv-service.js
@@ -9,6 +9,16 @@ module.exports = {
     }
 
     return result;
+  },
+
+  sanitizeProperties({ objectToSanitize, propertiesToSanitize }) {
+    const sanitizedObject = Object.assign({}, objectToSanitize);
+    propertiesToSanitize.forEach((property) => {
+      if (property in sanitizedObject) {
+        sanitizedObject[property] = this.sanitize(sanitizedObject[property]);
+      }
+    });
+    return sanitizedObject;
   }
 
 };

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -5,6 +5,11 @@ const bluebird = require('bluebird');
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignWithoutOrganizationError } = require('../errors');
 const csvService = require('../services/csv-service');
 
+const propertiesToSanitize = [
+  'campaignName', 'targetProfileName',
+  'participantLastName', 'participantFirstName', 'participantExternalId'
+];
+
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   if (_.isNil(organizationId)) {
     throw new CampaignWithoutOrganizationError(`Campaign without organization : ${organizationId}`);
@@ -209,7 +214,7 @@ function _createOneLineOfCSV({
   const knowledgeElements = participantKnowledgeElements
     .filter((ke) => _.find(targetProfile.skills, { id: ke.skillId }));
 
-  const lineMap = _getCommonColumns({
+  let lineMap = _getCommonColumns({
     organization,
     campaign,
     targetProfile,
@@ -228,6 +233,8 @@ function _createOneLineOfCSV({
       knowledgeElements,
     }));
   }
+
+  lineMap = csvService.sanitizeProperties({ objectToSanitize: lineMap, propertiesToSanitize });
 
   const lineArray = headers.map(({ property }) => {
     return property in lineMap ? lineMap[property] : 'NA';

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -16,9 +16,17 @@ describe('Acceptance | API | Campaign Controller', () => {
   beforeEach(async () => {
     server = await createServer();
     organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
-    targetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: organization.id });
+    targetProfile = databaseBuilder.factory.buildTargetProfile({
+      organizationId: organization.id,
+      name: '+Profile 2'
+    });
     databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
-    campaign = databaseBuilder.factory.buildCampaign({ organizationId: organization.id, targetProfileId: targetProfile.id });
+    campaign = databaseBuilder.factory.buildCampaign({
+      name: '@Campagne de Test N°2',
+      organizationId: organization.id,
+      targetProfileId: targetProfile.id,
+      idPixLabel: '+Identifiant entreprise'
+    });
     campaignWithoutOrga = databaseBuilder.factory.buildCampaign({ organizationId: null });
     await databaseBuilder.commit();
   });
@@ -119,7 +127,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     let accessToken;
     let user;
     let userId;
-    const externalId = 'my external id';
+    const externalId = '@my external id';
     const participationStartDate = '2018-01-01';
     const assessmentStartDate = '2018-01-02';
 
@@ -130,7 +138,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     }
 
     beforeEach(async () => {
-      user = databaseBuilder.factory.buildUser();
+      user = databaseBuilder.factory.buildUser({ firstName: '@Jean', lastName: '=Bono' });
       userId = user.id;
       accessToken = _createTokenWithAccessId(userId);
 
@@ -183,7 +191,7 @@ describe('Acceptance | API | Campaign Controller', () => {
         '"Nom du Profil Cible";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
-        `"${campaign.idPixLabel}";` +
+        `"'${campaign.idPixLabel}";` +
         '"% de progression";' +
         '"Date de début";' +
         '"Partage (O/N)";' +
@@ -197,7 +205,7 @@ describe('Acceptance | API | Campaign Controller', () => {
         '"Acquis maitrisés du domaine Information et données";' +
         '"\'@accesDonnées1"' +
         '\n' +
-        `"${organization.name}";${campaign.id};"${campaign.name}";"${targetProfile.name}";"${user.lastName}";"${user.firstName}";"${externalId}";0;${participationStartDate};"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"\n`;
+        `"${organization.name}";${campaign.id};"'${campaign.name}";"'${targetProfile.name}";"'${user.lastName}";"'${user.firstName}";"'${externalId}";0;${participationStartDate};"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"\n`;
 
       // when
       const response = await server.inject(request);

--- a/api/tests/unit/domain/services/csv-service_test.js
+++ b/api/tests/unit/domain/services/csv-service_test.js
@@ -96,5 +96,68 @@ describe('Unit | Service | csv-service', function() {
       });
     });
   });
+  describe('#sanitizeProperties', () => {
+
+    const objectToSanitize = {
+      cleanProperty: 'cleanProperty',
+      uncleanProperty1: '+uncleanProperty',
+      uncleanProperty2: '-uncleanProperty',
+      uncleanProperty3: '=uncleanProperty',
+      uncleanProperty4: '@uncleanProperty'
+    };
+
+    context('when there is no properties', () => {
+
+      it('should return the object as-is', () => {
+        // when
+        const returnedObject = service.sanitizeProperties({ objectToSanitize, propertiesToSanitize: [] });
+
+        // then
+        expect(returnedObject).to.deep.equal(objectToSanitize);
+      });
+    });
+
+    context('when there is no matching properties', () => {
+
+      it('should return the object as-is', () => {
+        // given
+        const propertiesToSanitize = [ 'noExistingProperty1', 'noExistingProperty2', 'noExistingProperty3'];
+
+        // when
+        const returnedObject = service.sanitizeProperties({ objectToSanitize, propertiesToSanitize });
+
+        // then
+        expect(returnedObject).to.deep.equal(objectToSanitize);
+      });
+
+    });
+
+    context('when there are properties', () => {
+
+      it('should sanitize the properties ', () => {
+        // given
+        const propertiesToSanitize = [
+          'uncleanProperty1',
+          'uncleanProperty2',
+          'uncleanProperty3',
+          'uncleanProperty4'
+        ];
+
+        const expectedSanitizedObject = {
+          cleanProperty: 'cleanProperty',
+          uncleanProperty1: '\'+uncleanProperty',
+          uncleanProperty2: '\'-uncleanProperty',
+          uncleanProperty3: '\'=uncleanProperty',
+          uncleanProperty4: '\'@uncleanProperty'
+        };
+
+        // when
+        const sanitizedObject = service.sanitizeProperties({ objectToSanitize, propertiesToSanitize });
+
+        // then
+        expect(sanitizedObject).to.deep.equal(expectedSanitizedObject);
+      });
+    });
+  });
 
 });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -10,7 +10,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
   describe('#startWritingCampaignResultsToStream', () => {
 
-    const user = domainBuilder.buildUser();
+    const user = domainBuilder.buildUser({ firstName: '@Jean', lastName: '=Bono' });
     const organization = user.memberships[0].organization;
     const listSkills = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
     listSkills.forEach((skill) => { skill.competenceId = 'recCompetence1'; });
@@ -61,10 +61,12 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
     ];
 
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: listSkills, name: 'Profile 1' });
+    const targetProfile = domainBuilder.buildTargetProfile({
+      skills: listSkills, name: '+Profile 1'
+    });
 
     const campaign = domainBuilder.buildCampaign({
-      name:'Campaign "Name"',
+      name:'@Campagne de Test N°1',
       code:'AZERTY123',
       organizationId: organization.id,
       idPixLabel: 'Mail Pro',
@@ -177,7 +179,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           isShared: true,
           createdAt: new Date('2019-02-25T10:00:00Z'),
           sharedAt: new Date('2019-03-01T23:04:05Z'),
-          participantExternalId: 'Mon mail pro',
+          participantExternalId: '+Mon mail pro',
           userId: 123,
           participantFirstName: user.firstName,
           participantLastName: user.lastName,
@@ -186,11 +188,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
         const csvSecondLine = `"${organization.name}";` +
           `${campaign.id};` +
-          '"Campaign ""Name""";' +
-          `"${targetProfile.name}";` +
-          `"${user.lastName}";` +
-          `"${user.firstName}";` +
-          `"${campaignParticipationResultData.participantExternalId}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${user.lastName}";` +
+          `"'${user.firstName}";` +
+          `"'${campaignParticipationResultData.participantExternalId}";` +
           '1;' +
           '2019-02-25;' +
           '"Oui";' +
@@ -240,7 +242,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
           isShared: false,
           createdAt: new Date('2019-02-25T10:00:00Z'),
           sharedAt: new Date('2019-03-01T23:04:05Z'),
-          participantExternalId: 'Mon mail pro',
+          participantExternalId: '-Mon mail pro',
           userId: 123,
           participantFirstName: user.firstName,
           participantLastName: user.lastName,
@@ -251,11 +253,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
         const csvSecondLine =
           `"${organization.name}";` +
           `${campaign.id};` +
-          '"Campaign ""Name""";' +
-          `"${targetProfile.name}";` +
-          `"${user.lastName}";` +
-          `"${user.firstName}";` +
-          `"${campaignParticipationResultData.participantExternalId}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${user.lastName}";` +
+          `"'${user.firstName}";` +
+          `"'${campaignParticipationResultData.participantExternalId}";` +
           '1;' +
           '2019-02-25;' +
           '"Non";' +


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'export csv des résultats d'une campagne, si les nom, prénom et identifiant externe
 commencent par un '@' : 
- ils seront mal retranscrits dans un tableur.
- ils peuvent permettre l'exécution de code malicieux

## :robot: Solution
Echapper les chaines de caractères commençant par les symboles =, -, +, ou @
avec le caractère " ' "
