### PR TITLE
[BUGFIX] Bloquer l'inscription si le formulaire n'est pas valide (PO-381).

### DIFF
--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -51,10 +51,11 @@ const userValidationJoiSchema = Joi.object({
       'boolean.base': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
       'any.only': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
     }),
-}).oxor('username', 'email')
+}).xor('username', 'email')
   .required()
   .messages({
     'any.required': 'Aucun champ n\'est renseigné.',
+    'object.missing': 'Vous devez renseigner une adresse e-mail et/ou un identifiant.',
   });
 
 module.exports = {

--- a/api/lib/interfaces/jsonapi/unprocessable-entity-error.js
+++ b/api/lib/interfaces/jsonapi/unprocessable-entity-error.js
@@ -24,7 +24,18 @@ function _formatRelationship({ attribute, message }) {
   };
 }
 
+function _formatUndefinedAttribute({ message }) {
+  return {
+    status: '422',
+    title: 'Invalid data attributes',
+    detail: message
+  };
+}
+
 function _formatInvalidAttribute({ attribute, message }) {
+  if (!attribute) {
+    return _formatUndefinedAttribute({ message });
+  }
   if (attribute.endsWith('Id')) {
     return _formatRelationship({ attribute, message });
   }

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -198,6 +198,22 @@ describe('Unit | UseCase | create-user', () => {
     });
   });
 
