### PR TITLE
[DESIGN-SYSTEM] Uniformisation des couleurs (CERTIF) (PF-1163)

### DIFF
--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -36,7 +36,7 @@ body, html{
   margin: 0;
   height: 100%;
   font-family: $roboto;
-  background-color: $porcelain;
+  background-color: $grey-10;
 }
 
 body > .ember-view {

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -36,6 +36,7 @@ body, html{
   margin: 0;
   height: 100%;
   font-family: $roboto;
+  color: $black;
   background-color: $grey-10;
 }
 

--- a/certif/app/styles/components/ember-cli-notifications-ie-fallback.scss
+++ b/certif/app/styles/components/ember-cli-notifications-ie-fallback.scss
@@ -9,13 +9,13 @@
     max-width: 400px;
   }
   *::-ms-backdrop, .ember-cli-notifications-notification__container > div {
-    background-color: #64ce83;
+    background-color: $success;
     border-radius: 3px;
     max-height: 800px;
     margin-bottom: 1rem;
   }
   *::-ms-backdrop, .ember-cli-notifications-notification__container .c-notification--error {
-    background-color: #e74c3c;
+    background-color: $error;
   }
   *::-ms-backdrop, .c-notification__icon {
     padding: 0.5rem 0;

--- a/certif/app/styles/components/finalize.scss
+++ b/certif/app/styles/components/finalize.scss
@@ -19,25 +19,25 @@
 .app-modal-body{
 
   &__attention {
-    color: $black;
+    color: $grey-100;
     font-weight: 500;
     font-size: 1.2rem;
   }
 
   &__warning{
-    color: $gun-powder;
+    color: $grey-90;
     font-weight: 300;
     font-size: 1em;
   }
 
   &__contextual{
-    border: 2px solid $alto;
-    background-color: $alto;
+    border: 2px solid $grey-20;
+    background-color: $grey-20;
     border-radius: 4px;
     padding: 10px 0;
     font-size: 1rem;
     font-weight: bold;
-    color: $nero;
+    color: $grey-80;
     outline: 0;
   }
 }

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -42,10 +42,10 @@
     border-radius: 3px;
     align-items: center;
     background-color: white;
-    border: 2px solid $alto;
+    border: 2px solid $grey-20;
 
     &:focus-within {
-      border: 2px solid $dodger-blue;
+      border: 2px solid $communication-dark;
     }
 
     input {
@@ -79,13 +79,13 @@
 
   &-icon {
     &__eye {
-      color: $dove-gray;
+      color: $grey-45;
       transition: .5s;
       font-size: 1.1rem;
       margin-top: 2px;
 
       &:hover {
-        color: $nero;
+        color: $grey-80;
         cursor: pointer;
       }
     }

--- a/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
@@ -3,7 +3,7 @@
   padding: 22px 32px;
 
   &__header-container{
-    color: $grey;
+    color: $grey-40;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -26,16 +26,16 @@
     width: 100%;
     height: 116px;
     resize: none;
-    border-color: $alto;
+    border-color: $grey-20;
     border-style: solid;
     border-radius: 4px;
     padding: 8px;
     font-family: $roboto;
-    color: $grey;
+    color: $grey-40;
     font-size: 1rem;
 
     &:focus {
-      outline: 2px solid $mariner;
+      outline: 2px solid $communication-light;
       -moz-outline-radius: 4px;
       border: none;
     }

--- a/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
+++ b/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
@@ -1,7 +1,7 @@
 .session-finalization-formbuilder-link-step {
   padding: 26px 32px;
   font-family: $roboto;
-  color: $grey;
+  color: $grey-40;
 
   &__text {
     display: inline-block;

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -13,13 +13,13 @@
   &__textarea {
     font-family: $roboto;
     font-size: 0.8125rem;
-    color: $nero;
+    color: $grey-80;
     width: 100%;
     height: 50px;
     padding: 4px;
     max-height: 52px;
     resize: none;
-    border: 1px solid $alto;
+    border: 1px solid $grey-20;
     border-radius: 4px;
   }
 
@@ -36,11 +36,11 @@
     width: 10px;
     height: 4px;
     border-radius: 1px;
-    background-color: $nobel;
+    background-color: $grey-22;
   }
 
   .checkbox:hover &__dash-icon{
-    background-color: $grey;
+    background-color: $grey-40;
   }
 
 }

--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -5,9 +5,9 @@
 
   &__title {
     display: flex;
-    background: $wild-sand;
+    background: $grey-10;
     margin: 8px;
-    color: $comet;
+    color: $grey-50;
     font-weight: bold;
     padding: 20px 0 19px 24px;
   }
@@ -17,6 +17,6 @@
   }
 
   &__border {
-    border-top: 1px solid $alto;
+    border-top: 1px solid $grey-20;
   }
 }

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -47,7 +47,7 @@ $pix-modal-border-radius: 5px;
 
     .pix-modal__container {
       border-radius: $pix-modal-border-radius;
-      background-color: $porcelain;
+      background-color: $grey-10;
       box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.2);
       font-size: 1.6em;
       position: relative;
@@ -81,7 +81,7 @@ $pix-modal-border-radius: 5px;
         &__subtitle {
           margin: 0;
           text-align: center;
-          color: $nero;
+          color: $grey-80;
           font-family: $roboto;
           font-weight: 400;
           font-size: 1em;
@@ -116,7 +116,7 @@ $pix-modal-border-radius: 5px;
         }
 
         &--border {
-          border-top: 1px solid $alto;
+          border-top: 1px solid $grey-20;
         }
       }
     }
