### PR TITLE
[TECH] Ajouter la possibilité d'avoir un type de campagne (PO-389).

### DIFF
--- a/api/db/migrations/20200320170707_add-type-to-campaign.js
+++ b/api/db/migrations/20200320170707_add-type-to-campaign.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'campaigns';
+const COLUMN_NAME = 'type';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.string(COLUMN_NAME).notNullable().defaultTo('');
+  }).then(() => {
+    return knex(TABLE_NAME)
+      .update({
+        type: 'TEST_GIVEN'
+      });
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -4,6 +4,7 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     id: 1,
     name: 'Campagne 1',
     code: 'AZERTY123',
+    type: 'TEST_GIVEN',
     organizationId: 1,
     creatorId: 2,
     targetProfileId: 2,
@@ -14,6 +15,7 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     id: 2,
     name: 'Campagne 2',
     code: 'AZERTY456',
+    type: 'TEST_GIVEN',
     title: 'Parcours recherche avancée',
     customLandingPageText: 'Ce parcours est proposé aux collaborateurs de Dragon & Co',
     organizationId: 1,
@@ -26,6 +28,7 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     id: 3,
     name: 'Campagne without logo',
     code: 'AZERTY789',
+    type: 'TEST_GIVEN',
     organizationId: 2,
     creatorId: 2,
     targetProfileId: 1,
@@ -35,6 +38,7 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     id: 4,
     name: 'Campagne restreinte',
     code: 'RESTRICTD',
+    type: 'TEST_GIVEN',
     organizationId: 3,
     creatorId: 4,
     targetProfileId: 1,
@@ -44,9 +48,29 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     id: 5,
     name: 'Campagne Pix Emploi',
     code: 'QWERTY789',
+    type: 'TEST_GIVEN',
     organizationId: 1,
     creatorId: 2,
     targetProfileId: 100321,
     idPixLabel: 'identifiant entreprise',
+  });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 6,
+    name: 'Campagne Récupération Profils',
+    code: 'SNAP123',
+    type: 'PROFILES_COLLECTION',
+    organizationId: 1,
+    creatorId: 2,
+  });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 7,
+    name: 'Campagne Récupération Profils restreinte',
+    code: 'SNAP456',
+    type: 'PROFILES_COLLECTION',
+    organizationId: 3,
+    creatorId: 4,
+    idPixLabel: 'identifiant élève',
   });
 };

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -1,3 +1,8 @@
+const types = {
+  TEST_GIVEN: 'TEST_GIVEN',
+  PROFILES_COLLECTION: 'PROFILES_COLLECTION',
+};
+
 class Campaign {
 
   constructor({
@@ -13,6 +18,7 @@ class Campaign {
     customLandingPageText,
     isRestricted = false,
     archivedAt,
+    type,
     // includes
     targetProfile,
     campaignReport,
@@ -35,6 +41,7 @@ class Campaign {
     this.customLandingPageText = customLandingPageText;
     this.isRestricted = isRestricted;
     this.archivedAt = archivedAt;
+    this.type = type;
     // includes
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;
@@ -46,5 +53,7 @@ class Campaign {
     this.creatorId = creatorId;
   }
 }
+
+Campaign.types = types;
 
 module.exports = Campaign;

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -6,6 +6,7 @@ const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
 
 module.exports = async function createCampaign({ campaign, campaignRepository, userRepository, organizationService }) {
   campaignValidator.validate(campaign);
+  campaign.type = Campaign.types.TEST_GIVEN;
   return _checkCreatorHasAccessToCampaignOrganization(campaign.creatorId, campaign.organizationId, userRepository)
     .then(() => _checkOrganizationHasAccessToTargetProfile(campaign.targetProfileId, campaign.organizationId, organizationService))
     .then(() => campaignCodeGenerator.generate(campaignRepository))

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
 
   serialize(campaigns, meta, { tokenForCampaignResults, ignoreCampaignReportRelationshipData = true } = {}) {
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'createdAt', 'customLandingPageText', 'archivedAt', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator'],
+      attributes: ['name', 'code', 'title', 'type', 'createdAt', 'customLandingPageText', 'archivedAt', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator'],
       typeForAttribute(attribute) {
         if (attribute === 'creator') {
           return 'users';

--- a/api/tests/tooling/database-builder/factory/build-campaign.js
+++ b/api/tests/tooling/database-builder/factory/build-campaign.js
@@ -2,6 +2,7 @@ const faker = require('faker');
 const buildOrganization = require('./build-organization');
 const buildTargetProfile = require('./build-target-profile');
 const buildUser = require('./build-user');
+const Campaign = require('../../../../lib/domain/models/Campaign');
 const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 
@@ -13,15 +14,19 @@ module.exports = function buildCampaign({
   idPixLabel = faker.random.word(),
   customLandingPageText = faker.lorem.text(),
   archivedAt,
+  type = 'TEST_GIVEN',
   createdAt = faker.date.recent(),
   organizationId,
   creatorId,
   targetProfileId,
 } = {}) {
 
+  if (type === Campaign.types.TEST_GIVEN) {
+    targetProfileId = _.isUndefined(targetProfileId) ? buildTargetProfile({ organizationId }).id : targetProfileId;
+  }
+
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   creatorId = _.isUndefined(creatorId) ? buildUser().id : creatorId;
-  targetProfileId = _.isUndefined(targetProfileId) ? buildTargetProfile({ organizationId }).id : targetProfileId;
 
   const values = {
     id,
@@ -32,6 +37,7 @@ module.exports = function buildCampaign({
     idPixLabel,
     customLandingPageText,
     archivedAt,
+    type,
     organizationId,
     creatorId,
     targetProfileId,

--- a/api/tests/tooling/domain-builder/factory/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign.js
@@ -3,24 +3,24 @@ const faker = require('faker');
 const buildTargetProfile = require('./build-target-profile');
 const buildUser = require('./build-user');
 
-module.exports = function buildCampaign(
-  {
-    id = 1,
-    name = faker.company.companyName(),
-    code = 'AZERTY123',
-    title = faker.random.word(),
-    idPixLabel = faker.random.word(),
-    customLandingPageText = faker.lorem.text(),
-    archivedAt,
-    createdAt = faker.date.recent(),
-    creatorId = faker.random.number(2),
-    creator = buildUser({ id: creatorId }),
-    organizationId = faker.random.number(2),
-    targetProfileId = faker.random.number(2),
-    targetProfile = buildTargetProfile({ id: targetProfileId }),
-    isRestricted = false,
-    organizationLogoUrl
-  } = {}) {
+function buildCampaign({
+  id = 1,
+  name = faker.company.companyName(),
+  code = 'AZERTY123',
+  title = faker.random.word(),
+  idPixLabel = faker.random.word(),
+  customLandingPageText = faker.lorem.text(),
+  archivedAt,
+  type = Campaign.types.TEST_GIVEN,
+  createdAt = faker.date.recent(),
+  creatorId = faker.random.number(2),
+  creator = buildUser({ id: creatorId }),
+  organizationId = faker.random.number(2),
+  targetProfileId = faker.random.number(2),
+  targetProfile = buildTargetProfile({ id: targetProfileId }),
+  isRestricted = false,
+  organizationLogoUrl
+} = {}) {
   return new Campaign({
     id,
     name,
@@ -29,6 +29,45 @@ module.exports = function buildCampaign(
     idPixLabel,
     customLandingPageText,
     archivedAt,
+    type,
+    createdAt,
+    creatorId,
+    creator,
+    organizationId,
+    targetProfileId,
+    targetProfile,
+    isRestricted,
+    organizationLogoUrl
+  });
+}
+
+buildCampaign.ofTypeTestGiven = function({
+  id = 1,
+  name = faker.company.companyName(),
+  code = 'AZERTY123',
+  title = faker.random.word(),
+  idPixLabel = faker.random.word(),
+  customLandingPageText = faker.lorem.text(),
+  archivedAt,
+  type = Campaign.types.TEST_GIVEN,
+  createdAt = faker.date.recent(),
+  creatorId = faker.random.number(2),
+  creator = buildUser({ id: creatorId }),
+  organizationId = faker.random.number(2),
+  targetProfileId = faker.random.number(2),
+  targetProfile = buildTargetProfile({ id: targetProfileId }),
+  isRestricted = false,
+  organizationLogoUrl
+} = {}) {
+  return new Campaign({
+    id,
+    name,
+    code,
+    title,
+    idPixLabel,
+    customLandingPageText,
+    archivedAt,
+    type,
     createdAt,
     creatorId,
     creator,
@@ -39,3 +78,43 @@ module.exports = function buildCampaign(
     organizationLogoUrl
   });
 };
+
+buildCampaign.ofTypeProfilesCollection = function({
+  id = 1,
+  name = faker.company.companyName(),
+  code = 'AZERTY123',
+  title = null,
+  idPixLabel = faker.random.word(),
+  customLandingPageText = faker.lorem.text(),
+  archivedAt,
+  type = Campaign.types.PROFILES_COLLECTION,
+  createdAt = faker.date.recent(),
+  creatorId = faker.random.number(2),
+  creator = buildUser({ id: creatorId }),
+  organizationId = faker.random.number(2),
+  targetProfileId = null,
+  targetProfile = null,
+  isRestricted = false,
+  organizationLogoUrl
+} = {}) {
+  return new Campaign({
+    id,
+    name,
+    code,
+    title,
+    idPixLabel,
+    customLandingPageText,
+    archivedAt,
+    type,
+    createdAt,
+    creatorId,
+    creator,
+    organizationId,
+    targetProfileId,
+    targetProfile,
+    isRestricted,
+    organizationLogoUrl
+  });
+};
+
+module.exports = buildCampaign;

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Models | CampaignParticipation', () => {
 
     it('should return the targetProfileId from campaign associated', () => {
       // given
-      const campaign = domainBuilder.buildCampaign();
+      const campaign = domainBuilder.buildCampaign.ofTypeTestGiven();
       const campaignParticipation = new CampaignParticipation({
         id: 1,
         campaign,

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -197,7 +197,7 @@ describe('Unit | Service | ScorecardService', function() {
       beforeEach(async () => {
         const skill = domainBuilder.buildSkill({ id: skillId });
         const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
-        campaign = domainBuilder.buildCampaign({ targetProfileId: targetProfile.id, targetProfile });
+        campaign = domainBuilder.buildCampaign.ofTypeTestGiven({ targetProfileId: targetProfile.id, targetProfile });
         campaignParticipation1 = domainBuilder.buildCampaignParticipation({ id: 1, campaign, campaignId: campaign.id, isShared: false });
         campaignParticipation2 = domainBuilder.buildCampaignParticipation({ id: 2, campaign, campaignId: campaign.id, isShared: false });
         oldAssessment1 = domainBuilder.buildAssessment.ofTypeSmartPlacement({ id: assessmentId1, state: 'started', campaignParticipationId: campaignParticipation1.id, userId });

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
     beforeEach(() => {
       userId = faker.random.number();
       // given
-      campaign = domainBuilder.buildCampaign({
+      campaign = domainBuilder.buildCampaign.ofTypeTestGiven({
         id: 'campaignId',
       });
 
@@ -68,7 +68,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
         userId,
         campaignParticipationId: campaignParticipation.id
       });
-      
+
       campaignRepository.getByCode.resolves(campaign);
       assessmentRepository.save.resolves(assessment);
       assessmentRepository.get.resolves(assessment);

--- a/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
+++ b/api/tests/unit/domain/usecases/find-smart-placement-assessments_test.js
@@ -32,7 +32,7 @@ describe('Unit | UseCase | find-smart-placement-assessments', () => {
     const userId = 1234;
     const campaignCode = 'Code';
     const filters = { type: 'SMART_PLACEMENT', codeCampaign: campaignCode };
-    const campaign = domainBuilder.buildCampaign({ code: campaignCode });
+    const campaign = domainBuilder.buildCampaign.ofTypeTestGiven({ code: campaignCode });
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign });
     const assessment = domainBuilder.buildAssessment.ofTypeSmartPlacement({
       userId,

--- a/api/tests/unit/domain/usecases/get-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-assessment_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | get-assessment', () => {
 
   beforeEach(() => {
     assessmentResult = domainBuilder.buildAssessmentResult();
-    campaign = domainBuilder.buildCampaign({ title: expectedCampaignName });
+    campaign = domainBuilder.buildCampaign.ofTypeTestGiven({ title: expectedCampaignName });
     campaignParticipation = domainBuilder.buildCampaignParticipation({ campaign });
     competence = domainBuilder.buildCompetence({ id: 'recsvLz0W2ShyfD63', name: expectedAssessmentTitle });
     course = domainBuilder.buildCourse({ id: 'ABC123', name: expectedCourseName });

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -43,7 +43,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
     userId = user.id;
     assessment = domainBuilder.buildSmartPlacementAssessment({ userId: userId });
     assessmentId = assessment.id;
-    campaign = domainBuilder.buildCampaign();
+    campaign = domainBuilder.buildCampaign.ofTypeTestGiven();
     campaignParticipation = domainBuilder.buildCampaignParticipation({
       id: campaignParticipationId,
       campaignId: campaign.id

--- a/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-results-to-stream_test.js
@@ -65,7 +65,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
       skills: listSkills, name: '+Profile 1'
     });
 
-    const campaign = domainBuilder.buildCampaign({
+    const campaign = domainBuilder.buildCampaign.ofTypeTestGiven({
       name:'@Campagne de Test N°1',
       code:'AZERTY123',
       organizationId: organization.id,
@@ -461,7 +461,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-results-to-stream'
 
         findResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
 
-        const campaignWithoutIdPixLabel = domainBuilder.buildCampaign({
+        const campaignWithoutIdPixLabel = domainBuilder.buildCampaign.ofTypeTestGiven({
           name: 'CampaignName',
           code: 'AZERTY123',
           organizationId: organization.id,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -27,6 +27,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           organizationName: 'College Victor Hugo',
           idPixLabel: 'company id',
           targetProfile: domainBuilder.buildTargetProfile({ id: '123', name: 'TargetProfile1' }),
+          type: 'TEST_GIVEN'
         });
 
         const expectedSerializedCampaign = {
@@ -45,6 +46,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'organization-logo-url': 'some logo',
               'organization-name': 'College Victor Hugo',
               'is-restricted': false,
+              type: 'TEST_GIVEN',
             },
             relationships: {
               'target-profile': {
@@ -119,7 +121,8 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           organizationName: 'College Victor Hugo',
           idPixLabel: 'company id',
           targetProfile: domainBuilder.buildTargetProfile({ id: '123', name: 'TargetProfile1' }),
-          campaignReport
+          campaignReport,
+          type: 'TEST_GIVEN',
         });
 
         const expectedSerializedCampaign = {
@@ -138,6 +141,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'organization-logo-url': 'some logo',
               'organization-name': 'College Victor Hugo',
               'is-restricted': false,
+              type: 'TEST_GIVEN',
             },
             relationships: {
               'target-profile': {

--- a/high-level-tests/e2e/cypress/fixtures/campaigns.json
+++ b/high-level-tests/e2e/cypress/fixtures/campaigns.json
@@ -3,6 +3,7 @@
     "id": 1,
     "name": "Campagne de la Néra",
     "code": "NERA",
+    "type": "TEST_GIVEN",
     "organizationId": 1,
     "creatorId": 1,
     "targetProfileId": 1
@@ -10,6 +11,7 @@
     "id": 2,
     "name": "Campagne du Mur",
     "code": "WALL",
+    "type": "TEST_GIVEN",
     "idPixLabel": "Numéro de bataillon",
     "organizationId": 1,
     "creatorId": 1,
@@ -18,6 +20,7 @@
     "id": 3,
     "name": "Campagne de Winterfell",
     "code": "WINTER",
+    "type": "TEST_GIVEN",
     "organizationId": 2,
     "creatorId": 3,
     "targetProfileId": 1

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -2,9 +2,13 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 import ENV from 'pix-orga/config/environment';
 
+const PROFILES_COLLECTION_TEXT = 'Récupération profils';
+const TEST_GIVEN_TEXT = 'Parcours de test';
+
 export default DS.Model.extend({
   name: DS.attr('string'),
   code: DS.attr('string'),
+  type: DS.attr('string'),
   title: DS.attr('string'),
   createdAt: DS.attr('date'),
   creator: DS.belongsTo('user'),
@@ -18,6 +22,13 @@ export default DS.Model.extend({
   targetProfile: DS.belongsTo('target-profile'),
   campaignReport: DS.belongsTo('campaign-report'),
   campaignCollectiveResult: DS.belongsTo('campaign-collective-result'),
+
+  isTypeProfilesCollection: computed.equal('type', 'PROFILES_COLLECTION'),
+  isTypeTestGiven: computed.equal('type', 'TEST_GIVEN'),
+
+  readableType: computed('isTypeProfilesCollection', function() {
+    return this.isTypeProfilesCollection ? PROFILES_COLLECTION_TEXT : TEST_GIVEN_TEXT;
+  }),
 
   url: computed('code', function() {
     const code = this.code;

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -21,7 +21,7 @@
 }
 
 .campaign-details-header {
-  &__title {
+  &__headline {
     display: flex;
     align-items: center;
   }
@@ -32,6 +32,14 @@
     padding-right: 10px;
     padding-left: 10px;
     min-width: 345px;
+  }
+
+  &__title {
+    margin-bottom: 10px;
+  }
+
+  &__return-button {
+    margin-right: 6px;
   }
 }
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -1,9 +1,9 @@
 <div class="campaign-details__header">
-  <div class="campaign-details-header__title">
-    <LinkTo @route="authenticated.campaigns" class="icon-button campaign-details-content__return-button">
+  <div class="campaign-details-header__headline">
+    <LinkTo aria-label="Retour" @route="authenticated.campaigns" class="icon-button campaign-details-header__return-button">
       <FaIcon @icon='arrow-left'></FaIcon>
     </LinkTo>
-    <h1 class="page__title page-title">{{@campaign.name}}</h1>
+    <h1 class="page__title page-title campaign-details-header__title">{{@campaign.name}}</h1>
   </div>
 
   <div class="campaign-details-header__report">
@@ -36,7 +36,10 @@
       <FaIcon @icon='archive'></FaIcon>
     </div>
     <div class="campaign-archived-banner__text">Campagne archivée</div>
-    <button type="button" class="button button--link campaign-archived-banner__unarchive-button" {{on 'click' (fn this.unarchiveCampaign @campaign.id)}}>Désarchiver la campagne</button>
+    <button type="button" class="button button--link campaign-archived-banner__unarchive-button" {{on 'click'
+                                                                                                      (fn this.unarchiveCampaign @campaign.id)}}>
+      Désarchiver la campagne
+    </button>
   </div>
 {{/if}}
 
@@ -54,8 +57,10 @@
   </nav>
 
   <div class="campaign-details-controls__export-button">
-    <a class="button button--link button--with-icon" href="{{@campaign.urlToResult}}" target="_blank" rel="noopener noreferrer" download>
-      Exporter résultats (.csv)<FaIcon @icon='file-download'></FaIcon>
+    <a class="button button--link button--with-icon" href="{{@campaign.urlToResult}}" target="_blank"
+       rel="noopener noreferrer" download>
+      Exporter résultats (.csv)
+      <FaIcon @icon='file-download'></FaIcon>
     </a>
   </div>
 </div>

--- a/orga/tests/acceptance/campaign-details-test.js
+++ b/orga/tests/acceptance/campaign-details-test.js
@@ -107,7 +107,7 @@ module('Acceptance | Campaign Details', function(hooks) {
       await visit('/campagnes/1');
 
       // when
-      await click('.campaign-details-content__return-button');
+      await click('[aria-label="Retour"]');
 
       // then
       assert.equal(currentURL(), '/campagnes');

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -35,7 +35,6 @@ module('Unit | Model | campaign', function(hooks) {
   test('it should compute the isArchived property from the archivation date at creation', function(assert) {
     const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('campaign', {
-      id: 1,
       archivedAt: new Date('2010-10-10'),
     }));
     assert.equal(model.isArchived, true);
@@ -44,10 +43,33 @@ module('Unit | Model | campaign', function(hooks) {
   test('it should compute the isArchived property from the archivation date when set to null', function(assert) {
     const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('campaign', {
-      id: 1,
       archivedAt: new Date('2010-10-10'),
     }));
     model.set('archivedAt', null);
     assert.equal(model.isArchived, false);
+  });
+
+  module('#readableType', function(hooks) {
+    let store;
+
+    hooks.beforeEach(function() {
+      store = this.owner.lookup('service:store');
+    });
+
+    test('it should compute the readableType property when type is TEST_GIVEN', function(assert) {
+      // when
+      const model = store.createRecord('campaign', { type: 'TEST_GIVEN' });
+
+      // then
+      assert.equal(model.readableType, 'Parcours de test');
+    });
+
+    test('it should compute the readableType property when type is PROFILES_COLLECTION', function(assert) {
+      // when
+      const model = store.createRecord('campaign', { type: 'PROFILES_COLLECTION' });
+
+      // then
+      assert.equal(model.readableType, 'Récupération profils');
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité permettant de partager son profil au prescripteur arrive. Pour arriver à cela, il nous faut définir un type de campagne.
Afin que les US suivantes ne soient pas dépendantes, on a décidé de faire une US purement TECH, introduisant cette notion de type.

## :robot: Solution
Les campagne seront soit de type TEST soit de type COLLECT_PROFILES. Il nous faut également ajouter ce champ en base, et migrer toutes les campagnes déjà présentes en base.

## :rainbow: Tester
- S'assurer qu'il y a bien type dans la table `campaign` en base ;
- S'assurer que les anciennes campagnes ont bien été migrées (on ne peut vérifier qu'en local et en intégration, en RA la base se re-créée de zéro).