### PR TITLE
[TECH] Nettoyage du modèle Course (PF-1137)

### DIFF
--- a/api/lib/domain/models/Course.js
+++ b/api/lib/domain/models/Course.js
@@ -1,6 +1,3 @@
-const _ = require('lodash');
-const Tube = require('./Tube');
-
 class Course {
 
   constructor({
@@ -11,13 +8,9 @@ class Course {
     name,
     type,
     // includes
-    assessment,
-    competenceSkills = [],
-    tubes = [],
     // references
     challenges = [],
     competences = [],
-    userId,
   } = {}) {
     this.id = id;
     // attributes
@@ -26,48 +19,13 @@ class Course {
     this.imageUrl = imageUrl;
     this.type = type;
     // includes
-    this.assessment = assessment;
-    this.competenceSkills = competenceSkills;
-    this.tubes = tubes;
     // references
     this.challenges = challenges; // Array of Record IDs
     this.competences = competences; // Array of Record IDs
-    this.userId = userId;
   }
 
   get nbChallenges() {
     return this.challenges.length;
-  }
-
-  addCompetenceSkills(competenceSkills) {
-    this.competenceSkills = competenceSkills;
-  }
-
-  findTube(tubeName) {
-    return this.tubes.find((tube) => tube.name === tubeName);
-  }
-
-  computeTubes(listSkills) {
-    const tubes = [];
-
-    listSkills.forEach((skill) => {
-      const tubeNameOfSkill = skill.tubeName;
-
-      if (!tubes.find((tube) => tube.name === tubeNameOfSkill)) {
-        tubes.push(new Tube({ skills: [skill] }));
-      } else {
-        const tube = this.findTube(tubeNameOfSkill);
-        tube.addSkill(skill);
-      }
-      this.tubes = tubes;
-
-    });
-
-    tubes.forEach((tube) =>  {
-      tube.skills = _.sortBy(tube.skills, ['difficulty']);
-    });
-    this.tubes = tubes;
-    return tubes;
   }
 }
 

--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -50,9 +50,9 @@ function findMaxRewardingSkills(...args) {
   )(...args);
 }
 
-function _getMaxRewardingSkills({ availableSkills, predictedLevel, courseTubes, knowledgeElements }) {
+function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements }) {
   return _.reduce(availableSkills, (acc, skill) => {
-    const skillReward = _computeReward({ skill, predictedLevel, courseTubes, knowledgeElements });
+    const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements });
     if (skillReward > acc.maxReward) {
       acc.maxReward = skillReward;
       acc.maxRewardingSkills = [skill];
@@ -70,10 +70,10 @@ function _clearSkillsIfNotRewarding(skills) {
   return _.filter(skills, (skill) => skill.reward !== 0);
 }
 
-function _computeReward({ skill, predictedLevel, courseTubes, knowledgeElements }) {
+function _computeReward({ skill, predictedLevel, tubes, knowledgeElements }) {
   const proba = _probaOfCorrectAnswer(predictedLevel, skill.difficulty);
-  const extraSkillsIfSolvedCount = _getNewSkillsInfoIfSkillSolved(skill, courseTubes, knowledgeElements).length;
-  const failedSkillsIfUnsolvedCount = _getNewSkillsInfoIfSkillUnsolved(skill, courseTubes, knowledgeElements).length;
+  const extraSkillsIfSolvedCount = _getNewSkillsInfoIfSkillSolved(skill, tubes, knowledgeElements).length;
+  const failedSkillsIfUnsolvedCount = _getNewSkillsInfoIfSkillUnsolved(skill, tubes, knowledgeElements).length;
 
   return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount;
 }
@@ -84,8 +84,8 @@ function _probaOfCorrectAnswer(userEstimatedLevel, challengeDifficulty) {
   return 1 / (1 + Math.exp(-(userEstimatedLevel - challengeDifficulty)));
 }
 
-function _getNewSkillsInfoIfSkillSolved(skillTested, courseTubes, knowledgeElements) {
-  let extraValidatedSkills = _findTubeByName(courseTubes, skillTested.tubeName)
+function _getNewSkillsInfoIfSkillSolved(skillTested, tubes, knowledgeElements) {
+  let extraValidatedSkills = _findTubeByName(tubes, skillTested.tubeName)
     .getEasierThan(skillTested)
     .filter(_skillNotTestedYet(knowledgeElements));
 
@@ -95,8 +95,8 @@ function _getNewSkillsInfoIfSkillSolved(skillTested, courseTubes, knowledgeEleme
   return _.uniqBy(extraValidatedSkills, 'id');
 }
 
-function _getNewSkillsInfoIfSkillUnsolved(skillTested, courseTubes, knowledgeElements) {
-  let extraFailedSkills =  _findTubeByName(courseTubes, skillTested.tubeName)
+function _getNewSkillsInfoIfSkillUnsolved(skillTested, tubes, knowledgeElements) {
+  let extraFailedSkills =  _findTubeByName(tubes, skillTested.tubeName)
     .getHarderThan(skillTested)
     .filter(_skillNotTestedYet(knowledgeElements));
 
@@ -106,8 +106,8 @@ function _getNewSkillsInfoIfSkillUnsolved(skillTested, courseTubes, knowledgeEle
   return _.uniqBy(extraFailedSkills, 'id');
 }
 
-function _findTubeByName(courseTubes, tubeName) {
-  return courseTubes.find((tube) => tube.name === tubeName);
+function _findTubeByName(tubes, tubeName) {
+  return tubes.find((tube) => tube.name === tubeName);
 }
 
 function _skillNotTestedYet(knowledgesElements) {

--- a/api/lib/domain/services/smart-random/skills-filter.js
+++ b/api/lib/domain/services/smart-random/skills-filter.js
@@ -7,19 +7,19 @@ module.exports = {
   getFilteredSkillsForNextChallenge
 };
 
-function getFilteredSkillsForFirstChallenge({ knowledgeElements, courseTubes, targetSkills }) {
+function getFilteredSkillsForFirstChallenge({ knowledgeElements, tubes, targetSkills }) {
   return pipe(
     _getUntestedSkills.bind(null, knowledgeElements),
-    _keepSkillsFromEasyTubes.bind(null, courseTubes),
+    _keepSkillsFromEasyTubes.bind(null, tubes),
     _removeTimedSkillsIfNeeded.bind(null, true),
     _focusOnDefaultLevel.bind(null),
   )(targetSkills);
 }
 
-function getFilteredSkillsForNextChallenge({ knowledgeElements, courseTubes, predictedLevel, isLastChallengeTimed, targetSkills }) {
+function getFilteredSkillsForNextChallenge({ knowledgeElements, tubes, predictedLevel, isLastChallengeTimed, targetSkills }) {
   return pipe(
     _getUntestedSkills.bind(null,knowledgeElements),
-    _keepSkillsFromEasyTubes.bind(null, courseTubes),
+    _keepSkillsFromEasyTubes.bind(null, tubes),
     _removeTimedSkillsIfNeeded.bind(null, isLastChallengeTimed),
     _removeTooDifficultSkills.bind(null, predictedLevel),
   )(targetSkills);
@@ -29,15 +29,15 @@ function _getUntestedSkills(knowledgeElements, skills) {
   return _.filter(skills, _skillNotAlreadyTested(knowledgeElements));
 }
 
-function _getPrioritySkills(courseTubes) {
+function _getPrioritySkills(tubes) {
   return pipe(
     _getEasyTubes,
     _getSkillsFromTubes,
-  )(courseTubes);
+  )(tubes);
 }
 
-function _keepSkillsFromEasyTubes(courseTubes, targetSkills) {
-  const skillsFromEasyTubes = _getPrioritySkills(courseTubes);
+function _keepSkillsFromEasyTubes(tubes, targetSkills) {
+  const skillsFromEasyTubes = _getPrioritySkills(tubes);
   const availableSkillsFromEasyTubes = _.intersectionBy(targetSkills, skillsFromEasyTubes, 'id');
   if (!_.isEmpty(availableSkillsFromEasyTubes)) {
     return availableSkillsFromEasyTubes;
@@ -45,12 +45,12 @@ function _keepSkillsFromEasyTubes(courseTubes, targetSkills) {
   return targetSkills;
 }
 
-function _getEasyTubes(courseTubes) {
-  return _.filter(courseTubes, (tube) => tube.getHardestSkill().difficulty <= constants.MAX_LEVEL_TO_BE_AN_EASY_TUBE);
+function _getEasyTubes(tubes) {
+  return _.filter(tubes, (tube) => tube.getHardestSkill().difficulty <= constants.MAX_LEVEL_TO_BE_AN_EASY_TUBE);
 }
 
-function _getSkillsFromTubes(courseTubes) {
-  return _.flatMap(courseTubes, (tube) => tube.skills);
+function _getSkillsFromTubes(tubes) {
+  return _.flatMap(tubes, (tube) => tube.skills);
 }
 
 function _skillNotAlreadyTested(knowledgeElements) {

--- a/api/lib/domain/services/tube-service.js
+++ b/api/lib/domain/services/tube-service.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const Tube = require('../models/Tube');
+
+function computeTubesFromSkills(skills) {
+  const tubes = [];
+
+  skills.forEach((skill) => {
+    const tubeNameOfSkill = skill.tubeName;
+    const existingTube = tubes.find((tube) => tube.name === tubeNameOfSkill);
+    if (existingTube) {
+      existingTube.addSkill(skill);
+    } else {
+      tubes.push(new Tube({ skills: [skill], name: tubeNameOfSkill }));
+    }
+  });
+  tubes.forEach((tube) =>  {
+    tube.skills = _.sortBy(tube.skills, ['difficulty']);
+  });
+
+  return tubes;
+}
+
+module.exports = {
+  computeTubesFromSkills,
+};

--- a/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/course-serializer.js
@@ -4,10 +4,7 @@ module.exports = {
 
   serialize(courses) {
     return new Serializer('course', {
-      attributes: ['name', 'description', 'nbChallenges', 'type', 'imageUrl', 'assessment'],
-      assessment: {
-        ref: 'id',
-      }
+      attributes: ['name', 'description', 'nbChallenges', 'type', 'imageUrl'],
     }).serialize(courses);
   }
 

--- a/api/tests/integration/domain/services/tube-service_test.js
+++ b/api/tests/integration/domain/services/tube-service_test.js
@@ -1,0 +1,44 @@
+const { expect } = require('../../../test-helper');
+const Skill = require('../../../../lib/domain/models/Skill');
+const Tube = require('../../../../lib/domain/models/Tube');
+const { computeTubesFromSkills } = require('../../../../lib/domain/services/tube-service');
+
+describe('Integration | Domain | Services | TubeService', () => {
+
+  describe('#computeTubesFromSkills', function() {
+    it('should return an array of tubes when all challenges require only one skill', function() {
+      // given
+      const web4 = new Skill({ name: '@web4' });
+      const web5 = new Skill({ name: '@web5' });
+      const url1 = new Skill({ name: '@url1' });
+      const listSkills = [web4, web5, url1];
+      const tubeWeb = new Tube({ skills: [web4, web5] });
+      const tubeUrl = new Tube({ skills: [url1] });
+      const expectedTubes = [tubeWeb, tubeUrl];
+
+      // when
+      const actualTubes = computeTubesFromSkills(listSkills);
+
+      // then
+      expect(actualTubes).to.deep.equal(expectedTubes);
+    });
+
+    it('should not add the same skill twice in a tube', function() {
+      // given
+      const web4 = new Skill({ name: '@web4' });
+      const web5 = new Skill({ name: '@web5' });
+      const url1 = new Skill({ name: '@url1' });
+      const listSkills = [web5, web4, url1, url1];
+      const tubeWeb = new Tube({ skills: [web4, web5] });
+      const tubeUrl = new Tube({ skills: [url1] });
+      const expectedTubes = [tubeWeb, tubeUrl];
+
+      // when
+      const actualTubes = computeTubesFromSkills(listSkills);
+
+      // then
+      expect(actualTubes).to.deep.equal(expectedTubes);
+    });
+
+  });
+});

--- a/api/tests/unit/domain/models/Course_test.js
+++ b/api/tests/unit/domain/models/Course_test.js
@@ -1,78 +1,15 @@
 const { expect } = require('../../../test-helper');
-const Challenge = require('../../../../lib/domain/models/Challenge');
-const Competence = require('../../../../lib/domain/models/Competence');
 const Course = require('../../../../lib/domain/models/Course');
-const Skill = require('../../../../lib/domain/models/Skill');
-const Tube = require('../../../../lib/domain/models/Tube');
 
 describe('Unit | Domain | Models | Course', () => {
-
-  describe('#constructor', () => {
-
-    it('should set @challenges relationships property to empty array by default', () => {
-      // given
-      const course = new Course({});
-
-      // when
-      const result = course.challenges;
-
-      // then
-      expect(result).to.exist;
-      expect(result).to.have.lengthOf(0);
-    });
-
-    it('should set @challenges relationships property to the one given in params', () => {
-      // given
-      const challenges = [
-        Challenge.fromAttributes(),
-        Challenge.fromAttributes(),
-        Challenge.fromAttributes(),
-      ];
-      const course = new Course({ challenges });
-
-      // when
-      const result = course.challenges;
-
-      // then
-      expect(result).to.deep.equal(challenges);
-    });
-
-    it('should set @competences relationships property to empty array by default', () => {
-      // given
-      const course = new Course({});
-
-      // when
-      const result = course.competences;
-
-      // then
-      expect(result).to.exist;
-      expect(result).to.have.lengthOf(0);
-    });
-
-    it('should set @competences relationships property to the one given in params', () => {
-      // given
-      const competences = [
-        new Competence(),
-        new Competence(),
-        new Competence(),
-      ];
-      const course = new Course({ competences });
-
-      // when
-      const result = course.competences;
-
-      // then
-      expect(result).to.deep.equal(competences);
-    });
-  });
 
   describe('#nbChallenges', () => {
 
     it('should return the number of challenges', () => {
       // given
       const challenges = [
-        new Challenge(),
-        new Challenge()
+        'firstChallenge',
+        'secondChallenge',
       ];
       const course = new Course({ challenges });
 
@@ -81,61 +18,6 @@ describe('Unit | Domain | Models | Course', () => {
 
       // then
       expect(result).to.equal(2);
-    });
-  });
-
-  describe('#computeTubes', function() {
-    it('should return an array of tubes when all challenges require only one skill', function() {
-      // given
-      const web4 = new Skill({ name: '@web4' });
-      const web5 = new Skill({ name: '@web5' });
-      const url1 = new Skill({ name: '@url1' });
-      const listSkills = [web4, web5, url1];
-      const course = new Course();
-      const tubeWeb = new Tube({ skills: [web4, web5] });
-      const tubeUrl = new Tube({ skills: [url1] });
-
-      // when
-      course.computeTubes(listSkills);
-
-      // then
-      const expectedTubes = [tubeWeb, tubeUrl];
-      expect(course.tubes).to.deep.equal(expectedTubes);
-    });
-
-    it('should not add the same skill twice in a tube', function() {
-      // given
-      const web4 = new Skill({ name: '@web4' });
-      const web5 = new Skill({ name: '@web5' });
-      const url1 = new Skill({ name: '@url1' });
-      const listSkills = [web5, web4, url1, url1];
-      const course = new Course();
-      const tubeWeb = new Tube({ skills: [web4, web5] });
-      const tubeUrl = new Tube({ skills: [url1] });
-
-      // when
-      course.computeTubes(listSkills);
-
-      // then
-      const expectedTubes = [tubeWeb, tubeUrl];
-      expect(course.tubes).to.deep.equal(expectedTubes);
-    });
-
-  });
-
-  describe('#findTube', function() {
-    it('should return the tube with the required name', function() {
-      // given
-      const url1 = new Skill({ name: '@url1' });
-      const course = new Course();
-      const tubeUrl = new Tube({ skills: [url1] });
-      course.tubes = [tubeUrl];
-
-      // when
-      const tube = course.findTube('url');
-
-      // then
-      expect(tube).to.deep.equal(tubeUrl);
     });
   });
 });

--- a/api/tests/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/unit/domain/services/smart-random/skills-filter_test.js
@@ -23,7 +23,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
         knowledgeElements,
-        courseTubes: tubes,
+        tubes,
         targetSkills: targetProfile.skills
       });
 
@@ -43,7 +43,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
         knowledgeElements,
-        courseTubes: tubes,
+        tubes,
         targetSkills: targetProfile.skills
       });
 
@@ -68,7 +68,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
         knowledgeElements,
-        courseTubes: tubes,
+        tubes,
         targetSkills: targetProfile.skills
       });
 
@@ -91,7 +91,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
         knowledgeElements,
-        courseTubes: tubes,
+        tubes,
         targetSkills: targetProfile.skills
       });
 
@@ -115,7 +115,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
         knowledgeElements,
-        courseTubes: tubes,
+        tubes,
         targetSkills: targetProfile.skills
       });
 
@@ -222,7 +222,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           knowledgeElements,
           predictedLevel: 2,
           targetSkills: targetProfile.skills,
-          courseTubes: tubes,
+          tubes,
           isLastChallengeTimed: false,
         });
 
@@ -250,7 +250,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           knowledgeElements,
           predictedLevel: 5,
           targetSkills: targetProfile.skills,
-          courseTubes: tubes,
+          tubes,
           isLastChallengeTimed: false,
         });
 
@@ -276,7 +276,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           knowledgeElements,
           predictedLevel: 5,
           targetSkills: targetProfile.skills,
-          courseTubes: tubes,
+          tubes,
           isLastChallengeTimed: false,
         });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/course-serializer_test.js
@@ -20,9 +20,6 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function() {
           'rec_challenge_4',
           'rec_challenge_5'
         ],
-        assessment: {
-          id: 455
-        }
       });
 
       // when
@@ -40,14 +37,6 @@ describe('Unit | Serializer | JSONAPI | course-serializer', function() {
             'nb-challenges': 5,
             'type': course.type
           },
-          relationships: {
-            assessment: {
-              data: {
-                type: 'assessments',
-                id: '455'
-              }
-            }
-          }
         }
       });
     });

