### PR TITLE
[CLEANUP] Convertir les classes PixApp en syntaxe native (PF-1194).

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -1,3 +1,4 @@
+import classic from 'ember-classic-decorator';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
@@ -8,12 +9,16 @@ const FRENCH_DOMAIN_EXTENSION = 'fr';
 const FRENCH_LOCALE = 'fr-fr';
 const FRENCHSPOKEN_LOCALE = 'fr';
 
-export default JSONAPIAdapter.extend(DataAdapterMixin, {
-  currentDomain: service(),
-  host: ENV.APP.API_HOST,
-  namespace: 'api',
+@classic
+export default class Application extends JSONAPIAdapter.extend(DataAdapterMixin) {
+  @service
+  currentDomain;
 
-  headers: computed('session.data.authenticated.access_token', function() {
+  host = ENV.APP.API_HOST;
+  namespace = 'api';
+
+  @computed('session.data.authenticated.access_token')
+  get headers() {
     const headers = {};
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
@@ -22,5 +27,5 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
       FRENCH_LOCALE
       : FRENCHSPOKEN_LOCALE;
     return headers;
-  })
-});
+  }
+}

--- a/mon-pix/app/adapters/assessment.js
+++ b/mon-pix/app/adapters/assessment.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class Assessment extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForUpdateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.completeAssessment) {
       delete adapterOptions.completeAssessment;
@@ -11,5 +12,5 @@ export default ApplicationAdapter.extend({
     }
 
     return url;
-  },
-});
+  }
+}

--- a/mon-pix/app/adapters/campaign-participation.js
+++ b/mon-pix/app/adapters/campaign-participation.js
@@ -1,16 +1,16 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class CampaignParticipation extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForUpdateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.beginImprovement) {
       delete adapterOptions.beginImprovement;
       return url + '/begin-improvement';
     }
     return url;
-  },
-
-});
+  }
+}
 

--- a/mon-pix/app/adapters/certification-candidate.js
+++ b/mon-pix/app/adapters/certification-candidate.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class CertificationCandidate extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForCreateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.joinSession) {
       delete adapterOptions.joinSession;
@@ -13,5 +14,5 @@ export default ApplicationAdapter.extend({
     }
 
     return url;
-  },
-});
+  }
+}

--- a/mon-pix/app/adapters/challenge.js
+++ b/mon-pix/app/adapters/challenge.js
@@ -1,11 +1,11 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class Challenge extends ApplicationAdapter {
   urlForQueryRecord(query) {
     const url = `${this.host}/${this.namespace}/assessments/${query.assessmentId}/next`;
     delete query.assessmentId;
     return url;
-  },
-
-});
+  }
+}

--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -1,15 +1,16 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class CompetenceEvaluation extends ApplicationAdapter {
   urlForQueryRecord(query) {
     if (query.startOrResume) {
       delete query.startOrResume;
-      return `${this._super(...arguments)}/start-or-resume`;
+      return `${super.urlForQueryRecord(...arguments)}/start-or-resume`;
     }
 
-    return this._super(...arguments);
-  },
+    return super.urlForQueryRecord(...arguments);
+  }
 
   queryRecord(store, type, query) {
     if (query.startOrResume) {
@@ -18,7 +19,6 @@ export default ApplicationAdapter.extend({
       return this.ajax(url, 'POST', { data: { competenceId: query.competenceId } });
     }
 
-    return this._super(...arguments);
-  },
-
-});
+    return super.queryRecord(...arguments);
+  }
+}

--- a/mon-pix/app/adapters/correction.js
+++ b/mon-pix/app/adapters/correction.js
@@ -1,7 +1,8 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class Correction extends ApplicationAdapter {
   // refresh cache
   refreshRecord(type, challenge) {
     const url = `${this.host}/${this.namespace}/cache`;
@@ -10,4 +11,4 @@ export default ApplicationAdapter.extend({
     };
     return this.ajax(url, 'DELETE', { data: payload });
   }
-});
+}

--- a/mon-pix/app/adapters/scorecard.js
+++ b/mon-pix/app/adapters/scorecard.js
@@ -1,15 +1,16 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class Scorecard extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     if (adapterOptions.resetCompetence) {
       delete adapterOptions.resetCompetence;
       return `${this.host}/${this.namespace}/users/${adapterOptions.userId}/competences/${adapterOptions.competenceId}/reset`;
     }
 
-    return this._super(...arguments);
-  },
+    return super.urlForUpdateRecord(...arguments);
+  }
 
   updateRecord(store, type, snapshot) {
     if (snapshot.adapterOptions.resetCompetence) {
@@ -18,6 +19,6 @@ export default ApplicationAdapter.extend({
       return this.ajax(url, 'POST');
     }
 
-    return this._super(...arguments);
-  },
-});
+    return super.updateRecord(...arguments);
+  }
+}

--- a/mon-pix/app/adapters/student-user-association.js
+++ b/mon-pix/app/adapters/student-user-association.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class StudentUserAssociation extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForCreateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.searchForMatchingStudent) {
       delete adapterOptions.searchForMatchingStudent;
@@ -11,7 +12,7 @@ export default ApplicationAdapter.extend({
     }
 
     return url;
-  },
+  }
 
   createRecord(store, type, snapshot) {
     if (snapshot.adapterOptions && snapshot.adapterOptions.searchForMatchingStudent) {
@@ -19,8 +20,7 @@ export default ApplicationAdapter.extend({
       const data = this.serialize(snapshot);
       return this.ajax(url, 'PUT', { data });
     }
-    return this._super(...arguments);
-  },
-
-});
+    return super.createRecord(...arguments);
+  }
+}
 

