### PR TITLE
[BUGFIX] Corriger la gestion des nombres décimaux en answer (PF-1155).

### DIFF
--- a/api/lib/domain/services/solution-service-qrocm-dep.js
+++ b/api/lib/domain/services/solution-service-qrocm-dep.js
@@ -143,9 +143,9 @@ module.exports = {
     const preTreatedAnswers = applyPreTreatments(yamlAnswer);
 
     // Convert Yaml to JS objects
-    const answers = jsYaml.safeLoad(preTreatedAnswers);
-    const solutions = jsYaml.safeLoad(yamlSolution);
-    const scoring = jsYaml.safeLoad(_.ensureString(yamlScoring));
+    const answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
+    const solutions = jsYaml.safeLoad(yamlSolution, { schema: jsYaml.FAILSAFE_SCHEMA });
+    const scoring = jsYaml.safeLoad(yamlScoring || '', { schema: jsYaml.FAILSAFE_SCHEMA });
 
     // Treatments
     const treatedSolutions = _applyTreatmentsToSolutions(solutions, deactivations);

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -73,8 +73,8 @@ module.exports = {
     const preTreatedSolutions = applyPreTreatments(yamlSolution);
 
     // Convert YAML to JSObject
-    const answers = jsYaml.safeLoad(preTreatedAnswers);
-    const solutions = jsYaml.safeLoad(preTreatedSolutions);
+    const answers = jsYaml.safeLoad(preTreatedAnswers, { schema: jsYaml.FAILSAFE_SCHEMA });
+    const solutions = jsYaml.safeLoad(preTreatedSolutions, { schema: jsYaml.FAILSAFE_SCHEMA });
 
     // Treatments
     const treatedSolutions = _applyTreatmentsToSolutions(solutions, enabledTreatments);

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -65,6 +65,16 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
         solution: 'Google:\n- 987\nYahoo:\n- 123'
       },
       {
+        when: 'Both answers are correct with 1 solution that contains only decimal numbers with comma',
+        answer: 'num1: "123,00"\nnum2: 987',
+        solution: 'Google:\n- 987\nYahoo:\n- 123,00'
+      },
+      {
+        when: 'Both answers are correct with 1 solution that contains only decimal numbers with dot',
+        answer: 'num1: "123.00"\nnum2: 987',
+        solution: 'Google:\n- 987\nYahoo:\n- 123.00'
+      },
+      {
         when: 'Both answers are correct with 2 solutions',
         answer: 'num1: Google\nnum2: Yahoo',
         solution: twoPossibleSolutions

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -117,6 +117,18 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       solution: 'num1:\n- 888\nnum2:\n- 64',
       enabledTreatments: ['t1', 't2', 't3']
     }, {
+      case: 'solution contains decimal numbers with a comma',
+      output: { result: ANSWER_OK, resultDetails: { 'num1': true, 'num2': true } },
+      answer: 'num1: "888,00"\nnum2: 64',
+      solution: 'num1:\n- 888,00\nnum2:\n- 64',
+      enabledTreatments: ['t1', 't2', 't3']
+    }, {
+      case: 'solution contains decimal numbers with a dot',
+      output: { result: ANSWER_OK, resultDetails: { 'num1': true, 'num2': true } },
+      answer: 'num1: "888.00"\nnum2: 64',
+      solution: 'num1:\n- 888.00\nnum2:\n- 64',
+      enabledTreatments: ['t1', 't2', 't3']
+    }, {
       case: 'leading/trailing spaces in solution',
       output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
       answer: '9lettres: c o u r g e t t e\n6lettres: t o m a t e',


### PR DESCRIPTION
## :unicorn: Problème
Les nombres au format `1234.0`, `1234.00`, ... sont convertis comme suit `1234` et ne sont plus au format String.

## :robot: Solution
Ajouter le [schéma de validation](https://github.com/nodeca/js-yaml#safeload-string---options-) `jsYaml.FAILSAFE_SCHEMA` lors de la conversion des réponses.

## :rainbow: Remarques
On en a profité pour supprimer une dépendance à la surcharge de lodash (lodashUtils) et pour remplacer `_.ensureString(foo)` par `foo || ''` directement à la conversion du scoring des answers.

## 💯 Pour tester
https://app-pr1175.review.pix.fr/challenges/recSP9tZ5WUjjYMgN/preview
Solution 1 : `b2:m4`
Solution 2 : `7045,0` ou `7045.0`