### PR TITLE
[BUGFIX] Des utilisateurs sont bloqués sur une épreuve. (PF-1187).

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -83,7 +83,7 @@ async function _getKnowledgeElements({ assessment, answer, challenge, skillRepos
     return [];
   }
 
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId });
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId: assessment.userId, assessmentId: assessment.id });
   let targetSkills;
   if (assessment.isCompetenceEvaluation()) {
     targetSkills = await skillRepository.findByCompetenceId(assessment.competenceId);
@@ -109,7 +109,17 @@ function _getSkillsFilteredByStatus(knowledgeElements, targetSkills, status) {
     .map((skillId) => targetSkills.find((skill) => skill.id === skillId));
 }
 
-async function _addLevelUpInformation({ answerSaved, scorecardService, userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository, scorecardBeforeAnswer  }) {
+async function _addLevelUpInformation(
+  {
+    answerSaved,
+    scorecardService,
+    userId,
+    competenceId,
+    competenceRepository,
+    competenceEvaluationRepository,
+    knowledgeElementRepository,
+    scorecardBeforeAnswer
+  }) {
   answerSaved.levelup = {};
 
   if (scorecardBeforeAnswer) {

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,10 +1,7 @@
-const _ = require('lodash');
 const {
   ChallengeAlreadyAnsweredError,
   ForbiddenAccess
 } = require('../errors');
-const constants = require('../constants');
-
 const Examiner = require('../models/Examiner');
 const KnowledgeElement = require('../models/KnowledgeElement');
 
@@ -39,7 +36,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   const challenge = await challengeRepository.get(answer.challengeId);
   const correctedAnswer = _evaluateAnswer(challenge, answer);
 
-  let scorecardBeforeAnswer;
+  let scorecardBeforeAnswer = null;
   if (correctedAnswer.result.isOK() && assessment.hasKnowledgeElements()) {
     scorecardBeforeAnswer = await scorecardService.computeScorecard({
       userId,
@@ -62,7 +59,16 @@ module.exports = async function correctAnswerThenUpdateAssessment(
 
   let answerSaved = await answerRepository.saveWithKnowledgeElements(correctedAnswer, knowledgeElementsFromAnswer);
 
-  answerSaved = _addLevelUpInformation({ answerSaved, correctedAnswer, assessment, knowledgeElementsFromAnswer, scorecardBeforeAnswer });
+  answerSaved = await _addLevelUpInformation({
+    answerSaved,
+    scorecardService,
+    userId,
+    competenceId: challenge.competenceId,
+    competenceRepository,
+    competenceEvaluationRepository,
+    knowledgeElementRepository,
+    scorecardBeforeAnswer
+  });
 
   return answerSaved;
 };
@@ -103,19 +109,24 @@ function _getSkillsFilteredByStatus(knowledgeElements, targetSkills, status) {
     .map((skillId) => targetSkills.find((skill) => skill.id === skillId));
 }
 
-function _addLevelUpInformation({ answerSaved, correctedAnswer, assessment, knowledgeElementsFromAnswer, scorecardBeforeAnswer }) {
+async function _addLevelUpInformation({ answerSaved, scorecardService, userId, competenceId, competenceRepository, competenceEvaluationRepository, knowledgeElementRepository, scorecardBeforeAnswer  }) {
   answerSaved.levelup = {};
 
-  if (correctedAnswer.result.isOK() && (assessment.isCompetenceEvaluation() || assessment.isSmartPlacement())) {
-    const sumPixEarned = _.sumBy(knowledgeElementsFromAnswer, 'earnedPix');
-    const totalPix = scorecardBeforeAnswer.exactlyEarnedPix + sumPixEarned;
-    const userLevel = Math.min(constants.MAX_REACHABLE_LEVEL, _.floor(totalPix / constants.PIX_COUNT_BY_LEVEL));
+  if (scorecardBeforeAnswer) {
+    const scorecardAfterAnswer = await scorecardService.computeScorecard({
+      userId,
+      competenceId,
+      competenceRepository,
+      competenceEvaluationRepository,
+      knowledgeElementRepository,
+      blockReachablePixAndLevel: true,
+    });
 
-    if (scorecardBeforeAnswer.level < userLevel) {
+    if (scorecardBeforeAnswer.level < scorecardAfterAnswer.level) {
       answerSaved.levelup = {
         id: answerSaved.id,
-        competenceName: scorecardBeforeAnswer.name,
-        level: userLevel,
+        competenceName: scorecardAfterAnswer.name,
+        level: scorecardAfterAnswer.level,
       };
     }
   }

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -46,6 +46,17 @@ module.exports = {
       .then(_dropResetKnowledgeElements);
   },
 
+  findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {
+    return BookshelfKnowledgeElement
+      .query((qb) => {
+        qb.where({ userId, assessmentId });
+      })
+      .fetchAll()
+      .then(_toDomain)
+      .then(_getUniqMostRecents)
+      .then(_dropResetKnowledgeElements);
+  },
+
   findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
     return BookshelfKnowledgeElement
       .where({ userId, competenceId })

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -123,6 +123,37 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
   });
 
+  describe('#findUniqByUserIdAndAssessmentId', () => {
+
+    let knowledgeElementsWanted;
+    let userId, assessmentId;
+
+    beforeEach(async () => {
+      // given
+      userId = databaseBuilder.factory.buildUser().id;
+      assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+      const otherAssessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+
+      knowledgeElementsWanted = _.map([
+        { id: 1, skillId: '1', userId, assessmentId },
+        { id: 2, skillId: '3', createdAt: new Date('2020-02-01'), userId, assessmentId },
+      ], ((ke) => databaseBuilder.factory.buildKnowledgeElement(ke)));
+
+      databaseBuilder.factory.buildKnowledgeElement({ id: 4, skillId: '5', userId, assessmentId: otherAssessmentId });
+      databaseBuilder.factory.buildKnowledgeElement({ id: 3, skillId: '3', createdAt: new Date('2020-01-01'), userId, assessmentId },);
+
+      await databaseBuilder.commit();
+    });
+
+    it('should find the knowledge elements for assessment associated with a user id', async () => {
+      // when
+      const knowledgeElementsFound = await KnowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId, assessmentId });
+      expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
+      expect(knowledgeElementsFound).have.lengthOf(2);
+    });
+
+  });
+
   describe('#findUniqByUserIdGroupedByCompetenceId', () => {
 
     let userId;

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -148,6 +148,8 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     it('should find the knowledge elements for assessment associated with a user id', async () => {
       // when
       const knowledgeElementsFound = await KnowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId, assessmentId });
+
+      // then
       expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
       expect(knowledgeElementsFound).have.lengthOf(2);
     });

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -15,6 +15,10 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
   let validator;
   let correctAnswerValue;
   let answer;
+  const addOneLevel = {
+    level: 1,
+    pix: 8
+  };
 
   const answerRepository = {
     findByChallengeAndAssessment: () => undefined,
@@ -185,14 +189,14 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           // given
           const scorecardAfterAnswer = domainBuilder.buildUserScorecard({
             name: scorecard.name,
-            level: scorecard.level + 1,
-            earnedPix: scorecard.earnedPix + 8,
-            exactlyEarnedPix: scorecard.exactlyEarnedPix + 8 });
+            level: scorecard.level + addOneLevel.level,
+            earnedPix: scorecard.earnedPix + addOneLevel.pix,
+            exactlyEarnedPix: scorecard.exactlyEarnedPix + addOneLevel.pix });
           scorecardService.computeScorecard
             .onFirstCall().resolves(scorecard)
             .onSecondCall().resolves(scorecardAfterAnswer);
-
           const expectedLevel = scorecardAfterAnswer.level;
+
           // when
           const result = await correctAnswerThenUpdateAssessment({
             answer,
@@ -413,9 +417,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
           // given
           const scorecardAfterAnswer = domainBuilder.buildUserScorecard({
             name: scorecard.name,
-            level: scorecard.level + 1,
-            earnedPix: scorecard.earnedPix + 8,
-            exactlyEarnedPix: scorecard.exactlyEarnedPix + 8 });
+            level: scorecard.level + addOneLevel.level,
+            earnedPix: scorecard.earnedPix + addOneLevel.pix,
+            exactlyEarnedPix: scorecard.exactlyEarnedPix + addOneLevel.pix });
           scorecardService.computeScorecard
             .onFirstCall().resolves(scorecard)
             .onSecondCall().resolves(scorecardAfterAnswer);

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -183,7 +183,16 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
       context('when the user responds correctly', async () => {
         it('should add the level up to the answer when the user gain one level', async () => {
           // given
-          const expectedLevel = scorecard.level + 1;
+          const scorecardAfterAnswer = domainBuilder.buildUserScorecard({
+            name: scorecard.name,
+            level: scorecard.level + 1,
+            earnedPix: scorecard.earnedPix + 8,
+            exactlyEarnedPix: scorecard.exactlyEarnedPix + 8 });
+          scorecardService.computeScorecard
+            .onFirstCall().resolves(scorecard)
+            .onSecondCall().resolves(scorecardAfterAnswer);
+
+          const expectedLevel = scorecardAfterAnswer.level;
           // when
           const result = await correctAnswerThenUpdateAssessment({
             answer,
@@ -207,10 +216,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         });
 
         it('should return an empty levelup when not gaining a level', async () => {
-          KnowledgeElement.createKnowledgeElementsForAnswer.returns([
-            domainBuilder.buildKnowledgeElement({ earnedPix: 0 }),
-            domainBuilder.buildKnowledgeElement({ earnedPix: 0 }),
-          ]);
+          scorecardService.computeScorecard
+            .onFirstCall().resolves(scorecard)
+            .onSecondCall().resolves(scorecard);
 
           // when
           const result = await correctAnswerThenUpdateAssessment({
@@ -403,8 +411,15 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
       context('when the user responds correctly', async () => {
         it('should add the level up to the answer when the user gain one level', async () => {
           // given
-          const expectedLevel = scorecard.level + 1;
-
+          const scorecardAfterAnswer = domainBuilder.buildUserScorecard({
+            name: scorecard.name,
+            level: scorecard.level + 1,
+            earnedPix: scorecard.earnedPix + 8,
+            exactlyEarnedPix: scorecard.exactlyEarnedPix + 8 });
+          scorecardService.computeScorecard
+            .onFirstCall().resolves(scorecard)
+            .onSecondCall().resolves(scorecardAfterAnswer);
+          const expectedLevel = scorecardAfterAnswer.level;
           // when
           const result = await correctAnswerThenUpdateAssessment({
             answer,
@@ -429,10 +444,9 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
 
         it('should return an empty levelup when not gaining a level', async () => {
           // given
-          KnowledgeElement.createKnowledgeElementsForAnswer.returns([
-            domainBuilder.buildKnowledgeElement({ earnedPix: 0 }),
-            domainBuilder.buildKnowledgeElement({ earnedPix: 0 }),
-          ]);
+          scorecardService.computeScorecard
+            .onFirstCall().resolves(scorecard)
+            .onSecondCall().resolves(scorecard);
 
           // when
           const result = await correctAnswerThenUpdateAssessment({

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -27,7 +27,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
   const skillRepository = { findByCompetenceId: () => undefined };
   const scorecardService = { computeScorecard: () => undefined };
   const knowledgeElementRepository = {
-    findUniqByUserId: () => undefined,
+    findUniqByUserIdAndAssessmentId: () => undefined,
   };
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     sinon.stub(skillRepository, 'findByCompetenceId');
     sinon.stub(targetProfileRepository, 'getByCampaignId');
     sinon.stub(scorecardService, 'computeScorecard');
-    sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+    sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
     sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer');
     assessment = domainBuilder.buildAssessment({ userId });
     answer = domainBuilder.buildAnswer({ assessmentId: assessment.id, value: correctAnswerValue });
@@ -113,7 +113,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
 
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 22, exactlyEarnedPix: 22 });
         skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
-        knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([knowledgeElement]);
+        knowledgeElementRepository.findUniqByUserIdAndAssessmentId.withArgs({ userId: assessment.userId, assessmentId: assessment.id }).resolves([knowledgeElement]);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([
           firstCreatedKnowledgeElement, secondCreatedKnowledgeElement,
         ]);
@@ -157,7 +157,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
 
         // then
         expect(skillRepository.findByCompetenceId).to.have.been.calledWith(assessment.competenceId);
-        expect(knowledgeElementRepository.findUniqByUserId).to.have.been.calledWith({ userId: assessment.userId });
+        expect(knowledgeElementRepository.findUniqByUserIdAndAssessmentId).to.have.been.calledWith({ userId: assessment.userId, assessmentId: assessment.id });
       });
 
       it('should return the saved answer - with the id', async () => {
@@ -289,7 +289,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         targetProfile = domainBuilder.buildTargetProfile({ skills });
         challengeRepository.get.resolves(challenge);
 
-        knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves([knowledgeElement]);
+        knowledgeElementRepository.findUniqByUserIdAndAssessmentId.withArgs({ userId: assessment.userId, assessmentId: assessment.id }).resolves([knowledgeElement]);
 
         targetProfileRepository.getByCampaignId.resolves(targetProfile);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur : 
- Il répond à l'épreuve. L’answer est enregistré mais aucun Knowledge-Element pour cette réponse.
- L’algorithme cherche sa prochaine épreuve :
-Les KE n’ayant pas été enregistré, les skills associés ne sont pas considérés comme vus
-L’algorithme propose à nouveau de testé le skill précédemment vu, et repropose donc la même épreuve
- L’utilisateur revoie la même épreuve
- Mais vu qu’il y a déjà répondu (on le sait via l’answer), l'épreuve est noté comme “Déjà Répondu”
- L’utilisateur voit qu’il a déjà répondu à cette épreuve, et on lui demande de Poursuivre
- Au moment de Poursuivre, l’algorithme repropose encore la même épreuve, et l’utilisateur est bloqué

## :robot: Solution
- Pour savoir quels KE créés, ne prendre que ceux de l'assessment en cours et ignorer ceux des autres assessments. Il y aura donc des doublons de couple (SkillId, UserId, Status).
- Ne pas passer par les KE créé pour calculer les succès (pour éviter de revenir au bug des succès)

## :rainbow: Remarques
Pour les détails : 
https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1293058102/2020-03-25+Le+bug+des+answers+sans+KE

## :100: Pour tester
