### PR TITLE
[CLEANUP] Convertir les composants de Pix App en syntaxe native (PF-1165).

### DIFF
--- a/mon-pix/app/components/beta-logo.js
+++ b/mon-pix/app/components/beta-logo.js
@@ -1,7 +1,3 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-
-  tagName: 'div',
-  classNames: ['beta-logo']
-});
+export default class BetaLogo extends Component {}

--- a/mon-pix/app/components/certification-banner.js
+++ b/mon-pix/app/components/certification-banner.js
@@ -1,6 +1,6 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-export default Component.extend({
-  currentUser: service(),
-});
+export default class CertificationBanner extends Component {
+  @service currentUser;
+}

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import classic from 'ember-classic-decorator';
 
 function _pad(num, size) {
   let s = num + '';
@@ -8,98 +10,98 @@ function _pad(num, size) {
   return s;
 }
 
-export default Component.extend({
-  store: service(),
-  peeker: service(),
-  currentUser: service(),
+@classic
+export default class CertificationJoiner extends Component {
+  @service store;
+  @service peeker;
+  @service currentUser;
 
-  isLoading: false,
-  errorMessage: null,
-  showCongratulationsBanner: true,
-  sessionId: null,
-  firstName: null,
-  lastName: null,
-  dayOfBirth: null,
-  monthOfBirth: null,
-  yearOfBirth: null,
+  @tracked isLoading = false;
+  @tracked errorMessage = null;
+  @tracked showCongratulationsBanner = true;
+  @tracked sessionId = null;
+  @tracked firstName = null;
+  @tracked lastName = null;
+  @tracked dayOfBirth = null;
+  @tracked monthOfBirth = null;
+  @tracked yearOfBirth = null;
 
-  birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+  get birthdate() {
     const monthOfBirth = _pad(this.monthOfBirth, 2);
     const dayOfBirth = _pad(this.dayOfBirth, 2);
     return [this.yearOfBirth, monthOfBirth, dayOfBirth].join('-');
-  }),
+  }
 
-  success() {},
+  success() {}
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
     if (this.getCurrentCandidate()) {
       this.success();
     }
-  },
+  }
 
   joinCertificationSession() {
     const { firstName, lastName, birthdate, sessionId } = this;
 
-    return this.store
-      .createRecord('certification-candidate', {
-        sessionId,
-        birthdate,
-        firstName: firstName
-          ? firstName.trim()
-          : null,
-        lastName:
-        lastName
-          ? lastName.trim()
-          : null,
-      })
-      .save({ adapterOptions: { joinSession: true, sessionId } });
-  },
+    return this.store.createRecord('certification-candidate', {
+      sessionId,
+      birthdate,
+      firstName: firstName
+        ? firstName.trim()
+        : null,
+      lastName: lastName
+        ? lastName.trim()
+        : null,
+    }).save({ adapterOptions: { joinSession: true, sessionId } });
+  }
 
   getCurrentCandidate() {
     return this.peeker.findOne('certification-candidate');
-  },
+  }
 
-  actions: {
-    closeBanner() {
-      this.set('showCongratulationsBanner', false);
-    },
+  @action
+  closeBanner() {
+    this.showCongratulationsBanner = false;
+  }
 
-    async attemptNext() {
-      this.set('stepsData.joiner', { sessionId: this.sessionId });
-      this.set('isLoading', true);
-      try {
-        await this.joinCertificationSession();
-        this.success();
-      } catch (err) {
-        const currentCandidate = this.getCurrentCandidate();
-        if (currentCandidate) {
-          currentCandidate.deleteRecord();
-        }
-        this.set('isLoading', false);
-        this.set('errorMessage',
-          'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.');
+  @action
+  async attemptNext() {
+    this.stepsData.joiner = { sessionId: this.sessionId };
+    this.isLoading = true;
+    try {
+      await this.joinCertificationSession();
+      this.success();
+    } catch (err) {
+      const currentCandidate = this.getCurrentCandidate();
+      if (currentCandidate) {
+        currentCandidate.deleteRecord();
       }
-    },
-
-    handleDayInputChange(event) {
-      const { value } = event.target;
-
-      if (value.length === 2) {
-        document.getElementById('certificationJoinerMonthOfBirth').focus();
-      }
-    },
-
-    handleMonthInputChange(event) {
-      const { value } = event.target;
-
-      if (value.length === 2) {
-        document.getElementById('certificationJoinerYearOfBirth').focus();
-      }
-    },
-
-    handleInputFocus(value, event) {
-      event.target.select();
+      this.isLoading = false;
+      this.errorMessage = 'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.';
     }
-  },
-});
+  }
+
+  @action
+  handleDayInputChange(event) {
+    const { value } = event.target;
+
+    if (value.length === 2) {
+      document.getElementById('certificationJoinerMonthOfBirth').focus();
+    }
+  }
+
+  @action
+  handleMonthInputChange(event) {
+    const { value } = event.target;
+
+    if (value.length === 2) {
+      document.getElementById('certificationJoinerYearOfBirth').focus();
+    }
+  }
+
+  @action
+  handleInputFocus(value, event) {
+    event.target.select();
+  }
+}

--- a/mon-pix/app/components/certification-not-certifiable.js
+++ b/mon-pix/app/components/certification-not-certifiable.js
@@ -1,4 +1,3 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-});
+export default class CertificationNotCertifiable extends Component {}

--- a/mon-pix/app/components/certification-results-page.js
+++ b/mon-pix/app/components/certification-results-page.js
@@ -1,16 +1,15 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-export default Component.extend({
-  classNames: ['certification-results-page'],
+export default class CertificationResultsPage extends Component {
+  @tracked validSupervisor = false;
+  @tracked notFinishedYet = true;
 
-  validSupervisor: false,
-  notFinishedYet: true,
-
-  actions: {
-    validateBySupervisor: function() {
-      if (this.validSupervisor) {
-        this.set('notFinishedYet', false);
-      }
+  @action
+  validateBySupervisor() {
+    if (this.validSupervisor) {
+      this.notFinishedYet = false;
     }
   }
-});
+}

--- a/mon-pix/app/components/certification-stepper-join.js
+++ b/mon-pix/app/components/certification-stepper-join.js
@@ -1,5 +1,3 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-  tagName: '',
-});
+export default class CertificationStepperJoin extends Component {}

--- a/mon-pix/app/components/certification-stepper-start.js
+++ b/mon-pix/app/components/certification-stepper-start.js
@@ -1,4 +1,3 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-});
+export default class CertificationStepperStart extends Component {}

--- a/mon-pix/app/components/certifications-list-item.js
+++ b/mon-pix/app/components/certifications-list-item.js
@@ -1,24 +1,37 @@
-import { computed } from '@ember/object';
 import Component from '@ember/component';
+import { classNames, classNameBindings } from '@ember-decorators/component';
+import { computed } from '@ember/object';
+import classic from 'ember-classic-decorator';
 
 const { and, or, not, equal } = computed;
 
-export default Component.extend({
-  certification: null,
-  classNames: ['certifications-list-item'],
-  classNameBindings: [
-    'certification.isPublished:certifications-list-item__published-item:certifications-list-item__unpublished-item',
-    'isClickable:certifications-list-item__clickable:certifications-list-item__not-clickable',
-  ],
+@classic
+@classNames('certifications-list-item')
+@classNameBindings(
+  'certification.isPublished:certifications-list-item__published-item:certifications-list-item__unpublished-item',
+  'isClickable:certifications-list-item__clickable:certifications-list-item__not-clickable'
+)
+export default class CertificationsListItem extends Component {
+  certification = null;
 
-  isValidated: equal('certification.status', 'validated'),
-  isNotValidated: not('isValidated'),
+  @equal('certification.status', 'validated')
+  isValidated;
 
-  isNotPublished: not('certification.isPublished'),
-  isPublishedAndRejected: and('isNotValidated', 'certification.isPublished'),
-  isPublishedAndValidated: and('isValidated', 'certification.isPublished'),
+  @not('isValidated')
+  isNotValidated;
 
-  shouldDisplayComment: and('isNotValidated', 'certification.{isPublished,commentForCandidate}'),
+  @not('certification.isPublished')
+  isNotPublished;
 
-  isClickable: or('shouldDisplayComment', 'isPublishedAndValidated'),
-});
+  @and('isNotValidated', 'certification.isPublished')
+  isPublishedAndRejected;
+
+  @and('isValidated', 'certification.isPublished')
+  isPublishedAndValidated;
+
+  @and('isNotValidated', 'certification.{isPublished,commentForCandidate}')
+  shouldDisplayComment;
+
+  @or('shouldDisplayComment', 'isPublishedAndValidated')
+  isClickable;
+}

--- a/mon-pix/app/components/certifications-list.js
+++ b/mon-pix/app/components/certifications-list.js
@@ -1,6 +1,9 @@
 import Component from '@ember/component';
+import { classNames } from '@ember-decorators/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['certifications-list'],
-  certifications: null,
-});
+@classic
+@classNames('certifications-list')
+export default class CertificationsList extends Component {
+  certifications = null;
+}

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
+import { classNames } from '@ember-decorators/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-
-  classNames: ['challenge-actions'],
-});
-
+@classic
+@classNames('challenge-actions')
+export default class ChallengeActions extends Component {}

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -1,65 +1,66 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { attributeBindings, classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-
-  // Element
-  classNames: ['challenge-embed-simulator'],
-  attributeBindings: ['embedDocumentHeightStyle:style'],
-
+@classic
+@classNames('challenge-embed-simulator')
+@attributeBindings('embedDocumentHeightStyle:style')
+export default class ChallengeEmbedSimulator extends Component {
   // Data props
-  embedDocument: null,
+  embedDocument = null;
 
   // CPs
-  embedDocumentHeightStyle: computed('embedDocument.height', function() {
+  @computed('embedDocument.height')
+  get embedDocumentHeightStyle() {
     return htmlSafe(`height: ${this.get('embedDocument.height')}px`);
-  }),
+  }
 
-  // Actions
-  actions: {
-    launchSimulator() {
-      const iframe = this._getIframe();
+  @action
+  launchSimulator() {
+    const iframe = this._getIframe();
 
-      // TODO: use correct targetOrigin once the embeds are hosted behind our domain
-      iframe.contentWindow.postMessage('launch', '*');
-      iframe.focus();
+    // TODO: use correct targetOrigin once the embeds are hosted behind our domain
+    iframe.contentWindow.postMessage('launch', '*');
+    iframe.focus();
 
-      this.toggleProperty('_isSimulatorNotYetLaunched');
-      this._unblurSimulator();
-    },
+    this.toggleProperty('_isSimulatorNotYetLaunched');
+    this._unblurSimulator();
+  }
 
-    rebootSimulator() {
-      this._rebootSimulator();
-    },
-  },
+  @action
+  rebootSimulator() {
+    this._rebootSimulator();
+  }
 
   // Internals
-  _isSimulatorNotYetLaunched: true,
-  _hiddenSimulatorClass: null,
+  _isSimulatorNotYetLaunched = true;
+
+  _hiddenSimulatorClass = null;
 
   didUpdateAttrs() {
     this.set('_isSimulatorNotYetLaunched', true);
     this.set('_hiddenSimulatorClass', 'hidden-class');
-  },
+  }
 
   didRender() {
-    this._super(...arguments);
+    super.didRender(...arguments);
     const iframe = this._getIframe();
     iframe.onload = () => {
       this._removePlaceholder();
     };
-  },
+  }
 
   _removePlaceholder() {
     if (this.embedDocument.url) {
       this.set('_hiddenSimulatorClass', null);
     }
-  },
+  }
 
   _getIframe() {
     return this.element.querySelector('.embed__iframe');
-  },
+  }
 
   /* This method is not tested because it would be too difficult (add an observer on a complicated stubbed DOM API element!) */
   _rebootSimulator() {
@@ -76,10 +77,10 @@ export default Component.extend({
       iframe.src = tmpSrc;
     };
     iframe.src = '';
-  },
+  }
 
   _unblurSimulator() {
     const $simulatorPanel = this.element.getElementsByClassName('embed__simulator').item(0);
     $simulatorPanel.classList.remove('blurred');
   }
-});
+}

--- a/mon-pix/app/components/challenge-illustration.js
+++ b/mon-pix/app/components/challenge-illustration.js
@@ -1,19 +1,19 @@
 import Component from '@ember/component';
