### PR TITLE
[BUFIX] Problème d'affichage d'une équipe avec beaucoup de membres. (PO-323).

### DIFF
--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
+  margin-bottom: 20px;
 
   &__header {
     display: flex;


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga l'affichage d'une équipe ne se fait pas correctement quand elle contient beaucoup de membre, l'utilisateur peut ne pas comprendre qu'il s'agit de la fin du tableau.

## :robot: Solution
Ajouter un margin-bottom afin de voir la fin du tableau et donc comprendre que c'est la fin de la page.
