### PR TITLE
[EXPEDIT] Mauvais affichage des heures sur la liste des sessions (PA-183)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -11,8 +11,8 @@ function _getNumberOf(certifications, booleanFct) {
   );
 }
 
-function _formatHumanReadableLocaleDateTime(date) {
-  return date ? (new Date(date)).toLocaleString('fr-FR') : date;
+function _formatHumanReadableLocaleDateTime(date, options) {
+  return date ? (new Date(date)).toLocaleString('fr-FR', options) : date;
 }
 
 export const CREATED = 'created';
@@ -81,7 +81,7 @@ export default class Session extends Model {
 
   @computed('date')
   get displayDate() {
-    return _formatHumanReadableLocaleDateTime(this.date);
+    return _formatHumanReadableLocaleDateTime(this.date, { day: 'numeric', month: 'numeric', year: 'numeric' });
   }
 
   @computed('finalizedAt')

--- a/admin/app/templates/components/routes/authenticated/sessions/list-items.hbs
+++ b/admin/app/templates/components/routes/authenticated/sessions/list-items.hbs
@@ -28,7 +28,7 @@
           <td>{{session.id}}</td>
           <td>{{session.certificationCenter}}</td>
           <td>TODO</td>
-          <td>{{session.displayDate}}</td>
+          <td>{{session.displayDate}} à {{session.time}}</td>
           <td>{{session.displayStatus}}</td>
           <td>{{session.displayFinalizationDate}}</td>
           <td>{{session.countPublishedCertifications}}</td>

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -10,11 +10,11 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   test('it should display sessions list', async function(assert) {
     // given
     const now = new Date();
-    const displayDate = now.toLocaleString('fr-FR');
+    const displayDate = now.toLocaleString('fr-FR', { day: 'numeric', month: 'numeric', year: 'numeric' });
     const sessions = [
-      { id: 1, certificationCenter: 'Centre A', date: now, displayDate },
-      { id: 2, certificationCenter: 'Centre B', date: now, displayDate },
-      { id: 3, certificationCenter: 'Centre C', date: now, displayDate },
+      { id: 1, certificationCenter: 'Centre A', date: now, time: '14:00:00', displayDate },
+      { id: 2, certificationCenter: 'Centre B', date: now, time: '14:00:00', displayDate },
+      { id: 3, certificationCenter: 'Centre C', date: now, time: '14:00:00', displayDate },
     ];
 
     sessions.meta = { rowCount: 3 };
@@ -29,7 +29,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText(sessions[0].id.toString());
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText(sessions[0].certificationCenter);
-    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText(displayDate);
+    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText(displayDate + ' à ' + sessions[0].time);
     assert.dom('table tbody tr').exists({ count: 3 });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L’heure de début de session affichée dans la liste des session dans Pix Admin est erronée.
Heure de début dans Pix certif : 
![image](https://user-images.githubusercontent.com/38167520/76944981-364ba680-6902-11ea-89ca-c41c58afc613.png)
Heure de début dans la liste des sessions dans Pix Admin :
![image](https://user-images.githubusercontent.com/38167520/76945017-3ea3e180-6902-11ea-865e-d21c5bda5c04.png)


## :robot: Solution
Une session est en fait composée d'une date et d'une heure : 
<img width="304" alt="image" src="https://user-images.githubusercontent.com/38167520/76945364-ad813a80-6902-11ea-9f53-8e8ff4484cec.png">

On affichait uniquement la date qui était formattée avec toLocalString (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date/toLocaleString), ce qui part défaut est formatté avec une heure. 

Il faut donc formatter la date dans le format souhaité, par exemple JJ/MM/AAAA et après afficher l'heure.

## :rainbow: Remarques
J'aime les mangues 🥭