-import { trySet } from '@ember/object';
+import { classNames } from '@ember-decorators/component';
+import { trySet, action } from '@ember/object';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['challenge-illustration'],
-  src: null,
-  alt: null,
+@classic
+@classNames('challenge-illustration')
+export default class ChallengeIllustration extends Component {
+  src = null;
+  alt = null;
+  hiddenClass = 'challenge-illustration__loaded-image--hidden';
+  displayPlaceholder = true;
 
-  hiddenClass: 'challenge-illustration__loaded-image--hidden',
-  displayPlaceholder: true,
-
-  actions: {
-    onImageLoaded() {
-      trySet(this, 'displayPlaceholder', false);
-      trySet(this, 'hiddenClass', null);
-    }
-  },
-
-});
+  @action
+  onImageLoaded() {
+    trySet(this, 'displayPlaceholder', false);
+    trySet(this, 'hiddenClass', null);
+  }
+}

--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,26 +1,26 @@
+import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
+import classic from 'ember-classic-decorator';
 
-const ChallengeItemQcm = ChallengeItemGeneric.extend({
-
-  _hasError: function() {
+@classic
+class ChallengeItemQcm extends ChallengeItemGeneric {
+  _hasError() {
     return this._getAnswerValue().length < 1;
-  },
+  }
 
   // FIXME refactor that
   _getAnswerValue() {
     return this.$('input[type=checkbox][id^=checkbox_]:checked').map(function() {return this.name; }).get().join(',');
-  },
+  }
 
   _getErrorMessage() {
     return 'Pour valider, sélectionner au moins une réponse. Sinon, passer.';
-  },
-
-  actions: {
-    answerChanged: function() {
-      this.set('errorMessage', null);
-    }
   }
 
-});
+  @action
+  answerChanged() {
+    this.set('errorMessage', null);
+  }
+}
 
 export default ChallengeItemQcm;

--- a/mon-pix/app/components/challenge-item-qcu.js
+++ b/mon-pix/app/components/challenge-item-qcu.js
@@ -1,10 +1,12 @@
+import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
+import classic from 'ember-classic-decorator';
 
-const ChallengeItemQcu = ChallengeItemGeneric.extend({
-
-  _hasError: function() {
+@classic
+class ChallengeItemQcu extends ChallengeItemGeneric {
+  _hasError() {
     return this._getAnswerValue().length < 1;
-  },
+  }
 
   // FIXME refactor this
   _getAnswerValue() {
@@ -12,18 +14,16 @@ const ChallengeItemQcu = ChallengeItemGeneric.extend({
     return this.$('.challenge-proposals input:radio:checked').map(function() {
       return this.getAttribute('data-value');
     }).get().join('');
-  },
+  }
 
   _getErrorMessage() {
     return 'Pour valider, sélectionner une réponse. Sinon, passer.';
-  },
-
-  actions: {
-    answerChanged: function() {
-      this.set('errorMessage', null);
-    }
   }
 
-});
+  @action
+  answerChanged() {
+    this.set('errorMessage', null);
+  }
+}
 
 export default ChallengeItemQcu;

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -1,26 +1,26 @@
+import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
+import classic from 'ember-classic-decorator';
 
-const ChallengeItemQroc = ChallengeItemGeneric.extend({
-
-  _hasError: function() {
+@classic
+class ChallengeItemQroc extends ChallengeItemGeneric {
+  _hasError() {
     return this._getAnswerValue().length < 1;
-  },
+  }
 
   // FIXME refactor that
   _getAnswerValue() {
     return (this.$('[data-uid="qroc-proposal-uid"]')).val();
-  },
+  }
 
   _getErrorMessage() {
     return 'Pour valider, saisir une réponse. Sinon, passer.';
-  },
-
-  actions: {
-    answerChanged() {
-      this.set('errorMessage', null);
-    }
   }
 
-});
+  @action
+  answerChanged() {
+    this.set('errorMessage', null);
+  }
+}
 
 export default ChallengeItemQroc;

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,19 +1,21 @@
+import { action } from '@ember/object';
 import _ from 'mon-pix/utils/lodash-custom';
+import classic from 'ember-classic-decorator';
 
 import ChallengeItemGeneric from './challenge-item-generic';
 import jsyaml from 'js-yaml';
 
-const ChallengeItemQrocm = ChallengeItemGeneric.extend({
-
-  _hasError: function() {
+@classic
+class ChallengeItemQrocm extends ChallengeItemGeneric {
+  _hasError() {
     const allAnswers = this._getRawAnswerValue(); // ex. {"logiciel1":"word", "logiciel2":"excel", "logiciel3":""}
     const hasAtLeastOneAnswer = _(allAnswers).hasSomeTruthyProps();
     return _.isFalsy(hasAtLeastOneAnswer);
-  },
+  }
 
   _getAnswerValue() {
     return jsyaml.safeDump(this._getRawAnswerValue());
-  },
+  }
 
   // XXX : data is extracted from DOM of child component, breaking child encapsulation.
   // This is not "the Ember way", however it makes code easier to read,
@@ -25,18 +27,16 @@ const ChallengeItemQrocm = ChallengeItemGeneric.extend({
       result[element.getAttribute('name')] = element.value;
     });
     return result;
-  },
+  }
 
   _getErrorMessage() {
     return 'Pour valider, saisir au moins une réponse. Sinon, passer.';
-  },
-
-  actions: {
-    answerChanged() {
-      this.set('errorMessage', null);
-    }
   }
 
-});
+  @action
+  answerChanged() {
+    this.set('errorMessage', null);
+  }
+}
 
 export default ChallengeItemQrocm;

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -1,30 +1,33 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
+@classic
+@classNames('challenge-statement')
+export default class ChallengeStatement extends Component {
+  @service mailGenerator;
 
-  mailGenerator: service(),
-
-  classNames: ['challenge-statement'],
-
-  challenge: null,
-  assessment: null,
+  challenge = null;
+  assessment = null;
 
   didReceiveAttrs() {
     this.set('selectedAttachmentUrl', this.get('challenge.attachments.firstObject'));
-  },
+  }
 
-  challengeInstruction: computed('challenge.instruction', function() {
+  @computed('challenge.instruction')
+  get challengeInstruction() {
     const instruction = this.get('challenge.instruction');
     if (!instruction) {
       return null;
     }
     return instruction.replace('${EMAIL}', this._formattedEmailForInstruction());
-  }),
+  }
 
-  challengeEmbedDocument: computed('challenge.hasValidEmbedDocument', function() {
+  @computed('challenge.hasValidEmbedDocument')
+  get challengeEmbedDocument() {
     if (this.get('challenge.hasValidEmbedDocument')) {
       return {
         url: this.get('challenge.embedUrl'),
@@ -33,25 +36,25 @@ export default Component.extend({
       };
     }
     return undefined;
-  }),
+  }
 
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
     this.id = 'challenge_statement_' + this.get('challenge.id');
-  },
+  }
 
-  attachmentsData: computed('challenge.attachments', function() {
+  @computed('challenge.attachments')
+  get attachmentsData() {
     return this.get('challenge.attachments');
-  }),
+  }
 
-  actions: {
-    selectAttachementUrl(attachementUrl) {
-      this.set('selectedAttachmentUrl', attachementUrl);
-    }
-  },
+  @action
+  selectAttachementUrl(attachementUrl) {
+    this.set('selectedAttachmentUrl', attachementUrl);
+  }
 
-  _formattedEmailForInstruction: function() {
+  _formattedEmailForInstruction() {
     return this.mailGenerator
       .generateEmail(this.get('challenge.id'), this.get('assessment.id'), window.location.hostname, config.environment);
-  },
-});
+  }
+}

--- a/mon-pix/app/components/checkpoint-continue.js
+++ b/mon-pix/app/components/checkpoint-continue.js
@@ -1,5 +1,7 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['checkpoint__continue']
-});
+@classic
+@classNames('checkpoint__continue')
+export default class CheckpointContinue extends Component {}

--- a/mon-pix/app/components/circle-chart.js
+++ b/mon-pix/app/components/circle-chart.js
@@ -1,7 +1,7 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-
-  classNames: ['circle-chart'],
-
-});
+@classic
+@classNames('circle-chart')
+export default class CircleChart extends Component {}

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -1,7 +1,8 @@
-import { equal } from '@ember/object/computed';
-import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import resultIconUrl from 'mon-pix/utils/result-icon-url';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 const TEXT_FOR_RESULT = {
   ok: {
@@ -41,19 +42,31 @@ const TEXT_FOR_RESULT = {
   }
 };
 
-export default Component.extend({
+@classic
+export default class ComparisonWindow extends Component {
+  answer = null;
+  index = null;
 
-  answer: null,
-  index: null,
+  @equal('answer.challenge.type', 'QROC')
+  isAssessmentChallengeTypeQroc;
 
-  isAssessmentChallengeTypeQroc: equal('answer.challenge.type', 'QROC'),
-  isAssessmentChallengeTypeQcm: equal('answer.challenge.type', 'QCM'),
-  isAssessmentChallengeTypeQcu: equal('answer.challenge.type', 'QCU'),
-  isAssessmentChallengeTypeQrocm: equal('answer.challenge.type', 'QROCM'),
-  isAssessmentChallengeTypeQrocmInd: equal('answer.challenge.type', 'QROCM-ind'),
-  isAssessmentChallengeTypeQrocmDep: equal('answer.challenge.type', 'QROCM-dep'),
+  @equal('answer.challenge.type', 'QCM')
+  isAssessmentChallengeTypeQcm;
 
-  resultItem: computed('answer.result', function() {
+  @equal('answer.challenge.type', 'QCU')
+  isAssessmentChallengeTypeQcu;
+
+  @equal('answer.challenge.type', 'QROCM')
+  isAssessmentChallengeTypeQrocm;
+
+  @equal('answer.challenge.type', 'QROCM-ind')
+  isAssessmentChallengeTypeQrocmInd;
+
+  @equal('answer.challenge.type', 'QROCM-dep')
+  isAssessmentChallengeTypeQrocmDep;
+
+  @computed('answer.result')
+  get resultItem() {
     let resultItem = TEXT_FOR_RESULT['default'];
     const answerStatus = this.get('answer.result');
 
@@ -61,9 +74,10 @@ export default Component.extend({
       resultItem = TEXT_FOR_RESULT[answerStatus];
     }
     return resultItem;
-  }),
+  }
 
-  resultItemIcon: computed('resultItem', function() {
+  @computed('resultItem')
+  get resultItemIcon() {
     return resultIconUrl(this.get('resultItem.status'));
-  }),
-});
+  }
+}

--- a/mon-pix/app/components/competence-card-desktop.js
+++ b/mon-pix/app/components/competence-card-desktop.js
@@ -1,13 +1,16 @@
-import Component from '@ember/component';
 import { computed } from '@ember/object';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  scorecard: null,
+@classic
+export default class CompetenceCardDesktop extends Component {
+  scorecard = null;
 
-  displayedLevel: computed('scorecard.{level,isNotStarted}', function() {
+  @computed('scorecard.{level,isNotStarted}')
+  get displayedLevel() {
     if (this.scorecard.isNotStarted) {
       return null;
     }
     return this.scorecard.level;
-  })
-});
+  }
+}

--- a/mon-pix/app/components/competence-card.js
+++ b/mon-pix/app/components/competence-card.js
@@ -1,13 +1,16 @@
-import Component from '@ember/component';
 import { computed } from '@ember/object';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  scorecard: null,
+@classic
+export default class CompetenceCard extends Component {
+  scorecard = null;
 
-  displayedLevel: computed('scorecard.{level,isNotStarted}', function() {
+  @computed('scorecard.{level,isNotStarted}')
+  get displayedLevel() {
     if (this.scorecard.isNotStarted) {
       return null;
     }
     return this.scorecard.level;
-  })
-});
+  }
+}

--- a/mon-pix/app/components/corner-ribbon.js
+++ b/mon-pix/app/components/corner-ribbon.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-});
+@classic
+export default class CornerRibbon extends Component {}

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,56 +1,54 @@
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import $ from 'jquery';
-import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
 import config from 'mon-pix/config/environment';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 import { topLevelLabels, questions } from 'mon-pix/static-data/feedback-panel-issue-labels';
 
