### PR TITLE
[BUGFIX] Permettre la connexion aux utilisateurs dont un des memberships a été supprimé (PO-376).

### DIFF
--- a/api/db/seeds/data/po376-builder.js
+++ b/api/db/seeds/data/po376-builder.js
@@ -1,0 +1,57 @@
+const _ = require('lodash');
+
+module.exports = function organizationsBuilder({ databaseBuilder }) {
+
+  const user1Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'USER 1',
+    lastName: 'PO-376',
+    email: 'user1@example.net',
+    rawPassword: 'pix123',
+  }).id;
+
+  const user2Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'USER 2',
+    lastName: 'PO-376',
+    email: 'user2@example.net',
+    rawPassword: 'pix123',
+  }).id;
+
+  const user3Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'USER 3',
+    lastName: 'PO-376',
+    email: 'user3@example.net',
+    rawPassword: 'pix123',
+  }).id;
+
+  const user4Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'USER 4',
+    lastName: 'PO-376',
+    email: 'user4@example.net',
+    rawPassword: 'pix123',
+  }).id;
+
+  const orgaAId = databaseBuilder.factory.buildOrganization({
+    type: 'SCO',
+    name: 'ORGANISATION SCO A',
+  }).id;
+  const orgaBId = databaseBuilder.factory.buildOrganization({
+    type: 'SCO',
+    name: 'ORGANISATION SCO B',
+  }).id;
+
+  _.each([
+    { userId: user1Id, organizationId: orgaAId },
+
+    { userId: user2Id, organizationId: orgaAId },
+    { userId: user2Id, organizationId: orgaBId },
+
+    { userId: user3Id, organizationId: orgaAId },
+    { userId: user3Id, organizationId: orgaBId },
+
+    { userId: user4Id, organizationId: orgaAId },
+    { userId: user4Id, organizationId: orgaBId },
+  ], (membership) => {
+    databaseBuilder.factory.buildMembership(membership);
+  });
+
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -24,6 +24,8 @@ const targetProfilesBuilder = require('./data/target-profiles-builder');
 const usersBuilder = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 
+const po376Builder = require('./data/po376-builder');
+
 const SEQUENCE_RESTART_AT_NUMBER = 10000000;
 const SEED_NUMBER = 20110228;
 
@@ -63,6 +65,8 @@ exports.seed = (knex) => {
   certificationCandidatesBuilder({ databaseBuilder });
   certificationCoursesBuilder({ databaseBuilder });
   certificationScoresBuilder({ databaseBuilder });
+
+  po376Builder({ databaseBuilder });
 
   return databaseBuilder.commit()
     .then(() => alterSequenceIfPG(knex));

--- a/orga/app/controllers/terms-of-service.js
+++ b/orga/app/controllers/terms-of-service.js
@@ -9,18 +9,7 @@ export default class TermOfServiceController extends Controller {
 
   @action
   async submit() {
-    const user = this.currentUser.user;
-    await user.save({ adapterOptions: { acceptPixOrgaTermsOfService: true } });
-
-    const userOrgaSettings = await user.userOrgaSettings;
-    if (!userOrgaSettings) {
-      const userMemberships = await this.currentUser.user.memberships;
-      const membership = await userMemberships.firstObject;
-      const organization = await membership.organization;
-      await this.store.createRecord('user-orga-setting', { user, organization }).save();
-      await this.currentUser.load();
-    }
-
+    await this.currentUser.user.save({ adapterOptions: { acceptPixOrgaTermsOfService: true } });
     this.transitionToRoute('application');
   }
 }

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -88,39 +88,6 @@ module('Acceptance | terms-of-service', function(hooks) {
       // then
       assert.equal(currentURL(), '/cgu');
     });
-
-    module('When user has no user-orga-settings', () => {
-
-      test('it should create the user-orga-settings', async function(assert) {
-        // given
-        await visit('/cgu');
-        const previousSettingsCount = server.schema.userOrgaSettings.all().length;
-
-        // when
-        await click('button[type=submit]');
-
-        // then
-        const actualSettingsCount = server.schema.userOrgaSettings.all().length;
-        assert.equal(actualSettingsCount, previousSettingsCount + 1);
-      });
-
-      test('it should reload the currentUser service', async function(assert) {
-        const currentUser = this.owner.lookup('service:currentUser');
-
-        // given
-        await visit('/cgu');
-        const previousOrganization = currentUser.organization;
-
-        // when
-        await click('button[type=submit]');
-
-        // then
-        const actualOrganization = currentUser.organization;
-        assert.notOk(previousOrganization);
-        const firstOrganization = currentUser.user.memberships.firstObject.organization;
-        assert.equal(actualOrganization.id, firstOrganization.get('id'));
-      });
-    });
   });
 
   module('When user has already accepted terms of service', function(hooks) {

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -29,186 +29,229 @@ module('Unit | Service | current-user', function(hooks) {
         data: { authenticated: { user_id: connectedUserId } }
       });
       currentUserService = this.owner.lookup('service:currentUser');
-      currentUserService.set('store', storeStub);
-      currentUserService.set('session', sessionStub);
+      currentUserService.store = storeStub;
+      currentUserService.session = sessionStub;
     });
 
     test('should load the current user', async function(assert) {
-      // When
+      // when
       await currentUserService.load();
 
-      // Then
+      // then
       assert.equal(currentUserService.user, connectedUser);
     });
 
     test('should load the memberships', async function(assert) {
-      // Given
+      // given
       const firstOrganization = Object.create({ id: 9 });
       const secondOrganization = Object.create({ id: 10 });
       const memberships = [Object.create({ organization: firstOrganization }), Object.create({ organization: secondOrganization })];
       connectedUser.memberships = memberships;
 
-      // When
+      // when
       await currentUserService.load();
 
-      // Then
+      // then
       assert.equal(currentUserService.memberships, memberships);
     });
 
     test('should load the organization', async function(assert) {
-      // Given
+      // given
       const organization = Object.create({ id: 9 });
       connectedUser.memberships = [Object.create({ organization })];
       connectedUser.userOrgaSettings = Object.create({ organization });
 
-      // When
+      // when
       await currentUserService.load();
 
-      // Then
+      // then
       assert.equal(currentUserService.organization, organization);
     });
 