--- a/mon-pix/app/adapters/user-tutorial.js
+++ b/mon-pix/app/adapters/user-tutorial.js
@@ -1,10 +1,10 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class UserTutorial extends ApplicationAdapter {
   createRecord(store, type, { adapterOptions }) {
     const url = `${this.host}/${this.namespace}/users/me/tutorials/${adapterOptions.tutorialId}`;
     return this.ajax(url, 'PUT');
-  },
-
-});
+  }
+}

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -1,19 +1,20 @@
+import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-export default ApplicationAdapter.extend({
-
+@classic
+export default class User extends ApplicationAdapter {
   shouldBackgroundReloadRecord() {
     return false;
-  },
+  }
 
   urlForCreateRecord(query, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForCreateRecord(...arguments);
     if (adapterOptions && adapterOptions.isStudentDependentUser) {
       return `${this.host}/${this.namespace}/student-dependent-users`;
     }
 
     return url;
-  },
+  }
 
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
@@ -25,13 +26,13 @@ export default ApplicationAdapter.extend({
       serializedUser.data.attributes['with-username'] = adapterOptions.withUsername;
       return this.ajax(url, 'POST', { data: serializedUser });
     }
-    return this._super(...arguments);
-  },
+    return super.createRecord(...arguments);
+  }
 
   urlForQueryRecord(query) {
     if (query.me) {
       delete query.me;
-      return `${this._super(...arguments)}/me`;
+      return `${super.urlForQueryRecord(...arguments)}/me`;
     }
 
     if (query.passwordResetTemporaryKey) {
@@ -40,11 +41,11 @@ export default ApplicationAdapter.extend({
       return `${this.host}/${this.namespace}/password-reset-demands/${temporaryKey}`;
     }
 
-    return this._super(...arguments);
-  },
+    return super.urlForQueryRecord(...arguments);
+  }
 
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
-    const url = this._super(...arguments);
+    const url = super.urlForUpdateRecord(...arguments);
 
     if (adapterOptions && adapterOptions.rememberUserHasSeenAssessmentInstructions) {
       delete adapterOptions.rememberUserHasSeenAssessmentInstructions;
@@ -59,5 +60,5 @@ export default ApplicationAdapter.extend({
     }
 
     return url;
-  },
-});
+  }
+}

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -1,14 +1,17 @@
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import { computed } from '@ember/object';
+import Controller from '@ember/controller';
 
 const { and } = computed;
 
-export default Controller.extend({
-  queryParams: ['newLevel', 'competenceLeveled'],
+@classic
+export default class ChallengeController extends Controller {
+  queryParams = ['newLevel', 'competenceLeveled'];
+  newLevel = null;
+  competenceLeveled = null;
 
-  newLevel: null,
-  competenceLeveled: null,
+  @and('model.assessment.showLevelup', 'newLevel')
+  showLevelup;
 
-  showLevelup: and('model.assessment.showLevelup', 'newLevel'),
-  pageTitle: 'Évaluation en cours',
-});
+  pageTitle = 'Évaluation en cours';
+}

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -1,46 +1,50 @@
+import classic from 'ember-classic-decorator';
+import { action, computed } from '@ember/object';
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
 
 const { and } = computed;
 
-export default Controller.extend({
+@classic
+export default class CheckpointController extends Controller {
+  queryParams = ['finalCheckpoint', 'newLevel', 'competenceLeveled'];
+  finalCheckpoint = false;
+  newLevel = null;
+  competenceLeveled = null;
+  isShowingModal = false;
+  answer = null;
+  challenge = null;
 
-  queryParams: ['finalCheckpoint', 'newLevel', 'competenceLeveled'],
+  @and('model.showLevelup', 'newLevel')
+  showLevelup;
 
-  finalCheckpoint: false,
-  newLevel: null,
-  competenceLeveled: null,
-
-  isShowingModal: false,
-  answer: null,
-  challenge: null,
-
-  showLevelup: and('model.showLevelup', 'newLevel'),
-
-  nextPageButtonText: computed('finalCheckpoint', function() {
+  @computed('finalCheckpoint')
+  get nextPageButtonText() {
     return this.finalCheckpoint ? 'Voir mes résultats' : 'Continuer mon parcours';
-  }),
-
-  completionPercentage: computed('finalCheckpoint', 'model.progression.completionPercentage', function() {
-    return this.finalCheckpoint ? 100 : this.get('model.progression.completionPercentage');
-  }),
-
-  shouldDisplayAnswers: computed('model.answersSinceLastCheckpoints', function() {
-    return !!this.get('model.answersSinceLastCheckpoints.length');
-  }),
-
-  pageTitle: computed('finalCheckpoint', function() {
-    return this.finalCheckpoint ? 'Fin de votre évaluation' : 'Avancement de l\'évaluation';
-  }),
-
-  actions: {
-    openComparisonWindow(answer) {
-      this.set('answer', answer);
-      this.set('isShowingModal', true);
-    },
-
-    closeComparisonWindow() {
-      this.set('isShowingModal', false);
-    },
   }
-});
+
+  @computed('finalCheckpoint', 'model.progression.completionPercentage')
+  get completionPercentage() {
+    return this.finalCheckpoint ? 100 : this.get('model.progression.completionPercentage');
+  }
+
+  @computed('model.answersSinceLastCheckpoints')
+  get shouldDisplayAnswers() {
+    return !!this.get('model.answersSinceLastCheckpoints.length');
+  }
+
+  @computed('finalCheckpoint')
+  get pageTitle() {
+    return this.finalCheckpoint ? 'Fin de votre évaluation' : 'Avancement de l\'évaluation';
+  }
+
+  @action
+  openComparisonWindow(answer) {
+    this.set('answer', answer);
+    this.set('isShowingModal', true);
+  }
+
+  @action
+  closeComparisonWindow() {
+    this.set('isShowingModal', false);
+  }
+}

--- a/mon-pix/app/controllers/assessments/results.js
+++ b/mon-pix/app/controllers/assessments/results.js
@@ -1,19 +1,21 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
+@classic
+export default class ResultsController extends Controller {
+  isShowingModal = false;
+  answer = null;
+  pageTitle = 'Fin de test de démo';
 
-  isShowingModal: false,
-  answer: null,
-  pageTitle: 'Fin de test de démo',
-
-  actions: {
-    openComparisonWindow(answer) {
-      this.set('answer', answer);
-      this.set('isShowingModal', true);
-    },
-
-    closeComparisonWindow() {
-      this.set('isShowingModal', false);
-    },
+  @action
+  openComparisonWindow(answer) {
+    this.set('answer', answer);
+    this.set('isShowingModal', true);
   }
-});
+
+  @action
+  closeComparisonWindow() {
+    this.set('isShowingModal', false);
+  }
+}

--- a/mon-pix/app/controllers/campaigns.js
+++ b/mon-pix/app/controllers/campaigns.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Parcours',
-
-});
+@classic
+export default class CampaignsController extends Controller {
+  pageTitle = 'Parcours';
+}

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,17 +1,19 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['participantExternalId'],
-  participantExternalId: null,
-  isLoading: false,
-  pageTitle: 'Présentation',
+@classic
+export default class CampaignLandingPageController extends Controller {
+  queryParams = ['participantExternalId'];
+  participantExternalId = null;
+  isLoading = false;
+  pageTitle = 'Présentation';
 
-  actions: {
-    startCampaignParticipation() {
-      this.set('isLoading', true);
-      return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-        queryParams: { hasSeenLanding: true, participantExternalId: this.participantExternalId }
-      });
-    }
+  @action
+  startCampaignParticipation() {
+    this.set('isLoading', true);
+    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
+      queryParams: { hasSeenLanding: true, participantExternalId: this.participantExternalId }
+    });
   }
