### PR TITLE
[FEATURE] Ajouter l'identifiant externe dans la liste des organisations (PA-113).

### DIFF
--- a/admin/app/templates/components/routes/authenticated/organizations/list-items.hbs
+++ b/admin/app/templates/components/routes/authenticated/organizations/list-items.hbs
@@ -5,6 +5,7 @@
         <tr>
           <th>Nom</th>
           <th>Type</th>
+          <th>Identifiant externe</th>
         </tr>
         <tr>
           <th>{{input id="name" value=nameValue keyUp=(action triggerFiltering 'name' nameValue) class="table-admin-input"}}</th>
@@ -18,6 +19,7 @@
           <tr onclick={{action goToOrganizationPage organization.id}} class="tr--clickable">
             <td>{{organization.name}}</td>
             <td>{{organization.type}}</td>
+            <td>{{organization.externalId}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
@@ -7,22 +7,36 @@ module('Integration | Component | routes/authenticated/organizations | list-item
 
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(async function() {
+    const triggerFiltering = function() {};
+    const goToOrganizationPage = function() {};
+
+    this.set('triggerFiltering', triggerFiltering);
+    this.set('goToOrganizationPage', goToOrganizationPage);
+  });
+
+  test('it should display header with name, type and externalId', async function(assert) {
+    // when
+    await render(hbs`{{routes/authenticated/organizations/list-items triggerFiltering=triggerFiltering goToOrganizationPage=goToOrganizationPage}}`);
+
+    // then
+    assert.dom('table thead tr:first-child th:first-child').hasText('Nom');
+    assert.dom('table thead tr:first-child th:nth-child(2)').hasText('Type');
+    assert.dom('table thead tr:first-child th:nth-child(3)').hasText('Identifiant externe');
+  });
+
   test('it should display organization list', async function(assert) {
     // given
+    const externalId = '1234567A';
     const organizations = [
-      { id: 1, name: 'École ACME', type: 'SCO' },
-      { id: 2, name: 'Université BROS', type: 'SUP' },
-      { id: 3, name: 'Entreprise KSSOS', type: 'PRO' },
+      { id: 1, name: 'École ACME', type: 'SCO', externalId },
+      { id: 2, name: 'Université BROS', type: 'SUP', externalId },
+      { id: 3, name: 'Entreprise KSSOS', type: 'PRO', externalId },
     ];
     organizations.meta = {
       rowCount: 3
     };
-    const triggerFiltering = function() {};
-    const goToOrganizationPage = function() {};
-
     this.set('organizations', organizations);
-    this.set('triggerFiltering', triggerFiltering);
-    this.set('goToOrganizationPage', goToOrganizationPage);
 
     // when
     await render(hbs`{{routes/authenticated/organizations/list-items organizations=organizations triggerFiltering=triggerFiltering goToOrganizationPage=goToOrganizationPage}}`);
@@ -30,6 +44,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText('École ACME');
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('SCO');
+    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText(externalId);
     assert.dom('table tbody tr').exists({ count: 3 });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'information Identifiant externe est utile dans la gestion des organisations.
Mais cette information n'est pas visible dans le liste des organisations.

## :robot: Solution
Ajouter la colonne Identifiant externe dans la page listant les organisations.

## :rainbow: Remarques
La fonction de recherche sera traitée dans un autre ticket.
