### PR TITLE
[BUGFIX] Numéro de session dans la barre de recherche incohérent avec la page affichée (PA-191)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session.js
+++ b/admin/app/controllers/authenticated/sessions/session.js
@@ -1,9 +1,12 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class SessionController extends Controller {
   @service router;
+
+  @tracked inputId;
 
   @action
   loadSession() {

--- a/admin/app/routes/authenticated/sessions/session.js
+++ b/admin/app/routes/authenticated/sessions/session.js
@@ -3,7 +3,12 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class SessionRoute extends Route {
-  @service notifications
+  @service notifications;
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    this.controllerFor('authenticated.sessions.session').inputId = model.id;
+  }
 
   @action
   error(anError) {

--- a/admin/app/templates/authenticated/sessions/session.hbs
+++ b/admin/app/templates/authenticated/sessions/session.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <div class="page-title"> Sessions de certification </div>
+  <div class="page-title">Sessions de certification</div>
   <div class="page-actions">
     <form class='form-inline' {{action "loadSession" on='submit'}}>
       <Input placeholder="Identifiant" @type="text" @value={{this.inputId}} />

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { FINALIZED } from 'pix-admin/models/session';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Session pages', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function() {
+
+    test('it should not be accessible by an unauthenticated user', async function(assert) {
+      // when
+      await visit('/sessions/session');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function(hooks) {
+
+    let session;
+
+    hooks.beforeEach(async () => {
+      // given
+      await authenticateSession({ userId: 1 });
+      session = server.create('session', {
+        id: 1,
+        certificationCenterName: 'Centre des Staranne',
+        status: FINALIZED,
+        resultsSentToPrescriberAt: new Date('2020-01-01T03:00:00Z'),
+        examinerGlobalComment: 'Commentaire du surveillant',
+      });
+    });
+
+    module('On sessions.session.informations page', function(hooks) {
+
+      hooks.beforeEach(async () => {
+        // when
+        await visit('/sessions/1');
+      });
+
+      test('it should be accessible for an authenticated user', function(assert) {
+        // then
+        assert.equal(currentURL(), '/sessions/1');
+      });
+
+      module('Search section', function() {
+
+        test('it should show a header with title and sessionId search', function(assert) {
+          // then
+          assert.dom('.page-title').hasText('Sessions de certification');
+          assert.equal(document.querySelector('.page-actions form input').value, '1');
+        });
+
+        test('it load new session when user give a new sessionId', async  function(assert) {
+          // when
+          const sessionIdInput = document.querySelector('.page-actions form input');
+          await fillIn(sessionIdInput, '2');
+          await click('.navbar-item:first-child');
+
+          // then
+          assert.equal(sessionIdInput.value, '2');
+          assert.dom('.page-actions form button').hasText('Charger');
+          assert.equal(currentURL(), '/sessions/1');
+        });
+      });
+
+      module('Tabs section', function() {
+
+        test('tab "Informations" is clickable', async function(assert) {
+          // when
+          await click('.navbar-item:first-child');
+
+          // then
+          assert.dom('.navbar-item:first-child').hasText('Informations');
+          assert.equal(currentURL(), '/sessions/1');
+        });
+
+        test('tab "Certifications" is clickable', async function(assert) {
+          // when
+          await click('.navbar-item:last-child');
+
+          // then
+          assert.dom('.navbar-item:last-child').hasText('Certifications');
+          assert.equal(currentURL(), '/sessions/1/certifications');
+        });
+      });
+
+      module('Informations section', function() {
+
+        test('it show session informations', function(assert) {
+          // then
+          assert.dom('.session-info__details .row div:last-child').hasText(session.certificationCenterName);
+          assert.dom('[data-test-id="session-info__sent-to-prescriber-at"]').hasText(session.resultsSentToPrescriberAt.toLocaleString('fr-FR'));
+          assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
+        });
+      });
+    });
+
+    module('On sessions.session.certifications page', function(hooks) {
+
+      let certification;
+
+      hooks.beforeEach(async () => {
+        // given
+        certification = server.create('certification', {
+          sessionId: 1,
+          firstName: 'Annie',
+          isPublished: true,
+        });
+        // when
+        await visit('/sessions/1/certifications');
+      });
+
+      module('Certification section', function() {
+
+        test('it show certifications informations', function(assert) {
+          // then
+          const circle = document.querySelector('.certification-list tbody tr td:last-child div svg circle');
+          assert.dom('.certification-list tbody tr td:nth-child(2)').hasText(certification.firstName);
+          assert.equal(circle.attributes.fill.value, '#39B97A');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'input de recherche d'un id de session n'est pas toujours en accord avec la valeur de l'id de session de la page affichée (présent notamment dans l'url)
![image](https://user-images.githubusercontent.com/38167520/77772483-820bf780-7048-11ea-90fd-da9093430330.png)


## :robot: Solution
Initialiser l'input à l'id de la session sur laquelle on est lors d'une transition / chargement d'une session.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour reproduire le bug
1- Aller sur une page de détail d'une session (par exemple la session 4) : http://localhost:4202/sessions/4
2- Taper dans l'input de recherche un nouvel id (par exemple 5, pas besoin de valider).
3- Aller sur une autre session via la liste des sessions http://localhost:4202/sessions/list. Par exemple la 6 : constater que le champ est resté à 5 au lieu d'être à 6. 
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/38167520/77773060-60f7d680-7049-11ea-9fed-c8408c595a27.png">