-});
+}

--- a/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
@@ -1,46 +1,47 @@
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 
-export default Controller.extend({
+@classic
+export default class FillInCampaignCodeController extends Controller {
+  @service store;
 
-  store: service(),
+  campaignCode = null;
+  errorMessage = null;
 
-  campaignCode: null,
-  errorMessage: null,
+  @action
+  async startCampaign() {
+    this.set('errorMessage', null);
 
-  actions: {
+    if (!this.campaignCode) {
+      this.set('errorMessage', 'Merci de renseigner le code du parcours.');
 
-    async startCampaign() {
-      this.set('errorMessage', null);
+    } else {
+      const campaignCode = this.campaignCode.toUpperCase();
 
-      if (!this.campaignCode) {
-        this.set('errorMessage', 'Merci de renseigner le code du parcours.');
+      const campaignCodeExists = await this.store.query('campaign', { filter: { code: campaignCode } })
+        .then(() => true,
+          (error) => {
+            if (error.errors[0].status === '403') {
+              this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+              return false;
+            }
+            if (error.errors[0].status === '404') {
+              this.set('errorMessage', 'Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+              return false;
+            }
+            throw (error);
+          });
 
-      } else {
-        const campaignCode = this.campaignCode.toUpperCase();
-
-        const campaignCodeExists = await this.store.query('campaign', { filter: { code: campaignCode } })
-          .then(() => true,
-            (error) => {
-              if (error.errors[0].status === '403') {
-                this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
-                return false;
-              }
-              if (error.errors[0].status === '404') {
-                this.set('errorMessage', 'Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
-                return false;
-              }
-              throw (error);
-            });
-
-        if (campaignCodeExists) {
-          return this.transitionToRoute('campaigns.start-or-resume', campaignCode);
-        }
+      if (campaignCodeExists) {
+        return this.transitionToRoute('campaigns.start-or-resume', campaignCode);
       }
-    },
-
-    clearErrorMessage() {
-      this.set('errorMessage', null);
     }
   }
-});
+
+  @action
+  clearErrorMessage() {
+    this.set('errorMessage', null);
+  }
+}

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -1,6 +1,7 @@
-import Controller from '@ember/controller';
-import { computed } from '@ember/object';
+import classic from 'ember-classic-decorator';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 
 const ERROR_INPUT_MESSAGE_MAP = {
@@ -34,100 +35,107 @@ const isMonthValid = (value) => value > 0 && value <= 12;
 const isYearValid = (value) => value > 999 && value <= 9999;
 const isStringValid = (value) => !!value.trim();
 
-export default Controller.extend({
-  queryParams: ['participantExternalId'],
-  participantExternalId: null,
+@classic
+export default class JoinRestrictedCampaignController extends Controller {
+  queryParams = ['participantExternalId'];
+  participantExternalId = null;
 
-  store: service(),
-  session: service(),
+  @service session;
+  @service store;
 
-  firstName: '',
-  lastName: '',
-  dayOfBirth: '',
-  monthOfBirth: '',
-  yearOfBirth: '',
-  pageTitle: 'Rejoindre',
+  firstName = '';
+  lastName = '';
+  dayOfBirth = '';
+  monthOfBirth = '';
+  yearOfBirth = '';
+  pageTitle = 'Rejoindre';
 
-  birthdate: computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+  @computed('yearOfBirth', 'monthOfBirth', 'dayOfBirth')
+  get birthdate() {
     const dayOfBirth = standardizeNumberInTwoDigitFormat(this.dayOfBirth.trim());
     const monthOfBirth = standardizeNumberInTwoDigitFormat(this.monthOfBirth.trim());
     const yearOfBirth = this.yearOfBirth.trim();
     return [yearOfBirth, monthOfBirth, dayOfBirth].join('-');
-  }),
+  }
 
-  isFormNotValid: computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth', function() {
+  @computed('firstName', 'lastName', 'yearOfBirth', 'monthOfBirth', 'dayOfBirth')
+  get isFormNotValid() {
     return !isStringValid(this.firstName) || !isStringValid(this.lastName)
     || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
-  }),
+  }
 
-  isDisabled: computed('session.data.authenticated.source', function() {
+  @computed('session.data.authenticated.source')
+  get isDisabled() {
     return this.session.data.authenticated.source === 'external';
-  }),
+  }
 
-  isLoading: false,
-  errorMessage: null,
+  isLoading = false;
+  errorMessage = null;
 
   init() {
-    this._super();
+    super.init();
     this.validation = validation;
-  },
+  }
 
-  actions: {
-    attemptNext() {
-      this.set('errorMessage', null);
-      this.set('isLoading', true);
-      this._validateInputName('firstName', this.firstName);
-      this._validateInputName('lastName', this.lastName);
-      this._validateInputDay('dayOfBirth', this.dayOfBirth);
-      this._validateInputMonth('monthOfBirth', this.monthOfBirth);
-      this._validateInputYear('yearOfBirth', this.yearOfBirth);
-      if (this.isFormNotValid) {
-        return this.set('isLoading', false);
-      }
+  @action
+  attemptNext() {
+    this.set('errorMessage', null);
+    this.set('isLoading', true);
+    this._validateInputName('firstName', this.firstName);
+    this._validateInputName('lastName', this.lastName);
+    this._validateInputDay('dayOfBirth', this.dayOfBirth);
+    this._validateInputMonth('monthOfBirth', this.monthOfBirth);
+    this._validateInputYear('yearOfBirth', this.yearOfBirth);
+    if (this.isFormNotValid) {
+      return this.set('isLoading', false);
+    }
 
-      const campaignCode = this.model;
-      const studentUserAssociation = this.store.createRecord('student-user-association', {
-        id: campaignCode + '_' + this.lastName,
-        firstName: this.firstName,
-        lastName: this.lastName,
-        birthdate: this.birthdate,
-        campaignCode,
+    const campaignCode = this.model;
+    const studentUserAssociation = this.store.createRecord('student-user-association', {
+      id: campaignCode + '_' + this.lastName,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      birthdate: this.birthdate,
+      campaignCode,
+    });
+
+    return studentUserAssociation.save().then(() => {
+      this.set('isLoading', false);
+      this.transitionToRoute('campaigns.start-or-resume', this.model, {
+        queryParams: { associationDone: true, participantExternalId: this.participantExternalId }
       });
+    }, (errorResponse) => {
+      studentUserAssociation.unloadRecord();
+      this._setErrorMessageForAttemptNextAction(errorResponse);
+      this.set('isLoading', false);
+    });
+  }
 
-      return studentUserAssociation.save().then(() => {
-        this.set('isLoading', false);
-        this.transitionToRoute('campaigns.start-or-resume', this.model, {
-          queryParams: { associationDone: true, participantExternalId: this.participantExternalId }
-        });
-      }, (errorResponse) => {
-        studentUserAssociation.unloadRecord();
-        this._setErrorMessageForAttemptNextAction(errorResponse);
-        this.set('isLoading', false);
-      });
-    },
+  @action
+  triggerInputStringValidation(key, value) {
+    this._validateInputName(key, value);
+  }
 
-    triggerInputStringValidation(key, value) {
-      this._validateInputName(key, value);
-    },
+  @action
+  triggerInputDayValidation(key, value) {
+    value = value.trim();
+    this._standardizeNumberInInput('dayOfBirth', value);
+    this._validateInputDay(key, value);
+  }
 
-    triggerInputDayValidation(key, value) {
-      value = value.trim();
-      this._standardizeNumberInInput('dayOfBirth', value);
-      this._validateInputDay(key, value);
-    },
+  @action
+  triggerInputMonthValidation(key, value) {
+    value = value.trim();
+    this._standardizeNumberInInput('monthOfBirth', value);
+    this._validateInputMonth(key, value);
+  }
 
-    triggerInputMonthValidation(key, value) {
-      value = value.trim();
-      this._standardizeNumberInInput('monthOfBirth', value);
-      this._validateInputMonth(key, value);
-    },
-
-    triggerInputYearValidation(key, value) {
-      value = value.trim();
-      this.set('yearOfBirth', value);
-      this._validateInputYear(key, value);
-    },
-  },
+  @action
+  triggerInputYearValidation(key, value) {
+    value = value.trim();
+    this.set('yearOfBirth', value);
+    this._validateInputYear(key, value);
+  }
 
   _setErrorMessageForAttemptNextAction(errorResponse) {
     errorResponse.errors.forEach((error) => {
@@ -139,34 +147,34 @@ export default Controller.extend({
       }
       return this.set('errorMessage', error.detail);
     });
-  },
+  }
 
   _executeFieldValidation(key, value, isValid) {
     const isInvalidInput = !isValid(value);
     const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
     const messageObject = 'validation.' + key + '.message';
     return this.set(messageObject, message);
-  },
+  }
 
   _validateInputName(key, value) {
     this._executeFieldValidation(key, value, isStringValid);
-  },
+  }
 
   _validateInputDay(key, value) {
     this._executeFieldValidation(key, value, isDayValid);
-  },
+  }
 
   _validateInputMonth(key, value) {
     this._executeFieldValidation(key, value, isMonthValid);
-  },
+  }
 
   _validateInputYear(key, value) {
     this._executeFieldValidation(key, value, isYearValid);
-  },
+  }
 
   _standardizeNumberInInput(attribute, value) {
     if (value) {
       this.set(attribute, standardizeNumberInTwoDigitFormat(value));
     }
   }
-});
+}

