### PR TITLE
[FEATURE] Ajouter un bouton de documentation qui pointe vers un lien différent en fonction du type de centre de certification (PC-136)

### DIFF
--- a/api/db/seeds/data/certification/certification-center-memberships-builder.js
+++ b/api/db/seeds/data/certification/certification-center-memberships-builder.js
@@ -1,6 +1,19 @@
-const { CERTIF_CENTER_ID } = require('./certification-centers-builder');
-const { PIX_CERTIF_USER_ID } = require('./users');
+const {
+  SCO_CERTIF_CENTER_ID,
+  PRO_CERTIF_CENTER_ID,
+  SUP_CERTIF_CENTER_ID,
+  NONE_CERTIF_CENTER_ID,
+} = require('./certification-centers-builder');
+const {
+  PIX_SCO_CERTIF_USER_ID,
+  PIX_PRO_CERTIF_USER_ID,
+  PIX_SUP_CERTIF_USER_ID,
+  PIX_NONE_CERTIF_USER_ID,
+} = require('./users');
 
 module.exports = function certificationCenterMembershipsBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_CERTIF_USER_ID, certificationCenterId: CERTIF_CENTER_ID });
+  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_SCO_CERTIF_USER_ID, certificationCenterId: SCO_CERTIF_CENTER_ID });
+  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_PRO_CERTIF_USER_ID, certificationCenterId: PRO_CERTIF_CENTER_ID });
+  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_SUP_CERTIF_USER_ID, certificationCenterId: SUP_CERTIF_CENTER_ID });
+  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_NONE_CERTIF_USER_ID, certificationCenterId: NONE_CERTIF_CENTER_ID });
 };

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -1,13 +1,38 @@
 const faker = require('faker');
 
