### PR TITLE
[FEATURE] Filtrer la liste des organisations par l'identifiant externe (PA-172).

### DIFF
--- a/admin/app/components/routes/authenticated/organizations/list-items.js
+++ b/admin/app/components/routes/authenticated/organizations/list-items.js
@@ -10,4 +10,8 @@ export default Component.extend({
   typeValue: computed('type', function() {
     return this.get('type');
   }),
+
+  externalIdValue: computed('externalId', function() {
+    return this.get('externalId');
+  }),
 });

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -4,11 +4,14 @@ import { debounce } from '@ember/runloop';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default Controller.extend({
-  queryParams: ['pageNumber', 'pageSize', 'name', 'type'],
+
+  queryParams: ['pageNumber', 'pageSize', 'name', 'type', 'externalId'],
+
   pageNumber: DEFAULT_PAGE_NUMBER,
   pageSize: 10,
   name: null,
   type: null,
+  externalId: null,
 
   searchFilter: null,
 
@@ -18,6 +21,7 @@ export default Controller.extend({
   },
 
   actions: {
+
     triggerFiltering(fieldName, value) {
       this.set('searchFilter', { fieldName, value });
       debounce(this, this.setFieldName, 500);

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
+
   queryParams: {
     pageNumber: {
       refreshModel: true,
@@ -15,6 +16,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
     type: {
       refreshModel: true,
     },
+    externalId: {
+      refreshModel: true,
+    },
   },
 
   model(params) {
@@ -22,6 +26,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       filter: {
         name: params.name ? params.name.trim() : '',
         type: params.type ? params.type.trim() : '',
+        externalId: params.externalId ? params.externalId.trim() : '',
       },
       page: {
         number: params.pageNumber,
@@ -36,6 +41,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.set('pageSize', 10);
       controller.set('name', null);
       controller.set('type', null);
+      controller.set('externalId', null);
     }
   }
 });

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -13,6 +13,7 @@
       organizations=model
       name=name
       type=type
+      externalId=externalId
       triggerFiltering=(action 'triggerFiltering')
       goToOrganizationPage=(action 'goToOrganizationPage')
     }}

--- a/admin/app/templates/components/routes/authenticated/organizations/list-items.hbs
+++ b/admin/app/templates/components/routes/authenticated/organizations/list-items.hbs
@@ -10,6 +10,7 @@
         <tr>
           <th>{{input id="name" value=nameValue keyUp=(action triggerFiltering 'name' nameValue) class="table-admin-input"}}</th>
           <th>{{input id="type" value=typeValue keyUp=(action triggerFiltering 'type' typeValue) class="table-admin-input"}}</th>
+          <th>{{input id="externalId" value=externalIdValue keyUp=(action triggerFiltering 'externalId' externalIdValue) class="table-admin-input"}}</th>
         </tr>
       </thead>
 

--- a/admin/tests/acceptance/organization-list-test.js
+++ b/admin/tests/acceptance/organization-list-test.js
@@ -6,6 +6,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | Organization List', function(hooks) {
+
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -45,15 +46,35 @@ module('Acceptance | Organization List', function(hooks) {
       assert.dom('.organization-list .table-admin tbody tr').exists({ count: 12 });
     });
 
-    test('it should display the current filter when organizations are filtered', async function(assert) {
-      // given
-      server.createList('organization', 12);
+    module('when filters are used', function(hooks) {
 
-      // when
-      await visit('/organizations/list?name=sav');
+      hooks.beforeEach(async () => {
+        server.createList('organization', 12);
+      });
 
-      // then
-      assert.dom('#name').hasValue('sav');
+      test('it should display the current filter when organizations are filtered by name', async function(assert) {
+        // when
+        await visit('/organizations/list?name=sav');
+
+        // then
+        assert.dom('#name').hasValue('sav');
+      });
+
+      test('it should display the current filter when organizations are filtered by type', async function(assert) {
+        // when
+        await visit('/organizations/list?type=SCO');
+
+        // then
+        assert.dom('#type').hasValue('SCO');
+      });
+
+      test('it should display the current filter when organizations are filtered by externalId', async function(assert) {
+        // when
+        await visit('/organizations/list?externalId=1234567A');
+
+        // then
+        assert.dom('#externalId').hasValue('1234567A');
+      });
     });
 
     test('it should redirect to organization details on click', async function(assert) {

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
@@ -25,6 +25,16 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     assert.dom('table thead tr:first-child th:nth-child(3)').hasText('Identifiant externe');
   });
 
+  test('if should display search inputs', async function(assert) {
+    // when
+    await render(hbs`{{routes/authenticated/organizations/list-items triggerFiltering=triggerFiltering goToOrganizationPage=goToOrganizationPage}}`);
+
+    // then
+    assert.dom('table thead tr:nth-child(2) input#name').exists();
+    assert.dom('table thead tr:nth-child(2) input#type').exists();
+    assert.dom('table thead tr:nth-child(2) input#externalId').exists();
+  });
+
   test('it should display organization list', async function(assert) {
     // given
     const externalId = '1234567A';

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -30,7 +30,7 @@ exports.register = async (server) => {
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
           '- Elle permet de récupérer & chercher une liste d’organisations\n' +
-          '- Cette liste est paginée et filtrée selon un **name** et/ou un **type** donnés'
+          '- Cette liste est paginée et filtrée selon un **name** et/ou un **type** et/ou un **identifiant externe** donnés'
         ]
       }
     },

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -38,12 +38,15 @@ function _toDomain(bookshelfOrganization) {
 }
 
 function _setSearchFiltersForQueryBuilder(filter, qb) {
-  const { name, type } = filter;
+  const { name, type, externalId } = filter;
   if (name) {
     qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
   }
   if (type) {
     qb.whereRaw('LOWER("type") LIKE ?', `%${type.toLowerCase()}%`);
+  }
+  if (externalId) {
+    qb.whereRaw('LOWER("externalId") LIKE ?', `%${externalId.toLowerCase()}%`);
   }
 }
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -245,8 +245,8 @@ describe('Acceptance | Application | organization-controller', () => {
 
       const userPixMaster = databaseBuilder.factory.buildUser.withPixRolePixMaster();
 
-      databaseBuilder.factory.buildOrganization({ name: 'The name of the organization', type: 'SUP' });
-      databaseBuilder.factory.buildOrganization({ name: 'Organization of the night', type: 'PRO' });
+      databaseBuilder.factory.buildOrganization({ name: 'The name of the organization', type: 'SUP', externalId: '1234567A' });
+      databaseBuilder.factory.buildOrganization({ name: 'Organization of the night', type: 'PRO', externalId: '1234568A' });
 
       options = {
         method: 'GET',
@@ -309,7 +309,7 @@ describe('Acceptance | Application | organization-controller', () => {
 
       it('should return a 200 status code with paginated and filtered data', async () => {
         // given
-        options.url = '/api/organizations?filter[name]=orga&page[number]=2&page[size]=1';
+        options.url = '/api/organizations?filter[name]=orga&filter[externalId]=A&page[number]=2&page[size]=1';
         const expectedMetaData = { page: 2, pageSize: 1, rowCount: 2, pageCount: 2 };
 
         // when
@@ -324,7 +324,7 @@ describe('Acceptance | Application | organization-controller', () => {
 
       it('should return a 200 status code with empty result', async () => {
         // given
-        options.url = '/api/organizations?filter[name]=orga&filter[type]=sco&page[number]=1&page[size]=1';
+        options.url = '/api/organizations?filter[name]=orga&filter[type]=sco&filter[externalId]=B&page[number]=1&page[size]=1';
         const expectedMetaData = { page: 1, pageSize: 1, rowCount: 0, pageCount: 0 };
 
         // when

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -243,7 +243,6 @@ describe('Integration | Repository | Organization', function() {
         expect(matchingOrganizations[0]).to.be.an.instanceOf(Organization);
         expect(pagination).to.deep.equal(expectedPagination);
       });
-
     });
 
     context('when there are lots of Organizations (> 10) in the database', () => {
@@ -319,24 +318,49 @@ describe('Integration | Repository | Organization', function() {
       });
     });
 
-    context('when there are multiple Organizations matching the fields "name", "type" search pattern', () => {
+    context('when there are multiple Organizations matching the same "externalId" search pattern', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganization({ externalId: '1234567A' });
+        databaseBuilder.factory.buildOrganization({ externalId: '1234567B' });
+        databaseBuilder.factory.buildOrganization({ externalId: '1234567C' });
+        databaseBuilder.factory.buildOrganization({ externalId: '123456AD' });
+        return databaseBuilder.commit();
+      });
+
+      it('should return only Organizations matching "externalId" if given in filters', async () => {
+        // given
+        const filter = { externalId: 'a' };
+        const page = { number: 1, size: 10 };
+        const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
+
+        // when
+        const { models: matchingOrganizations, pagination } = await organizationRepository.findPaginatedFiltered({ filter, page });
+
+        // then
+        expect(_.map(matchingOrganizations, 'externalId')).to.have.members(['1234567A', '123456AD']);
+        expect(pagination).to.deep.equal(expectedPagination);
+      });
+    });
+
+    context('when there are multiple Organizations matching the fields "name", "type" and "externalId" search pattern', () => {
 
       beforeEach(() => {
         // Matching organizations
-        databaseBuilder.factory.buildOrganization({ name: 'name_ok_1', type: 'SCO' });
-        databaseBuilder.factory.buildOrganization({ name: 'name_ok_2', type: 'SCO' });
-        databaseBuilder.factory.buildOrganization({ name: 'name_ok_3', type: 'SCO' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_1', type: 'SCO', externalId: '1234567A' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_2', type: 'SCO', externalId: '1234568A' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_3', type: 'SCO', externalId: '1234569A' });
 
         // Unmatching organizations
-        databaseBuilder.factory.buildOrganization({ name: 'name_ko_4', type: 'SCO' });
-        databaseBuilder.factory.buildOrganization({ name: 'name_ok_5', type: 'SUP' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ko_4', type: 'SCO', externalId: '1234567B' });
+        databaseBuilder.factory.buildOrganization({ name: 'name_ok_5', type: 'SUP', externalId: '1234567C' });
 
         return databaseBuilder.commit();
       });
 
-      it('should return only Organizations matching "name" AND "type" if given in filters', async () => {
+      it('should return only Organizations matching "name" AND "type" "AND" "externalId" if given in filters', async () => {
         // given
-        const filter = { name: 'name_ok', type: 'SCO' };
+        const filter = { name: 'name_ok', type: 'SCO', externalId: 'a' };
         const page = { number: 1, size: 10 };
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
 
@@ -346,6 +370,7 @@ describe('Integration | Repository | Organization', function() {
         // then
         expect(_.map(matchingOrganizations, 'name')).to.have.members(['name_ok_1', 'name_ok_2', 'name_ok_3']);
         expect(_.map(matchingOrganizations, 'type')).to.have.members(['SCO', 'SCO', 'SCO']);
+        expect(_.map(matchingOrganizations, 'externalId')).to.have.members(['1234567A', '1234568A', '1234569A']);
         expect(pagination).to.deep.equal(expectedPagination);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Si Pix Admin il n'est pas possible de filtrer la liste des organisations par l'identifiant externe.

## :robot: Solution
Ajoutez un champs spécifique pour faire ce filtrage.