--- a/mon-pix/app/controllers/campaigns/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/skill-review.js
@@ -1,43 +1,46 @@
+import classic from 'ember-classic-decorator';
+import { action, computed } from '@ember/object';
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
 import _ from 'lodash';
 
-export default Controller.extend({
+@classic
+export default class SkillReviewController extends Controller {
+  displayLoadingButton = false;
+  displayErrorMessage = false;
+  displayImprovementButton = false;
+  pageTitle = 'Résultat';
 
-  displayLoadingButton: false,
-  displayErrorMessage: false,
-  displayImprovementButton: false,
-  pageTitle: 'Résultat',
-
-  shouldShowBadge: computed('model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled}', function() {
+  @computed(
+    'model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled}'
+  )
+  get shouldShowBadge() {
     const badge = this.get('model.campaignParticipation.campaignParticipationResult.badge.content');
     const areBadgeCriteriaFulfilled = this.get('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled');
     return (!_.isEmpty(badge) && areBadgeCriteriaFulfilled);
-  }),
-
-  actions: {
-    shareCampaignParticipation() {
-      this.set('displayErrorMessage', false);
-      this.set('displayLoadingButton', true);
-      const campaignParticipation = this.get('model.campaignParticipation');
-      campaignParticipation.set('isShared', true);
-      return campaignParticipation.save()
-        .then(() => {
-          this.set('displayLoadingButton', false);
-        })
-        .catch(() => {
-          campaignParticipation.rollbackAttributes();
-          this.set('displayLoadingButton', false);
-          this.set('displayErrorMessage', true);
-        });
-    },
-
-    async improvementCampaignParticipation() {
-      const assessment = this.get('model.assessment');
-      const campaignParticipation = this.get('model.campaignParticipation');
-      await campaignParticipation.save({ adapterOptions: { beginImprovement: true } });
-      return this.transitionToRoute('campaigns.start-or-resume', assessment.get('codeCampaign'));
-    },
-
   }
-});
+
+  @action
+  shareCampaignParticipation() {
+    this.set('displayErrorMessage', false);
+    this.set('displayLoadingButton', true);
+    const campaignParticipation = this.get('model.campaignParticipation');
+    campaignParticipation.set('isShared', true);
+    return campaignParticipation.save()
+      .then(() => {
+        this.set('displayLoadingButton', false);
+      })
+      .catch(() => {
+        campaignParticipation.rollbackAttributes();
+        this.set('displayLoadingButton', false);
+        this.set('displayErrorMessage', true);
+      });
+  }
+
+  @action
+  async improvementCampaignParticipation() {
+    const assessment = this.get('model.assessment');
+    const campaignParticipation = this.get('model.campaignParticipation');
+    await campaignParticipation.save({ adapterOptions: { beginImprovement: true } });
+    return this.transitionToRoute('campaigns.start-or-resume', assessment.get('codeCampaign'));
+  }
+}

--- a/mon-pix/app/controllers/campaigns/tutorial.js
+++ b/mon-pix/app/controllers/campaigns/tutorial.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Didacticiel',
-
-});
+@classic
+export default class TutorialController extends Controller {
+  pageTitle = 'Didacticiel';
+}

--- a/mon-pix/app/controllers/certification-course.js
+++ b/mon-pix/app/controllers/certification-course.js
@@ -1,6 +1,8 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: 'code',
-  code: null
-});
+@classic
+export default class CertificationCourseController extends Controller {
+  queryParams = 'code';
+  code = null;
+}