-export default Component.extend({
+@classic
+@classNames('feedback-panel')
+export default class FeedbackPanel extends Component {
+  @service store;
 
-  classNames: ['feedback-panel'],
+  assessment = null;
+  challenge = null;
+  isFormOpened = false;
+  _content = null;
+  _category = null;
+  _error = null;
+  _isSubmitted = false;
+  nextCategory = null;
+  quickHelpInstructions = null;
+  displayTextBox = null;
+  displayQuestionDropdown = false;
+  _questions = questions;
 
-  store: service(),
-
-  assessment: null,
-  challenge: null,
-
-  isFormOpened: false,
-
-  _content: null,
-  _category: null,
-  _error: null,
-  _isSubmitted: false,
-
-  nextCategory: null,
-  quickHelpInstructions: null,
-  displayTextBox: null,
-  displayQuestionDropdown: false,
-
-  _questions: questions,
-
-  categories: computed('context', function() {
+  @computed('context')
+  get categories() {
     const context = this.context === 'comparison-window' ? 'displayOnlyOnChallengePage' : 'displayOnlyOnComparisonWindow';
     return topLevelLabels.filter((label) => !label[context]);
-  }),
+  }
 
-  _scrollToPanel: function() {
+  _scrollToPanel() {
     $('html,body').animate({
       scrollTop: $('.feedback-panel__view').offset().top - 15
     }, config.APP.SCROLL_DURATION);
-  },
+  }
 
-  _resetPanel: function() {
+  _resetPanel() {
     this.set('_isSubmitted', false);
     this.set('_error', null);
-  },
+  }
 
-  didReceiveAttrs: function() {
-    this._super();
+  didReceiveAttrs() {
+    super.didReceiveAttrs();
     this._resetPanel();
     this.set('_content', null);
-  },
+  }
 
   _showFeedbackActionBasedOnCategoryType(category) {
     this.set('displayTextBox', false);
@@ -61,75 +59,76 @@ export default Component.extend({
     } else if (category.type === 'textbox') {
       this.set('displayTextBox', true);
     }
-  },
+  }
 
-  actions: {
+  @action
+  toggleFeedbackForm() {
+    if (this.isFormOpened) {
+      this.set('isFormOpened', false);
+      this._resetPanel();
+    } else {
+      this.set('isFormOpened', true);
+      this._scrollToPanel();
+    }
+  }
 
-    toggleFeedbackForm() {
-      if (this.isFormOpened) {
-        this.set('isFormOpened', false);
-        this._resetPanel();
-      } else {
-        this.set('isFormOpened', true);
-        this._scrollToPanel();
-      }
-    },
+  @action
+  async sendFeedback() {
+    const content = this._content;
+    const category = this._category;
+    const answer = this.answer ? this.answer.value : null;
 
-    async sendFeedback() {
-      const content = this._content;
-      const category = this._category;
-      const answer = this.answer ? this.answer.value : null;
+    if (isEmpty(content) || isEmpty(content.trim())) {
+      this.set('_error', 'Vous devez saisir un message.');
+      return;
+    }
 
-      if (isEmpty(content) || isEmpty(content.trim())) {
-        this.set('_error', 'Vous devez saisir un message.');
-        return;
-      }
+    const feedback = this.store.createRecord('feedback', {
+      content,
+      category,
+      assessment: this.assessment,
+      challenge: this.challenge,
+      answer,
+    });
 
-      const feedback = this.store.createRecord('feedback', {
-        content,
-        category,
-        assessment: this.assessment,
-        challenge: this.challenge,
-        answer,
-      });
+    await feedback.save();
 
-      await feedback.save();
+    this.set('_isSubmitted', true);
+    this.set('_content', null);
+    this.set('_category', null);
+    this.set('nextCategory', null);
+    this.set('displayTextBox', false);
+    this.set('tutorialContent', null);
+    this.set('displayQuestionDropdown', false);
+  }
 
-      this.set('_isSubmitted', true);
-      this.set('_content', null);
-      this.set('_category', null);
-      this.set('nextCategory', null);
-      this.set('displayTextBox', false);
-      this.set('tutorialContent', null);
-      this.set('displayQuestionDropdown', false);
-    },
+  @action
+  displayCategoryOptions() {
+    this.set('displayTextBox', false);
+    this.set('quickHelpInstructions', null);
+    this.set('_error', null);
+    this.set('displayQuestionDropdown', false);
 
-    displayCategoryOptions() {
+    this.set('nextCategory', this._questions[event.target.value]);
+    this.set('_category', event.target.value);
+
+    if (this.nextCategory.length > 1) {
+      this.set('displayQuestionDropdown', true);
+    } else {
+      this._showFeedbackActionBasedOnCategoryType(this.nextCategory[0]);
+    }
+  }
+
+  @action
+  showFeedback() {
+    if (event.target.value === 'default') {
       this.set('displayTextBox', false);
       this.set('quickHelpInstructions', null);
       this.set('_error', null);
-      this.set('displayQuestionDropdown', false);
-
-      this.set('nextCategory', this._questions[event.target.value]);
-      this.set('_category', event.target.value);
-
-      if (this.nextCategory.length > 1) {
-        this.set('displayQuestionDropdown', true);
-      } else {
-        this._showFeedbackActionBasedOnCategoryType(this.nextCategory[0]);
-      }
-    },
-
-    showFeedback() {
-      if (event.target.value === 'default') {
-        this.set('displayTextBox', false);
-        this.set('quickHelpInstructions', null);
-        this.set('_error', null);
-      }
-
-      this.set('_error', null);
-      this.set('_category', this.nextCategory[event.target.value].name);
-      this._showFeedbackActionBasedOnCategoryType(this.nextCategory[event.target.value]);
     }
+
+    this.set('_error', null);
+    this.set('_category', this.nextCategory[event.target.value].name);
+    this._showFeedbackActionBasedOnCategoryType(this.nextCategory[event.target.value]);
   }
-});
+}

--- a/mon-pix/app/components/form-textfield-date.js
+++ b/mon-pix/app/components/form-textfield-date.js
@@ -1,5 +1,7 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 const INPUT_VALIDATION_STATUS_MAP = {
   default: 'form-textfield__input--default',
@@ -19,61 +21,80 @@ const INPUT_CONTAINER_VALIDATION_STATUS_MAP = {
   success: 'form-textfield__input-container--success'
 };
 
-export default Component.extend({
-  classNames: ['form-textfield'],
+@classic
+@classNames('form-textfield')
+export default class FormTextfieldDate extends Component {
+  label = '';
+  dayTextfieldName = '';
+  monthTextfieldName = '';
+  yearTextfieldName = '';
+  dayValidationMessage = '';
+  monthValidationMessage = '';
+  yearValidationMessage = '';
+  require = false;
+  help = '';
+  disabled = false;
+  onValidateDay = () => {};
+  onValidateMonth = () => {};
+  onValidateYear = () => {};
 
-  label: '',
-  dayTextfieldName: '',
-  monthTextfieldName: '',
-  yearTextfieldName: '',
-  dayValidationMessage: '',
-  monthValidationMessage: '',
-  yearValidationMessage: '',
-  require: false,
-  help: '',
-  disabled: false,
-
-  onValidateDay: () => {},
-  onValidateMonth: () => {},
-  onValidateYear: () => {},
-
-  dayHasIcon: computed('dayValidationStatus', 'disabled', function() {
+  @computed('dayValidationStatus', 'disabled')
+  get dayHasIcon() {
     return this.dayValidationStatus !== 'default' && !this.disabled;
-  }),
-  monthHasIcon: computed('monthValidationStatus', 'disabled', function() {
+  }
+
+  @computed('monthValidationStatus', 'disabled')
+  get monthHasIcon() {
     return this.monthValidationStatus !== 'default' && !this.disabled;
-  }),
-  yearHasIcon: computed('yearValidationStatus', 'disabled',  function() {
+  }
+
+  @computed('yearValidationStatus', 'disabled')
+  get yearHasIcon() {
     return this.yearValidationStatus !== 'default' && !this.disabled;
-  }),
+  }
 
-  dayInputContainerStatusClass: computed('dayValidationStatus', function() {
+  @computed('dayValidationStatus')
+  get dayInputContainerStatusClass() {
     return INPUT_CONTAINER_VALIDATION_STATUS_MAP[this.dayValidationStatus] || null;
-  }),
-  monthInputContainerStatusClass: computed('monthValidationStatus', function() {
+  }
+
+  @computed('monthValidationStatus')
+  get monthInputContainerStatusClass() {
     return INPUT_CONTAINER_VALIDATION_STATUS_MAP[this.monthValidationStatus] || null;
-  }),
-  yearInputContainerStatusClass: computed('yearValidationStatus', function() {
+  }
+
+  @computed('yearValidationStatus')
+  get yearInputContainerStatusClass() {
     return INPUT_CONTAINER_VALIDATION_STATUS_MAP[this.yearValidationStatus] || null;
-  }),
+  }
 
-  dayInputValidationStatus: computed('dayValidationStatus', function() {
+  @computed('dayValidationStatus')
+  get dayInputValidationStatus() {
     return INPUT_VALIDATION_STATUS_MAP[this.dayValidationStatus] || '';
-  }),
-  monthInputValidationStatus: computed('monthValidationStatus', function() {
-    return INPUT_VALIDATION_STATUS_MAP[this.monthValidationStatus] || '';
-  }),
-  yearInputValidationStatus: computed('yearValidationStatus', function() {
-    return INPUT_VALIDATION_STATUS_MAP[this.yearValidationStatus] || '';
-  }),
+  }
 
-  dayValidationMessageClass: computed('dayValidationStatus', function() {
+  @computed('monthValidationStatus')
+  get monthInputValidationStatus() {
+    return INPUT_VALIDATION_STATUS_MAP[this.monthValidationStatus] || '';
+  }
+
+  @computed('yearValidationStatus')
+  get yearInputValidationStatus() {
+    return INPUT_VALIDATION_STATUS_MAP[this.yearValidationStatus] || '';
+  }
+
+  @computed('dayValidationStatus')
+  get dayValidationMessageClass() {
     return MESSAGE_VALIDATION_STATUS_MAP[this.dayValidationStatus] || '';
-  }),
-  monthValidationMessageClass: computed('monthValidationStatus', function() {
+  }
+
+  @computed('monthValidationStatus')
+  get monthValidationMessageClass() {
     return MESSAGE_VALIDATION_STATUS_MAP[this.monthValidationStatus] || '';
-  }),
-  yearValidationMessageClass: computed('yearValidationStatus', function() {
+  }
+
+  @computed('yearValidationStatus')
+  get yearValidationMessageClass() {
     return MESSAGE_VALIDATION_STATUS_MAP[this.yearValidationStatus] || '';
-  }),
-});
+  }
+}

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -1,7 +1,9 @@
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 const INPUT_VALIDATION_STATUS_MAP = {
   default: 'form-textfield__input--default',
@@ -27,23 +29,28 @@ const INPUT_CONTAINER_VALIDATION_STATUS_MAP = {
   success: 'form-textfield__input-container--success'
 };
 
-export default Component.extend({
-  classNames: ['form-textfield'],
+@classic
+@classNames('form-textfield')
+export default class FormTextfield extends Component {
+  label = '';
+  textfieldName = '';
+  validationMessage = '';
+  validationStatus = 'default';
 
-  label: '',
-  textfieldName: '',
-  validationMessage: '',
-  validationStatus: 'default',
-  isPassword: equal('textfieldName','password'),
-  isEmail: equal('textfieldName','email'),
-  isPasswordVisible: false,
-  require: false,
-  help: '',
-  disabled: false,
+  @equal('textfieldName', 'password')
+  isPassword;
 
-  onValidate: () => {},
+  @equal('textfieldName', 'email')
+  isEmail;
 
-  textfieldType: computed('textfieldName', 'isPasswordVisible',  function() {
+  isPasswordVisible = false;
+  require = false;
+  help = '';
+  disabled = false;
+  onValidate = () => {};
+
+  @computed('textfieldName', 'isPasswordVisible')
+  get textfieldType() {
     if (this.textfieldName === 'password') {
       return this.isPasswordVisible ? 'text' : 'password';
     }
@@ -51,43 +58,48 @@ export default Component.extend({
       return 'email';
     }
     return 'text';
-  }),
+  }
 
   _isValidationStatusNotDefault() {
     return this.validationStatus !== 'default';
-  },
+  }
 
-  hasIcon: computed('validationStatus', 'user.errors.content', 'disabled', function() {
+  @computed('validationStatus', 'user.errors.content', 'disabled')
+  get hasIcon() {
     return this._isValidationStatusNotDefault() && !this.disabled;
-  }),
+  }
 
-  displayMessage: computed('hasIcon', 'validationMessage', function() {
+  @computed('hasIcon', 'validationMessage')
+  get displayMessage() {
     return !isEmpty(this.validationMessage) || this.hasIcon;
-  }),
+  }
 
-  inputContainerStatusClass: computed('validationStatus', function() {
+  @computed('validationStatus')
+  get inputContainerStatusClass() {
     const inputValidationStatus = this.validationStatus;
     return INPUT_CONTAINER_VALIDATION_STATUS_MAP[inputValidationStatus] || null;
-  }),
+  }
 
-  iconType: computed('validationStatus', function() {
+  @computed('validationStatus')
+  get iconType() {
     const inputValidationStatus = this.validationStatus;
     return ICON_TYPE_STATUS_MAP[inputValidationStatus] || '';
-  }),
+  }
 
-  inputValidationStatus: computed('validationStatus', function() {
+  @computed('validationStatus')
+  get inputValidationStatus() {
     const inputValidationStatus = this.validationStatus;
     return INPUT_VALIDATION_STATUS_MAP[inputValidationStatus] || '';
-  }),
+  }
 
-  validationMessageClass: computed('validationStatus', function() {
+  @computed('validationStatus')
+  get validationMessageClass() {
     const inputValidationStatus = this.validationStatus;
     return MESSAGE_VALIDATION_STATUS_MAP[inputValidationStatus] || '';
-  }),
-
-  actions: {
-    togglePasswordVisibility() {
-      this.toggleProperty('isPasswordVisible');
-    }
   }
-});
+
+  @action
+  togglePasswordVisibility() {
+    this.toggleProperty('isPasswordVisible');
+  }
+}

--- a/mon-pix/app/components/g-recaptcha.js
+++ b/mon-pix/app/components/g-recaptcha.js
@@ -1,47 +1,46 @@
+import { classNames } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
+@classic
+@classNames('gg-recaptcha')
+export default class GRecaptcha extends Component {
+  @service googleRecaptcha;
 
-  classNames: ['gg-recaptcha'],
-
-  googleRecaptcha: service(),
-
-  validateRecaptcha: null, // action
-  resetRecaptcha: null, // action
-
-  tokenHasBeenUsed: null,
-  validation: null,
+  validateRecaptcha = null; // action
+  resetRecaptcha = null; // action
+  tokenHasBeenUsed = null;
+  validation = null;
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
     const component = this;
     this.googleRecaptcha.loadScript().then(function() {
       component.renderRecaptcha();
     });
-  },
+  }
 
   didUpdateAttrs() {
-    this._super(...arguments);
+    super.didUpdateAttrs(...arguments);
     if (this.tokenHasBeenUsed) {
       this.googleRecaptcha.reset();
     }
-  },
+  }
 
   renderRecaptcha() {
     const callback = this.validateCallback.bind(this);
     const expiredCallback = this.expiredCallback.bind(this);
     this.googleRecaptcha.render('g-recaptcha-container', callback, expiredCallback);
-  },
+  }
 
   validateCallback(recaptchaResponse) {
     this.set('recaptchaToken', recaptchaResponse);
     this.set('tokenHasBeenUsed', false);
-  },
+  }
 
   expiredCallback() {
     this.set('recaptchaToken', null);
     this.set('tokenHasBeenUsed', false);
   }
-
-});
+}

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -1,20 +1,24 @@
+import { action, computed } from '@ember/object';
 import { isNone } from '@ember/utils';
