### PR TITLE
[TECH] Ajout d'une règle de linter pour éviter les injections SQL

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -2,3 +2,9 @@ extends: '../.eslintrc.yaml'
 
 globals:
   include: true
+
+rules:
+  no-restricted-syntax: [error, {
+    selector: "CallExpression[callee.object.name='knex'][callee.property.name='raw'][arguments.0.type='TemplateLiteral']",
+    message: "do not use template strings with knex.raw to avoid SQL injection"
+  }]

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -55,6 +55,7 @@ async function emptyAllTables() {
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 
   const query = _dbSpecificQueries.emptyTableQuery;
+  // eslint-disable-next-line no-restricted-syntax
   return knex.raw(`${query}${tables}`);
 }
 

--- a/api/db/migrations/.eslintrc.yaml
+++ b/api/db/migrations/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: '../../../.eslintrc.yaml'
+
+rules:
+  no-restricted-syntax: off

--- a/api/db/seeds/.eslintrc.yaml
+++ b/api/db/seeds/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: '../../../.eslintrc.yaml'
+
+rules:
+  no-restricted-syntax: off


### PR DESCRIPTION
## :unicorn: Problème
L'utilisation de `knex.raw` pour effectuer des opérations SQL **sans** utiliser les bindings crée une faille de sécurité de type `SQL injection` [https://fr.wikipedia.org/wiki/Injection_SQL]().

## :robot: Solution
Pour imposer le bon usage de la fonction `knex.raw`, une règle de linter est ajoutée.
C'est la règle `no-restricted-syntax` qui permet d'interdire le code spécifier par le sélecteur AST.
Tout appel à `knew.raw` avec un premier argument qui est une `template string` est interdit.

## :rainbow: Remarques
`knex.raw` est parfois utilisé avec une template string pour formatter sur plusieurs lignes une longue instruction SQL.
C'est uniquement le cas dans les `seeds` et les `migrations`.
La règle `no-restricted-syntax` est donc spécifiquement ignorée pour ces deux répertoires.

## :100: Pour tester
Un appel comme le suivant doit lever une erreur du linter.
```js
  knex.raw(`INSERT INTO "user-tutorials" ("userId", "tutorialId") VALUES (${userId}, '${tutorialId}') ON CONFLICT DO NOTHING`);
```

## 🤔 Pour aller plus loin
Il est possible de décomposer l'AST d'un code JS en utilisant https://astexplorer.net (choisir `espree` comme parser).
Plus d'infos sur la règle ESLint `no-restricted-syntax` : https://eslint.org/docs/rules/no-restricted-syntax.
