### PR TITLE
[TECH] Enregistrer l'obtention d'un badge en BDD (PF-1135).

### DIFF
--- a/api/db/migrations/20200302104707_create_badge_acquisitions.js
+++ b/api/db/migrations/20200302104707_create_badge_acquisitions.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'badge-acquisitions';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable(TABLE_NAME, (table) => {
+      table.increments('id').primary();
+      table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+      table.integer('userId').references('users.id').index();
+      table.integer('badgeId').references('badges.id');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/models/BadgeAcquisition.js
+++ b/api/lib/domain/models/BadgeAcquisition.js
@@ -1,0 +1,19 @@
+class BadgeAcquisition {
+  constructor({
+    id,
+    // attributes
+    // includes
+    // references
+    userId,
+    badgeId,
+  } = {}) {
+    this.id = id;
+    // attributes
+    // includes
+    // references
+    this.userId = userId;
+    this.badgeId = badgeId;
+  }
+}
+
+module.exports = BadgeAcquisition;

--- a/api/lib/domain/usecases/get-campaign-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-participation-result.js
@@ -8,6 +8,7 @@ module.exports = async function getCampaignParticipationResult(
     campaignParticipationId,
     assessmentRepository,
     badgeRepository,
+    badgeAcquisitionRepository,
     campaignParticipationRepository,
     campaignRepository,
     competenceRepository,
@@ -39,6 +40,13 @@ module.exports = async function getCampaignParticipationResult(
 
   if (_hasBadgeInformation(badge)) {
     campaignParticipationResult.areBadgeCriteriaFulfilled = badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult });
+
+    if (campaignParticipationResult.areBadgeCriteriaFulfilled) {
+      badgeAcquisitionRepository.create({
+        badgeId: campaignParticipationResult.badge.id,
+        userId
+      });
+    }
   }
 
   return campaignParticipationResult;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -4,6 +4,7 @@ const injectDefaults = require('../../infrastructure/utils/inject-defaults');
 const dependencies = {
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
+  badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
   badgeCriteriaService: require('../../domain/services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),

--- a/api/lib/infrastructure/data/badge-acquisition.js
+++ b/api/lib/infrastructure/data/badge-acquisition.js
@@ -1,0 +1,17 @@
+const Bookshelf = require('../bookshelf');
+
+require('./badge');
+require('./user');
+
+module.exports = Bookshelf.model('BadgeAcquisition', {
+
+  tableName: 'badge-acquisitions',
+
+  badge() {
+    return this.belongsTo('Badge', 'badgeId');
+  },
+
+  user() {
+    return this.belongsTo('User', 'userId');
+  },
+});

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -1,0 +1,11 @@
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const BookshelfBadgeAcquisition = require('../../infrastructure/data/badge-acquisition');
+
+module.exports = {
+
+  async create({ badgeId, userId }) {
+    const result = await new BookshelfBadgeAcquisition({ badgeId, userId }).save();
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfBadgeAcquisition, result);
+  },
+
+};

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -1,0 +1,46 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+
+const BadgeAcquisition = require('../../../../lib/domain/models/BadgeAcquisition');
+const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
+
+describe('Integration | Repository | Badge Acquisition', () => {
+
+  describe('#create', () => {
+
+    let badgeAcquisition;
+    let badgeAcquisitionToCreate;
+
+    beforeEach(async () => {
+      const badgeId = databaseBuilder.factory.buildBadge().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      badgeAcquisitionToCreate = databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });
+      badgeAcquisitionToCreate.id = undefined;
+      await databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      return knex('badge-acquisitions').delete();
+    });
+
+    it('should persist the badge acquisition in db', async () => {
+      // when
+      badgeAcquisition = await badgeAcquisitionRepository.create(badgeAcquisitionToCreate);
+
+      // then
+      const result = await knex('badge-acquisitions').where('id', badgeAcquisition.id);
+
+      expect(result).to.have.lengthOf(1);
+    });
+
+    it('should return the saved badge acquired', async () => {
+      // when
+      badgeAcquisition = await badgeAcquisitionRepository.create(badgeAcquisitionToCreate);
+
+      // then
+      expect(badgeAcquisition).to.be.an.instanceOf(BadgeAcquisition);
+
+      expect(badgeAcquisition).to.have.property('id').and.not.to.be.null;
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-badge-acquisition.js
+++ b/api/tests/tooling/database-builder/factory/build-badge-acquisition.js
@@ -1,0 +1,18 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildBadgeAcquisition({
+  id,
+  badgeId,
+  userId,
+} = {}) {
+
+  const values = {
+    id,
+    badgeId,
+    userId,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'badge-acquisitions',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -3,6 +3,7 @@ module.exports = {
   buildAssessment: require('./build-assessment'),
   buildAssessmentResult: require('./build-assessment-result'),
   buildBadge: require('./build-badge'),
+  buildBadgeAcquisition: require('./build-badge-acquisition'),
   buildCampaign: require('./build-campaign'),
   buildCampaignParticipation: require('./build-campaign-participation'),
   buildCompetenceEvaluation: require('./build-competence-evaluation'),

--- a/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
@@ -32,6 +32,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
     assessmentRepository,
     badgeRepository,
     knowledgeElementRepository,
+    badgeAcquisitionRepository,
     badgeCriteriaService;
 
   let usecaseDependencies;
@@ -44,6 +45,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
     assessmentRepository = { get: sinon.stub() };
     badgeRepository = { findOneByTargetProfileId: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    badgeAcquisitionRepository = { create: sinon.stub() };
     badgeCriteriaService = { areBadgeCriteriaFulfilled: sinon.stub() };
     sinon.stub(CampaignParticipationResult, 'buildFrom').returns(campaignParticipationResult);
 
@@ -57,6 +59,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       assessmentRepository,
       badgeRepository,
       knowledgeElementRepository,
+      badgeAcquisitionRepository,
       badgeCriteriaService,
     };
   });
@@ -76,6 +79,18 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
         badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
+      it('should create the badge acquisition', async () => {
+        // when
+        await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        sinon.assert.calledOnce(badgeAcquisitionRepository.create);
+        sinon.assert.calledWith(badgeAcquisitionRepository.create, {
+          badgeId: campaignParticipationResult.badge.id ,
+          userId
+        });
+      });
+
       it('should get the campaignParticipationResult', async () => {
         // when
         const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
@@ -90,6 +105,14 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
         badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(false);
+      });
+
+      it('should not create the badge acquisition', async () => {
+        // when
+        await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        sinon.assert.notCalled(badgeAcquisitionRepository.create);
       });
 
       it('should get the campaignParticipationResult', async () => {
@@ -118,6 +141,18 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
         badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
+      it('should create the badge acquisition', async () => {
+        // when
+        await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        sinon.assert.calledOnce(badgeAcquisitionRepository.create);
+        sinon.assert.calledWith(badgeAcquisitionRepository.create, {
+          badgeId: campaignParticipationResult.badge.id ,
+          userId
+        });
+      });
+
       it('should get the campaignParticipationResult', async () => {
         // when
         const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
@@ -132,6 +167,14 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
         badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(false);
+      });
+
+      it('should not create the badge acquisition', async () => {
+        // when
+        await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        sinon.assert.notCalled(badgeAcquisitionRepository.create);
       });
 
       it('should get the campaignParticipationResult', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de savoir si un badge a été obtenu en vue de la mise en place des certifications sur la base des badges.

## :robot: Solution
Il est nécessaire vérifier si les critères de badges sont validés pour enregistrer l'acquisition d'un badge pour un utilisateur. Nous procédons donc à : 
- une sauvegarde en base dans la table `badge-acquisitions` lorsque les critères d'un badge sont validés.

## 🌈 Remarques 
La gamification peut s'exprimer sous l'équation suivante :
```
Gamification = Rules + Goals + Volontary Participation + Feedback
```
Concrètement, dans le code, cela va se modéliser selon les termes métier par :
```
Gamification = BadgeCriteria + Badge + BadgeAcquisition
```
avec : 
- `BadgeCriteria = Rules`
- `BadgeAcquisition = Goals`
- `Badge = Feedback`