### PR TITLE
[TECH] Ajout de l'index de answerId dans la table knowledge-elements.

### DIFF
--- a/api/db/migrations/20200325191553_add-index-on-answer-in-knowledge-element.js
+++ b/api/db/migrations/20200325191553_add-index-on-answer-in-knowledge-element.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'knowledge-elements';
+const COLUMN_NAME = 'answerId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropIndex(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20200326075515_add-index-on-assessmentId-in-table-knowledge-elements.js
+++ b/api/db/migrations/20200326075515_add-index-on-assessmentId-in-table-knowledge-elements.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'knowledge-elements';
+const ASSESSMENTID_COLUMN = 'assessmentId';
+const OLD_INDEX_ASSESSMENTID = 'knowledge-elements_assessmentId_idx';
+
+exports.up = async function(knex) {
+  await knex.raw(`DROP INDEX IF EXISTS "${OLD_INDEX_ASSESSMENTID}"`);
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(ASSESSMENTID_COLUMN);
+  });
+};
+
+exports.down = async function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(ASSESSMENTID_COLUMN);
+    table.index(ASSESSMENTID_COLUMN, OLD_INDEX_ASSESSMENTID);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on étudie les problèmes des utilisateurs, on a parfois besoin de savoir ce qu'il a fait en répondant à une épreuve. L'index n'étant plus là entre la table answers et knowledge-elements, les temps de réponses sont très grands. 
De plus, il est très difficile de supprimer une answer sans cet index.

## :robot: Solution
- Ajout de l'index sur la colonne `answerId` de la table `knowledge-elements`
- Remplacement de l'index sur la colonne `assessmentId` de la table `knowledge-elements` ajouté à la main lors d'une urgence par un index via migration.

## :rainbow: Remarques
Cette indexation risque de prendre beaucoup de temps.
Faudrait-il la faire en dehors d'une migration pour ne pas la faire pendant une MEP ?
+ Tant qu'à le faire pendant une MEP, autant réparer l'index `assessmentId` au passage !


@MelanieMEB libre à toi de virer mon commit ! c'est une proposition
