### PR TITLE
[CLEANUP] Faire les calculs de score et de niveau à un seul endroit.

### DIFF
--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -49,13 +49,13 @@ class Scorecard {
     return { userId: _.parseInt(userId), competenceId };
   }
 
-  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation, blockReachablePixAndLevel = false }) {
+  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation, allowExcessPix = false, allowExcessLevel = false }) {
     const {
       realTotalPixScoreForCompetence,
       pixScoreForCompetence,
       currentLevel,
       pixAheadForNextLevel
-    } = scoringService.calculateScoringInformationForCompetence(knowledgeElements, blockReachablePixAndLevel);
+    } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements, allowExcessPix, allowExcessLevel });
     const remainingDaysBeforeReset = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 
     return new Scorecard({

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -3,6 +3,7 @@ const Assessment = require('./Assessment');
 const CompetenceEvaluation = require('./CompetenceEvaluation');
 const KnowledgeElement = require('./KnowledgeElement');
 const constants = require('../constants');
+const scoringService = require('../services/scoring/scoring-service');
 
 const statuses = {
   NOT_STARTED: 'NOT_STARTED',
@@ -48,9 +49,13 @@ class Scorecard {
     return { userId: _.parseInt(userId), competenceId };
   }
 
-  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation, blockReachablePixAndLevel }) {
-    const exactlyEarnedPix = _(knowledgeElements).sumBy('earnedPix');
-    const totalEarnedPix = _getTotalEarnedPix(exactlyEarnedPix, blockReachablePixAndLevel);
+  static buildFrom({ userId, knowledgeElements, competence, competenceEvaluation, blockReachablePixAndLevel = false }) {
+    const {
+      realTotalPixScoreForCompetence,
+      pixScoreForCompetence,
+      currentLevel,
+      pixAheadForNextLevel
+    } = scoringService.calculateScoringInformationForCompetence(knowledgeElements, blockReachablePixAndLevel);
     const remainingDaysBeforeReset = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
 
     return new Scorecard({
@@ -60,10 +65,10 @@ class Scorecard {
       competenceId: competence.id,
       index: competence.index,
       area: competence.area,
-      earnedPix: totalEarnedPix,
-      exactlyEarnedPix,
-      level: _getCompetenceLevel(totalEarnedPix),
-      pixScoreAheadOfNextLevel: _getPixScoreAheadOfNextLevel(totalEarnedPix),
+      earnedPix: pixScoreForCompetence,
+      exactlyEarnedPix: realTotalPixScoreForCompetence,
+      level: currentLevel,
+      pixScoreAheadOfNextLevel: pixAheadForNextLevel,
       status: _getScorecardStatus(competenceEvaluation, knowledgeElements),
       remainingDaysBeforeReset,
     });
@@ -86,23 +91,6 @@ function _getScorecardStatus(competenceEvaluation, knowledgeElements) {
     return statuses.COMPLETED;
   }
   return statuses.STARTED;
-}
-
-function _getTotalEarnedPix(exactlyEarnedPix, blockReachablePixAndLevel) {
-  const userTotalEarnedPix = _.floor(exactlyEarnedPix);
-  if (blockReachablePixAndLevel) {
-    return Math.min(userTotalEarnedPix, constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
-  }
-  return userTotalEarnedPix;
-}
-
-function _getCompetenceLevel(earnedPix) {
-  const userLevel = _.floor(earnedPix / constants.PIX_COUNT_BY_LEVEL);
-  return Math.min(constants.MAX_REACHABLE_LEVEL, userLevel);
-}
-
-function _getPixScoreAheadOfNextLevel(earnedPix) {
-  return earnedPix % constants.PIX_COUNT_BY_LEVEL;
 }
 
 Scorecard.statuses = statuses;

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -11,6 +11,7 @@ const _ = require('lodash');
 
 const AnswerStatus = require('../models/AnswerStatus');
 const CertificationContract = require('../../domain/models/CertificationContract');
+const scoringService = require('./scoring/scoring-service');
 
 const { CertificationComputeError } = require('../../../lib/domain/errors');
 
@@ -89,9 +90,9 @@ function _getCertifiedLevel(numberOfCorrectAnswers, competence, reproductibility
     return UNCERTIFIED_LEVEL;
   }
   if (reproductibilityRate < MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED && numberOfCorrectAnswers === 2) {
-    return competence.estimatedLevel - 1;
+    return scoringService.getBlockedLevel(competence.estimatedLevel - 1);
   }
-  return competence.estimatedLevel;
+  return scoringService.getBlockedLevel(competence.estimatedLevel);
 }
 
 function _getSumScoreFromCertifiedCompetences(listCompetences) {
@@ -106,7 +107,7 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
       index: competence.index,
       area_code: competence.area.code,
       id: competence.id,
-      positionedLevel: competence.estimatedLevel,
+      positionedLevel: scoringService.getBlockedLevel(competence.estimatedLevel),
       positionedScore: competence.pixScore,
       obtainedLevel: _getCertifiedLevel(numberOfCorrectAnswers, competence, reproductibilityRate),
       obtainedScore: competence.pixScore - _computedPixToRemovePerCompetence(numberOfCorrectAnswers, competence,

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -4,7 +4,7 @@ const KnowledgeElement = require('../models/KnowledgeElement');
 const Scorecard = require('../models/Scorecard');
 const _ = require('lodash');
 
-async function computeScorecard({ userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository, blockReachablePixAndLevel = false }) {
+async function computeScorecard({ userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository, allowExcessPix = false, allowExcessLevel = false }) {
   const [knowledgeElements, competence, competenceEvaluations] = await Promise.all([
     knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId }),
     competenceRepository.get(competenceId),
@@ -18,7 +18,8 @@ async function computeScorecard({ userId, competenceId, competenceRepository, co
     knowledgeElements,
     competenceEvaluation,
     competence,
-    blockReachablePixAndLevel
+    allowExcessPix,
+    allowExcessLevel
   });
 }
 

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -1,11 +1,7 @@
-const {
-  MAX_REACHABLE_LEVEL,
-  MAX_REACHABLE_PIX_BY_COMPETENCE,
-} = require('../../constants');
-
 const AssessmentScore = require('../../models/AssessmentScore');
 const CompetenceMark = require('../../models/CompetenceMark');
 const certificationService = require('../../services/certification-service');
+const scoringService = require('../../services/scoring/scoring-service');
 const _ = require('lodash');
 
 async function calculateAssessmentScore(assessment) {
@@ -14,8 +10,8 @@ async function calculateAssessmentScore(assessment) {
 
   const competenceMarks = competencesWithMark.map((certifiedCompetence) => {
     return new CompetenceMark({
-      level: Math.min(certifiedCompetence.obtainedLevel, MAX_REACHABLE_LEVEL),
-      score: Math.min(certifiedCompetence.obtainedScore, MAX_REACHABLE_PIX_BY_COMPETENCE),
+      level: scoringService.getBlockedLevel(certifiedCompetence.obtainedLevel),
+      score: scoringService.getCompetencePixScore(certifiedCompetence.obtainedScore),
       area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,
     });

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -11,7 +11,7 @@ async function calculateAssessmentScore(assessment) {
   const competenceMarks = competencesWithMark.map((certifiedCompetence) => {
     return new CompetenceMark({
       level: scoringService.getBlockedLevel(certifiedCompetence.obtainedLevel),
-      score: scoringService.getCompetencePixScore(certifiedCompetence.obtainedScore),
+      score: scoringService.getBlockedPixScore(certifiedCompetence.obtainedScore),
       area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,
     });

--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -20,8 +20,11 @@ function calculateScoringInformationForCompetence(knowledgeElements, blockReacha
   };
 }
 
-function getblockedLevel(level) {
+function getBlockedLevel(level) {
   return _getBlockedLevel(level);
+}
+function getCompetencePixScore(pixScore) {
+  return _getBlockedPixScoreByCompetence(pixScore);
 }
 
 function getCompetenceLevelByPix(pix) {
@@ -35,9 +38,10 @@ function totalUserPixScore(pixEarnedByCompetence) {
 
 module.exports = {
   calculateScoringInformationForCompetence,
-  getblockedLevel,
+  getBlockedLevel,
   getCompetenceLevelByPix,
-  totalUserPixScore
+  totalUserPixScore,
+  getCompetencePixScore
 };
 
 function _getPixScoreForOneCompetence(exactlyEarnedPix, blockReachablePixAndLevel = true) {

--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -1,0 +1,69 @@
+const {
+  PIX_COUNT_BY_LEVEL,
+  MAX_REACHABLE_LEVEL,
+  MAX_REACHABLE_PIX_BY_COMPETENCE,
+} = require('../../constants');
+
+const _ = require('lodash');
+
+function calculateScoringInformationForCompetence(knowledgeElements, blockReachablePixAndLevel = true) {
+
+  const realTotalPixScoreForCompetence = _(knowledgeElements).sumBy('earnedPix');
+  const pixScoreForCompetence = _getPixScoreForOneCompetence(realTotalPixScoreForCompetence, blockReachablePixAndLevel);
+  const currentLevel = _getCompetenceLevel(pixScoreForCompetence, blockReachablePixAndLevel);
+  const pixAheadForNextLevel = _getPixScoreAheadOfNextLevel(pixScoreForCompetence);
+  return {
+    realTotalPixScoreForCompetence,
+    pixScoreForCompetence,
+    currentLevel,
+    pixAheadForNextLevel
+  };
+}
+
+function getblockedLevel(level) {
+  return _getBlockedLevel(level);
+}
+
+function getCompetenceLevelByPix(pix) {
+  return _getCompetenceLevel(pix, true);
+}
+
+function totalUserPixScore(pixEarnedByCompetence) {
+  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => _getBlockedPixScoreByCompetence(pixEarnedForOneCompetence));
+  return _.sum(pixByCompetenceLimited);
+}
+
+module.exports = {
+  calculateScoringInformationForCompetence,
+  getblockedLevel,
+  getCompetenceLevelByPix,
+  totalUserPixScore
+};
+
+function _getPixScoreForOneCompetence(exactlyEarnedPix, blockReachablePixAndLevel = true) {
+  const userEarnedPix = _.floor(exactlyEarnedPix);
+  if (blockReachablePixAndLevel) {
+    return _getBlockedPixScoreByCompetence(userEarnedPix);
+  }
+  return userEarnedPix;
+}
+
+function _getCompetenceLevel(pixScoreForCompetence, blockReachablePixAndLevel = true) {
+  const level = _.floor(pixScoreForCompetence / PIX_COUNT_BY_LEVEL);
+  if (blockReachablePixAndLevel) {
+    return _getBlockedLevel(level);
+  }
+  return level;
+}
+
+function _getPixScoreAheadOfNextLevel(earnedPix) {
+  return earnedPix % PIX_COUNT_BY_LEVEL;
+}
+
+function _getBlockedLevel(level) {
+  return Math.min(level, MAX_REACHABLE_LEVEL);
+}
+
+function _getBlockedPixScoreByCompetence(pixScore) {
+  return Math.min(pixScore, MAX_REACHABLE_PIX_BY_COMPETENCE);
+}

--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -10,7 +10,7 @@ function calculateScoringInformationForCompetence({ knowledgeElements, allowExce
 
   const realTotalPixScoreForCompetence = _(knowledgeElements).sumBy('earnedPix');
   const pixScoreForCompetence = _getPixScoreForOneCompetence(realTotalPixScoreForCompetence, allowExcessPix);
-  const currentLevel = getCompetenceLevel(pixScoreForCompetence, allowExcessLevel);
+  const currentLevel = getCompetenceLevel(realTotalPixScoreForCompetence, allowExcessLevel);
   const pixAheadForNextLevel = _getPixScoreAheadOfNextLevel(pixScoreForCompetence);
   return {
     realTotalPixScoreForCompetence,
@@ -23,12 +23,12 @@ function calculateScoringInformationForCompetence({ knowledgeElements, allowExce
 function getBlockedLevel(level) {
   return Math.min(level, MAX_REACHABLE_LEVEL);
 }
-function getCompetencePixScore(pixScore) {
+function getBlockedPixScore(pixScore) {
   return Math.min(pixScore, MAX_REACHABLE_PIX_BY_COMPETENCE);
 }
 
 function totalUserPixScore(pixEarnedByCompetence) {
-  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => getCompetencePixScore(pixEarnedForOneCompetence));
+  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => getBlockedPixScore(pixEarnedForOneCompetence));
   return _.sum(pixByCompetenceLimited);
 }
 
@@ -37,7 +37,7 @@ function _getPixScoreForOneCompetence(exactlyEarnedPix, allowExcessPix = false) 
   if (allowExcessPix) {
     return userEarnedPix;
   }
-  return getCompetencePixScore(userEarnedPix);
+  return getBlockedPixScore(userEarnedPix);
 }
 
 function getCompetenceLevel(pixScoreForCompetence, allowExcessLevel = false) {
@@ -55,7 +55,8 @@ function _getPixScoreAheadOfNextLevel(earnedPix) {
 module.exports = {
   calculateScoringInformationForCompetence,
   getBlockedLevel,
+  getBlockedPixScore,
   getCompetenceLevel,
   totalUserPixScore,
-  getCompetencePixScore
+
 };

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -114,7 +114,9 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
     const scorecard = Scorecard.buildFrom({
       userId,
       knowledgeElements: knowledgeElementsByCompetence[competence.id],
-      competence
+      competence,
+      allowExcessPix: true,
+      allowExcessLevel: true
     });
 
     userCompetence.estimatedLevel = scorecard.level;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -45,7 +45,6 @@ module.exports = async function correctAnswerThenUpdateAssessment(
       competenceRepository,
       competenceEvaluationRepository,
       knowledgeElementRepository,
-      blockReachablePixAndLevel: true,
     });
   }
 
@@ -145,7 +144,6 @@ async function _addLevelUpInformation(
     competenceRepository,
     competenceEvaluationRepository,
     knowledgeElementRepository,
-    blockReachablePixAndLevel: true,
   });
 
   if (scorecardBeforeAnswer.level < scorecardAfterAnswer.level) {

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -1,6 +1,6 @@
 const { NotFoundError } = require('../errors');
-const { MAX_REACHABLE_LEVEL } = require('../constants');
 const Assessment = require('../models/Assessment');
+const scoringService = require('../services/scoring/scoring-service');
 
 module.exports = async function getAssessment(
   {
@@ -18,7 +18,7 @@ module.exports = async function getAssessment(
   const assessmentResult = assessment.getLastAssessmentResult();
 
   if (assessmentResult) {
-    assessment.estimatedLevel = Math.min(assessmentResult.level, MAX_REACHABLE_LEVEL);
+    assessment.estimatedLevel = scoringService.getblockedLevel(assessmentResult.level);
     assessment.pixScore = assessmentResult.pixScore;
   } else {
     assessment.estimatedLevel = null;

--- a/api/lib/domain/usecases/get-assessment.js
+++ b/api/lib/domain/usecases/get-assessment.js
@@ -18,7 +18,7 @@ module.exports = async function getAssessment(
   const assessmentResult = assessment.getLastAssessmentResult();
 
   if (assessmentResult) {
-    assessment.estimatedLevel = scoringService.getblockedLevel(assessmentResult.level);
+    assessment.estimatedLevel = scoringService.getBlockedLevel(assessmentResult.level);
     assessment.pixScore = assessmentResult.pixScore;
   } else {
     assessment.estimatedLevel = null;

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -15,7 +15,6 @@ module.exports = async function getScorecard({ authenticatedUserId, scorecardId,
     competenceRepository,
     competenceEvaluationRepository,
     knowledgeElementRepository,
-    blockReachablePixAndLevel: true,
   });
 };
 

--- a/api/lib/domain/usecases/get-user-scorecards.js
+++ b/api/lib/domain/usecases/get-user-scorecards.js
@@ -17,8 +17,7 @@ module.exports = async function getUserScorecards({ userId, knowledgeElementRepo
       userId,
       knowledgeElements: knowledgeElementsForCompetence,
       competence,
-      competenceEvaluation,
-      blockReachablePixAndLevel: true
+      competenceEvaluation
     });
   });
 };

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -2,7 +2,7 @@ const KnowledgeElement = require('../../domain/models/KnowledgeElement');
 const BookshelfKnowledgeElement = require('../data/knowledge-element');
 const _ = require('lodash');
 const Bookshelf = require('../bookshelf');
-const constants = require('../../domain/constants');
+const scoringService = require('../../domain/services/scoring/scoring-service');
 
 function _toDomain(knowledgeElementBookshelf) {
   const knowledgeElements = knowledgeElementBookshelf.toJSON();
@@ -84,8 +84,8 @@ module.exports = {
       .where({ rank: 1 })
       .groupBy('competenceId')
       .then((pixEarnedByCompetence) => {
-        const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) =>  Math.min(constants.MAX_REACHABLE_PIX_BY_COMPETENCE, pixEarnedForOneCompetence.earnedPix));
-        return _.sum(pixByCompetenceLimited);
+        const pixScoreByCompetence = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) =>  pixEarnedForOneCompetence.earnedPix);
+        return scoringService.totalUserPixScore(pixScoreByCompetence);
       });
   },
 

--- a/api/tests/integration/domain/services/scoring/scoring-certification_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-certification_test.js
@@ -68,8 +68,9 @@ describe('Integration | Domain | services | scoring | scoring-certification-serv
       it('should ceil the level and the score to a maximum threshold', async () => {
         // given
         const MAX_REACHABLE_LEVEL = 5;
-        const MAX_REACHABLE_PIX_BY_COMPETENCE = 40;
-        const competenceWithMarkAboveThreshold = { index: '1.1', obtainedLevel: 6, obtainedScore: 50, area_code: '1', };
+        const MAX_REACHABLE_PIX = 40;
+        const nbrPix = 50;
+        const competenceWithMarkAboveThreshold = { index: '1.1', obtainedLevel: 6, obtainedScore: nbrPix, area_code: '1', };
         const assessment = domainBuilder.buildAssessment({ id: assessmentId, courseId });
 
         sinon.stub(certificationService, 'calculateCertificationResultByAssessmentId').resolves({ competencesWithMark: [competenceWithMarkAboveThreshold] });
@@ -78,9 +79,9 @@ describe('Integration | Domain | services | scoring | scoring-certification-serv
         const assessmentScore = await scoringCertificationService.calculateAssessmentScore(assessment);
 
         // then
-        expect(assessmentScore.nbPix).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+        expect(assessmentScore.nbPix).to.equal(MAX_REACHABLE_PIX);
         expect(assessmentScore.competenceMarks[0].level).to.equal(MAX_REACHABLE_LEVEL);
-        expect(assessmentScore.competenceMarks[0].score).to.equal(MAX_REACHABLE_PIX_BY_COMPETENCE);
+        expect(assessmentScore.competenceMarks[0].score).to.equal(MAX_REACHABLE_PIX);
       });
     });
 

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -160,17 +160,29 @@ describe('Unit | Domain | Models | Scorecard', () => {
     });
 
     context('when the user level is beyond the upper limit allowed', () => {
+      let knowledgeElements;
       beforeEach(() => {
         // given
-        const knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
+        knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
       });
       // then
-      it('should have the competence level capped at the maximum value', () => {
+      it('should have the competence level capped at the maximum value if we block', () => {
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: true });
+
         expect(actualScorecard.level).to.equal(5);
+        expect(actualScorecard.earnedPix).to.equal(40);
       });
+
+      it('should have the competence level not capped at the maximum value if we do not block', () => {
+        //when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+
+        expect(actualScorecard.level).to.equal(15);
+        expect(actualScorecard.earnedPix).to.equal(120);
+      });
+
     });
 
     context('when the user pix score is higher than the max', () => {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -167,20 +167,20 @@ describe('Unit | Domain | Models | Scorecard', () => {
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
       });
       // then
-      it('should have the competence level capped at the maximum value if we block', () => {
+      it('should have the competence level capped at the maximum value', () => {
         //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, blockReachablePixAndLevel: true });
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
 
         expect(actualScorecard.level).to.equal(5);
         expect(actualScorecard.earnedPix).to.equal(40);
       });
 
-      it('should have the competence level not capped at the maximum value if we do not block', () => {
+      it('should have the competence level not capped at the maximum value if we allow it', () => {
         //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence, allowExcessLevel : true });
 
         expect(actualScorecard.level).to.equal(15);
-        expect(actualScorecard.earnedPix).to.equal(120);
+        expect(actualScorecard.earnedPix).to.equal(40);
       });
 
     });
@@ -192,35 +192,30 @@ describe('Unit | Domain | Models | Scorecard', () => {
         knowledgeElements = [{ earnedPix: 50 }, { earnedPix: 70 }];
         computeDaysSinceLastKnowledgeElementStub.withArgs(knowledgeElements).returns(0);
       });
-      it('should have the same number of pix if blockReachablePixAndLevel is not defined', () => {
-        //when
-        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
-        // then
-        expect(actualScorecard.earnedPix).to.equal(120);
-      });
-      it('should have the same number of pix if blockReachablePixAndLevel is false', () => {
+
+      it('should have the number of pix blocked', () => {
         //when
         actualScorecard = Scorecard.buildFrom({
           userId,
           knowledgeElements,
           competenceEvaluation,
           competence,
-          blockReachablePixAndLevel: false
-        });
-        // then
-        expect(actualScorecard.earnedPix).to.equal(120);
-      });
-      it('should have the number of pix blocked if blockReachablePixAndLevel is true', () => {
-        //when
-        actualScorecard = Scorecard.buildFrom({
-          userId,
-          knowledgeElements,
-          competenceEvaluation,
-          competence,
-          blockReachablePixAndLevel: true
         });
         // then
         expect(actualScorecard.earnedPix).to.equal(constants.MAX_REACHABLE_PIX_BY_COMPETENCE);
+      });
+
+      it('should have the same number of pix if we allow it', () => {
+        //when
+        actualScorecard = Scorecard.buildFrom({
+          userId,
+          knowledgeElements,
+          competenceEvaluation,
+          competence,
+          allowExcessPix: true
+        });
+        // then
+        expect(actualScorecard.earnedPix).to.equal(120);
       });
 
     });

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -68,7 +68,8 @@ describe('Unit | Service | ScorecardService', function() {
           knowledgeElements: knowledgeElementList,
           competence,
           competenceEvaluation,
-          blockReachablePixAndLevel: false
+          allowExcessLevel: false,
+          allowExcessPix: false
         }).returns(expectedUserScorecard);
 
         // when

--- a/api/tests/unit/domain/services/scoring/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-service_test.js
@@ -11,7 +11,7 @@ describe('Unit | Service | Scoring Service', () => {
 
   describe('#calculateScoringInformationForCompetence', function() {
 
-    it('should return the information about pix score and level for one competence', () => {
+    it('should return the information about pix score and level for given competence', () => {
       // given
       const knowledgeElements = [
         domainBuilder.buildKnowledgeElement({ earnedPix: 3.7 }),
@@ -27,10 +27,10 @@ describe('Unit | Service | Scoring Service', () => {
       };
 
       // when
-      const scoring = scoringService.calculateScoringInformationForCompetence( { knowledgeElements });
+      const scoring = scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
 
       // then
-      expect(scoring).to.be.deep.equal(expectedScoring);
+      expect(scoring).to.deep.equal(expectedScoring);
     });
 
     it('should return the information about pix score and level for one competence blocked with max information', () => {

--- a/api/tests/unit/domain/services/scoring/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-service_test.js
@@ -27,7 +27,7 @@ describe('Unit | Service | Scoring Service', () => {
       };
 
       // when
-      const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements);
+      const scoring = scoringService.calculateScoringInformationForCompetence( { knowledgeElements });
 
       // then
       expect(scoring).to.be.deep.equal(expectedScoring);
@@ -49,13 +49,13 @@ describe('Unit | Service | Scoring Service', () => {
       };
 
       // when
-      const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements);
+      const scoring = scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
 
       // then
       expect(scoring).to.be.deep.equal(expectedScoring);
     });
 
-    context('when we do not block level and pix', () => {
+    context('when we allow an excess in pix or level', () => {
       it('should return the information about pix score and level for one competence blocked not blocked', () => {
         // given
         const knowledgeElements = [
@@ -63,7 +63,8 @@ describe('Unit | Service | Scoring Service', () => {
           domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
           domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
         ];
-        const blockReachablePixAndLevel = false;
+        const allowExcessLevel = true;
+        const allowExcessPix = true;
         const expectedScoring = {
           realTotalPixScoreForCompetence: 56,
           pixScoreForCompetence: 56,
@@ -72,7 +73,7 @@ describe('Unit | Service | Scoring Service', () => {
         };
 
         // when
-        const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements, blockReachablePixAndLevel);
+        const scoring = scoringService.calculateScoringInformationForCompetence({ knowledgeElements, allowExcessLevel, allowExcessPix });
 
         // then
         expect(scoring).to.be.deep.equal(expectedScoring);

--- a/api/tests/unit/domain/services/scoring/scoring-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-service_test.js
@@ -1,0 +1,84 @@
+const scoringService = require('../../../../../lib/domain/services/scoring/scoring-service');
+const {
+  PIX_COUNT_BY_LEVEL,
+  MAX_REACHABLE_LEVEL,
+  MAX_REACHABLE_PIX_BY_COMPETENCE,
+} = require('../../../../../lib/domain/constants');
+
+const { expect, domainBuilder } = require('../../../../test-helper');
+
+describe('Unit | Service | Scoring Service', () => {
+
+  describe('#calculateScoringInformationForCompetence', function() {
+
+    it('should return the information about pix score and level for one competence', () => {
+      // given
+      const knowledgeElements = [
+        domainBuilder.buildKnowledgeElement({ earnedPix: 3.7 }),
+        domainBuilder.buildKnowledgeElement({ earnedPix: 4.4 }),
+        domainBuilder.buildKnowledgeElement({ earnedPix: 1.2 }),
+      ];
+
+      const expectedScoring = {
+        realTotalPixScoreForCompetence: 9.3,
+        pixScoreForCompetence: 9,
+        currentLevel: 1,
+        pixAheadForNextLevel: 1,
+      };
+
+      // when
+      const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements);
+
+      // then
+      expect(scoring).to.be.deep.equal(expectedScoring);
+    });
+
+    it('should return the information about pix score and level for one competence blocked with max information', () => {
+      // given
+      const knowledgeElements = [
+        domainBuilder.buildKnowledgeElement({ earnedPix: MAX_REACHABLE_PIX_BY_COMPETENCE }),
+        domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
+        domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
+      ];
+
+      const expectedScoring = {
+        realTotalPixScoreForCompetence: 56,
+        pixScoreForCompetence: MAX_REACHABLE_PIX_BY_COMPETENCE,
+        currentLevel: MAX_REACHABLE_LEVEL,
+        pixAheadForNextLevel: 0
+      };
+
+      // when
+      const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements);
+
+      // then
+      expect(scoring).to.be.deep.equal(expectedScoring);
+    });
+
+    context('when we do not block level and pix', () => {
+      it('should return the information about pix score and level for one competence blocked not blocked', () => {
+        // given
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({ earnedPix: MAX_REACHABLE_PIX_BY_COMPETENCE }),
+          domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
+          domainBuilder.buildKnowledgeElement({ earnedPix: PIX_COUNT_BY_LEVEL }),
+        ];
+        const blockReachablePixAndLevel = false;
+        const expectedScoring = {
+          realTotalPixScoreForCompetence: 56,
+          pixScoreForCompetence: 56,
+          currentLevel: 7,
+          pixAheadForNextLevel: 0
+        };
+
+        // when
+        const scoring = scoringService.calculateScoringInformationForCompetence(knowledgeElements, blockReachablePixAndLevel);
+
+        // then
+        expect(scoring).to.be.deep.equal(expectedScoring);
+      });
+
+    });
+
+  });
+});

--- a/api/tests/unit/domain/usecases/get-user-scorecards_test.js
+++ b/api/tests/unit/domain/usecases/get-user-scorecards_test.js
@@ -132,24 +132,21 @@ describe('Unit | UseCase | get-user-scorecard', () => {
           userId,
           knowledgeElements: knowledgeElementGroupedByCompetenceId[1],
           competence: competenceList[0],
-          competenceEvaluation: competenceEvaluationOfCompetence1,
-          blockReachablePixAndLevel: true,
+          competenceEvaluation: competenceEvaluationOfCompetence1
         }).returns(expectedUserScorecard[0]);
 
         Scorecard.buildFrom.withArgs({
           userId,
           knowledgeElements: knowledgeElementGroupedByCompetenceId[2],
           competence: competenceList[1],
-          competenceEvaluation: undefined,
-          blockReachablePixAndLevel: true,
+          competenceEvaluation: undefined
         }).returns(expectedUserScorecard[1]);
 
         Scorecard.buildFrom.withArgs({
           userId,
           knowledgeElements: undefined,
           competence: competenceList[2],
-          competenceEvaluation: undefined,
-          blockReachablePixAndLevel: true,
+          competenceEvaluation: undefined
         }).returns(expectedUserScorecard[2]);
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
- La façon dont on faisait nos arrondis/somme/minimum pour calculer le score en pix et le niveau par compétence était fait à différents endroits, pouvant entraîner des différences.

## :robot: Solution
- Création du `scoringService` utilisé dans les différents endroits qui calcules des pix.
 
## :rainbow: Remarques
- Dans le cas des certifications, on souhaite pouvoir dépasser le nombre de pix actuel.
- Modification de la manière dont on vérifie les succès. Avant, on calculait le level et le nombre de pix, et on vérifiait par rapport au nombre de Pix sur les KE gagnés. Suite à un bug, il y avait des KE qui n'auraient pas dû être dans la liste qui sont apparu, et qui ont donc fait buggué les succès. Pour éviter cela, on réutilise le scorecardService.

## 👓 Mais où est-ce qu'on calcule les Pix et les niveaux : 
- Sur le profile, dans les scorecard : le nombre de Pix et le niveau sont plafonnés
- Sur le profile, dans le nombre de pix total : le nombre de Pix est plafonné
- En fin de compétence, dans les compétences :  le nombre de Pix et le niveau sont plafonnés
- En fin de certification : le nom de Pix est plafonné ainsi que le niveau. Pour le calcul du nombre de pix finale, au moment de retirer 8 pix, on les retire sur le nombre total non plafonné.