### PR TITLE
[BUGFIX] Harmoniser le calcul de pourcentage de progression d'un candidat sur une campagne (PO-325)

### DIFF
--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -1,4 +1,6 @@
+const campaignParticipationService = require('../services/campaign-participation-service');
 const CompetenceResult = require('./CompetenceResult');
+
 const _ = require('lodash');
 
 class CampaignParticipationResult {
@@ -10,6 +12,7 @@ class CampaignParticipationResult {
     totalSkillsCount,
     testedSkillsCount,
     validatedSkillsCount,
+    knowledgeElementsCount,
     // relationships
     competenceResults = [],
     badge,
@@ -21,6 +24,7 @@ class CampaignParticipationResult {
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = testedSkillsCount;
     this.validatedSkillsCount = validatedSkillsCount;
+    this.knowledgeElementsCount = knowledgeElementsCount,
     // relationships
     this.competenceResults = competenceResults;
     this.badge = badge;
@@ -42,6 +46,7 @@ class CampaignParticipationResult {
       totalSkillsCount,
       testedSkillsCount,
       validatedSkillsCount,
+      knowledgeElementsCount: targetedKnowledgeElements.length,
       areBadgeCriteriaFulfilled: false,
       isCompleted: assessment.isCompleted(),
       competenceResults: targetedCompetenceResults,
@@ -55,6 +60,10 @@ class CampaignParticipationResult {
     } else {
       return 0;
     }
+  }
+
+  get progress() {
+    return campaignParticipationService.progress(this.isCompleted, this.knowledgeElementsCount, this.totalSkillsCount);
   }
 }
 

--- a/api/lib/domain/services/campaign-participation-service.js
+++ b/api/lib/domain/services/campaign-participation-service.js
@@ -1,0 +1,12 @@
+const _ = require('lodash');
+
+function progress(campaignParticipationCompleted, numberOfKnowledgeElements, numberOfSkillsInTargetProfile) {
+  if (campaignParticipationCompleted) {
+    return 1;
+  }
+  return _.round(numberOfKnowledgeElements / numberOfSkillsInTargetProfile, 3);
+}
+
+module.exports = {
+  progress,
+};

--- a/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-results-to-stream.js
@@ -1,3 +1,5 @@
+const campaignParticipationService = require('../services/campaign-participation-service');
+
 const _ = require('lodash');
 const moment = require('moment');
 const bluebird = require('bluebird');
@@ -53,7 +55,7 @@ function _createHeaderOfCSV(skills, competences, areas, idPixLabel) {
 
     ...(idPixLabel ? [ { title: csvService.sanitize(idPixLabel), property: 'participantExternalId' } ] : []),
 
-    { title: '% de progression', property: 'percentageProgression' },
+    { title: '% de progression', property: 'progress' },
     { title: 'Date de début', property: 'createdAt' },
     { title: 'Partage (O/N)', property: 'isShared' },
     { title: 'Date du partage', property: 'sharedAt' },
@@ -126,10 +128,6 @@ function _getCommonColumns({
   campaignParticipationResultData,
   knowledgeElements,
 }) {
-  const percentageProgression = _.round(
-    knowledgeElements.length / (targetProfile.skills.length),
-    3,
-  );
 
   return {
     organizationName: organization.name,
@@ -138,7 +136,7 @@ function _getCommonColumns({
     targetProfileName: targetProfile.name,
     participantLastName,
     participantFirstName,
-    percentageProgression,
+    progress: campaignParticipationService.progress(campaignParticipationResultData.isCompleted, knowledgeElements.length, targetProfile.skills.length),
     createdAt: moment.utc(campaignParticipationResultData.createdAt).format('YYYY-MM-DD'),
     isShared: campaignParticipationResultData.isShared ? 'Oui' : 'Non',
     ...(campaign.idPixLabel ? { participantExternalId: campaignParticipationResultData.participantExternalId } : {}),

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -6,6 +6,8 @@ const User = require('../../domain/models/User');
 const { NotFoundError } = require('../../domain/errors');
 const queryBuilder = require('../utils/query-builder');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const Bookshelf = require('../bookshelf');
+
 const fp = require('lodash/fp');
 const _ = require('lodash');
 
@@ -44,32 +46,25 @@ module.exports = {
       .then(_toDomain);
   },
 
-  findResultDataByCampaignId: async function(campaignId) {
-    const { models } = await BookshelfCampaignParticipation
-      .where({ campaignId })
-      .fetchAll({
-        withRelated: [{
-          user: (qb) => {
-            qb.columns('id', 'firstName', 'lastName');
-          },
-        }, 'assessments']
+  async findResultDataByCampaignId(campaignId) {
+    const results = await Bookshelf.knex.with('campaignParticipationWithUserAndRankedAssessment',
+      (qb) => {
+        qb.select([
+          'campaign-participations.*',
+          'assessments.state',
+          _assessmentRankByCreationDate(),
+          'users.firstName',
+          'users.lastName',
+        ])
+          .from('campaign-participations')
+          .leftJoin('users', 'campaign-participations.userId', 'users.id')
+          .leftJoin('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
+          .where({ campaignId: campaignId });
+      })
+      .from('campaignParticipationWithUserAndRankedAssessment')
+      .where({ rank: 1 });
 
-      });
-
-    return models.map((bookshelfCampaignParticipation) => {
-
-      return {
-        id: bookshelfCampaignParticipation.get('id'),
-        createdAt: new Date(bookshelfCampaignParticipation.get('createdAt')),
-        isShared: Boolean(bookshelfCampaignParticipation.get('isShared')),
-        sharedAt: bookshelfCampaignParticipation.get('sharedAt'),
-        participantExternalId: bookshelfCampaignParticipation.get('participantExternalId'),
-        userId: bookshelfCampaignParticipation.get('userId'),
-        isCompleted: _lastAssessmentCompleted(bookshelfCampaignParticipation),
-        participantFirstName: bookshelfCampaignParticipation.related('user').get('firstName'),
-        participantLastName: bookshelfCampaignParticipation.related('user').get('lastName'),
-      };
-    });
+    return results.map(_rowToResult);
   },
 
   findLatestOngoingByUserId(userId) {
@@ -207,11 +202,20 @@ function _getLastAssessmentIdForCampaignParticipation(bookshelfCampaignParticipa
   return null;
 }
 
-function _lastAssessmentCompleted(bookshelfCampaignParticipation) {
-  const lastAssessment = _.last(bookshelfCampaignParticipation.related('assessments').sortBy(['createdAt']));
-  let isCompleted = false;
-  if (lastAssessment) {
-    isCompleted = lastAssessment.get('state') == 'completed';
-  }
-  return isCompleted;
+function _assessmentRankByCreationDate() {
+  return Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', ['assessments.campaignParticipationId', 'assessments.createdAt']);
+}
+
+function _rowToResult(row) {
+  return {
+    id: row.id,
+    createdAt: new Date(row.createdAt),
+    isShared: Boolean(row.isShared),
+    sharedAt: row.sharedAt ? new Date(row.sharedAt) : null,
+    participantExternalId: row.participantExternalId,
+    userId: row.userId,
+    isCompleted: row.state === 'completed',
+    participantFirstName: row.firstName,
+    participantLastName: row.lastName,
+  };
 }

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -11,7 +11,8 @@ module.exports = {
         'isCompleted',
         'areBadgeCriteriaFulfilled',
         'badge',
-        'competenceResults'
+        'competenceResults',
+        'progress'
       ],
       badge: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -55,7 +55,8 @@ module.exports = {
             'totalSkillsCount',
             'testedSkillsCount',
             'validatedSkillsCount',
-            'competenceResults'
+            'competenceResults',
+            'progress'
           ],
           competenceResults: {
             ref: 'id',

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -159,6 +159,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       databaseBuilder.factory.buildAssessment({
         userId: user.id,
         type: 'SMART_PLACEMENT',
+        state: 'completed',
         createdAt: new Date(assessmentStartDate),
         campaignParticipationId: campaignParticipation.id
       });
@@ -205,7 +206,7 @@ describe('Acceptance | API | Campaign Controller', () => {
         '"Acquis maitrisés du domaine Information et données";' +
         '"\'@accesDonnées1"' +
         '\n' +
-        `"${organization.name}";${campaign.id};"'${campaign.name}";"'${targetProfile.name}";"'${user.lastName}";"'${user.firstName}";"'${externalId}";0;${participationStartDate};"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"\n`;
+        `"${organization.name}";${campaign.id};"'${campaign.name}";"'${targetProfile.name}";"'${user.lastName}";"'${user.firstName}";"'${externalId}";1;${participationStartDate};"Non";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA";"NA"\n`;
 
       // when
       const response = await server.inject(request);

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -371,6 +371,7 @@ describe('Acceptance | API | Campaign Participations', () => {
               'tested-skills-count': 7,
               'total-skills-count': 7,
               'validated-skills-count': 5,
+              'progress': 1,
             },
             relationships: {
               'competence-results': {

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -161,6 +161,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
           id: campaignParticipation.id.toString(),
           attributes: {
             'mastery-percentage': 38,
+            'progress': 1,
             'total-skills-count': 8,
             'tested-skills-count': 5,
             'validated-skills-count': 3,

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -207,10 +207,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(() => {
-      return knex('assessments').delete();
-    });
-
     it('should return all the campaign-participation links to the given campaign', async () => {
       // given
       const campaignId = campaign1.id;
@@ -239,14 +235,14 @@ describe('Integration | Repository | Campaign Participation', () => {
       beforeEach(async () => {
         databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation1.id,
-          createdAt: new Date('2020-01-01'),
-          state: 'started',
-        });
-        databaseBuilder.factory.buildAssessment({
-          campaignParticipationId: campaignParticipation1.id,
           createdAt: new Date('2020-01-02'),
           state: 'completed',
 
+        });
+        databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation1.id,
+          createdAt: new Date('2020-01-01'),
+          state: 'started',
         });
         await databaseBuilder.commit();
       });
@@ -312,6 +308,27 @@ describe('Integration | Repository | Campaign Participation', () => {
             participantLastName: 'Last',
           }
         ]);
+      });
+    });
+
+    context('When the share at is null', () => {
+      it('Should return null as shared date', async () => {
+        // given
+        const campaign = databaseBuilder.factory.buildCampaign({ sharedAt: null });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId,
+          isShared: false,
+          sharedAt: null
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const participationResultDatas = await campaignParticipationRepository.findResultDataByCampaignId(campaign.id);
+
+        // then
+        expect(participationResultDatas[0].sharedAt).to.equal(null);
       });
     });
   });

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -58,6 +58,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
         totalSkillsCount: 4,
         testedSkillsCount: 2,
         validatedSkillsCount: 1,
+        knowledgeElementsCount: 2,
         badge: {
           id: 1,
           imageUrl: '/img/banana.svg',
@@ -113,6 +114,19 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
 
       // then
       expect(campaignParticipationResult.masteryPercentage).to.be.equal(expectedMasteryPercentage);
+    });
+  });
+
+  describe('#progress', () => {
+    it('should return the percentage of progression for the campaign', function() {
+      // when
+      const campaignParticipationResult = new CampaignParticipationResult({
+        totalSkillsCount: 100,
+        knowledgeElementsCount: 75,
+      });
+
+      // then
+      expect(campaignParticipationResult.progress).to.equal(0.75);
     });
   });
 });

--- a/api/tests/unit/domain/services/campaign-participation-service_test.js
+++ b/api/tests/unit/domain/services/campaign-participation-service_test.js
@@ -1,0 +1,36 @@
+const { expect } = require('../../../test-helper');
+
+const campaignParticipationService = require('./../../../../lib/domain/services/campaign-participation-service');
+
+describe('Unit | Service | Campaign Participation Service',() => {
+  describe('progress', () => {
+
+    context('when campaign participation is completed ',() => {
+      it('should return 1',() => {
+        // when
+        const progress = campaignParticipationService.progress(true, 10, 20);
+
+        // then
+        expect(progress).to.equal(1);
+      });
+    });
+
+    context('when campaign participation is not completed', () => {
+      it('should return Percentage Progression', () => {
+        // when
+        const progress = campaignParticipationService.progress(false, 11, 33);
+
+        // then
+        expect(progress).to.equal(0.333);
+      });
+
+      it('should return round percentage progression', () => {
+        // when
+        const progress = campaignParticipationService.progress(false, 6, 9);
+
+        // then
+        expect(progress).to.equal(0.667);
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -40,6 +40,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
             'tested-skills-count': testedSkillsCount,
             'total-skills-count': totalSkillsCount,
             'validated-skills-count': validatedSkillsCount,
+            'progress': 1,
           },
           id: '1',
           relationships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -35,6 +35,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
         totalSkillsCount: 10,
         testedSkillsCount: 5,
         validatedSkillsCount: 4,
+        progress: 1,
         competenceResults
       };
       const meta = {};
@@ -130,6 +131,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
               'tested-skills-count': 5,
               'total-skills-count': 10,
               'validated-skills-count': 4,
+              'progress': 1
             },
             relationships: {
               'competence-results': {

--- a/orga/app/helpers/percentage.js
+++ b/orga/app/helpers/percentage.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import _ from 'lodash';
+
+export function percentage([ratio]) {
+  return _.round(ratio * 100, 1);
+}
+
+export default helper(percentage);

--- a/orga/app/models/campaign-participation-result.js
+++ b/orga/app/models/campaign-participation-result.js
@@ -8,17 +8,10 @@ export default DS.Model.extend({
   validatedSkillsCount: DS.attr('number'),
   isCompleted: DS.attr('boolean'),
   competenceResults: DS.hasMany('competenceResult'),
+  progress: DS.attr('number'),
 
   totalSkillsCounts: computed.mapBy('competenceResults', 'totalSkillsCount'),
   maxTotalSkillsCountInCompetences: computed.max('totalSkillsCounts'),
-
-  percentageProgression: computed('totalSkillsCount', 'testedSkillsCount', 'isCompleted', function() {
-    if (this.isCompleted) {
-      return 100;
-    }
-
-    return Math.round(this.testedSkillsCount * 100 / this.totalSkillsCount);
-  }),
 
   masteryPercentage: computed('totalSkillsCount', 'validatedSkillsCount', function() {
     return Math.round(this.validatedSkillsCount * 100 / this.totalSkillsCount);

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
@@ -22,7 +22,7 @@
       <div class="participant-results-content participant-results-content--large">
         <div class="label-text participant-results-content__label-text">Avancement</div>
         <div aria-label="Avancement" class="content-text">
-          {{@campaignParticipation.campaignParticipationResult.percentageProgression}}%
+          {{percentage @campaignParticipation.campaignParticipationResult.progress}}%
           <div class="participant-results-content__progress-bar progress-bar">
             {{#if @campaignParticipation.campaignParticipationResult.isCompleted}}
               <div class="participant-results-content__progress-bar progress-bar progress-bar--completed"></div>

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
@@ -114,6 +114,7 @@ module('Integration | Component | routes/authenticated/campaign/details/particip
       testedSkillsCount: 29,
       validatedSkillsCount: 15,
       isCompleted: true,
+      progress: 1
     }));
 
     const campaignParticipation  = run(() => store.createRecord('campaign-participation', {

--- a/orga/tests/unit/helpers/percentage-test.js
+++ b/orga/tests/unit/helpers/percentage-test.js
@@ -1,0 +1,17 @@
+import { percentage } from 'pix-orga/helpers/percentage';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | percentage', function(hooks) {
+  setupTest(hooks);
+
+  module('percentage', () => {
+    test('it multiply by 100 the given value', function(assert) {
+      assert.equal(percentage([1]), 100);
+    });
+
+    test('it rounds the given value with one digit', function(assert) {
+      assert.equal(percentage([0.088]), 8.8);
+    });
+  });
+});

--- a/orga/tests/unit/models/campaign-participation-result-test.js
+++ b/orga/tests/unit/models/campaign-participation-result-test.js
@@ -5,24 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Model | campaign-participation-result', function(hooks) {
   setupTest(hooks);
 
-  test('should have a 100% progression when completed', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign-participation-result', {
-      isCompleted: true,
-    }));
-    assert.equal(model.percentageProgression, 100);
-  });
-
-  test('should have a rounded progression', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign-participation-result', {
-      isCompleted: false,
-      totalSkillsCount: 11,
-      testedSkillsCount: 3
-    }));
-    assert.equal(model.percentageProgression, 27);
-  });
-
   module('maxTotalSkillsCountInCompetences', function() {
 
     test('should calculate max total skills', function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Le pourcentage de progression dans le CSV téléchargeable n'est pas le même que le pourcentage affiché dans la vue des résultats d'un candidat.

Pour reproduire :
Quand un candidat a terminé le parcours en répondant faux à certaines questions mais qu'il ne partage pas ses résultats.
Dans le CSV la progression du candidat n'est pas 1 comme dans la vue des résultats.

## :robot: Solution
Passer le % à 100 si l'assessment est terminé.
Avoir ce calcul à un seul endroit dans l'application