### PR TITLE
[BUGFIX] Réinitialiser l'URL des campagnes quand je change d'organisation (PO-361).

### DIFF
--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -52,7 +52,9 @@ export default Component.extend({
 
       await this.currentUser.load();
 
-      this.router.replaceWith('/');
+      const queryParams = {};
+      Object.keys(this.router.currentRoute.queryParams).forEach((key) => queryParams[key] = undefined);
+      this.router.replaceWith('authenticated', { queryParams });
     }
   }
 

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, visit } from '@ember/test-helpers';
+import { click, visit , currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -76,6 +76,18 @@ module('Acceptance | Switch Organization', function(hooks) {
         assert.dom('.logged-user-menu-item__organization-name').exists();
         assert.dom('.logged-user-menu-item__organization-name').hasText('BRO & Evil Associates');
         assert.dom('.logged-user-menu-item__organization-externalId').hasText('(EXTBRO)');
+      });
+
+      module('When user is on campaign page with pagination', function() {
+
+        test('it should reset the queryParams when redirecting', async function(assert) {
+          await visit('/campagnes?pageNumber=2&pageSize=10&name=test&status=archived');
+
+          await click('.logged-user-summary__link');
+          await click('.logged-user-menu-item');
+
+          assert.equal(currentURL(), '/campagnes');
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans la liste des campagnes de Pix Orga, lorsque je filtre/change le nombre de campagnes affichées ou de page, des queryParams sont ajoutés à l'URL. Lorsque l'on change d'organisation principale, nous redirigeons l'utilisateur vers cette liste des campagnes mais les queryParams sont conservés.  

## :robot: Solution
Supprimer les queryParams au moment de la redirection.