@@ -130,7 +130,7 @@ $pix-modal-border-radius: 5px;
   padding: 15px;
   border-radius: $pix-modal-border-radius;
   background-color: $white;
-  border: 2px solid $alto;
+  border: 2px solid $grey-20;
   color: $grey-45;
   letter-spacing: 0.2em;
   box-sizing: border-box;
@@ -139,7 +139,7 @@ $pix-modal-border-radius: 5px;
   text-align: center;
 
   &:focus {
-    border-color: $dodger-blue;
+    border-color: $communication-dark;
   }
 
   @include device-is('tablet') {

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -131,7 +131,7 @@ $pix-modal-border-radius: 5px;
   border-radius: $pix-modal-border-radius;
   background-color: $white;
   border: 2px solid $alto;
-  color: #6a6d76;
+  color: $grey-45;
   letter-spacing: 0.2em;
   box-sizing: border-box;
   margin-bottom: 5px;
@@ -158,5 +158,5 @@ $pix-modal-border-radius: 5px;
 }
 
 .ember-modal-overlay.translucent {
-  background-color: rgba(red(#3e4149), green(#3e4149), blue(#3e4149), 0.95);
+  background-color: rgba($grey-70, 0.95);
 }

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -1,36 +1,7 @@
-// Colors
-$astronaut: #213371;
-$mariner: #355BD1;
-$denim: #0D7DC4;
-$dodger-blue: #3D68FF;
-$aqua: #388AFF;
-$heliotrope: #985FFF;
-$porcelain: #f2f3f4;
-$wild-sand: #f5f5f5;
-$orange: #FFBE00;
-$white: #FFFFFF;
-$sublte: #F9F9F9;
-$alto: #DDDDDD;
-$ernest: #EEEEEE;
-$nobel: #b7b7b7;
-$idol:#c6c6c6;
-$dusty-gray: #999999;
-$dove-gray: #666666;
-$grey: #767676;
-$comet: #585F75;
-$tundora: #444444;
-$gun-powder: #414657;
-$mine-shaft: #333333;
-$nero: #222222;
-$black: #000000;
-
-// Gradients
-$grey-gradient: linear-gradient(0deg, $comet 0%, $gun-powder 100%);
-
 // See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
 
 // primary
-$pix-blue: #3D68FF;
+$communication-dark: #3D68FF;
 $pix-yellow: #FFBE00;
 $blue-zodia: #505F79;
 $white: #ffffff;
@@ -39,8 +10,8 @@ $orga: #00DDFF;
 $pix-purple: #8A49FF;
 // gradients app
 $pix-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
-$pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
-$pix-certif-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
+$communication-dark-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
+$pix-certif-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
 $pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
 $pix-pinkie-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
 $pix-purplie: #6B20DC;

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -1,20 +1,22 @@
 // See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
 
 // primary
-$communication-dark: #3D68FF;
-$pix-yellow: #FFBE00;
 $blue-zodia: #505F79;
+$yellow: #FFBE00;
 $white: #ffffff;
+$black: #07142E;
 // secondary
-$orga: #00DDFF;
-$pix-purple: #8A49FF;
-// gradients app
-$pix-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
-$communication-dark-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
-$pix-certif-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
-$pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
-$pix-pinkie-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
+$pix-orga: #00DDFF;
 $pix-purplie: #6B20DC;
+$pix-purple: #8A49FF;
+// gradients
+$pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
+$pix-eggplant-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
+$pix-green-gradient: linear-gradient(-45deg, #52D987 0%, #1A8C89 100%);
+$pix-orange-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
+$pix-pink-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
+$pix-purple-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
+$pix-teal-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
 $pix-yellow-gradient: linear-gradient(180deg, #FFBE00 0%, #FF9F00 100%);
 // light
 $grey-5: #FAFBFC;
@@ -35,22 +37,17 @@ $grey-80: #253858;
 $grey-90: #172B4D;
 $grey-100: #091E42;
 // gradients domain
-$information-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
-$content-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
-$communication-gradient: linear-gradient(0deg, #12A3FF 0%, #3D68FF 100%);
-$security-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
-$environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
 // solids
-$information-dark: #F24645;
-$information-light: #F1A141;
-$content-dark: #1A8C89;
-$content-light: #52D987;
-$communication-dark: #3D68FF;
-$communication-light: #12A3FF;
-$security-dark: #AC008D;
-$security-light: #FF3F94;
 $environment-dark: #5E2563;
 $environment-light: #564DA6;
+$communication-dark: #3D68FF;
+$communication-light: #12A3FF;
+$content-dark: #1A8C89;
+$content-light: #52D987;
+$information-dark: #F24645;
+$information-light: #F1A141;
+$security-dark: #AC008D;
+$security-light: #FF3F94;
 // status
 $error: #FF4B00;
 $success: #57C884;

--- a/certif/app/styles/globals/colors.scss
+++ b/certif/app/styles/globals/colors.scss
@@ -26,3 +26,61 @@ $black: #000000;
 
 // Gradients
 $grey-gradient: linear-gradient(0deg, $comet 0%, $gun-powder 100%);
+
+// See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
+
+// primary
+$pix-blue: #3D68FF;
+$pix-yellow: #FFBE00;
+$blue-zodia: #505F79;
+$white: #ffffff;
+// secondary
+$orga: #00DDFF;
+$pix-purple: #8A49FF;
+// gradients app
+$pix-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
+$pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
+$pix-certif-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
+$pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
+$pix-pinkie-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
+$pix-purplie: #6B20DC;
+$pix-yellow-gradient: linear-gradient(180deg, #FFBE00 0%, #FF9F00 100%);
+// light
+$grey-5: #FAFBFC;
+$grey-10: #F4F5F7;
+$grey-15: #EAECF0;
+$grey-20: #DFE1E6;
+$grey-22: #C1C7D0;
+$grey-25: #A5ADBA;
+// medium
+$grey-30: #97A0AF;
+$grey-35: #8993A4;
+$grey-40: #7A869A;
+$grey-45: #6B778C;
+$grey-50: #5E6C84;
+// dark
+$grey-70: #344563;
+$grey-80: #253858;
+$grey-90: #172B4D;
+$grey-100: #091E42;
+// gradients domain
+$information-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
+$content-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
+$communication-gradient: linear-gradient(0deg, #12A3FF 0%, #3D68FF 100%);
+$security-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
+$environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
+// solids
+$information-dark: #F24645;
+$information-light: #F1A141;
+$content-dark: #1A8C89;
+$content-light: #52D987;
+$communication-dark: #3D68FF;
+$communication-light: #12A3FF;
+$security-dark: #AC008D;
+$security-light: #FF3F94;
+$environment-dark: #5E2563;
+$environment-light: #564DA6;
+// status
+$error: #FF4B00;
+$success: #57C884;
+$warning: #FFBE00;

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -1,6 +1,6 @@
 .label {
   display: inline-block;
-  color: $tundora;
+  color: $grey-70;
   font-size: 0.94rem;
   font-weight: 500;
   padding-bottom: 5px;
@@ -8,16 +8,16 @@
 }
 
 .input {
-  border: 2px solid $alto;
+  border: 2px solid $grey-20;
   border-radius: 4px;
   height: 40px;
   font-size: 1rem;
   padding-left: 15px;
-  color: $nero;
+  color: $grey-80;
   outline: none;
 
   &:focus {
-    border: 2px solid $dodger-blue;
+    border: 2px solid $communication-dark;
   }
 
   &--small {
@@ -38,16 +38,16 @@ input[type=number] {
 }
 
 .textarea {
-  border: 2px solid $alto;
+  border: 2px solid $grey-20;
   border-radius: 4px;
   font-size: 1rem;
   padding: 8px;
-  color: $nero;
+  color: $grey-80;
   outline: none;
   resize: none;
 
   &:focus {
-    border: 2px solid $dodger-blue;
+    border: 2px solid $communication-dark;
   }
 }
 
@@ -59,13 +59,13 @@ input[type=number] {
 
 .select {
   font-size: 1rem;
-  border: 2px $alto solid;
+  border: 2px $grey-20 solid;
   height: 46px;
   background-color: white;
   outline: none;
 
   &:focus {
-    border: 2px solid $dodger-blue;
+    border: 2px solid $communication-dark;
   }
 }
 
@@ -76,14 +76,14 @@ input[type=number] {
   letter-spacing: 0.019rem;
   text-align: center;
   border-radius: 5px;
-  background-color: $dodger-blue;
+  background-color: $communication-dark;
   color: white;
   cursor: pointer;
   border: none;
   outline: none;
 
   &:hover, &:active, &:focus {
-    background-color: $mariner;
+    background-color: darken($communication-dark, 10%);
     transition: background-color 0.2s ease;
   }
 
@@ -106,35 +106,35 @@ input[type=number] {
     color: black;
 
     &:hover, &:active, &:focus {
-      background-color: $alto;
+      background-color: $grey-20;
     }
   }
 
   &--grey {
-    background-color: $comet;
+    background-color: $grey-50;
     color: $white;
 
     &:hover, &:active, &:focus {
-      background-color: $gun-powder;
+      background-color: $grey-90;
     }
   }
 
   &--lightgrey {
-    background-color: $ernest;
-    color: $tundora;
+    background-color: $grey-15;
+    color: $grey-70;
 
     &:hover, &:active, &:focus {
-      background-color: $alto;
+      background-color: $grey-20;
     }
 
   }
 
   &--no-color {
     background-color: transparent;
-    color: $nero;
+    color: $grey-80;
 
     &:hover, &:active, &:focus {
-      background-color: $alto;
+      background-color: $grey-20;
     }
   }
 
@@ -170,7 +170,7 @@ input[type=number] {
 }
 
 .icon-button {
-  color: $dove-gray;
+  color: $grey-45;
   padding: 6px 8px;
   border: none;
   font-size: 1rem;
@@ -179,7 +179,7 @@ input[type=number] {
   outline: none;
 
   &:hover, &:active {
-    background-color: $alto;
+    background-color: $grey-20;
     border-radius: 16px;
     transition: background-color 0.2s ease;
   }
@@ -198,13 +198,13 @@ input[type=number] {
   margin: 10px 20px 11px 0px;
   border-radius: 50%;
   vertical-align: middle;
-  box-shadow: 0 0 0 2px $alto;
-  border: 4px solid $wild-sand;
+  box-shadow: 0 0 0 2px $grey-20;
+  border: 4px solid $grey-10;
 }
 
 .radio-button:checked + .radio-button-span {
-  box-shadow: 0 0 0 2px $dodger-blue;
-  background-color: $dodger-blue;
+  box-shadow: 0 0 0 2px $communication-dark;
+  background-color: $communication-dark;
 }
 
 .checkbox {
@@ -219,17 +219,17 @@ input[type=number] {
   transition: box-shadow .1s linear;
 
   &--unchecked {
-    border: 2px solid $alto;
+    border: 2px solid $grey-20;
 
     &:hover {
-      background-color: $porcelain;
-      box-shadow: 0 0px 0px 8px rgba($grey, 0.1);
-      border-color: $grey;
+      background-color: $grey-10;
+      box-shadow: 0 0px 0px 8px rgba($grey-40, 0.1);
+      border-color: $grey-40;
     }
   }
 
   &--checked {
-    background-color: $aqua;
-    border: 2px solid $aqua;
+    background-color: $communication-light;
+    border: 2px solid $communication-light;
   }
 }

--- a/certif/app/styles/globals/panels.scss
+++ b/certif/app/styles/globals/panels.scss
@@ -19,7 +19,7 @@
     border-bottom: 2px solid transparent;
     outline: none;
     cursor: pointer;
-    color: $dusty-gray;
+    color: $grey-35;
     font-family: $roboto;
     font-size: 0.9rem;
     font-weight: 500;
@@ -27,13 +27,13 @@
     text-decoration: none;
 
     &:hover {
-      color: $aqua;
+      color: $communication-dark;
     }
   }
 
   &-item.active {
-    border-bottom: 2px solid $aqua;
-    color: $aqua;
+    border-bottom: 2px solid $communication-dark;
+    color: $communication-dark;
   }
 }
 
@@ -66,7 +66,7 @@
 .tooltip-text {
   visibility: hidden;
   width: 140px;
-  background-color: $nero;
+  background-color: $grey-80;
   color: white;
   text-align: center;
   border-radius: 6px;
@@ -80,6 +80,6 @@
     content: "";
     border-width: 5px;
     border-style: solid;
-    border-color: $nero transparent transparent transparent;
+    border-color: $grey-80 transparent transparent transparent;
   }
 }

--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -15,27 +15,27 @@
   }
 
   thead {
-    color: $mine-shaft;
+    color: $grey-70;
   }
 
   tbody {
-    color: $dove-gray;
+    color: $grey-45;
 
     tr {
       &:hover, &:focus, &:active {
-        color: $nero;
-        background-color: $wild-sand;
+        color: $grey-80;
+        background-color: $grey-10;
         transition: 0.25s ease;
       }
       &:hover .checkbox--unchecked {
-        border-color: $grey;
+        border-color: $grey-40;
       }
     }
   }
 
   tr {
     height: 60px;
-    border-top: 2px solid $wild-sand;
+    border-top: 2px solid $grey-10;
   }
 
   td, th {

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -1,36 +1,36 @@
 .paragraph {
-  color: $dove-gray;
+  color: $grey-45;
   font-family: $open-sans;
   font-size: 0.875rem;
   line-height: 20px;
 }
 
 .one-line-text {
-  color: $dove-gray;
+  color: $grey-45;
   font-family: $roboto;
   font-size: 0.75rem;
 }
 
 .information-text {
-  color: $dove-gray;
+  color: $grey-45;
   font-family: $open-sans;
   font-size: 1.2rem;
 }
 
 .label-text {
-  color: $dusty-gray;
+  color: $grey-35;
   font-family: $roboto;
   font-size: 0.8125rem;
   font-weight: 400;
 }
 
 .content-text {
-  color: $dove-gray;
+  color: $grey-45;
   font-family: $roboto;
   font-size: 1rem;
 
   &--bold {
-    color: $nero;
+    color: $grey-80;
     font-weight: 700;
   }
 

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -2,12 +2,12 @@
   font-family: $roboto;
   font-weight: 300;
   font-size: 2.25rem;
-  color: $nero;
+  color: $grey-80;
 }
 
 .form-title {
   font-family: $open-sans;
   font-weight: 300;
   font-size: 1.9rem;
-  color: $nero;
+  color: $grey-80;
 }

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -50,13 +50,13 @@
 }
 
 .certification-center-label {
-  color: $dove-gray;
+  color: $grey-45;
   font-size: 0.8125rem;
   text-transform: uppercase;
 }
 
 .certification-center-name {
-  color: $dove-gray;
+  color: $grey-45;
   font-size: 0.8125rem;
 }
 
@@ -64,7 +64,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background-color: $wild-sand;
   overflow: auto;
 
   &__topbar {

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -29,7 +29,7 @@
   &__date {
     padding-right: 40px;
     margin-right: 40px;
-    border-right: 1px solid $alto;
+    border-right: 1px solid $grey-20;
   }
 }
 
@@ -43,7 +43,7 @@
   flex-direction: row;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $alto;
+    border-bottom: 1px solid $grey-20;
   }
 }
 
@@ -54,7 +54,7 @@
 
   &--push-right {
     margin-left: auto;
-    border-left: 1px solid $alto;
+    border-left: 1px solid $grey-20;
   }
 
   &--multiple {
@@ -87,7 +87,7 @@
   }
 
   &:not(:last-child) {
-    border-right: 1px solid $alto;
+    border-right: 1px solid $grey-20;
   }
 
   &__label {

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -41,14 +41,14 @@
   box-sizing: border-box;
   flex-flow: row nowrap;
   margin-bottom: 1.3rem;
-  border: 0.062rem solid #d6d6d6;
+  border: 0.062rem solid $grey-22;
   border-radius: 1.25rem;
   background: $wild-sand;
   position: relative;
 }
 
 .panel-actions__action-icon {
-  color: #ccc;
+  color: $grey-22;
   font-size: 1.87rem;
   width: 3.125rem;
   text-align: center;

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -87,7 +87,7 @@
 }
 
 .panel-actions__warning-icon {
-  color: $pix-yellow;
+  color: $yellow;
   margin-right: 8px;
   font-size: 1.5rem;
 }

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -43,7 +43,7 @@
   margin-bottom: 1.3rem;
   border: 0.062rem solid $grey-22;
   border-radius: 1.25rem;
-  background: $wild-sand;
+  background: $grey-10;
   position: relative;
 }
 
@@ -63,14 +63,14 @@
   flex-flow: column nowrap;
   margin-left: 1.25rem;
   width: 65%;
-  color: $dove-gray;
+  color: $grey-45;
   font-size: 0.8rem;
 }
 
 .panel-actions__title {
   margin-bottom: 0.625rem;
   font-weight: bold;
-  color: $tundora;
+  color: $grey-70;
 }
 
 .panel-actions__button {
@@ -87,7 +87,7 @@
 }
 
 .panel-actions__warning-icon {
-  color: $orange;
+  color: $pix-yellow;
   margin-right: 8px;
   font-size: 1.5rem;
 }
@@ -95,7 +95,7 @@
 .panel-header {
   display: flex;
   align-items: center;
-  color: $grey;
+  color: $grey-40;
   padding: 16px 0;
   margin: 0 16px;
 
@@ -117,7 +117,7 @@
     margin-left: 16px;
     font-size: 0.82rem;
     font-weight: normal;
-    color: $dove-gray;
+    color: $grey-45;
   }
 }
 
@@ -130,7 +130,7 @@
 
   &__icon {
     font-size: 1.25rem;
-    color: $dusty-gray;
+    color: $grey-35;
   }
 }
 
@@ -140,9 +140,9 @@
 }
 
 .certification-candidates-input {
-  background: $sublte;
+  background: $grey-5;
   border-radius: 4px;
-  border: 1px solid $alto;
+  border: 1px solid $grey-20;
   height: 35px;
   min-width: 24px;
   flex-grow: 1;
@@ -199,16 +199,16 @@
 
     &__button {
       font-size: 1rem;
-      color: $dusty-gray;
+      color: $grey-35;
 
       &--disabled {
         font-size: 1rem;
-        background-color: $idol;
+        background-color: $grey-22;
         color: $white;
         cursor: not-allowed;
 
         &:hover, &:active, &:focus {
-          background-color: $dusty-gray;
+          background-color: $grey-35;
         }
       }
     }

--- a/certif/app/styles/pages/authenticated/terms-of-service.scss
+++ b/certif/app/styles/pages/authenticated/terms-of-service.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: $pix-certif-gradient;
+  background: $pix-green-gradient;
   align-items: center;
 }
 

--- a/certif/app/styles/pages/authenticated/terms-of-service.scss
+++ b/certif/app/styles/pages/authenticated/terms-of-service.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: $grey-gradient;
+  background: $pix-certif-gradient;
   align-items: center;
 }
 
@@ -29,7 +29,7 @@
   &__title {
     margin-bottom: 30px;
     text-align: center;
-    color: $nero;
+    color: $grey-80;
     font-family: $roboto;
     font-size: 18px;
     font-weight: 300;
@@ -40,7 +40,7 @@
     height: 1px;
     margin-bottom: 30px;
     border: none;
-    background-color: $alto;
+    background-color: $grey-20;
   }
 
   &__text {

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width:100%;
   height:100%;
-  background: $grey-gradient;
+  background: $pix-certif-gradient;
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.1);
   align-items: center;
   padding-top: 50px;

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width:100%;
   height:100%;
-  background: $pix-certif-gradient;
+  background: $pix-green-gradient;
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.1);
   align-items: center;
   padding-top: 50px;


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du design system qui se met en place afin de faciliter les échanges entre designers et developpeurs, une uniformisation des couleurs entre toutes les app est souhaitable.
Côté développeur, on recopie systématiquement certains éléments qui sont pourtant communs entre toutes les app, c'est le cas des couleurs. Cette ré-implémentation cause une perte de temps et même parfois des erreurs inattendues. 

## :robot: Solution
Changer / adapter toutes les couleurs de pix certif à celles définitives et présentes sur ZeroHeight : https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a . 

## :rainbow: Remarques
Ce travail sera fait prochainement sur pix orga ainsi que sur mon-pix. 
L'étape suivante serait de regrouper la palette de couleurs dans le dossier de design system "pix-ui" qui devrait arriver très prochainement.