-import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  displayHelp: 'hexagon-score__information--hidden',
+@classic
+export default class HexagonScore extends Component {
+  displayHelp = 'hexagon-score__information--hidden';
 
-  score: computed('pixScore', function() {
+  @computed('pixScore')
+  get score() {
     return (isNone(this.pixScore) || this.pixScore === 0) ? '–' : Math.floor(this.pixScore);
-  }),
-
-  actions: {
-    hideHelp: function() {
-      this.set('displayHelp', 'hexagon-score__information--hidden');
-    },
-    showHelp: function() {
-      this.set('displayHelp', 'hexagon-score__information--visible');
-    }
   }
-});
+
+  @action
+  hideHelp() {
+    this.set('displayHelp', 'hexagon-score__information--hidden');
+  }
+
+  @action
+  showHelp() {
+    this.set('displayHelp', 'hexagon-score__information--visible');
+  }
+}

--- a/mon-pix/app/components/inaccessible-campaign.js
+++ b/mon-pix/app/components/inaccessible-campaign.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-});
+@classic
+export default class InaccessibleCampaign extends Component {}

--- a/mon-pix/app/components/learning-more-panel.js
+++ b/mon-pix/app/components/learning-more-panel.js
@@ -1,12 +1,15 @@
-import Component from '@ember/component';
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['learning-more-panel'],
+@classic
+@classNames('learning-more-panel')
+export default class LearningMorePanel extends Component {
+  learningMoreTutorials = null;
 
-  learningMoreTutorials: null,
-
-  hasLearningMoreItems: computed('learningMoreTutorials.length', function() {
+  @computed('learningMoreTutorials.length')
+  get hasLearningMoreItems() {
     return this.get('learningMoreTutorials.length') > 0;
-  }),
-});
+  }
+}

--- a/mon-pix/app/components/levelup-notif.js
+++ b/mon-pix/app/components/levelup-notif.js
@@ -1,16 +1,18 @@
+import { action } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  closeLevelup: false,
+@classic
+export default class LevelupNotif extends Component {
+  closeLevelup = false;
 
   didUpdateAttrs() {
-    this._super(...arguments);
+    super.didUpdateAttrs(...arguments);
     this.set('closeLevelup', false);
-  },
+  }
 
-  actions: {
-    close: function() {
-      this.set('closeLevelup', true);
-    },
-  },
-});
+  @action
+  close() {
+    this.set('closeLevelup', true);
+  }
+}

--- a/mon-pix/app/components/navbar-burger-menu.js
+++ b/mon-pix/app/components/navbar-burger-menu.js
@@ -1,9 +1,11 @@
-import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  currentUser: service(),
+@classic
+export default class NavbarBurgerMenu extends Component {
+  @service currentUser;
 
-  showUserTutorialsInMenu: config.APP.FT_ACTIVATE_USER_TUTORIALS
-});
+  showUserTutorialsInMenu = config.APP.FT_ACTIVATE_USER_TUTORIALS
+}

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -1,23 +1,29 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
-import Component from '@ember/component';
-import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  router: service(),
-  session: service(),
+@classic
+@classNames('navbar-desktop-header')
+export default class NavbarDesktopHeader extends Component {
+  @service router;
+  @service session;
 
-  classNames: ['navbar-desktop-header'],
-  _canDisplayMenu: false,
-  _menuItems: [
+  _canDisplayMenu = false;
+
+  _menuItems = [
     { name: 'Se connecter', link: 'login', class: 'navbar-menu-signin-link' },
     { name: 'S’inscrire', link: 'inscription', class: 'navbar-menu-signup-link' }
-  ],
+  ];
 
-  isUserLogged: alias('session.isAuthenticated'),
+  @alias('session.isAuthenticated')
+  isUserLogged;
 
-  menu: computed('isUserLogged', function() {
+  @computed('isUserLogged')
+  get menu() {
     const menuItems = this._menuItems;
     return this.isUserLogged ? menuItems.filterBy('permanent', true) : menuItems;
-  })
-});
+  }
+}

--- a/mon-pix/app/components/navbar-desktop-menu.js
+++ b/mon-pix/app/components/navbar-desktop-menu.js
@@ -1,5 +1,7 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['navbar-desktop-menu']
-});
+@classic
+@classNames('navbar-desktop-menu')
+export default class NavbarDesktopMenu extends Component {}

--- a/mon-pix/app/components/navbar-header.js
+++ b/mon-pix/app/components/navbar-header.js
@@ -1,7 +1,9 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['navbar-header'],
-
-  burger: null,
-});
+@classic
+@classNames('navbar-header')
+export default class NavbarHeader extends Component {
+  burger = null;
+}

--- a/mon-pix/app/components/navbar-mobile-header.js
+++ b/mon-pix/app/components/navbar-mobile-header.js
@@ -1,13 +1,16 @@
-import Component from '@ember/component';
-import { alias } from '@ember/object/computed';
+import { classNames } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  session: service(),
+@classic
+@classNames('navbar-mobile-header')
+export default class NavbarMobileHeader extends Component {
+  @service session;
 
-  classNames: ['navbar-mobile-header'],
+  @alias('session.isAuthenticated')
+  isUserLogged;
 
-  isUserLogged: alias('session.isAuthenticated'),
-
-  burger: null,
-});
+  burger = null;
+}

--- a/mon-pix/app/components/no-certification-panel.js
+++ b/mon-pix/app/components/no-certification-panel.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-});
+@classic
+export default class NoCertificationPanel extends Component {}

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -1,33 +1,32 @@
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import ENV from 'mon-pix/config/environment';
 
-export default Component.extend({
+@classic
+export default class PasswordResetDemandForm extends Component {
+  @service store;
 
-  store: service(),
+  email = '';
+  _displayErrorMessage = false;
+  _displaySuccessMessage = false;
+  urlHome = ENV.APP.HOME_HOST;
 
-  email: '',
-  _displayErrorMessage: false,
-  _displaySuccessMessage: false,
-  urlHome: ENV.APP.HOME_HOST,
+  @action
+  savePasswordResetDemand() {
+    this.set('_displayErrorMessage', false);
+    this.set('_displaySuccessMessage', false);
 
-  actions: {
+    const trimedEmail = this.email ? this.email.trim() : '';
 
-    savePasswordResetDemand() {
-      this.set('_displayErrorMessage', false);
-      this.set('_displaySuccessMessage', false);
-
-      const trimedEmail = this.email ? this.email.trim() : '';
-
-      this.store.createRecord('password-reset-demand', { email: trimedEmail })
-        .save()
-        .then(() => {
-          this.set('_displaySuccessMessage', true);
-        })
-        .catch(() => {
-          this.set('_displayErrorMessage', true);
-        });
-    }
-
+    this.store.createRecord('password-reset-demand', { email: trimedEmail })
+      .save()
+      .then(() => {
+        this.set('_displaySuccessMessage', true);
+      })
+      .catch(() => {
+        this.set('_displayErrorMessage', true);
+      });
   }
-});
+}

--- a/mon-pix/app/components/pix-logo.js
+++ b/mon-pix/app/components/pix-logo.js
@@ -1,7 +1,7 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-
-  classNames: ['pix-logo']
-
-});
+@classic
+@classNames('pix-logo')
+export default class PixLogo extends Component {}

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -1,21 +1,25 @@
 import { computed } from '@ember/object';
-import Component from '@ember/component';
-import ENV from 'mon-pix/config/environment';
+import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/string';
 import colorGradient from 'mon-pix/utils/color-gradient';