--- a/mon-pix/app/controllers/certifications/results.js
+++ b/mon-pix/app/controllers/certifications/results.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Avancement de votre certification',
-
-});
+@classic
+export default class ResultsController extends Controller {
+  pageTitle = 'Avancement de votre certification';
+}

--- a/mon-pix/app/controllers/certifications/start.js
+++ b/mon-pix/app/controllers/certifications/start.js
@@ -1,7 +1,10 @@
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 
-export default Controller.extend({
-  currentUser: service(),
-  pageTitle: 'Rejoindre une session de certification',
-});
+@classic
+export default class StartController extends Controller {
+  @service currentUser;
+
+  pageTitle = 'Rejoindre une session de certification';
+}

--- a/mon-pix/app/controllers/competences/details.js
+++ b/mon-pix/app/controllers/competences/details.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Compétence',
-
-});
+@classic
+export default class DetailsController extends Controller {
+  pageTitle = 'Compétence';
+}

--- a/mon-pix/app/controllers/competences/results.js
+++ b/mon-pix/app/controllers/competences/results.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Résultats de votre compétence',
-
-});
+@classic
+export default class ResultsController extends Controller {
+  pageTitle = 'Résultats de votre compétence';
+}

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Inscription',
-
-});
+@classic
+export default class InscriptionController extends Controller {
+  pageTitle = 'Inscription';
+}

--- a/mon-pix/app/controllers/login.js
+++ b/mon-pix/app/controllers/login.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Connexion',
-
-});
+@classic
+export default class LoginController extends Controller {
+  pageTitle = 'Connexion';
+}

--- a/mon-pix/app/controllers/not-connected.js
+++ b/mon-pix/app/controllers/not-connected.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Déconnecté',
-
-});
+@classic
+export default class NotConnectedController extends Controller {
+  pageTitle = 'Déconnecté';
+}

--- a/mon-pix/app/controllers/password-reset-demand.js
+++ b/mon-pix/app/controllers/password-reset-demand.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Oubli de mot de passe',
-
-});
+@classic
+export default class PasswordResetDemandController extends Controller {
+  pageTitle = 'Oubli de mot de passe';
+}

--- a/mon-pix/app/controllers/profile.js
+++ b/mon-pix/app/controllers/profile.js
@@ -1,9 +1,10 @@
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 
-export default Controller.extend({
+@classic
+export default class ProfileController extends Controller {
+  @service currentUser;
 
-  currentUser: service(),
-  pageTitle: 'Votre profil',
-
-});
+  pageTitle = 'Votre profil';
+}

--- a/mon-pix/app/controllers/reset-password.js
+++ b/mon-pix/app/controllers/reset-password.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Changer mon mot de passe',
-
-});
+@classic
+export default class ResetPasswordController extends Controller {
+  pageTitle = 'Changer mon mot de passe';
+}

--- a/mon-pix/app/controllers/user-certifications.js
+++ b/mon-pix/app/controllers/user-certifications.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Mes certifications',
-
-});
+@classic
+export default class UserCertificationsController extends Controller {
+  pageTitle = 'Mes certifications';
+}

--- a/mon-pix/app/controllers/user-tutorials.js
+++ b/mon-pix/app/controllers/user-tutorials.js
@@ -1,7 +1,7 @@
+import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-
-  pageTitle: 'Mes tutos',
-
-});
+@classic
+export default class UserTutorialsController extends Controller {
+  pageTitle = 'Mes tutos';
+}

