### PR TITLE
[CLEANUP] Supprimer les méthodes dépréciées fromAttributes (PF-1174)

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -70,14 +70,6 @@ class Assessment {
     this.campaignParticipationId = campaignParticipationId;
   }
 
-  /**
-   * @deprecated
-   */
-  static fromAttributes(attributes) {
-    const assessment = new Assessment();
-    return Object.assign(assessment, attributes);
-  }
-
   isCompleted() {
     return this.state === Assessment.states.COMPLETED;
   }

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -20,14 +20,6 @@ class CertificationChallenge {
     this.competenceId = competenceId;
     this.courseId = courseId;
   }
-
-  /**
-   * @deprecated
-   */
-  static fromAttributes(attributes) {
-    const certificationChallenge = new CertificationChallenge();
-    return Object.assign(certificationChallenge, attributes);
-  }
 }
 
 module.exports = CertificationChallenge;

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -85,18 +85,6 @@ class Challenge {
     this.competenceId = competenceId;
   }
 
-  /**
-   * @deprecated
-   */
-  static fromAttributes(attributes) {
-    const challenge = new Challenge();
-    Object.assign(challenge, attributes);
-    if (!challenge.skills) {
-      challenge.skills = [];
-    }
-    return challenge;
-  }
-
   addSkill(skill) {
     this.skills.push(skill);
   }

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -86,7 +86,7 @@ module.exports = {
       courseId = json.data.relationships.course.data.id;
     }
 
