### PR TITLE
[BUGFIX] Mauvaise notification d'erreur lors de l'échec de l'ajout unitaire de candidat sur PixCertif (PC-139)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -60,7 +60,7 @@ export default class AuthenticatedSessionsDetailsCertificationCandidatesControll
         headers: { Authorization: `Bearer ${access_token}` },
       });
       this.currentSession.certificationCandidates.reload();
-      this.notifications.success('La liste des candidats a été importée avec succès', {
+      this.notifications.success('La liste des candidats a été importée avec succès.', {
         autoClear,
         clearDuration,
       });
@@ -73,7 +73,7 @@ export default class AuthenticatedSessionsDetailsCertificationCandidatesControll
           clearDuration,
         });
       } else {
-        this.notifications.error('Une erreur s\'est produite lors de l\'import des candidats', {
+        this.notifications.error('Une erreur s\'est produite lors de l\'import des candidats.', {
           autoClear,
           clearDuration,
         });
@@ -116,7 +116,7 @@ export default class AuthenticatedSessionsDetailsCertificationCandidatesControll
         clearDuration,
       });
     } catch (err) {
-      let errorText = 'Une erreur s\'est produite lors de l\'ajout du candidat';
+      let errorText = 'Une erreur s\'est produite lors de l\'ajout du candidat.';
       if (_.get(err, 'errors[0].status') === '409' || err === 'Duplicate') {
         errorText = 'Ce candidat est déjà dans la liste, vous ne pouvez pas l\'ajouter à nouveau.';
       }

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -116,7 +116,7 @@ export default class AuthenticatedSessionsDetailsCertificationCandidatesControll
         clearDuration,
       });
     } catch (err) {
-      let errorText = 'Une erreur s\'est produite lors de la suppression du candidat';
+      let errorText = 'Une erreur s\'est produite lors de l\'ajout du candidat';
       if (_.get(err, 'errors[0].status') === '409' || err === 'Duplicate') {
         errorText = 'Ce candidat est déjà dans la liste, vous ne pouvez pas l\'ajouter à nouveau.';
       }

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -129,6 +129,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
             // then
             assert.dom('[data-test-notification-message="error"]').exists();
+            assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat');
           });
         });
 

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -129,7 +129,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
             // then
             assert.dom('[data-test-notification-message="error"]').exists();
-            assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat');
+            assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat.');
           });
         });
 
@@ -163,6 +163,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
             // then
             assert.dom('[data-test-notification-message="success"]').exists();
+            assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
           });
 
           test('it should add a new candidate entry', async function(assert) {
@@ -231,6 +232,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
         // then
         assert.dom('[data-test-notification-message="success"]').exists();
+        assert.dom('[data-test-notification-message="success"]').hasText('La liste des candidats a été importée avec succès.');
       });
 
       test('it should display a generic error message when uploading an invalid file', async function(assert) {
@@ -243,6 +245,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
         // then
         assert.dom('[data-test-notification-message="error"]').exists();
+        assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'import des candidats.');
       });
 
       test('it should display a specific error message when importing is forbidden', async function(assert) {

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -155,6 +155,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
           // then
           assert.dom('[data-test-notification-message="success"]').exists();
+          assert.dom('[data-test-notification-message="success"]').hasText('Les informations de la session ont été transmises avec succès.');
         });
 
       });

--- a/certif/tests/test-helper.js
+++ b/certif/tests/test-helper.js
@@ -3,6 +3,19 @@ import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
+import NotificationMessageService from 'ember-cli-notifications/services/notifications';
+
+NotificationMessageService.reopen({
+  removeNotification(notification) {
+    if (!notification) {
+      return;
+    }
+
+    notification.set('dismiss', true);
+    this.content.removeObject(notification);
+  }
+});
+
 setApplication(Application.create(config.APP));
 
 start();


### PR DESCRIPTION
## :unicorn: Problème
La notification d'erreur qui s'affiche lors de l'échec de l'ajout d'un candidat contient une phrase incorrecte. La phrase parle d'une opération de suppression, alors qu'il s'agit d'une opération d'ajout.

## :robot: Solution
Correction du mot + renforcement des tests sur la vérification du contenu de la notification.

## :rainbow: Remarques
Le bonus : réduction du temps d'exécution des tests grâce à du bidouillage dans le service de notifications.
En effet, certains d'entre vous ont certainement constaté un rallongement pénible des tests d'acceptance provoquant l'affichage de la notification _**ember-cli-notification**_.
C'est dû à ce code-ci : ->
https://github.com/mansona/ember-cli-notifications/blob/master/addon/services/notifications.js#L73
On remarque l'ajout d'un délai dans la runLoop() de 500ms fixes.
En m'inspirant des propositions réalisées dans l'issue https://github.com/mansona/ember-cli-notifications/issues/111, je propose la modif suivante :
Réouvrir le service et surcharger la méthode `removeNotification()` en virant le délai. Cette modification est réalisée dans le fichier `tests/test-helper.js`

## :100: Pour tester
Reproduire le bug :
1) Sur intégration, se connecter sur PixCertif avec : **certifsco@example.net** _**Azerty123***_
2) Se rendre dans l'onglet _Candidats_ d'une session
3) Appuyer sur le bouton _Ajouter un candidat_ en bas de la page, en header du tableau de candidats.
4) Remplir le formulaire avec une erreur. Par exemple, avec une adresse email au format invalide.
5) Constater la mauvaise formulation de la notification d'erreur. Le mot parle de l'échec d'une suppression, or il s'agit d'une opération d'ajout.
NOTE : Pour tester en RA, il existe le même compte mais avec un MDP différent :
certifsco@example.net    pix123