### PR TITLE
[TECH] Mise en transaction de la création des éléments nécessaires à un test de certification (CertifCourse, assessment et challenges) (PF-1179)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -29,7 +29,7 @@ module.exports = {
           });
         } else {
           assessment.state = 'started';
-          return assessmentRepository.save(assessment);
+          return assessmentRepository.save({ assessment });
         }
       })
       .then((assessment) => {

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -4,6 +4,7 @@ const certificationResultSerializer = require('../../infrastructure/serializers/
 const certificationSerializer = require('../../infrastructure/serializers/jsonapi/certification-serializer');
 const certificationCourseSerializer = require('../../infrastructure/serializers/jsonapi/certification-course-serializer');
 const usecases = require('../../domain/usecases');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = {
 
@@ -30,8 +31,9 @@ module.exports = {
     const accessCode = request.payload.data.attributes['access-code'];
     const sessionId = request.payload.data.attributes['session-id'];
 
-    const { created, certificationCourse } =
-      await usecases.retrieveLastOrCreateCertificationCourse({ sessionId, accessCode, userId });
+    const { created, certificationCourse } = await DomainTransaction.execute((domainTransaction) => {
+      return usecases.retrieveLastOrCreateCertificationCourse({ domainTransaction, sessionId, accessCode, userId });
+    });
 
     const serialized = await certificationCourseSerializer.serialize(certificationCourse);
 

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -1,19 +1,20 @@
-const certificationChallengeRepository = require('../../infrastructure/repositories/certification-challenge-repository');
+
+const _ = require('lodash');
+const CertificationChallenge = require('../models/CertificationChallenge');
 
 module.exports = {
 
-  saveChallenges(userCompetences, certificationCourse) {
-    const saveChallengePromises = [];
-    userCompetences.forEach((userCompetence) => {
-      userCompetence.challenges.forEach((challenge) => {
-        saveChallengePromises.push(certificationChallengeRepository.save(challenge, certificationCourse));
+  generateCertificationChallenges(userCompetences, certificationCourseId) {
+    return _.flatMap(userCompetences, (userCompetence) => {
+      return _.map(userCompetence.challenges, (challenge) => {
+        return new CertificationChallenge({
+          challengeId: challenge.id,
+          competenceId: challenge.competenceId,
+          associatedSkillName: challenge.testedSkill,
+          associatedSkillId: undefined, // TODO: Add skillId
+          courseId: certificationCourseId,
+        });
       });
     });
-
-    return Promise.all(saveChallengePromises)
-      .then((certificationChallenges) => {
-        certificationCourse.challenges = certificationChallenges;
-        return certificationCourse;
-      });
   }
 };

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -121,7 +121,7 @@ async function _resetSmartPlacementAssessment({ assessment, resetSkills, assessm
   });
 
   await assessmentRepository.abortByAssessmentId(assessment.id);
-  return await assessmentRepository.save(newAssessment);
+  return await assessmentRepository.save({ assessment: newAssessment });
 }
 
 function _computeResetSkillsNotIncludedInTargetProfile({ targetObjectSkills, resetSkills }) {

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -22,7 +22,7 @@ async function getCertificationProfile({ userId, limitDate, isV2Certification = 
   return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1(certificationProfile);
 }
 
-async function fillCertificationProfileWithCertificationChallenges(certificationProfile) {
+async function fillCertificationProfileWithChallenges(certificationProfile) {
   const allChallenges = await challengeRepository.list();
   const challengesAlreadyAnswered = certificationProfile.challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
 
@@ -144,5 +144,5 @@ async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredC
 
 module.exports = {
   getCertificationProfile,
-  fillCertificationProfileWithCertificationChallenges,
+  fillCertificationProfileWithChallenges,
 };

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -30,5 +30,5 @@ function _createImprovingAssessment({ userId, campaignParticipationId, assessmen
     courseId: Assessment.courseIdMessage.SMART_PLACEMENT,
     isImproving: true,
   });
-  return assessmentRepository.save(assessment);
+  return assessmentRepository.save({ assessment });
 }

--- a/api/lib/domain/usecases/create-assessment-for-campaign.js
+++ b/api/lib/domain/usecases/create-assessment-for-campaign.js
@@ -36,7 +36,7 @@ module.exports = async function createAssessmentForCampaign(
   assessment.courseId = Assessment.courseIdMessage.SMART_PLACEMENT;
   assessment.campaignParticipationId = campaignParticipation.id;
 
-  const assessmentCreated = await assessmentRepository.save(assessment);
+  const assessmentCreated = await assessmentRepository.save({ assessment });
 
   return assessmentCreated;
 };

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -19,7 +19,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     throw new NotFoundError('Session not found');
   }
 
-  const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId, sessionId);
+  const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId });
   if (existingCertificationCourse) {
     return {
       created: false,
@@ -57,7 +57,7 @@ async function _startNewCertification({
 
   await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
-  const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId, sessionId);
+  const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId });
   if (existingCertificationCourse) {
     return {
       created: false,

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -55,7 +55,7 @@ async function _startNewCertification({
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+  await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
   const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId, sessionId);
   if (existingCertificationCourse) {

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -68,7 +68,7 @@ async function _startNewCertification({
   const newCertificationCourse = await _generateCertificationCourseFromCandidateParticipation({ userId, sessionId, certificationCandidateRepository });
   const savedCertificationCourse = await certificationCourseRepository.save(newCertificationCourse);
   const newAssessment = _generateAssessmentForCertificationCourse({ userId, certificationCourseId: savedCertificationCourse.id });
-  const savedAssessment = await assessmentRepository.save(newAssessment);
+  const savedAssessment = await assessmentRepository.save({ assessment: newAssessment });
   const newCertificationChallenges = certificationChallengesService.generateCertificationChallenges(certificationProfile.userCompetences, savedCertificationCourse.id);
   const savedChallenges = await Promise.all(newCertificationChallenges.map((certificationChallenge) => certificationChallengeRepository.save(certificationChallenge)));
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -70,7 +70,7 @@ async function _startNewCertification({
   const newAssessment = _generateAssessmentForCertificationCourse({ userId, certificationCourseId: savedCertificationCourse.id });
   const savedAssessment = await assessmentRepository.save({ assessment: newAssessment });
   const newCertificationChallenges = certificationChallengesService.generateCertificationChallenges(certificationProfile.userCompetences, savedCertificationCourse.id);
-  const savedChallenges = await Promise.all(newCertificationChallenges.map((certificationChallenge) => certificationChallengeRepository.save(certificationChallenge)));
+  const savedChallenges = await Promise.all(newCertificationChallenges.map((certificationChallenge) => certificationChallengeRepository.save({ certificationChallenge })));
 
   savedCertificationCourse.assessment = savedAssessment;
   savedCertificationCourse.challenges = savedChallenges;

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -66,7 +66,7 @@ async function _startNewCertification({
   }
 
   const newCertificationCourse = await _generateCertificationCourseFromCandidateParticipation({ userId, sessionId, certificationCandidateRepository });
-  const savedCertificationCourse = await certificationCourseRepository.save(newCertificationCourse);
+  const savedCertificationCourse = await certificationCourseRepository.save({ certificationCourse: newCertificationCourse });
   const newAssessment = _generateAssessmentForCertificationCourse({ userId, certificationCourseId: savedCertificationCourse.id });
   const savedAssessment = await assessmentRepository.save({ assessment: newAssessment });
   const newCertificationChallenges = certificationChallengesService.generateCertificationChallenges(certificationProfile.userCompetences, savedCertificationCourse.id);

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -26,7 +26,7 @@ async function _createSmartPlacementAssessment(userId, assessmentRepository, cre
     courseId: Assessment.courseIdMessage.SMART_PLACEMENT,
     campaignParticipationId: createdCampaignParticipation.id
   });
-  return assessmentRepository.save(assessment);
+  return assessmentRepository.save({ assessment });
 }
 
 async function _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository) {

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -45,7 +45,7 @@ function _createAssessment({ userId, competenceId, assessmentRepository }) {
     type: Assessment.types.COMPETENCE_EVALUATION,
     courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
   });
-  return assessmentRepository.save(assessment);
+  return assessmentRepository.save({ assessment });
 }
 
 function _createCompetenceEvaluation(competenceId, assessmentId, userId, competenceEvaluationRepository) {

--- a/api/lib/infrastructure/data/certification-course.js
+++ b/api/lib/infrastructure/data/certification-course.js
@@ -17,16 +17,16 @@ module.exports = Bookshelf.model('CertificationCourse', {
     return rawAttributes;
   },
 
+  acquiredPartnerCertifications() {
+    return this.hasMany('CertificationPartnerAcquisition', 'certificationCourseId');
+  },
+
   assessment() {
     return this.hasOne('Assessment', 'certificationCourseId');
   },
 
   challenges() {
     return this.hasMany('CertificationChallenge', 'courseId');
-  },
-
-  acquiredPartnerCertifications() {
-    return this.hasMany('CertificationPartnerAcquisition', 'certificationCourseId');
   },
 
   session() {

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -58,10 +58,10 @@ module.exports = {
       });
   },
 
-  save(assessment) {
+  save({ assessment, domainTransaction = {} }) {
     return assessment.validate()
       .then(() => new BookshelfAssessment(_adaptModelToDb(assessment)))
-      .then((bookshelfAssessment) => bookshelfAssessment.save())
+      .then((bookshelfAssessment) => bookshelfAssessment.save(null, { transacting: domainTransaction.knexTransaction }))
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -23,17 +23,15 @@ function _toDomain(model) {
 
 module.exports = {
 
-  // TODO modifier pour que cela prenne un CertificationChallenge en entrée
-  save(challenge, certificationCourse) {
-    const certificationChallenge = new CertificationChallengeBookshelf({
-      challengeId: challenge.id,
-      competenceId: challenge.competenceId,
-      associatedSkill: challenge.testedSkill,
-      associatedSkillId: undefined, // TODO: Add skillId
-      courseId: certificationCourse.id,
+  save(certificationChallenge) {
+    const certificationChallengeToSave = new CertificationChallengeBookshelf({
+      challengeId: certificationChallenge.challengeId,
+      competenceId: certificationChallenge.competenceId,
+      associatedSkill: certificationChallenge.associatedSkillName,
+      associatedSkillId: certificationChallenge.associatedSkillId,
+      courseId: certificationChallenge.courseId,
     });
-
-    return certificationChallenge.save()
+    return certificationChallengeToSave.save()
       .then((certificationChallenge) => {
         return _toDomain(certificationChallenge);
       });

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -23,7 +23,7 @@ function _toDomain(model) {
 
 module.exports = {
 
-  save(certificationChallenge) {
+  save({ certificationChallenge, domainTransaction = {} }) {
     const certificationChallengeToSave = new CertificationChallengeBookshelf({
       challengeId: certificationChallenge.challengeId,
       competenceId: certificationChallenge.competenceId,
@@ -31,7 +31,7 @@ module.exports = {
       associatedSkillId: certificationChallenge.associatedSkillId,
       courseId: certificationChallenge.courseId,
     });
-    return certificationChallengeToSave.save()
+    return certificationChallengeToSave.save(null, { transacting: domainTransaction.knexTransaction })
       .then((certificationChallenge) => {
         return _toDomain(certificationChallenge);
       });

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -43,21 +43,6 @@ module.exports = {
     return _toDomain(certificationCourse);
   },
 
-  async getLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
-    try {
-      const certificationCourse = await CertificationCourseBookshelf
-        .where({ userId, sessionId })
-        .orderBy('createdAt', 'desc')
-        .fetch({ require: true, withRelated: ['assessment', 'challenges', 'acquiredPartnerCertifications'] });
-      return _toDomain(certificationCourse);
-    } catch (err) {
-      if (err instanceof CertificationCourseBookshelf.NotFoundError) {
-        throw new NotFoundError(`Certification course with userId ${userId} and sessionId ${sessionId} does not exist.`);
-      }
-      throw err;
-    }
-  },
-
   async update(certificationCourse) {
     const certificationCourseData = _adaptModelToDb(certificationCourse);
     const certificationCourseBookshelf = new CertificationCourseBookshelf(certificationCourseData);

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -35,6 +35,14 @@ module.exports = {
     }
   },
 
+  async findOneCertificationCourseByUserIdAndSessionId(userId, sessionId) {
+    const certificationCourse = await CertificationCourseBookshelf
+      .where({ userId, sessionId })
+      .orderBy('createdAt', 'desc')
+      .fetch({ withRelated: ['assessment', 'challenges'] });
+    return _toDomain(certificationCourse);
+  },
+
   async getLastCertificationCourseByUserIdAndSessionId(userId, sessionId) {
     try {
       const certificationCourse = await CertificationCourseBookshelf

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -35,11 +35,11 @@ module.exports = {
     }
   },
 
-  async findOneCertificationCourseByUserIdAndSessionId(userId, sessionId) {
+  async findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId, domainTransaction = {} }) {
     const certificationCourse = await CertificationCourseBookshelf
       .where({ userId, sessionId })
       .orderBy('createdAt', 'desc')
-      .fetch({ withRelated: ['assessment', 'challenges'] });
+      .fetch({ withRelated: ['assessment', 'challenges'], transacting: domainTransaction.knexTransaction });
     return _toDomain(certificationCourse);
   },
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -9,9 +9,10 @@ const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
 
-  async save(certificationCourse) {
+  async save({ certificationCourse, domainTransaction = {} }) {
     const certificationCourseToSave = _adaptModelToDb(certificationCourse);
-    const savedCertificationCourse = await new CertificationCourseBookshelf(certificationCourseToSave).save();
+    const options = { transacting : domainTransaction.knexTransaction };
+    const savedCertificationCourse = await new CertificationCourseBookshelf(certificationCourseToSave).save(null, options);
     return _toDomain(savedCertificationCourse);
   },
 

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -395,7 +395,7 @@ describe('Integration | Service | User Service', function() {
     });
   });
 
-  describe('#fillCertificationProfileWithCertificationChallenges', () => {
+  describe('#fillCertificationProfileWithChallenges', () => {
     let certificationProfile;
     let userCompetence1;
     let userCompetence2;
@@ -426,7 +426,7 @@ describe('Integration | Service | User Service', function() {
 
     it('should list available challenges', async () => {
       // when
-      await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       sinon.assert.calledOnce(challengeRepository.list);
@@ -438,7 +438,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.challengeIdsCorrectlyAnswered = ['challengeRecordIdFive'];
 
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -458,7 +458,7 @@ describe('Integration | Service | User Service', function() {
         certificationProfile.challengeIdsCorrectlyAnswered = [];
 
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -478,7 +478,7 @@ describe('Integration | Service | User Service', function() {
         certificationProfile.challengeIdsCorrectlyAnswered = ['challengeRecordIdEleven'];
 
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -498,7 +498,7 @@ describe('Integration | Service | User Service', function() {
         certificationProfile.challengeIdsCorrectlyAnswered = ['challengeRecordIdOne'];
 
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -516,7 +516,7 @@ describe('Integration | Service | User Service', function() {
           ['challengeRecordIdFour', 'challengeRecordIdTwo'];
 
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -535,7 +535,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.challengeIdsCorrectlyAnswered =
         ['challengeRecordIdFour', 'challengeRecordIdFive', 'challengeRecordIdSeven'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -567,7 +567,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.challengeIdsCorrectlyAnswered =
         ['challengeRecordIdSix', 'challengeRecordIdFive', 'challengeRecordIdSeven'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -599,7 +599,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.challengeIdsCorrectlyAnswered =
         ['challengeRecordIdSix', 'challengeRecordIdFive', 'challengeRecordIdSeven', 'challengeRecordIdEight'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -630,7 +630,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.userCompetences = [userCompetence1, userCompetence2];
       certificationProfile.challengeIdsCorrectlyAnswered = ['challengeRecordIdFive', 'challengeRecordIdFive'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -661,7 +661,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.userCompetences = [userCompetence1, userCompetence2];
       certificationProfile.challengeIdsCorrectlyAnswered = ['nonExistentchallengeRecordId'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -692,7 +692,7 @@ describe('Integration | Service | User Service', function() {
       certificationProfile.userCompetences = [userCompetence1, userCompetence2];
       certificationProfile.challengeIdsCorrectlyAnswered = ['challengeRecordIdThree'];
       // when
-      const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+      const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
       expect(actualCertificationProfile.userCompetences).to.deep.equal([
@@ -726,7 +726,7 @@ describe('Integration | Service | User Service', function() {
         certificationProfile.challengeIdsCorrectlyAnswered =
           ['challengeRecordIdSix', 'challengeRecordIdFive', 'challengeRecordIdSeven', 'challengeRecordIdEight'];
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences[1].skills)
@@ -751,7 +751,7 @@ describe('Integration | Service | User Service', function() {
           challenge2ForSkillSearch1,
         ]);
         // when
-        const actualCertificationProfile = await userService.fillCertificationProfileWithCertificationChallenges(certificationProfile);
+        const actualCertificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
         // then
         expect(actualCertificationProfile.userCompetences[0].skills)

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -319,7 +319,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
     it('should save new assessment if not already existing', async () => {
       // when
-      assessmentReturned = await assessmentRepository.save(assessmentToBeSaved);
+      assessmentReturned = await assessmentRepository.save({ assessment: assessmentToBeSaved });
 
       // then
       const assessmentsInDb = await knex('assessments').where('id', assessmentReturned.id).first('id', 'userId');

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -9,13 +9,13 @@ describe('Integration | Repository | Certification Challenge', function() {
 
   describe('#save', () => {
 
-    let certificationCourseObject;
     let certificationChallenge;
 
     beforeEach(async () => {
-      certificationCourseObject = databaseBuilder.factory.buildCertificationCourse();
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
 
-      certificationChallenge = domainBuilder.buildCertificationChallenge();
+      certificationChallenge = domainBuilder.buildCertificationChallenge({ courseId: certificationCourseId });
+      certificationChallenge.id = undefined;
       await databaseBuilder.commit();
     });
 
@@ -23,13 +23,13 @@ describe('Integration | Repository | Certification Challenge', function() {
       return knex('certification-challenges').delete();
     });
 
-    it('should return certification challenge object', () => {
-      const promise = certificationChallengeRepository.save(certificationChallenge, certificationCourseObject);
+    it('should return certification challenge object', async () => {
+      const savedCertificationChallenge = await certificationChallengeRepository.save(certificationChallenge);
 
       // then
-      return promise.then((savedCertificationChallenge) => {
-        expect(savedCertificationChallenge.challengeId).to.deep.equal(certificationChallenge.id);
-      });
+      expect(savedCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);
+      expect(savedCertificationChallenge).to.have.property('id').and.not.null;
+      expect(savedCertificationChallenge.challengeId).to.equal(certificationChallenge.challengeId);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -24,7 +24,7 @@ describe('Integration | Repository | Certification Challenge', function() {
     });
 
     it('should return certification challenge object', async () => {
-      const savedCertificationChallenge = await certificationChallengeRepository.save(certificationChallenge);
+      const savedCertificationChallenge = await certificationChallengeRepository.save({ certificationChallenge });
 
       // then
       expect(savedCertificationChallenge).to.be.an.instanceOf(CertificationChallenge);

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -177,6 +177,43 @@ describe('Integration | Repository | Certification Course', function() {
 
   });
 
+  describe('#findOneCertificationCourseByUserIdAndSessionId', function() {
+
+    const createdAt = new Date('2018-12-11T01:02:03Z');
+    const createdAtLater = new Date('2018-12-12T01:02:03Z');
+    let userId;
+    let sessionId;
+
+    beforeEach(() => {
+      // given
+      userId = databaseBuilder.factory.buildUser({}).id;
+      sessionId = databaseBuilder.factory.buildSession({}).id;
+      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt });
+      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt: createdAtLater });
+
+      databaseBuilder.factory.buildCertificationCourse({ sessionId });
+      databaseBuilder.factory.buildCertificationCourse({ userId });
+
+      return databaseBuilder.commit();
+    });
+
+    it('should retrieve the most recently created certification course with given userId, sessionId', async () => {
+      // when
+      const certificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId, sessionId);
+
+      // then
+      expect(certificationCourse.createdAt).to.deep.equal(createdAtLater);
+    });
+
+    it('should return null when no certification course found', async () => {
+      // when
+      const result = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId + 1, sessionId + 1);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+
   describe('#getLastCertificationCourseByUserIdAndSessionId', function() {
 
     const createdAt = new Date('2018-12-11T01:02:03Z');

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -214,43 +214,6 @@ describe('Integration | Repository | Certification Course', function() {
     });
   });
 
-  describe('#getLastCertificationCourseByUserIdAndSessionId', function() {
-
-    const createdAt = new Date('2018-12-11T01:02:03Z');
-    const createdAtLater = new Date('2018-12-12T01:02:03Z');
-    let userId;
-    let sessionId;
-
-    beforeEach(() => {
-      // given
-      userId = databaseBuilder.factory.buildUser().id;
-      sessionId = databaseBuilder.factory.buildSession().id;
-      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt });
-      databaseBuilder.factory.buildCertificationCourse({ userId, sessionId, createdAt: createdAtLater });
-
-      databaseBuilder.factory.buildCertificationCourse({ sessionId });
-      databaseBuilder.factory.buildCertificationCourse({ userId });
-
-      return databaseBuilder.commit();
-    });
-
-    it('should retrieve the last certification course with given userId, sessionId', async () => {
-      // when
-      const certificationCourse = await certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId(userId, sessionId);
-
-      // then
-      expect(certificationCourse.createdAt).to.deep.equal(createdAtLater);
-    });
-
-    it('should throw not found error when no certification course found', async () => {
-      // when
-      const result = await catchErr(certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId)(userId + 1, sessionId + 1);
-
-      // then
-      expect(result).to.be.instanceOf(NotFoundError);
-    });
-  });
-
   describe('#update', () => {
     let certificationCourse;
 

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -199,7 +199,7 @@ describe('Integration | Repository | Certification Course', function() {
 
     it('should retrieve the most recently created certification course with given userId, sessionId', async () => {
       // when
-      const certificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId, sessionId);
+      const certificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId });
 
       // then
       expect(certificationCourse.createdAt).to.deep.equal(createdAtLater);
@@ -207,7 +207,7 @@ describe('Integration | Repository | Certification Course', function() {
 
     it('should return null when no certification course found', async () => {
       // when
-      const result = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId(userId + 1, sessionId + 1);
+      const result = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({ userId: userId + 1, sessionId });
 
       // then
       expect(result).to.be.null;

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, domainBuilder, catchErr, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder, knex } = require('../../../test-helper');
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const BookshelfCertificationCourse = require('../../../../lib/infrastructure/data/certification-course');
 const { NotFoundError } = require('../../../../lib/domain/errors');
@@ -37,7 +37,7 @@ describe('Integration | Repository | Certification Course', function() {
 
     it('should persist the certif course in db', async () => {
       // when
-      await certificationCourseRepository.save(certificationCourse);
+      await certificationCourseRepository.save({ certificationCourse });
 
       // then
       const certificationCourseSaved = await knex('certification-courses').select();
@@ -46,7 +46,7 @@ describe('Integration | Repository | Certification Course', function() {
 
     it('should return the saved certification course', async () => {
       // when
-      const savedCertificationCourse = await certificationCourseRepository.save(certificationCourse);
+      const savedCertificationCourse = await certificationCourseRepository.save({ certificationCourse });
 
       // then
       expect(savedCertificationCourse).to.be.an.instanceOf(CertificationCourse);

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -98,7 +98,7 @@ describe('Unit | Controller | assessment-controller-save', () => {
         await controller.save(request, hFake);
 
         // then
-        expect(assessmentRepository.save).to.have.been.calledWith(expected);
+        expect(assessmentRepository.save).to.have.been.calledWith({ assessment: expected });
       });
     });
   });

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -1,27 +1,34 @@
-const { sinon, expect } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
+const CertificationChallenge = require('../../../../lib/domain/models/CertificationChallenge');
 const certificationChallengesService = require('../../../../lib/domain/services/certification-challenges-service');
-const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
 
-describe('Unit | Service | Certification Challenge Service', function() {
+describe('Unit | Service | Certification Challenge Service', () => {
 
-  describe('#saveChallenges', () => {
+  describe('#generateCertificationChallenges', () => {
 
+    const certificationCourseId = 'certification-course-id';
     const challenge1 = {
-      id: 'challenge1',
-      competence: 'Savoir tester',
-      testedSkill: '@skill1'
+      id: 'challengeId11',
+      competenceId: 'competenceId1',
+      testedSkill: 'skill1',
     };
+    const certificationChallenge1 = new CertificationChallenge({
+      challengeId: challenge1.id,
+      competenceId: challenge1.competenceId,
+      associatedSkillName: challenge1.testedSkill,
+      courseId: certificationCourseId,
+    });
     const challenge2 = {
-      id: 'challenge2',
-      competence: 'Savoir debugguer',
-      testedSkill: '@skill2'
+      id: 'challengeId2',
+      competence: 'competenceId2',
+      testedSkill: 'skill2'
     };
-
-    const certificationProfileWithOneCompetence = [
-      {
-        challenges: [challenge1, challenge2]
-      }
-    ];
+    const certificationChallenge2 = new CertificationChallenge({
+      challengeId: challenge2.id,
+      competenceId: challenge2.competenceId,
+      associatedSkillName: challenge2.testedSkill,
+      courseId: certificationCourseId,
+    });
 
     const certificationProfileWithTwoCompetence = [
       {
@@ -31,54 +38,12 @@ describe('Unit | Service | Certification Challenge Service', function() {
       }
     ];
 
-    const certificationCourse = {
-      id :'certification-course-id'
-    };
-
-    beforeEach(() => {
-      sinon.stub(certificationChallengeRepository, 'save').resolves('challenge');
-    });
-
-    context('when profile return one competence with two challenges', () => {
-      it('should call certification Challenge Repository save twice', () => {
-        //When
-        const promise = certificationChallengesService.saveChallenges(certificationProfileWithOneCompetence, certificationCourse);
-
-        //Then
-        return promise.then(() => {
-          sinon.assert.calledTwice(certificationChallengeRepository.save);
-          sinon.assert.calledWith(certificationChallengeRepository.save,challenge1 ,certificationCourse);
-          sinon.assert.calledWith(certificationChallengeRepository.save,challenge2 ,certificationCourse);
-        });
-      });
-    });
-
-    context('when profile return two competences with one challenge', () => {
-      it('should call certification Challenge Repository save twice', () => {
-        //When
-        const promise = certificationChallengesService.saveChallenges(certificationProfileWithTwoCompetence, certificationCourse);
-
-        //Then
-        return promise.then(() => {
-          sinon.assert.calledTwice(certificationChallengeRepository.save);
-          sinon.assert.calledWith(certificationChallengeRepository.save,challenge1 ,certificationCourse);
-          sinon.assert.calledWith(certificationChallengeRepository.save,challenge2 ,certificationCourse);
-        });
-      });
-    });
-
-    it('should return the certification course with its challenges', function() {
+    it('should return certification challenges objects generated from the provided userCompetences and certificationCourseId', async () => {
       // when
-      const promise = certificationChallengesService.saveChallenges(certificationProfileWithTwoCompetence, certificationCourse);
+      const actualCertificationChallenges = await certificationChallengesService.generateCertificationChallenges(certificationProfileWithTwoCompetence, certificationCourseId);
 
       // then
-      return promise.then((certificationCourse) => {
-        expect(certificationCourse).to.deep.equal({
-          id :'certification-course-id',
-          challenges : ['challenge', 'challenge'],
-        });
-      });
+      expect(actualCertificationChallenges).to.have.deep.members([ certificationChallenge1, certificationChallenge2 ]);
     });
-
   });
 });

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -271,8 +271,8 @@ describe('Unit | Service | ScorecardService', function() {
           userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
         });
         // given
-        expect(assessmentRepository.save.args[0][0]).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 1 });
-        expect(assessmentRepository.save.args[1][0]).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 2 });
+        expect(assessmentRepository.save.args[0][0].assessment).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 1 });
+        expect(assessmentRepository.save.args[1][0].assessment).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 2 });
       });
 
       context('when campaign is already shared', function() {

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -53,7 +53,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     return promise.then(() => {
       expect(assessmentRepository.save).to.have.been.called;
 
-      const assessmentToSave = assessmentRepository.save.firstCall.args[0];
+      const assessmentToSave = assessmentRepository.save.firstCall.args[0].assessment;
       expect(assessmentToSave.type).to.equal(Assessment.types.SMARTPLACEMENT);
       expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
       expect(assessmentToSave.userId).to.equal(userId);

--- a/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-assessment-for-campaign_test.js
@@ -90,7 +90,7 @@ describe('Unit | UseCase | create-assessment-for-campaign', () => {
       // then
       return promise.then(() => {
         expect(assessmentRepository.save).to.have.been.called;
-        expect(assessmentRepository.save).to.have.been.calledWith(assessment);
+        expect(assessmentRepository.save).to.have.been.calledWith({ assessment });
       });
     });
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -287,7 +287,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(assessmentRepository.save).to.have.been.calledWith(sinon.match(mockAssessment));
+            expect(assessmentRepository.save).to.have.been.calledWith({ assessment: sinon.match(mockAssessment) });
           });
         });
       });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const sessionRepository = { get: sinon.stub() };
   const certificationChallengesService = { generateCertificationChallenges: sinon.stub() };
   const userService = {
-    fillCertificationProfileWithCertificationChallenges: sinon.stub(),
+    fillCertificationProfileWithChallenges: sinon.stub(),
     getCertificationProfile: sinon.stub(),
   };
   const parameters = {
@@ -156,7 +156,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             existingCertificationCourse = Symbol('existingCertificationCourse');
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
               .withArgs(userId, sessionId).onCall(1).resolves(existingCertificationCourse);
-            userService.fillCertificationProfileWithCertificationChallenges.withArgs(certificationProfile).resolves();
+            userService.fillCertificationProfileWithChallenges.withArgs(certificationProfile).resolves();
           });
 
           it('should return it with flag created marked as false', async function() {
@@ -185,7 +185,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(userService.fillCertificationProfileWithCertificationChallenges).to.have.been.calledWith(certificationProfile);
+            expect(userService.fillCertificationProfileWithChallenges).to.have.been.calledWith(certificationProfile);
           });
 
         });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
   const certificationChallengeRepository = { save: sinon.stub() };
   const certificationCourseRepository = {
-    getLastCertificationCourseByUserIdAndSessionId: sinon.stub(),
+    findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
     save: sinon.stub(),
   };
   const sessionRepository = { get: sinon.stub() };
@@ -41,7 +41,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
   afterEach(() => {
     clock.restore();
-    certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId.reset();
+    certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.reset();
   });
 
   context('when session access code is different from provided access code', () => {
@@ -77,7 +77,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
       let existingCertificationCourse;
       beforeEach(() => {
         existingCertificationCourse = Symbol('existingCertificationCourse');
-        certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId.withArgs(userId, sessionId).resolves(existingCertificationCourse);
+        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs(userId, sessionId).resolves(existingCertificationCourse);
       });
 
       it('should return it with flag created marked as false', async function() {
@@ -102,8 +102,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
       let certificationProfile;
 
       beforeEach(() => {
-        certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
-          .withArgs(userId, sessionId).onCall(0).rejects(new NotFoundError());
+        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+          .withArgs(userId, sessionId).onCall(0).resolves(null);
       });
 
       context('when the user is not certifiable', () => {
@@ -154,7 +154,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           let existingCertificationCourse;
           beforeEach(() => {
             existingCertificationCourse = Symbol('existingCertificationCourse');
-            certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
+            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
               .withArgs(userId, sessionId).onCall(1).resolves(existingCertificationCourse);
             userService.fillCertificationProfileWithCertificationChallenges.withArgs(certificationProfile).resolves();
           });
@@ -232,16 +232,16 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           };
 
           beforeEach(() => {
-            certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
-              .withArgs(userId, sessionId).onCall(1).rejects(new NotFoundError());
+            certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
+              .withArgs(userId, sessionId).onCall(1).resolves(null);
             userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
             certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
             certificationCourseRepository.save.resolves(savedCertificationCourse);
             assessmentRepository.save.resolves(savedAssessment);
             certificationChallengesService.generateCertificationChallenges
               .withArgs(certificationProfile.userCompetences, savedCertificationCourse.id).returns(generatedCertificationChallenges);
-            certificationChallengeRepository.save.withArgs(challenge1, savedCertificationCourse).resolves(savedCertificationChallenge1);
-            certificationChallengeRepository.save.withArgs(challenge2, savedCertificationCourse).resolves(savedCertificationChallenge2);
+            certificationChallengeRepository.save.withArgs(challenge1).resolves(savedCertificationChallenge1);
+            certificationChallengeRepository.save.withArgs(challenge2).resolves(savedCertificationChallenge2);
           });
 
           it('should return it with flag created marked as true with related ressources', async function() {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -274,7 +274,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(certificationCourseRepository.save).to.have.been.calledWith(sinon.match(mockCertificationCourse));
+            expect(certificationCourseRepository.save).to.have.been.calledWith({ certificationCourse: sinon.match(mockCertificationCourse) });
           });
 
           it('should have save the assessment based on an appropriate argument', async function() {

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -1,331 +1,296 @@
-const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 
 const { UserNotAuthorizedToCertifyError, NotFoundError } = require('../../../../lib/domain/errors');
-const certificationChallengesService = require('../../../../lib/domain/services/certification-challenges-service');
-const userService = require('../../../../lib/domain/services/user-service');
 const retrieveLastOrCreateCertificationCourse = require('../../../../lib/domain/usecases/retrieve-last-or-create-certification-course');
-const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
-const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/session-repository');
-const CertificationProfile = require('../../../../lib/domain/models/CertificationProfile');
-const UserCompetence = require('../../../../lib/domain/models/UserCompetence');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => {
 
-  describe('#retrieveLastOrCreateCertificationCourse', () => {
+  let clock;
+  const now = new Date('2019-01-01T05:06:07Z');
+  const userId = 'userId';
+  const sessionId = 'sessionId';
+  const accessCode = 'accessCode';
+  let foundSession;
+  const assessmentRepository = { save: sinon.stub() };
+  const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
+  const certificationChallengeRepository = { save: sinon.stub() };
+  const certificationCourseRepository = {
+    getLastCertificationCourseByUserIdAndSessionId: sinon.stub(),
+    save: sinon.stub(),
+  };
+  const sessionRepository = { get: sinon.stub() };
+  const certificationChallengesService = { generateCertificationChallenges: sinon.stub() };
+  const userService = {
+    fillCertificationProfileWithCertificationChallenges: sinon.stub(),
+    getCertificationProfile: sinon.stub(),
+  };
+  const parameters = {
+    assessmentRepository,
+    certificationCandidateRepository,
+    certificationChallengeRepository,
+    certificationCourseRepository,
+    sessionRepository,
+    certificationChallengesService,
+    userService,
+  };
 
-    const fiveCompetencesWithLevelHigherThan0 = [
-      new UserCompetence({ id: 'competence1', pixScore: 8, estimatedLevel: 1 }),
-      new UserCompetence({ id: 'competence2', pixScore: 0, estimatedLevel: 0 }),
-      new UserCompetence({ id: 'competence3', pixScore: 24, estimatedLevel: 3 }),
-      new UserCompetence({ id: 'competence4', pixScore: 32, estimatedLevel: 4 }),
-      new UserCompetence({ id: 'competence5', pixScore: 40, estimatedLevel: 5 }),
-      new UserCompetence({ id: 'competence6', pixScore: 48, estimatedLevel: 6 }),
-    ];
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
+  });
 
-    context('when a certification course already exists for given sessionId and userId', () => {
+  afterEach(() => {
+    clock.restore();
+    certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId.reset();
+  });
 
-      let userId;
-      let sessionId;
-      let accessCode;
-      let certificationCourse;
+  context('when session access code is different from provided access code', () => {
 
-      beforeEach(() => {
-        userId = 12345;
-        sessionId = 23;
-        accessCode = 'ABCD12';
-        certificationCourse = domainBuilder.buildCertificationCourse({ id: 'newlyCreatedCertificationCourse', sessionId, userId, createdAt: new Date('2018-12-12T01:02:03Z') });
-
-        sinon.stub(sessionRepository, 'get').resolves({ id: sessionId, accessCode });
-        sinon.stub(certificationCourseRepository, 'save').resolves();
-      });
-
-      context('when a certification course already exists from the beginning', () => {
-
-        beforeEach(() => {
-          sinon.stub(certificationCourseRepository, 'getLastCertificationCourseByUserIdAndSessionId').resolves(certificationCourse);
-        });
-
-        it('should get last started certification course for given sessionId and userId', async function() {
-          // when
-          const result = await retrieveLastOrCreateCertificationCourse({
-            sessionId,
-            accessCode,
-            userId,
-            sessionRepository,
-            userService,
-            certificationCandidateRepository,
-            certificationChallengesService,
-            certificationCourseRepository,
-            assessmentRepository,
-          });
-
-          // then
-          expect(result).to.deep.equal({
-            created: false,
-            certificationCourse
-          });
-        });
-
-      });
-
-      context('when a certification course has been created meanwhile', () => {
-
-        beforeEach(() => {
-          sinon.stub(certificationCourseRepository, 'getLastCertificationCourseByUserIdAndSessionId')
-            .onFirstCall().rejects(new NotFoundError())
-            .onSecondCall().resolves(certificationCourse);
-          const certificationProfile = new CertificationProfile({ userCompetences: fiveCompetencesWithLevelHigherThan0 });
-          sinon.stub(certificationCandidateRepository, 'getBySessionIdAndUserId').resolves({ firstName: 'Moi', lastName: 'Moche', birthdate: 'Méchant', birthplace: 'En enfer' });
-          sinon.stub(userService, 'getCertificationProfile').resolves(certificationProfile);
-          sinon.stub(userService, 'fillCertificationProfileWithCertificationChallenges').withArgs(certificationProfile).resolves(certificationProfile);
-        });
-
-        it('should get last started certification course for given sessionId and userId', async function() {
-          // when
-          const result = await retrieveLastOrCreateCertificationCourse({
-            sessionId,
-            accessCode,
-            userId,
-            sessionRepository,
-            userService,
-            certificationCandidateRepository,
-            certificationChallengesService,
-            certificationCourseRepository,
-            assessmentRepository,
-          });
-
-          // then
-          expect(result).to.deep.equal({
-            created: false,
-            certificationCourse
-          });
-        });
-
-      });
-
+    beforeEach(() => {
+      foundSession = { accessCode: 'differentAccessCode' };
+      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
     });
 
-    context('when the session does not exist', function() {
-      let userId;
-      let accessCode;
-      let sessionId;
-
-      beforeEach(() => {
-        userId = 12345;
-        accessCode = 'ABCD12';
-        sessionId = 23;
-        sinon.stub(sessionRepository, 'get').rejects(new NotFoundError());
+    it('should throw a not found error', async () => {
+      // when
+      const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
+        sessionId,
+        accessCode,
+        userId,
+        ...parameters,
       });
 
-      it('should rejects an error when the session does not exist',  async function() {
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when session access code is the same as the provided access code', () => {
+
+    beforeEach(() => {
+      foundSession = { accessCode };
+      sessionRepository.get.withArgs(sessionId).resolves(foundSession);
+    });
+
+    context('when a certification course with provided userId and sessionId already exists', () => {
+
+      let existingCertificationCourse;
+      beforeEach(() => {
+        existingCertificationCourse = Symbol('existingCertificationCourse');
+        certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId.withArgs(userId, sessionId).resolves(existingCertificationCourse);
+      });
+
+      it('should return it with flag created marked as false', async function() {
         // when
-        const result = await catchErr(retrieveLastOrCreateCertificationCourse)({
+        const result = await retrieveLastOrCreateCertificationCourse({
           sessionId,
           accessCode,
           userId,
-          sessionRepository,
-          userService,
-          certificationCandidateRepository,
-          certificationChallengesService,
-          certificationCourseRepository,
-          assessmentRepository,
+          ...parameters,
         });
 
         // then
-        expect(result).to.be.an.instanceOf(NotFoundError);
+        expect(result).to.deep.equal({
+          created: false,
+          certificationCourse: existingCertificationCourse,
+        });
       });
+
     });
 
-    context('when no certification course already exists for given sessionId and userId', function() {
-
-      let userId;
-      let sessionId;
-      let accessCode;
-      let certificationCourse;
-      let certificationCourseWithNbOfChallenges;
-
-      const now = new Date('2019-01-01T05:06:07Z');
-      let clock;
-
-      const noCompetences = [];
-      const oneCompetenceWithLevel0 = [new UserCompetence({ id: 'competence1', pixScore: 0, estimatedLevel: 0 })];
-      const oneCompetenceWithLevel5 = [new UserCompetence({ id: 'competence1', pixScore: 40, estimatedLevel: 5 })];
-      const fiveCompetencesAndOneWithLevel0 = [
-        new UserCompetence({ id: 'competence1', pixScore: 8, estimatedLevel: 1 }),
-        new UserCompetence({ id: 'competence2', pixScore: 16, estimatedLevel: 2 }),
-        new UserCompetence({ id: 'competence3', pixScore: 0, estimatedLevel: 0 }),
-        new UserCompetence({ id: 'competence4', pixScore: 32, estimatedLevel: 4 }),
-        new UserCompetence({ id: 'competence5', pixScore: 40, estimatedLevel: 5 }),
-      ];
+    context('when no certification course exists for this userId and sessionId', () => {
+      let certificationProfile;
 
       beforeEach(() => {
-        clock = sinon.useFakeTimers(now);
-        userId = 12345;
-        sessionId = 23;
-        accessCode = 'ABCD12';
-        sinon.stub(sessionRepository, 'get').resolves({ id: sessionId, accessCode });
-        sinon.stub(certificationCourseRepository, 'getLastCertificationCourseByUserIdAndSessionId').rejects(new NotFoundError());
-        certificationCourse = domainBuilder.buildCertificationCourse({
-          id: 'newlyCreatedCertificationCourse',
-          sessionId,
-          userId,
-          createdAt: new Date('2018-12-12T01:02:03Z')
-        });
-
-        certificationCourseWithNbOfChallenges = domainBuilder.buildCertificationCourse({
-          id: 'certificationCourseWithChallenges',
-          sessionId,
-          userId,
-          createdAt: new Date('2018-12-12T01:02:03Z'),
-          nbChallenges: 3
-        });
+        certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
+          .withArgs(userId, sessionId).onCall(0).rejects(new NotFoundError());
       });
 
-      afterEach(() => {
-        clock.restore();
-      });
+      context('when the user is not certifiable', () => {
 
-      [
-        { label: 'User Has No AirtableCompetence', competences: noCompetences },
-        { label: 'User Has Only 1 AirtableCompetence at Level 0', competences: oneCompetenceWithLevel0 },
-        { label: 'User Has Only 1 AirtableCompetence at Level 5', competences: oneCompetenceWithLevel5 },
-        { label: 'User Has 5 Competences with 1 at Level 0', competences: fiveCompetencesAndOneWithLevel0 },
-      ].forEach(function(testCase) {
+        beforeEach(() => {
+          certificationProfile = { isCertifiable: sinon.stub().returns(false) };
+          userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
+        });
 
-        it(`should not create a new certification if ${testCase.label}`, async function() {
-          // given
-          const certificationProfile = new CertificationProfile({ userCompetences: testCase.competences });
-          sinon.stub(userService, 'getCertificationProfile').withArgs({ userId, limitDate: now }).resolves(certificationProfile);
-          sinon.stub(userService, 'fillCertificationProfileWithCertificationChallenges').withArgs(certificationProfile).resolves(certificationProfile);
-          sinon.stub(certificationCourseRepository, 'save');
-          sinon.stub(assessmentRepository, 'save');
-
+        it('should throw a UserNotAuthorizedToCertifyError', async function() {
           // when
-          const result = await catchErr(retrieveLastOrCreateCertificationCourse)({
+          const error = await catchErr(retrieveLastOrCreateCertificationCourse)({
             sessionId,
             accessCode,
             userId,
-            sessionRepository,
-            userService,
-            certificationCandidateRepository,
-            certificationChallengesService,
-            certificationCourseRepository,
-            assessmentRepository,
+            ...parameters,
           });
 
           // then
-          expect(result).to.be.an.instanceOf(UserNotAuthorizedToCertifyError);
+          expect(error).to.be.an.instanceOf(UserNotAuthorizedToCertifyError);
+        });
+
+        it('should not create any new resource', async function() {
+          // when
+          await catchErr(retrieveLastOrCreateCertificationCourse)({
+            sessionId,
+            accessCode,
+            userId,
+            ...parameters,
+          });
+
+          // then
           sinon.assert.notCalled(certificationCourseRepository.save);
           sinon.assert.notCalled(assessmentRepository.save);
+          sinon.assert.notCalled(certificationChallengeRepository.save);
         });
       });
 
-      context('when the user has no link with a certification candidate in the session', () => {
+      context('when user is certifiable', () => {
 
-        it('should throw a not found error', async function() {
-          // given
-          const certificationProfile = new CertificationProfile({ userCompetences: fiveCompetencesWithLevelHigherThan0 });
-          sinon.stub(userService, 'getCertificationProfile').withArgs({ userId, limitDate: now })
-            .resolves(certificationProfile);
-          sinon.stub(userService, 'fillCertificationProfileWithCertificationChallenges').withArgs(certificationProfile)
-            .resolves(certificationProfile);
-          sinon.stub(certificationCandidateRepository, 'getBySessionIdAndUserId')
-            .rejects(new NotFoundError());
+        beforeEach(() => {
+          certificationProfile = { isCertifiable: sinon.stub().returns(true), userCompetences: 'someUserCompetences' };
+          userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
+        });
 
-          // when
-          const err = await catchErr(retrieveLastOrCreateCertificationCourse)({
-            sessionId,
-            accessCode,
+        context('when a certification course has been created meanwhile', () => {
+
+          let existingCertificationCourse;
+          beforeEach(() => {
+            existingCertificationCourse = Symbol('existingCertificationCourse');
+            certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
+              .withArgs(userId, sessionId).onCall(1).resolves(existingCertificationCourse);
+            userService.fillCertificationProfileWithCertificationChallenges.withArgs(certificationProfile).resolves();
+          });
+
+          it('should return it with flag created marked as false', async function() {
+            // when
+            const result = await retrieveLastOrCreateCertificationCourse({
+              sessionId,
+              accessCode,
+              userId,
+              ...parameters,
+            });
+
+            // then
+            expect(result).to.deep.equal({
+              created: false,
+              certificationCourse: existingCertificationCourse,
+            });
+          });
+
+          it('should have filled the certification profile with challenges anyway', async () => {
+            // when
+            await retrieveLastOrCreateCertificationCourse({
+              sessionId,
+              accessCode,
+              userId,
+              ...parameters,
+            });
+
+            // then
+            expect(userService.fillCertificationProfileWithCertificationChallenges).to.have.been.calledWith(certificationProfile);
+          });
+
+        });
+
+        context('when a certification still has not been created meanwhile', () => {
+
+          const foundCertificationCandidate = {
+            firstName: Symbol('firstName'),
+            lastName: Symbol('lastName'),
+            birthdate: Symbol('birthdate'),
+            birthCity: Symbol('birthCity'),
+            externalId: Symbol('externalId'),
+          };
+          const mockCertificationCourse = {
             userId,
-            sessionRepository,
-            userService,
-            certificationCandidateRepository,
-            certificationChallengesService,
-            certificationCourseRepository,
-            assessmentRepository,
-          });
-
-          // then
-          expect(err).to.be.an.instanceOf(NotFoundError);
-        });
-      });
-
-      context('when the user has a link with a certification candidate in the session', () => {
-
-        it('should create the certification course with status "started", if at least 5 competences with level higher than 0', async function() {
-          // given
-          sinon.stub(certificationCandidateRepository, 'getBySessionIdAndUserId')
-            .resolves({ firstName: 'prénom', lastName: 'nom', birthdate:'DDN', birthplace:'lieu' });
-          const certificationProfile = new CertificationProfile({ userCompetences: fiveCompetencesWithLevelHigherThan0 });
-          sinon.stub(userService, 'getCertificationProfile').withArgs({ userId, limitDate: now })
-            .resolves(certificationProfile);
-          sinon.stub(userService, 'fillCertificationProfileWithCertificationChallenges').withArgs(certificationProfile)
-            .resolves(certificationProfile);
-          sinon.stub(certificationChallengesService, 'saveChallenges').resolves(certificationCourseWithNbOfChallenges);
-          sinon.stub(certificationCourseRepository, 'save').resolves(certificationCourse);
-          sinon.stub(assessmentRepository, 'save').resolves();
-
-          // when
-          const newCertification = await retrieveLastOrCreateCertificationCourse({
             sessionId,
-            accessCode,
+            firstName: foundCertificationCandidate.firstName,
+            lastName: foundCertificationCandidate.lastName,
+            birthdate: foundCertificationCandidate.birthdate,
+            birthplace: foundCertificationCandidate.birthCity,
+            externalId: foundCertificationCandidate.externalId,
+            isV2Certification: true,
+          };
+          const savedCertificationCourse = {
+            id: 'savedCertificationCourse',
+          };
+          const mockAssessment = {
             userId,
-            sessionRepository,
-            userService,
-            certificationCandidateRepository,
-            certificationChallengesService,
-            certificationCourseRepository,
-            assessmentRepository,
+            certificationCourseId: savedCertificationCourse.id,
+            state: Assessment.states.STARTED,
+            type: Assessment.types.CERTIFICATION,
+          };
+          const savedAssessment = {
+            id: 'savedAssessment',
+          };
+          const challenge1 = 'challenge1';
+          const challenge2 = 'challenge2';
+          const generatedCertificationChallenges = [challenge1, challenge2];
+          const savedCertificationChallenge1 = {
+            id: 'savedCertificationChallenge1',
+          };
+          const savedCertificationChallenge2 = {
+            id: 'savedCertificationChallenge2',
+          };
+
+          beforeEach(() => {
+            certificationCourseRepository.getLastCertificationCourseByUserIdAndSessionId
+              .withArgs(userId, sessionId).onCall(1).rejects(new NotFoundError());
+            userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
+            certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
+            certificationCourseRepository.save.resolves(savedCertificationCourse);
+            assessmentRepository.save.resolves(savedAssessment);
+            certificationChallengesService.generateCertificationChallenges
+              .withArgs(certificationProfile.userCompetences, savedCertificationCourse.id).returns(generatedCertificationChallenges);
+            certificationChallengeRepository.save.withArgs(challenge1, savedCertificationCourse).resolves(savedCertificationChallenge1);
+            certificationChallengeRepository.save.withArgs(challenge2, savedCertificationCourse).resolves(savedCertificationChallenge2);
           });
 
-          // then
-          expect(newCertification).to.deep.equal({
-            created: true,
-            certificationCourse: certificationCourseWithNbOfChallenges
+          it('should return it with flag created marked as true with related ressources', async function() {
+            // when
+            const result = await retrieveLastOrCreateCertificationCourse({
+              sessionId,
+              accessCode,
+              userId,
+              ...parameters,
+            });
+
+            // then
+            expect(result).to.deep.equal({
+              created: true,
+              certificationCourse: {
+                ...savedCertificationCourse,
+                assessment: savedAssessment,
+                challenges: [savedCertificationChallenge1, savedCertificationChallenge2],
+              },
+            });
           });
-          sinon.assert.calledOnce(assessmentRepository.save);
+
+          it('should have save the certification course based on an appropriate argument', async function() {
+            // when
+            await retrieveLastOrCreateCertificationCourse({
+              sessionId,
+              accessCode,
+              userId,
+              ...parameters,
+            });
+
+            // then
+            expect(certificationCourseRepository.save).to.have.been.calledWith(sinon.match(mockCertificationCourse));
+          });
+
+          it('should have save the assessment based on an appropriate argument', async function() {
+            // when
+            await retrieveLastOrCreateCertificationCourse({
+              sessionId,
+              accessCode,
+              userId,
+              ...parameters,
+            });
+
+            // then
+            expect(assessmentRepository.save).to.have.been.calledWith(sinon.match(mockAssessment));
+          });
         });
       });
-
     });
-
-    context('when the access code does not correspond to the given sessionId', () => {
-      let userId;
-      let accessCode;
-      let wrongAccessCode;
-      let sessionId;
-
-      beforeEach(() => {
-        userId = 12345;
-        accessCode = 'ABCD12';
-        wrongAccessCode = 'ABCD13';
-        sessionId = 6789;
-
-        sinon.stub(sessionRepository, 'get').resolves({ id: sessionId, accessCode });
-      });
-
-      it('should not find the session', async function() {
-        // when
-        const result = await catchErr(retrieveLastOrCreateCertificationCourse)({
-          sessionId: sessionId,
-          wrongAccessCode,
-          userId,
-          sessionRepository,
-          userService,
-          certificationCandidateRepository,
-          certificationChallengesService,
-          certificationCourseRepository,
-          assessmentRepository,
-        });
-
-        // then
-        expect(result).to.be.an.instanceOf(NotFoundError);
-      });
-
-    });
-
   });
-
 });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -8,6 +8,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
   let clock;
   const now = new Date('2019-01-01T05:06:07Z');
+  const domainTransaction = Symbol('someDomainTransaction');
   const userId = 'userId';
   const sessionId = 'sessionId';
   const accessCode = 'accessCode';
@@ -26,6 +27,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
     getCertificationProfile: sinon.stub(),
   };
   const parameters = {
+    domainTransaction,
     assessmentRepository,
     certificationCandidateRepository,
     certificationChallengeRepository,
@@ -77,7 +79,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
       let existingCertificationCourse;
       beforeEach(() => {
         existingCertificationCourse = Symbol('existingCertificationCourse');
-        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs({ userId, sessionId }).resolves(existingCertificationCourse);
+        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs({ userId, sessionId, domainTransaction }).resolves(existingCertificationCourse);
       });
 
       it('should return it with flag created marked as false', async function() {
@@ -103,7 +105,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
       beforeEach(() => {
         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-          .withArgs({ userId, sessionId }).onCall(0).resolves(null);
+          .withArgs({ userId, sessionId, domainTransaction }).onCall(0).resolves(null);
       });
 
       context('when the user is not certifiable', () => {
@@ -155,7 +157,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           beforeEach(() => {
             existingCertificationCourse = Symbol('existingCertificationCourse');
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId, sessionId }).onCall(1).resolves(existingCertificationCourse);
+              .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(existingCertificationCourse);
             userService.fillCertificationProfileWithChallenges.withArgs(certificationProfile).resolves();
           });
 
@@ -233,15 +235,15 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
           beforeEach(() => {
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs({ userId, sessionId }).onCall(1).resolves(null);
+              .withArgs({ userId, sessionId, domainTransaction }).onCall(1).resolves(null);
             userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
             certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
             certificationCourseRepository.save.resolves(savedCertificationCourse);
             assessmentRepository.save.resolves(savedAssessment);
             certificationChallengesService.generateCertificationChallenges
               .withArgs(certificationProfile.userCompetences, savedCertificationCourse.id).returns(generatedCertificationChallenges);
-            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge1 }).resolves(savedCertificationChallenge1);
-            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge2 }).resolves(savedCertificationChallenge2);
+            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge1, domainTransaction }).resolves(savedCertificationChallenge1);
+            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge2, domainTransaction }).resolves(savedCertificationChallenge2);
           });
 
           it('should return it with flag created marked as true with related ressources', async function() {
@@ -274,7 +276,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(certificationCourseRepository.save).to.have.been.calledWith({ certificationCourse: sinon.match(mockCertificationCourse) });
+            expect(certificationCourseRepository.save).to.have.been.calledWith({ certificationCourse: sinon.match(mockCertificationCourse), domainTransaction });
           });
 
           it('should have save the assessment based on an appropriate argument', async function() {
@@ -287,7 +289,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             });
 
             // then
-            expect(assessmentRepository.save).to.have.been.calledWith({ assessment: sinon.match(mockAssessment) });
+            expect(assessmentRepository.save).to.have.been.calledWith({ assessment: sinon.match(mockAssessment), domainTransaction });
           });
         });
       });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -77,7 +77,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
       let existingCertificationCourse;
       beforeEach(() => {
         existingCertificationCourse = Symbol('existingCertificationCourse');
-        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs(userId, sessionId).resolves(existingCertificationCourse);
+        certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId.withArgs({ userId, sessionId }).resolves(existingCertificationCourse);
       });
 
       it('should return it with flag created marked as false', async function() {
@@ -103,7 +103,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
       beforeEach(() => {
         certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-          .withArgs(userId, sessionId).onCall(0).resolves(null);
+          .withArgs({ userId, sessionId }).onCall(0).resolves(null);
       });
 
       context('when the user is not certifiable', () => {
@@ -155,7 +155,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           beforeEach(() => {
             existingCertificationCourse = Symbol('existingCertificationCourse');
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs(userId, sessionId).onCall(1).resolves(existingCertificationCourse);
+              .withArgs({ userId, sessionId }).onCall(1).resolves(existingCertificationCourse);
             userService.fillCertificationProfileWithChallenges.withArgs(certificationProfile).resolves();
           });
 
@@ -233,7 +233,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
 
           beforeEach(() => {
             certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId
-              .withArgs(userId, sessionId).onCall(1).resolves(null);
+              .withArgs({ userId, sessionId }).onCall(1).resolves(null);
             userService.getCertificationProfile.withArgs({ userId, limitDate: now }).resolves(certificationProfile);
             certificationCandidateRepository.getBySessionIdAndUserId.withArgs({ sessionId, userId }).resolves(foundCertificationCandidate);
             certificationCourseRepository.save.resolves(savedCertificationCourse);

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -240,8 +240,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             assessmentRepository.save.resolves(savedAssessment);
             certificationChallengesService.generateCertificationChallenges
               .withArgs(certificationProfile.userCompetences, savedCertificationCourse.id).returns(generatedCertificationChallenges);
-            certificationChallengeRepository.save.withArgs(challenge1).resolves(savedCertificationChallenge1);
-            certificationChallengeRepository.save.withArgs(challenge2).resolves(savedCertificationChallenge2);
+            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge1 }).resolves(savedCertificationChallenge1);
+            certificationChallengeRepository.save.withArgs({ certificationChallenge: challenge2 }).resolves(savedCertificationChallenge2);
           });
 
           it('should return it with flag created marked as true with related ressources', async function() {

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -79,7 +79,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
 
       // then
       expect(assessmentRepository.save).to.have.been.called;
-      const assessmentToSave = assessmentRepository.save.firstCall.args[0];
+      const assessmentToSave = assessmentRepository.save.firstCall.args[0].assessment;
       expect(assessmentToSave.type).to.equal(Assessment.types.SMARTPLACEMENT);
       expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
       expect(assessmentToSave.userId).to.equal(userId);

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -72,12 +72,12 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
       beforeEach(() => {
         competenceEvaluationRepository.getByCompetenceIdAndUserId.rejects(new NotFoundError);
 
-        assessmentRepository.save.withArgs(new Assessment({
+        assessmentRepository.save.withArgs({ assessment: new Assessment({
           courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
           type: Assessment.types.COMPETENCE_EVALUATION,
           userId, state: Assessment.states.STARTED,
           competenceId,
-        })).resolves({ id: assessmentId });
+        }) }).resolves({ id: assessmentId });
 
         competenceEvaluationRepository.save.withArgs(new CompetenceEvaluation({
           status: CompetenceEvaluation.statuses.STARTED,
@@ -115,12 +115,12 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
           .onFirstCall().resolves(resetCompetenceEvaluation)
           .onSecondCall().resolves(updatedCompetenceEvaluation);
 
-        assessmentRepository.save.withArgs(new Assessment({
+        assessmentRepository.save.withArgs({ assessment: new Assessment({
           courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
           type: Assessment.types.COMPETENCE_EVALUATION,
           userId, state: Assessment.states.STARTED,
           competenceId,
-        })).resolves({ id: newAssessmentId });
+        }) }).resolves({ id: newAssessmentId });
 
         competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId.resolves();
         competenceEvaluationRepository.updateAssessmentId.resolves();


### PR DESCRIPTION
## :unicorn: Problème
On souhaite éviter d'ajouter davantage de données incohérentes à la base de données en cas de ralentissements serveurs ou BDD. En effet, nous avons actuellement en BDD des certificationCourse sans challenges ou sans assessment. Nous souhaitons éviter cela à l'avenir.

## :robot: Solution
Mise en transaction de la création du certification-course, de son assessment et de ses challenges.

## :rainbow: Remarques
