### PR TITLE
[TECH] Ajout d'une gestion de droits à la fonctionnalité de campagne de récupération profils (PO-390).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -25,8 +25,9 @@
           Département : <span class="organization__provinceCode">{{@organization.provinceCode}}</span><br>
         {{/if}}
         {{#if @organization.isOrganizationSCO}}
-          Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span>
+          Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
         {{/if}}
+        A accès aux campagnes de récupération profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
         Crédits : <span class="organization__credit">{{@organization.credit}}</span>
       </p>
     </div>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -7,6 +7,10 @@ export default class OrganizationInformationSection extends Component {
     return this.args.organization.isManagingStudents ? 'Oui' : 'Non';
   }
 
+  get canCollectProfiles() {
+    return this.args.organization.canCollectProfiles ? 'Oui' : 'Non';
+  }
+
   @action
   updateLogo(file) {
     return file.readAsDataURL().then((b64) => {

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -9,6 +9,7 @@ export default class Organization extends Model {
   @attr() externalId;
   @attr() provinceCode;
   @attr() isManagingStudents;
+  @attr() canCollectProfiles;
   @attr() credit;
 
   @equal('type', 'SCO') isOrganizationSCO;

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -25,10 +25,22 @@ module('Integration | Component | organization-information-section', function(ho
     this.set('organization', organization);
 
     // when
-    await render(hbs`{{organization-information-section organization=organization}}`);
+    await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
 
     // then
     assert.dom('.organization__credit').hasText('350');
+  });
+
+  test('it should display canCollectProfiles', async function(assert) {
+    // given
+    const organization = EmberObject.create({ canCollectProfiles: true });
+    this.set('organization', organization);
+
+    // when
+    await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
+    // then
+    assert.dom('.organization__canCollectProfiles').hasText('Oui');
   });
 
   module('When organization is SCO', function(hooks) {

--- a/api/db/migrations/20200324101353_add-can-collect-profiles-to-organization.js
+++ b/api/db/migrations/20200324101353_add-can-collect-profiles-to-organization.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'canCollectProfiles';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/dragon-and-co-builder.js
+++ b/api/db/seeds/data/dragon-and-co-builder.js
@@ -27,7 +27,8 @@ module.exports = function addDragonAndCoWithrelated({ databaseBuilder }) {
     id: 1,
     type: 'PRO',
     name: 'Dragon & Co',
-    logoUrl: require('../src/dragonAndCoBase64')
+    logoUrl: require('../src/dragonAndCoBase64'),
+    canCollectProfiles: true,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -18,6 +18,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     type: 'SCO',
     name: 'The Night Watch',
     isManagingStudents: true,
+    canCollectProfiles: true,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -10,6 +10,7 @@ class Organization {
     provinceCode,
     isManagingStudents,
     credit,
+    canCollectProfiles,
     // includes
     memberships = [],
     targetProfileShares = [],
@@ -26,6 +27,7 @@ class Organization {
     this.provinceCode = provinceCode;
     this.isManagingStudents = isManagingStudents;
     this.credit = credit;
+    this.canCollectProfiles = canCollectProfiles;
     // includes
     this.memberships = memberships;
     this.targetProfileShares = targetProfileShares;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -18,6 +18,7 @@ function _toDomain(bookshelfOrganization) {
     provinceCode: rawOrganization.provinceCode,
     isManagingStudents: Boolean(rawOrganization.isManagingStudents),
     credit: rawOrganization.credit,
+    canCollectProfiles: Boolean(rawOrganization.canCollectProfiles),
   });
 
   let members = [];

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
         record.targetProfiles = [];
         return record;
       },
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'memberships', 'students', 'targetProfiles'],
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'memberships', 'students', 'targetProfiles'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -547,6 +547,7 @@ describe('Acceptance | Application | organization-controller', () => {
               'external-id': organization.externalId,
               'province-code': organization.provinceCode,
               'is-managing-students': organization.isManagingStudents,
+              'can-collect-profiles': organization.canCollectProfiles,
               'credit': organization.credit,
             },
             'id': organization.id.toString(),

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -109,14 +109,37 @@ describe('Integration | Repository | Organization', function() {
     describe('success management', function() {
 
       let insertedOrganization;
+      const organizationAttributes = {
+        type: 'SCO',
+        name: 'Organization of the dark side',
+        logoUrl: 'some logo url',
+        credit: 154,
+        externalId: '100',
+        provinceCode: '75',
+        isManagingStudents: 'true',
+        canCollectProfiles: 'true',
+      };
+
+      let expectedAttributes;
 
       beforeEach(async () => {
-        insertedOrganization = databaseBuilder.factory.buildOrganization({
+        insertedOrganization = databaseBuilder.factory.buildOrganization(organizationAttributes);
+        expectedAttributes = {
+          id:  insertedOrganization.id,
           type: 'SCO',
           name: 'Organization of the dark side',
           logoUrl: 'some logo url',
           credit: 154,
-        });
+          externalId: '100',
+          provinceCode: '75',
+          isManagingStudents: true,
+          canCollectProfiles: true,
+          members: [],
+          memberships: [],
+          students: [],
+          targetProfileShares: [],
+          organizationInvitations: []
+        };
         await databaseBuilder.commit();
       });
 
@@ -125,12 +148,7 @@ describe('Integration | Repository | Organization', function() {
         const foundOrganization = await organizationRepository.get(insertedOrganization.id);
 
         // then
-        expect(foundOrganization).to.be.an.instanceof(Organization);
-        expect(foundOrganization.type).to.equal(insertedOrganization.type);
-        expect(foundOrganization.name).to.equal(insertedOrganization.name);
-        expect(foundOrganization.logoUrl).to.equal(insertedOrganization.logoUrl);
-        expect(foundOrganization.id).to.equal(insertedOrganization.id);
-        expect(foundOrganization.credit).to.equal(insertedOrganization.credit);
+        expect(foundOrganization).to.deep.equal(expectedAttributes);
       });
 
       it('should return a rejection when organization id is not found', function() {

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -10,6 +10,7 @@ const buildOrganization = function buildOrganization({
   provinceCode = faker.random.alphaNumeric(3),
   isManagingStudents = false,
   credit = 500,
+  canCollectProfiles = false,
   createdAt = faker.date.recent(),
   updatedAt = faker.date.recent(),
 } = {}) {
@@ -23,6 +24,7 @@ const buildOrganization = function buildOrganization({
     provinceCode,
     isManagingStudents,
     credit,
+    canCollectProfiles,
     createdAt,
     updatedAt,
   };

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -36,11 +36,12 @@ function buildOrganization(
     provinceCode = '2A',
     isManagingStudents = false,
     credit = 500,
+    canCollectProfiles = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     memberships = [],
     targetProfileShares = []
   } = {}) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, memberships, targetProfileShares });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, canCollectProfiles, createdAt, memberships, targetProfileShares });
 }
 
 buildOrganization.withMembers = function(
@@ -53,6 +54,7 @@ buildOrganization.withMembers = function(
     provinceCode = '2A',
     isManagingStudents = false,
     credit = 500,
+    canCollectProfiles = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     members = [
       _buildMember({ id: 1, firstName: 'John', lastName: 'Doe', email: 'john.doe@example.com' }),
@@ -60,7 +62,7 @@ buildOrganization.withMembers = function(
     ]
   } = {}
 ) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, members });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, canCollectProfiles, createdAt, members });
 };
 
 buildOrganization.withStudents = function(
@@ -73,11 +75,12 @@ buildOrganization.withStudents = function(
     provinceCode = '2A',
     isManagingStudents = true,
     credit = 500,
+    canCollectProfiles = false,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     students = []
   } = {}
 ) {
-  const organization = new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, createdAt, students });
+  const organization = new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, canCollectProfiles, createdAt, students });
 
   organization.students = [
     _buildStudent({ id: 1, lastName: 'Doe', firstName: 'John', organization }),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -25,6 +25,7 @@ describe('Unit | Serializer | organization-serializer', () => {
             'province-code': organization.provinceCode,
             'is-managing-students': organization.isManagingStudents,
             'credit': organization.credit,
+            'can-collect-profiles': organization.canCollectProfiles
           },
           relationships: {
             memberships: {

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -1,16 +1,20 @@
-import DS from 'ember-data';
 import { equal } from '@ember/object/computed';
+import DS from 'ember-data';
 
-export default DS.Model.extend({
-  name: DS.attr('string'),
-  type: DS.attr('string'),
-  externalId: DS.attr('string'),
-  campaigns: DS.hasMany('campaign'),
-  targetProfiles: DS.hasMany('target-profile'),
-  memberships: DS.hasMany('membership'),
-  organizationInvitations: DS.hasMany('organization-invitation'),
-  students: DS.hasMany('student'),
-  isManagingStudents: DS.attr('boolean'),
+const { Model, attr, hasMany } = DS;
 
-  isSco: equal('type', 'SCO'),
-});
+export default class Organization extends Model {
+  @attr('string') name;
+  @attr('string') type;
+  @attr('string') externalId;
+  @attr('boolean') isManagingStudents;
+  @attr('boolean') canCollectProfiles;
+
+  @hasMany('campaign') campaigns;
+  @hasMany('target-profile') targetProfiles;
+  @hasMany('membership') memberships;
+  @hasMany('organization-invitation') organizationInvitations;
+  @hasMany('student') students;
+
+  @equal('type', 'SCO') isSco;
+}


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité de créer une Campagne de récupération de profils n'est pas souhaitée pour toutes les organisations, notamment côté PRO, où le pricing n'est pas défini. Mais, une partie des PRO va en avoir besoin, leur permettant de voir où on sont les utilisateurs au niveau des compétences numériques lorsqu'ils débutent au sein de l'organisation.

D'autre part, on ne peut pas se permettre d'afficher des choses et leur permettre la création de campagne de récupération profils pour ces mêmes utilisateurs PRO, même pour un court instant.

## :robot: Solution
C'est pourquoi cet aspect a été développé entièrement techniquement, cela nous permet d'avancer sur les sujets que l'on ne doit pas afficher pour les prescripteurs non autorisés.

On a ajouté le champ `canCollectProfiles` en base, et on l'a remonté jusqu'au front.

## :rainbow: Remarques
Cette PR a été réalisée en MOB Programming.

## :100: Pour tester
- Voir en base le nouveau champ `canCollectProfiles` dans la table `Organization` ;
- Voir l'affichage du champ dans Pix Admin dans le détail d'une Organisation.
