### PR TITLE
[BUGFIX] Affichage menu sous IE (PC-140)

### DIFF
--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -14,6 +14,7 @@
 }
 
 .sidebar {
+  min-height: inherit;
   z-index: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## :unicorn: Problème
La barre de menu ne prend pas toute la hauteur de l'écran.
![image](https://user-images.githubusercontent.com/38167520/78007549-ba5c5000-733e-11ea-9cb8-c4fa676ee701.png)


## :robot: Solution
Il semblerait que `display: flex;` sous IE provoque des soucis avec la height de l'enfant. Il faut donc mettre : `min-heigth: 100vh;` ou `min-height: inherit` pour ce dernier. 

https://stackoverflow.com/questions/26596813/internet-explorer-doesnt-honor-my-min-height-100-with-flexbox

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix certif sous IE et cliquer sur une session pour afficher sa page de détails
