### PR TITLE
[TECH] Suppression de la table Snapshots (PF-1126).

### DIFF
--- a/api/db/migrations/20200306143100_delete-snapshots-table.js
+++ b/api/db/migrations/20200306143100_delete-snapshots-table.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'snapshots';
+
+exports.up = function(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .createTable(TABLE_NAME, (t) => {
+      t.increments().primary();
+      t.string('studentCode');
+      t.string('campaignCode');
+      t.integer('organizationId').unsigned().references('organizations.id');
+      t.integer('userId').unsigned().references('users.id');
+      t.string('score');
+      t.json('profile').notNullable();
+      t.integer('testsFinished');
+      t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+      t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    });
+};


### PR DESCRIPTION
## :unicorn: Problème
Tout le code lié à Pix Board a déjà été supprimé. La table Snapshots en est la dernière trace, et n'est donc plus utilisée.

## :robot: Solution
Supprimer cette table, qui est désormais inutile ! 🎉 

## :rainbow: Remarques
end of pix board 🎉 🎉 
