### PR TITLE
[BUGFIX] Des utilisateurs avaient un succès pour un niveau pas encore atteint (PF-1171).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -100,7 +100,7 @@ function _getSkillsFilteredByStatus(knowledgeElements, targetSkills, status) {
   return knowledgeElements
     .filter((knowledgeElement) => knowledgeElement.status === status)
     .map((knowledgeElement) => knowledgeElement.skillId)
-    .filter((skillId) => targetSkills.find((skill) => skill.id === skillId));
+    .map((skillId) => targetSkills.find((skill) => skill.id === skillId));
 }
 
 function _addLevelUpInformation({ answerSaved, correctedAnswer, assessment, knowledgeElementsFromAnswer, scorecardBeforeAnswer }) {

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -262,7 +262,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     context('and assessment is a SMART_PLACEMENT', () => {
       let firstKnowledgeElement;
       let secondKnowledgeElement;
-      let scorecard, knowledgeElement, targetProfile, skills, challenge;
+      let scorecard, knowledgeElement, targetProfile, skills, challenge, skillAlreadyValidated, skillNotAlreadyValidated;
 
       beforeEach(() => {
         // given
@@ -270,9 +270,11 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         assessment.campaignParticipation = domainBuilder.buildCampaignParticipation();
         assessmentRepository.get.resolves(assessment);
         skills = domainBuilder.buildSkillCollection({ minLevel: 1, maxLevel: 4 });
-        challenge = domainBuilder.buildChallenge({ skills: [skills[2]], id: answer.challengeId, validator });
+        skillAlreadyValidated = skills[0];
+        skillNotAlreadyValidated = skills[2];
+        challenge = domainBuilder.buildChallenge({ skills: [skillNotAlreadyValidated], id: answer.challengeId, validator });
 
-        knowledgeElement = domainBuilder.buildKnowledgeElement({ status: 'validated', skillId: skills[0].id });
+        knowledgeElement = domainBuilder.buildKnowledgeElement({ status: 'validated', skillId: skillAlreadyValidated.id });
         firstKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 2 });
         secondKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 1.8 });
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 20, exactlyEarnedPix: 20.2 });
@@ -371,7 +373,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           answer: answerCreated,
           challenge: challenge,
           previouslyFailedSkills: [],
-          previouslyValidatedSkills: [skills[0]],
+          previouslyValidatedSkills: [skillAlreadyValidated],
           targetSkills: targetProfile.skills,
           userId: assessment.userId
         };

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -262,20 +262,23 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     context('and assessment is a SMART_PLACEMENT', () => {
       let firstKnowledgeElement;
       let secondKnowledgeElement;
-      let scorecard, knowledgeElement, targetProfile;
+      let scorecard, knowledgeElement, targetProfile, skills, challenge;
 
       beforeEach(() => {
         // given
         assessment.type = Assessment.types.SMARTPLACEMENT;
         assessment.campaignParticipation = domainBuilder.buildCampaignParticipation();
         assessmentRepository.get.resolves(assessment);
+        skills = domainBuilder.buildSkillCollection({ minLevel: 1, maxLevel: 4 });
+        challenge = domainBuilder.buildChallenge({ skills: [skills[2]], id: answer.challengeId, validator });
 
+        knowledgeElement = domainBuilder.buildKnowledgeElement({ status: 'validated', skillId: skills[0].id });
         firstKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 2 });
         secondKnowledgeElement = domainBuilder.buildKnowledgeElement({ earnedPix: 1.8 });
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 20, exactlyEarnedPix: 20.2 });
-        targetProfile = domainBuilder.buildTargetProfile();
+        targetProfile = domainBuilder.buildTargetProfile({ skills });
+        challengeRepository.get.resolves(challenge);
 
-        knowledgeElement = domainBuilder.buildKnowledgeElement();
         knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([knowledgeElement]);
 
         targetProfileRepository.getByCampaignId.resolves(targetProfile);
@@ -368,7 +371,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           answer: answerCreated,
           challenge: challenge,
           previouslyFailedSkills: [],
-          previouslyValidatedSkills: [],
+          previouslyValidatedSkills: [skills[0]],
           targetSkills: targetProfile.skills,
           userId: assessment.userId
         };


### PR DESCRIPTION
## :unicorn: Problème
Les succès montraient aux utilisateurs des niveaux gagnés qu'ils n'avaient pas encore.
Exemple : un niveau gagné 3 sur une épreuve alors qu'il n'était que niveau 2.
Cause du problème : 
- Sauvegarde des KE sur les acquis déjà validé précédemment
- Au moment de calculer le nombre de Pix gagnés pour une épreuve, on regardait les KE créé, et donc on comptait les pix des acquis déjà validés précédemment
- Le total de Pix pour la compétence restait le même, car il on ignore les doublons
LA cause du problème : 
- Lors d'un précédent refacto, modification d'un `.map`par un `.filter`, qu'aucun test ne regardait. Au lieu de renvoyer l'acquis en entier, on renvoyait un tableau avec les ID d'acquis. Au moment de comparer deux acquis (celui déjà validé et celui en cours de validation), la méthode qui compare deux acquis par leur ID ne fonctionnait pas.

## :robot: Solution
- Remettre le `.map`
- Ajout d'un test pour vérifié que c'est bien l'acquis en entier que l'on reçoit.
