### PR TITLE
[INFRA] Retrait du feature toggle FT_IS_SESSION_FINALIZATION_ACTIVE (PC-137)

### DIFF
--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -1,18 +1,19 @@
+import { computed } from '@ember/object';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'pix-certif/config/environment';
-import { computed } from '@ember/object';
 
-export default JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: ENV.APP.API_HOST,
-  namespace: 'api',
+export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapterMixin) {
+  host = ENV.APP.API_HOST;
+  namespace = 'api';
 
-  headers: computed('session.data.authenticated.access_token', function() {
+  @computed('session.data.authenticated.access_token')
+  get headers() {
     const headers = {};
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
 
     return headers;
-  }),
-});
+  }
+}

--- a/certif/app/adapters/certification-candidate.js
+++ b/certif/app/adapters/certification-candidate.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from './application';
 
-export default class SessionAdapter extends ApplicationAdapter {
+export default class CertificationCandidateAdapter extends ApplicationAdapter {
 
   urlForCreateRecord(modelName, { adapterOptions }) {
     const url = super.urlForCreateRecord(...arguments);

--- a/certif/app/adapters/certification-report.js
+++ b/certif/app/adapters/certification-report.js
@@ -1,9 +1,9 @@
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
+export default class CertificationReportAdapter extends ApplicationAdapter {
 
   urlForCreateRecord(modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForCreateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.registerToSession) {
       delete adapterOptions.registerToSession;
@@ -13,5 +13,5 @@ export default ApplicationAdapter.extend({
     }
 
     return url;
-  },
-});
+  }
+}

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -18,9 +18,9 @@ export default class SessionAdapter extends ApplicationAdapter {
       const data = {
         data: {
           attributes: {
-            'examiner-global-comment': model.get('examinerGlobalComment'),
+            'examiner-global-comment': model.examinerGlobalComment,
           },
-          included: model.get('certificationReports')
+          included: model.certificationReports
             .filter((certificationReport) => certificationReport.hasDirtyAttributes)
             .map((certificationReport) => ({
               type: 'certification-reports',

--- a/certif/app/app.js
+++ b/certif/app/app.js
@@ -4,12 +4,9 @@ import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 export default class App extends Application {
-  constructor() {
-    super(...arguments);
-    this.modulePrefix = config.modulePrefix;
-    this.podModulePrefix = config.podModulePrefix;
-    this.Resolver = Resolver;
-  }
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
 }
 
 loadInitializers(App, config.modulePrefix);

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -7,20 +7,12 @@ import ENV from 'pix-certif/config/environment';
 export default class LoginForm extends Component {
 
   @service session;
-  @tracked isPasswordVisible;
-  @tracked isErrorMessagePresent;
 
-  @tracked errorMessage;
-
-  constructor() {
-    super(...arguments);
-
-    this.email = null;
-    this.password = null;
-    this.isPasswordVisible = false;
-    this.isErrorMessagePresent = false;
-    this.errorMessage = null;
-  }
+  email = null;
+  password = null;
+  @tracked isPasswordVisible = false;
+  @tracked isErrorMessagePresent = false;
+  @tracked errorMessage = null;
 
   get passwordInputType() {
     return this.isPasswordVisible ? 'text' : 'password';

--- a/certif/app/components/session-finalization-formbuilder-link-step.js
+++ b/certif/app/components/session-finalization-formbuilder-link-step.js
@@ -2,10 +2,5 @@ import Component from '@glimmer/component';
 import config from '../config/environment';
 
 export default class SessionFinalizationFormBuilderLinkStep extends Component {
-
-  constructor() {
-    super(...arguments);
-
-    this.formBuilderLinkUrl = config.formBuilderLinkUrl;
-  }
+  formBuilderLinkUrl = config.formBuilderLinkUrl;
 }

--- a/certif/app/components/session-finalization-reports-informations-step.js
+++ b/certif/app/components/session-finalization-reports-informations-step.js
@@ -1,12 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class SessionFinalizationReportsInformationsStep extends Component {
-
-  constructor() {
-    super(...arguments);
-
-    this.textareaMaxLength = 500;
-  }
+  textareaMaxLength = 500;
 
   get certifReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
-export default class AuthenticatedSessionsDetailsController extends Controller {
+export default class SessionsDetailsController extends Controller {
 
   @alias('model') session;
 

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -9,16 +9,11 @@ import config from '../../../../config/environment';
 
 export default class AuthenticatedSessionsDetailsCertificationCandidatesController extends Controller {
 
-  @alias('model') currentSession;
-  @tracked candidatesInStaging;
   @service session;
   @service notifications;
 
-  constructor() {
-    super(...arguments);
-
-    this.candidatesInStaging = [];
-  }
+  @alias('model') currentSession;
+  @tracked candidatesInStaging = [];
 
   @computed('currentSession.certificationCandidates.{[],@each.isLinked}')
   get importAllowed() {

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 
 import config from '../../../../config/environment';
 
-export default class AuthenticatedSessionsDetailsCertificationCandidatesController extends Controller {
+export default class CertificationCandidatesController extends Controller {
 
   @service session;
   @service notifications;

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -7,14 +7,8 @@ import config from '../../../../config/environment';
 export default class AuthenticatedSessionsDetailsParametersController extends Controller {
 
   @alias('model') session;
-  @tracked tooltipText;
-
-  constructor() {
-    super(...arguments);
-
-    this.isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
-    this.tooltipText = 'Copier le lien direct';
-  }
+  @tracked tooltipText = 'Copier le lien direct';
+  isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
 
   @action
   clipboardSuccess() {

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -4,7 +4,7 @@ import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import config from '../../../../config/environment';
 
-export default class AuthenticatedSessionsDetailsParametersController extends Controller {
+export default class SessionParametersController extends Controller {
 
   @alias('model') session;
   @tracked tooltipText = 'Copier le lien direct';

--- a/certif/app/controllers/authenticated/sessions/details/parameters.js
+++ b/certif/app/controllers/authenticated/sessions/details/parameters.js
@@ -2,13 +2,11 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
-import config from '../../../../config/environment';
 
 export default class SessionParametersController extends Controller {
 
   @alias('model') session;
   @tracked tooltipText = 'Copier le lien direct';
-  isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
 
   @action
   clipboardSuccess() {

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -9,19 +9,13 @@ import { sumBy } from 'lodash';
 
 export default class AuthenticatedSessionsFinalizeController extends Controller {
 
-  @alias('model') session;
   @service notifications;
-  @tracked isLoading;
-  @tracked showConfirmModal;
 
-  constructor() {
-    super(...arguments);
-
-    this.isLoading = false;
-    this.showConfirmModal = false;
-    this.examinerGlobalCommentMaxLength = 500;
-    this.examinerCommentMaxLength = 500;
-  }
+  @alias('model') session;
+  examinerGlobalCommentMaxLength = 500;
+  examinerCommentMaxLength = 500;
+  @tracked isLoading = false;
+  @tracked showConfirmModal = false;
 
   @computed('session.certificationReports.@each.hasSeenEndTestScreen')
   get uncheckedHasSeenEndTestScreenCount() {

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import config from '../../../config/environment';
 import { sumBy } from 'lodash';
 
-export default class AuthenticatedSessionsFinalizeController extends Controller {
+export default class SessionsFinalizeController extends Controller {
 
   @service notifications;
 

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -6,7 +6,7 @@ import config from '../../../config/environment';
 
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
-export default class AuthenticatedSessionsListController extends Controller {
+export default class SessionsListController extends Controller {
   isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
   sortingOrder = SORTING_ORDER;
 

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -2,12 +2,10 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { notEmpty } from '@ember/object/computed';
 import { sort } from '@ember/object/computed';
-import config from '../../../config/environment';
 
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
 export default class SessionsListController extends Controller {
-  isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
   sortingOrder = SORTING_ORDER;
 
   @notEmpty('model') hasSession;

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -7,14 +7,11 @@ import config from '../../../config/environment';
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
 export default class AuthenticatedSessionsListController extends Controller {
+  isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
+  sortingOrder = SORTING_ORDER;
+
   @notEmpty('model') hasSession;
   @sort('model', 'sortingOrder') sortedSessions;
-
-  constructor() {
-    super(...arguments);
-    this.isSessionFinalizationActive = config.APP.isSessionFinalizationActive;
-    this.sortingOrder = SORTING_ORDER;
-  }
 
   @action
   goToDetails(session) {

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
-export default class AuthenticatedSessionsNewController extends Controller {
+export default class SessionsNewController extends Controller {
 
   @alias('model') session;
 

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
-export default class AuthenticatedSessionsUpdateController extends Controller {
+export default class SessionsUpdateController extends Controller {
 
   @alias('model') session;
 

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -1,26 +1,25 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-import { inject as service } from '@ember/service';
-
-export default Route.extend(ApplicationRouteMixin, {
-  routeAfterAuthentication: 'authenticated',
-  currentUser: service(),
+export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
+  @service currentUser;
+  routeAfterAuthentication = 'authenticated';
 
   beforeModel() {
     return this._loadCurrentUser();
-  },
+  }
 
   async sessionAuthenticated() {
     await this._loadCurrentUser();
     this.transitionTo(this.routeAfterAuthentication);
-  },
+  }
 
   sessionInvalidated() {
     this.transitionTo('login');
-  },
+  }
 
   _loadCurrentUser() {
     return this.currentUser.load();
-  },
-});
+  }
+}

--- a/certif/app/routes/authenticated.js
+++ b/certif/app/routes/authenticated.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
 
-export default class Authenticated extends Route.extend(AuthenticatedRouteMixin) {
+export default class AuthenticatedRoute extends Route.extend(AuthenticatedRouteMixin) {
   @service currentUser;
 
   beforeModel(transition) {

--- a/certif/app/routes/authenticated/index.js
+++ b/certif/app/routes/authenticated/index.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class AuthenticatedIndexRoute extends Route {
+export default class IndexRoute extends Route {
 
   @service currentUser;
 

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-export default class AuthenticatedSessionsDetailsRoute extends Route {
+export default class SessionsDetailsRoute extends Route {
   model(params) {
     return this.store.findRecord('session', params.session_id);
   }

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-export default class AuthenticatedSessionsDetailsCertificationCandidatesRoute extends Route {
+export default class CertificationCandidatesRoute extends Route {
   model() {
     return this.modelFor('authenticated.sessions.details');
   }

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 
 import config from '../../../config/environment';
 
-export default class AuthenticatedSessionsFinalizeRoute extends Route {
+export default class SessionsFinalizeRoute extends Route {
   @service notifications;
 
   async model({ session_id }) {

--- a/certif/app/routes/authenticated/sessions/list.js
+++ b/certif/app/routes/authenticated/sessions/list.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class AuthenticatedSessionsListRoute extends Route {
+export default class SessionsListRoute extends Route {
   @service currentUser;
 
   model() {

--- a/certif/app/routes/authenticated/sessions/new.js
+++ b/certif/app/routes/authenticated/sessions/new.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class AuthenticatedSessionsNewRoute extends Route {
+export default class SessionsNewRoute extends Route {
   @service currentUser;
 
   model() {

--- a/certif/app/routes/authenticated/sessions/update.js
+++ b/certif/app/routes/authenticated/sessions/update.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import moment from 'moment';
 
-export default class AuthenticatedSessionsUpdateRoute extends Route {
+export default class SessionsUpdateRoute extends Route {
 
   async model({ session_id }) {
     const session = await this.store.findRecord('session', session_id);

--- a/certif/app/routes/login.js
+++ b/certif/app/routes/login.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Route.extend(UnauthenticatedRouteMixin, {
-});
+export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+}

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -47,7 +47,7 @@
   </div>
 
   <div class="session-details-row">
-    {{#if (and this.isSessionFinalizationActive this.session.hasStarted) }}
+    {{#if this.session.hasStarted}}
       <div class="session-details-buttons">
         <LinkTo @route="authenticated.sessions.update" @model={{this.session.id}} class="button button--regular button--grey button--link session-details-content__update-button">
             Modifier

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -22,9 +22,7 @@
             <th class="table__column">Date</th>
             <th class="table__column table__column--small">Heure</th>
             <th class="table__column table__column--wide">Surveillant(s)</th>
-          {{#if this.isSessionFinalizationActive }}
-              <th class="table__column table__column--wide">Statut</th>
-          {{/if}}
+            <th class="table__column table__column--wide">Statut</th>
           </tr>
           </thead>
 
@@ -37,9 +35,7 @@
                 <td>{{moment-format session.date 'DD/MM/YYYY' allow-empty=true}}</td>
                 <td>{{moment-format session.time 'HH:mm' 'HH:mm:ss' allow-empty=true}}</td>
                 <td>{{session.examiner}}</td>
-              {{#if this.isSessionFinalizationActive }}
-                  <td>{{session.displayStatus}}</td>
-              {{/if}}
+                <td>{{session.displayStatus}}</td>
             </tr>
           {{/each}}
           </tbody>

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -1,4 +1,7 @@
 'use strict';
+const _ = require('lodash');
+
+const ACTIVE_FEATURE_TOGGLES = [];
 
 module.exports = function(environment) {
   const ENV = {
@@ -101,6 +104,13 @@ module.exports = function(environment) {
     // here you can enable a production-specific feature
     //ENV.APP.API_HOST = 'https://pix.fr/api';
   }
+
+  // Warn for unknown feature toggles
+  _.each(process.env, (value, key) => {
+    if (key.startsWith('FT_') && _.indexOf(ACTIVE_FEATURE_TOGGLES, key) === -1) {
+      console.warn(`Unknown feature toggle ${key}. Please remove it from your environment variables.`);
+    }
+  });
 
   return ENV;
 };

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -19,7 +19,6 @@ module.exports = function(environment) {
 
     APP: {
       API_HOST: process.env.API_HOST || '',
-      isSessionFinalizationActive: process.env.FT_IS_SESSION_FINALIZATION_ACTIVE === 'true',
       API_ERROR_MESSAGES : {
         BAD_REQUEST: { CODE: '400', MESSAGE: 'Les données envoyées ne sont pas au bon format.' },
         INTERNAL_SERVER_ERROR: {

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -40,8 +40,6 @@ module('Acceptance | Session List', function(hooks) {
         expires_in: 3600,
         token_type: 'Bearer token type',
       });
-      const controller = this.owner.lookup('controller:authenticated.sessions.list');
-      controller.set('isSessionFinalizationActive', false);
     });
 
     test('it should be accessible', async function(assert) {
@@ -63,7 +61,7 @@ module('Acceptance | Session List', function(hooks) {
     module('when some sessions exist', function() {
       const nbExtraSessions = 11;
 
-      test('it should list the sessions and their attributes', async function(assert) {
+      test('it should list the sessions and their attributes with status', async function(assert) {
         // given
         const firstSession = server.create('session', { address: 'Adresse', certificationCenterId, date: '2020-01-01', time: '14:00' });
         server.createList('session', nbExtraSessions, { certificationCenterId, date: '2019-01-01' });
@@ -74,7 +72,7 @@ module('Acceptance | Session List', function(hooks) {
         // then
         const formattedDate = moment(firstSession.date, 'YYYY-MM-DD').format('DD/MM/YYYY');
         assert.dom('table tbody tr').exists({ count: nbExtraSessions + 1 });
-        assert.dom('table tbody tr:first-child').hasText(`${firstSession.id} ${firstSession.address} ${firstSession.room} ${formattedDate} ${firstSession.time} ${firstSession.examiner}`);
+        assert.dom('table tbody tr:first-child').hasText(`${firstSession.id} ${firstSession.address} ${firstSession.room} ${formattedDate} ${firstSession.time} ${firstSession.examiner} ${statusToDisplayName.created}`);
       });
 
       test('it should sort the sessions from recent to older', async function(assert) {
@@ -105,26 +103,6 @@ module('Acceptance | Session List', function(hooks) {
         // then
         assert.equal(currentURL(), `/sessions/${firstSession.id}`);
       });
-
-      module('When finalization feature is active', function() {
-
-        test('it should list the sessions and their attributes with statut', async function(assert) {
-          // given
-          const controller = this.owner.lookup('controller:authenticated.sessions.list');
-          controller.set('isSessionFinalizationActive', true);
-          const firstSession = server.create('session', { address: 'Adresse', certificationCenterId, date: '2020-01-01', time: '14:00' });
-          server.createList('session', nbExtraSessions, { certificationCenterId, date: '2019-01-01' });
-
-          // when
-          await visit('/sessions/liste');
-
-          // then
-          const formattedDate = moment(firstSession.date, 'YYYY-MM-DD').format('DD/MM/YYYY');
-          assert.dom('table tbody tr').exists({ count: nbExtraSessions + 1 });
-          assert.dom('table tbody tr:first-child').hasText(`${firstSession.id} ${firstSession.address} ${firstSession.room} ${formattedDate} ${firstSession.time} ${firstSession.examiner} ${statusToDisplayName.created}`);
-        });
-      });
-
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Contexte
La feature de finalisation de session dans PixCertif était soumise à feature toggle.
La feature est maintenant considérée comme stable, on retire donc le toggle.

## :robot: Solution
- Retrait du toggle (+ ne pas oublier de le retirer dans les autres environnements + dans le template des PR)
- Application de quelques bonnes pratiques octane :
 - Privilégier `init()` à `constructor()`
 - Inutile d'initialiser des propriétés dans `init()` si c'est pour y mettre une valeur simple
 - Transformation des Mixin en native classe qui étend d'un Mixin (sauf pour AppModal, c'était difficile)
 - Renommage des classes. Dans le doute, à l'époque, j'avais donné un nom à rallonge aux classes car j'avais peur d'avoir des collisions sur les noms. En fait c'est pas possible.

La réf que @jonathanperret m'a transmis pour appliquer ces règles :
https://blog.emberjs.com/2019/01/26/emberjs-native-class-update-2019-edition.html

## :rainbow: Remarques

## :100: Pour tester
S'assurer que la toggle est bien retirée de l'environnement de la front-review, puis constater que le bouton de finalisation est bien affichée lorsqu'il existe au moins un candidat dans la session qui a passé sa certif + constater l'affichage permanent de la colonne statut dans la liste des sessions.