--- a/mon-pix/app/routes/assessments.js
+++ b/mon-pix/app/routes/assessments.js
@@ -1,9 +1,9 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
+@classic
+export default class AssessmentsRoute extends Route {
   model(params) {
     return this.store.findRecord('assessment', params.assessment_id);
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/assessments/checkpoint.js
+++ b/mon-pix/app/routes/assessments/checkpoint.js
@@ -1,10 +1,11 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
+@classic
+export default class CheckpointRoute extends Route {
   model() {
     return this.modelFor('assessments');
-  },
+  }
 
   async afterModel(assessment) {
 
@@ -17,6 +18,5 @@ export default Route.extend({
 
       assessment.set('campaign', campaigns.get('firstObject'));
     }
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/assessments/results.js
+++ b/mon-pix/app/routes/assessments/results.js
@@ -1,11 +1,12 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-export default Route.extend({
-
+@classic
+export default class ResultsRoute extends Route {
   model() {
     return this.modelFor('assessments').reload();
-  },
+  }
 
   async afterModel(assessment) {
     if (assessment.get('isCertification')) {
@@ -16,6 +17,5 @@ export default Route.extend({
       ...answers.map((answer) => answer.challenge),
       ...answers.map((answer) => answer.correction)
     ]);
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -1,19 +1,21 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import ENV from 'mon-pix/config/environment';
 
-export default Route.extend({
-
-  hasSeenCheckpoint: false,
-  campaignCode: null,
-  newLevel: null,
-  competenceLeveled: null,
+@classic
+export default class ResumeRoute extends Route {
+  hasSeenCheckpoint = false;
+  campaignCode = null;
+  newLevel = null;
+  competenceLeveled = null;
 
   beforeModel(transition) {
     this.set('hasSeenCheckpoint', transition.to.queryParams.hasSeenCheckpoint);
     this.set('campaignCode', transition.to.queryParams.campaignCode);
     this.set('newLevel', transition.to.queryParams.newLevel || null);
     this.set('competenceLeveled', transition.to.queryParams.competenceLeveled || null);
-  },
+  }
 
   async afterModel(assessment) {
     if (assessment.isCompleted) {
@@ -26,14 +28,13 @@ export default Route.extend({
     } else {
       return this._resumeAssessmentWithoutCheckpoint(assessment, nextChallenge);
     }
-  },
+  }
 
-  actions: {
-    loading(transition, originRoute) {
-      // allows the loading template to be shown or not
-      return originRoute._router.currentRouteName !== 'assessments.challenge';
-    }
-  },
+  @action
+  loading(transition, originRoute) {
+    // allows the loading template to be shown or not
+    return originRoute._router.currentRouteName !== 'assessments.challenge';
+  }
 
   _resumeAssessmentWithoutCheckpoint(assessment, nextChallenge) {
     const {
@@ -46,7 +47,7 @@ export default Route.extend({
       return this._rateAssessment(assessment);
     }
     return this._routeToNextChallenge(assessment, nextChallengeId);
-  },
+  }
 
   _resumeAssessmentWithCheckpoint(assessment, nextChallenge) {
     const {
@@ -73,7 +74,7 @@ export default Route.extend({
       return this._routeToNextChallenge(assessment, nextChallengeId);
     }
     return this._routeToNextChallenge(assessment, nextChallengeId);
-  },
+  }
 
   _parseState(assessment, nextChallenge) {
     const assessmentHasNoMoreQuestions = !nextChallenge;
@@ -90,17 +91,17 @@ export default Route.extend({
       nextChallenge,
       assessmentIsCompleted
     };
-  },
+  }
 
   _routeToNextChallenge(assessment, nextChallengeId) {
     return this.replaceWith('assessments.challenge', assessment.id, nextChallengeId, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
-  },
+  }
 
   async _rateAssessment(assessment) {
     await assessment.save({ adapterOptions: { completeAssessment: true } });
 
     return this._routeToResults(assessment);
-  },
+  }
 
   _routeToResults(assessment) {
     if (assessment.isCertification) {
@@ -113,13 +114,13 @@ export default Route.extend({
       return this.replaceWith('competences.results', assessment.competenceId, assessment.id);
     }
     return this.replaceWith('assessments.results', assessment.id);
-  },
+  }
 
   _routeToCheckpoint(assessment) {
     return this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
-  },
+  }
 
   _routeToFinalCheckpoint(assessment) {
     return this.replaceWith('assessments.checkpoint', assessment.id, { queryParams: { finalCheckpoint: true, newLevel: this.newLevel, competenceLeveled: this.competenceLeveled } });
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -1,20 +1,22 @@
-import Route from '@ember/routing/route';
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Route.extend({
+@classic
+export default class CampaignLandingPageRoute extends Route {
+  @service session;
 
-  campaignCode: null,
-  session: service(),
+  campaignCode = null;
 
   deactivate() {
     this.controller.set('isLoading', false);
-  },
+  }
 
   async model(params) {
     const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
 
     return campaigns.get('firstObject');
-  },
+  }
 
   afterModel(campaign) {
     if (campaign.isRestricted && this._userIsUnauthenticated()) {
@@ -22,9 +24,9 @@ export default Route.extend({
         queryParams: { campaignIsRestricted: true }
       });
     }
-  },
+  }
 
   _userIsUnauthenticated() {
     return this.get('session.isAuthenticated') === false;
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/routes/campaigns/fill-in-campaign-code.js
@@ -1,7 +1,9 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  deactivate: function() {
+@classic
+export default class FillInCampaignCodeRoute extends Route {
+  deactivate() {
     this.controller.set('campaignCode', null);
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -1,13 +1,16 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
-export default Route.extend(AuthenticatedRouteMixin, {
+@classic
+export default class JoinRestrictedCampaignRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
+  @service session;
 
-  currentUser: service(),
-  session: service(),
-  _isReady: false,
+  _isReady = false;
 
   async beforeModel(transition) {
     this.set('_isReady', false);
@@ -19,27 +22,26 @@ export default Route.extend(AuthenticatedRouteMixin, {
         queryParams: { associationDone: true }
       });
     }
-  },
+  }
 
   model(params) {
     return params.campaign_code;
-  },
+  }
 
   afterModel() {
     this.set('_isReady', true);
-  },
+  }
 
   setupController(controller) {
-    this._super(...arguments);
+    super.setupController(...arguments);
     if (this.session.data.authenticated.source === 'external') {
       controller.set('firstName', this.currentUser.user.firstName);
       controller.set('lastName', this.currentUser.user.lastName);
     }
-  },
+  }
 
-  actions: {
-    loading() {
-      return this._isReady;
-    }
-  },
-});
+  @action
+  loading() {
+    return this._isReady;
+  }
+}

--- a/mon-pix/app/routes/campaigns/skill-review.js
+++ b/mon-pix/app/routes/campaigns/skill-review.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
+@classic
+export default class SkillReviewRoute extends Route.extend(AuthenticatedRouteMixin) {
   model(params) {
     const store = this.store;
     const assessmentId = params.assessment_id;
@@ -12,12 +13,12 @@ export default Route.extend(AuthenticatedRouteMixin, {
         .then((campaignParticipations) => campaignParticipations.get('firstObject')),
       assessment: store.findRecord('assessment', assessmentId),
     });
-  },
+  }
 
   async afterModel(model) {
     await model.campaignParticipation.belongsTo('campaignParticipationResult').reload();
     await model.campaignParticipation.belongsTo('campaign').reload({ include: 'targetProfile' });
     const improvableNextChallenge = await this.store.queryRecord('challenge', { assessmentId: model.assessment.id, tryImproving: true });
     this.controllerFor('campaigns.skill-review').set('displayImprovementButton', !!improvableNextChallenge);
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -1,23 +1,25 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
-export default Route.extend(AuthenticatedRouteMixin, {
+@classic
+export default class StartOrResumeRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
+  @service session;
 
-  session: service(),
-  currentUser: service(),
-
-  campaignCode: null,
-  campaign: null,
-  associationDone: false,
-  campaignIsRestricted: false,
-  givenParticipantExternalId: null,
-  userHasSeenLanding: false,
-  userHasJustConsultedTutorial: false,
-  authenticationRoute: 'inscription',
-  _isReady: false,
+  campaignCode = null;
+  campaign = null;
+  associationDone = false;
+  campaignIsRestricted = false;
+  givenParticipantExternalId = null;
+  userHasSeenLanding = false;
+  userHasJustConsultedTutorial = false;
+  authenticationRoute = 'inscription';
+  _isReady = false;
 
   beforeModel(transition) {
     this.set('_isReady', false);
@@ -35,15 +37,15 @@ export default Route.extend(AuthenticatedRouteMixin, {
     if (this._userIsUnauthenticated() && !this.userHasSeenLanding && !this.campaignIsRestricted) {
       return this.replaceWith('campaigns.campaign-landing-page', this.campaignCode, { queryParams: transition.to.queryParams });
     }
-    this._super(...arguments);
-  },
+    super.beforeModel(...arguments);
+  }
 
   async model() {
     this.set('isLoading', true);
     const campaigns = await this.store.query('campaign', { filter: { code: this.campaignCode } });
 
     return campaigns.get('firstObject');
-  },
+  }
 
   async afterModel(campaign) {
 
@@ -75,15 +77,15 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
 
     return this.replaceWith('assessments.resume', assessment.get('id'));
-  },
+  }
 
   _userIsUnauthenticated() {
     return this.get('session.isAuthenticated') === false;
-  },
+  }
 
   _thereIsNoAssessment(assessments) {
     return isEmpty(assessments);
-  },
+  }
 
   _showTutorial(assessment) {
     return (
@@ -92,11 +94,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
       && !assessment.isCompleted
       && !this.currentUser.user.hasSeenAssessmentInstructions
     );
-  },
+  }
 
-  actions: {
-    loading() {
-      return this._isReady;
-    }
-  },
-});
+  @action
+  loading() {
+    return this._isReady;
+  }
+}

--- a/mon-pix/app/routes/certifications/results.js
+++ b/mon-pix/app/routes/certifications/results.js
@@ -1,10 +1,11 @@
+import classic from 'ember-classic-decorator';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
+@classic
+export default class ResultsRoute extends Route.extend(AuthenticatedRouteMixin) {
   model(params) {
     // FIXME certification number is a domain attribute and should not be queried as a technical id
     return params.certification_number;
   }
-});
+}

--- a/mon-pix/app/routes/certifications/resume.js
+++ b/mon-pix/app/routes/certifications/resume.js
@@ -1,10 +1,11 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
+@classic
+export default class ResumeRoute extends Route {
   model(params) {
     const store = this.store;
     const certificationCourse = store.peekRecord('certification-course', params.certification_course_id);
     this.replaceWith('assessments.resume', certificationCourse.get('assessment'));
   }
-});
+}

--- a/mon-pix/app/routes/certifications/start.js
+++ b/mon-pix/app/routes/certifications/start.js
@@ -1,12 +1,14 @@
+import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-  currentUser: service(),
+@classic
+export default class StartRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
 
   model() {
     const user = this.currentUser.user;
     return user.belongsTo('certificationProfile').reload();
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/challenge-preview.js
+++ b/mon-pix/app/routes/challenge-preview.js
@@ -1,11 +1,12 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
+@classic
+export default class ChallengePreviewRoute extends Route {
   model(params) {
     const store = this.store;
     return store.findRecord('challenge', params.challenge_id);
-  },
+  }
 
   afterModel(challenge) {
     const store = this.store;
@@ -19,4 +20,4 @@ export default Route.extend({
       return this.replaceWith('assessments.challenge', assessment.id, challenge.id);
     });
   }
-});
+}

--- a/mon-pix/app/routes/competences.js
+++ b/mon-pix/app/routes/competences.js
@@ -1,11 +1,12 @@
-import Route from '@ember/routing/route';
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
-  currentUser: service(),
+@classic
+export default class CompetencesRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
 
   model(params) {
     const scorecardId = this.currentUser.user.id + '_' + params.competence_id;
@@ -13,6 +14,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
       'scorecard',
       scorecardId
     );
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/competences/details.js
+++ b/mon-pix/app/routes/competences/details.js
@@ -1,21 +1,21 @@
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
-  currentUser: service(),
-  session: service(),
+@classic
+export default class DetailsRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
+  @service session;
 
   model(params, transition) {
     const scorecardId = this.currentUser.user.id + '_' + transition.to.parent.params.competence_id;
     return this.store.peekRecord('scorecard', scorecardId, {
       reload: true,
     });
-  },
+  }
 
   afterModel(scorecard) {
     return scorecard.hasMany('tutorials').reload();
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -1,8 +1,10 @@
+import classic from 'ember-classic-decorator';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 import Route from '@ember/routing/route';
 
-export default Route.extend(AuthenticatedRouteMixin, {
+@classic
+export default class ResultsRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model(params) {
     const competenceEvaluations = await this.store.query('competenceEvaluation', {
       filter: {
@@ -10,9 +12,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
       },
     });
     return competenceEvaluations.firstObject;
-  },
+  }
 
   afterModel(competenceEvaluation) {
     return competenceEvaluation.belongsTo('scorecard').reload();
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/competences/resume.js
+++ b/mon-pix/app/routes/competences/resume.js
@@ -1,22 +1,23 @@
+import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
-export default Route.extend(AuthenticatedRouteMixin, {
+@classic
+export default class ResumeRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service session;
+  @service router;
 
-  session: service(),
-  router: service(),
-  competenceId: null,
+  competenceId = null;
 
   model(params, transition) {
     const competenceId = transition.to.parent.params.competence_id;
     const competenceEvaluation = this.store.queryRecord('competenceEvaluation', { competenceId, startOrResume: true });
     return competenceEvaluation;
-  },
+  }
 
   afterModel(competenceEvaluation) {
     return this.replaceWith('assessments.resume', competenceEvaluation.get('assessment.id'));
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/courses/create-assessment.js
+++ b/mon-pix/app/routes/courses/create-assessment.js
@@ -1,10 +1,11 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
+@classic
+export default class CreateAssessmentRoute extends Route {
   async afterModel(course) {
     const store = this.store;
     const assessment = await store.createRecord('assessment', { course, type: 'DEMO' }).save();
     return this.replaceWith('assessments.resume', assessment.id);
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,18 +1,19 @@
-import Route from '@ember/routing/route';
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import _ from 'lodash';
 
-export default Route.extend({
-
-  session: service(),
+@classic
+export default class ErrorRoute extends Route {
+  @service session;
 
   hasUnauthorizedError(error) {
     const statusCode = _.get(error, 'errors[0].code');
     return statusCode === 401;
-  },
+  }
 
   setupController(controller, error) {
-    this._super(...arguments);
+    super.setupController(...arguments);
     controller.set('errorMessage', error);
 
     if (error.errors && error.errors[0]) {
@@ -30,5 +31,4 @@ export default Route.extend({
       return this.transitionTo('logout');
     }
   }
-
-});
+}

--- a/mon-pix/app/routes/index.js
+++ b/mon-pix/app/routes/index.js
@@ -1,9 +1,10 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
+@classic
+export default class IndexRoute extends Route.extend(AuthenticatedRouteMixin) {
   redirect() {
     this.replaceWith('profile');
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/login-or-register-to-access-restricted-campaign.js
+++ b/mon-pix/app/routes/login-or-register-to-access-restricted-campaign.js
@@ -1,11 +1,11 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Route.extend(UnauthenticatedRouteMixin, {
-
+@classic
+export default class LoginOrRegisterToAccessRestrictedCampaignRoute extends Route.extend(UnauthenticatedRouteMixin) {
   async model(params) {
     const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
     return campaigns.firstObject;
   }
-
-});
+}

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -1,16 +1,17 @@
+import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default Route.extend(UnauthenticatedRouteMixin, {
+@classic
+export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
+  @service session;
 
-  session: service(),
-
-  actions: {
-    async authenticate(login, password) {
-      const scope = 'mon-pix';
-      const trimedLogin = login ? login.trim() : '';
-      return this.session.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });
-    }
+  @action
+  async authenticate(login, password) {
+    const scope = 'mon-pix';
+    const trimedLogin = login ? login.trim() : '';
+    return this.session.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });
   }
-});
+}

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -1,11 +1,12 @@
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
-  session: service(),
+@classic
+export default class LogoutRoute extends Route {
+  @service session;
 
   beforeModel() {
     const session = this.session;
@@ -13,7 +14,7 @@ export default Route.extend({
     if (session.get('isAuthenticated')) {
       return session.invalidate();
     }
-  },
+  }
 
   afterModel() {
     if (this.source === 'external') {
@@ -21,14 +22,13 @@ export default Route.extend({
     } else {
       return this._redirectToHome();
     }
-  },
+  }
 
   _redirectToDisconnectedPage() {
     return this.transitionTo('not-connected');
-  },
+  }
 
   _redirectToHome() {
     return window.location.replace(ENV.APP.HOME_HOST);
-  },
-
-});
+  }
+}

--- a/mon-pix/app/routes/not-connected.js
+++ b/mon-pix/app/routes/not-connected.js
@@ -1,4 +1,6 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Route.extend(UnauthenticatedRouteMixin);
+@classic
+export default class NotConnectedRoute extends Route.extend(UnauthenticatedRouteMixin) {}

--- a/mon-pix/app/routes/not-found.js
+++ b/mon-pix/app/routes/not-found.js
@@ -1,8 +1,10 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+@classic
+export default class NotFoundRoute extends Route {
   afterModel(model, transition) {
     transition.abort();
     this.transitionTo('index');
   }
-});
+}

--- a/mon-pix/app/routes/password-reset-demand.js
+++ b/mon-pix/app/routes/password-reset-demand.js
@@ -1,5 +1,5 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-
-});
+@classic
+export default class PasswordResetDemandRoute extends Route {}

