### PR TITLE
[FEATURE] Changer la façon de contacter le support de la page d'erreur (PF-1166).

### DIFF
--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -8,7 +8,7 @@
         <div class="error-page__main-content">
           <h1 class="error-page-main-content__title">Oups, une erreur est survenue !</h1>
           <p>Nous vous invitons à recharger cette page ou <LinkTo @route="login">revenir à la page d’accueil</LinkTo>.</p>
-          <p>Vous pouvez aussi nous contacter par courriel à l’adresse <a href="mailto:support@pix.fr">support@pix.fr</a> en nous copiant le code d'erreur ci-dessous.</p>
+          <p>Vous pouvez aussi nous contacter via <a href="https://support.pix.fr/support/tickets/new">le formulaire du centre d'aide</a> en nous précisant le code d'erreur ci-dessous dans la description.</p>
           <p>Nous vous prions de nous excuser pour la gêne occasionnée.</p>
           <p>L'équipe Pix.</p>
           <LinkTo @route="login" class="button button--extra-big button--link error-page__index-link">


### PR DESCRIPTION
## :unicorn: Problème
Sur la page erreur, on proposait à l'utilisateur d'envoyer un mail, alors qu'un formulaire de contact a été créé à cet effet.

## :robot: Solution
Changer le lien de contact.