-import { inject as service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 const { and } = computed;
 
 const minWidthPercent = 1.7;
 const minWidthPixel = 16;
 
-export default Component.extend({
-  media: service(),
+@classic
+export default class ProgressBar extends Component {
+  @service media;
 
-  showProgressBar: and('media.isDesktop', 'assessment.showProgressBar'),
+  @and('media.isDesktop', 'assessment.showProgressBar')
+  showProgressBar;
 
-  currentStepIndex: computed('answerId', 'assessment.answers.[]', 'challengeId', 'maxStepsNumber', function() {
+  @computed('answerId', 'assessment.answers.[]', 'challengeId', 'maxStepsNumber')
+  get currentStepIndex() {
     const persistedAnswersIds = this.assessment.hasMany('answers').ids().filter((id) => id != null);
     const currentAnswerId = this.answerId;
 
@@ -26,9 +30,12 @@ export default Component.extend({
     }
 
     return index % this.maxStepsNumber;
-  }),
+  }
 
-  maxStepsNumber: computed('assessment.{hasCheckpoints,certificationCourse.nbChallenges,course.nbChallenges}', function() {
+  @computed(
+    'assessment.{hasCheckpoints,certificationCourse.nbChallenges,course.nbChallenges}'
+  )
+  get maxStepsNumber() {
     if (this.get('assessment.hasCheckpoints')) {
       return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     }
@@ -38,13 +45,15 @@ export default Component.extend({
     }
 
     return this.get('assessment.course.nbChallenges');
-  }),
+  }
 
-  currentStepNumber: computed('currentStepIndex', function() {
+  @computed('currentStepIndex')
+  get currentStepNumber() {
     return this.currentStepIndex + 1;
-  }),
+  }
 
-  steps: computed('currentStepIndex', 'maxStepsNumber', function() {
+  @computed('currentStepIndex', 'maxStepsNumber')
+  get steps() {
     const steps = [];
 
     const gradient = colorGradient('#388AFF', '#985FFF', this.maxStepsNumber);
@@ -58,13 +67,14 @@ export default Component.extend({
     }
 
     return steps;
-  }),
+  }
 
-  progressionWidth: computed('currentStepIndex', 'maxStepsNumber', function() {
+  @computed('currentStepIndex', 'maxStepsNumber')
+  get progressionWidth() {
     const widthPercent = minWidthPercent + (100 - minWidthPercent) * this.currentStepIndex  / (this.maxStepsNumber - 1);
 
     const width = this.currentStepIndex === 0 ? `${minWidthPixel}px` : `${widthPercent}%`;
 
     return htmlSafe(`width: ${width};`);
-  }),
-});
+  }
+}

--- a/mon-pix/app/components/progression-gauge.js
+++ b/mon-pix/app/components/progression-gauge.js
@@ -1,15 +1,17 @@
-import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-
-  totalGaugeStyle: computed('total', function() {
+@classic
+export default class ProgressionGauge extends Component {
+  @computed('total')
+  get totalGaugeStyle() {
     return htmlSafe(`width: ${this.total}%`);
-  }),
+  }
 
-  valueGaugeStyle: computed('value', function() {
+  @computed('value')
+  get valueGaugeStyle() {
     return htmlSafe(`width: ${this.value}%`);
-  }),
-
-});
+  }
+}

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -1,26 +1,28 @@
-import { computed } from '@ember/object';
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import createProposalAnswerTuples from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 
-export default Component.extend({
+@classic
+@classNames('qcm-proposals')
+export default class QcmProposals extends Component {
+  answerValue = null;
+  proposals = null;
+  answerChanged = null;
 
-  answerValue: null,
-  proposals: null,
-  answerChanged: null,
-  classNames: ['qcm-proposals'],
-
-  labeledCheckboxes: computed('proposals', 'answerValue', function() {
+  @computed('proposals', 'answerValue')
+  get labeledCheckboxes() {
     const arrayOfProposals = proposalsAsArray(this.proposals);
     const arrayOfBoolean = valueAsArrayOfBoolean(this.answerValue);
 
     return createProposalAnswerTuples(arrayOfProposals, arrayOfBoolean);
-  }),
-
-  actions: {
-    checkboxClicked() {
-      this.answerChanged();
-    }
   }
-});
+
+  @action
+  checkboxClicked() {
+    this.answerChanged();
+  }
+}

--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -1,22 +1,27 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import _ from 'mon-pix/utils/lodash-custom';
 
-export default Component.extend({
-  classNames: ['qcm-solution-panel'],
-  answer: null,
-  solution: null,
-  challenge: null,
+@classic
+@classNames('qcm-solution-panel')
+export default class QcmSolutionPanel extends Component {
+  answer = null;
+  solution = null;
+  challenge = null;
 
-  solutionArray: computed('solution', function() {
+  @computed('solution')
+  get solutionArray() {
     const solution = this.solution;
     return _.isNonEmptyString(solution) ? valueAsArrayOfBoolean(solution) : [];
-  }),
+  }
 
-  labeledCheckboxes: computed('answer', function() {
+  @computed('answer')
+  get labeledCheckboxes() {
     const answer = this.get('answer.value');
     let checkboxes  = [];
     if (_.isNonEmptyString(answer)) {
@@ -26,5 +31,5 @@ export default Component.extend({
       checkboxes = labeledCheckboxes(proposalsArray, answerArray);
     }
     return checkboxes;
-  })
-});
+  }
+}

--- a/mon-pix/app/components/qcu-proposals.js
+++ b/mon-pix/app/components/qcu-proposals.js
@@ -1,34 +1,34 @@
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 
-export default Component.extend({
+@classic
+export default class QcuProposals extends Component {
+  answerValue = null;
+  proposals = null;
+  answerChanged = null; // action
 
-  answerValue: null,
-  proposals: null,
-  answerChanged: null, // action
-
-  labeledRadios: computed('proposals', 'answerValue', function() {
+  @computed('proposals', 'answerValue')
+  get labeledRadios() {
     const arrayOfProposals = proposalsAsArray(this.proposals);
     return labeledCheckboxes(arrayOfProposals, valueAsArrayOfBoolean(this.answerValue));
-  }),
+  }
 
   _uncheckAllRadioButtons() {
     this.$(':radio').prop('checked', false);
-  },
+  }
 
   _checkAgainTheSelectedOption(index) {
     this.$(`:radio:nth(${index})`).prop('checked', true);
-  },
-
-  actions: {
-    radioClicked(index) {
-      this._uncheckAllRadioButtons();
-      this._checkAgainTheSelectedOption(index);
-      this.answerChanged();
-    }
   }
 
-});
+  @action
+  radioClicked(index) {
+    this._uncheckAllRadioButtons();
+    this._checkAgainTheSelectedOption(index);
+    this.answerChanged();
+  }
+}

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -1,22 +1,27 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import _ from 'mon-pix/utils/lodash-custom';
 
-export default Component.extend({
-  classNames: ['qcu-solution-panel'],
-  answer: null,
-  solution: null,
-  challenge: null,
+@classic
+@classNames('qcu-solution-panel')
+export default class QcuSolutionPanel extends Component {
+  answer = null;
+  solution = null;
+  challenge = null;
 
-  solutionArray: computed('solution', function() {
+  @computed('solution')
+  get solutionArray() {
     const solution = this.solution;
     return _.isNonEmptyString(solution) ? valueAsArrayOfBoolean(solution) : [];
-  }),
+  }
 
-  labeledRadios: computed('answer', function() {
+  @computed('answer')
+  get labeledRadios() {
     const answer = this.get('answer.value');
     let radiosArray = [];
     if (_.isNonEmptyString(answer)) {
@@ -27,5 +32,5 @@ export default Component.extend({
     }
 
     return radiosArray;
-  })
-});
+  }
+}

--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -1,33 +1,36 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
-export default Component.extend({
+@classic
+@classNames('qroc-proposal')
+export default class QrocProposal extends Component {
+  format = null;
+  proposals = null;
+  answerValue = null;
+  answerChanged = null; // action
 
-  classNames: ['qroc-proposal'],
-
-  format: null,
-  proposals: null,
-  answerValue: null,
-  answerChanged: null, // action
-
-  _blocks: computed('proposals', function() {
+  @computed('proposals')
+  get _blocks() {
     return proposalsAsBlocks(this.proposals);
-  }),
+  }
 
-  userAnswer : computed('answerValue', function() {
+  @computed('answerValue')
+  get userAnswer() {
     const answer = this.answerValue || '';
     return answer.indexOf('#ABAND#') > -1 ? '' : answer;
-  }),
+  }
 
-  didInsertElement: function() {
+  didInsertElement() {
 
     this.$('input').keydown(() => {
       this.answerChanged();
     });
-  },
+  }
 
-  willRender: function() {
+  willRender() {
     this.notifyPropertyChange('proposals');
   }
-});
+}

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -1,5 +1,6 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
 const classByResultValue = {
   ok: 'correction-qroc-box-answer--correct',
@@ -7,32 +8,36 @@ const classByResultValue = {
   aband: 'correction-qroc-box-answer--aband',
 };
 
-export default Component.extend({
+@classic
+export default class QrocSolutionPanel extends Component {
+  answer = null;
+  solution = null;
 
-  answer: null,
-  solution: null,
-
-  inputClass: computed('answer.result', function() {
+  @computed('answer.result')
+  get inputClass() {
     return classByResultValue[this.get('answer.result')] || '';
-  }),
+  }
 
-  isResultOk: computed('answer', function() {
+  @computed('answer')
+  get isResultOk() {
     return this.get('answer.result') === 'ok';
-  }),
+  }
 
-  answerToDisplay: computed('answer', function() {
+  @computed('answer')
+  get answerToDisplay() {
     const answer = this.get('answer.value');
     if (answer === '#ABAND#') {
       return 'Pas de réponse';
     }
     return answer;
-  }),
+  }
 
-  solutionToDisplay: computed('solution', function() {
+  @computed('solution')
+  get solutionToDisplay() {
     const solutionVariants = this.solution;
     if (!solutionVariants) {
       return '';
     }
     return solutionVariants.split('\n')[0];
-  })
-});
+  }
+}

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -1,5 +1,6 @@
-import Component from '@ember/component';
 import { computed } from '@ember/object';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import { htmlSafe } from '@ember/template';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
@@ -13,9 +14,10 @@ const classByResultValue = {
   aband: 'correction-qroc-box-answer--aband'
 };
 
-export default Component.extend({
-
-  inputFields: computed('challenge.proposals', 'answer.value', function() {
+@classic
+export default class QrocmDepSolutionPanel extends Component {
+  @computed('challenge.proposals', 'answer.value')
+  get inputFields() {
     const escapedProposals = this.get('challenge.proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
     const answers = answersAsObject(this.get('answer.value'), _.keys(labels));
@@ -29,17 +31,20 @@ export default Component.extend({
         inputClass: answerIsEmpty ? classByResultValue['aband'] : this.inputClass,
       };
     });
-  }),
+  }
 
-  answerIsCorrect: computed('answer.result', function() {
+  @computed('answer.result')
+  get answerIsCorrect() {
     return this.answer.result === 'ok';
-  }),
+  }
 
-  inputClass: computed('answer.result', function() {
+  @computed('answer.result')
+  get inputClass() {
     return classByResultValue[this.answer.result];
-  }),
+  }
 
-  expectedAnswers: computed('solution', 'inputFields.length', function() {
+  @computed('solution', 'inputFields.length')
+  get expectedAnswers() {
     const inputFieldsCount = this.inputFields.length;
     const solutions = jsyaml.safeLoad(this.solution);
     const solutionsKeys = Object.keys(solutions);
@@ -51,6 +56,5 @@ export default Component.extend({
     return inputFieldsCount === solutionsKeys.length ?
       `${expectedAnswers.slice(0, -1).join(', ')} et ${expectedAnswers.slice(-1)}` :
       `${expectedAnswers.join(' ou ')} ou ...`;
-  })
-
-});
+  }
+}

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -1,6 +1,7 @@
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import _ from 'lodash';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import solutionsAsObject from 'mon-pix/utils/solution-as-object';
@@ -24,9 +25,10 @@ function _computeInputClass(answerOutcome) {
   return 'correction-qroc-box-answer--wrong';
 }
 
-const QrocmIndSolutionPanel = Component.extend({
-
-  inputFields: computed('challenge.proposals', 'answer.value', 'solution', function() {
+@classic
+class QrocmIndSolutionPanel extends Component {
+  @computed('challenge.proposals', 'answer.value', 'solution')
+  get inputFields() {
 
     const escapedProposals = this.get('challenge.proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
@@ -55,9 +57,8 @@ const QrocmIndSolutionPanel = Component.extend({
     });
 
     return inputFields;
-  })
-
-});
+  }
+}
 
 export default QrocmIndSolutionPanel;
 

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -1,28 +1,28 @@
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import classic from 'ember-classic-decorator';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
-export default Component.extend({
+@classic
+@classNames('qrocm-proposal')
+export default class QrocmProposal extends Component {
+  proposals = null;
+  answersValue = null;
+  answerChanged = null; // action
+  format = null;
 
-  classNames: ['qrocm-proposal'],
-
-  proposals: null,
-  answersValue: null,
-  answerChanged: null, // action
-  format: null,
-
-  _blocks: computed('proposals', function() {
+  @computed('proposals')
+  get _blocks() {
     return proposalsAsBlocks(this.proposals)
       .map((block) => {
         block.showText = block.text && !block.ariaLabel && !block.input;
         return block;
       });
-  }),
-
-  actions: {
-    onInputChange: function() {
-      this.answerChanged();
-    }
   }
 
-});
+  @action
+  onInputChange() {
+    this.answerChanged();
+  }
+}

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -1,4 +1,6 @@
+import { action } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import isPasswordValid from '../utils/password-validator';
 import ENV from 'mon-pix/config/environment';
 
@@ -22,27 +24,28 @@ const SUBMISSION_MAP = {
   }
 };
 
-export default Component.extend({
-  _displaySuccessMessage: null,
-  validation: VALIDATION_MAP['default'],
-  urlHome: ENV.APP.HOME_HOST,
+@classic
+export default class ResetPasswordForm extends Component {
+  _displaySuccessMessage = null;
+  validation = VALIDATION_MAP['default'];
+  urlHome = ENV.APP.HOME_HOST;
 
-  actions: {
-    validatePassword() {
-      const password = this.get('user.password');
-      const validationStatus = (isPasswordValid(password)) ? 'default' : 'error';
-      this.set('validation', VALIDATION_MAP[validationStatus]);
-    },
-
-    handleResetPassword() {
-      this.set('_displaySuccessMessage', false);
-      return this.user.save({ adapterOptions: { updatePassword: true, temporaryKey: this.temporaryKey } })
-        .then(() => {
-          this.set('validation', SUBMISSION_MAP['default']);
-          this.set('_displaySuccessMessage', true);
-          this.set('user.password', null);
-        })
-        .catch(() => this.set('validation', SUBMISSION_MAP['error']));
-    }
+  @action
+  validatePassword() {
+    const password = this.get('user.password');
+    const validationStatus = (isPasswordValid(password)) ? 'default' : 'error';
+    this.set('validation', VALIDATION_MAP[validationStatus]);
   }
-});
+
+  @action
+  handleResetPassword() {
+    this.set('_displaySuccessMessage', false);
+    return this.user.save({ adapterOptions: { updatePassword: true, temporaryKey: this.temporaryKey } })
+      .then(() => {
+        this.set('validation', SUBMISSION_MAP['default']);
+        this.set('_displaySuccessMessage', true);
+        this.set('user.password', null);
+      })
+      .catch(() => this.set('validation', SUBMISSION_MAP['error']));
+  }
+}

--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -1,20 +1,27 @@
-import _maxBy from 'lodash/maxBy';
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import { filterBy } from '@ember/object/computed';
+import _maxBy from 'lodash/maxBy';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
+@classic
+@classNames('resume-campaign-banner')
+export default class ResumeCampaignBanner extends Component {
+  campaignParticipations = [];
 
-  classNames: ['resume-campaign-banner'],
-  campaignParticipations: [],
+  @filterBy('campaignParticipations', 'isShared', false)
+  unsharedCampaignParticipations;
 
-  unsharedCampaignParticipations: filterBy('campaignParticipations', 'isShared', false),
-
-  lastUnsharedCampaignParticipation: computed('unsharedCampaignParticipations.@each.createdAt', function() {
+  @computed('unsharedCampaignParticipations.@each.createdAt')
+  get lastUnsharedCampaignParticipation() {
     return _maxBy(this.unsharedCampaignParticipations, 'createdAt');
-  }),
+  }
 
-  campaignToResumeOrShare: computed('lastUnsharedCampaignParticipation.campaign.{title,code},lastUnsharedCampaignParticipation.assessment.isCompleted', function() {
+  @computed(
+    'lastUnsharedCampaignParticipation.campaign.{title,code},lastUnsharedCampaignParticipation.assessment.isCompleted'
+  )
+  get campaignToResumeOrShare() {
     if (this.lastUnsharedCampaignParticipation) {
       return {
         title: this.lastUnsharedCampaignParticipation.campaign.get('title'),
@@ -24,6 +31,5 @@ export default Component.extend({
     }
 
     return null;
-  }),
-
-});
+  }
+}

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -1,36 +1,41 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject } from '@ember/service';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
+@classic
+export default class LoginForm extends Component {
+  @inject()
+  session;
 
-  session: inject(),
-  store: inject(),
+  @inject()
+  store;
 
-  login: null,
-  password: null,
-  isLoading: false,
-  isPasswordVisible: false,
-  passwordInputType: computed('isPasswordVisible', function() {
+  login = null;
+  password = null;
+  isLoading = false;
+  isPasswordVisible = false;
+
+  @computed('isPasswordVisible')
+  get passwordInputType() {
     return this.isPasswordVisible ? 'text' : 'password';
-  }),
+  }
 
-  isErrorMessagePresent: false,
+  isErrorMessagePresent = false;
 
-  actions: {
-    authenticate() {
-      this.set('isLoading', true);
-      const login = this.login;
-      const password = this.password;
+  @action
+  authenticate() {
+    this.set('isLoading', true);
+    const login = this.login;
+    const password = this.password;
 
-      this._authenticate(password, login);
-    },
+    this._authenticate(password, login);
+  }
 
-    togglePasswordVisibility() {
-      this.toggleProperty('isPasswordVisible');
-    }
-
-  },
+  @action
+  togglePasswordVisibility() {
+    this.toggleProperty('isPasswordVisible');
+  }
 
   async _authenticate(password, login) {
     const scope = 'mon-pix';
@@ -41,5 +46,4 @@ export default Component.extend({
     }
     this.set('isLoading', false);
   }
-
-});
+}

--- a/mon-pix/app/components/routes/login-or-register.js
+++ b/mon-pix/app/components/routes/login-or-register.js
@@ -1,12 +1,13 @@
+import { action } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
+@classic
+export default class LoginOrRegister extends Component {
+  displayRegisterForm = true;
 
-  displayRegisterForm: true,
-
-  actions: {
-    toggleFormsVisibility() {
-      this.toggleProperty('displayRegisterForm');
-    },
+  @action
+  toggleFormsVisibility() {
+    this.toggleProperty('displayRegisterForm');
   }
-});
+}

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -1,6 +1,7 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject } from '@ember/service';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 
 import isEmailValid from '../../utils/email-validator';
@@ -21,45 +22,52 @@ const isMonthValid = (value) => value > 0 && value <= 12;
 const isYearValid = (value) => value > 999 && value <= 9999;
 const isStringValid = (value) => !!value.trim();
 
-export default Component.extend({
+@classic
+export default class RegisterForm extends Component {
+  @inject()
+  session;
 
-  session: inject(),
-  store: inject(),
+  @inject()
+  store;
 
-  studentDependentUser: null,
-  studentUserAssociation: null,
-  isLoading: false,
-  errorMessage: null,
-  matchingStudentFound: false,
-  isPasswordVisible: false,
-  loginWithUsername: true,
+  studentDependentUser = null;
+  studentUserAssociation = null;
+  isLoading = false;
+  errorMessage = null;
+  matchingStudentFound = false;
+  isPasswordVisible = false;
+  loginWithUsername = true;
 
-  passwordInputType: computed('isPasswordVisible', function() {
+  @computed('isPasswordVisible')
+  get passwordInputType() {
     return this.isPasswordVisible ? 'text' : 'password';
-  }),
+  }
 
-  username: '',
-  email: '',
-  password: '',
+  username = '';
+  email = '';
+  password = '';
+  firstName = '';
+  lastName = '';
+  dayOfBirth = '';
+  monthOfBirth = '';
+  yearOfBirth = '';
 
-  firstName: '',
-  lastName: '',
-  dayOfBirth: '',
-  monthOfBirth: '',
-  yearOfBirth: '',
-  birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+  @computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth')
+  get birthdate() {
     const dayOfBirth = standardizeNumberInTwoDigitFormat(this.dayOfBirth.trim());
     const monthOfBirth = standardizeNumberInTwoDigitFormat(this.monthOfBirth.trim());
     const yearOfBirth = this.yearOfBirth.trim();
     return [yearOfBirth, monthOfBirth, dayOfBirth].join('-');
-  }),
+  }
 
-  isSearchFormNotValid: computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+  @computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth')
+  get isSearchFormNotValid() {
     return !isStringValid(this.firstName) || !isStringValid(this.lastName)
       || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
-  }),
+  }
 
-  isCreationFormNotValid: computed('email','username','password', function() {
+  @computed('email', 'username', 'password')
+  get isCreationFormNotValid() {
     const isPasswordNotValid = !isPasswordValid(this.get('password'));
     const isUsernameNotValid = !isStringValid(this.get('username'));
     const isEmailNotValid = !isEmailValid(this.get('email'));
@@ -67,7 +75,7 @@ export default Component.extend({
       return isUsernameNotValid || isPasswordNotValid;
     }
     return isEmailNotValid || isPasswordNotValid;
-  }),
+  }
 
   init() {
     const validation = {
@@ -106,131 +114,143 @@ export default Component.extend({
     };
 
     this.set('validation', validation);
-    this._super(...arguments);
-  },
+    super.init(...arguments);
+  }
 
   willDestroyElement() {
     if (this.studentUserAssociation) this.studentUserAssociation.unloadRecord();
     if (this.studentDependentUser) this.studentDependentUser.unloadRecord();
-    this._super(...arguments);
-  },
+    super.willDestroyElement(...arguments);
+  }
 
-  actions: {
+  @action
+  searchForMatchingStudent() {
+    this.set('errorMessage', null);
+    this.set('isLoading', true);
+    this._validateInputString('firstName', this.firstName);
+    this._validateInputString('lastName', this.lastName);
+    this._validateInputDay('dayOfBirth', this.dayOfBirth);
+    this._validateInputMonth('monthOfBirth', this.monthOfBirth);
+    this._validateInputYear('yearOfBirth', this.yearOfBirth);
+    if (this.isSearchFormNotValid) {
+      return this.set('isLoading', false);
+    }
 
-    searchForMatchingStudent() {
-      this.set('errorMessage', null);
-      this.set('isLoading', true);
-      this._validateInputString('firstName', this.firstName);
-      this._validateInputString('lastName', this.lastName);
-      this._validateInputDay('dayOfBirth', this.dayOfBirth);
-      this._validateInputMonth('monthOfBirth', this.monthOfBirth);
-      this._validateInputYear('yearOfBirth', this.yearOfBirth);
-      if (this.isSearchFormNotValid) {
-        return this.set('isLoading', false);
-      }
+    this.studentUserAssociation = this.store.createRecord('student-user-association', {
+      id: this.campaignCode + '_' + this.lastName,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      birthdate: this.birthdate,
+      campaignCode: this.campaignCode,
+    });
 
-      this.studentUserAssociation = this.store.createRecord('student-user-association', {
-        id: this.campaignCode + '_' + this.lastName,
-        firstName: this.firstName,
-        lastName: this.lastName,
-        birthdate: this.birthdate,
-        campaignCode: this.campaignCode,
-      });
-
-      return this.studentUserAssociation.save({ adapterOptions: { searchForMatchingStudent: true } })
-        .then((response) => {
-          this.set('matchingStudentFound', true);
-          this.set('isLoading', false);
-          this.set('username', response.username);
-          return this.studentDependentUser = this.store.createRecord('user', {
-            firstName: this.firstName,
-            lastName: this.lastName,
-            email: '',
-            username: this.username,
-            password: '',
-          });
-        }, (errorResponse) => {
-          this.studentUserAssociation.unloadRecord();
-          this.set('isLoading', false);
-          errorResponse.errors.forEach((error) => {
-            if (error.status === '404') {
-              return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
-            }
-            if (error.status === '409') {
-              return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');
-            }
-            return this.set('errorMessage', error.detail);
-          });
-        });
-    },
-
-    async register() {
-      this.set('isLoading', true);
-      try {
-        this.set('studentDependentUser.password', this.password);
-        if (this.loginWithUsername) {
-          this.set('studentDependentUser.username', this.get('username'));
-          this.set('studentDependentUser.email', undefined);
-        } else {
-          this.set('studentDependentUser.email', this.get('email'));
-          this.set('studentDependentUser.username', undefined);
-        }
-        await this.studentDependentUser.save({
-          adapterOptions: {
-            isStudentDependentUser: true,
-            campaignCode: this.campaignCode,
-            birthdate: this.birthdate,
-            withUsername: this.loginWithUsername,
-          }
-        });
-      } catch (error) {
+    return this.studentUserAssociation.save({ adapterOptions: { searchForMatchingStudent: true } })
+      .then((response) => {
+        this.set('matchingStudentFound', true);
         this.set('isLoading', false);
-        return this._updateInputsStatus();
-      }
+        this.set('username', response.username);
+        return this.studentDependentUser = this.store.createRecord('user', {
+          firstName: this.firstName,
+          lastName: this.lastName,
+          email: '',
+          username: this.username,
+          password: '',
+        });
+      }, (errorResponse) => {
+        this.studentUserAssociation.unloadRecord();
+        this.set('isLoading', false);
+        errorResponse.errors.forEach((error) => {
+          if (error.status === '404') {
+            return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+          }
+          if (error.status === '409') {
+            return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');
+          }
+          return this.set('errorMessage', error.detail);
+        });
+      });
+  }
 
+  @action
+  async register() {
+    this.set('isLoading', true);
+    try {
+      this.set('studentDependentUser.password', this.password);
       if (this.loginWithUsername) {
-        await this._authenticate(this.get('studentDependentUser.username'), this.get('studentDependentUser.password'));
+        this.set('studentDependentUser.username', this.get('username'));
+        this.set('studentDependentUser.email', undefined);
       } else {
-        await this._authenticate(this.get('studentDependentUser.email'), this.get('studentDependentUser.password'));
+        this.set('studentDependentUser.email', this.get('email'));
+        this.set('studentDependentUser.username', undefined);
       }
-
-      this.set('studentDependentUser.password', null);
+      await this.studentDependentUser.save({
+        adapterOptions: {
+          isStudentDependentUser: true,
+          campaignCode: this.campaignCode,
+          birthdate: this.birthdate,
+          withUsername: this.loginWithUsername,
+        }
+      });
+    } catch (error) {
       this.set('isLoading', false);
-    },
+      return this._updateInputsStatus();
+    }
 
-    onToggle(data) {
-      this.set('loginWithUsername', data);
-    },
+    if (this.loginWithUsername) {
+      await this._authenticate(this.get('studentDependentUser.username'), this.get('studentDependentUser.password'));
+    } else {
+      await this._authenticate(this.get('studentDependentUser.email'), this.get('studentDependentUser.password'));
+    }
 
-    togglePasswordVisibility() {
-      this.toggleProperty('isPasswordVisible');
-    },
+    this.set('studentDependentUser.password', null);
+    this.set('isLoading', false);
+  }
 
-    triggerInputStringValidation(key, value) {
-      this._validateInputString(key, value);
-    },
-    triggerInputDayValidation(key, value) {
-      value = value.trim();
-      this._standardizeNumberInInput('dayOfBirth', value);
-      this._validateInputDay(key, value);
-    },
-    triggerInputMonthValidation(key, value) {
-      value = value.trim();
-      this._standardizeNumberInInput('monthOfBirth', value);
-      this._validateInputMonth(key, value);
-    },
-    triggerInputYearValidation(key, value) {
-      value = value.trim();
-      this.set('yearOfBirth', value);
-      this._validateInputYear(key, value);
-    },
-    triggerInputEmailValidation(key, value) {
-      this._validateInputEmail(key, value);
-    },
-    triggerInputPasswordValidation(key, value) {
-      this._validateInputPassword(key, value);
-    },
-  },
+  @action
+  onToggle(data) {
+    this.set('loginWithUsername', data);
+  }
+
+  @action
+  togglePasswordVisibility() {
+    this.toggleProperty('isPasswordVisible');
+  }
+
+  @action
+  triggerInputStringValidation(key, value) {
+    this._validateInputString(key, value);
+  }
+
+  @action
+  triggerInputDayValidation(key, value) {
+    value = value.trim();
+    this._standardizeNumberInInput('dayOfBirth', value);
+    this._validateInputDay(key, value);
+  }
+
+  @action
+  triggerInputMonthValidation(key, value) {
+    value = value.trim();
+    this._standardizeNumberInInput('monthOfBirth', value);
+    this._validateInputMonth(key, value);
+  }
+
+  @action
+  triggerInputYearValidation(key, value) {
+    value = value.trim();
+    this.set('yearOfBirth', value);
+    this._validateInputYear(key, value);
+  }
+
+  @action
+  triggerInputEmailValidation(key, value) {
+    this._validateInputEmail(key, value);
+  }
+
+  @action
+  triggerInputPasswordValidation(key, value) {
+    this._validateInputPassword(key, value);
+  }
 
   _executeFieldValidation(key, value, isValid) {
     const isInvalidInput = !isValid(value);
@@ -240,7 +260,7 @@ export default Component.extend({
     const messageObject = 'validation.' + key + '.message';
     this.set(statusObject, status);
     return this.set(messageObject, message);
-  },
+  }
 
   _updateInputsStatus() {
     const errors = this.get('studentDependentUser.errors');
@@ -250,41 +270,40 @@ export default Component.extend({
       this.set(statusObject, 'error');
       this.set(messageObject, message);
     });
-  },
+  }
 
   _validateInputString(key, value) {
     this._executeFieldValidation(key, value, isStringValid);
-  },
+  }
 
   _validateInputDay(key, value) {
     this._executeFieldValidation(key, value, isDayValid);
-  },
+  }
 
   _validateInputMonth(key, value) {
     this._executeFieldValidation(key, value, isMonthValid);
-  },
+  }
 
   _validateInputYear(key, value) {
     this._executeFieldValidation(key, value, isYearValid);
-  },
+  }
 
   _validateInputEmail(key, value) {
     this._executeFieldValidation(key, value, isEmailValid);
-  },
+  }
 
   _validateInputPassword(key, value) {
     this._executeFieldValidation(key, value, isPasswordValid);
-  },
+  }
 
   _standardizeNumberInInput(attribute, value) {
     if (value) {
       this.set(attribute, standardizeNumberInTwoDigitFormat(value));
     }
-  },
+  }
 
   _authenticate(login, password) {
     const scope = 'mon-pix';
     return this.session.authenticate('authenticator:oauth2', { login, password, scope });
-  },
-
-});
+  }
+}

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -1,38 +1,48 @@
-import Component from '@ember/component';
-import EmberObject, { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
+import EmberObject, { action, computed } from '@ember/object';
 import { A as EmberArray } from '@ember/array';
 
-export default Component.extend({
+@classic
+export default class ScorecardDetails extends Component {
+  @service
+  currentUser;
 
-  currentUser: service(),
-  store: service(),
+  @service
+  store;
 
-  scorecard: null,
-  showResetModal: false,
+  scorecard = null;
+  showResetModal = false;
 
-  level: computed('scorecard.{level,isNotStarted}', function() {
+  @computed('scorecard.{level,isNotStarted}')
+  get level() {
     return this.get('scorecard.isNotStarted') ? null : this.get('scorecard.level');
-  }),
+  }
 
-  isProgressable: computed('scorecard.{isMaxLevel,isNotStarted,isFinished}', function() {
+  @computed('scorecard.{isMaxLevel,isNotStarted,isFinished}')
+  get isProgressable() {
     return !(this.get('scorecard.isFinished') || this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
-  }),
+  }
 
-  displayWaitSentence: computed('scorecard.remainingDaysBeforeReset', function() {
+  @computed('scorecard.remainingDaysBeforeReset')
+  get displayWaitSentence() {
     return this.get('scorecard.remainingDaysBeforeReset') > 0;
-  }),
+  }
 
-  displayResetButton: computed('scorecard.remainingDaysBeforeReset', function() {
+  @computed('scorecard.remainingDaysBeforeReset')
+  get displayResetButton() {
     return this.get('scorecard.remainingDaysBeforeReset') === 0;
-  }),
+  }
 
-  remainingDaysText: computed('scorecard.remainingDaysBeforeReset', function() {
+  @computed('scorecard.remainingDaysBeforeReset')
+  get remainingDaysText() {
     const daysBeforeReset = this.get('scorecard.remainingDaysBeforeReset');
     return `Remise à zéro disponible dans ${daysBeforeReset} ${daysBeforeReset <= 1 ? 'jour' : 'jours'}`;
-  }),
+  }
 
-  tutorialsGroupedByTubeName: computed('scorecard.tutorials', function() {
+  @computed('scorecard.tutorials')
+  get tutorialsGroupedByTubeName() {
     const tutorialsGroupedByTubeName = EmberArray();
     const tutorials = this.scorecard.tutorials;
 
@@ -51,22 +61,22 @@ export default Component.extend({
       }
     });
     return tutorialsGroupedByTubeName;
-  }),
+  }
 
-  actions: {
-    openModal() {
-      this.set('showResetModal', true);
-    },
+  @action
+  openModal() {
+    this.set('showResetModal', true);
+  }
 
-    closeModal() {
-      this.set('showResetModal', false);
-    },
+  @action
+  closeModal() {
+    this.set('showResetModal', false);
+  }
 
-    reset() {
-      this.scorecard.save({ adapterOptions: { resetCompetence: true, userId: this.currentUser.user.id, competenceId: this.get('scorecard.competenceId') } });
+  @action
+  reset() {
+    this.scorecard.save({ adapterOptions: { resetCompetence: true, userId: this.currentUser.user.id, competenceId: this.get('scorecard.competenceId') } });
 
-      this.set('showResetModal', false);
-    }
-  },
-
-});
+    this.set('showResetModal', false);
+  }
+}

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -1,20 +1,21 @@
+import { action } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import ENV from 'mon-pix/config/environment';
 
-export default Component.extend({
-  displayErrorMessage: false,
-  username: '',
-  password: '',
-  urlHome: ENV.APP.HOME_HOST,
+@classic
+export default class SigninForm extends Component {
+  displayErrorMessage = false;
+  username = '';
+  password = '';
+  urlHome = ENV.APP.HOME_HOST;
 
-  actions: {
-    signin() {
-      this.set('displayErrorMessage', false);
-      this.authenticateUser(this.username, this.password)
-        .catch(() => {
-          this.set('displayErrorMessage', true);
-        });
-    }
+  @action
+  signin() {
+    this.set('displayErrorMessage', false);
+    this.authenticateUser(this.username, this.password)
+      .catch(() => {
+        this.set('displayErrorMessage', true);
+      });
   }
-
-});
+}

--- a/mon-pix/app/components/tutorial-panel.js
+++ b/mon-pix/app/components/tutorial-panel.js
@@ -1,31 +1,36 @@
-import Component from '@ember/component';
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: [ 'tutorial-panel' ],
+@classic
+@classNames('tutorial-panel')
+export default class TutorialPanel extends Component {
+  hint = null;
+  tutorials = null;
 
-  hint: null,
-  tutorials: null,
-
-  shouldDisplayHintOrTuto: computed('tutorials', 'hint', function() {
+  @computed('tutorials', 'hint')
+  get shouldDisplayHintOrTuto() {
     const tutorials = this.tutorials || [];
     const hint = this.hint || [];
 
     return (hint.length > 0) || (tutorials.length > 0);
-  }),
+  }
 
-  shouldDisplayHint: computed('hint', function() {
+  @computed('hint')
+  get shouldDisplayHint() {
     const hint = this.hint || [];
     return hint.length > 0;
-  }),
+  }
 
-  shouldDisplayTutorial: computed('tutorials', function() {
+  @computed('tutorials')
+  get shouldDisplayTutorial() {
     const tutorials = this.tutorials || [];
     return tutorials.length > 0;
-  }),
+  }
 
-  limitedTutorials: computed('tutorials', function() {
+  @computed('tutorials')
+  get limitedTutorials() {
     return this.tutorials.slice(0, 3);
-  }),
-
-});
+  }
+}