--- a/mon-pix/app/routes/profile.js
+++ b/mon-pix/app/routes/profile.js
@@ -1,14 +1,15 @@
+import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
-  currentUser: service(),
+@classic
+export default class ProfileRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service currentUser;
 
   model() {
     return this.currentUser.user;
-  },
+  }
 
   async afterModel(user) {
     // This reloads are necessary to keep the ui in sync when the
@@ -16,5 +17,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
     user.belongsTo('pixScore').reload();
     user.hasMany('scorecards').reload();
     user.hasMany('campaignParticipations').reload();
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -1,15 +1,15 @@
+import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default Route.extend(UnauthenticatedRouteMixin, {
-
-  session: service(),
+@classic
+export default class ResetPasswordRoute extends Route.extend(UnauthenticatedRouteMixin) {
+  @service session;
 
   async model(params) {
     const passwordResetTemporaryKey = params.temporary_key;
     const user = await this.store.queryRecord('user', { passwordResetTemporaryKey });
     return { user, temporaryKey: passwordResetTemporaryKey };
   }
-
-});
+}

--- a/mon-pix/app/routes/user-certifications/get.js
+++ b/mon-pix/app/routes/user-certifications/get.js
@@ -1,8 +1,9 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
+@classic
+export default class GetRoute extends Route.extend(AuthenticatedRouteMixin) {
   model(params) {
     return this.store.findRecord('certification', params.id, { reload: true })
       .then((certification) => {
@@ -11,5 +12,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
         }
         return certification;
       });
-  },
-});
+  }
+}