--- a/mon-pix/app/models/course.js
+++ b/mon-pix/app/models/course.js
@@ -5,7 +5,6 @@ export default class Course extends Model {
 
   // attributes
   @attr('string') description;
-  @attr('number') duration;
   @attr('string') imageUrl;
   @attr('string') name;
   @attr('number') nbChallenges;

--- a/mon-pix/app/routes/courses/create-assessment.js
+++ b/mon-pix/app/routes/courses/create-assessment.js
@@ -1,24 +1,10 @@
 import Route from '@ember/routing/route';
-import { isEmpty } from '@ember/utils';
 
 export default Route.extend({
 
-  afterModel(course) {
+  async afterModel(course) {
     const store = this.store;
-
-    return store.query('assessment', { filter: { type: course.get('type'), courseId: course.id, resumable: true } })
-      .then((assessments) => {
-        if (this._thereIsNoResumableAssessment(assessments)) {
-          return store.createRecord('assessment', { course, type: course.get('type') }).save();
-        } else {
-          return assessments.get('firstObject');
-        }
-      }).then((assessment) => {
-        return this.replaceWith('assessments.resume', assessment.get('id'));
-      });
+    const assessment = await store.createRecord('assessment', { course, type: course.type }).save();
+    return this.replaceWith('assessments.resume', assessment.id);
   },
-
-  _thereIsNoResumableAssessment(assessments) {
-    return isEmpty(assessments);
-  }
 });

--- a/mon-pix/mirage/data/demo.js
+++ b/mon-pix/mirage/data/demo.js
@@ -1,0 +1,4 @@
+export default {
+  demoChallengeIds: ['recChallengeDemo1', 'recChallengeDemo1', 'recChallengeDemo1'],
+  demoCourseId: 'recDemoCourse',
+};

--- a/mon-pix/mirage/routes/get-assessment.js
+++ b/mon-pix/mirage/routes/get-assessment.js
@@ -24,5 +24,6 @@ export default function(schema, request) {
   if (assessment) {
     return assessment.obj;
   }
+
   return schema.assessments.find(assessmentId);
 }

--- a/mon-pix/mirage/routes/get-next-challenge.js
+++ b/mon-pix/mirage/routes/get-next-challenge.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import refQcmChallengeFull from '../data/challenges/ref-qcm-challenge';
 import refQcuChallengeFull from '../data/challenges/ref-qcu-challenge';
 import refQrocChallengeFull from '../data/challenges/ref-qroc-challenge';
@@ -5,6 +6,7 @@ import refQrocmChallengeFull from '../data/challenges/ref-qrocm-challenge';
 import refQcmNotYetAnsweredChallengeFull from '../data/challenges/ref-qcm-challenge_not_yet_answered';
 import refTimedChallengeBis from '../data/challenges/ref-timed-challenge-bis';
 import { challengeIds } from '../data/challenges/challenge-ids';
+import demoData from '../data/demo';
 
 function getNextChallengeForDynamicAssessment(assessment, challenges) {
   const answers = assessment.answers.models;
@@ -43,6 +45,9 @@ export default function(schema, request) {
   const assessmentId = request.params.assessmentId;
   // dynamic assessment
   const assessment = schema.assessments.find(assessmentId);
+  if (assessment && assessment.type === 'DEMO') {
+    return _getNextChallengeForDemo(schema, assessment);
+  }
   if (assessment) {
     const challenges = schema.challenges.find(challengeIds).models;
     return getNextChallengeForDynamicAssessment(assessment, challenges);
@@ -50,4 +55,12 @@ export default function(schema, request) {
 
   // testing assessment
   return getNextChallengeForTestingAssessment(assessmentId, null);
+}
+
+function _getNextChallengeForDemo(schema, assessment) {
+  const answers = schema.answers.findBy({ assessmentId: assessment.id });
+  const answeredChallengeIds = _.map(answers, 'challengeId');
+
+  const nextChallengeId = _(demoData.demoChallengeIds).difference(answeredChallengeIds).first();
+  return schema.challenges.find(nextChallengeId);
 }

--- a/mon-pix/mirage/routes/post-assessments.js
+++ b/mon-pix/mirage/routes/post-assessments.js
@@ -3,8 +3,18 @@ import _ from 'mon-pix/utils/lodash-custom';
 import refAssessment from '../data/assessments/ref-assessment';
 
 export default function(schema, request) {
-
   const requestedAssessment = JSON.parse(request.requestBody);
+  let courseData = null;
+  if (requestedAssessment.data.relationships) {
+    courseData = requestedAssessment.data.relationships.course.data;
+  }
+
+  // DEMO
+  if (courseData && _.startsWith(courseData.id, 'rec')) {
+    const course = schema.challenges.find(courseData.id);
+    return schema.assessments.create({ course, state: 'started', type: 'DEMO' });
+  }
+
   const newAssessment = {
     'user-id': 'user_id',
     'user-name': 'Jane Doe',
@@ -16,8 +26,8 @@ export default function(schema, request) {
   ];
   let assessment;
   let courseId;
-  if (requestedAssessment.data.relationships) {
-    courseId = requestedAssessment.data.relationships.course.data.id;
+  if (courseData) {
+    courseId = courseData.id;
     assessment = _.find(allAssessments,
       (assessment) => assessment.data.relationships.course.data.id === courseId);
   }
@@ -39,7 +49,6 @@ export default function(schema, request) {
     newAssessment.type = 'CERTIFICATION';
     newAssessment.courseId = 'certification-number';
     newAssessment['certification-number'] = 'certification-number';
-
   }
 
   return schema.assessments.create(newAssessment);

--- a/mon-pix/mirage/scenarios/default.js
+++ b/mon-pix/mirage/scenarios/default.js
@@ -1,14 +1,8 @@
+import demoData from '../data/demo';
+
 export default function(server) {
-
   /* eslint max-statements: off */
-  // server.loadFixtures('courses');
   server.loadFixtures('challenges');
-
-  // server.create('course', {
-  //   id: 'certification-number',
-  //   nbChallenges: 3,
-  //   type: 'CERTIFICATION',
-  // });
 
   server.create('progression', {
     id: 12
@@ -91,5 +85,21 @@ export default function(server) {
   server.create('password-reset-demand', {
     temporaryKey: 'temporaryKey',
     email: 'jane@acme.com',
+  });
+
+  // DEMO
+  demoData.demoChallengeIds.forEach((challengeId) => {
+    server.create('challenge', {
+      id: challengeId,
+      type: 'QROC',
+      instruction: 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre',
+      proposals: 'Ecris ce que tu veux !',
+    });
+  });
+  server.create('course', {
+    id: demoData.demoCourseId,
+    description: 'Demo course',
+    nbChallenges: demoData.demoChallengeIds.length,
+    type: 'DEMO',
   });
 }

--- a/mon-pix/tests/acceptance/starting-a-course-test.js
+++ b/mon-pix/tests/acceptance/starting-a-course-test.js
@@ -1,52 +1,22 @@
 import { currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
-import { authenticateByEmail } from '../helpers/authentification';
-import visitWithAbortedTransition from '../helpers/visit';
-import defaultScenario from '../../mirage/scenarios/default';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import visitWithAbortedTransition from '../helpers/visit';
+import defaultScenario from '../../mirage/scenarios/default';
+import demoData from '../../mirage/data/demo';
 
 describe('Acceptance | Starting a course', function() {
   setupApplicationTest();
   setupMirage();
-  let user;
-  let assessment;
-  let urlOfFirstChallenge;
 
   beforeEach(async function() {
     defaultScenario(this.server);
-    user = server.create('user', 'withEmail');
-    await authenticateByEmail(user);
-    await visitWithAbortedTransition('/profil');
   });
 
   it('should be able to start a test directly from the course endpoint', async function() {
-    assessment = server.create('assessment');
-    urlOfFirstChallenge = `/assessments/${assessment.id}/challenges/receop4TZKvtjjG0V`;
-    await visitWithAbortedTransition(`/courses/${assessment.course.id}`);
-    expect(currentURL()).to.be.equal(urlOfFirstChallenge);
-  });
-
-  it('should resume the assessment', async function() {
-    // given
-    const startedAssessment = server.create('assessment', 'withStartedState', 'withPlacementType');
-
-    //when
-    await visitWithAbortedTransition(`/courses/${startedAssessment.course.id}`);
-
-    // then
-    expect(currentURL()).to.be.equal(`/assessments/${startedAssessment.id}/challenges/receop4TZKvtjjG0V`);
-  });
-
-  it('should start an assessment', async function() {
-    // given
-    const completedAssessment = server.create('assessment', 'withCompletedState', 'withPlacementType');
-
-    // when
-    await visitWithAbortedTransition(`/courses/${completedAssessment.course.id}`);
-
-    // then
-    expect(currentURL()).to.be.equal(`/assessments/${completedAssessment.id}/results`);
+    await visitWithAbortedTransition(`/courses/${demoData.demoCourseId}`);
+    expect(currentURL().startsWith('/assessments/'));
   });
 });

--- a/mon-pix/tests/unit/routes/courses/create-assessment-test.js
+++ b/mon-pix/tests/unit/routes/courses/create-assessment-test.js
@@ -8,86 +8,38 @@ describe('Unit | Route | Courses | Create Assessment', function() {
   setupTest();
 
   let route;
-  let queryRecordStub;
   let createRecordStub;
-  let queryStub;
-  let getAssessmentStub;
   let storeStub;
   let course;
-  let assessment;
   let createdAssessment;
-  let challenge;
 
   beforeEach(function() {
-    course = EmberObject.create({ id: 1, type: 'PLACEMENT' });
-    assessment = EmberObject.create({ id: 123 });
+    course = EmberObject.create({ id: 1, type: 'DEMO' });
     createdAssessment = EmberObject.create({ id: 1234 });
-    challenge = EmberObject.create({ id: 1 });
     createRecordStub = sinon.stub().returns({
       save: sinon.stub().resolves(createdAssessment),
     });
-    queryRecordStub = sinon.stub().resolves(challenge);
-    getAssessmentStub = sinon.stub().returns(assessment);
-    queryStub = sinon.stub().resolves({
-      get: getAssessmentStub,
-    }),
-
-    storeStub = Service.create({
-      queryRecord: queryRecordStub, query: queryStub, createRecord: createRecordStub });
+    storeStub = Service.create({ createRecord: createRecordStub });
     route = this.owner.lookup('route:courses.create-assessment');
     route.set('store', storeStub);
     route.replaceWith = sinon.stub();
   });
 
   describe('#afterModel', function() {
-    it('should call queryStub with filters', function() {
+    it('should call the creation of a new assessment', async function() {
       // when
-      const promise = route.afterModel(course);
+      await route.afterModel(course);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledWith(queryStub, 'assessment', { filter: { type: course.get('type'), courseId: course.id, resumable: true } });
-      });
+      sinon.assert.calledWith(createRecordStub, 'assessment', { course, type: course.type });
     });
 
-    context('when there is a started assessment', function() {
+    it('should redirect to resume assessment route', async function() {
+      // when
+      await route.afterModel(course);
 
-      it('should resume the assessment', function() {
-        // when
-        const promise = route.afterModel(course);
-
-        // then
-        return promise.then(() => {
-          sinon.assert.calledWith(route.replaceWith, 'assessments.resume', assessment.get('id'));
-        });
-      });
-    });
-
-    context('when there is no started assessment', function() {
-
-      beforeEach(function() {
-        queryStub.resolves([]);
-      });
-
-      it('create a new assessment for the course', function() {
-        // when
-        const promise = route.afterModel(course);
-
-        // then
-        return promise.then(() => {
-          sinon.assert.calledWith(createRecordStub, 'assessment', { course, type: course.get('type') });
-        });
-      });
-
-      it('should resume the assessment', function() {
-        // when
-        const promise = route.afterModel(course);
-
-        // then
-        return promise.then(() => {
-          sinon.assert.calledWith(route.replaceWith, 'assessments.resume', createdAssessment.get('id'));
-        });
-      });
+      // then
+      sinon.assert.calledWith(route.replaceWith, 'assessments.resume', createdAssessment.id);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il fut un temps où le Course était utilisé un peu partout. Au fil des années et des évolutions de la base de code, le concept modèle de Course n'est plus utilisé que pour les démo. Ce legacy peut rendre difficile la lecture de code sur les démo. De plus, certaines parties du code sont restées inchangées au fil des évolutions. On a donc toujours un code qui permet de répondre à plusieurs types de "Courses", ce qui n'a plus de sens désormais puisqu'il ne s'agit que de démo à chaque fois !

## :robot: Solution
- Simplification du chemin côté front pour créer un assessment de Demo. En effet, avant on demandait au serveur si il existait un assessment pour cette démo et cet utilisateur (ce qui n'a pas de sens vu qu'on est pas authentifié pour une démo !)
- Le modèle portait historiquement des méthodes pour extraire des tubes d'une liste d'acquis, on sort cette logique dans un service dédié.
- Suppression de champs plus utilisés à la fois dans le modèle côté API et côté front

## :rainbow: Remarques
FONC : tester non régression sur DEMO CERTIF PARCOURS COMPETENCE