-    test('should set isAdminInOrganization to true', async function(assert) {
-      // Given
-      const organization = Object.create({ id: 9 });
-      const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
-      connectedUser.memberships = [membership];
-      connectedUser.userOrgaSettings = Object.create({ organization });
+    module('When member is not ADMIN', function() {
 
-      // When
-      await currentUserService.load();
+      test('should set isAdminInOrganization to false', async function(assert) {
+        // given
+        const organization = Object.create({ id: 9 });
+        const membership = Object.create({ organization, organizationRole: 'MEMBER', isAdmin: false });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
 
-      // Then
-      assert.equal(currentUserService.isAdminInOrganization, true);
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.isAdminInOrganization, false);
+      });
     });
 
-    test('should set isAdminInOrganization to false', async function(assert) {
-      // Given
-      const organization = Object.create({ id: 9 });
-      const membership = Object.create({ organization, organizationRole: 'MEMBER', isAdmin: false });
-      connectedUser.memberships = [membership];
-      connectedUser.userOrgaSettings = Object.create({ organization });
+    module('When member is ADMIN', function() {
 
-      // When
-      await currentUserService.load();
+      test('should set isAdminInOrganization to true', async function(assert) {
+        // given
+        const organization = Object.create({ id: 9 });
+        const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
 
-      // Then
-      assert.equal(currentUserService.isAdminInOrganization, false);
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.isAdminInOrganization, true);
+      });
+
+      test('should set canAccessStudentsPage to true when type is SCO', async function(assert) {
+        // given
+        const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: true, isSco: true });
+        const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
+
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.canAccessStudentsPage, true);
+      });
+
+      test('should set canAccessStudentsPage to false when type is PRO', async function(assert) {
+        // given
+        const organization = Object.create({ id: 9, type: 'PRO', isManagingStudents: true, isSco: false });
+        const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
+
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.canAccessStudentsPage, false);
+      });
+
+      test('should set canAccessStudentsPage to false when isManagingStudents is false', async function(assert) {
+        // given
+        const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
+        const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
+
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.canAccessStudentsPage, false);
+      });
+
+      test('should prefer organization from userOrgaSettings rather than first membership', async function(assert) {
+        // given
+        const organization1 = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
+        const organization2 = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
+        const membership1 = Object.create({ organization: organization1, organizationRole: 'ADMIN', isAdmin: true });
+        const membership2 = Object.create({ organization: organization2, organizationRole: 'ADMIN', isAdmin: true });
+        const userOrgaSettings = Object.create({ organization: organization2 });
+        connectedUser.memberships = [membership1, membership2];
+        connectedUser.userOrgaSettings = userOrgaSettings;
+
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.equal(currentUserService.organization.id, organization2.id);
+      });
+
+      module('when user has no userOrgaSettings', function(hooks) {
+
+        let firstOrganization;
+
+        hooks.beforeEach(function() {
+          firstOrganization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
+          const secondOrganization = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
+          const membership1 = Object.create({ organization: firstOrganization, organizationRole: 'ADMIN', isAdmin: true });
+          const membership2 = Object.create({ organization: secondOrganization, organizationRole: 'ADMIN', isAdmin: true });
+          connectedUser.memberships = [membership1, membership2];
+
+          storeStub.createRecord = sinon.stub().returns({
+            save: sinon.stub()
+          });
+        });
+
+        test('should create it', async function(assert) {
+          // given
+          const createRecordSpy = sinon.spy();
+          storeStub.createRecord = createRecordSpy;
+
+          // when
+          await currentUserService.load();
+
+          // then
+          assert.equal(createRecordSpy.callCount, 1);
+          assert.ok(createRecordSpy.calledWith('user-orga-setting', {
+            user: connectedUser,
+            organization: firstOrganization
+          }));
+        });
+
+        test('should set the first membership\'s organization as current organization', async function(assert) {
+          // when
+          await currentUserService.load();
+
+          // then
+          assert.equal(currentUserService.organization, firstOrganization);
+        });
+
+        test('should set isAdminInOrganization', async function(assert) {
+          // when
+          await currentUserService.load();
+
+          // then
+          assert.equal(currentUserService.isAdminInOrganization, true);
+        });
+
+        test('should set canAccessStudentsPage', async function(assert) {
+          // when
+          await currentUserService.load();
+
+          // then
+          assert.equal(currentUserService.canAccessStudentsPage, false);
+        });
+      });
     });
 
