### PR TITLE
[CLEANUP] Retrait d'un .only oublié dans les tests PixAdmin (PA-185)

### DIFF
--- a/admin/tests/unit/controllers/authenticated/certifications/sessions/info/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/sessions/info/list-test.js
@@ -123,7 +123,7 @@ module('Unit | Controller | authenticated/certifications/sessions/info/list', fu
       assert.equal(controller.displayConfirm, false);
     });
 
-    module.only('when session is not yet published', function() {
+    module('when session is not yet published', function() {
 
       test('shoud publish all certifications', async function(assert) {
         // given


### PR DESCRIPTION
## :unicorn: Problème
module.only() dans les test auto.

## :robot: Solution
Le retirer.

## :rainbow: Remarques
