### PR TITLE
[FEATURE] Modifier l'entrée de menu de réinitialisation de mot de passe (PO-338).

### DIFF
--- a/orga/app/styles/globals/buttons.scss
+++ b/orga/app/styles/globals/buttons.scss
@@ -89,8 +89,28 @@
     }
   }
 
-  &--with-icon-and-text:hover {
-    background-color: $alto;
+  &--with-icon-and-text {
+    &:hover, &:focus, &:active, &:visited {
+      background-color: $alto;
+    }
+  }
+
+  &--round-with-icon {
+    background-color: $white;
+    border-radius: 17px;
+    color: $dove-gray;
+    font-size: 1.4rem;
+    height: 34px;
+    padding: 1px 6px;
+    width: 34px;
+
+    &:hover {
+      background-color: $porcelain;
+    }
+
+    &:focus, &:active, &:visited {
+      background-color: $alto;
+    }
   }
 
 }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -14,7 +14,23 @@
     margin-left: auto;
   }
 
-  .authentication-methods {
+  &__authentication-methods {
     white-space: pre;
+  }
+
+  &__password-reset-cell {
+    text-align: right;
+  }
+
+  &__manage-button {
+    margin-right: 32px;
+  }
+
+  &__tooltip {
+    background-color: $astronaut;
+    bottom: 42px;
+    border-radius: 4px;
+    left: 55px;
+    width: 64px;
   }
 }

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -18,7 +18,7 @@
         <th>Prénom</th>
         <th>Date de naissance</th>
         <th>Connecté avec</th>
-        <th>Mot de passe</th>
+        <th></th>
       </tr>
       </thead>
 
@@ -29,13 +29,15 @@
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td class="authentication-methods">{{student.authenticationMethods}}</td>
-            <td>
+            <td class="list-students-page__authentication-methods">{{student.authenticationMethods}}</td>
+            <td class="list-students-page__password-reset-cell">
               {{#if student.hasUsername}}
-                <button class="button button--with-icon-and-text button-edit-role"
-                        type="button" {{action 'openPasswordReset' student}}>
-                  Réinitialiser
-                </button>
+                <div class="tooltip">
+                  <span class="tooltip-text list-students-page__tooltip">Gérer</span>
+                  <button class="button button--round-with-icon list-students-page__manage-button" type="button" {{action 'openPasswordReset' student}}>
+                    {{fa-icon "cog" }}
+                  </button>
+                </div>
               {{/if}}
             </td>
           </tr>

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -115,7 +115,7 @@ module('Acceptance | Student List', function(hooks) {
         assert.dom('.table thead th:nth-child(2)').hasText('Prénom');
         assert.dom('.table thead th:nth-child(3)').hasText('Date de naissance');
         assert.dom('.table thead th:nth-child(4)').hasText('Connecté avec');
-        assert.dom('.table thead th:nth-child(5)').hasText('Mot de passe');
+        assert.dom('.table thead th:nth-child(5)').hasText('');
       });
 
       module('when student have a username', async function() {
@@ -125,7 +125,7 @@ module('Acceptance | Student List', function(hooks) {
           await visit('/eleves');
 
           // then
-          assert.dom('.table tbody tr:nth-child(6) td:last-child button').hasText('Réinitialiser');
+          assert.dom('.table tbody tr:nth-child(6) td:last-child button .fa-cog').exists();
         });
 
         test('it should open password modal window', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     assert.dom('.table thead tr th:nth-child(2)').hasText('Prénom');
     assert.dom('.table thead tr th:nth-child(3)').hasText('Date de naissance');
     assert.dom('.table thead tr th:nth-child(4)').hasText('Connecté avec');
-    assert.dom('.table thead tr th:last-child').hasText('Mot de passe');
+    assert.dom('.table thead tr th:last-child').hasText('');
   });
 
   test('it should display a list of students', async function(assert) {
@@ -141,7 +141,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       assert.dom('.table tbody tr:first-child td:first-child').hasText('lastName');
       assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('firstName');
       assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/10/2008');
-      assert.dom('.table tbody tr:first-child td:last-child button').hasText('Réinitialiser');
+      assert.dom('.table tbody tr:first-child td:last-child button .fa-cog').exists();
     });
 
     test('it should not display password update button when student have not username', async function(assert) {
@@ -172,8 +172,8 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
 
       // then
-      assert.dom('.table tbody tr:first-child td:last-child button').doesNotExist();
-      assert.dom('.table tbody tr:nth-child(2) td:last-child button').hasText('Réinitialiser');
+      assert.dom('.table tbody tr:first-child td:last-child button .fa-cog').doesNotExist();
+      assert.dom('.table tbody tr:nth-child(2) td:last-child button .fa-cog').exists();
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans la liste des élèves de Pix Orga, il existe une colonne "Mot de passe" qui contient des boutons "Réinitialiser" permettant d'ouvrir une modal de changement de mot de passe pour les élèves ayant créé un compte avec identifiant. Dans le futur, cette modal ne permettra pas uniquement de réinitialiser un mot de passe mais proposera plusieurs actions s'inscrivant dans une gestion plus globale du compte d'un élève. Il apparaît alors que le titre de la colonne, ainsi que le libellé du bouton ne sont plus en accord avec les futurs objectifs de cette modal.    

## :robot: Solution
Il a été choisi de supprimer le nom de la colonne et de remplacer le texte du bouton "Réinitialiser" par une icone représentant un engrenage. De plus, le survol de ce bouton, le libellé "Gérer" doit apparaître.