--- a/mon-pix/app/components/user-certifications-detail-area.js
+++ b/mon-pix/app/components/user-certifications-detail-area.js
@@ -1,11 +1,15 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-detail-area'],
-  area: null,
+@classic
+@classNames('user-certifications-detail-area')
+export default class UserCertificationsDetailArea extends Component {
+  area = null;
 
-  sortedCompetences: computed('area.resultCompetences.[]', function() {
+  @computed('area.resultCompetences.[]')
+  get sortedCompetences() {
     return this.get('area.resultCompetences').sortBy('index');
-  })
-});
+  }
+}

--- a/mon-pix/app/components/user-certifications-detail-competence.js
+++ b/mon-pix/app/components/user-certifications-detail-competence.js
@@ -1,8 +1,10 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-detail-competence'],
-  competence: null,
-  levels: [1,2,3,4,5,6,7,8],
-
-});
+@classic
+@classNames('user-certifications-detail-competence')
+export default class UserCertificationsDetailCompetence extends Component {
+  competence = null;
+  levels = [1,2,3,4,5,6,7,8];
+}

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -1,6 +1,9 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-detail-header'],
-  certification: null,
-});
+@classic
+@classNames('user-certifications-detail-header')
+export default class UserCertificationsDetailHeader extends Component {
+  certification = null;
+}