-    test('should set canAccessStudentsPage to true', async function(assert) {
-      // Given
-      const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: true, isSco: true });
-      const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
-      connectedUser.memberships = [membership];
-      connectedUser.userOrgaSettings = Object.create({ organization });
+    module('when organization in userOrgaSettings doesn\'t match with memberships', function(hooks) {
 
-      // When
-      await currentUserService.load();
-
-      // Then
-      assert.equal(currentUserService.canAccessStudentsPage, true);
-    });
-
-    test('should set canAccessStudentsPage to false when type is PRO', async function(assert) {
-      // Given
-      const organization = Object.create({ id: 9, type: 'PRO', isManagingStudents: true, isSco: false });
-      const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
-      connectedUser.memberships = [membership];
-      connectedUser.userOrgaSettings = Object.create({ organization });
-
-      // When
-      await currentUserService.load();
-
-      // Then
-      assert.equal(currentUserService.canAccessStudentsPage, false);
-    });
-
-    test('should set canAccessStudentsPage to false when isManagingStudents is false', async function(assert) {
-      // Given
-      const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
-      const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
-      connectedUser.memberships = [membership];
-      connectedUser.userOrgaSettings = Object.create({ organization });
-
-      // When
-      await currentUserService.load();
-
-      // Then
-      assert.equal(currentUserService.canAccessStudentsPage, false);
-    });
-
-    test('should prefer organization from userOrgaSettings rather than first membership', async function(assert) {
-      // Given
-      const organization1 = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
-      const organization2 = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
-      const membership1 = Object.create({ organization: organization1, organizationRole: 'ADMIN', isAdmin: true });
-      const membership2 = Object.create({ organization: organization2, organizationRole: 'ADMIN', isAdmin: true });
-      const userOrgaSettings = Object.create({ organization: organization2 });
-      connectedUser.memberships = [membership1, membership2];
-      connectedUser.userOrgaSettings = userOrgaSettings;
-
-      // When
-      await currentUserService.load();
-
-      // Then
-      assert.equal(currentUserService.organization.id, organization2.id);
-    });
-
-    module('when user has no userOrgaSettings', function(hooks) {
-
+      let saveStub;
       let firstOrganization;
 
       hooks.beforeEach(function() {
         firstOrganization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
-        const organization2 = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
+        const secondOrganization = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
+        const notMatchingOrganization = Object.create({ id: 11, type: 'SCO', isManagingStudents: false, isSco: true });
+
         const membership1 = Object.create({ organization: firstOrganization, organizationRole: 'ADMIN', isAdmin: true });
-        const membership2 = Object.create({ organization: organization2, organizationRole: 'ADMIN', isAdmin: true });
+        const membership2 = Object.create({ organization: secondOrganization, organizationRole: 'ADMIN', isAdmin: true });
         connectedUser.memberships = [membership1, membership2];
 
-        storeStub.createRecord = sinon.stub().returns({
-          save: sinon.stub()
-        });
+        saveStub = sinon.stub();
+
+        connectedUser.userOrgaSettings = Object.create({ organization: notMatchingOrganization, save: saveStub });
       });
 
-      test('should create it', async function(assert) {
-        // Given
-        const createRecordSpy = sinon.spy();
-        storeStub.createRecord = createRecordSpy;
-
-        // When
+      test('should update the organization of the userOrgaSettings', async function(assert) {
+        // when
         await currentUserService.load();
 
-        // Then
-        assert.equal(createRecordSpy.callCount, 1);
-        assert.ok(createRecordSpy.calledWith('user-orga-setting', {
-          user: connectedUser,
-          organization: firstOrganization
-        }));
+        // then
+        assert.equal(saveStub.callCount, 1);
       });
 
-      test('should set the first membership\'s organization as current organization', async function(assert) {
-        // When
+      test('should set the membership\'s organization as current organization', async function(assert) {
+        // when
         await currentUserService.load();
 
-        // Then
+        // then
         assert.equal(currentUserService.organization, firstOrganization);
-      });
-
-      test('should set isAdminInOrganization', async function(assert) {
-        // When
-        await currentUserService.load();
-
-        // Then
-        assert.equal(currentUserService.isAdminInOrganization, true);
-      });
-
-      test('should set canAccessStudentsPage', async function(assert) {
-        // When
-        await currentUserService.load();
-
-        // Then
-        assert.equal(currentUserService.canAccessStudentsPage, false);
+        assert.equal(currentUserService.organization, firstOrganization);
       });
     });
   });
@@ -216,17 +259,17 @@ module('Unit | Service | current-user', function(hooks) {
   module('user is not authenticated', function() {
 
     test('should do nothing', async function(assert) {
-      // Given
+      // given
       const sessionStub = Service.create({
         isAuthenticated: false,
       });
       const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.set('session', sessionStub);
+      currentUser.session = sessionStub;
 
-      // When
+      // when
       await currentUser.load();
 
-      // Then
+      // then
       assert.equal(currentUser.user, null);
     });
   });
@@ -234,7 +277,7 @@ module('Unit | Service | current-user', function(hooks) {
   module('user token is expired', function() {
 
     test('should redirect to login', async function(assert) {
-      // Given
+      // given
       const connectedUserId = 1;
       const storeStub = Service.create({
         queryRecord: () => reject({ errors: [{ code: 401 }] })
@@ -245,13 +288,13 @@ module('Unit | Service | current-user', function(hooks) {
         invalidate: () => resolve('invalidate'),
       });
       const currentUser = this.owner.lookup('service:currentUser');
-      currentUser.set('store', storeStub);
-      currentUser.set('session', sessionStub);
+      currentUser.store = storeStub;
+      currentUser.session = sessionStub;
 
-      // When
+      // when
       const result = await currentUser.load();
 
-      // Then
+      // then
       assert.equal(result, 'invalidate');
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Il arrive parfois que nos utilisateurs de Pix Orga souhaitent supprimer l'accès à l'organisation à certaines personnes. N'ayant pas de moyen de le faire depuis nos applications pour le moment, la solution consiste à supprimer le membership de l'utilisateur (lien entre un user et une orga) en base de données. Cependant, il arrive parfois que l'organisation courante (stockée dans la table user-orga-settings) corresponde à l'organisation du membership qui vient d'être supprimé ce qui cause l'impossibilité pour l'utilisateur d'accéder à Pix Orga. 

## :robot: Solution

- Créer le userOrgaSettings d'un utilisateur si celui-ci n'existe pas au moment où l'on souhaite y accéder.
- Mettre à jour l'organisation du userOrgaSettings avec l'organisation du premier membership si l'organisation n'existe plus dans les memberships. 

## ☝️ Remarque
Auparavant, les settings de l'utilisateur étaient créés à la validation des CGU, et modifiés lors d'un changement d'orga courante.
Désormais, ils sont créés dès qu'on en a besoin s'ils n'existent pas.

## 🔭À venir
Le front fait des opérations qui devraient être réalisées dans l'api, voir la DB, en plus d'un trop grand nombre de requêtes dès qu'on veut remonter le current-user. On a décidé de réaliser ce refacto dans une autre PR