### PR TITLE
[INFRA] Réduit le temps de disparition de la notification pendant les tests d'acceptance (PO-396)

### DIFF
--- a/orga/tests/test-helper.js
+++ b/orga/tests/test-helper.js
@@ -2,6 +2,18 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import NotificationMessageService from 'ember-cli-notifications/services/notifications';
+
+NotificationMessageService.reopen({
+  removeNotification(notification) {
+    if (!notification) {
+      return;
+    }
+
+    notification.set('dismiss', true);
+    this.content.removeObject(notification);
+  }
+});
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
## :unicorn: Problème
Les tests d'acceptance sont rallongés à cause du temps de disparition de la notification ember-cli-notification.

## :robot: Solution
C'est dû à ce code-ci : ->
https://github.com/mansona/ember-cli-notifications/blob/master/addon/services/notifications.js#L73
On remarque l'ajout d'un délai dans la runLoop() de 500ms fixes.
En m'inspirant des propositions réalisées dans l'issue mansona/ember-cli-notifications#111, je propose la modif suivante :
Réouvrir le service et surcharger la méthode removeNotification() en virant le délai. Cette modification est réalisée dans le fichier tests/test-helper.js

## :rainbow: Remarques

## :100: Pour tester
Chronométrer le temps d'exécution des tests PixOrga avant et après ;) ~20% de temps en moins.