--- a/mon-pix/app/components/user-certifications-detail-profile.js
+++ b/mon-pix/app/components/user-certifications-detail-profile.js
@@ -1,11 +1,15 @@
+import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-detail-profile'],
-  resultCompetenceTree: null,
+@classic
+@classNames('user-certifications-detail-profile')
+export default class UserCertificationsDetailProfile extends Component {
+  resultCompetenceTree = null;
 
-  sortedAreas: computed('resultCompetenceTree.areas.[]', function() {
+  @computed('resultCompetenceTree.areas.[]')
+  get sortedAreas() {
     return this.get('resultCompetenceTree.areas').sortBy('code');
-  })
-});
+  }
+}

--- a/mon-pix/app/components/user-certifications-detail-result.js
+++ b/mon-pix/app/components/user-certifications-detail-result.js
@@ -1,6 +1,9 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-detail-result'],
-  certification: null,
-});
+@classic
+@classNames('user-certifications-detail-result')
+export default class UserCertificationsDetailResult extends Component {
+  certification = null;
+}

--- a/mon-pix/app/components/user-certifications-panel.js
+++ b/mon-pix/app/components/user-certifications-panel.js
@@ -1,6 +1,9 @@
+import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 
-export default Component.extend({
-  classNames: ['user-certifications-panel'],
-  certifications: null,
-});
+@classic
+@classNames('user-certifications-panel')
+export default class UserCertificationsPanel extends Component {
+  certifications = null;
+}

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -1,7 +1,9 @@
-import { on } from '@ember/object/evented';
-import { computed } from '@ember/object';
+import { classNames } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
+import { on } from '@ember-decorators/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import {
   EKMixin as EmberKeyboardMixin,
   keyDown
