### PR TITLE
[CLEANUP] Convertir les services PixApp en syntaxe native (PF-1193).

### DIFF
--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,10 +1,10 @@
+import classic from 'ember-classic-decorator';
 import Service  from '@ember/service';
 import { last } from 'lodash';
 
-export default Service.extend({
-
+@classic
+export default class CurrentDomainService extends Service {
   getExtension() {
     return last(location.hostname.split('.'));
   }
-
-});
+}

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,8 +1,6 @@
-import classic from 'ember-classic-decorator';
 import Service  from '@ember/service';
 import { last } from 'lodash';
 
-@classic
 export default class CurrentDomainService extends Service {
   getExtension() {
     return last(location.hostname.split('.'));

--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -1,10 +1,12 @@
+import classic from 'ember-classic-decorator';
 import Service, { inject as service } from '@ember/service';
 import _ from 'lodash';
 
-export default Service.extend({
+@classic
+export default class CurrentUserService extends Service {
+  @service session;
 
-  session: service(),
-  store: service(),
+  @service store;
 
   async load() {
     if (this.get('session.isAuthenticated')) {
@@ -20,4 +22,4 @@ export default Service.extend({
       }
     }
   }
-});
+}

--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -1,19 +1,20 @@
-import classic from 'ember-classic-decorator';
 import Service, { inject as service } from '@ember/service';
 import _ from 'lodash';
 
-@classic
 export default class CurrentUserService extends Service {
   @service session;
-
   @service store;
 
-  async load() {
-    if (this.get('session.isAuthenticated')) {
-      try {
-        const user = await this.store.queryRecord('user', { me: true });
+  _user = undefined;
 
-        this.set('user', user);
+  get user() {
+    return this._user;
+  }
+
+  async load() {
+    if (this.session.isAuthenticated) {
+      try {
+        this._user = await this.store.queryRecord('user', { me: true });
       }
       catch (error) {
         if (_.get(error, 'errors[0].code') === 401) {

--- a/mon-pix/app/services/google-recaptcha.js
+++ b/mon-pix/app/services/google-recaptcha.js
@@ -1,3 +1,4 @@
+import classic from 'ember-classic-decorator';
 import { assert } from '@ember/debug';
 import Service from '@ember/service';
 import jQuery from 'jquery';
@@ -5,8 +6,8 @@ import RSVP from 'rsvp';
 import config from 'mon-pix/config/environment';
 
 // XXX Inspired of https://guides.emberjs.com/v2.13.0/tutorial/service/#toc_fetching-maps-with-a-service
-export default Service.extend({
-
+@classic
+export default class GoogleRecaptchaService extends Service {
   loadScript() {
     return new RSVP.Promise(function(resolve) {
       jQuery.getScript('https://www.google.com/recaptcha/api.js?onload=onGrecaptchaLoad&render=explicit', function() {
@@ -15,7 +16,7 @@ export default Service.extend({
         };
       });
     });
-  },
+  }
 
   render(containerId, callback, expiredCallback) {
     const grecaptcha = window.grecaptcha;
@@ -28,11 +29,10 @@ export default Service.extend({
       };
       grecaptcha.render(containerId, parameters);
     }
-  },
+  }
 
   reset() {
     const grecaptcha = window.grecaptcha;
     grecaptcha.reset();
   }
-
-});
+}

--- a/mon-pix/app/services/google-recaptcha.js
+++ b/mon-pix/app/services/google-recaptcha.js
@@ -1,4 +1,3 @@
-import classic from 'ember-classic-decorator';
 import { assert } from '@ember/debug';
 import Service from '@ember/service';
 import jQuery from 'jquery';
@@ -6,7 +5,6 @@ import RSVP from 'rsvp';
 import config from 'mon-pix/config/environment';
 
 // XXX Inspired of https://guides.emberjs.com/v2.13.0/tutorial/service/#toc_fetching-maps-with-a-service
-@classic
 export default class GoogleRecaptchaService extends Service {
   loadScript() {
     return new RSVP.Promise(function(resolve) {

--- a/mon-pix/app/services/mail-generator.js
+++ b/mon-pix/app/services/mail-generator.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import Service from '@ember/service';
 import moment from 'moment';
 
-export default Service.extend({
-
-  generateEmail: (challengeId, assessmentId, host, environment) => {
+@classic
+export default class MailGeneratorService extends Service {
+  generateEmail = (challengeId, assessmentId, host, environment) => {
 
     const fullyQualifiedDomainName = (environment !== 'development') ? 'pix-infra.ovh' : 'localhost';
 
@@ -13,6 +14,5 @@ export default Service.extend({
     }
 
     return `${challengeId}-${assessmentId}-${moment().format('DDMM')}${applicationReviewName}@${fullyQualifiedDomainName}`;
-  }
-
-});
+  };
+}

--- a/mon-pix/app/services/mail-generator.js
+++ b/mon-pix/app/services/mail-generator.js
@@ -1,8 +1,6 @@
-import classic from 'ember-classic-decorator';
 import Service from '@ember/service';
 import moment from 'moment';
 
-@classic
 export default class MailGeneratorService extends Service {
   generateEmail = (challengeId, assessmentId, host, environment) => {
 

--- a/mon-pix/app/services/peeker.js
+++ b/mon-pix/app/services/peeker.js
@@ -1,7 +1,9 @@
+import classic from 'ember-classic-decorator';
 import Service, { inject as service } from '@ember/service';
 
-export default Service.extend({
-  store: service(),
+@classic
+export default class PeekerService extends Service {
+  @service store;
 
   get(modelName, predicateFn) {
     const peeked = this.find(modelName, predicateFn);
@@ -12,12 +14,12 @@ export default Service.extend({
       throw new Error('Multiple records were found for model ' + modelName + '. Consider using #find() instead.');
     }
     return peeked[0];
-  },
+  }
 
   findOne(modelName, predicateFn) {
     const peeked = this.find(modelName, predicateFn);
     return peeked[0];
-  },
+  }
 
   find(modelName, predicateFn) {
     predicateFn = this.checkPredicateFn(predicateFn);
@@ -28,7 +30,7 @@ export default Service.extend({
       }
     });
     return peeked;
-  },
+  }
 
   checkPredicateFn(predicateFn) {
 
@@ -53,8 +55,8 @@ export default Service.extend({
       throw new Error('The second argument must be a Function');
     }
     return predicateFn;
-  },
-  
+  }
+
   haveCommonProperties(keys, firstObj, secondObj, matchingKeys = false) {
 
     // The function exists when all keys have been compared recursively for clarity.
@@ -70,4 +72,4 @@ export default Service.extend({
     const key = keys[0];
     return firstObj[key] === secondObj[key] && this.haveCommonProperties(keys.slice(1), firstObj, secondObj, true);
   }
-});
+}

--- a/mon-pix/app/services/peeker.js
+++ b/mon-pix/app/services/peeker.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import Service, { inject as service } from '@ember/service';
 
-@classic
 export default class PeekerService extends Service {
   @service store;
 

--- a/mon-pix/app/services/splash.js
+++ b/mon-pix/app/services/splash.js
@@ -1,10 +1,12 @@
+import classic from 'ember-classic-decorator';
 import Service from '@ember/service';
 
-export default Service.extend({
+@classic
+export default class SplashService extends Service {
   hide() {
     const splash = document.getElementById('app-splash');
     if (splash) {
       splash.parentNode.removeChild(splash);
     }
   }
-});
+}

--- a/mon-pix/app/services/splash.js
+++ b/mon-pix/app/services/splash.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import Service from '@ember/service';
 
-@classic
 export default class SplashService extends Service {
   hide() {
     const splash = document.getElementById('app-splash');


### PR DESCRIPTION
## :unicorn: Problème
Le passage à Ember Octane implique d'utiliser une syntaxe JS Native.

## :robot: Solution
Utilisation du codemod associé 

## ⚠️ Potentiels impacts fonctionnels à vérifier
- [ ] Changements de domaine (current-domain)
- [ ] Récupération de l'utilisateur courant
- [ ] Google Recaptcha
- [ ] Générateur de mails
- [ ] Peeker (?)
- [ ] Splash (?)