-    return Assessment.fromAttributes({
+    return new Assessment({
       id: json.data.id,
       type,
       courseId,

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -35,7 +35,7 @@ describe('Integration | Service | User Service', function() {
   }
 
   function _createChallenge(id, competence, skills, testedSkill, status = 'validé') {
-    const challenge = Challenge.fromAttributes();
+    const challenge = new Challenge();
     challenge.id = id;
     challenge.skills = skills;
     challenge.competenceId = competence;

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -100,19 +100,19 @@ describe('Integration | Service | User Service', function() {
       const assessmentResult1 = new AssessmentResult({ level: 1, pixScore: 12 });
       const assessmentResult2 = new AssessmentResult({ level: 2, pixScore: 23 });
       const assessmentResult3 = new AssessmentResult({ level: 0, pixScore: 2 });
-      const assessment1 = Assessment.fromAttributes({
+      const assessment1 = new Assessment({
         id: 13,
         status: 'completed',
         competenceId: 'competenceRecordIdOne',
         assessmentResults: [assessmentResult1]
       });
-      const assessment2 = Assessment.fromAttributes({
+      const assessment2 = new Assessment({
         id: 1637,
         status: 'completed',
         competenceId: 'competenceRecordIdTwo',
         assessmentResults: [assessmentResult2]
       });
-      const assessment3 = Assessment.fromAttributes({
+      const assessment3 = new Assessment({
         id: 145,
         status: 'completed',
         competenceId: 'competenceRecordIdUnknown',

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -16,14 +16,14 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
     beforeEach(() => {
 
-      assessmentWithoutScore = Assessment.fromAttributes({
+      assessmentWithoutScore = new Assessment({
         id: 1,
         courseId: 'recHzEA6lN4PEs7LG',
         userId: 5,
         type: 'DEMO',
       });
 
-      assessmentWithScore = Assessment.fromAttributes({
+      assessmentWithScore = new Assessment({
         id: 1,
         courseId: 'recHzEA6lN4PEs7LG', userId: 5,
         estimatedLevel: 0,
@@ -52,7 +52,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       const PREVIEW_ASSESSMENT_ID = 245;
 
       beforeEach(() => {
-        assessmentRepository.get.resolves(Assessment.fromAttributes({
+        assessmentRepository.get.resolves(new Assessment({
           id: 1,
           courseId: 'null2356871',
           userId: 5,
@@ -109,7 +109,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
     describe('when the assessment is a certification assessment', function() {
 
-      const certificationAssessment = Assessment.fromAttributes({
+      const certificationAssessment = new Assessment({
         id: 'assessmentId',
         type: Assessment.types.CERTIFICATION,
       });
@@ -146,7 +146,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
 
     describe('when the assessment is a smart placement assessment', () => {
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         id: 1,
         courseId: 'courseId',
         userId: 5,

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -34,7 +34,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
       it('should save an assessment with the type SMART_PLACEMENT and with a fake courseId', async function() {
         // given
-        const expectedAssessment = Assessment.fromAttributes({
+        const expectedAssessment = new Assessment({
           id: 42,
           courseId: null,
           type: 'SMART_PLACEMENT',
@@ -86,7 +86,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
 
       it('should save an assessment with type PREVIEW', async function() {
         // given
-        const expected = Assessment.fromAttributes({
+        const expected = new Assessment({
           id: 42,
           courseId: null,
           type: 'PREVIEW',

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -1,6 +1,5 @@
 const { expect, sinon } = require('../../../test-helper');
 const Hapi = require('@hapi/hapi');
-const Challenge = require('../../../../lib/domain/models/Challenge');
 const ChallengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
 
@@ -20,7 +19,7 @@ describe('Unit | Controller | challenge-controller', function() {
 
   describe('#get', function() {
 
-    const challenge = Challenge.fromAttributes({ 'id': 'challenge_id' });
+    const challenge = Symbol('someChallenge');
 
     it('should fetch and return the given challenge, serialized as JSONAPI', async () => {
       // given

--- a/api/tests/unit/domain/models/Answer_test.js
+++ b/api/tests/unit/domain/models/Answer_test.js
@@ -1,5 +1,4 @@
 const Answer = require('../../../../lib/domain/models/Answer');
-const Challenge = require('../../../../lib/domain/models/Challenge');
 const Skill = require('../../../../lib/domain/models/Skill');
 const { expect, domainBuilder } = require('../../../test-helper');
 
@@ -85,9 +84,9 @@ describe('Unit | Domain | Models | Answer', () => {
 
     it('should exist', () => {
       // given
-      const challenge = Challenge.fromAttributes();
       const answer = new Answer({ result: 'ko' });
-      answer.challenge = challenge;
+      answer.challenge = { skills: [] };
+
       // then
       expect(answer.maxDifficulty).to.exist;
     });
@@ -96,9 +95,7 @@ describe('Unit | Domain | Models | Answer', () => {
       // given
       const web5 = new Skill({ name: '@web5' });
       const url1 = new Skill({ name: '@url1' });
-      const challenge = Challenge.fromAttributes();
-      challenge.addSkill(web5);
-      challenge.addSkill(url1);
+      const challenge = { skills: [web5, url1] };
       const answer = new Answer({ result: 'ko' });
       answer.challenge = challenge;
 

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -8,7 +8,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return true when its state is completed', () => {
       // given
-      const assessment = Assessment.fromAttributes({ state: 'completed' });
+      const assessment = new Assessment({ state: 'completed' });
 
       // when
       const isCompleted = assessment.isCompleted();
@@ -19,7 +19,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return false when its state is not completed', () => {
       // given
-      const assessment = Assessment.fromAttributes({ state: '' });
+      const assessment = new Assessment({ state: '' });
 
       // when
       const isCompleted = assessment.isCompleted();
@@ -51,7 +51,7 @@ describe('Unit | Domain | Models | Assessment', () => {
         emitter: 'Gerard',
       });
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         status: 'completed',
         assessmentResults: [assessmentResultComputed, assessmentResultJury, assessmentResultJuryOld],
       });
@@ -66,7 +66,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return null when assessment has no result', () => {
       // given
-      const assessment = Assessment.fromAttributes({ status: '' });
+      const assessment = new Assessment({ status: '' });
 
       // when
       const lastResult = assessment.getLastAssessmentResult();
@@ -94,7 +94,7 @@ describe('Unit | Domain | Models | Assessment', () => {
         emitter: 'Michel',
       });
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         status: 'completed',
         assessmentResults: [assessmentResultComputed, assessmentResultJury],
       });
@@ -108,7 +108,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return null when assessment has no result', () => {
       // given
-      const assessment = Assessment.fromAttributes({ status: '' });
+      const assessment = new Assessment({ status: '' });
 
       // when
       const pixScore = assessment.getPixScore();
@@ -136,7 +136,7 @@ describe('Unit | Domain | Models | Assessment', () => {
         emitter: 'Michel',
       });
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         status: 'completed',
         assessmentResults: [assessmentResultComputed, assessmentResultJury],
       });
@@ -150,7 +150,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return null when assessment has no result', () => {
       // given
-      const assessment = Assessment.fromAttributes({ status: '' });
+      const assessment = new Assessment({ status: '' });
 
       // when
       const level = assessment.getLevel();
@@ -165,7 +165,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return the same object with state completed', () => {
       // given
-      const assessment = Assessment.fromAttributes({ state: 'started', userId: 2 });
+      const assessment = new Assessment({ state: 'started', userId: 2 });
 
       // when
       assessment.setCompleted();
@@ -182,7 +182,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return resolved promise when object is valid', () => {
       // given
-      assessment = Assessment.fromAttributes({ type: 'DEMO' });
+      assessment = new Assessment({ type: 'DEMO' });
 
       // when
       const promise = assessment.validate();
@@ -193,7 +193,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return rejected promise when Certification assessment has no userId', () => {
       //given
-      assessment = Assessment.fromAttributes({ type: 'CERTIFICATION' });
+      assessment = new Assessment({ type: 'CERTIFICATION' });
 
       // when
       const promise = assessment.validate();
@@ -204,7 +204,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return rejected promise when Competence evaluation assessment has no userId', () => {
       //given
-      assessment = Assessment.fromAttributes({ type: 'COMPETENCE_EVALUATION' });
+      assessment = new Assessment({ type: 'COMPETENCE_EVALUATION' });
 
       // when
       const promise = assessment.validate();
@@ -215,7 +215,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return rejected promise when Smart Placement assessment has no userId', () => {
       //given
-      assessment = Assessment.fromAttributes({ type: 'SMART_PLACEMENT' });
+      assessment = new Assessment({ type: 'SMART_PLACEMENT' });
 
       // when
       const promise = assessment.validate();
@@ -228,7 +228,7 @@ describe('Unit | Domain | Models | Assessment', () => {
   describe('#isSmartPlacement', () => {
     it('should return true when the assessment is a SMART_PLACEMENT', () => {
       // given
-      const assessment = Assessment.fromAttributes({ type: 'SMART_PLACEMENT' });
+      const assessment = new Assessment({ type: 'SMART_PLACEMENT' });
 
       // when
       const isSmartPlacementAssessment = assessment.isSmartPlacement();
@@ -239,7 +239,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return false when the assessment is not a SMART_PLACEMENT', () => {
       // given
-      const assessment = Assessment.fromAttributes({ type: 'PLACEMENT' });
+      const assessment = new Assessment({ type: 'PLACEMENT' });
 
       // when
       const isSmartPlacementAssessment = assessment.isSmartPlacement();
@@ -250,7 +250,7 @@ describe('Unit | Domain | Models | Assessment', () => {
 
     it('should return false when the assessment has no type', () => {
       // given
-      const assessment = Assessment.fromAttributes({});
+      const assessment = new Assessment({});
 
       // when
       const isSmartPlacementAssessment = assessment.isSmartPlacement();
@@ -406,7 +406,7 @@ describe('Unit | Domain | Models | Assessment', () => {
         level: 3,
       });
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         assessmentResults: [assessmentResultComputed]
       });
 
@@ -426,7 +426,7 @@ describe('Unit | Domain | Models | Assessment', () => {
         level: 0,
       });
 
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         assessmentResults: [assessmentResultComputed]
       });
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -44,7 +44,7 @@ describe('Unit | Domain | Models | Challenge', () => {
 
     it('should return false when the skill is not known', () => {
       // given
-      const challenge = Challenge.fromAttributes();
+      const challenge = new Challenge();
 
       // when
       const result = challenge.hasSkill(new Skill('@recherche1'));
@@ -55,7 +55,7 @@ describe('Unit | Domain | Models | Challenge', () => {
 
     it('should return true when the skill is known', () => {
       // given
-      const challenge = Challenge.fromAttributes();
+      const challenge = new Challenge();
       challenge.skills.push(new Skill('@recherche1'));
 
       // when
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | Challenge', () => {
     it('should add a skill', () => {
       // given
       const skill = new Skill('@web3');
-      const challenge = Challenge.fromAttributes();
+      const challenge = new Challenge();
 
       // when
       challenge.addSkill(skill);
@@ -108,7 +108,7 @@ describe('Unit | Domain | Models | Challenge', () => {
     it('should exist', function() {
       // given
       const url1 = new Skill({ name: '@url1' });
-      const challenge = Challenge.fromAttributes();
+      const challenge = new Challenge();
       challenge.addSkill(url1);
 
       // then
@@ -119,7 +119,7 @@ describe('Unit | Domain | Models | Challenge', () => {
       // given
       const web5 = new Skill({ name: '@web5' });
       const url1 = new Skill({ name: '@url1' });
-      const challenge = Challenge.fromAttributes();
+      const challenge = new Challenge();
       challenge.addSkill(url1);
       challenge.addSkill(web5);
 

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -23,7 +23,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
       it('should reject with a assessment not completed error', async () => {
         // given
         const userId = 'userId';
-        const assessment = Assessment.fromAttributes({ state: 'started', userId });
+        const assessment = new Assessment({ state: 'started', userId });
         const answer = new Answer({ assessmentId: 1, challengeId: 12 });
         assessmentRepository.get.resolves(assessment);
         answerRepository.get.resolves(answer);
@@ -51,7 +51,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
         const assessmentId = 1;
         const challengeId = 12;
         const userId = 'userId';
-        const assessment = Assessment.fromAttributes({ state: 'started', type: Assessment.types.SMARTPLACEMENT, userId });
+        const assessment = new Assessment({ state: 'started', type: Assessment.types.SMARTPLACEMENT, userId });
         const answer = new Answer({ assessmentId, challengeId });
         const correction = new Correction({ id: 123 });
         assessmentRepository.get.resolves(assessment);
@@ -81,7 +81,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
         const assessmentId = 1;
         const challengeId = 12;
         const userId = 'userId';
-        const assessment = Assessment.fromAttributes({ state: 'started', type: Assessment.types.COMPETENCE_EVALUATION, userId });
+        const assessment = new Assessment({ state: 'started', type: Assessment.types.COMPETENCE_EVALUATION, userId });
         const answer = new Answer({ assessmentId, challengeId });
         const correction = new Correction({ id: 123 });
         assessmentRepository.get.resolves(assessment);
@@ -113,7 +113,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
       const assessmentId = 1;
       const challengeId = 12;
       const userId = 'userId';
-      const assessment = Assessment.fromAttributes({ state: 'completed', userId });
+      const assessment = new Assessment({ state: 'completed', userId });
       const answer = new Answer({ assessmentId, challengeId });
       const correction = new Correction({ id: 123 });
       assessmentRepository.get.resolves(assessment);
@@ -144,7 +144,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
       const assessmentId = 1;
       const challengeId = 12;
       const userId = 'userId';
-      const assessment = Assessment.fromAttributes({ state: 'completed', userId });
+      const assessment = new Assessment({ state: 'completed', userId });
       const answer = new Answer({ assessmentId, challengeId });
       assessmentRepository.get.resolves(assessment);
       answerRepository.get.resolves(answer);
@@ -171,7 +171,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
       const assessmentId = 1;
       const challengeId = 12;
       const userId = 'userId';
-      const assessment = Assessment.fromAttributes({ state: 'completed', userId });
+      const assessment = new Assessment({ state: 'completed', userId });
       const answer = new Answer({ assessmentId, challengeId });
       assessmentRepository.get.resolves(assessment);
       answerRepository.get.resolves(answer);

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon } = require('../../../test-helper');
 
 const getNextChallengeForCertification = require('../../../../lib/domain/usecases/get-next-challenge-for-certification');
-const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 
@@ -17,41 +16,37 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       challengeRepository = { get: sinon.stub().resolves() };
     });
 
-    it('should use the assessmentService to select the next CertificationChallenge', () => {
+    it('should use the assessmentService to select the next CertificationChallenge', async () => {
       // given
-      const nextChallenge = CertificationChallenge.fromAttributes({ skills : [] });
+      const nextChallenge = Symbol('nextChallenge');
       const assessment = Assessment.fromAttributes({ id: 156, certificationCourseId: 54516 });
 
       certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextChallenge);
 
       // when
-      const promise = getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
+      await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      return promise.then(() => {
-        expect(certificationChallengeRepository.getNonAnsweredChallengeByCourseId).to.have.been.calledWith(156, 54516);
-      });
+      expect(certificationChallengeRepository.getNonAnsweredChallengeByCourseId).to.have.been.calledWith(156, 54516);
     });
 
-    it('should return the next Challenge', () => {
+    it('should return the next Challenge', async () => {
       // given
       const challengeId = 15167432;
       const nextChallengeToAnswer = Challenge.fromAttributes({ challengeId, skills : [] });
-      const nextCertificationChallenge = CertificationChallenge.fromAttributes({ challengeId, skills : [] });
+      const nextCertificationChallenge = { challengeId };
       const assessment = Assessment.fromAttributes({ id: 156, courseId: 54516 });
 
       certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
       challengeRepository.get.resolves(nextChallengeToAnswer);
 
       // when
-      const promise = getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
+      const challenge = await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      return promise.then((challenge) => {
-        expect(challenge).to.be.an.instanceOf(Challenge);
-        expect(challenge).to.equal(nextChallengeToAnswer);
-        expect(challengeRepository.get).to.have.been.calledWith(challengeId);
-      });
+      expect(challenge).to.be.an.instanceOf(Challenge);
+      expect(challenge).to.equal(nextChallengeToAnswer);
+      expect(challengeRepository.get).to.have.been.calledWith(challengeId);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
     it('should use the assessmentService to select the next CertificationChallenge', async () => {
       // given
       const nextChallenge = Symbol('nextChallenge');
-      const assessment = Assessment.fromAttributes({ id: 156, certificationCourseId: 54516 });
+      const assessment = new Assessment({ id: 156, certificationCourseId: 54516 });
 
       certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextChallenge);
 
@@ -34,7 +34,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const challengeId = 15167432;
       const nextChallengeToAnswer = Symbol('nextChallengeToAnswer');
       const nextCertificationChallenge = { challengeId };
-      const assessment = Assessment.fromAttributes({ id: 156, courseId: 54516 });
+      const assessment = new Assessment({ id: 156, courseId: 54516 });
 
       certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
       challengeRepository.get.resolves(nextChallengeToAnswer);

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -2,7 +2,6 @@ const { expect, sinon } = require('../../../test-helper');
 
 const getNextChallengeForCertification = require('../../../../lib/domain/usecases/get-next-challenge-for-certification');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const Challenge = require('../../../../lib/domain/models/Challenge');
 
 describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', () => {
 
@@ -33,7 +32,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
     it('should return the next Challenge', async () => {
       // given
       const challengeId = 15167432;
-      const nextChallengeToAnswer = Challenge.fromAttributes({ challengeId, skills : [] });
+      const nextChallengeToAnswer = Symbol('nextChallengeToAnswer');
       const nextCertificationChallenge = { challengeId };
       const assessment = Assessment.fromAttributes({ id: 156, courseId: 54516 });
 
@@ -44,7 +43,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const challenge = await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      expect(challenge).to.be.an.instanceOf(Challenge);
       expect(challenge).to.equal(nextChallengeToAnswer);
       expect(challengeRepository.get).to.have.been.calledWith(challengeId);
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -9,7 +9,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
 
     it('should convert a Certification Course model object into JSON API data', function() {
       // given
-      const assessment = Assessment.fromAttributes({
+      const assessment = new Assessment({
         'id': 'assessment_id',
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -60,7 +60,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
 
       it('should be the the first associated to the challenge when it exists', () => {
         // given
-        const challenge = Challenge.fromAttributes();
+        const challenge = new Challenge();
         challenge.id = 1;
         challenge.competenceId = 'competence_id';
 
@@ -81,7 +81,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function() {
 
       it('should be null when no competence is associated to the challenge (ex: DEMO course)', () => {
         // given
-        const challenge = Challenge.fromAttributes();
+        const challenge = new Challenge();
         challenge.id = 1;
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
On supprime ces méthodes taggées dépréciées depuis déjà trop de temps.

## :robot: Solution
Dans 99% des cas, ces méthodes dépréciées étaient utilisées dans les tests. On remplace le constructeur. Pareil pour le seul cas encore utilisé dans le code de production, à savoir dans le déserialiseur d'_Assessment_.
Le seul controller dans lequel on déserialise un assessment c'est dans le cas d'une Démo, c'est donc le test fonctionnel de non-régression à réaliser ici.

## :rainbow: Remarques
