### PR TITLE
[TECH] Ajoute des scripts npm pour lancer les tests d'intégration ou d'acceptance

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -116,12 +116,13 @@
     "start": "node bin/www",
     "start:watch": "nodemon --signal SIGTERM bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
-    "test:api": "NODE_ENV=test mocha --recursive --exit --reporter dot tests",
-    "test:api:unit": "env NODE_ENV=test mocha --recursive --exit --reporter dot tests/unit",
+    "test:api": "npm run test:api:path -- tests",
+    "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
+    "test:api:unit": "npm run test:api:path -- tests/unit",
+    "test:api:integration": "npm run test:api:path -- tests/integration",
+    "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
-    "test:scripts": "NODE_ENV=test mocha --recursive --reporter dot ./tests/unit/scripts",
-    "test:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
     "test:lint": "npm test && npm run lint"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Dans l'api, il existe un script npm pour lancer uniquement les tests unitaires, mais pas de script npm pour lancer uniquement les tests d'intégration ou les tests d'acceptance.

## :robot: Solution

Comme c'est quelque-chose que je fais souvent pendant le développement, je propose d'ajouter ces scripts npm.