### PR TITLE
Pf xxxx add feature flag to enable locale management

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,13 +1,13 @@
 const path = require('path');
 
-function parseJSONEnv(varName) {
+function _parseJSONEnv(varName) {
   if (process.env[varName]) {
     return JSON.parse(process.env[varName]);
   }
   return undefined;
 }
 
-function isFeatureEnabled(environmentVariable) {
+function _isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
 }
 
@@ -39,13 +39,13 @@ module.exports = (function() {
     },
 
     logging: {
-      enabled: isFeatureEnabled(process.env.LOG_ENABLED),
+      enabled: _isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
       logLevel: (process.env.LOG_LEVEL || 'info'),
     },
 
     mailing: {
-      enabled: isFeatureEnabled(process.env.MAILING_ENABLED),
+      enabled: _isFeatureEnabled(process.env.MAILING_ENABLED),
       provider: process.env.MAILING_PROVIDER || 'mailjet', /* sendinblue */
       mailjet: {
         apiKey: process.env.MAILJET_API_KEY,
@@ -67,7 +67,7 @@ module.exports = (function() {
     },
 
     captcha: {
-      enabled: isFeatureEnabled(process.env.RECAPTCHA_ENABLED),
+      enabled: _isFeatureEnabled(process.env.RECAPTCHA_ENABLED),
       googleRecaptchaSecret: process.env.RECAPTCHA_KEY
     },
 
@@ -78,9 +78,9 @@ module.exports = (function() {
     },
 
     saml: {
-      spConfig: parseJSONEnv('SAML_SP_CONFIG'),
-      idpConfig: parseJSONEnv('SAML_IDP_CONFIG'),
-      attributeMapping: parseJSONEnv('SAML_ATTRIBUTE_MAPPING') || {
+      spConfig: _parseJSONEnv('SAML_SP_CONFIG'),
+      idpConfig: _parseJSONEnv('SAML_IDP_CONFIG'),
+      attributeMapping: _parseJSONEnv('SAML_ATTRIBUTE_MAPPING') || {
         samlId: 'IDO',
         firstName: 'PRE',
         lastName: 'NOM',
@@ -115,11 +115,11 @@ module.exports = (function() {
     pixOrgaUrl: process.env.PIXORGA_URL,
 
     sentry: {
-      enabled: isFeatureEnabled(process.env.SENTRY_ENABLED),
+      enabled: _isFeatureEnabled(process.env.SENTRY_ENABLED),
       dsn: process.env.SENTRY_DSN,
       environment: (process.env.SENTRY_ENVIRONMENT || 'development'),
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
-      debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
+      debug: _isFeatureEnabled(process.env.SENTRY_DEBUG),
     },
   };
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -104,7 +104,7 @@ module.exports = (function() {
     },
 
     system: {
-      samplingHeapProfilerEnabled: (process.env.SYSTEM_SAMPLING_HEAP_PROFILER_ENABLED === 'true'),
+      samplingHeapProfilerEnabled: _isFeatureEnabled(process.env.SYSTEM_SAMPLING_HEAP_PROFILER_ENABLED),
     },
 
     features: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -121,6 +121,10 @@ module.exports = (function() {
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
       debug: _isFeatureEnabled(process.env.SENTRY_DEBUG),
     },
+
+    locale: {
+      enabled: _isFeatureEnabled(process.env.LOCALE_MANAGEMENT_ENABLED)
+    }
   };
 
   if (process.env.NODE_ENV === 'test') {
@@ -161,6 +165,8 @@ module.exports = (function() {
     config.pixOrgaUrl = 'http://dev.pix-orga.fr';
 
     config.sentry.enabled = false;
+
+    config.locale.enabled = true;
   }
 
   return config;

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const hashInt = require('hash-int');
+const config = require('../../config');
 const UNEXISTING_ITEM = null;
 
 module.exports = {
@@ -9,6 +10,9 @@ module.exports = {
     }
     const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
+    if (!config.locale.enabled) {
+      return _pickChallengeAtIndex(chosenSkill.challenges, key);
+    }
     const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => challenge.locale === locale));
     if (_.isEmpty(localeChallenges)) {
       return _pickChallengeAtIndex(chosenSkill.challenges, key);

--- a/api/sample.env
+++ b/api/sample.env
@@ -193,6 +193,13 @@ AIRTABLE_API_KEY=keyblo10ZCvCqBAJg
 # default: none
 AIRTABLE_BASE=app3fvsqhtHJntXaC
 
+# Enable or disable learning content locale management.
+#
+# presence: optionnal
+# type: Boolean
+# default: `false`
+LOCALE_MANAGEMENT_ENABLED=false
+
 # =======
 # LOGGING
 # =======

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -1,4 +1,5 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const config = require('../../../../lib/config');
 const pickChallengeService = require('../../../../lib/domain/services/pick-challenge-service');
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 const _ = require('lodash');
@@ -10,81 +11,161 @@ describe('Unit | Service | PickChallengeService', () => {
     const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locale: FRENCH_SPOKEN });
     const frenchChallenge = domainBuilder.buildChallenge({ locale: FRENCH_FRANCE });
     const randomSeed = 'some-random-seed';
+    const configLocaleEnabledCurrentValue = config.locale.enabled;
 
-    context('when challenge in selected locale exists', () => {
+    context('when locale management feature is disabled', () => {
 
-      it('should return challenge in selected locale', async () => {
-        // given
-        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
+      before(() => {
+        config.locale.enabled = false;
+      });
 
-        // when
-        const challenge = await pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN
+      after(() => {
+        config.locale.enabled = configLocaleEnabledCurrentValue;
+      });
+
+      context('when challenge exists', () => {
+
+        it('should return challenge', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
+
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.equal(frenchChallenge);
         });
 
-        // then
-        expect(challenge).to.equal(frenchSpokenChallenge);
+        it('should always return the same challenge', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, otherFrenchSpokenChallenge] }];
+
+          // when
+          const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          }));
+          const challenges = await Promise.all(pickChallengePromises);
+
+          // then
+          expect(challenges).to.contains(frenchChallenge);
+          expect(challenges).to.not.contains(otherFrenchSpokenChallenge);
+          expect(challenges).to.not.contains(frenchSpokenChallenge);
+        });
       });
 
-      it('should always return the same challenge in selected locale', async () => {
-        // given
-        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, otherFrenchSpokenChallenge] }];
+      context('when there is no skills', () => {
 
-        // when
-        const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN
-        }));
-        const challenges = await Promise.all(pickChallengePromises);
+        it('should return null', async () => {
+          // given
+          const skills = [];
 
-        // then
-        expect(challenges).to.contains(frenchSpokenChallenge);
-        expect(challenges).to.not.contains(otherFrenchSpokenChallenge);
-        expect(challenges).to.not.contains(frenchChallenge);
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.be.null;
+        });
+
       });
+
     });
 
-    context('when challenge in selected locale does not exists', () => {
+    context('when locale management feature is enabled', () => {
 
-      it('should return challenge in other locale', async () => {
-        // given
-        const skills = [{ challenges: [frenchChallenge] }];
-
-        // when
-        const challenge = await pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN
-        });
-
-        // then
-        expect(challenge).to.equal(frenchChallenge);
+      before(() => {
+        config.locale.enabled = true;
       });
 
-    });
+      after(() => {
+        config.locale.enabled = configLocaleEnabledCurrentValue;
+      });
 
-    context('when there is no skills', () => {
+      context('when challenge in selected locale exists', () => {
 
-      it('should return null', async () => {
-        // given
-        const skills = [];
+        it('should return challenge in selected locale', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
 
-        // when
-        const challenge = await pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.equal(frenchSpokenChallenge);
         });
 
-        // then
-        expect(challenge).to.be.null;
+        it('should always return the same challenge in selected locale', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, otherFrenchSpokenChallenge] }];
+
+          // when
+          const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          }));
+          const challenges = await Promise.all(pickChallengePromises);
+
+          // then
+          expect(challenges).to.contains(frenchSpokenChallenge);
+          expect(challenges).to.not.contains(otherFrenchSpokenChallenge);
+          expect(challenges).to.not.contains(frenchChallenge);
+        });
+      });
+
+      context('when challenge in selected locale does not exists', () => {
+
+        it('should return challenge in other locale', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge] }];
+
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.equal(frenchChallenge);
+        });
+
+      });
+
+      context('when there is no skills', () => {
+
+        it('should return null', async () => {
+          // given
+          const skills = [];
+
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: FRENCH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.be.null;
+        });
+
       });
 
     });
 
   });
-})
-;
+
+});


### PR DESCRIPTION
## :unicorn: Problème
La gestion des locales a été développée mais le référentiel de contenu n'est pas entièrement prêt.
Certaines épreuves ne sont pas disponibles dans toutes les locales nécessaires.

## :robot: Solution
Ajout d'une variable d'environnement côté API permettant la désactivation de la gestion des locales.
La variable s'appelle `LOCALE_MANAGEMENT_ENABLED` et est à `false` par défaut.

## :rainbow: Remarques
RAS