-const CERTIF_CENTER_ID = 1;
-const CERTIF_CENTER_NAME = 'Centre des Anne-Étoiles';
+const SCO_CERTIF_CENTER_ID = 1;
+const SCO_CERTIF_CENTER_NAME = 'Centre SCO des Anne-Étoiles';
+const PRO_CERTIF_CENTER_ID = 2;
+const PRO_CERTIF_CENTER_NAME = 'Centre PRO des Anne-Étoiles';
+const SUP_CERTIF_CENTER_ID = 3;
+const SUP_CERTIF_CENTER_NAME = 'Centre SUP des Anne-Étoiles';
+const NONE_CERTIF_CENTER_ID = 4;
+const NONE_CERTIF_CENTER_NAME = 'Centre NOTYPE des Anne-Étoiles';
 
 function certificationCentersBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildCertificationCenter({
-    id: CERTIF_CENTER_ID,
-    name: CERTIF_CENTER_NAME,
+    id: SCO_CERTIF_CENTER_ID,
+    name: SCO_CERTIF_CENTER_NAME,
+    type: 'SCO',
+  });
+
+  databaseBuilder.factory.buildCertificationCenter({
+    id: PRO_CERTIF_CENTER_ID,
+    name: PRO_CERTIF_CENTER_NAME,
+    type: 'PRO',
+  });
+
+  databaseBuilder.factory.buildCertificationCenter({
+    id: SUP_CERTIF_CENTER_ID,
+    name: SUP_CERTIF_CENTER_NAME,
+    type: 'SUP',
+  });
+
+  databaseBuilder.factory.buildCertificationCenter({
+    id: NONE_CERTIF_CENTER_ID,
+    name: NONE_CERTIF_CENTER_NAME,
+    type: null,
   });
 
   for (let i = 0; i < 200; i++) {
@@ -20,6 +45,12 @@ function certificationCentersBuilder({ databaseBuilder }) {
 
 module.exports = {
   certificationCentersBuilder,
-  CERTIF_CENTER_ID,
-  CERTIF_CENTER_NAME,
+  SCO_CERTIF_CENTER_ID,
+  SCO_CERTIF_CENTER_NAME,
+  PRO_CERTIF_CENTER_ID,
+  PRO_CERTIF_CENTER_NAME,
+  SUP_CERTIF_CENTER_ID,
+  SUP_CERTIF_CENTER_NAME,
+  NONE_CERTIF_CENTER_ID,
+  NONE_CERTIF_CENTER_NAME,
 };

--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -1,4 +1,4 @@
-const { CERTIF_CENTER_ID, CERTIF_CENTER_NAME } = require('./certification-centers-builder');
+const { SCO_CERTIF_CENTER_ID, SCO_CERTIF_CENTER_NAME } = require('./certification-centers-builder');
 const { statuses } = require('../../../../lib/domain/models/Session');
 const EMPTY_SESSION_ID = 1;
 const STARTED_SESSION_ID = 2;
@@ -8,8 +8,8 @@ const NO_PROBLEM_FINALIZED_SESSION_ID = 5;
 const PROBLEMS_FINALIZED_SESSION_ID = 6;
 
 function certificationSessionsBuilder({ databaseBuilder }) {
-  const certificationCenter = CERTIF_CENTER_NAME;
-  const certificationCenterId = CERTIF_CENTER_ID;
+  const certificationCenter = SCO_CERTIF_CENTER_NAME;
+  const certificationCenterId = SCO_CERTIF_CENTER_ID;
   const address = 'Anne-Star Street';
   const room = 'Salle Anne';
   const examiner = 'Anne-Quelquechose';

--- a/api/db/seeds/data/certification/users.js
+++ b/api/db/seeds/data/certification/users.js
@@ -1,19 +1,49 @@
-const PIX_CERTIF_USER_ID = 100;
-const CERTIF_SUCCESS_USER_ID = 101;
-const CERTIF_FAILURE_USER_ID = 102;
-const CERTIF_REGULAR_USER1_ID = 103;
-const CERTIF_REGULAR_USER2_ID = 104;
-const CERTIF_REGULAR_USER3_ID = 105;
-const CERTIF_REGULAR_USER4_ID = 106;
-const CERTIF_REGULAR_USER5_ID = 107;
+const PIX_SCO_CERTIF_USER_ID = 100;
+const PIX_PRO_CERTIF_USER_ID = 101;
+const PIX_SUP_CERTIF_USER_ID = 102;
+const PIX_NONE_CERTIF_USER_ID = 103;
+const CERTIF_SUCCESS_USER_ID = 104;
+const CERTIF_FAILURE_USER_ID = 105;
+const CERTIF_REGULAR_USER1_ID = 106;
+const CERTIF_REGULAR_USER2_ID = 107;
+const CERTIF_REGULAR_USER3_ID = 108;
+const CERTIF_REGULAR_USER4_ID = 109;
+const CERTIF_REGULAR_USER5_ID = 110;
 
 function certificationUsersBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildUser.withUnencryptedPassword({
-    id: PIX_CERTIF_USER_ID,
-    firstName: 'Chef',
+    id: PIX_SCO_CERTIF_USER_ID,
+    firstName: 'SCO',
     lastName: 'Certification',
-    email: 'certif@example.net',
+    email: 'certifsco@example.net',
+    rawPassword: 'pix123',
+    cgu: true,
+  });
+
+  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    id: PIX_PRO_CERTIF_USER_ID,
+    firstName: 'PRO',
+    lastName: 'Certification',
+    email: 'certifpro@example.net',
+    rawPassword: 'pix123',
+    cgu: true,
+  });
+
+  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    id: PIX_SUP_CERTIF_USER_ID,
+    firstName: 'SUP',
+    lastName: 'Certification',
+    email: 'certifsup@example.net',
+    rawPassword: 'pix123',
+    cgu: true,
+  });
+
+  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    id: PIX_NONE_CERTIF_USER_ID,
+    firstName: 'NONE',
+    lastName: 'Certification',
+    email: 'certifnone@example.net',
     rawPassword: 'pix123',
     cgu: true,
   });
