### PR TITLE
[FEATURE] Gérer la localisation des acquis francophone ou franco-français (PF-1035).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -6,14 +6,14 @@ const assessmentRepository = require('../../infrastructure/repositories/assessme
 const assessmentSerializer = require('../../infrastructure/serializers/jsonapi/assessment-serializer');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
-const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
+const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
   save(request, h) {
 
     const assessment = assessmentSerializer.deserialize(request.payload);
-    assessment.userId = requestResponseUtils.extractUserIdFromRequest(request);
+    assessment.userId = extractUserIdFromRequest(request);
 
     return Promise.resolve()
       .then(() => {
@@ -45,7 +45,7 @@ module.exports = {
 
   async findByFilters(request) {
     let assessments = [];
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+    const userId = extractUserIdFromRequest(request);
 
     if (userId) {
       const filters = extractParameters(request.query).filter;
@@ -95,7 +95,8 @@ module.exports = {
 };
 
 async function _getChallenge(assessment, request) {
-  // TODO: Extract locale from Headers and pass it as arguments of usescases functions
+  const locale  = extractLocaleFromRequest(request);
+
   if (assessment.isPreview()) {
     return usecases.getNextChallengeForPreview({});
   }
@@ -117,10 +118,7 @@ async function _getChallenge(assessment, request) {
   }
 
   if (assessment.isCompetenceEvaluation()) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    return usecases.getNextChallengeForCompetenceEvaluation({
-      assessment,
-      userId
-    });
+    const userId = extractUserIdFromRequest(request);
+    return usecases.getNextChallengeForCompetenceEvaluation({ assessment, userId, locale });
   }
 }

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -95,6 +95,7 @@ module.exports = {
 };
 
 async function _getChallenge(assessment, request) {
+  // TODO: Extract locale from Headers and pass it as arguments of usescases functions
   if (assessment.isPreview()) {
     return usecases.getNextChallengeForPreview({});
   }
@@ -104,7 +105,7 @@ async function _getChallenge(assessment, request) {
   }
 
   if (assessment.isDemo()) {
-    return usecases.getNextChallengeForDemo({ assessment, });
+    return usecases.getNextChallengeForDemo({ assessment });
   }
 
   if (assessment.isSmartPlacement()) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -111,10 +111,7 @@ async function _getChallenge(assessment, request) {
 
   if (assessment.isSmartPlacement()) {
     const tryImproving = Boolean(request.query.tryImproving);
-    return usecases.getNextChallengeForSmartPlacement({
-      assessment,
-      tryImproving
-    });
+    return usecases.getNextChallengeForSmartPlacement({ assessment, tryImproving, locale });
   }
 
   if (assessment.isCompetenceEvaluation()) {

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -30,4 +30,8 @@ module.exports = {
     SCOPE: 'pix-certif',
     NOT_LINKED_CERTIFICATION_MSG: 'L\'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d\'y accéder.'
   },
+  LOCALE: {
+    FRENCH_FRANCE: 'fr-fr',
+    FRENCH_SPOKEN: 'fr',
+  },
 };

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -57,7 +57,7 @@ class Challenge {
       status,
       timer,
       type,
-      locale = 'fr-fr',
+      locale,
       // includes
       answer,
       skills = [],

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -39,6 +39,7 @@ class Challenge {
    * @param validator
    * @param competenceId
    * @param format
+   * @param locale
    */
   constructor(
     {
@@ -55,8 +56,9 @@ class Challenge {
       proposals,
       status,
       timer,
-      // includes
       type,
+      locale = 'fr-fr',
+      // includes
       answer,
       skills = [],
       // references
@@ -78,6 +80,7 @@ class Challenge {
     this.timer = timer;
     this.status = status;
     this.type = type;
+    this.locale = locale;
     // includes
     this.skills = skills;
     this.validator = validator;

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,15 +1,21 @@
+const _ = require('lodash');
 const hashInt = require('hash-int');
 const UNEXISTING_ITEM = null;
 
 module.exports = {
-  // TODO: add locale argument (with default to 'fr-fr'?)
-  pickChallenge(skills, randomSeed) {
+  pickChallenge({ skills, randomSeed, locale, key = Math.abs(hashInt(randomSeed)) }) {
     if (skills.length === 0) {
       return UNEXISTING_ITEM;
     }
-    const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
-    // TODO: filter challenges to get only locale compliant ones
-    return chosenSkill.challenges[key % chosenSkill.challenges.length];
+    const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => challenge.locale === locale));
+    if (_.isEmpty(localeChallenges)) {
+      return _pickChallengeAtIndex(chosenSkill.challenges, key);
+    }
+    return _pickChallengeAtIndex(localeChallenges, key);
   }
 };
+
+function _pickChallengeAtIndex(challenges, index) {
+  return challenges[index % challenges.length];
+}

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -2,13 +2,14 @@ const hashInt = require('hash-int');
 const UNEXISTING_ITEM = null;
 
 module.exports = {
+  // TODO: add locale argument (with default to 'fr-fr'?)
   pickChallenge(skills, randomSeed) {
     if (skills.length === 0) {
       return UNEXISTING_ITEM;
     }
     const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
-    // TODO: Filter on selected language only
+    // TODO: filter challenges to get only locale compliant ones
     return chosenSkill.challenges[key % chosenSkill.challenges.length];
   }
 };

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -3,10 +3,11 @@ const hashInt = require('hash-int');
 const UNEXISTING_ITEM = null;
 
 module.exports = {
-  pickChallenge({ skills, randomSeed, locale, key = Math.abs(hashInt(randomSeed)) }) {
+  pickChallenge({ skills, randomSeed, locale }) {
     if (skills.length === 0) {
       return UNEXISTING_ITEM;
     }
+    const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
     const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => challenge.locale === locale));
     if (_.isEmpty(localeChallenges)) {

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,0 +1,14 @@
+const hashInt = require('hash-int');
+const UNEXISTING_ITEM = null;
+
+module.exports = {
+  pickChallenge(skills, randomSeed) {
+    if (skills.length === 0) {
+      return UNEXISTING_ITEM;
+    }
+    const key = Math.abs(hashInt(randomSeed));
+    const chosenSkill = skills[key % skills.length];
+    // TODO: Filter on selected language only
+    return chosenSkill.challenges[key % chosenSkill.challenges.length];
+  }
+};

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -11,6 +11,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   challengeRepository,
   answerRepository,
   skillRepository,
+  pickChallengeService,
   assessment,
   userId,
 }) {
@@ -27,17 +28,11 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
     throw new AssessmentEndedError();
   }
 
-  return _pickChallenge(possibleSkillsForNextChallenge, assessment.id);
+  return pickChallengeService.pickChallenge(possibleSkillsForNextChallenge, assessment.id);
 };
 
 function _checkIfAssessmentBelongsToUser(assessment, userId) {
   if (assessment.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntity();
   }
-}
-function _pickChallenge(skills, randomSeed) {
-  if (skills.length === 0) { return UNEXISTING_ITEM; }
-  const key = Math.abs(hashInt(randomSeed));
-  const chosenSkill = skills[key % skills.length];
-  return chosenSkill.challenges[key % chosenSkill.challenges.length];
 }

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -6,6 +6,7 @@ const UNEXISTING_ITEM = null;
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
 
+// TODO: add locale parameter
 module.exports = async function getNextChallengeForCompetenceEvaluation({
   knowledgeElementRepository,
   challengeRepository,

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -1,12 +1,9 @@
 /* eslint-disable no-unused-vars */
 const { AssessmentEndedError, UserNotAuthorizedToAccessEntity } = require('../errors');
-const hashInt = require('hash-int');
-const UNEXISTING_ITEM = null;
 
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
 
-// TODO: add locale parameter
 module.exports = async function getNextChallengeForCompetenceEvaluation({
   knowledgeElementRepository,
   challengeRepository,
@@ -15,6 +12,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   pickChallengeService,
   assessment,
   userId,
+  locale
 }) {
 
   _checkIfAssessmentBelongsToUser(assessment, userId);
@@ -29,7 +27,11 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
     throw new AssessmentEndedError();
   }
 
-  return pickChallengeService.pickChallenge(possibleSkillsForNextChallenge, assessment.id);
+  return pickChallengeService.pickChallenge({
+    skills: possibleSkillsForNextChallenge,
+    randomSeed: assessment.id,
+    locale: locale
+  });
 };
 
 function _checkIfAssessmentBelongsToUser(assessment, userId) {

--- a/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
@@ -2,8 +2,6 @@
 const { AssessmentEndedError } = require('../errors');
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
-const hashInt = require('hash-int');
-const UNEXISTING_ITEM = null;
 
 module.exports = async function getNextChallengeForSmartPlacement({
   knowledgeElementRepository,
@@ -12,6 +10,7 @@ module.exports = async function getNextChallengeForSmartPlacement({
   answerRepository,
   improvementService,
   assessment,
+  pickChallengeService,
   tryImproving
 }) {
   if (tryImproving) {
@@ -29,13 +28,6 @@ module.exports = async function getNextChallengeForSmartPlacement({
     throw new AssessmentEndedError();
   }
 
-  return _pickChallenge(possibleSkillsForNextChallenge, assessment.id);
-
+  return pickChallengeService.pickChallenge(possibleSkillsForNextChallenge, assessment.id);
 };
 
-function _pickChallenge(skills, randomSeed) {
-  if (skills.length === 0) { return UNEXISTING_ITEM; }
-  const key = Math.abs(hashInt(randomSeed));
-  const chosenSkill = skills[key % skills.length];
-  return chosenSkill.challenges[key % chosenSkill.challenges.length];
-}

--- a/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-smart-placement.js
@@ -11,7 +11,8 @@ module.exports = async function getNextChallengeForSmartPlacement({
   improvementService,
   assessment,
   pickChallengeService,
-  tryImproving
+  tryImproving,
+  locale,
 }) {
   if (tryImproving) {
     assessment.isImproving = true;
@@ -28,6 +29,10 @@ module.exports = async function getNextChallengeForSmartPlacement({
     throw new AssessmentEndedError();
   }
 
-  return pickChallengeService.pickChallenge(possibleSkillsForNextChallenge, assessment.id);
+  return pickChallengeService.pickChallenge({
+    skills: possibleSkillsForNextChallenge,
+    randomSeed: assessment.id,
+    locale
+  });
 };
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -35,6 +35,7 @@ const dependencies = {
   organizationService: require('../../domain/services/organization-service'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
+  pickChallengeService: require('../services/pick-challenge-service'),
   resetPasswordService: require('../../domain/services/reset-password-service'),
   reCaptchaValidator: require('../../infrastructure/validators/grecaptcha-validator'),
   scoringCertificationService: require('../../domain/services/scoring/scoring-certification-service'),

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -61,7 +61,7 @@ class RedisCache extends Cache {
   }
 
   flushAll() {
-    logger.info('Flusing Redis database');
+    logger.info('Flushing Redis database');
 
     return this._client.flushall();
   }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../domain/constants').LOCALE;
 
 const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
 
@@ -104,10 +105,10 @@ module.exports = datasource.extend({
 function _convertLangueToLocale(Langue) {
   switch (Langue) {
     case 'Francophone':
-      return 'fr';
+      return FRENCH_SPOKEN;
     case 'Franco Français':
-      return 'fr-fr';
+      return FRENCH_FRANCE;
     default:
-      return 'fr';
+      return FRENCH_SPOKEN;
   }
 }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -31,6 +31,7 @@ module.exports = datasource.extend({
     'Embed height',
     'Texte alternatif illustration',
     'Format',
+    'Langue',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -77,6 +78,7 @@ module.exports = datasource.extend({
       competenceId,
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
+      locale: _convertLangueToLocale(airtableRecord.get('Langue'))
     };
   },
 
@@ -99,3 +101,13 @@ module.exports = datasource.extend({
   },
 });
 
+function _convertLangueToLocale(Langue) {
+  switch (Langue) {
+    case 'Francophone':
+      return 'fr';
+    case 'Franco Français':
+      return 'fr-fr';
+    default:
+      return 'fr';
+  }
+}

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -92,5 +92,6 @@ function _adaptChallengeFromDataObjects({ challengeDataObject, skillDataObjects 
     competenceId: challengeDataObject.competenceId,
     illustrationAlt: challengeDataObject.illustrationAlt,
     format: challengeDataObject.format,
+    locale: challengeDataObject.locale,
   });
 }

--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -1,5 +1,6 @@
-const tokenService = require('../../domain/services/token-service');
 const accept = require('@hapi/accept');
+const tokenService = require('../../domain/services/token-service');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../domain/constants').LOCALE;
 
 module.exports = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
 
@@ -16,10 +17,10 @@ function extractUserIdFromRequest(request) {
 }
 
 function extractLocaleFromRequest(request) {
-  const defaultLocale = 'fr-fr';
+  const defaultLocale = FRENCH_FRANCE;
   const languageHeader = request.headers && request.headers['accept-language'];
   if (!languageHeader) {
     return defaultLocale;
   }
-  return accept.language(languageHeader, ['fr', 'fr-fr']) || defaultLocale;
+  return accept.language(languageHeader, [FRENCH_SPOKEN, FRENCH_FRANCE]) || defaultLocale;
 }

--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -1,6 +1,7 @@
 const tokenService = require('../../domain/services/token-service');
+const accept = require('@hapi/accept');
 
-module.exports = { escapeFileName, extractUserIdFromRequest };
+module.exports = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
 
 function escapeFileName(fileName) {
   return fileName.replace(/[^_. A-Za-z0-9-]/g, '_');
@@ -12,4 +13,13 @@ function extractUserIdFromRequest(request) {
     return tokenService.extractUserId(token);
   }
   return null;
+}
+
+function extractLocaleFromRequest(request) {
+  const defaultLocale = 'fr-fr';
+  const languageHeader = request.headers && request.headers['accept-language'];
+  if (!languageHeader) {
+    return defaultLocale;
+  }
+  return accept.language(languageHeader, ['fr', 'fr-fr']) || defaultLocale;
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -203,12 +203,27 @@
       }
     },
     "@hapi/accept": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
-      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+      "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+          "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+          "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+        }
       }
     },
     "@hapi/address": {
@@ -355,6 +370,15 @@
         "@hapi/topo": "3.x.x"
       },
       "dependencies": {
+        "@hapi/accept": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
+          "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+          "requires": {
+            "@hapi/boom": "7.x.x",
+            "@hapi/hoek": "8.x.x"
+          }
+        },
         "@hapi/ammo": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
   "main": "server.js",
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
+    "@hapi/accept": "^5.0.1",
     "@hapi/hapi": "^18.4.1",
     "@hapi/inert": "^5.2.2",
     "@hapi/joi": "^16.1.8",

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -1,0 +1,175 @@
+const { airtableBuilder, databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const createServer = require('../../../../server');
+
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
+const competenceId = 'recCompetence';
+
+const skillWeb1Id = 'recAcquisWeb1';
+const skillWeb1Name = '@web1';
+const skillWeb1 = airtableBuilder.factory.buildSkill({
+  id: skillWeb1Id,
+  nom: skillWeb1Name,
+  compétenceViaTube: [competenceId],
+});
+
+const skillWeb2Id = 'recAcquisWeb2';
+const skillWeb2Name = '@web2';
+const skillWeb2 = airtableBuilder.factory.buildSkill({
+  id: skillWeb2Id,
+  nom: skillWeb2Name,
+  compétenceViaTube: [competenceId],
+});
+
+const skillWeb3Id = 'recAcquisWeb3';
+const skillWeb3Name = '@web3';
+const skillWeb3 = airtableBuilder.factory.buildSkill({
+  id: skillWeb3Id,
+  nom: skillWeb3Name,
+  compétenceViaTube: [competenceId],
+});
+
+const competenceReference = '1.1 Mener une recherche et une veille d’information';
+const competence = airtableBuilder.factory.buildCompetence({
+  id: competenceId,
+  epreuves: [],
+  titre: 'Mener une recherche et une veille d’information',
+  tests: [],
+  acquisIdentifiants: [skillWeb1Id],
+  tubes: [],
+  acquisViaTubes: [skillWeb1Id],
+  reference: competenceReference,
+  testsRecordID: [],
+  acquis: [skillWeb1Name],
+});
+
+const frenchCallengeId = 'recFrenchChallengeId';
+const frenchChallenge = airtableBuilder.factory.buildChallenge.untimed({
+  id: frenchCallengeId,
+  tests: [],
+  competences: [competenceId],
+  statut: 'validé',
+  acquix: [skillWeb2Id],
+  acquis: [skillWeb2Name],
+  langue: 'Franco Français',
+});
+
+const frenchSpokenChallengeId = 'recFrenchSpokenChallengeId';
+const frenchSpokenChallenge = airtableBuilder.factory.buildChallenge.untimed({
+  id: frenchSpokenChallengeId,
+  tests: [],
+  competences: [competenceId],
+  statut: 'validé',
+  acquix: [skillWeb2Id],
+  acquis: [skillWeb2Name],
+  langue: 'Francophone',
+});
+
+describe('Acceptance | API | assessment-controller-get-next-challenge-locale-management', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+
+    airtableBuilder.mockList({ tableName: 'Domaines' })
+      .returns([airtableBuilder.factory.buildArea()])
+      .activate();
+
+    airtableBuilder.mockList({ tableName: 'Competences' })
+      .returns([competence])
+      .activate();
+
+    airtableBuilder.mockList({ tableName: 'Acquis' })
+      .returns([skillWeb1, skillWeb2, skillWeb3])
+      .activate();
+  });
+
+  afterEach(() => {
+    airtableBuilder.cleanAll();
+    return cache.flushAll();
+  });
+
+  describe('GET /api/assessments/:assessment_id/next', () => {
+
+    const assessmentId = 1;
+    const userId = 1234;
+
+    context('when there is one challenge in the accepted language (fr)', () => {
+      beforeEach(async () => {
+        airtableBuilder.mockList({ tableName: 'Epreuves' })
+          .returns([frenchSpokenChallenge, frenchChallenge])
+          .activate();
+
+        databaseBuilder.factory.buildUser({ id: userId });
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentId,
+          type: Assessment.types.COMPETENCE_EVALUATION,
+          userId,
+          competenceId
+        });
+        databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+        await databaseBuilder.commit();
+      });
+
+      it('should return the challenge in the accepted language (fr-fr)', () => {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/assessments/${assessmentId}/next`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+            'accept-language': 'fr-fr'
+          }
+        };
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.result.data.id).to.equal(frenchChallenge.id);
+        });
+      });
+    });
+
+    context('when there is no challenge in the accepted language (fr-fr)', () => {
+      beforeEach(async () => {
+        airtableBuilder.mockList({ tableName: 'Epreuves' })
+          .returns([frenchSpokenChallenge])
+          .activate();
+
+        databaseBuilder.factory.buildUser({ id: userId });
+        databaseBuilder.factory.buildAssessment({
+          id: assessmentId,
+          type: Assessment.types.COMPETENCE_EVALUATION,
+          userId,
+          competenceId
+        });
+        databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
+        await databaseBuilder.commit();
+      });
+
+      it('should return the challenge in the fallback language (fr)', () => {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/assessments/${assessmentId}/next`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+            'accept-language': 'fr-fr'
+          }
+        };
+
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.result.data.id).to.equal(frenchSpokenChallenge.id);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -3,6 +3,7 @@ const cache = require('../../../../lib/infrastructure/caches/learning-content-ca
 const createServer = require('../../../../server');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { FRENCH_FRANCE } = require('../../../../lib/domain/constants').LOCALE;
 
 const competenceId = 'recCompetence';
 
@@ -77,7 +78,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
     const userId = 1234;
     context('when assessment is a competence evaluation', () => {
 
-      context('when there is one challenge in the accepted language (fr)', () => {
+      context('when there is one challenge in the accepted language (fr-fr)', () => {
         beforeEach(async () => {
           airtableBuilder.mockList({ tableName: 'Epreuves' })
             .returns([frenchSpokenChallenge, frenchChallenge])
@@ -101,7 +102,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
             url: `/api/assessments/${assessmentId}/next`,
             headers: {
               authorization: generateValidRequestAuthorizationHeader(userId),
-              'accept-language': 'fr-fr'
+              'accept-language': FRENCH_FRANCE,
             }
           };
 
@@ -139,7 +140,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
             url: `/api/assessments/${assessmentId}/next`,
             headers: {
               authorization: generateValidRequestAuthorizationHeader(userId),
-              'accept-language': 'fr-fr'
+              'accept-language': FRENCH_FRANCE,
             }
           };
 

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -103,6 +103,7 @@ const buildChallenge = function buildChallenge({
   createdTime = '2016-08-24T11:59:02.000Z',
   format = 'mots',
   illustrationAlt = 'texte alternatif à l\'image',
+  langue = 'Francophone',
 } = {}) {
 
   return rawBuildChallenge({
@@ -138,6 +139,7 @@ const buildChallenge = function buildChallenge({
     createdTime,
     illustrationAlt,
     format,
+    langue,
   });
 };
 
@@ -245,6 +247,7 @@ buildChallenge.untimed = function buildUntimedChallenge({
   createdTime = '2016-08-24T11:59:02.000Z',
   format = 'petit',
   illustrationAlt = 'texte alternatif à l\'image',
+  langue = 'Francophone',
 } = {}) {
 
   return rawBuildChallenge({
@@ -279,6 +282,7 @@ buildChallenge.untimed = function buildUntimedChallenge({
     createdTime,
     illustrationAlt,
     format,
+    langue,
   });
 };
 
@@ -315,6 +319,7 @@ function rawBuildChallenge({
   createdTime,
   illustrationAlt,
   format,
+  langue,
 }) {
 
   return {
@@ -351,6 +356,7 @@ function rawBuildChallenge({
       'domaines': domaines,
       'Texte alternatif illustration': illustrationAlt,
       'format': format,
+      'Langue': langue,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -23,6 +23,7 @@ module.exports = function buildChallengeAirtableDataObject({
   embedHeight = 500,
   format = 'petit',
   illustrationAlt = 'texte alternatif à l\'image',
+  locale = 'fr',
 } = {}) {
 
   return {
@@ -47,5 +48,6 @@ module.exports = function buildChallengeAirtableDataObject({
     embedHeight,
     illustrationAlt,
     format,
+    locale,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -18,6 +18,7 @@ module.exports = function buildChallenge(
     status = 'validé',
     timer,
     type = Challenge.Type.QCM,
+    locale = 'fr',
     // includes
     answer,
     validator = new Validator(),
@@ -40,6 +41,7 @@ module.exports = function buildChallenge(
     status,
     timer,
     type,
+    locale,
     // includes
     answer,
     validator,

--- a/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
@@ -23,6 +23,7 @@ module.exports = function ChallengeAirtableDataObjectFixture({
   embedTitle = 'Epreuve de selection de dossier',
   embedHeight = 500,
   format = 'petit',
+  locale = 'fr',
 } = {}) {
   return {
     id,
@@ -46,5 +47,6 @@ module.exports = function ChallengeAirtableDataObjectFixture({
     embedTitle,
     embedHeight,
     format,
+    locale,
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
@@ -124,6 +124,7 @@ module.exports = function challengeRawAirTableFixture({ id, fields } = { id: 're
         'recsvLz0W2ShyfD63',
       ],
       'Format': 'petit',
+      'Langue': 'Francophone'
     }, fields),
     'createdTime': '2016-08-24T11:59:02.000Z',
   });

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -6,6 +6,7 @@ const certificationChallengeRepository = require('../../../../lib/infrastructure
 const usecases = require('../../../../lib/domain/usecases');
 const { AssessmentEndedError } = require('../../../../lib/domain/errors');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
@@ -146,7 +147,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
     describe('when the assessment is a smart placement assessment', () => {
 
-      const defaultLocale = 'fr-fr';
+      const defaultLocale = FRENCH_FRANCE;
       const assessment = new Assessment({
         id: 1,
         courseId: 'courseId',
@@ -184,7 +185,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call the usecase getNextChallengeForSmartPlacement with the locale', async () => {
         // given
-        const locale = 'fr';
+        const locale = FRENCH_SPOKEN;
 
         // when
         await assessmentController.getNextChallenge({
@@ -218,7 +219,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       });
 
       it('should call the usecase getNextChallengeForCompetenceEvaluation', async () => {
-        const locale = 'fr';
+        const locale = FRENCH_SPOKEN;
         const request = {
           params: { id: 1 },
           headers: {

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -195,9 +195,13 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       });
 
       it('should call the usecase getNextChallengeForCompetenceEvaluation', async () => {
+        const locale = 'fr';
         const request = {
           params: { id: 1 },
-          headers: { authorization: generateValidRequestAuthorizationHeader(userId) }
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+            'accept-language': locale
+          }
         };
         // when
         await assessmentController.getNextChallenge(request);
@@ -206,6 +210,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         expect(usecases.getNextChallengeForCompetenceEvaluation).to.have.been.calledWith({
           assessment,
           userId,
+          locale,
         });
       });
     });

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -1,4 +1,4 @@
-const { sinon, expect, hFake, domainBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const { sinon, expect, domainBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
@@ -64,7 +64,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should return a null data directly', async () => {
         // when
-        const response = await assessmentController.getNextChallenge({ params: { id: PREVIEW_ASSESSMENT_ID } }, hFake);
+        const response = await assessmentController.getNextChallenge({ params: { id: PREVIEW_ASSESSMENT_ID } });
 
         // then
         expect(response).to.deep.equal({ data: null });
@@ -83,7 +83,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       context('when the assessment is a DEMO', () => {
         it('should reply with no data', async () => {
           // when
-          const response = await assessmentController.getNextChallenge({ params: { id: 7531 } }, hFake);
+          const response = await assessmentController.getNextChallenge({ params: { id: 7531 } });
 
           // then
           expect(response).to.deep.equal({ data: null });
@@ -99,7 +99,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should not evaluate assessment score', async () => {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 7531 } }, hFake);
+        await assessmentController.getNextChallenge({ params: { id: 7531 } });
 
         // then
         expect(usecases.getAssessment).not.to.have.been.called;
@@ -123,7 +123,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         usecases.getNextChallengeForCertification.resolves();
 
         // when
-        await assessmentController.getNextChallenge({ params: { id: 12 } }, hFake);
+        await assessmentController.getNextChallenge({ params: { id: 12 } });
 
         // then
         expect(usecases.getNextChallengeForCertification).to.have.been.calledOnce;
@@ -137,7 +137,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         usecases.getNextChallengeForCertification.rejects(new AssessmentEndedError());
 
         // when
-        const response = await assessmentController.getNextChallenge({ params: { id: 12 } }, hFake);
+        const response = await assessmentController.getNextChallenge({ params: { id: 12 } });
 
         // then
         expect(response).to.deep.equal({ data: null });
@@ -159,7 +159,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call the usecase getNextChallengeForSmartPlacement with tryImproving at false when the query not exists', async () => {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 1 }, query: { } }, hFake);
+        await assessmentController.getNextChallenge({ params: { id: 1 }, query: { } });
 
         // then
         expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledWith({
@@ -170,7 +170,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call the usecase getNextChallengeForSmartPlacement with the query tryImproving', async () => {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 1 }, query: { tryImproving: true } }, hFake);
+        await assessmentController.getNextChallenge({ params: { id: 1 }, query: { tryImproving: true } });
 
         // then
         expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledWith({
@@ -200,7 +200,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) }
         };
         // when
-        await assessmentController.getNextChallenge(request, hFake);
+        await assessmentController.getNextChallenge(request);
 
         // then
         expect(usecases.getNextChallengeForCompetenceEvaluation).to.have.been.calledWith({

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -146,6 +146,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
     describe('when the assessment is a smart placement assessment', () => {
 
+      const defaultLocale = 'fr-fr';
       const assessment = new Assessment({
         id: 1,
         courseId: 'courseId',
@@ -159,12 +160,13 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
       it('should call the usecase getNextChallengeForSmartPlacement with tryImproving at false when the query not exists', async () => {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 1 }, query: { } });
+        await assessmentController.getNextChallenge({ params: { id: 1 }, query: {} });
 
         // then
         expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledWith({
           assessment,
-          tryImproving: false
+          tryImproving: false,
+          locale: defaultLocale,
         });
       });
 
@@ -175,7 +177,28 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
         // then
         expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledWith({
           assessment,
-          tryImproving: true
+          tryImproving: true,
+          locale: defaultLocale,
+        });
+      });
+
+      it('should call the usecase getNextChallengeForSmartPlacement with the locale', async () => {
+        // given
+        const locale = 'fr';
+
+        // when
+        await assessmentController.getNextChallenge({
+          params: { id: 1 }, query: { tryImproving: true },
+          headers: {
+            'accept-language': locale
+          }
+        });
+
+        // then
+        expect(usecases.getNextChallengeForSmartPlacement).to.have.been.calledWith({
+          assessment,
+          tryImproving: true,
+          locale,
         });
       });
     });
@@ -215,4 +238,5 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       });
     });
   });
-});
+})
+;

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -29,6 +29,7 @@ describe('Unit | Domain | Models | Challenge', () => {
         competenceId: 'recsvLz0W2ShyfD63',
         illustrationAlt: 'Texte alternatif à l\'image',
         format: 'phrase',
+        locale: 'fr',
       };
 
       // when

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -1,14 +1,14 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const pickChallengeService = require('../../../../lib/domain/services/pick-challenge-service');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 const _ = require('lodash');
 
 describe('Unit | Service | PickChallengeService', () => {
 
   describe('#pickChallenge', () => {
-    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locale: 'fr' });
-    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locale: 'fr' });
-    const frenchChallenge = domainBuilder.buildChallenge({ locale: 'fr-fr' });
-    const frLocale = 'fr';
+    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locale: FRENCH_SPOKEN });
+    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locale: FRENCH_SPOKEN });
+    const frenchChallenge = domainBuilder.buildChallenge({ locale: FRENCH_FRANCE });
     const randomSeed = 'some-random-seed';
 
     context('when challenge in selected locale exists', () => {
@@ -21,7 +21,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const challenge = await pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: frLocale
+          locale: FRENCH_SPOKEN
         });
 
         // then
@@ -36,7 +36,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: frLocale
+          locale: FRENCH_SPOKEN
         }));
         const challenges = await Promise.all(pickChallengePromises);
 
@@ -57,7 +57,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const challenge = await pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: frLocale
+          locale: FRENCH_SPOKEN
         });
 
         // then
@@ -76,7 +76,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const challenge = await pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: frLocale
+          locale: FRENCH_SPOKEN
         });
 
         // then

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -1,0 +1,90 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const pickChallengeService = require('../../../../lib/domain/services/pick-challenge-service');
+const _ = require('lodash');
+
+describe('Unit | Service | PickChallengeService', () => {
+
+  describe('#pickChallenge', () => {
+    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locale: 'fr' });
+    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locale: 'fr' });
+    const frenchChallenge = domainBuilder.buildChallenge({ locale: 'fr-fr' });
+    const frLocale = 'fr';
+    const randomSeed = 'some-random-seed';
+
+    context('when challenge in selected locale exists', () => {
+
+      it('should return challenge in selected locale', async () => {
+        // given
+        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: frLocale
+        });
+
+        // then
+        expect(challenge).to.equal(frenchSpokenChallenge);
+      });
+
+      it('should always return the same challenge in selected locale', async () => {
+        // given
+        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, otherFrenchSpokenChallenge] }];
+
+        // when
+        const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: frLocale
+        }));
+        const challenges = await Promise.all(pickChallengePromises);
+
+        // then
+        expect(challenges).to.contains(frenchSpokenChallenge);
+        expect(challenges).to.not.contains(otherFrenchSpokenChallenge);
+        expect(challenges).to.not.contains(frenchChallenge);
+      });
+    });
+
+    context('when challenge in selected locale does not exists', () => {
+
+      it('should return challenge in other locale', async () => {
+        // given
+        const skills = [{ challenges: [frenchChallenge] }];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: frLocale
+        });
+
+        // then
+        expect(challenge).to.equal(frenchChallenge);
+      });
+
+    });
+
+    context('when there is no skills', () => {
+
+      it('should return null', async () => {
+        // given
+        const skills = [];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: frLocale
+        });
+
+        // then
+        expect(challenge).to.be.null;
+      });
+
+    });
+
+  });
+})
+;

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -10,8 +10,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
     let userId, assessmentId, competenceId,
       assessment, lastAnswer, challenges, targetSkills,
       answerRepository, challengeRepository, skillRepository,
-      knowledgeElementRepository,
-      recentKnowledgeElements, actualComputedChallenge;
+      knowledgeElementRepository, pickChallengeService,
+      recentKnowledgeElements, actualComputedChallenge,
+      challengeUrl21, challengeUrl22;
 
     beforeEach(async () => {
 
@@ -27,6 +28,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       answerRepository = { findLastByAssessment: sinon.stub().resolves(lastAnswer) };
       challengeRepository = { findByCompetenceId: sinon.stub().resolves(challenges) };
       skillRepository = { findByCompetenceId: sinon.stub().resolves(targetSkills) };
+      pickChallengeService = { pickChallenge: sinon.stub().resolves(challengeUrl22) };
 
       recentKnowledgeElements = [{ createdAt: 4, skillId: 'url2' }, { createdAt: 2, skillId: 'web1' }];
       knowledgeElementRepository = { findUniqByUserId: sinon.stub().resolves(recentKnowledgeElements) };
@@ -34,7 +36,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       const web2 = domainBuilder.buildSkill({ name: '@web2' });
       web2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_web2_1' }), domainBuilder.buildChallenge({ id: 'challenge_web2_2' })];
       const url2 = domainBuilder.buildSkill({ name: '@url2' });
-      url2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_url2_1' }), domainBuilder.buildChallenge({ id: 'challenge_url2_2' })];
+      challengeUrl21 = domainBuilder.buildChallenge({ id: 'challenge_url2_1' });
+      challengeUrl22 = domainBuilder.buildChallenge({ id: 'challenge_url2_2' });
+      url2.challenges = [challengeUrl21, challengeUrl22];
       const search2 = domainBuilder.buildSkill({ name: '@search2' });
       search2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_search2_1' }), domainBuilder.buildChallenge({ id: 'challenge_search2_2' })];
 
@@ -53,7 +57,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           answerRepository,
           challengeRepository,
           knowledgeElementRepository,
-          skillRepository
+          skillRepository,
+          pickChallengeService
         });
       });
       it('should throw a UserNotAuthorizedToAccessEntity error', () => {
@@ -70,6 +75,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           challengeRepository,
           knowledgeElementRepository,
           skillRepository,
+          pickChallengeService
         });
       });
       it('should have fetched the answers', () => {
@@ -94,9 +100,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       });
 
       it('should have returned the next challenge', () => {
-        for (let i = 0; i < 5; i++) {
-          expect(actualComputedChallenge.id).to.equal('challenge_url2_2');
-        }
+        expect(actualComputedChallenge.id).to.equal(challengeUrl22.id);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
@@ -2,6 +2,7 @@ const { expect, sinon, domainBuilder } = require('../../../test-helper');
 
 const getNextChallengeForSmartPlacement = require('../../../../lib/domain/usecases/get-next-challenge-for-smart-placement');
 const smartRandom = require('../../../../lib/domain/services/smart-random/smart-random');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', () => {
 
@@ -44,7 +45,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
       const search2 = domainBuilder.buildSkill({ name: '@search2' });
       search2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_search2_1' }), domainBuilder.buildChallenge({ id: 'challenge_search2_2' })];
 
-      locale = 'fr';
+      locale = FRENCH_SPOKEN;
       possibleSkillsForNextChallenge = [web2, url2, search2];
 
       sinon.stub(smartRandom, 'getPossibleSkillsForNextChallenge').returns({

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
@@ -12,7 +12,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
       knowledgeElementRepository, recentKnowledgeElements,
       targetProfileRepository, targetProfile, skills, actualNextChallenge,
       improvementService, pickChallengeService,
-      challengeWeb21, challengeWeb22;
+      challengeWeb21, challengeWeb22, possibleSkillsForNextChallenge, locale;
 
     beforeEach(async () => {
 
@@ -44,9 +44,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
       const search2 = domainBuilder.buildSkill({ name: '@search2' });
       search2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_search2_1' }), domainBuilder.buildChallenge({ id: 'challenge_search2_2' })];
 
+      locale = 'fr';
+      possibleSkillsForNextChallenge = [web2, url2, search2];
+
       sinon.stub(smartRandom, 'getPossibleSkillsForNextChallenge').returns({
         hasAssessmentEnded: false,
-        possibleSkillsForNextChallenge: [web2, url2, search2],
+        possibleSkillsForNextChallenge,
       });
 
       actualNextChallenge = await getNextChallengeForSmartPlacement({
@@ -57,7 +60,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
         targetProfileRepository,
         improvementService,
         pickChallengeService,
-        tryImproving: true
+        tryImproving: true,
+        locale,
       });
     });
 
@@ -99,6 +103,14 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
 
     it('should have returned the next challenge', () => {
       expect(actualNextChallenge.id).to.equal(challengeWeb22.id);
+    });
+
+    it('should have pick challenge with skills, randomSeed and locale', () => {
+      expect(pickChallengeService.pickChallenge).to.have.been.calledWithExactly({
+        skills: possibleSkillsForNextChallenge,
+        randomSeed: assessmentId,
+        locale,
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-smart-placement_test.js
@@ -11,7 +11,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
       assessment, lastAnswer, answerRepository, challengeRepository, challenges,
       knowledgeElementRepository, recentKnowledgeElements,
       targetProfileRepository, targetProfile, skills, actualNextChallenge,
-      improvementService;
+      improvementService, pickChallengeService,
+      challengeWeb21, challengeWeb22;
 
     beforeEach(async () => {
 
@@ -29,12 +30,15 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
       targetProfile = { skills };
       targetProfileRepository = { get: sinon.stub().resolves(targetProfile) };
       improvementService = { filterKnowledgeElementsIfImproving: sinon.stub().returns(recentKnowledgeElements) };
+      pickChallengeService = { pickChallenge: sinon.stub().resolves(challengeWeb22) };
 
       recentKnowledgeElements = [{ createdAt: 4, skillId: 'url2' }, { createdAt: 2, skillId: 'web1' }];
       knowledgeElementRepository = { findUniqByUserId: sinon.stub().resolves(recentKnowledgeElements) };
 
       const web2 = domainBuilder.buildSkill({ name: '@web2' });
-      web2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_web2_1' }), domainBuilder.buildChallenge({ id: 'challenge_web2_2' })];
+      challengeWeb21 = domainBuilder.buildChallenge({ id: 'challenge_web2_1' });
+      challengeWeb22 = domainBuilder.buildChallenge({ id: 'challenge_web2_2' });
+      web2.challenges = [challengeWeb21, challengeWeb22];
       const url2 = domainBuilder.buildSkill({ name: '@url2' });
       url2.challenges = [domainBuilder.buildChallenge({ id: 'challenge_url2_1' }), domainBuilder.buildChallenge({ id: 'challenge_url2_2' })];
       const search2 = domainBuilder.buildSkill({ name: '@search2' });
@@ -52,6 +56,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
         knowledgeElementRepository,
         targetProfileRepository,
         improvementService,
+        pickChallengeService,
         tryImproving: true
       });
     });
@@ -93,9 +98,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-smart-placement', 
     });
 
     it('should have returned the next challenge', () => {
-      for (let i = 0; i < 5; i++) {
-        expect(actualNextChallenge.id).to.equal('challenge_web2_2');
-      }
+      expect(actualNextChallenge.id).to.equal(challengeWeb22.id);
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -5,6 +5,7 @@ const challengeDatasource = require('../../../../../lib/infrastructure/datasourc
 const challengeAirtableDataObjectFixture = require('../../../../tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture');
 const challengeRawAirTableFixture = require('../../../../tooling/fixtures/infrastructure/challengeRawAirTableFixture');
 const cache = require('../../../../../lib/infrastructure/caches/learning-content-cache');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', () => {
 
@@ -117,7 +118,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     describe('when Language is Francophone', () => {
       it('should create a Challenge from the AirtableRecord with locale set to \'fr\'', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: 'fr' });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: FRENCH_SPOKEN });
         const frenchSpokenChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Francophone' } });
 
         // when
@@ -131,7 +132,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     describe('when Language is Franco Français', () => {
       it('should create a Challenge from the AirtableRecord with locale set to \'fr-fr\'', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: 'fr-fr' });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: FRENCH_FRANCE });
         const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Franco Français' } });
 
         // when

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -26,7 +26,11 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     }),
     challenge_competence1_notValidated = challengeRawAirTableFixture({
       id: 'challenge-competence1-notValidated',
-      fields: { 'Compétences (via tube) (id persistant)': [competence1.id], 'Acquix (id persistant)': [web1.id], Statut: 'proposé' }
+      fields: {
+        'Compétences (via tube) (id persistant)': [competence1.id],
+        'Acquix (id persistant)': [web1.id],
+        Statut: 'proposé'
+      }
     }),
     challenge_competence2 = challengeRawAirTableFixture({
       id: 'challenge-competence2',
@@ -110,15 +114,32 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
   describe('#fromAirTableObject', () => {
 
-    it('should create a Challenge from the AirtableRecord', () => {
-      // given
-      const expectedChallenge = challengeAirtableDataObjectFixture();
+    describe('when Language is Francophone', () => {
+      it('should create a Challenge from the AirtableRecord with locale set to \'fr\'', () => {
+        // given
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: 'fr' });
+        const frenchSpokenChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Francophone' } });
 
-      // when
-      const challenge = challengeDatasource.fromAirTableObject(challengeRawAirTableFixture());
+        // when
+        const challenge = challengeDatasource.fromAirTableObject(frenchSpokenChallenge);
 
-      // then
-      expect(challenge).to.deep.equal(expectedChallenge);
+        // then
+        expect(challenge).to.deep.equal(expectedChallenge);
+      });
+    });
+
+    describe('when Language is Franco Français', () => {
+      it('should create a Challenge from the AirtableRecord with locale set to \'fr-fr\'', () => {
+        // given
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: 'fr-fr' });
+        const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Franco Français' } });
+
+        // when
+        const challenge = challengeDatasource.fromAirTableObject(frenchChallenge);
+
+        // then
+        expect(challenge).to.deep.equal(expectedChallenge);
+      });
     });
 
     it('should deal with a missing illustration', () => {

--- a/api/tests/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/request-response-utils_test.js
@@ -1,5 +1,5 @@
 const { expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
-const { escapeFileName, extractUserIdFromRequest } = require('../../../../lib/infrastructure/utils/request-response-utils');
+const { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest } = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Utils | Request Utils', function() {
 
@@ -43,5 +43,70 @@ describe('Unit | Utils | Request Utils', function() {
       expect(escapedFileName).to.equal('file-name with invalid_chars _____________.csv');
     });
 
+  });
+
+  describe('#extractLocaleFromRequest', function() {
+    it('should return fr-fr locale when there is no header (to ensure retro-compat)', function() {
+      // given
+      const request = {};
+
+      // when
+      const locale = extractLocaleFromRequest(request);
+
+      // then
+      expect(locale).to.equal('fr-fr');
+    });
+
+    it('should return fr-fr locale when header is fr-FR', function() {
+      // given
+      const request = {
+        headers: { 'accept-language': 'fr-FR' }
+      };
+
+      // when
+      const locale = extractLocaleFromRequest(request);
+
+      // then
+      expect(locale).to.equal('fr-fr');
+    });
+
+    it('should return fr locale when header is fr', function() {
+      // given
+      const request = {
+        headers: { 'accept-language': 'fr' }
+      };
+
+      // when
+      const locale = extractLocaleFromRequest(request);
+
+      // then
+      expect(locale).to.equal('fr');
+    });
+
+    it('should return fr-fr locale when header is de (to ensure retro-compat)', function() {
+      // given
+      const request = {
+        headers: { 'accept-language': 'de' }
+      };
+
+      // when
+      const locale = extractLocaleFromRequest(request);
+
+      // then
+      expect(locale).to.equal('fr-fr');
+    });
+
+    it('should return fr-fr locale when header is fr-BE (to ensure retro-compat)', function() {
+      // given
+      const request = {
+        headers: { 'accept-language': 'fr-BE' }
+      };
+
+      // when
+      const locale = extractLocaleFromRequest(request);
+
+      // then
+      expect(locale).to.equal('fr-fr');
+    });
   });
 });

--- a/api/tests/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/request-response-utils_test.js
@@ -1,5 +1,6 @@
 const { expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest } = require('../../../../lib/infrastructure/utils/request-response-utils');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Utils | Request Utils', function() {
 
@@ -54,7 +55,7 @@ describe('Unit | Utils | Request Utils', function() {
       const locale = extractLocaleFromRequest(request);
 
       // then
-      expect(locale).to.equal('fr-fr');
+      expect(locale).to.equal(FRENCH_FRANCE);
     });
 
     it('should return fr-fr locale when header is fr-FR', function() {
@@ -67,7 +68,7 @@ describe('Unit | Utils | Request Utils', function() {
       const locale = extractLocaleFromRequest(request);
 
       // then
-      expect(locale).to.equal('fr-fr');
+      expect(locale).to.equal(FRENCH_FRANCE);
     });
 
     it('should return fr locale when header is fr', function() {
@@ -80,7 +81,7 @@ describe('Unit | Utils | Request Utils', function() {
       const locale = extractLocaleFromRequest(request);
 
       // then
-      expect(locale).to.equal('fr');
+      expect(locale).to.equal(FRENCH_SPOKEN);
     });
 
     it('should return fr-fr locale when header is de (to ensure retro-compat)', function() {
@@ -93,7 +94,7 @@ describe('Unit | Utils | Request Utils', function() {
       const locale = extractLocaleFromRequest(request);
 
       // then
-      expect(locale).to.equal('fr-fr');
+      expect(locale).to.equal(FRENCH_FRANCE);
     });
 
     it('should return fr-fr locale when header is fr-BE (to ensure retro-compat)', function() {
@@ -106,7 +107,7 @@ describe('Unit | Utils | Request Utils', function() {
       const locale = extractLocaleFromRequest(request);
 
       // then
-      expect(locale).to.equal('fr-fr');
+      expect(locale).to.equal(FRENCH_FRANCE);
     });
   });
 });

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -1,9 +1,15 @@
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
-import { computed } from '@ember/object';
 import ENV from 'mon-pix/config/environment';
 
+const FRENCH_DOMAIN_EXTENSION = 'fr';
+const FRENCH_LOCALE = 'fr-fr';
+const FRENCHSPOKEN_LOCALE = 'fr';
+
 export default JSONAPIAdapter.extend(DataAdapterMixin, {
+  currentDomain: service(),
   host: ENV.APP.API_HOST,
   namespace: 'api',
 
@@ -12,6 +18,9 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
+    headers['Accept-Language'] = this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION ?
+      FRENCH_LOCALE
+      : FRENCHSPOKEN_LOCALE;
     return headers;
   })
 });

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,0 +1,10 @@
+import Service  from '@ember/service';
+import { last } from 'lodash';
+
+export default Service.extend({
+
+  getExtension() {
+    return last(location.hostname.split('.'));
+  }
+
+});

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -35,4 +35,26 @@ describe('Unit | Route | subscribers', function() {
     // Then
     expect(applicationAdapter.headers['Authorization']).to.be.undefined;
   });
+
+  it('should add Accept-Language header set to fr-fr when the current domain contains pix.fr', function() {
+    // Given
+    const applicationAdapter = this.owner.lookup('adapter:application');
+
+    // When
+    applicationAdapter.set('currentDomain', { getExtension() { return 'fr'; } });
+
+    // Then
+    expect(applicationAdapter.headers['Accept-Language']).to.equal('fr-fr');
+  });
+
+  it('should add Accept-Language header set to fr-fr when the current domain contains pix.digital', function() {
+    // Given
+    const applicationAdapter = this.owner.lookup('adapter:application');
+
+    // When
+    applicationAdapter.set('currentDomain', { getExtension() { return 'digital'; } });
+
+    // Then
+    expect(applicationAdapter.headers['Accept-Language']).to.equal('fr');
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans l'objectif d'internationaliser l'accès à pix, il est nécessaire de proposer un référentiel unique et cohérent de manière mondiale.
Les acquis sont validés à travers des épreuves qui elles sont localisées.

## :robot: Solution
Pour le moment, 2 localisations sont proposées.
Francophone : accessible via le site app.pix.digital (et à terme pix.org)
Franco-français : accessible via le site app.pix.fr.

Les acquis spécifiques France sont sortis du référentiel Pix et seront intégrés dans un référentiel Pix+ dédié.
Une colonne langue est ajoutée dans la table Epreuves. Cette colonne peut prendre la valeur `Francophone` ou `Franco Français`.

L'application front, en fonction de l'extension du domaine, valorise le header `Accept-Language` afin que l'API fournisse une épreuve correctement localisée.

## :rainbow: Remarques
Pour tester fonctionnellement, utiliser la campagne I18NFRFR1.
En passant par `https://app-pr1179.review.pix.fr` on ne doit voir que des épreuves Franco Françaises dont les id (visibles dans l'URL) sont :
```
rec4mYfhm45A222ab
recIfeIpWdbKqYMwK
```

En passant par `https://app-pr1179.review.pix.digital` on ne doit voir que des épreuves Francophones dont les id (visibles dans l'URL) sont :
```
recWpT2sM4pxAmtkn
recC2rFjqkPgWbAsH
recqT7JmZiaNGvqqQ
rec0w5ytv6Yv71Ha8
recLcqVu6MH6H17fL
recByKZgHtkfJVzgu
recOXWVjd6laRhtWD
```


Au préalable, il faut créer cette campagne en utilisant les requêtes SQL suivantes.

Création du target profile
```sql
INSERT INTO "target-profiles" ("name", "isPublic")
VALUES ('i18n', true)
RETURNING id;
```

Association du target profile avec un acquis contenant des épreuves francophone ET franco française.
```sql
INSERT INTO "target-profiles_skills" ("targetProfileId", "skillId")
VALUES (##id du target profile créé juste au-dessus##, 'recybd8jWDNiFpbgq');
```

Création de la campagne
```sql
INSERT INTO "campaigns" ("name", "code", "targetProfileId", "title", "organizationId")
VALUES ('i18n', 'I18NFRFR1', ##id du target profile créé juste au-dessus##, 'Campagne i18n', 1)
```

## 📓 Pour tester la valorisation du header en développement.
Ajouter ces 2 lignes dans le fichier `/etc/hosts`
```
127.0.0.1 localhost.fr
127.0.0.1 localhost.digital 
```

1. Aller sur `localhost.fr:4200`, se connecter et vérifier dans les outils d'inspection, onglet `Network`, que le header `Accept-Language` vaut `fr-fr` dans les requêtes vers l'API.

1. Aller sur `localhost.digital:4200`, se connecter et vérifier dans les outils d'inspection, onglet `Network`, que le header `Accept-Language` vaut `fr` dans les requêtes vers l'API.