### PR TITLE
[FEATURE] Affichage du nombre de crédits octroyés à une organisation dans Pix Admin (PA-173).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -10,6 +10,7 @@ export default Model.extend({
   externalId: attr(),
   provinceCode: attr(),
   isManagingStudents: attr(),
+  credit: attr(),
 
   // Relationships
   memberships: hasMany('membership'),

--- a/admin/app/templates/components/organization-information-section.hbs
+++ b/admin/app/templates/components/organization-information-section.hbs
@@ -25,8 +25,9 @@
           Département : <span class="organization__provinceCode">{{organization.provinceCode}}</span><br>
         {{/if}}
         {{#if isOrganizationSCO}}
-          Gère des élèves : <span class="organization__isManagingStudents">{{isManagingStudents}}</span>
+          Gère des élèves : <span class="organization__isManagingStudents">{{isManagingStudents}}</span><br>
         {{/if}}
+        Crédits : <span class="organization__credit">{{organization.credit}}</span>
       </p>
     </div>
   </div>

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -16,6 +16,18 @@ module('Integration | Component | organization-information-section', function(ho
     assert.dom('.organization__information').exists();
   });
 
+  test('it should display credit', async function(assert) {
+    // given
+    const organization = EmberObject.create({ credit: 350 });
+    this.set('organization', organization);
+
+    // when
+    await render(hbs`{{organization-information-section organization=organization}}`);
+
+    // then
+    assert.dom('.organization__credit').hasText('350');
+  });
+
   module('When organization is SCO', function(hooks) {
 
     let organization;

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -9,6 +9,7 @@ class Organization {
     externalId,
     provinceCode,
     isManagingStudents,
+    credit,
     // includes
     memberships = [],
     targetProfileShares = [],
@@ -24,6 +25,7 @@ class Organization {
     this.externalId = externalId;
     this.provinceCode = provinceCode;
     this.isManagingStudents = isManagingStudents;
+    this.credit = credit;
     // includes
     this.memberships = memberships;
     this.targetProfileShares = targetProfileShares;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -17,6 +17,7 @@ function _toDomain(bookshelfOrganization) {
     externalId: rawOrganization.externalId,
     provinceCode: rawOrganization.provinceCode,
     isManagingStudents: Boolean(rawOrganization.isManagingStudents),
+    credit: rawOrganization.credit,
   });
 
   let members = [];

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
         record.targetProfiles = [];
         return record;
       },
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'memberships', 'students', 'targetProfiles'],
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'memberships', 'students', 'targetProfiles'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -516,7 +516,15 @@ describe('Acceptance | Application | organization-controller', () => {
 
       beforeEach(async () => {
         const userPixMaster = databaseBuilder.factory.buildUser.withPixRolePixMaster();
-        organization = databaseBuilder.factory.buildOrganization();
+        organization = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          name: 'Organization catalina',
+          logoUrl: 'some logo url',
+          externalId: 'ABC123',
+          provinceCode: '45',
+          isManagingStudents: true,
+          credit: 666,
+        });
 
         await databaseBuilder.commit();
 
@@ -539,6 +547,7 @@ describe('Acceptance | Application | organization-controller', () => {
               'external-id': organization.externalId,
               'province-code': organization.provinceCode,
               'is-managing-students': organization.isManagingStudents,
+              'credit': organization.credit,
             },
             'id': organization.id.toString(),
             'relationships': {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -111,7 +111,12 @@ describe('Integration | Repository | Organization', function() {
       let insertedOrganization;
 
       beforeEach(async () => {
-        insertedOrganization = databaseBuilder.factory.buildOrganization();
+        insertedOrganization = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          name: 'Organization of the dark side',
+          logoUrl: 'some logo url',
+          credit: 154,
+        });
         await databaseBuilder.commit();
       });
 
@@ -125,6 +130,7 @@ describe('Integration | Repository | Organization', function() {
         expect(foundOrganization.name).to.equal(insertedOrganization.name);
         expect(foundOrganization.logoUrl).to.equal(insertedOrganization.logoUrl);
         expect(foundOrganization.id).to.equal(insertedOrganization.id);
+        expect(foundOrganization.credit).to.equal(insertedOrganization.credit);
       });
 
       it('should return a rejection when organization id is not found', function() {

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -9,6 +9,7 @@ const buildOrganization = function buildOrganization({
   externalId = faker.lorem.word().toUpperCase(),
   provinceCode = faker.random.alphaNumeric(3),
   isManagingStudents = false,
+  credit = 500,
   createdAt = faker.date.recent(),
   updatedAt = faker.date.recent(),
 } = {}) {
@@ -18,11 +19,12 @@ const buildOrganization = function buildOrganization({
     type,
     name,
     logoUrl,
-    createdAt,
     externalId,
     provinceCode,
     isManagingStudents,
-    updatedAt
+    credit,
+    createdAt,
+    updatedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -35,11 +35,12 @@ function buildOrganization(
     externalId = 'OrganizationIdLinksToExternalSource',
     provinceCode = '2A',
     isManagingStudents = false,
+    credit = 500,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     memberships = [],
     targetProfileShares = []
   } = {}) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, memberships, targetProfileShares });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, memberships, targetProfileShares });
 }
 
 buildOrganization.withMembers = function(
@@ -51,6 +52,7 @@ buildOrganization.withMembers = function(
     externalId = 'OrganizationIdLinksToExternalSource',
     provinceCode = '2A',
     isManagingStudents = false,
+    credit = 500,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     members = [
       _buildMember({ id: 1, firstName: 'John', lastName: 'Doe', email: 'john.doe@example.com' }),
@@ -58,7 +60,7 @@ buildOrganization.withMembers = function(
     ]
   } = {}
 ) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, members });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, members });
 };
 
 buildOrganization.withStudents = function(
@@ -70,11 +72,12 @@ buildOrganization.withStudents = function(
     externalId = 'OrganizationIdLinksToExternalSource',
     provinceCode = '2A',
     isManagingStudents = true,
+    credit = 500,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     students = []
   } = {}
 ) {
-  const organization = new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, createdAt, students });
+  const organization = new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, students });
 
   organization.students = [
     _buildStudent({ id: 1, lastName: 'Doe', firstName: 'John', organization }),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -24,6 +24,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'external-id': organization.externalId,
             'province-code': organization.provinceCode,
             'is-managing-students': organization.isManagingStudents,
+            'credit': organization.credit,
           },
           relationships: {
             memberships: {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les utilisateurs de Pix Admin ne voient pas combien de crédits ont été octroyés à une organisation donnée.

## :robot: Solution
Afficher ce champ dans le détail d'une organisation.

## :rainbow: Remarques
La possibilité de modifier cette valeur arrive après ;)