--- a/mon-pix/app/routes/user-certifications/index.js
+++ b/mon-pix/app/routes/user-certifications/index.js
@@ -1,10 +1,10 @@
+import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend(AuthenticatedRouteMixin, {
-
+@classic
+export default class IndexRoute extends Route.extend(AuthenticatedRouteMixin) {
   model() {
     return this.store.findAll('certification');
   }
-
-});
+}

--- a/mon-pix/app/transforms/array.js
+++ b/mon-pix/app/transforms/array.js
@@ -1,13 +1,13 @@
+import classic from 'ember-classic-decorator';
 import Transform from '@ember-data/serializer/transform';
 
-export default Transform.extend({
-
+@classic
+export default class Array extends Transform {
   deserialize(serialized) {
     return serialized;
-  },
+  }
 
   serialize(deserialized) {
     return deserialized;
   }
-
-});
+}

--- a/mon-pix/app/transforms/date-only.js
+++ b/mon-pix/app/transforms/date-only.js
@@ -1,14 +1,17 @@
+import classic from 'ember-classic-decorator';
 import Transform from '@ember-data/serializer/transform';
 
-export default Transform.extend({
-  serialize: function(date) {
+@classic
+export default class DateOnly extends Transform {
+  serialize(date) {
     return date;
-  },
-  deserialize: function(date) {
+  }
+
+  deserialize(date) {
     const dateRegex = '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
     if (date && date.search(dateRegex) === 0) {
       return date;
     }
     return null;
   }
-});
+}


### PR DESCRIPTION
## :unicorn: Problème
Les composants de Pix App suivent la syntaxe classique d'Ember. Ember Octane nécessite d'utiliser la syntaxe JS native.

## :robot: Solution

Cette PR continue la démarche d'intelligence collective grâce à un [Codemod pour faciliter la conversion des classes en syntaxe native](https://github.com/ember-codemods/ember-native-class-codemod)

Nous croyons que cette démarche d'intelligence collective va permettre de : 
- sécuriser la réécriture du code au maximum
- transmettre les connaissances nécessaires à chacun par la pratique (on regarde ce que font les autres, on se documente, etc.)
- conserver du temps sur la Roadmap pour continuer d'apporter sainement et sereinement de la valeur à nos utilisateurs 

Nous avons conservé le décorateur `@classic` qui permet : 
- une transition complète vers la syntaxe native 
- une transition douce d'Ember Classic vers Ember Octane

[Why do I need this decorator?](https://github.com/emberjs/ember-classic-decorator#why-do-i-need-this-decorator)

## 🚀 La suite 
Chaque édition d'un component devra donc amener sa conversion en component Glimmer selon : 

Cette checklist
- [How do I refactor and remove classic?](https://github.com/emberjs/ember-classic-decorator#how-do-i-refactor-and-remove-classic)

Et ces documentations
- [Doc Ember officielle sur les Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/)
- [Doc Ember officielle sur les états et actions de Components](https://guides.emberjs.com/release/components/component-state-and-actions/)
- [Cheat sheet Classic vs Octane](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

## 🌈 Remarques
Certains components n'ont pas été convertis par le codemod compte tenu de : 
- leur complexité
- la transgression de certains standards

Nous n'y avons pas touché pour éviter les régressions non contrôlées.