### PR TITLE
[BUGFIX] Intégration de Matomo avec les apps front.

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -75,6 +75,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.APP.API_HOST = process.env.API_HOST || 'http://localhost:3000';
+    ENV.matomo.url = 'https://stats.pix.fr/js/container_x4fRiAXl_dev_a6c96fc927042b6f6e773267.js';
     ENV.matomo.debug = true;
   }
 

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -77,6 +77,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.matomo.url = 'https://stats.pix.fr/js/container_cMIdKogu_dev_ace719fc09829675a21c66df.js';
     ENV.matomo.debug = true;
   }
 

--- a/mon-pix/app/routes/index.js
+++ b/mon-pix/app/routes/index.js
@@ -4,6 +4,6 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default Route.extend(AuthenticatedRouteMixin, {
 
   redirect() {
-    return this.transitionTo('profile');
+    this.replaceWith('profile');
   },
 });

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -88,6 +88,7 @@ module.exports = function(environment) {
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
     ENV.APP.API_HOST = process.env.API_HOST || 'http://localhost:3000';
     ENV.APP.HOME_HOST = process.env.HOME_HOST || '/';
+    ENV.matomo.url = 'https://stats.pix.fr/js/container_jKDD76j4_dev_179474167add1104d6c8a92b.js';
     ENV.matomo.debug = true;
   }
 

--- a/mon-pix/tests/unit/routes/index-test.js
+++ b/mon-pix/tests/unit/routes/index-test.js
@@ -11,13 +11,13 @@ describe('Unit | Route | index', function() {
     it('should redirect to /profil', async function() {
       // Given
       const route = this.owner.lookup('route:index');
-      route.transitionTo = sinon.spy();
+      route.replaceWith = sinon.spy();
 
       // When
       await route.redirect();
 
       // Then
-      sinon.assert.calledWith(route.transitionTo, 'profile');
+      sinon.assert.calledWith(route.replaceWith, 'profile');
     });
   });
 });

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -47,7 +47,7 @@ module.exports = function(environment) {
     },
 
     matomo: {
-      url: 'https://stats.pix.fr/js/container_jKDD76j4.js',
+      url: 'https://stats.pix.fr/js/container_p3ppIohn.js',
     },
 
     'ember-cli-notifications': {
@@ -65,6 +65,8 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.matomo.url = 'https://stats.pix.fr/js/container_p3ppIohn_dev_22b0fda418abe8fedbf89e9c.js';
+    ENV.matomo.debug = true;
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
## :unicorn: Problème

2 problèmes : 
- Pix Orga est branché sur le container Matomo de Pix App ce qui fausse les données remontées
- par ailleurs, le fait de rediriger la route `index` vers la route `profile` en utilisant `transitionTo` ajoute une entrée dans l'historique de navigation et compte une PageView `/index` dans Matomo non pertinente

## :robot: Solution

Cette PR fixe ces 2 problèmes.

## :rainbow: Remarques

Au passage, cette PR permet de tenir compte de l'environnement `development` pour le dev localhost.