### PR TITLE
[BUGFIX] La touche "Entrée" n'est pas prise en compte dans les questions à réponses multiples (PF-1176).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -29,6 +29,7 @@
   height: 46px;
   @include button-background-transition();
   border-radius: 23px;
+  background-color: transparent;
   border: 1px solid $slate-grey;
   display: flex;
   align-items: center;
@@ -85,7 +86,6 @@
   &:hover{
     background: $eucalyptus;
     text-decoration: none;
-
   }
 
   &:active,
@@ -162,7 +162,7 @@
 
 .challenge-actions__action-continue-text {
   width: 76px;
-  line-height: 4.6rem;
+  padding: 0;
   font-family: $font-roboto;
   font-size: 1.6rem;
   font-weight: $font-semi-bold;

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,22 +1,22 @@
 {{#if @answer}}
   <span class="challenge-actions__already-answered">Vous avez déjà répondu à cette question</span>
-  <a class="challenge-actions__action challenge-actions__action-continue" {{action resumeAssessment @assessment}} href="#">
+  <button class="button challenge-actions__action challenge-actions__action-continue" {{action resumeAssessment @assessment}}>
     <span class="challenge-actions__action-continue-text">Poursuivre</span>
-  </a>
+  </button>
 {{else}}
   {{#if this.isValidateButtonEnabled}}
-    <a class="challenge-actions__action challenge-actions__action-validate" {{action validateAnswer}} href="#">
+    <button class="button challenge-actions__action challenge-actions__action-validate" type="submit" {{action validateAnswer}}>
       <span class="challenge-actions__action-validate-text">Je valide</span>
-    </a>
+    </button>
   {{else}}
     <div class="challenge-actions__action challenge-actions__action-validate__loader">
       <div class="challenge-actions__action-validate__loader-bar"></div>
     </div>
   {{/if}}
   {{#if this.isSkipButtonEnabled}}
-    <a class="challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}} href="#">
+    <button class="button challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}}>
       <span class="challenge-actions__action-skip-text">Je passe</span>
-    </a>
+    </button>
   {{else}}
     <div class="challenge-actions__action challenge-actions__action-skip__loader">
       <div class="challenge-actions__action-skip__loader-bar"></div>


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire le bug.
1. Aller sur une question de type QROCM, choix multiples avec plusieurs champs de saisie.
2. Remplir les champs.
3. Appuyer sur la touche "Entrée".

Résultat attendu
Les réponses à la questions sont validées.
On passe à la question suivante.

Résultat observé
Rien ne se passe : ni la validation des réponses, ni la transition vers la prochaine question.

## :robot: Solution
Les boutons des challenges ne sont pas des `buttons` sémantiquement parlant, mais des balises `a`.
Remplacer le `a` par `button` corrige le problème.
On a du également corriger le style pour conserver la même apparence que l'application actuelle.

## :rainbow: Remarques
Test à ajouter pour se prémunir d'une éventuelle régression.
Prévoir une passe sur toute l'application pour éviter ce genre de désagrément.
Cela permettra également d'améliorer l'accessibilité de l'application.