### PR TITLE
[FEATURE] Ajouter une colonne credit à la table organizations (PO-300).

### DIFF
--- a/api/db/migrations/20200303153018_add-credit-column-to-organization.js
+++ b/api/db/migrations/20200303153018_add-credit-column-to-organization.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'credit';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).defaultTo(0);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Le pôle partenariat surveille régulièrement metabase pour voir si les orgas ne dépassent pas le nombre de crédits qu’elles ont acheté. Et avec le nombre d’orgas qui augmente, ça devient fastidieux.

## :robot: Solution
Ajout d'une colonne credit dans la table organizations 