+  context('when user email is not defined', () => {
+
+    it('should not check the non existence of email in UserRepository', async () => {
+      // given
+      const user = { email: null };
+
+      // when
+      await createUser({
+        user, reCaptchaToken, userRepository, reCaptchaValidator, encryptionService, mailService
+      });
+
+      // then
+      expect(userRepository.isEmailAvailable).to.not.have.been.called;
+    });
+  });
+
   context('when user is valid', () => {
 
     context('step hash password and save user', () => {

--- a/api/tests/unit/domain/validations/user-validator_test.js
+++ b/api/tests/unit/domain/validations/user-validator_test.js
@@ -181,6 +181,26 @@ describe('Unit | Domain | Validators | user-validator', function() {
           }
         });
 
+        it('should reject with error when neither email or username are defined', () => {
+          // given
+          const expectedError = {
+            attribute: undefined,
+            message: 'Vous devez renseigner une adresse e-mail et/ou un identifiant.'
+          };
+
+          user.email = undefined;
+          user.username = undefined;
+
+          // when
+          try {
+            userValidator.validate({ user });
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
         it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
           // given
           user = {

--- a/api/tests/unit/interfaces/jsonapi/unprocessable-entity-error-test.js
+++ b/api/tests/unit/interfaces/jsonapi/unprocessable-entity-error-test.js
@@ -48,6 +48,28 @@ describe('Unit | Interfaces | JSONAPI | Unprocessable Entity Error', () => {
     expect(unprocessableErrorOnFirstname.detail).to.equal('Le profile cible n’est pas renseigné.');
   });
 
+  it('should create a new JSONAPI unprocessable entity error with invalid data attribute, if attribute is undefined', () => {
+    // given
+    const invalidAttributes = [
+      {
+        attribute: undefined,
+        message: 'Vous devez renseigner une adresse e-mail et/ou un identifiant.',
+      }
+    ];
+
+    // when
+    const jsonApiUnprocessableError = JSONAPI.unprocessableEntityError(invalidAttributes);
+
+    // then
+    expect(jsonApiUnprocessableError.errors).to.have.lengthOf(1);
+
+    const unprocessableErrorOnFirstname = jsonApiUnprocessableError.errors[0];
+    expect(unprocessableErrorOnFirstname.status).to.equal('422');
+    expect(unprocessableErrorOnFirstname.source).to.be.undefined;
+    expect(unprocessableErrorOnFirstname.title).to.equal('Invalid data attributes');
+    expect(unprocessableErrorOnFirstname.detail).to.equal('Vous devez renseigner une adresse e-mail et/ou un identifiant.');
+  });
+
   it('should create a new JSONAPI unprocessable with multiple invalid attributes', () => {
     // given
     const invalidAttributes = [

--- a/orga/app/components/routes/register-form.js
+++ b/orga/app/components/routes/register-form.js
@@ -30,6 +30,8 @@ const validation = {
   }
 };
 
+const isStringValid = (value) => Boolean(value.trim());
+
 export default class RegisterForm extends Component {
 
   @service session;
@@ -43,6 +45,12 @@ export default class RegisterForm extends Component {
   @computed('isPasswordVisible')
   get passwordInputType() {
     return this.isPasswordVisible ? 'text' : 'password';
+  }
+
+  @computed('user.{firstName,lastName,email,password,cgu}')
+  get isFormValid() {
+    return isStringValid(this.user.firstName) && isStringValid(this.user.lastName) && isEmailValid(this.user.email)
+      && isPasswordValid(this.user.password) && this.user.cgu;
   }
 
   constructor() {
@@ -59,6 +67,9 @@ export default class RegisterForm extends Component {
   @action
   async register(event) {
     event.preventDefault();
+    if (!this.isFormValid) {
+      return this.set('isLoading', false);
+    }
     this.set('isLoading', true);
     try {
       await this.user.save();

--- a/orga/app/templates/components/routes/register-form.hbs
+++ b/orga/app/templates/components/routes/register-form.hbs
@@ -82,7 +82,7 @@
 
     <div class="input-container">
       {{#if this.isLoading}}
-        <button type="submit" class="button"><span class="loader-in-button">&nbsp;</span></button>
+        <button type="button" class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
         <button type="submit" class="button">Je m'inscris</button>
       {{/if}}

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -4,6 +4,7 @@ import { resolve } from 'rsvp';
 import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
@@ -77,76 +78,169 @@ module('Integration | Component | routes/register-form', function(hooks) {
 
   module('errors management', function() {
 
-    [{ stringFilledIn: '' },
-      { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
-      test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
-        // given
-        await render(hbs`{{routes/register-form}}`);
+    module('error display', () => {
 
-        // when
-        await fillIn('#register-firstName', stringFilledIn);
-        await triggerEvent('#register-firstName', 'focusout');
+      [{ stringFilledIn: '' },
+        { stringFilledIn: ' ' },
+      ].forEach(function({ stringFilledIn }) {
+        test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+          // given
+          await render(hbs`{{routes/register-form}}`);
 
-        // then
-        assert.dom('#register-firstName-container .alert-input--error').hasText(EMPTY_FIRSTNAME_ERROR_MESSAGE);
-        assert.dom('#register-firstName-container .input--error').exists();
+          // when
+          await fillIn('#register-firstName', stringFilledIn);
+          await triggerEvent('#register-firstName', 'focusout');
+
+          // then
+          assert.dom('#register-firstName-container .alert-input--error').hasText(EMPTY_FIRSTNAME_ERROR_MESSAGE);
+          assert.dom('#register-firstName-container .input--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: '' },
+        { stringFilledIn: ' ' },
+      ].forEach(function({ stringFilledIn }) {
+        test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+          // given
+          await render(hbs`{{routes/register-form}}`);
+
+          // when
+          await fillIn('#register-lastName', stringFilledIn);
+          await triggerEvent('#register-lastName', 'focusout');
+
+          // then
+          assert.dom('#register-lastName-container .alert-input--error').hasText(EMPTY_LASTNAME_ERROR_MESSAGE);
+          assert.dom('#register-lastName-container .input--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: ' ' },
+        { stringFilledIn: 'a' },
+        { stringFilledIn: 'shi.fu' },
+      ].forEach(function({ stringFilledIn }) {
+
+        test(`it should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+          // given
+          await render(hbs`{{routes/register-form}}`);
+
+          // when
+          await fillIn('#register-email', stringFilledIn);
+          await triggerEvent('#register-email', 'focusout');
+
+          // then
+          assert.dom('#register-email-container .alert-input--error').hasText(EMPTY_EMAIL_ERROR_MESSAGE);
+          assert.dom('#register-email-container .input--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: ' ' },
+        { stringFilledIn: 'password' },
+        { stringFilledIn: 'password1' },
+        { stringFilledIn: 'Password' },
+      ].forEach(function({ stringFilledIn }) {
+
+        test(`it should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+          // given
+          await render(hbs`{{routes/register-form}}`);
+
+          // when
+          await fillIn('#register-password', stringFilledIn);
+          await triggerEvent('#register-password', 'focusout');
+
+          // then
+          assert.dom('#register-password-container .alert-input--error').hasText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
+          assert.dom('#register-password-container .input-password--error').exists();
+        });
       });
     });
 
-    [{ stringFilledIn: '' },
-      { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
-      test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
-        // given
-        await render(hbs`{{routes/register-form}}`);
+    module('form submission', (hooks) => {
 
-        // when
-        await fillIn('#register-lastName', stringFilledIn);
-        await triggerEvent('#register-lastName', 'focusout');
+      let spy;
+      let validUser;
 
-        // then
-        assert.dom('#register-lastName-container .alert-input--error').hasText(EMPTY_LASTNAME_ERROR_MESSAGE);
-        assert.dom('#register-lastName-container .input--error').exists();
+      const fillForm = async function(user) {
+        await fillIn('#register-firstName', user.firstName);
+        await fillIn('#register-lastName', user.lastName);
+        await fillIn('#register-email', user.email);
+        await fillIn('#register-password', user.password);
+        if (user.cgu) {
+          await click('#register-cgu');
+        }
+      };
+
+      hooks.beforeEach(async function() {
+        validUser = {
+          firstName: 'pix',
+          lastName: 'pix',
+          email: 'shi@fu.me',
+          password: 'Mypassword1',
+          cgu: true
+        };
+
+        spy = sinon.spy();
+        this.owner.unregister('service:store');
+        this.owner.register('service:store', storeStub);
+        storeStub.prototype.createRecord = sinon.stub().returns({
+          save: spy
+        });
+
+        await render(hbs`{{routes/register-form organizationInvitationId=1 organizationInvitationCode='C0D3'}}`);
       });
-    });
 
-    [{ stringFilledIn: ' ' },
-      { stringFilledIn: 'a' },
-      { stringFilledIn: 'shi.fu' },
-    ].forEach(function({ stringFilledIn }) {
-
-      test(`it should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+      test('it should prevent submission when firstName is not valid', async function(assert) {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await fillForm({ ...validUser, ...{ firstName: '' } });
 
         // when
-        await fillIn('#register-email', stringFilledIn);
-        await triggerEvent('#register-email', 'focusout');
+        await click('.button');
 
         // then
-        assert.dom('#register-email-container .alert-input--error').hasText(EMPTY_EMAIL_ERROR_MESSAGE);
-        assert.dom('#register-email-container .input--error').exists();
+        assert.equal(spy.callCount, 0);
       });
-    });
 
-    [{ stringFilledIn: ' ' },
-      { stringFilledIn: 'password' },
-      { stringFilledIn: 'password1' },
-      { stringFilledIn: 'Password' },
-    ].forEach(function({ stringFilledIn }) {
-
-      test(`it should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+      test('it should prevent submission when lastName is not valid', async function(assert) {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await fillForm({ ...validUser, ...{ lastName: '' } });
 
         // when
-        await fillIn('#register-password', stringFilledIn);
-        await triggerEvent('#register-password', 'focusout');
+        await click('.button');
 
         // then
-        assert.dom('#register-password-container .alert-input--error').hasText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
-        assert.dom('#register-password-container .input-password--error').exists();
+        assert.equal(spy.callCount, 0);
+      });
+
+      test('it should prevent submission when email is not valid', async function(assert) {
+        // given
+        await fillForm({ ...validUser, ...{ email: '' } });
+
+        // when
+        await click('.button');
+
+        // then
+        assert.equal(spy.callCount, 0);
+      });
+
+      test('it should prevent submission when password is not valid', async function(assert) {
+        // given
+        await fillForm({ ...validUser, ...{ password: '' } });
+
+        // when
+        await click('.button');
+
+        // then
+        assert.equal(spy.callCount, 0);
+      });
+
+      test('it should prevent submission when cgu is not valid', async function(assert) {
+        // given
+        await fillForm({ ...validUser, ...{ cgu: false } });
+
+        // when
+        await click('.button');
+
+        // then
+        assert.equal(spy.callCount, 0);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'inscription, si la saisie de l'utilisateur est invalide (ex: email non renseigné), la soumission est possible. De plus, l'API renvoit une erreur 500.

## :robot: Solution
Ne pas faire appel à l'API si la saisie est invalide. 
Si les données reçues côté API sont invalides, renvoyer une erreur 422.

## :rainbow: Remarques
Mise à jour de la validation JOI pour rejeter le cas où ni l'email, ni le username ne sont fournis.
