### PR TITLE
[BUGFIX]  Publication des certif par session KO dans Pix Admin (pa-184)

### DIFF
--- a/admin/app/components/certification-list-checkbox.js
+++ b/admin/app/components/certification-list-checkbox.js
@@ -1,9 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  actions: {
-    onClick(index, record) {
-      this.clickOnRow(index, record);
-    }
-  }
-});

--- a/admin/app/components/certification-list.js
+++ b/admin/app/components/certification-list.js
@@ -4,12 +4,6 @@ export default class CertificationList extends Component {
 
   columns = [
     {
-      component: 'certification-list-checkbox',
-      useFilter: false,
-      mayBeHidden: false,
-      componentForSortCell: 'certification-list-select-all'
-    },
-    {
       propertyName: 'id',
       title: 'Id',
       routeName: 'authenticated.certifications.single.info',

--- a/admin/app/controllers/authenticated/certifications/sessions/info/list.js
+++ b/admin/app/controllers/authenticated/certifications/sessions/info/list.js
@@ -13,9 +13,9 @@ export default class ListController extends Controller {
   @service sessionInfoService;
   @service notifications;
 
-  displayConfirm = false;
+  @tracked displayConfirm = false;
   @tracked displaySessionReport = false;
-  confirmMessage = null;
+  @tracked confirmMessage = null;
   @tracked certificationsInSessionReport = [];
 
   @computed('model.certifications.@each.status')
@@ -153,6 +153,7 @@ export default class ListController extends Controller {
     try {
       await this.model.save({ adapterOptions: { updatePublishedCertifications: true, toPublish } });
       this.model.certifications.reload();
+      this.model.isPublished = toPublish;
       this.notifications.success(successText);
     } catch (error) {
       this.notifications.error(error);

--- a/admin/app/controllers/authenticated/certifications/single/info.js
+++ b/admin/app/controllers/authenticated/certifications/single/info.js
@@ -158,28 +158,6 @@ export default class InfoController extends Controller {
   }
 
   @action
-  onTogglePublish() {
-    this.set('displayConfirm', false);
-    const certification = this.certification;
-    const currentPublishState = certification.get('isPublished');
-    let operation;
-    if (currentPublishState) {
-      certification.set('isPublished', false);
-      operation = 'dépubliée';
-    } else {
-      certification.set('isPublished', true);
-      operation = 'publiée';
-    }
-    return certification.save({ adapterOptions: { updateMarks: false } })
-      .then(() => {
-        this.notifications.success('Certification ' + operation);
-      })
-      .catch((e) => {
-        this.notifications.error(e);
-      });
-  }
-
-  @action
   onCheckMarks() {
     const markStore = this._markStore;
     if (markStore.hasState()) {

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -64,12 +64,12 @@ export default class Session extends Model {
     return _getNumberOf(this.certifications, (certif) => !certif.hasSeenEndTestScreen);
   }
 
-  @computed('certifications.[]')
+  @computed('certifications.@each.status')
   get countNonValidatedCertifications() {
     return _getNumberOf(this.certifications, (certif) => certif.status !== 'validated');
   }
 
-  @computed('certifications.[]')
+  @computed('certifications.@each.isPublished')
   get countPublishedCertifications() {
     return _getNumberOf(this.certifications, (certif) => certif.isPublished);
   }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -45,7 +45,7 @@ export default class Session extends Model {
     return this.examinerGlobalComment && this.examinerGlobalComment.trim().length > 0;
   }
 
-  @computed('certifications.[]')
+  @computed('certifications.@each.isPublished')
   get isPublished() {
     return _.some(
       this.certifications.toArray(),

--- a/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
+++ b/admin/app/templates/authenticated/certifications/sessions/info/list.hbs
@@ -32,7 +32,7 @@
         {{else}}
           <button class="btn btn-primary certification-list-page--button__disabled" type="button">
             Publier la session
-            {{#bs-tooltip}}Vous ne pouvez pas publier la session tant qu'il reste des certifications en "error" ou "started".{{/bs-tooltip}}
+            <BsTooltip>Vous ne pouvez pas publier la session tant qu'il reste des certifications en "error" ou "started".</BsTooltip>
           </button>
         {{/if}}
 

--- a/admin/app/templates/authenticated/certifications/single/info.hbs
+++ b/admin/app/templates/authenticated/certifications/single/info.hbs
@@ -71,13 +71,6 @@
           <BsButton @class="single-certification-edit__button" @type="primary" @size="sm" @onClick={{action "onEdit"}}>
             Modifier
           </BsButton>
-          <BsButton @class="single-certification-edit__button" @type="primary" @size="sm" @onClick={{action "onTogglePublishConfirm"}}>
-            {{#if certification.isPublished}}
-              Dépublier
-            {{else}}
-              Publier
-            {{/if}}
-          </BsButton>
         {{/if}}
       </div>
     </div>

--- a/admin/app/templates/components/certification-list-checkbox.hbs
+++ b/admin/app/templates/components/certification-list-checkbox.hbs
@@ -1,1 +1,0 @@
-{{input type='checkbox' checked=isSelected}}

--- a/admin/app/templates/components/certification-list-select-all.hbs
+++ b/admin/app/templates/components/certification-list-select-all.hbs
@@ -1,3 +1,0 @@
-<Input @type="checkbox"
-       @checked={{if (is-equal selectedItems.length data.length) true false}}
-       @click={{action "onToggleAllSelection"}} />

--- a/admin/tests/unit/controllers/authenticated/certifications/sessions/info/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/sessions/info/list-test.js
@@ -44,7 +44,7 @@ module('Unit | Controller | authenticated/certifications/sessions/info/list', fu
       assert.equal(result, false);
     });
 
-    test('should be true when there is no certification in error orstarted', async function(assert) {
+    test('should be true when there is no certification in error or started', async function(assert) {
       // given
       controller.set('model', model);
       controller.model.certifications = [{ status: 'rejected' }, { status: 'validated' }];
@@ -69,16 +69,16 @@ module('Unit | Controller | authenticated/certifications/sessions/info/list', fu
         // given
         model.canPublish = true;
         model.isPublished = false;
-  
+
         // when
         await controller.actions.displayCertificationStatusUpdateConfirmationModal.call(controller);
-  
+
         // then
         assert.equal(controller.confirmMessage, 'Souhaitez-vous publier la session ?');
         assert.equal(controller.displayConfirm, true);
       });
     });
-    
+
     module('when session is published', function() {
 
       test('should update modal message to unpublish', async function(assert) {
@@ -122,32 +122,32 @@ module('Unit | Controller | authenticated/certifications/sessions/info/list', fu
       sinon.assert.called(notificationsStub.error);
       assert.equal(controller.displayConfirm, false);
     });
-    
-    module('when session is not yet published', function() {
+
+    module.only('when session is not yet published', function() {
 
       test('shoud publish all certifications', async function(assert) {
         // given
         controller.model.isPublished = false;
-  
+
         // when
         await controller.actions.toggleSessionPublication.call(controller);
-  
+
         // then
         sinon.assert.calledWith(controller.model.save, { adapterOptions: { updatePublishedCertifications: true, toPublish: true } });
         sinon.assert.calledWith(notificationsStub.success, 'Les certifications ont été correctement publiées.');
         assert.equal(controller.displayConfirm, false);
       });
     });
-    
+
     module('when session is published', function() {
 
       test('should unpublish all certifications', async function(assert) {
         // given
         model.isPublished = true;
-  
+
         // when
         await controller.actions.toggleSessionPublication.call(controller);
-  
+
         // then
         sinon.assert.calledWith(model.save, { adapterOptions: { updatePublishedCertifications: true, toPublish: false } });
         sinon.assert.calledWith(notificationsStub.success, 'Les certifications ont été correctement dépubliées.');


### PR DESCRIPTION
🦄 Problème

La migration de PIX admin sous Octane a écrasé quelques fonctionalités de la [PR](https://github.com/1024pix/pix/pull/1141/). La colonne permettant de sélectionner une ou plusieurs certifs d’une session est apparue à nouveau, et le bouton “Publier” ne fonctionne plus

🤖 Solution

Réparer la publication des certif par session en verifiant l'historique des fichiers

🌈 Remarques

La pagination n'est pas alignée. Ca peut-être fait en BSR si besoin
