### PR TITLE
[TECH] Exclure la branche master des tests sur la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+                - master
                 - prod
                 - /release-.*/
 


### PR DESCRIPTION
## :unicorn: Problème
On n'a pas besoin de faire tourner les tests sur **dev** et **master** dans le cadre des MEP et cela réduit le temps d'exécution des tests. 