### PR TITLE
[BUGFIX] Ne pas afficher une bande blanche en bas des CGUs de PixCertif (PC-80)

### DIFF
--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -34,7 +34,8 @@
 
 body, html{
   margin: 0;
-  height: 100%;
+  min-height: 100%;
+  min-height: 100vh;
   font-family: $roboto;
   color: $black;
   background-color: $grey-10;

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -1,6 +1,7 @@
 .app {
   display: flex;
-  height: 100%;
+  min-height: 100%;
+  min-height: 100vh;
 
   &__sidebar {
     width: 280px;
@@ -16,7 +17,6 @@
   z-index: 0;
   display: flex;
   flex-direction: column;
-  height: 100%;
   background: white;
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.1);
 

--- a/certif/app/styles/pages/authenticated/terms-of-service.scss
+++ b/certif/app/styles/pages/authenticated/terms-of-service.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
+  min-height: 100vh;
   background: $pix-green-gradient;
   align-items: center;
 }

--- a/certif/app/styles/pages/login.scss
+++ b/certif/app/styles/pages/login.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: column;
   width:100%;
-  height:100%;
+  min-height: 100%;
+  min-height: 100vh;
   background: $pix-green-gradient;
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.1);
   align-items: center;


### PR DESCRIPTION
## :unicorn: Problème
Un bloc blanc s'affiche sur certaines dimension lors de l'acceptation des cgu.
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/38167520/77764737-6bac6e80-703d-11ea-9b8c-2855379fc634.png">


## :robot: Solution
Redimensionner les heights du body, html qui ne prennaient pas toute la hauteur disponible. 
Adapter leurs enfants directs.
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/38167520/77764813-8aab0080-703d-11ea-83c2-e597b93f4ffa.png">


## :rainbow: Remarques
Il semblerait que IE ne supporte pas l'unité `vh` (https://caniuse.com/#search=vh), d'où l'ajout de `min-height: 100%` (il ne prendra pas en compte le `min-height: 100vh`; mais les autres browsers si).

## :100: Pour tester
1- Se loger sur certif avec un compte : certifsup@example.net, certifsco@example.net, certifpro@example.net. Redimensionner la page. Constater qu'il n'y a plus de bloc blanc. 
2- Finir de se loger. Constater que l'application n'a pas changé. 
3- Faire la même chose en changeant de navigateur (Chrome, IE 11 ...)