### PR TITLE
[BUGFIX] Faire en sorte que le logo de Pix Orga ne soit pas déformé sous IE (PO-289).

### DIFF
--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -16,3 +16,7 @@
     padding: 60px 100px;
   }
 }
+
+.panel__image {
+  text-align: center;
+}

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -1,6 +1,8 @@
 <div class="login-page">
   <div class="panel login-page__panel">
-    <img src="/pix-orga.svg" alt="Pix Orga">
+    <div class="panel__image">
+      <img src="/pix-orga.svg" alt="Pix Orga">
+    </div>
     <h1 class="form-title">Déjà utilisateur Pix ?</h1>
     <Routes::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Le logo sous IE de Pix Orga est déformé. 

## :robot: Solution
En prenant exemple sur Pix Certif, on a ajouté une div et un `text-align: center` sur celle-ci.
