### PR TITLE
[FEATURE] Lors de l'export des résultats, forcer les compétences à 0 pour les certifs rejected (PA-174)

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -9,6 +9,7 @@ const {
 const {
   CERTIF_SUCCESS_USER_ID,
   CERTIF_FAILED_USER_ID,
+  CERTIF_REGULAR_USER5_ID,
 } = require('./users');
 
 const A_LOT_OF_CANDIDATES_COUNT = 150;
@@ -18,9 +19,11 @@ const SUCCESS_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID = 3;
 const FAILURE_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID = 4;
 const SUCCESS_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID = 5;
 const FAILURE_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID = 6;
+const STARTED_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID = 7;
 const CANDIDATE_DATA_SUCCESS = { firstName: 'anne', lastName: 'success', birthdate: '2000-01-01', birthCity: 'Ici' };
 const CANDIDATE_DATA_FAILURE = { firstName: 'anne', lastName: 'failure', birthdate: '2000-01-01', birthCity: 'Ici' };
 const CANDIDATE_DATA_MISSING = { firstName: 'anne', lastName: 'missing', birthdate: '2000-01-01', birthCity: 'Ici' };
+const CANDIDATE_DATA_STARTED = { firstName: 'AnneNormale5', lastName: 'Certif5', birthdate: '2000-01-01', birthCity: 'Ici' };
 
 function certificationCandidatesBuilder({ databaseBuilder }) {
 
@@ -38,6 +41,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };
   const candidateDataFailureWithUser = { ...CANDIDATE_DATA_FAILURE, userId: CERTIF_FAILED_USER_ID };
   const candidateDataMissingWithUser = { ...CANDIDATE_DATA_MISSING, userId: null };
+  const candidateDataStartedWithUser = { ...CANDIDATE_DATA_STARTED, userId: CERTIF_REGULAR_USER5_ID };
 
   // Few candidates with some that have passed certification test
   sessionId = TO_FINALIZE_SESSION_ID;
@@ -55,6 +59,7 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
   sessionId = PROBLEMS_FINALIZED_SESSION_ID;
   databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId });
   databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataFailureWithUser, sessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: STARTED_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataStartedWithUser, sessionId });
   databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId });
 }
 
@@ -69,4 +74,5 @@ module.exports = {
   CANDIDATE_DATA_SUCCESS,
   CANDIDATE_DATA_FAILURE,
   CANDIDATE_DATA_MISSING,
+  CANDIDATE_DATA_STARTED
 };

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const {
   CERTIF_SUCCESS_USER_ID,
-  CERTIF_FAILURE_USER_ID
+  CERTIF_FAILURE_USER_ID,
+  CERTIF_REGULAR_USER5_ID
 } = require('./users');
 const {
   TO_FINALIZE_SESSION_ID,
@@ -11,6 +12,7 @@ const {
 const {
   CANDIDATE_DATA_SUCCESS,
   CANDIDATE_DATA_FAILURE,
+  CANDIDATE_DATA_STARTED,
 } = require('./certification-candidates-builder');
 const { CERTIFICATION_CHALLENGES_DATA } = require('./certification-data');
 
@@ -20,6 +22,7 @@ const ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID = 102;
 const ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID = 103;
 const ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID = 104;
 const ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID = 105;
+const ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID = 106;
 
 function certificationCoursesBuilder({ databaseBuilder }) {
   // Each certification tests present the same questions
@@ -30,6 +33,7 @@ function certificationCoursesBuilder({ databaseBuilder }) {
     { userId: CERTIF_FAILURE_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: true },
     { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true },
     { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false },
+    { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false },
   ], (certificationCourseData) => {
     _buildCertificationCourse(databaseBuilder, certificationCourseData);
   });
@@ -57,4 +61,5 @@ module.exports = {
   ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
   ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID,
   ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID,
+  ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
 } ;

--- a/api/db/seeds/data/certification/certification-scores-builder.js
+++ b/api/db/seeds/data/certification/certification-scores-builder.js
@@ -6,6 +6,7 @@ const {
   ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID,
   ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID,
   ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID,
+  ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
 } = require('./certification-courses-builder');
 const {
   CERTIFICATION_FAILURE_ANSWERS_DATA,
@@ -20,7 +21,7 @@ function certificationScoresBuilder({ databaseBuilder }) {
   // Idem for the "failed" user, but in a "failed" way.
   const createdAt = new Date('2020-01-31T00:00:00Z');
   _.each(
-    [ ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID ],
+    [ ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID ],
     (assessmentId) => {
       _buildSuccessScore(databaseBuilder, createdAt, assessmentId);
     });
@@ -35,10 +36,18 @@ function _buildSuccessScore(databaseBuilder, createdAt, assessmentId) {
   _.each(CERTIFICATION_SUCCESS_ANSWERS_DATA, (answerData) => {
     databaseBuilder.factory.buildAnswer({ ...answerData, value: 'Dummy value', assessmentId, createdAt });
   });
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'validated', commentForJury: null,
-    commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
-  }).id;
+  let assessmentResultId;
+  if (assessmentId === ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID) {
+    assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+      level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'started', commentForJury: null,
+      commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
+    }).id;
+  } else {
+    assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+      level: null, pixScore: 518, emitter: 'PIX-ALGO', status: 'validated', commentForJury: null,
+      commentForCandidate: null, commentForOrganization: null, juryId: null, assessmentId, createdAt,
+    }).id;
+  }
   _.each(CERTIFICATION_SUCCESS_COMPETENCE_MARKS_DATA, (competenceMarkData) => {
     databaseBuilder.factory.buildCompetenceMark({ ...competenceMarkData, assessmentResultId, createdAt });
   });


### PR DESCRIPTION
## ☕️ Contexte
**Après avoir publié les résultats** d’une session de certification, le pôle certif **exporte le fichier des résultats** de toutes les certif de la session afin de le transmettre au prescripteur de la certification. 
Or parfois, le pôle certif doit ‘invalider” une certification, et donc passer une certif à l’origine ‘started’ ou ‘validated’ au statut ‘rejected’ manuellement dans Pix Admin.

## :unicorn: Problème
Dans le fichier des résultats, ces certif passées manuellement de ‘started’ ou ‘validated’ à ‘rejected’ gardent les infos d’origine. Mais on ne veut pas que le prescripteur ait des valeurs > 0 (pour les compétences évaluées) pour les certif ‘rejected’.

## :robot: Solution
Dans le fichier des résultats, mettre des 0 pour les certif ‘rejected’ pour les compétences évaluées (les compétences non évaluées restent avec des tirets).

## :rainbow: Remarques
**Tech...**
J'ai rajouté dans les seeds une nouvelle certif au status "validated" (cas qui n'existe pas encore dans nos données) dans la session 6.

**A venir ...**
Au cours de la discussion avec l'équipe certif (pôle, PO et dev) à propos de ce bug/ticket, un nouveau besoin a été soulevé.
Le pôle certif aimerait pouvoir distinguer :
- une certification "started" passée à "rejected" par le pôle certif à cause d'un problème particulier (pas assez de compétences, triche etc.).
- et une certification "rejected" parce que le candidat n'a pas réussi son test de certification.
Ceci fera l'objet d'un nouveau ticket.
