### PR TITLE
[TECH] Renforcer la contrainte d'unicité entre un assessment et un certification-course dans la table Assessments (PF-1161)

### DIFF
--- a/api/db/migrations/20200317112058_add_unique_constraint_on_userid_certificationcourseid_table_assessments.js
+++ b/api/db/migrations/20200317112058_add_unique_constraint_on_userid_certificationcourseid_table_assessments.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'assessments';
+const COLUMN_USER_ID = 'userId';
+const COLUMN_CERTIFICATION_COURSE_ID = 'certificationCourseId';
+
+exports.up = async (knex) => {
+  await knex.raw(`
+    WITH ASSESSMENTS_BY_CERTIFICATION_COURSES AS (
+      SELECT "as"."id" as assessment_id,
+        COUNT("as"."id") OVER (PARTITION BY "as"."certificationCourseId") AS cnt_assessments_per_certification_course,
+        ROW_NUMBER() OVER (PARTITION BY "as"."certificationCourseId" ORDER BY "as"."state", "as"."createdAt" DESC) as priority
+      FROM "assessments" as "as"
+      WHERE "as"."certificationCourseId" IS NOT NULL
+    )
+    UPDATE "assessments"
+    SET "certificationCourseId" = NULL
+    FROM ASSESSMENTS_BY_CERTIFICATION_COURSES
+    WHERE ASSESSMENTS_BY_CERTIFICATION_COURSES.assessment_id = "assessments"."id"
+      AND cnt_assessments_per_certification_course > 1 
+      AND priority <> 1;
+  `);
+
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique([COLUMN_USER_ID, COLUMN_CERTIFICATION_COURSE_ID]);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique([COLUMN_USER_ID, COLUMN_CERTIFICATION_COURSE_ID]);
+  });
+};

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -4,7 +4,6 @@ const BookshelfCertificationCourse = require('../../../../lib/infrastructure/dat
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
-const Assessment = require('../../../../lib/domain/models/Assessment');
 const _ = require('lodash');
 
 describe('Integration | Repository | Certification Course', function() {
@@ -129,50 +128,6 @@ describe('Integration | Repository | Certification Course', function() {
 
         // then
         expect(thisCertificationCourse.challenges.length).to.equal(2);
-      });
-
-      context('When the certification course has several assessments', () => {
-
-        context('When one of those assessment is completed', () => {
-          let completedAssessmentId;
-
-          beforeEach(() => {
-            databaseBuilder.factory.buildAssessment({ type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id, userId, state: Assessment.states.STARTED });
-            completedAssessmentId = databaseBuilder.factory.buildAssessment({ type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id, userId }).id;
-            return databaseBuilder.commit();
-          });
-
-          it('should retrieve associated completed assessment', async () => {
-            // when
-            const thisCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
-
-            // then
-            expect(thisCertificationCourse.assessment.id).to.equal(completedAssessmentId);
-          });
-        });
-
-        context('When no assessment is completed', () => {
-          let assessmentIds;
-
-          beforeEach(() => {
-            assessmentIds = _.map([
-              { type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id, userId, state: Assessment.states.STARTED },
-              { type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id, userId, state: Assessment.states.STARTED },
-              { type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id, userId, state: Assessment.states.STARTED },
-            ], (assessment) => databaseBuilder.factory.buildAssessment(assessment).id);
-            return databaseBuilder.commit();
-          });
-
-          it('should retrieve an assessment anyway', async () => {
-            // when
-            const actualCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
-
-            // then
-            expect(assessmentIds).to.include(actualCertificationCourse.assessment.id);
-          });
-
-        });
-
       });
 
       context('When the certification course has one assessment', () => {

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -29,11 +29,6 @@ describe('Integration | Repository | Certification ', () => {
     } = databaseBuilder.factory.buildCertificationCenter({ name: 'Certif College' });
     session = databaseBuilder.factory.buildSession({ certificationCenterId, certificationCenter });
     certificationCourse = databaseBuilder.factory.buildCertificationCourse({ userId, sessionId: session.id, isPublished: true });
-    databaseBuilder.factory.buildAssessment({
-      certificationCourseId: certificationCourse.id,
-      userId,
-      state: Assessment.states.STARTED,
-    });
     const {
       id: assessmentId,
       state: assessmentState,


### PR DESCRIPTION
## :unicorn: Problème
Il existe encore un certain nombre de données inconsistantes dans la base dues à des bugs résolus depuis. Notamment, nous comptons actuellement dans la base 65 certification-courses pour lesquels il existe plus d'un assessment :
```sql
WITH ASSESSMENTS_BY_CERTIFICATION_COURSES AS (
  SELECT distinct "as"."certificationCourseId" as id,
    COUNT("as"."id") OVER (PARTITION BY "as"."certificationCourseId") AS CNT_ASSESSMENTS_PER_CERTIFICATION_COURSE
  FROM "assessments" as "as"
  WHERE "as"."certificationCourseId" IS NOT NULL
)
SELECT COUNT(id)
FROM ASSESSMENTS_BY_CERTIFICATION_COURSES
WHERE CNT_ASSESSMENTS_PER_CERTIFICATION_COURSE > 1;
```
Par effet boule de neige, une telle inconsistance rend inutilement complexe des opérations simples, je pense notamment à récupérer l'`assessment-result` _valide_ d'une certif donnée.
Actuellement, dans le code, afin de pouvoir récupérer le bon `assessment-result` pour un `certification-course`, il faut d'abord sélectionner le _bon_ `assessment` :
- On collecte tous les `assessments` d'un `certification-course` donné.
- On trie par date de création (du plus récent vers le plus ancien).
- Dans cette liste triée, on prend le premier `assessment` au statut `completed`
 - Si aucun n'est `completed`, alors on prend le premier `assessment` tout court (donc le plus récent)

## :robot: Solution
Ajouter de la cohérence à la fois dans le schéma et dans les données. Pour cela on va "neutraliser" les assessments non utilisés en mettant leur colonne certificationCourseId, afin de pouvoir ajouter une contrainte d'unicité entre  les colonnes `userId` et `certificationCourseId` de la table `assessments`.

Pour rechercher la liste des `assessments` à neutraliser, on respecte la règle déjà établie dans le code qui nous permet de retrouver le bon `assessment` pour un `certification-course` donné.
On pourrait exprimer les règles de recherche ainsi :
Nous extrayons, dans un premier temps, tous les `assessments` de certification pour lesquels on peut trouver au moins un autre `assessment` lié au même `certification-course`. Considérant ces `assessments`, groupés par `certificationCourseId`, nous allons les trier d'abord par `statut` (pour avoir completed en premier), puis par date de création. Ainsi, le premier `assessment` par groupe issu de ce tri est l'`assessment` à conserver, les autres sont à supprimer.
Cela se traduit par cette requête :

```sql
WITH ASSESSMENTS_BY_CERTIFICATION_COURSES AS (
  SELECT "as"."id" as assessment_id,
    COUNT("as"."id") OVER (PARTITION BY "as"."certificationCourseId") AS cnt_assessments_per_certification_course,
    ROW_NUMBER() OVER (PARTITION BY "as"."certificationCourseId" ORDER BY "as"."state", "as"."createdAt" DESC) as priority
  FROM "assessments" as "as"
  WHERE "as"."certificationCourseId" IS NOT NULL
)
UPDATE "assessments"
SET "certificationCourseId" = NULL
FROM ASSESSMENTS_BY_CERTIFICATION_COURSES
WHERE ASSESSMENTS_BY_CERTIFICATION_COURSES.assessment_id = "assessments"."id"
  AND cnt_assessments_per_certification_course > 1 
  AND priority <> 1;
```

## :rainbow: Remarques
1) Telle qu'écrite, la mise en place de la contrainte d'unicité n'a pas de succès garanti. Il peut, en effet, y avoir entre-temps un doublon d'assessment sur un certification-course créer, ce qui empêcherait la mise en place de la contrainte d'unicité. Ce qui me met en confiance, c'est qu'en ces moments de confinement (COVID etc...), il n'y a pas de sessions de certification, et donc pas de création d'assessment de type certification.

Exécution de la migration (en mode SQL direct) sur la base de réplication (transaction rollbackée) :
- 83 `assessments` neutralisés