@@ -84,7 +114,10 @@ function certificationUsersBuilder({ databaseBuilder }) {
 
 module.exports = {
   certificationUsersBuilder,
-  PIX_CERTIF_USER_ID,
+  PIX_SCO_CERTIF_USER_ID,
+  PIX_PRO_CERTIF_USER_ID,
+  PIX_SUP_CERTIF_USER_ID,
+  PIX_NONE_CERTIF_USER_ID,
   CERTIF_SUCCESS_USER_ID,
   CERTIF_FAILURE_USER_ID,
   CERTIF_REGULAR_USER1_ID,

--- a/api/lib/domain/usecases/create-certification-center-membership.js
+++ b/api/lib/domain/usecases/create-certification-center-membership.js
@@ -1,3 +1,3 @@
 module.exports = function createCertificationCenterMembership({ userId, certificationCenterId, certificationCenterMembershipRepository }) {
-  return certificationCenterMembershipRepository.create(userId, certificationCenterId);
+  return certificationCenterMembershipRepository.save(userId, certificationCenterId);
 };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -17,7 +17,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObjects(BookshelfCertificationCenterMembership, certificationCenterMemberships);
   },
 
-  async create(userId, certificationCenterId) {
+  async save(userId, certificationCenterId) {
     try {
       const newCertificationCenterMembership = await new BookshelfCertificationCenterMembership({ userId, certificationCenterId })
         .save();

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -1,46 +1,36 @@
-const BookshelfCertificationCenterMembership = require('../data/certification-center-membership');
-const { CertificationCenterMembershipCreationError, AlreadyExistingMembershipError } = require('../../domain/errors');
-const { BaseHttpError } = require('../../application/http-errors');
-const CertificationCenterMembership = require('../../domain/models/CertificationCenterMembership');
-const CertificationCenter = require('../../domain/models/CertificationCenter');
 const bookshelfUtils = require('../utils/bookshelf-utils');
-
-function _toDomain(certificationCenterMembershipBookshelf) {
-  return new CertificationCenterMembership({
-    id: certificationCenterMembershipBookshelf.get('id'),
-    certificationCenter: new CertificationCenter({
-      id: certificationCenterMembershipBookshelf.related('certificationCenter').get('id'),
-      name: certificationCenterMembershipBookshelf.related('certificationCenter').get('name'),
-    })
-  });
-}
+const BookshelfCertificationCenterMembership = require('../data/certification-center-membership');
+const bookshelfToDomainConverter = require('../../infrastructure/utils/bookshelf-to-domain-converter');
+const { CertificationCenterMembershipCreationError, AlreadyExistingMembershipError } = require('../../domain/errors');
 
 module.exports = {
 
-  findByUserId(userId) {
-    return BookshelfCertificationCenterMembership
+  async findByUserId(userId) {
+    const certificationCenterMemberships = await BookshelfCertificationCenterMembership
       .where({ userId: userId })
       .fetchAll({
         withRelated: [
           'certificationCenter',
         ]
-      })
-      .then((certificationCenterMemberships) => certificationCenterMemberships.map(_toDomain));
+      });
+
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfCertificationCenterMembership, certificationCenterMemberships);
   },
 
-  create(userId, certificationCenterId) {
-    return new BookshelfCertificationCenterMembership({ userId, certificationCenterId })
-      .save()
-      .then(_toDomain)
-      .catch((err) => {
-        if (bookshelfUtils.isUniqConstraintViolated(err)) {
-          throw new AlreadyExistingMembershipError(`User is already member of certification center ${certificationCenterId}`);
-        }
-        if (bookshelfUtils.foreignKeyConstraintViolated(err)) {
-          throw new CertificationCenterMembershipCreationError();
-        }
-        throw new BaseHttpError(err);
-      });
+  async create(userId, certificationCenterId) {
+    try {
+      const newCertificationCenterMembership = await new BookshelfCertificationCenterMembership({ userId, certificationCenterId })
+        .save();
+      return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationCenterMembership, newCertificationCenterMembership);
+    } catch (err) {
+      if (bookshelfUtils.isUniqConstraintViolated(err)) {
+        throw new AlreadyExistingMembershipError(`User is already member of certification center ${certificationCenterId}`);
+      }
+      if (bookshelfUtils.foreignKeyConstraintViolated(err)) {
+        throw new CertificationCenterMembershipCreationError();
+      }
+      throw err;
+    }
   },
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -12,7 +12,7 @@ module.exports = {
       certificationCenter: {
         ref: 'id',
         included: true,
-        attributes: ['name', 'sessions'],
+        attributes: ['name', 'type', 'sessions'],
         sessions: {
           ref: 'id',
           ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
@@ -82,7 +82,8 @@ describe('Acceptance | Controller | users-controller-get-certification-center-me
               type: 'certificationCenters',
               id: certificationCenter.id.toString(),
               attributes: {
-                name: 'certifCenter',
+                name: certificationCenter.name,
+                type: certificationCenter.type,
               },
               relationships: {
                 sessions: {

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -1,17 +1,19 @@
-const { expect, knex, databaseBuilder } = require('../../../test-helper');
+const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
 const BookshelfCertificationCenterMembership = require('../../../../lib/infrastructure/data/certification-center-membership');
 const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
 const CertificationCenter = require('../../../../lib/domain/models/CertificationCenter');
+const { AlreadyExistingMembershipError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | Certification Center Membership', () => {
 
-  describe('#create', () => {
+  describe('#save', () => {
     let userId, certificationCenterId;
-    beforeEach(async () => {
+
+    beforeEach(() => {
       userId = databaseBuilder.factory.buildUser({}).id;
       certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
     afterEach(() => {
@@ -23,7 +25,7 @@ describe('Integration | Repository | Certification Center Membership', () => {
       const countCertificationCenterMembershipsBeforeCreate = await BookshelfCertificationCenterMembership.count();
 
       // when
-      await certificationCenterMembershipRepository.create(userId, certificationCenterId);
+      await certificationCenterMembershipRepository.save(userId, certificationCenterId);
 
       // then
       const countCertificationCenterMembershipsAfterCreate = await BookshelfCertificationCenterMembership.count();
@@ -32,7 +34,7 @@ describe('Integration | Repository | Certification Center Membership', () => {
 
     it('should return the certification center membership', async () => {
       // when
-      const createdCertificationCenterMembership = await certificationCenterMembershipRepository.create(userId, certificationCenterId);
+      const createdCertificationCenterMembership = await certificationCenterMembershipRepository.save(userId, certificationCenterId);
 
       // then
       expect(createdCertificationCenterMembership).to.be.an.instanceOf(CertificationCenterMembership);
@@ -40,18 +42,17 @@ describe('Integration | Repository | Certification Center Membership', () => {
 
     context('Error cases', () => {
 
-      beforeEach(async () => {
-        // given
+      beforeEach(() => {
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-        await databaseBuilder.commit();
+        return databaseBuilder.commit();
       });
 
-      it('should throw an error when a membership already exist for user + certificationCenter', () => {
+      it('should throw an error when a membership already exist for user + certificationCenter', async () => {
         // when
-        const promise = certificationCenterMembershipRepository.create(userId, certificationCenterId);
+        const error = await catchErr(certificationCenterMembershipRepository.save)(userId, certificationCenterId);
 
         // then
-        return expect(promise).to.have.been.rejectedWith(Error);
+        expect(error).to.be.instanceOf(AlreadyExistingMembershipError);
       });
 
     });
@@ -61,7 +62,8 @@ describe('Integration | Repository | Certification Center Membership', () => {
   describe('#findByUserId', () => {
 
     let userAsked, expectedCertificationCenter, expectedCertificationCenterMembership;
-    beforeEach(async () => {
+
+    beforeEach(() => {
       userAsked = databaseBuilder.factory.buildUser();
       const otherUser = databaseBuilder.factory.buildUser();
       expectedCertificationCenter = databaseBuilder.factory.buildCertificationCenter();
@@ -74,26 +76,24 @@ describe('Integration | Repository | Certification Center Membership', () => {
         userId: otherUser.id,
         certificationCenterId: otherCertificationCenter.id
       });
-      await databaseBuilder.commit();
+      return databaseBuilder.commit();
     });
 
-    it('should return certification center membership associated to the user', () => {
+    it('should return certification center membership associated to the user', async () => {
       // when
-      const promise = certificationCenterMembershipRepository.findByUserId(userAsked.id);
+      const certificationCenterMemberships = await certificationCenterMembershipRepository.findByUserId(userAsked.id);
 
       // then
-      return promise.then((certificationCenterMemberships) => {
-        expect(certificationCenterMemberships).to.be.an('array');
+      expect(certificationCenterMemberships).to.be.an('array');
 
-        const certificationCenterMembership = certificationCenterMemberships[0];
-        expect(certificationCenterMembership).to.be.an.instanceof(CertificationCenterMembership);
-        expect(certificationCenterMembership.id).to.equal(expectedCertificationCenterMembership.id);
+      const certificationCenterMembership = certificationCenterMemberships[0];
+      expect(certificationCenterMembership).to.be.an.instanceof(CertificationCenterMembership);
+      expect(certificationCenterMembership.id).to.equal(expectedCertificationCenterMembership.id);
 
-        const associatedCertificationCenter = certificationCenterMembership.certificationCenter;
-        expect(associatedCertificationCenter).to.be.an.instanceof(CertificationCenter);
-        expect(associatedCertificationCenter.id).to.equal(expectedCertificationCenter.id);
-        expect(associatedCertificationCenter.name).to.equal(expectedCertificationCenter.name);
-      });
+      const associatedCertificationCenter = certificationCenterMembership.certificationCenter;
+      expect(associatedCertificationCenter).to.be.an.instanceof(CertificationCenter);
+      expect(associatedCertificationCenter.id).to.equal(expectedCertificationCenter.id);
+      expect(associatedCertificationCenter.name).to.equal(expectedCertificationCenter.name);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -36,7 +36,6 @@ describe('Integration | Repository | Certification Center Membership', () => {
 
       // then
       expect(createdCertificationCenterMembership).to.be.an.instanceOf(CertificationCenterMembership);
-      expect(createdCertificationCenterMembership.certificationCenter).to.be.an.instanceOf(CertificationCenter);
     });
 
     context('Error cases', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -1,7 +1,5 @@
-const { expect } = require('../../../../test-helper');
+const { expect, domainBuilder } = require('../../../../test-helper');
 const certificationCenterMembershipSerializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
-const CertificationCenterMembership = require('../../../../../lib/domain/models/CertificationCenterMembership');
-const CertificationCenter = require('../../../../../lib/domain/models/CertificationCenter');
 
 describe('Unit | Serializer | JSONAPI | certification-center-membership-serializer', function() {
 
@@ -9,22 +7,18 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
 
     it('should convert a Certification Center Membership model object into JSON API data', function() {
       // given
-      const certificationCenter = new CertificationCenter({ id: 1, name: 'certifCenter' });
-
-      const certificationCenterMembership = new CertificationCenterMembership({
-        id: 1,
-        certificationCenter,
-      });
+      const certificationCenter = domainBuilder.buildCertificationCenter();
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({ certificationCenter });
 
       const expectedSerializedCertificationCenter = {
         data: [
           {
             attributes: {},
-            id: '1',
+            id: certificationCenterMembership.id.toString(),
             relationships: {
               'certification-center': {
                 data: {
-                  id: '1',
+                  id: certificationCenter.id.toString(),
                   type: 'certificationCenters',
                 }
               }
@@ -35,13 +29,14 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
         included: [
           {
             attributes: {
-              name: 'certifCenter'
+              name: certificationCenter.name,
+              type: certificationCenter.type,
             },
-            id: '1',
+            id: certificationCenter.id.toString(),
             relationships: {
               sessions: {
                 links: {
-                  related: '/api/certification-centers/1/sessions'
+                  related: `/api/certification-centers/${certificationCenter.id}/sessions`,
                 }
               }
             },

--- a/certif/app/authenticators/oauth2.js
+++ b/certif/app/authenticators/oauth2.js
@@ -4,4 +4,5 @@ import ENV from 'pix-certif/config/environment';
 export default class OAuth2Authenticator extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
+  sendClientIdAsQueryParam = true;
 }

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+
+const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
+const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
+
+export default class AuthenticatedController extends Controller {
+  get documentationLink() {
+    if (this.model.isSco) {
+      return LINK_SCO;
+    }
+    return LINK_OTHER;
+  }
+}

--- a/certif/app/models/certification-center.js
+++ b/certif/app/models/certification-center.js
@@ -4,5 +4,6 @@ const { Model, attr, hasMany } = DS;
 
 export default class CertificationCenter extends Model {
   @attr('string') name;
+  @attr('string') type;
   @hasMany('session') sessions;
 }

--- a/certif/app/models/certification-center.js
+++ b/certif/app/models/certification-center.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { equal } from '@ember/object/computed';
 
 const { Model, attr, hasMany } = DS;
 
@@ -6,4 +7,6 @@ export default class CertificationCenter extends Model {
   @attr('string') name;
   @attr('string') type;
   @hasMany('session') sessions;
+
+  @equal('type', 'SCO') isSco;
 }

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -1,9 +1,12 @@
-import Service, { inject as service } from '@ember/service';
 import _ from 'lodash';
+import Service, { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class CurrentUserService extends Service {
   @service session;
   @service store;
+  @tracked user;
+  @tracked certificationCenter;
 
   async load() {
     if (this.session.isAuthenticated) {

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -20,44 +20,72 @@
   background: white;
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.1);
 
-  &--padding-left {
+  &__logo {
     padding-left: 25px;
+    padding-top: 20px;
   }
 
-  &--padding-right {
-    padding-right: 15px;
-  }
-}
-
-.logo {
-  padding-top: 20px;
-
-  &__image {
+  &__logo-image {
     height: 60px;
   }
-}
 
-.sidebar__certification-center {
-  margin-top: 20px;
-}
+  &__certification-center {
+    margin-top: 20px;
+    padding-left: 25px;
+    padding-right: 15px;
+  }
 
-.certification-center {
-  padding-top: 15px;
+  &__certification-center-label {
+    color: $grey-45;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+  }
 
-  &__name {
+  &__certification-center-name {
+    color: $grey-45;
+    font-size: 0.8125rem;
     padding-top: 8px;
+  }
+
+  &__documentation {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
   }
 }
 
-.certification-center-label {
-  color: $grey-45;
-  font-size: 0.8125rem;
-  text-transform: uppercase;
-}
+.sidebar-documentation {
 
-.certification-center-name {
-  color: $grey-45;
-  font-size: 0.8125rem;
+  &__button {
+    height: 44px;
+    color: $grey-45;
+    font-family: $roboto;
+    font-size: 0.875rem;
+    line-height: 2.75rem;
+    text-decoration: none;
+    text-align: center;
+
+    &:hover {
+      background-color: $grey-20;
+    }
+
+    &:hover .sidebar-documentation__bar {
+      width: 100%;
+    }
+  }
+
+  &__icon {
+    margin-right: 8px;
+  }
+
+  &__bar {
+    width: 157px;
+    border: 1px solid $grey-45;
+    opacity: .25;
+    margin: 0 auto;
+    transition: .5s;
+  }
 }
 
 .main-content {

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -1,19 +1,24 @@
 <div class="app">
 
   <aside class="app__sidebar sidebar">
-    <header class="sidebar__logo logo sidebar--padding-left">
-      <img class="logo__image" src="{{this.rootUrl}}/pix-certif-logo.svg" alt="PixCertif">
+    <header class="sidebar__logo">
+      <img class="sidebar__logo-image" src="{{this.rootUrl}}/pix-certif-logo.svg" alt="PixCertif">
     </header>
 
-    <div class="sidebar--padding-left sidebar--padding-right">
-      <div class="sidebar__certification-center">
-        <div class="certification-center-label">
-          Centre de certification
-        </div>
-        <div class="certification-center__name certification-center-name">
-          {{this.model.name}}
-        </div>
+    <div class="sidebar__certification-center">
+      <div class="sidebar__certification-center-label">
+                Centre de certification
       </div>
+      <div class="sidebar__certification-center-name">
+                {{this.model.name}}
+      </div>
+    </div>
+    <div class="sidebar__documentation">
+      <a class="sidebar-documentation__button" href="{{this.documentationLink}}" target="_blank" rel="noopener noreferrer">
+      <div class="sidebar-documentation__bar"></div>
+        <FaIcon @icon='book' @class="sidebar-documentation__icon"></FaIcon>
+                Documentation
+      </a>
     </div>
   </aside>
 

--- a/certif/tests/acceptance/authentication-test.js
+++ b/certif/tests/acceptance/authentication-test.js
@@ -135,7 +135,7 @@ module('Acceptance | authentication', function(hooks) {
     test('it should show the name of certification center', async function(assert) {
       await visit('/sessions/liste');
 
-      assert.dom('.certification-center-name').hasText('Centre de certification du pix');
+      assert.dom('.sidebar__certification-center-name').hasText('Centre de certification du pix');
     });
 
     test('it should redirect user to the session list on root url', async function(assert) {

--- a/certif/tests/unit/controllers/authenticated-test.js
+++ b/certif/tests/unit/controllers/authenticated-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated', function(hooks) {
+  setupTest(hooks);
+
+  module('#get documentationLink', function() {
+    test('should return a different link whether the center is SCO or not', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated');
+
+      // when
+      controller.model = { isSco: true };
+      const actualScoLink = controller.documentationLink;
+      controller.model = { isSco: false };
+      const actualOtherLink = controller.documentationLink;
+
+      // then
+      assert.notEqual(actualScoLink, actualOtherLink);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Contexte
Le pôle Certif souhaite mettre à disposition aux utilisateurs de PixCertif la documentation liée à leur exercice. La documentation est différente selon le type du centre de certification :
- 1 Doc spécifique pour les SCO
- 1 Doc pour les autres

## :robot: Solution
On ajoute le bouton dans la bande latérale à la manière de PixOrga avec un lien conditionnel en fonction du type du centre de certification.

## :rainbow: Remarques