@@ -9,38 +11,40 @@ import {
 
 import config from 'mon-pix/config/environment';
 
-export default Component.extend(EmberKeyboardMixin, {
+@classic
+@classNames('logged-user-details')
+export default class UserLoggedMenu extends Component.extend(EmberKeyboardMixin) {
+  @service currentUser;
+  @service('-routing') routing;
 
-  currentUser: service(),
-  routing: service('-routing'),
+  keyboardActivated = true;
+  _canDisplayMenu = false;
+  showUserTutorialsInMenu = config.APP.FT_ACTIVATE_USER_TUTORIALS;
 
-  classNames: ['logged-user-details'],
-
-  keyboardActivated: true,
-  _canDisplayMenu: false,
-  showUserTutorialsInMenu: config.APP.FT_ACTIVATE_USER_TUTORIALS,
-
-  canDisplayLinkToProfile: computed('routing.currentRouteName', function() {
+  @computed('routing.currentRouteName')
+  get canDisplayLinkToProfile() {
     const currentRouteName = this.get('routing.currentRouteName');
 
     return currentRouteName !== 'profile';
-  }),
-
-  displayedIdentifier: computed('currentUser.user.email', function() {
-    return this.currentUser.user.email ? this.currentUser.user.email : this.currentUser.user.username;
-  }),
-
-  closeOnEsc: on(keyDown('Escape'), function() {
-    this.set('_canDisplayMenu', false);
-  }),
-
-  actions: {
-    toggleUserMenu() {
-      this.toggleProperty('_canDisplayMenu');
-    },
-
-    closeMenu() {
-      this.set('_canDisplayMenu', false);
-    }
   }
-});
+
+  @computed('currentUser.user.email')
+  get displayedIdentifier() {
+    return this.currentUser.user.email ? this.currentUser.user.email : this.currentUser.user.username;
+  }
+
+  @on(keyDown('Escape'))
+  closeOnEsc() {
+    this.set('_canDisplayMenu', false);
+  }
+
+  @action
+  toggleUserMenu() {
+    this.toggleProperty('_canDisplayMenu');
+  }
+
+  @action
+  closeMenu() {
+    this.set('_canDisplayMenu', false);
+  }
+}

--- a/mon-pix/app/components/warning-banner.js
+++ b/mon-pix/app/components/warning-banner.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import ENV from 'mon-pix/config/environment';
 
-export default Component.extend({
-  isEnabled: ENV.APP.IS_WARNING_BANNER_ENABLED
-});
+@classic
+export default class WarningBanner extends Component {
+  isEnabled = ENV.APP.IS_WARNING_BANNER_ENABLED;
+}

--- a/mon-pix/app/components/warning-page.js
+++ b/mon-pix/app/components/warning-page.js
@@ -1,5 +1,6 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import _ from 'mon-pix/utils/lodash-custom';
 
 function _pluralize(word, count) {
@@ -48,14 +49,15 @@ function _formatTimeForButton(time) {
   return `${formattedMinutes}:${formattedSeconds}`;
 }
 
-export default Component.extend({
-
-  allocatedHumanTime: computed('time', function() {
+@classic
+export default class WarningPage extends Component {
+  @computed('time')
+  get allocatedHumanTime() {
     return _formatTimeForText(this.time);
-  }),
+  }
 
-  allocatedTime: computed('time', function() {
+  @computed('time')
+  get allocatedTime() {
     return _formatTimeForButton(this.time);
-  }),
-
-});
+  }
+}

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,2 +1,2 @@
 {{title pageTitle}}
-<CertificationResultsPage @class="certification-results-page" @certificationNumber={{@model}} />
+<CertificationResultsPage @certificationNumber={{@model}} />

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,2 +1,2 @@
 {{title pageTitle}}
-<CertificationResultsPage @certificationNumber={{@model}} />
+<CertificationResultsPage @class="certification-results-page" @certificationNumber={{@model}} />

--- a/mon-pix/app/templates/components/beta-logo.hbs
+++ b/mon-pix/app/templates/components/beta-logo.hbs
@@ -1,1 +1,3 @@
-<div>Bêta</div>
+<div class="beta-logo">
+  Bêta
+</div>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -3559,6 +3559,35 @@
         }
       }
     },
+    "@ember-decorators/component": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/component/-/component-6.1.1.tgz",
+      "integrity": "sha512-Cj8tY/c0MC/rsipqsiWLh3YVN72DK92edPYamD/HzvftwzC6oDwawWk8RmStiBnG9PG/vntAt41l3S7HSSA+1Q==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/utils": "^6.1.1",
+        "ember-cli-babel": "^7.1.3"
+      }
+    },
+    "@ember-decorators/object": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/object/-/object-6.1.1.tgz",
+      "integrity": "sha512-cb4CNR9sRoA31J3FCOFLDuR9ztM4wO9w1WlS4JeNRS7Z69SlB/XSXB/vplA3i9OOaXEy/zKWbu5ndZrHz0gvLw==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/utils": "^6.1.1",
+        "ember-cli-babel": "^7.1.3"
+      }
+    },
+    "@ember-decorators/utils": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.1.1.tgz",
+      "integrity": "sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.3"
+      }
+    },
     "@ember/edition-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
@@ -3791,6 +3820,16 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
       }
     },
     "@ember/test-helpers": {
@@ -5061,15 +5100,15 @@
       }
     },
     "babel-eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
         "eslint-visitor-keys": "^1.0.0",
         "resolve": "^1.12.0"
       }
@@ -9514,6 +9553,16 @@
         }
       }
     },
+    "ember-classic-decorator": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ember-classic-decorator/-/ember-classic-decorator-1.0.7.tgz",
+      "integrity": "sha512-JsSw3aDJTy+KDGs0sEdXs8ZVCJ0f/5H4B4Qa1bjObd6wLWsL9NueAFHloxhuEm+tCRpVLvxfFFdTCeNeLSEddg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-filter-imports": "^3.0.0",
+        "ember-cli-babel": "^7.11.1"
+      }
+    },
     "ember-cli": {
       "version": "3.15.2",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.15.2.tgz",
@@ -12329,6 +12378,17 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "ember-decorators": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-6.1.1.tgz",
+      "integrity": "sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/component": "^6.1.1",
+        "@ember-decorators/object": "^6.1.1",
+        "ember-cli-babel": "^7.7.3"
       }
     },
     "ember-exam": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^1.1.0",
+    "@ember/render-modifiers": "^1.0.2",
     "@fortawesome/ember-fontawesome": "^0.2.1",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-regular-svg-icons": "^5.11.2",
@@ -48,6 +49,7 @@
     "chai-dom": "^1.8.1",
     "ember-auto-import": "^1.5.3",
     "ember-burger-menu": "^3.3.3",
+    "ember-classic-decorator": "^1.0.7",
     "ember-cli": "~3.15.2",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-autoprefixer": "^0.8.1",
@@ -72,6 +74,7 @@
     "ember-click-outside": "^1.2.1",
     "ember-collapsible-panel": "^3.2.1",
     "ember-data": "~3.15.0",
+    "ember-decorators": "^6.1.1",
     "ember-exam": "^4.0.9",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^7.0.0",

--- a/mon-pix/tests/unit/components/certification-joiner-test.js
+++ b/mon-pix/tests/unit/components/certification-joiner-test.js
@@ -10,9 +10,9 @@ describe('Unit | Component | certification-joiner', function() {
   describe('#init', function() {
     it('should pad birthdate elements with zeroes', function() {
       const component = this.owner.lookup('component:certification-joiner');
-      component.set('yearOfBirth', '2000');
-      component.set('monthOfBirth', '1');
-      component.set('dayOfBirth', '2');
+      component.yearOfBirth = 2000;
+      component.monthOfBirth = 1;
+      component.dayOfBirth = 2;
       expect(component.birthdate).to.equal('2000-01-02');
     });
   });
@@ -25,9 +25,9 @@ describe('Unit | Component | certification-joiner', function() {
       const createRecordMock = sinon.mock();
       createRecordMock.returns({ save: function() {} });
 
-      component.set('store', { createRecord: createRecordMock });
-      component.set('firstName', ' Michel ');
-      component.set('lastName', ' de Montaigne ');
+      component.store = { createRecord: createRecordMock };
+      component.firstName = ' Michel ';
+      component.lastName = ' de Montaigne ';
 
       // when
       await component.joinCertificationSession();


### PR DESCRIPTION
## :unicorn: Problème
Les composants de Pix App suivent la syntaxe classique d'Ember.

## :robot: Solution

Cette PR initie une démarche d'intelligence collective par échafaudage grâce à un [Codemod pour faciliter la conversion des classes en syntaxe native](https://github.com/ember-codemods/ember-native-class-codemod)

Nous croyons que cette démarche d'intelligence collective va permettre de : 
- sécuriser la réécriture du code au maximum
- transmettre les connaissances nécessaires à chacun par la pratique (on regarde ce que font les autres, on se documente, etc.)
- conserver du temps sur la Roadmap pour continuer d'apporter sainement et sereinement de la valeur à nos utilisateurs 

À cet effet, les premiers commits convertissent les componsants en Glimmer pour suivre la recommandation Octane. 

Pour les autres commits, nous avons conservé le décorateur `@classic` qui permet : 
- une transition complète vers la syntaxe native 
- une transition douce d'Ember Classic vers Ember Octane

[Why do I need this decorator?](https://github.com/emberjs/ember-classic-decorator#why-do-i-need-this-decorator)

## 🚀 La suite 
Chaque édition d'un component devra donc amener sa conversion en component Glimmer selon : 

Cette checklist
- [How do I refactor and remove classic?](https://github.com/emberjs/ember-classic-decorator#how-do-i-refactor-and-remove-classic)

Et ces documentations
- [Doc Ember officielle sur les Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/)
- [Doc Ember officielle sur les états et actions de Components](https://guides.emberjs.com/release/components/component-state-and-actions/)
- [Cheat sheet Classic vs Octane](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

## 🌈 Remarques
Certains components n'ont pas été convertis par le codemod compte tenu de : 
- leur complexité
- la transgression de certains standards

Nous n'y avons pas touché pour éviter les régressions non contrôlées.

## 🎉 Tips pour les nouveaux components
Pour utiliser le codemod depuis cette PR, il faut lancer le localhost de mon-pix puis exécuter la commande suivante : 

```bash
npx ember-native-class-codemod http://localhost:4200/path/to/server [OPTIONS] path/of/files/ or/some**/*glob.js
```

Type | Option
-- | --
Services | --type=services
Routes | --type=routes
Components | --type=components
Controllers | --type=controllers

Extrait de [Ember Native Class Codemod usage](https://github.com/ember-codemods/ember-native-class-codemod#usage)

