### PR TITLE
[CLEANUP] Ajouter les couleurs et les styles de titres du design system à PixApp (PF-1181).

### DIFF
--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -10,34 +10,12 @@
 }
 
 .learning-more-panel__hint-title {
-  color: $charcoal-grey;
-  text-align: center;
-  font-family: $font-open-sans;
-  font-size: 2.2rem;
-  font-weight: $font-semi-bold;
-
   // XXX Inspired from https://codepen.io/ericrasch/pen/Irlpm
   position: relative;
   z-index: 1;
 
-  &:before {
-    border-top: 2px solid #dfdfdf;
-    content:"";
-    margin: 0 auto;
-    position: absolute;
-    top: 50%; left: 0; right: 0; bottom: 0;
-    width: 100%;
-    z-index: -1;
-  }
-
   span {
     background: white;
-    padding: 0 15px;
-  }
-
-  @include device-is('desktop') {
-    font-size: 2.2rem;
-    line-height: 26px;
   }
 }
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -1,26 +1,21 @@
 .tutorials {
-  padding: 0 25px;
-  color: $dove-gray;
-  font-family: Roboto;
   width: 100%;
+  padding: 0 25px;
 
   &__header {
-    margin-bottom: 56px;
+    margin-bottom: 48px;
   }
 }
 
 .tutorials-header {
   &__title {
-    color: $grayish-grey;
-    font-weight: 400;
-    font-size: 3rem;
-    line-height: 1.1;
-    margin-top: 20px;
-    margin-bottom: 10px;
+    margin-bottom: 4px;
   }
 
   &__description {
-    font-family: "Open Sans", Arial, sans-serif;
+    font-family: $font-roboto;
+    font-weight: $font-normal;
+    color: $grey-90;
     font-size: 1.6rem;
     line-height: 2.6rem;
     margin: 0 0 10px;
@@ -28,18 +23,15 @@
 }
 
 .tube {
-  margin: 36px 0;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  margin-bottom: 40px;
 
   &__title {
+    font-size: 2rem;
+    font-weight: $font-normal;
     font-family: $font-open-sans;
-    font-size: 2.3rem;
-    color: $dove-gray;
-    margin: 12px 0;
-    font-weight: 400;
+    line-height: 3.4rem;
+    color: $grey-90;
+    margin-bottom: 24px;
   }
 
   &__content {
@@ -62,7 +54,7 @@
     border-radius: 6.75px;
     font-family: $font-roboto;
     background-color: $alabaster-grey;
-    padding: 30px 0;
+    padding: 40px 0;
     margin: 14px;
 
     @include device-is('desktop') {

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -20,7 +20,6 @@ $charcoal-grey: #3e4149;
 $grayish-grey: #39393A;
 $nero: #222222;
 $black: #000000;
-$n80: #253858;
 
 $periwinkle-blue: #c3d0ff;
 $jordy-blue: #8D9EF7;
@@ -52,6 +51,26 @@ $red-error: #E62600;
 $monza: #D60606;
 
 $purple: #985FFF;
+
+// light
+$grey-5: #FAFBFC;
+$grey-10: #F4F5F7;
+$grey-15: #EAECF0;
+$grey-20: #DFE1E6;
+$grey-22: #C1C7D0;
+$grey-25: #A5ADBA;
+// medium
+$grey-30: #97A0AF;
+$grey-35: #8993A4;
+$grey-40: #7A869A;
+$grey-45: #6B778C;
+$grey-50: #5E6C84;
+// dark
+$grey-70: #344563;
+$grey-80: #253858;
+$grey-90: #172B4D;
+$grey-100: #091E42;
+
 
 /*
   Area Colors

--- a/mon-pix/app/styles/globals/_titles.scss
+++ b/mon-pix/app/styles/globals/_titles.scss
@@ -1,6 +1,16 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0;
+}
+
 h3 {
   font-size: 2.6rem;
-  color: $n80;
+  color: $grey-90;
   font-family: $font-open-sans;
   font-weight: $font-light;
   letter-spacing: 0.015rem;
@@ -14,7 +24,7 @@ h3 {
 
 h4 {
   font-size: 2.4rem;
-  color: $n80;
+  color: $grey-90;
   font-family: $font-open-sans;
   font-weight: $font-normal;
   letter-spacing: 0;

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -57,7 +57,7 @@
   padding: 32px 16px 24px;
   text-align: center;
   align-items: center;
-  color: $n80;
+  color: $grey-80;
 
   display: flex;
   flex-direction: column;

--- a/mon-pix/app/templates/components/learning-more-panel.hbs
+++ b/mon-pix/app/templates/components/learning-more-panel.hbs
@@ -1,7 +1,7 @@
 {{#if hasLearningMoreItems}}
   <div class="learning-more-panel__container">
     <header class="learning-more-panel__hint-container-header">
-      <h3 class="learning-more-panel__hint-title"><span>Pour en apprendre davantage</span></h3>
+      <h4 class="learning-more-panel__hint-title"><span>Pour en apprendre davantage</span></h4>
     </header>
 
     <div class="learning-more-panel__list-container">

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -81,13 +81,13 @@
 <div class="scorecard-details__content">
   <div class="tutorials">
     <div class="tutorials__header">
-      <h2 class="tutorials-header__title">Cultivez vos compétences</h2>
+      <h3 class="tutorials-header__title">Cultivez vos compétences</h3>
       <p class="tutorials-header__description">Voici une sélection de tutos qui pourront vous aider à gagner des Pix.</p>
     </div>
     <div class="tutorial__list">
       {{#each tutorialsGroupedByTubeName as |tube|}}
         <div class="tube">
-          <h3 class="tube__title">{{tube.practicalTitle}}</h3>
+          <h4 class="tube__title">{{tube.practicalTitle}}</h4>
           <div class="tube__content">
             {{#each tube.tutorials as |tutorial|}}
               <TutorialItemOnScorecard @tutorial={{tutorial}} />


### PR DESCRIPTION
## :unicorn: Problème
Nos différentes applications n'ont pas des éléments visuels unifiés. C'est notamment le cas des couleurs et des styles de titres.

## :robot: Solution
Ajouter à Pix App les couleurs et les styles de titres qui sont mises en place par notre nouveau design system.