### PR TITLE
[TECH] Déplacer les critères de badge vers l'API (PF-1149).

### DIFF
--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -6,6 +6,7 @@ class CampaignParticipationResult {
     id,
     // attributes
     isCompleted,
+    masteryPercentage,
     totalSkillsCount,
     testedSkillsCount,
     validatedSkillsCount,
@@ -16,6 +17,7 @@ class CampaignParticipationResult {
     this.id = id;
     // attributes
     this.isCompleted = isCompleted;
+    this.masteryPercentage = masteryPercentage;
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = testedSkillsCount;
     this.validatedSkillsCount = validatedSkillsCount;
@@ -31,11 +33,17 @@ class CampaignParticipationResult {
     const targetedKnowledgeElements = _removeUntargetedKnowledgeElements(knowledgeElements, targetProfileSkillsIds);
     const targetedCompetenceResults = _.map(targetedCompetences, (competence) => _getTestedCompetenceResults(competence, targetedKnowledgeElements));
 
+    const validatedSkillsCount = _.sumBy(targetedCompetenceResults, 'validatedSkillsCount');
+    const totalSkillsCount = _.sumBy(targetedCompetenceResults, 'totalSkillsCount');
+    const testedSkillsCount = _.sumBy(targetedCompetenceResults, 'testedSkillsCount');
+    const masteryPercentage = Math.round(validatedSkillsCount * 100 / totalSkillsCount);
+
     return new CampaignParticipationResult({
       id: campaignParticipationId,
-      totalSkillsCount: _.sumBy(targetedCompetenceResults, 'totalSkillsCount'),
-      testedSkillsCount: _.sumBy(targetedCompetenceResults, 'testedSkillsCount'),
-      validatedSkillsCount: _.sumBy(targetedCompetenceResults, 'validatedSkillsCount'),
+      masteryPercentage,
+      totalSkillsCount,
+      testedSkillsCount,
+      validatedSkillsCount,
       isCompleted: assessment.isCompleted(),
       competenceResults: targetedCompetenceResults,
       badge,

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -5,7 +5,7 @@ class CampaignParticipationResult {
   constructor({
     id,
     // attributes
-    areBadgeCriteriaValidated,
+    areBadgeCriteriaFulfilled,
     isCompleted,
     masteryPercentage,
     totalSkillsCount,
@@ -17,7 +17,7 @@ class CampaignParticipationResult {
   } = {}) {
     this.id = id;
     // attributes
-    this.areBadgeCriteriaValidated = areBadgeCriteriaValidated;
+    this.areBadgeCriteriaFulfilled = areBadgeCriteriaFulfilled;
     this.isCompleted = isCompleted;
     this.masteryPercentage = masteryPercentage;
     this.totalSkillsCount = totalSkillsCount;
@@ -46,7 +46,7 @@ class CampaignParticipationResult {
       totalSkillsCount,
       testedSkillsCount,
       validatedSkillsCount,
-      areBadgeCriteriaValidated: false,
+      areBadgeCriteriaFulfilled: false,
       isCompleted: assessment.isCompleted(),
       competenceResults: targetedCompetenceResults,
       badge,

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -5,6 +5,7 @@ class CampaignParticipationResult {
   constructor({
     id,
     // attributes
+    areBadgeCriteriaValidated,
     isCompleted,
     masteryPercentage,
     totalSkillsCount,
@@ -16,6 +17,7 @@ class CampaignParticipationResult {
   } = {}) {
     this.id = id;
     // attributes
+    this.areBadgeCriteriaValidated = areBadgeCriteriaValidated;
     this.isCompleted = isCompleted;
     this.masteryPercentage = masteryPercentage;
     this.totalSkillsCount = totalSkillsCount;
@@ -44,6 +46,7 @@ class CampaignParticipationResult {
       totalSkillsCount,
       testedSkillsCount,
       validatedSkillsCount,
+      areBadgeCriteriaValidated: false,
       isCompleted: assessment.isCompleted(),
       competenceResults: targetedCompetenceResults,
       badge,

--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -1,7 +1,7 @@
-function reviewBadgeCriteria({ campaignParticipationResult }) {
+function areBadgeCriteriaFulfilled({ campaignParticipationResult }) {
   return (campaignParticipationResult.masteryPercentage >= 85);
 }
 
 module.exports = {
-  reviewBadgeCriteria,
+  areBadgeCriteriaFulfilled,
 };

--- a/api/lib/domain/services/badge-criteria-service.js
+++ b/api/lib/domain/services/badge-criteria-service.js
@@ -1,0 +1,7 @@
+function reviewBadgeCriteria({ campaignParticipationResult }) {
+  return (campaignParticipationResult.masteryPercentage >= 85);
+}
+
+module.exports = {
+  reviewBadgeCriteria,
+};

--- a/api/lib/domain/usecases/get-campaign-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-participation-result.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const CampaignParticipationResult = require('../../domain/models/CampaignParticipationResult');
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
@@ -12,6 +13,7 @@ module.exports = async function getCampaignParticipationResult(
     competenceRepository,
     knowledgeElementRepository,
     targetProfileRepository,
+    badgeCriteriaService,
   }
 ) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
@@ -26,7 +28,20 @@ module.exports = async function getCampaignParticipationResult(
 
   const badge = await badgeRepository.findOneByTargetProfileId(targetProfile.id);
 
-  return CampaignParticipationResult.buildFrom({ campaignParticipationId, assessment, competences, targetProfile, knowledgeElements, badge });
+  const campaignParticipationResult = CampaignParticipationResult.buildFrom({
+    campaignParticipationId,
+    assessment,
+    competences,
+    targetProfile,
+    knowledgeElements,
+    badge
+  });
+
+  if (!_.isEmpty(badge)) {
+    campaignParticipationResult.areBadgeCriteriaValidated = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+  }
+
+  return campaignParticipationResult;
 };
 
 async function _checkIfUserHasAccessToThisCampaignParticipation(userId, campaignParticipation, campaignRepository) {

--- a/api/lib/domain/usecases/get-campaign-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-participation-result.js
@@ -37,8 +37,8 @@ module.exports = async function getCampaignParticipationResult(
     badge
   });
 
-  if (!_.isEmpty(badge)) {
-    campaignParticipationResult.areBadgeCriteriaValidated = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+  if (_hasBadgeInformation(badge)) {
+    campaignParticipationResult.areBadgeCriteriaFulfilled = badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult });
   }
 
   return campaignParticipationResult;
@@ -54,4 +54,8 @@ async function _checkIfUserHasAccessToThisCampaignParticipation(userId, campaign
   if (!campaignParticipationBelongsToUser && !userIsMemberOfCampaignOrganization) {
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign participation');
   }
+}
+
+function _hasBadgeInformation(badge) {
+  return !_.isEmpty(badge);
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -5,6 +5,7 @@ const dependencies = {
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
+  badgeCriteriaService: require('../../domain/services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
   campaignCollectiveResultRepository: require('../../infrastructure/repositories/campaign-collective-result-repository'),
   campaignParticipationRepository: require('../../infrastructure/repositories/campaign-participation-repository'),

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(results) {
     return new Serializer('campaign-participation-result', {
-      attributes: ['totalSkillsCount', 'testedSkillsCount', 'validatedSkillsCount', 'isCompleted', 'badge', 'competenceResults'],
+      attributes: ['masteryPercentage', 'totalSkillsCount', 'testedSkillsCount', 'validatedSkillsCount', 'isCompleted', 'badge', 'competenceResults'],
       badge: {
         ref: 'id',
         attributes: ['altMessage', 'message', 'imageUrl'],

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -3,7 +3,16 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(results) {
     return new Serializer('campaign-participation-result', {
-      attributes: ['masteryPercentage', 'totalSkillsCount', 'testedSkillsCount', 'validatedSkillsCount', 'isCompleted', 'badge', 'competenceResults'],
+      attributes: [
+        'masteryPercentage',
+        'totalSkillsCount',
+        'testedSkillsCount',
+        'validatedSkillsCount',
+        'isCompleted',
+        'areBadgeCriteriaValidated',
+        'badge',
+        'competenceResults'
+      ],
       badge: {
         ref: 'id',
         attributes: ['altMessage', 'message', 'imageUrl'],

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
         'testedSkillsCount',
         'validatedSkillsCount',
         'isCompleted',
-        'areBadgeCriteriaValidated',
+        'areBadgeCriteriaFulfilled',
         'badge',
         'competenceResults'
       ],

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -165,7 +165,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
             'tested-skills-count': 5,
             'validated-skills-count': 3,
             'is-completed': true,
-            'are-badge-criteria-validated': false,
+            'are-badge-criteria-fulfilled': false,
           },
           relationships: {
             badge: {

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -160,6 +160,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
           type: 'campaign-participation-results',
           id: campaignParticipation.id.toString(),
           attributes: {
+            'mastery-percentage': 38,
             'total-skills-count': 8,
             'tested-skills-count': 5,
             'validated-skills-count': 3,

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -164,7 +164,8 @@ describe('Acceptance | API | Campaign Participation Result', () => {
             'total-skills-count': 8,
             'tested-skills-count': 5,
             'validated-skills-count': 3,
-            'is-completed': true
+            'is-completed': true,
+            'are-badge-criteria-validated': false,
           },
           relationships: {
             badge: {

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
@@ -5,7 +5,7 @@ const faker = require('faker');
 module.exports = function buildCampaignParticipationResult(
   {
     id = 1,
-    areBadgeCriteriaValidated = false,
+    areBadgeCriteriaFulfilled = false,
     isCompleted = faker.random.boolean(),
     masteryPercentage = 50,
     totalSkillsCount = 10,
@@ -16,7 +16,7 @@ module.exports = function buildCampaignParticipationResult(
   } = {}) {
   return new CampaignParticipationResult({
     id,
-    areBadgeCriteriaValidated,
+    areBadgeCriteriaFulfilled,
     isCompleted,
     masteryPercentage,
     totalSkillsCount,

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
@@ -6,6 +6,7 @@ module.exports = function buildCampaignParticipationResult(
   {
     id = 1,
     isCompleted = faker.random.boolean(),
+    masteryPercentage = 50,
     totalSkillsCount = 10,
     testedSkillsCount = 8,
     validatedSkillsCount = 5,
@@ -15,6 +16,7 @@ module.exports = function buildCampaignParticipationResult(
   return new CampaignParticipationResult({
     id,
     isCompleted,
+    masteryPercentage,
     totalSkillsCount,
     testedSkillsCount,
     validatedSkillsCount,

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
@@ -5,6 +5,7 @@ const faker = require('faker');
 module.exports = function buildCampaignParticipationResult(
   {
     id = 1,
+    areBadgeCriteriaValidated = false,
     isCompleted = faker.random.boolean(),
     masteryPercentage = 50,
     totalSkillsCount = 10,
@@ -15,6 +16,7 @@ module.exports = function buildCampaignParticipationResult(
   } = {}) {
   return new CampaignParticipationResult({
     id,
+    areBadgeCriteriaValidated,
     isCompleted,
     masteryPercentage,
     totalSkillsCount,

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -56,6 +56,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
         totalSkillsCount: 4,
         testedSkillsCount: 2,
         validatedSkillsCount: 1,
+        masteryPercentage: 25,
         badge: {
           id: 1,
           imageUrl: '/img/banana.svg',

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -53,7 +53,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
       expect(result).to.deep.equal({
         id: campaignParticipationId,
         isCompleted: false,
-        areBadgeCriteriaValidated: false,
+        areBadgeCriteriaFulfilled: false,
         totalSkillsCount: 4,
         testedSkillsCount: 2,
         validatedSkillsCount: 1,

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -53,6 +53,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
       expect(result).to.deep.equal({
         id: campaignParticipationId,
         isCompleted: false,
+        areBadgeCriteriaValidated: false,
         totalSkillsCount: 4,
         testedSkillsCount: 2,
         validatedSkillsCount: 1,

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -1,0 +1,42 @@
+const { domainBuilder, expect } = require('../../../test-helper');
+
+const badgeCriteriaService = require('../../../../lib/domain/services/badge-criteria-service');
+
+describe('Unit | Domain | Services | badge-criteria', () => {
+
+  describe('#reviewBadgeCriteria', () => {
+    const badge = domainBuilder.buildBadge();
+
+    let campaignParticipationResult = {};
+
+    context('when the badge criteria are validated', function() {
+
+      beforeEach(() =>  {
+        const badge = domainBuilder.buildBadge();
+        campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({ masteryPercentage: 94, badge });
+      });
+
+      it('should return true', async () => {
+        // when
+        const result = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+
+        // then
+        expect(result).to.be.equal(true);
+      });
+    });
+
+    context('when the badge criteria are not validated', function() {
+      beforeEach(() =>  {
+        campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({ masteryPercentage: 24, badge });
+      });
+
+      it('should return false', async () => {
+        // when
+        const result = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+
+        // then
+        expect(result).to.be.equal(false);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/badge-criteria-service_test.js
+++ b/api/tests/unit/domain/services/badge-criteria-service_test.js
@@ -4,12 +4,12 @@ const badgeCriteriaService = require('../../../../lib/domain/services/badge-crit
 
 describe('Unit | Domain | Services | badge-criteria', () => {
 
-  describe('#reviewBadgeCriteria', () => {
+  describe('#areBadgeCriteriaFulfilled', () => {
     const badge = domainBuilder.buildBadge();
 
     let campaignParticipationResult = {};
 
-    context('when the badge criteria are validated', function() {
+    context('when the badge criteria are fulfilled', function() {
 
       beforeEach(() =>  {
         const badge = domainBuilder.buildBadge();
@@ -18,21 +18,21 @@ describe('Unit | Domain | Services | badge-criteria', () => {
 
       it('should return true', async () => {
         // when
-        const result = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult });
 
         // then
         expect(result).to.be.equal(true);
       });
     });
 
-    context('when the badge criteria are not validated', function() {
+    context('when the badge criteria are not fulfilled', function() {
       beforeEach(() =>  {
         campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({ masteryPercentage: 24, badge });
       });
 
       it('should return false', async () => {
         // when
-        const result = await badgeCriteriaService.reviewBadgeCriteria({ campaignParticipationResult });
+        const result = await badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult });
 
         // then
         expect(result).to.be.equal(false);

--- a/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
@@ -44,7 +44,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
     assessmentRepository = { get: sinon.stub() };
     badgeRepository = { findOneByTargetProfileId: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
-    badgeCriteriaService = { reviewBadgeCriteria: sinon.stub() };
+    badgeCriteriaService = { areBadgeCriteriaFulfilled: sinon.stub() };
     sinon.stub(CampaignParticipationResult, 'buildFrom').returns(campaignParticipationResult);
 
     usecaseDependencies = {
@@ -73,7 +73,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       beforeEach(() => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
-        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(true);
+        badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
       it('should get the campaignParticipationResult', async () => {
@@ -85,11 +85,11 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       });
     });
 
-    context('when a badge is not available for the campaignParticipationResult', () => {
+    context('when no badge is available for the campaignParticipationResult', () => {
       beforeEach(() => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
-        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(false);
+        badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(false);
       });
 
       it('should get the campaignParticipationResult', async () => {
@@ -115,7 +115,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       beforeEach(() => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
-        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(true);
+        badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
       it('should get the campaignParticipationResult', async () => {
@@ -127,11 +127,11 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       });
     });
 
-    context('when a badge is not available for the campaignParticipationResult', () => {
+    context('when no badge is available for the campaignParticipationResult', () => {
       beforeEach(() => {
         // given
         badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
-        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(false);
+        badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).resolves(false);
       });
 
       it('should get the campaignParticipationResult', async () => {

--- a/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
@@ -10,7 +10,6 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
   const userId = 2;
   const campaignId = 'campaignId';
   const otherUserId = 3;
-  const campaignParticipationResult = { id: 'foo' };
   const campaignParticipation = {
     campaignId,
     userId,
@@ -21,6 +20,10 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
   const targetProfile = {
     id: 1
   };
+  const campaignParticipationResult = {
+    id: 'foo',
+    badge
+  };
 
   let campaignParticipationRepository,
     campaignRepository,
@@ -28,7 +31,10 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
     competenceRepository,
     assessmentRepository,
     badgeRepository,
-    knowledgeElementRepository;
+    knowledgeElementRepository,
+    badgeCriteriaService;
+
+  let usecaseDependencies;
 
   beforeEach(() => {
     campaignParticipationRepository = { get: sinon.stub() };
@@ -38,62 +44,105 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
     assessmentRepository = { get: sinon.stub() };
     badgeRepository = { findOneByTargetProfileId: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
+    badgeCriteriaService = { reviewBadgeCriteria: sinon.stub() };
     sinon.stub(CampaignParticipationResult, 'buildFrom').returns(campaignParticipationResult);
+
+    usecaseDependencies = {
+      userId,
+      campaignParticipationId,
+      campaignParticipationRepository,
+      campaignRepository,
+      targetProfileRepository,
+      competenceRepository,
+      assessmentRepository,
+      badgeRepository,
+      knowledgeElementRepository,
+      badgeCriteriaService,
+    };
   });
 
   context('when user belongs to the organization of the campaign', () => {
-
-    it('should get the campaignParticipationResult', async () => {
+    beforeEach(() => {
       // given
       campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
       targetProfileRepository.getByCampaignId.withArgs(campaignParticipation.campaignId).resolves(targetProfile);
-      badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, otherUserId).resolves(true);
+    });
 
-      // when
-      const actualCampaignParticipationResult = await getCampaignParticipationResult({
-        userId: otherUserId,
-        campaignParticipationId,
-        campaignParticipationRepository,
-        campaignRepository,
-        targetProfileRepository,
-        competenceRepository,
-        assessmentRepository,
-        badgeRepository,
-        knowledgeElementRepository,
+    context('when a badge is available for the campaignParticipationResult', () => {
+      beforeEach(() => {
+        // given
+        badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
+        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
-      // then
-      expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      it('should get the campaignParticipationResult', async () => {
+        // when
+        const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      });
     });
+
+    context('when a badge is not available for the campaignParticipationResult', () => {
+      beforeEach(() => {
+        // given
+        badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
+        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(false);
+      });
+
+      it('should get the campaignParticipationResult', async () => {
+        // when
+        const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      });
+    });
+
   });
 
   context('when campaignParticipation belongs to user', () => {
-
-    it('should get the campaignParticipationResult', async () => {
+    beforeEach(() => {
       // given
       campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
       targetProfileRepository.getByCampaignId.withArgs(campaignParticipation.campaignId).resolves(targetProfile);
-      badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
-
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, otherUserId).resolves(false);
+    });
 
-      // when
-      const actualCampaignParticipationResult = await getCampaignParticipationResult({
-        userId,
-        campaignParticipationId,
-        campaignParticipationRepository,
-        campaignRepository,
-        targetProfileRepository,
-        competenceRepository,
-        assessmentRepository,
-        badgeRepository,
-        knowledgeElementRepository,
+    context('when a badge is available for the campaignParticipationResult', () => {
+      beforeEach(() => {
+        // given
+        badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves(badge);
+        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(true);
       });
 
-      // then
-      expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      it('should get the campaignParticipationResult', async () => {
+        // when
+        const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      });
     });
+
+    context('when a badge is not available for the campaignParticipationResult', () => {
+      beforeEach(() => {
+        // given
+        badgeRepository.findOneByTargetProfileId.withArgs(targetProfileId).resolves({});
+        badgeCriteriaService.reviewBadgeCriteria.withArgs({ campaignParticipationResult }).resolves(false);
+      });
+
+      it('should get the campaignParticipationResult', async () => {
+        // when
+        const actualCampaignParticipationResult = await getCampaignParticipationResult(usecaseDependencies);
+
+        // then
+        expect(actualCampaignParticipationResult).to.deep.equal(campaignParticipationResult);
+      });
+    });
+
   });
 
   context('when user not belongs to the organization of the campaign or not own this campaignParticipation', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -24,6 +24,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
       const masteryPercentage = validatedSkillsCount * 100 / totalSkillsCount;
 
       const campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({
+        areBadgeCriteriaValidated: true,
         isCompleted: true,
         testedSkillsCount,
         totalSkillsCount,
@@ -34,6 +35,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
       const expectedSerializedCampaignParticipationResult = {
         data: {
           attributes: {
+            'are-badge-criteria-validated': true,
             'is-completed': true,
             'mastery-percentage': masteryPercentage,
             'tested-skills-count': testedSkillsCount,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -21,6 +21,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
       const testedSkillsCount = competenceResults[0].testedSkillsCount + competenceResults[1].testedSkillsCount;
       const totalSkillsCount = competenceResults[0].totalSkillsCount + competenceResults[1].totalSkillsCount;
       const validatedSkillsCount = competenceResults[0].validatedSkillsCount + competenceResults[1].validatedSkillsCount;
+      const masteryPercentage = validatedSkillsCount * 100 / totalSkillsCount;
 
       const campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({
         isCompleted: true,
@@ -34,6 +35,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
         data: {
           attributes: {
             'is-completed': true,
+            'mastery-percentage': masteryPercentage,
             'tested-skills-count': testedSkillsCount,
             'total-skills-count': totalSkillsCount,
             'validated-skills-count': validatedSkillsCount,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
       const masteryPercentage = validatedSkillsCount * 100 / totalSkillsCount;
 
       const campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({
-        areBadgeCriteriaValidated: true,
+        areBadgeCriteriaFulfilled: true,
         isCompleted: true,
         testedSkillsCount,
         totalSkillsCount,
@@ -35,7 +35,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
       const expectedSerializedCampaignParticipationResult = {
         data: {
           attributes: {
-            'are-badge-criteria-validated': true,
+            'are-badge-criteria-fulfilled': true,
             'is-completed': true,
             'mastery-percentage': masteryPercentage,
             'tested-skills-count': testedSkillsCount,

--- a/mon-pix/app/controllers/campaigns/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/skill-review.js
@@ -9,10 +9,10 @@ export default Controller.extend({
   displayImprovementButton: false,
   pageTitle: 'Résultat',
 
-  shouldShowBadge: computed('model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.masteryPercentage}', function() {
+  shouldShowBadge: computed('model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated}', function() {
     const badge = this.get('model.campaignParticipation.campaignParticipationResult.badge.content');
-    const masteryPercentage = this.get('model.campaignParticipation.campaignParticipationResult.masteryPercentage');
-    return (masteryPercentage >= 85 && !_.isEmpty(badge));
+    const areBadgeCriteriaValidated = this.get('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated');
+    return (!_.isEmpty(badge) && areBadgeCriteriaValidated);
   }),
 
   actions: {

--- a/mon-pix/app/controllers/campaigns/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/skill-review.js
@@ -9,10 +9,10 @@ export default Controller.extend({
   displayImprovementButton: false,
   pageTitle: 'Résultat',
 
-  shouldShowBadge: computed('model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated}', function() {
+  shouldShowBadge: computed('model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled}', function() {
     const badge = this.get('model.campaignParticipation.campaignParticipationResult.badge.content');
-    const areBadgeCriteriaValidated = this.get('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated');
-    return (!_.isEmpty(badge) && areBadgeCriteriaValidated);
+    const areBadgeCriteriaFulfilled = this.get('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled');
+    return (!_.isEmpty(badge) && areBadgeCriteriaFulfilled);
   }),
 
   actions: {

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -8,7 +8,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
-  @attr('boolean') areBadgeCriteriaValidated;
+  @attr('boolean') areBadgeCriteriaFulfilled;
 
   // includes
   @belongsTo('badge') badge;

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -1,10 +1,10 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { mapBy, max } from '@ember/object/computed';
-import { computed } from '@ember/object';
 
 export default class CampaignParticipationResult extends Model {
 
   // attributes
+  @attr('number') masteryPercentage;
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
@@ -17,9 +17,4 @@ export default class CampaignParticipationResult extends Model {
   @mapBy('competenceResults', 'totalSkillsCount') totalSkillsCounts;
 
   @max('totalSkillsCounts') maxTotalSkillsCountInCompetences;
-
-  @computed('totalSkillsCount', 'validatedSkillsCount')
-  get masteryPercentage() {
-    return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);
-  }
 }

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -8,6 +8,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
+  @attr('boolean') areBadgeCriteriaValidated;
 
   // includes
   @belongsTo('badge') badge;

--- a/mon-pix/mirage/routes/get-campaign-participation-result.js
+++ b/mon-pix/mirage/routes/get-campaign-participation-result.js
@@ -19,7 +19,7 @@ export default function(schema) {
     totalSkillsCount: 10,
     testedSkillsCount: 9,
     validatedSkillsCount: 9,
-    areBadgeCriteriaValidated: true,
+    areBadgeCriteriaFulfilled: true,
     competenceResults: [competenceResult],
     badge
   });

--- a/mon-pix/mirage/routes/get-campaign-participation-result.js
+++ b/mon-pix/mirage/routes/get-campaign-participation-result.js
@@ -19,6 +19,7 @@ export default function(schema) {
     totalSkillsCount: 10,
     testedSkillsCount: 9,
     validatedSkillsCount: 9,
+    areBadgeCriteriaValidated: true,
     competenceResults: [competenceResult],
     badge
   });

--- a/mon-pix/mirage/routes/get-campaign-participation-result.js
+++ b/mon-pix/mirage/routes/get-campaign-participation-result.js
@@ -15,6 +15,7 @@ export default function(schema) {
   });
 
   return schema.campaignParticipationResults.create({
+    masteryPercentage: 90,
     totalSkillsCount: 10,
     testedSkillsCount: 9,
     validatedSkillsCount: 9,

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -5,6 +5,7 @@ export default ApplicationSerializer.extend({
     'totalSkillsCount',
     'testedSkillsCount',
     'validatedSkillsCount',
+    'masteryPercentage',
     'isCompleted'
   ],
   include: ['badge', 'competenceResults'],

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -6,7 +6,8 @@ export default ApplicationSerializer.extend({
     'testedSkillsCount',
     'validatedSkillsCount',
     'masteryPercentage',
-    'isCompleted'
+    'isCompleted',
+    'areBadgeCriteriaValidated',
   ],
   include: ['badge', 'competenceResults'],
 });

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -7,7 +7,7 @@ export default ApplicationSerializer.extend({
     'validatedSkillsCount',
     'masteryPercentage',
     'isCompleted',
-    'areBadgeCriteriaValidated',
+    'areBadgeCriteriaFulfilled',
   ],
   include: ['badge', 'competenceResults'],
 });

--- a/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
@@ -42,7 +42,7 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
   });
 
   describe('#shouldShowBadge', () => {
-    context('when at least one badge is available', function() {
+    context('when some badge information is available', function() {
       beforeEach(function() {
         // given
         const badgePixEmploi = EmberObject.create({
@@ -56,24 +56,24 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
         controller.set('model.campaignParticipation.campaignParticipationResult.badge', badgePixEmploi);
       });
 
-      it('should return true when user validated the criteria of a badge', function() {
+      it('should return true when badge criteria are fulfilled', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', true);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled', true);
 
         // then
         expect(controller.shouldShowBadge).to.equal(true);
       });
 
-      it('should return false when user did not validated the criteria of a badge', function() {
+      it('should return false when badge criteria are not fulfilled', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);
       });
     });
 
-    context('when no badge is available', function() {
+    context('when no badge information is available', function() {
       beforeEach(function() {
         // given
         const emptyBadge = EmberObject.create({
@@ -82,17 +82,17 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
         controller.set('model.campaignParticipation.campaignParticipationResult.badge', emptyBadge);
       });
 
-      it('should return false when user validated the criteria of a badge', function() {
+      it('should return false when user badge criteria are fulfilled', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);
       });
 
-      it('should return false when user did not validated the criteria of a badge', function() {
+      it('should return false when badge criteria are not fulfilled', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);

--- a/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
@@ -56,17 +56,17 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
         controller.set('model.campaignParticipation.campaignParticipationResult.badge', badgePixEmploi);
       });
 
-      it('should return true when user masters more than 85 percent', function() {
+      it('should return true when user validated the criteria of a badge', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.masteryPercentage', 85);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', true);
 
         // then
         expect(controller.shouldShowBadge).to.equal(true);
       });
 
-      it('should return false when user masters less than 85 percent', function() {
+      it('should return false when user did not validated the criteria of a badge', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.masteryPercentage', 26);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);
@@ -82,17 +82,17 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
         controller.set('model.campaignParticipation.campaignParticipationResult.badge', emptyBadge);
       });
 
-      it('should return false when user masters more than 85 percent', function() {
+      it('should return false when user validated the criteria of a badge', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.masteryPercentage', 85);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);
       });
 
-      it('should return false when user masters less than 85 percent', function() {
+      it('should return false when user did not validated the criteria of a badge', function() {
         // when
-        controller.set('model.campaignParticipation.campaignParticipationResult.masteryPercentage', 26);
+        controller.set('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaValidated', false);
 
         // then
         expect(controller.shouldShowBadge).to.equal(false);

--- a/mon-pix/tests/unit/models/campaign-participation-result-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-result-test.js
@@ -39,19 +39,4 @@ describe('Unit | Model | Campaign-Participation-Result', function() {
       expect(maxTotalSkillsCountInCompetences).to.equal(11);
     });
   });
-
-  describe('masteryPercentage', function() {
-
-    it('should calculate total validated skills percentage', function() {
-      const model = store.createRecord('campaign-participation-result');
-      model.set('totalSkillsCount', 45);
-      model.set('validatedSkillsCount', 40);
-
-      // when
-      const masteryPercentage = model.get('masteryPercentage');
-
-      // then
-      expect(masteryPercentage).to.equal(89);
-    });
-  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les badges sont générés "en dur" dans le front.
Historiquement, nous avions créé cette dette technique pour évaluer l'intérêt de la solution dans les délais accordés.

## :robot: Solution
Pour vérifier si les critères de badges sont validés, nous procédons à : 
- un refactoring qui déplace le seul critère que nous avons pour le moment au niveau de l'API. 
- un refactoring côté front qui se base sur l'état `areBadgeCriteriaValidated` de la revue des critères d'obtention de badge faite côté back

## 🌈 Remarques 
La gamification peut s'exprimer sous l'équation suivante :
```
Gamification = Rules + Goals + Volontary Participation + Feedback
```
Concrètement, dans le code, cela va se modéliser selon les termes métier par :
```
Gamification = BadgeCriteria + Badge + BadgeAcquisition
```
avec : 
- `BadgeCriteria = Rules`
- `BadgeAcquisition = Goals`
- `Badge = Feedback`