### PR TITLE
[FEATURE] Affichage de la liste des profils cibles d'une organisation (PA-162).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -13,6 +13,7 @@ export default Model.extend({
 
   // Relationships
   memberships: hasMany('membership'),
+  targetProfiles: DS.hasMany('target-profile'),
 
   // Functions
   async hasMember(userEmail) {

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+});

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -20,4 +20,6 @@
 
   {{organization-members-section organization=model userEmail=userEmail addMembership=(action "addMembership")}}
 
+  {{organization-target-profiles-section targetProfiles=model.targetProfiles}}
+
 </main>

--- a/admin/app/templates/components/organization-target-profiles-section.hbs
+++ b/admin/app/templates/components/organization-target-profiles-section.hbs
@@ -1,0 +1,32 @@
+<section class="page-section mb_10">
+  <header class="page-section__header">
+    <h2 class="page-section__title">Profils cible</h2>
+  </header>
+  <div class="target-profiles-list content-text content-text--small">
+    <div class="table-admin">
+      <table>
+        <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nom du profil cible</th>
+        </tr>
+        </thead>
+
+        {{#if targetProfiles}}
+          <tbody>
+          {{#each targetProfiles as |targetProfile|}}
+            <tr>
+              <td>{{targetProfile.id}}</td>
+              <td>{{targetProfile.name}}</td>
+            </tr>
+          {{/each}}
+          </tbody>
+        {{/if}}
+      </table>
+
+      {{#unless targetProfiles}}
+        <div class="table__empty content-text">Aucun résultat</div>
+      {{/unless}}
+    </div>
+  </div>
+</section>

--- a/admin/tests/integration/components/organization-target-profiles-section-test.js
+++ b/admin/tests/integration/components/organization-target-profiles-section-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | organization-target-profiles-section', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display the target profile', async function(assert) {
+    // given
+    const targetProfile1 = EmberObject.create({ id: 123, name: 'target Profile of the Night' });
+    const targetProfile2 = EmberObject.create({ id: 456, name: 'target Profile of the Death' });
+    this.set('targetProfiles', [ targetProfile1, targetProfile2 ]);
+
+    // when
+    await render(hbs`{{organization-target-profiles-section targetProfiles=targetProfiles }}`);
+
+    // then
+    assert.dom('table tbody tr').exists({ count: 2 });
+    assert.dom('table tbody tr:first-child td:first-child').hasText('123');
+    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('target Profile of the Night');
+  });
+});

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -4,7 +4,11 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'memberships', 'students'],
+      transform(record) {
+        record.targetProfiles = [];
+        return record;
+      },
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'memberships', 'students', 'targetProfiles'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,
@@ -20,6 +24,15 @@ module.exports = {
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/organizations/${parent.id}/students`;
+          }
+        }
+      },
+      targetProfiles: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related: function(record, current, parent) {
+            return `/api/organizations/${parent.id}/target-profiles`;
           }
         }
       },

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -551,6 +551,11 @@ describe('Acceptance | Application | organization-controller', () => {
                 'links': {
                   'related': `/api/organizations/${organization.id}/students`
                 }
+              },
+              'target-profiles': {
+                'links': {
+                  'related': `/api/organizations/${organization.id}/target-profiles`
+                }
               }
             },
             'type': 'organizations'

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -35,6 +35,11 @@ describe('Unit | Serializer | organization-serializer', () => {
               links: {
                 related: `/api/organizations/${organization.id}/students`
               }
+            },
+            'target-profiles': {
+              links: {
+                related: `/api/organizations/${organization.id}/target-profiles`
+              }
             }
           }
         },


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la gestion des profils cibles ne se faisait pas dans Pix Admin, donnant lieu à beaucoup de support.

## :robot: Solution
Ajouter cette gestion dans Pix Admin, en commençant par l'affichage de la liste des profils cible actifs rattachés à une organisation.

## :rainbow: Remarques
Ensuite viendra la possibilité de rattacher directement dans Pix Admin. :)
