### PR TITLE
[BUGFIX] Autoriser l'affichage des autres membres d'une organisation pour un simple membre (PO-374).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -82,6 +82,10 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations/{id}/memberships',
       config: {
+        pre: [{
+          method: securityController.checkUserBelongsToOrganizationOrHasRolePixMaster,
+          assign: 'belongsToOrganization'
+        }],
         handler: organisationController.getMemberships,
         tags: ['api', 'organizations'],
         notes: [

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -82,10 +82,6 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations/{id}/memberships',
       config: {
-        pre: [{
-          method: securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster,
-          assign: 'isAdminInOrganizationOrHasRolePixMaster'
-        }],
         handler: organisationController.getMemberships,
         tags: ['api', 'organizations'],
         notes: [

--- a/api/lib/application/usecases/checkUserBelongsToOrganization.js
+++ b/api/lib/application/usecases/checkUserBelongsToOrganization.js
@@ -1,0 +1,10 @@
+const _ = require('lodash');
+const membershipRepository = require('../../infrastructure/repositories/membership-repository');
+
+module.exports = {
+
+  execute(userId, organizationId) {
+    return membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId })
+      .then((memberships) => !_.isEmpty(memberships));
+  }
+};

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -3,6 +3,7 @@ const checkUserIsAuthenticatedUseCase = require('../../application/usecases/chec
 const checkUserHasRolePixMasterUseCase = require('../../application/usecases/checkUserHasRolePixMaster');
 const checkUserIsAdminInOrganizationUseCase = require('../../application/usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase  = require('../../application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
+const checkUserBelongsToOrganizationUseCase  = require('../../application/usecases/checkUserBelongsToOrganization');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
 
@@ -101,6 +102,27 @@ function checkUserIsAdminInOrganization(request, h) {
     .catch(() => _replyWithAuthorizationError(h));
 }
 
+async function checkUserBelongsToOrganizationOrHasRolePixMaster(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyWithAuthorizationError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const organizationId = parseInt(request.params.id);
+
+  const belongsToOrganization = await checkUserBelongsToOrganizationUseCase.execute(userId, organizationId);
+  if (belongsToOrganization) {
+    return h.response(true);
+  }
+
+  const hasRolePixMaster = await checkUserHasRolePixMasterUseCase.execute(userId);
+  if (hasRolePixMaster) {
+    return h.response(true);
+  }
+
+  return _replyWithAuthorizationError(h);
+}
+
 async function checkUserIsAdminInOrganizationOrHasRolePixMaster(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyWithAuthorizationError(h);
@@ -166,6 +188,7 @@ async function checkUserIsAdminInScoOrganizationAndManagesStudents(request, h) {
 
 module.exports = {
   checkRequestedUserIsAuthenticatedUser,
+  checkUserBelongsToOrganizationOrHasRolePixMaster,
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
   checkUserIsAuthenticated,

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -703,28 +703,6 @@ describe('Acceptance | Application | organization-controller', () => {
         // then
         expect(response.statusCode).to.equal(401);
       });
-
-      it('should respond with a 403 - forbidden access - if user is not ADMIN in organization nor PIX_MASTER', async () => {
-        // given
-        const nonPixMasterUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMasterUserId);
-        databaseBuilder.factory.buildUser({
-          id: nonPixMasterUserId,
-        });
-        databaseBuilder.factory.buildMembership({
-          organizationRole : Membership.roles.MEMBER,
-          organizationId : organization.id,
-          userId : nonPixMasterUserId,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
     });
   });
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -703,6 +703,27 @@ describe('Acceptance | Application | organization-controller', () => {
         // then
         expect(response.statusCode).to.equal(401);
       });
+
+      it('should respond with a 403 - forbidden access - if user is not in organization nor is PIXMASTER', async () => {
+        // given
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildMembership({
+          organizationRole : Membership.roles.MEMBER,
+          organizationId : otherOrganizationId,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+
+        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
     });
   });
 

--- a/api/tests/acceptance/application/security-controller_test.js
+++ b/api/tests/acceptance/application/security-controller_test.js
@@ -201,9 +201,17 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
       });
       await databaseBuilder.commit();
       const options = {
-        method: 'GET',
-        url: `/api/organizations/${organizationId}/memberships`,
+        method: 'POST',
+        url: `/api/organizations/${organizationId}/invitations`,
         headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
+        payload: {
+          data: {
+            type: 'organization-invitations',
+            attributes: {
+              email: 'truc@example.net'
+            },
+          }
+        }
       };
 
       // when

--- a/api/tests/acceptance/application/security-controller_test.js
+++ b/api/tests/acceptance/application/security-controller_test.js
@@ -297,4 +297,39 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
 
   });
 
+  describe('#checkUserBelongsToOrganizationOrHasRolePixMaster', () => {
+    let userId;
+    let organizationId;
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is neither in the organization nor PIXMASTER', async () => {
+      // given
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organizationId}/memberships`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+  });
+
 });

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -27,6 +27,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(securityController, 'checkUserIsAdminInOrganization');
     sandbox.stub(securityController, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
     sandbox.stub(securityController, 'checkUserBelongsToScoOrganizationAndManagesStudents');
+    sandbox.stub(securityController, 'checkUserBelongsToOrganizationOrHasRolePixMaster');
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -106,7 +107,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     context('Success cases', () => {
 
       beforeEach(() => {
-        securityController.checkUserIsAdminInOrganizationOrHasRolePixMaster.returns(true);
+        securityController.checkUserBelongsToOrganizationOrHasRolePixMaster.returns(true);
       });
 
       const membership = domainBuilder.buildMembership();

--- a/api/tests/unit/application/usecases/checkUserBelongsToOrganization_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToOrganization_test.js
@@ -1,0 +1,58 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const useCase = require('../../../../lib/application/usecases/checkUserBelongsToOrganization');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+
+describe('Unit | Application | Use Case | checkUserBelongsToOrganization', () => {
+
+  beforeEach(() => {
+    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+  });
+
+  context('When user is in the organization', () => {
+
+    it('should return true', async () => {
+      // given
+      const userId = 1234;
+      const organization = domainBuilder.buildOrganization();
+      const membership = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+
+    it('should return true when there are several memberships', async () => {
+      // given
+      const userId = 1234;
+      const organization = domainBuilder.buildOrganization();
+      const membership1 = domainBuilder.buildMembership({ organization });
+      const membership2 = domainBuilder.buildMembership({ organization });
+      membershipRepository.findByUserIdAndOrganizationId.resolves([membership1, membership2]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+  });
+
+  context('When user is not in the organization', () => {
+
+    it('should return false', async () => {
+      // given
+      const userId = 1234;
+      const organization = domainBuilder.buildOrganization();
+      membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+
+      // when
+      const response = await useCase.execute(userId, organization.id);
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement si un user est membre, il ne peut pas filtrer (autre que sur lui) dans le filtre créé par. La route actuellement appelée retourne les membres de l'équipe d'une orga que pour les users admin.

## :robot: Solution
Ouvrir l'accès à la requête même aux membres d'une équipe.

## :rainbow: Remarques
Ceci est un bugfix, ce n'est pas très grave d'ouvrir la liste des membres aux membres, puisque c'est même ce qui veut être fait pour l'onglet "Equipe".