### PR TITLE
[FEATURE] Pouvoir modifier le nom de la campagne dans PIX Orga (PO-350). 

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -67,9 +67,9 @@ module.exports = {
   update(request) {
     const { userId } = request.auth.credentials;
     const campaignId = parseInt(request.params.id);
-    const { title, 'custom-landing-page-text': customLandingPageText } = request.payload.data.attributes;
+    const { name, title, 'custom-landing-page-text': customLandingPageText } = request.payload.data.attributes;
 
-    return usecases.updateCampaign({ userId, campaignId, title, customLandingPageText })
+    return usecases.updateCampaign({ userId, campaignId, name, title, customLandingPageText })
       .then(campaignSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-campaign.js
+++ b/api/lib/domain/usecases/update-campaign.js
@@ -4,6 +4,7 @@ module.exports = async function updateCampaign(
   {
     userId,
     campaignId,
+    name,
     title,
     customLandingPageText,
     userRepository,
@@ -21,8 +22,9 @@ module.exports = async function updateCampaign(
     throw new UserNotAuthorizedToUpdateResourceError(`User does not have an access to the organization ${organizationId}`);
   }
 
-  if (typeof title !== 'undefined') campaign.title = title;
-  if (typeof customLandingPageText !== 'undefined') campaign.customLandingPageText = customLandingPageText;
+  if (name !== undefined) campaign.name = name;
+  if (title !== undefined) campaign.title = title;
+  if (customLandingPageText !== undefined) campaign.customLandingPageText = customLandingPageText;
 
   await campaignRepository.update(campaign);
 

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -122,7 +122,7 @@ module.exports = {
 
   update(campaign) {
 
-    const campaignRawData = _.pick(campaign, ['title', 'customLandingPageText', 'archivedAt']);
+    const campaignRawData = _.pick(campaign, ['name', 'title', 'customLandingPageText', 'archivedAt']);
 
     return new BookshelfCampaign({ id: campaign.id })
       .save(campaignRawData, { patch: true })

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -455,6 +455,7 @@ describe('Integration | Repository | Campaign', () => {
 
     it('should update model in database', async () => {
       // given
+      campaign.name = 'New name';
       campaign.title = 'New title';
       campaign.customLandingPageText = 'New text';
       campaign.archivedAt = new Date('2020-12-12T06:07:08Z');
@@ -464,6 +465,7 @@ describe('Integration | Repository | Campaign', () => {
 
       // then
       expect(campaignSaved.id).to.equal(campaign.id);
+      expect(campaignSaved.name).to.equal('New name');
       expect(campaignSaved.title).to.equal('New title');
       expect(campaignSaved.customLandingPageText).to.equal('New text');
       expect(campaignSaved.archivedAt).to.deep.equal(new Date('2020-12-12T06:07:08Z'));

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -220,6 +220,7 @@ describe('Unit | Application | Controller | Campaign', () => {
         payload: {
           data: {
             attributes: {
+              name: 'New name',
               title: 'New title',
               'custom-landing-page-text': 'New text',
             }
@@ -229,6 +230,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
       updatedCampaign = {
         id: request.params.id,
+        name: request.payload.data.attributes.name,
         title: request.payload.data.attributes.title,
         customLandingPageText: request.payload.data.attributes['custom-landing-page-text'],
       };
@@ -236,6 +238,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       updateCampaignArgs = {
         userId: request.auth.credentials.userId,
         campaignId: updatedCampaign.id,
+        name: updatedCampaign.name,
         title: updatedCampaign.title,
         customLandingPageText: updatedCampaign.customLandingPageText,
       };

--- a/api/tests/unit/domain/usecases/update-campaign_test.js
+++ b/api/tests/unit/domain/usecases/update-campaign_test.js
@@ -13,6 +13,7 @@ describe('Unit | UseCase | update-campaign', () => {
   beforeEach(() => {
     originalCampaign = {
       id: 1,
+      name: 'Old name',
       title: 'Old title',
       customLandingPageText: 'Old text',
       organizationId,
@@ -39,10 +40,8 @@ describe('Unit | UseCase | update-campaign', () => {
     it('should update the campaign title only', () => {
       // given
       const updatedCampaign = {
-        id: originalCampaign.id,
+        ...originalCampaign,
         title: 'New title',
-        customLandingPageText: originalCampaign.customLandingPageText,
-        organizationId,
       };
 
       // when
@@ -65,10 +64,8 @@ describe('Unit | UseCase | update-campaign', () => {
     it('should update the campaign page text only', () => {
       // given
       const updatedCampaign = {
-        id: originalCampaign.id,
-        title: originalCampaign.title,
+        ...originalCampaign,
         customLandingPageText: 'New text',
-        organizationId,
       };
 
       // when
@@ -90,12 +87,7 @@ describe('Unit | UseCase | update-campaign', () => {
 
     it('should update the campaign archive date only', () => {
       // given
-      const updatedCampaign = {
-        id: originalCampaign.id,
-        title: originalCampaign.title,
-        customLandingPageText: originalCampaign.customLandingPageText,
-        organizationId,
-      };
+      const updatedCampaign = { ...originalCampaign };
 
       // when
       const promise = updateCampaign({
@@ -109,6 +101,53 @@ describe('Unit | UseCase | update-campaign', () => {
       return promise.then((resultCampaign) => {
         expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
         expect(resultCampaign.title).to.equal(originalCampaign.title);
+        expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
+      });
+    });
+
+    it('should update the campaign name only', () => {
+      // given
+      const updatedCampaign = {
+        ...originalCampaign,
+        name: 'New Name',
+      };
+
+      // when
+      const promise = updateCampaign({
+        userId: userWithMembership.id,
+        campaignId: updatedCampaign.id,
+        name: updatedCampaign.name,
+        title: originalCampaign.title,
+        userRepository,
+        campaignRepository,
+      });
+
+      // then
+      return promise.then((resultCampaign) => {
+        expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+        expect(resultCampaign.name).to.equal(updatedCampaign.name);
+        expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
+      });
+    });
+
+    it('should not update the campaign name if campaign name is undefine', () => {
+      // given
+      const updatedCampaign = { ...originalCampaign };
+
+      // when
+      const promise = updateCampaign({
+        userId: userWithMembership.id,
+        campaignId: updatedCampaign.id,
+        name: undefined,
+        title: originalCampaign.title,
+        userRepository,
+        campaignRepository,
+      });
+
+      // then
+      return promise.then((resultCampaign) => {
+        expect(campaignRepository.update).to.have.been.calledWithExactly(updatedCampaign);
+        expect(resultCampaign.name).to.equal(originalCampaign.name);
         expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
       });
     });

--- a/orga/app/routes/authenticated/campaigns/update.js
+++ b/orga/app/routes/authenticated/campaigns/update.js
@@ -5,6 +5,11 @@ export default Route.extend({
     return this.store.findRecord('campaign', params.campaign_id);
   },
 
+  setupController: function(controller, model) {
+    this._super(controller, model);
+    controller.set('campaignName', model.name);
+  },
+
   deactivate: function() {
     this.controller.model.rollbackAttributes();
   },

--- a/orga/app/templates/authenticated/campaigns/update.hbs
+++ b/orga/app/templates/authenticated/campaigns/update.hbs
@@ -1,5 +1,6 @@
 {{routes/authenticated/campaigns/update-item
   campaign=model
+  subTitle=campaignName
   update=(action 'update')
   cancel=(action 'cancel')
 }}

--- a/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
@@ -4,6 +4,18 @@
 
   <form {{action update campaign on='submit'}} class="campaign-creation-form">
     <div class="form__field">
+      <label for="campaign-name" class="label">Nom de la campagne</label>
+      <Input
+        @id="campaign-name"
+        @name="campaign-name"
+        @type="text"
+        @class="input"
+        @maxlength="255"
+        @value={{campaign.name}}
+      />
+    </div>
+
+    <div class="form__field">
       <label for="campaign-title" class="label">Titre du parcours</label>
       <Input
         @id="campaign-title"

--- a/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
@@ -1,6 +1,6 @@
 <div class="update-campaign-page">
   <h1 class="page__title page-title">Modification d'une campagne</h1>
-  <h2 class="page-sub-title">{{campaign.name}}</h2>
+  <h2 class="page-sub-title">{{subTitle}}</h2>
 
   <form {{action update campaign on='submit'}} class="campaign-creation-form">
     <div class="form__field">


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas changer le nom du campagne

## :robot: Solution
Ajouter le champ nom dans le formulaire d'édition des campagnes

