### PR TITLE
[BUGFIX] Pouvoir accepter une invitation à rejoindre Pix Orga lorsqu'on est déjà authentifié (PO-240).

### DIFF
--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -1,7 +1,8 @@
 {
   "baseUrl": "http://localhost:4200",
   "env": {
-    "API_URL": "http://localhost:3000"
+    "API_URL": "http://localhost:3000",
+    "ORGA_URL": "http://localhost:4201"
   },
   "video": false,
   "blacklistHosts": "*stats.pix.fr*"

--- a/high-level-tests/e2e/cypress/fixtures/organization-invitations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organization-invitations.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "organizationId": 1,
+    "email": "david.j.malan@example.net",
+    "status": "pending",
+    "code": "ABCDEFGHI5"
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -3,7 +3,8 @@
     "id": 1,
     "type": "PRO",
     "name": "Dragon & Co"
-  }, {
+  },
+  {
     "id": 2,
     "type": "SCO",
     "name": "The Night Watch",

--- a/high-level-tests/e2e/cypress/integration/organization-management.feature
+++ b/high-level-tests/e2e/cypress/integration/organization-management.feature
@@ -1,0 +1,12 @@
+#language: fr
+Fonctionnalité: Gestion d'une Organisation
+
+  Contexte:
+    Étant donné que les données de test sont chargées
+
+  Scénario: Je veux répondre à une invitation pour rejoindre mon organisation même si je suis déjà authentifié
+    Étant donné que je vais sur Pix Orga
+    Lorsque je suis connecté à Pix Orga
+    Alors je vois le menu Équipe
+    Lorsque je saisis l'URL de l'invitation 1 ayant le code "ABCDEFGHI5"
+    Alors je suis redirigé vers la page Rejoindre l'organisation

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -17,7 +17,7 @@ Cypress.Commands.add('login', (username, password) => {
         authenticator: 'authenticator:oauth2',
         token_type: 'bearer',
         access_token: response.body.access_token,
-        user_id: 1
+        user_id: response.body.user_id
       }
     }));
   });
@@ -72,17 +72,20 @@ Cypress.Commands.add('loginWithAlmostExpiredToken', () => {
   cy.wait(['@getCurrentUser']);
 });
 
-Cypress.Commands.add('visitOrga', (url) => {
-  return cy.visit(url, { app: 'orga' });
-});
-
 Cypress.Commands.add('visitMonPix', (url) => {
   return cy.visit(url, { app: 'default' });
 });
 
+Cypress.Commands.add('visitOrga', (url) => {
+  return cy.visit(url, { app: 'orga' });
+});
+
 Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  const ORGA_URL = Cypress.env('ORGA_URL');
+
   if (options.app === 'orga') {
-    url = 'http://localhost:4201';
+    url = ORGA_URL + url;
   }
+
   return originalFn(url, options);
 });

--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -22,7 +22,7 @@ then(`je choisis la réponse {string}`, (number) => {
   cy.get('#'+number).click();
 });
 
-then(`je vois la page de résultats`, (number) => {
+then(`je vois la page de résultats`, () => {
   cy.get('.assessment-results').should('exist');
 });
 

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -2,6 +2,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'users');
   cy.task('db:fixture', 'organizations');
   cy.task('db:fixture', 'memberships');
+  cy.task('db:fixture', 'organization-invitations');
   cy.task('db:fixture', 'user-orga-settings');
   cy.task('db:fixture', 'target-profiles');
   cy.task('db:fixture', 'target-profiles_skills');

--- a/high-level-tests/e2e/cypress/support/step_definitions/organization.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/organization.js
@@ -1,0 +1,14 @@
+then('je vois le menu Équipe', () => {
+  cy.get('.sidebar-menu').should('contain', 'Équipe');
+});
+
+when(`je saisis l'URL de l'invitation {int} ayant le code {string}`,(invitationId, code) => {
+  const urn = `/rejoindre?invitationId=${invitationId}&code=${code}`;
+  cy.visitOrga(urn);
+});
+
+then('je suis redirigé vers la page Rejoindre l\'organisation', () => {
+  cy.get('.login-or-register-panel__invitation')
+    .should('contain', 'Vous êtes invité(e) à rejoindre l\'organisation');
+});
+

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -15,7 +15,9 @@ export default class Router extends EmberRouter {
 
 Router.map(function() {
   this.route('login', { path: 'connexion' });
+
   this.route('join', { path: 'rejoindre' });
+  this.route('join-when-authenticated');
 
   this.route('terms-of-service', { path: '/cgu' });
 

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
 export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
+
   routeAfterAuthentication = 'authenticated';
 
   @service currentUser;
@@ -17,7 +18,14 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   }
 
   sessionInvalidated() {
-    this.transitionTo('login');
+    const alternativeRootURL = this.session.alternativeRootURL;
+
+    if (alternativeRootURL) {
+      this.session.alternativeRootURL = null;
+      window.location.replace(alternativeRootURL);
+    } else {
+      this.transitionTo('login');
+    }
   }
 
   _loadCurrentUser() {

--- a/orga/app/routes/join-when-authenticated.js
+++ b/orga/app/routes/join-when-authenticated.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
+
+export default class JoinWhenAuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {
+
+  @service session;
+
+  beforeModel(transition) {
+    super.beforeModel(...arguments);
+
+    const { queryParams } = transition.to;
+    const alternativeRootURL = transition.router.generate('join', { queryParams });
+
+    this.session.alternativeRootURL = alternativeRootURL;
+    this.session.invalidate();
+  }
+
+}

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -2,6 +2,9 @@ import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 export default class JoinRoute extends Route.extend(UnauthenticatedRouteMixin) {
+
+  routeIfAlreadyAuthenticated = 'join-when-authenticated';
+
   model(params) {
     return this.store.queryRecord('organization-invitation', {
       invitationId: params.invitationId,

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -1,13 +1,14 @@
 import { module, test } from 'qunit';
 import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
+
 import { currentSession } from 'ember-simple-auth/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
 import {
   createUserWithMembership,
   createUserWithMembershipAndTermsOfServiceAccepted,
 } from '../helpers/test-init';
-
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | join', function(hooks) {
 
@@ -312,4 +313,5 @@ module('Acceptance | join', function(hooks) {
       });
     });
   });
+
 });

--- a/orga/tests/unit/routes/join-when-authenticated-test.js
+++ b/orga/tests/unit/routes/join-when-authenticated-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | join-when-authenticated', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:join-when-authenticated');
+    assert.ok(route);
+  });
+});

--- a/scalingo.json
+++ b/scalingo.json
@@ -4,6 +4,10 @@
     "REVIEW_APP": {
       "description": "Indicates that the application is a review app",
       "value": "true"
+    },
+    "PIXORGA_URL": {
+      "generator": "template",
+      "template": "https://orga-pr%PR_NUMBER%.review.pix.fr"
     }
   },
   "scripts": {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on est déjà authentifié sur Pix Orga, il n'est pas possible de répondre à une invitation.

## :robot: Solution
Si l'utilisateur est déjà authentifié, le déconnecter, et le rediriger vers la page Rejoindre une organisation.

## :rainbow: Remarques
Un test Cypress a été créé à l'occasion.
