### PR TITLE
[FEATURE] Affichage des sujets d'un profil cible dans l'analyse d'une campagne (PO-397).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -5,6 +5,7 @@ const usecases = require('../../domain/usecases');
 const tokenService = require('../../../lib/domain/services/token-service');
 
 const campaignSerializer = require('../../infrastructure/serializers/jsonapi/campaign-serializer');
+const campaignAnalysisSerializer = require('../../infrastructure/serializers/jsonapi/campaign-analysis-serializer');
 const campaignReportSerializer = require('../../infrastructure/serializers/jsonapi/campaign-report-serializer');
 const campaignCollectiveResultSerializer = require('../../infrastructure/serializers/jsonapi/campaign-collective-result-serializer');
 
@@ -104,6 +105,14 @@ module.exports = {
 
     const campaignCollectiveResult = await usecases.computeCampaignCollectiveResult({ userId, campaignId });
     return campaignCollectiveResultSerializer.serialize(campaignCollectiveResult);
+  },
+
+  async getAnalysis(request) {
+    const { userId } = request.auth.credentials;
+    const campaignId = parseInt(request.params.id);
+
+    const campaignAnalysis = await usecases.computeCampaignAnalysis({ userId, campaignId });
+    return campaignAnalysisSerializer.serialize(campaignAnalysis);
   }
 };
 

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -90,13 +90,25 @@ exports.register = async function(server) {
       }
     },
     {
+      method: 'GET',
+      path: '/api/campaigns/{id}/analyses',
+      config: {
+        handler: campaignController.getAnalysis,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération de l\'analyse de la campagne par son id',
+        ],
+        tags: ['api', 'campaign']
+      }
+    },
+    {
       method: 'PUT',
       path: '/api/campaigns/{id}/archive',
       config: {
         handler: campaignController.archiveCampaign,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Archivage d\'une campagne son id',
+          '- Archivage d\'une campagne par son id',
         ],
       }
     },
@@ -107,7 +119,7 @@ exports.register = async function(server) {
         handler: campaignController.unarchiveCampaign,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Désarchivage d\'une campagne son id',
+          '- Désarchivage d\'une campagne par son id',
         ],
       }
     }

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,3 +1,4 @@
+const Joi = require('@hapi/joi');
 const campaignController = require('./campaign-controller');
 
 exports.register = async function(server) {
@@ -93,6 +94,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/campaigns/{id}/analyses',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().required()
+          }),
+        },
         handler: campaignController.getAnalysis,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -23,6 +23,7 @@ class Campaign {
     targetProfile,
     campaignReport,
     campaignCollectiveResult,
+    campaignAnalysis,
     creator,
     // references
     organizationId,
@@ -46,6 +47,7 @@ class Campaign {
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;
     this.campaignCollectiveResult = campaignCollectiveResult;
+    this.campaignAnalysis = campaignAnalysis;
     this.creator = creator;
     // references
     this.organizationId = organizationId;

--- a/api/lib/domain/models/CampaignAnalysis.js
+++ b/api/lib/domain/models/CampaignAnalysis.js
@@ -1,0 +1,14 @@
+class CampaignAnalysis {
+
+  constructor({
+    id,
+    // attributes
+    campaignTubeRecommendations = [],
+  } = {}) {
+    this.id = id;
+    // attributes
+    this.campaignTubeRecommendations = campaignTubeRecommendations;
+  }
+}
+
+module.exports = CampaignAnalysis;

--- a/api/lib/domain/models/CampaignTubeRecommendation.js
+++ b/api/lib/domain/models/CampaignTubeRecommendation.js
@@ -1,0 +1,26 @@
+class CampaignTubeRecommendation {
+
+  constructor({
+    // attributes
+    campaignId,
+    tubeId,
+    competenceId,
+    competenceName,
+    tubePracticalTitle,
+    areaColor,
+  } = {}) {
+    // attributes
+    this.campaignId = campaignId;
+    this.tubeId = tubeId;
+    this.competenceId = competenceId;
+    this.competenceName = competenceName;
+    this.tubePracticalTitle = tubePracticalTitle;
+    this.areaColor = areaColor;
+  }
+
+  get id() {
+    return `${this.campaignId}_${this.tubeId}`;
+  }
+}
+
+module.exports = CampaignTubeRecommendation;

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -10,6 +10,7 @@ class Skill {
     // references
     competenceId,
     tutorialIds = [],
+    tubeId,
   } = {}) {
     this.id = id;
     // attributes
@@ -19,6 +20,7 @@ class Skill {
     // references
     this.competenceId = competenceId;
     this.tutorialIds = tutorialIds;
+    this.tubeId = tubeId;
   }
 
   get difficulty() {

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -11,9 +11,9 @@ class Tube {
     practicalTitle,
     practicalDescription,
     // includes
-    skills = []
+    skills = [],
     // references
-
+    competenceId,
   } = {}) {
     // attributes
     this.id = id;
@@ -24,6 +24,7 @@ class Tube {
     // includes
     this.skills = skills;
     // references
+    this.competenceId = competenceId;
 
     if (name) {
       this.name = name;

--- a/api/lib/domain/usecases/compute-campaign-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-analysis.js
@@ -1,0 +1,49 @@
+const _ = require('lodash');
+const CampaignAnalysis = require('../models/CampaignAnalysis');
+const CampaignTubeRecommendation = require('../models/CampaignTubeRecommendation');
+const { UserNotAuthorizedToAccessEntity } = require('../errors');
+
+module.exports = async function computeCampaignAnalysis(
+  {
+    userId,
+    campaignId,
+    campaignRepository,
+    competenceRepository,
+    targetProfileRepository,
+    tubeRepository,
+  } = {}) {
+
+  const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
+
+  if (!hasUserAccessToResult) {
+    throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+  }
+
+  const [competences, tubes, targetProfile] = await Promise.all([
+    competenceRepository.list(),
+    tubeRepository.list(),
+    targetProfileRepository.getByCampaignId(campaignId)
+  ]);
+
+  const targetedTubeIds = _.uniq(_.map(targetProfile.skills, (skill) => skill.tubeId));
+
+  const campaignTubeRecommendations = _computeCampaignTubeRecommendations(campaignId, tubes, competences, targetedTubeIds);
+
+  return new CampaignAnalysis({ id: campaignId, campaignTubeRecommendations });
+};
+
+function _computeCampaignTubeRecommendations(campaignId, tubes, competences, targetedTubeIds) {
+  return _.map(targetedTubeIds, (tubeId) => {
+    const tube = _.find(tubes, { id: tubeId });
+    const competence = _.find(competences, { id: tube.competenceId });
+
+    return new CampaignTubeRecommendation({
+      campaignId,
+      tubeId,
+      competenceId: competence.id,
+      competenceName: competence.name,
+      tubePracticalTitle: tube.practicalTitle,
+      areaColor: competence.area.color,
+    });
+  });
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -75,6 +75,7 @@ module.exports = injectDependencies({
   authenticateUser: require('./authenticate-user'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
   completeAssessment: require('./complete-assessment'),
+  computeCampaignAnalysis: require('./compute-campaign-analysis'),
   computeCampaignCollectiveResult: require('./compute-campaign-collective-result'),
   correctAnswerThenUpdateAssessment: require('./correct-answer-then-update-assessment'),
   createAndAssociateUserToSchoolingRegistration: require('./create-and-associate-user-to-schooling-registration'),

--- a/api/lib/infrastructure/adapters/skill-adapter.js
+++ b/api/lib/infrastructure/adapters/skill-adapter.js
@@ -9,6 +9,7 @@ module.exports = {
       pixValue: skillAirtableDataObject.pixValue,
       competenceId: skillAirtableDataObject.competenceId,
       tutorialIds: skillAirtableDataObject.tutorialIds,
+      tubeId: skillAirtableDataObject.tubeId,
     });
   },
 };

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -19,14 +19,10 @@ module.exports = datasource.extend({
     'PixValue',
     'Compétence (via Tube) (id persistant)',
     'Status',
+    'Tube (id persistant)',
   ],
 
   fromAirTableObject(airtableRecord) {
-
-    let competenceId;
-    if (airtableRecord.get('Compétence (via Tube) (id persistant)')) {
-      competenceId = airtableRecord.get('Compétence (via Tube) (id persistant)')[0];
-    }
 
     return {
       id: airtableRecord.get('id persistant'),
@@ -36,8 +32,9 @@ module.exports = datasource.extend({
       tutorialIds: airtableRecord.get('Comprendre (id persistant)') || [],
       learningMoreTutorialIds: airtableRecord.get('En savoir plus (id persistant)') || [],
       pixValue: airtableRecord.get('PixValue'),
-      competenceId,
+      competenceId: _.head(airtableRecord.get('Compétence (via Tube) (id persistant)')),
       status: airtableRecord.get('Status'),
+      tubeId: _.head(airtableRecord.get('Tube (id persistant)')),
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -14,9 +14,11 @@ module.exports = datasource.extend({
     'Description',
     'Titre pratique',
     'Description pratique',
+    'Competences (id persistant)',
   ],
 
   fromAirTableObject(airtableRecord) {
+
     return {
       id: airtableRecord.get('id persistant'),
       name: airtableRecord.get('Nom'),
@@ -24,6 +26,7 @@ module.exports = datasource.extend({
       description: airtableRecord.get('Description'),
       practicalTitle: airtableRecord.get('Titre pratique'),
       practicalDescription: airtableRecord.get('Description pratique'),
+      competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
   },
 

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -117,7 +117,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'archivedAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator' ]);
+    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'archivedAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator', 'campaignAnalysis' ]);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -8,6 +8,7 @@ function _toDomain(skillData) {
     pixValue: skillData.pixValue,
     competenceId: skillData.competenceId,
     tutorialIds: skillData.tutorialIds,
+    tubeId: skillData.tubeId,
   });
 }
 

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -11,6 +11,7 @@ function _toDomain(tubeData) {
     description: tubeData.description,
     practicalTitle: tubeData.practicalTitle,
     practicalDescription: tubeData.practicalDescription,
+    competenceId: tubeData.competenceId,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
@@ -1,0 +1,14 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(results) {
+    return new Serializer('campaign-analysis', {
+      attributes: ['campaignTubeRecommendations'],
+      campaignTubeRecommendations: {
+        ref: 'id',
+        includes: true,
+        attributes: ['tubeId', 'competenceId', 'competenceName', 'tubePracticalTitle', 'areaColor'],
+      },
+    }).serialize(results);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -7,7 +7,9 @@ module.exports = {
 
   serialize(campaigns, meta, { tokenForCampaignResults, ignoreCampaignReportRelationshipData = true } = {}) {
     return new Serializer('campaign', {
-      attributes: ['name', 'code', 'title', 'type', 'createdAt', 'customLandingPageText', 'archivedAt', 'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator'],
+      attributes: ['name', 'code', 'title', 'type', 'createdAt', 'customLandingPageText', 'archivedAt',
+        'tokenForCampaignResults', 'idPixLabel', 'organizationLogoUrl', 'organizationName', 'targetProfile',
+        'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator', 'campaignAnalysis'],
       typeForAttribute(attribute) {
         if (attribute === 'creator') {
           return 'users';
@@ -45,6 +47,15 @@ module.exports = {
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/campaigns/${parent.id}/collective-results`;
+          }
+        }
+      },
+      campaignAnalysis: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/campaigns/${parent.id}/analyses`;
           }
         }
       },

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -10,6 +10,7 @@ describe('Integration | Application | Route | campaignRouter', () => {
     sinon.stub(campaignController, 'getCsvResults').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
 
     server = Hapi.server();
 
@@ -69,6 +70,31 @@ describe('Integration | Application | Route | campaignRouter', () => {
       return promise.then((res) => {
         expect(res.statusCode).to.equal(200);
       });
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/analyses', () => {
+
+    it('should return 200', async () => {
+      // given
+      const campaignId = 1;
+
+      // when
+      const result = await server.inject({ method: 'GET', url: `/api/campaigns/${campaignId}/analyses` });
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 400', async () => {
+      // given
+      const campaignId = 'wrongId';
+
+      // when
+      const result = await server.inject({ method: 'GET', url: `/api/campaigns/${campaignId}/analyses` });
+
+      // then
+      expect(result.statusCode).to.equal(400);
     });
   });
 

--- a/api/tests/tooling/airtable-builder/factory/build-skill.js
+++ b/api/tests/tooling/airtable-builder/factory/build-skill.js
@@ -46,7 +46,7 @@ module.exports = function buildSkill({
       'Description': description,
       'Statut de la description': statutDeLaDescription,
       'Level': level,
-      'Tube': tube,
+      'Tube (id persistant)': tube,
       'Status': status,
       'Nom': nom,
       'Record Id': recordId,

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -6,6 +6,9 @@ module.exports = function buildTube({
   titrePratique = 'Adresses',
   descriptionPratique = 'Connaitre le sujet',
   createdTime = '2018-03-15T14:35:03.000Z',
+  competences = [
+    'rectTASRUL6lz0sEJ',
+  ],
 } = {}) {
 
   return {
@@ -17,6 +20,7 @@ module.exports = function buildTube({
       'Description': description,
       'Titre pratique': titrePratique,
       'Description pratique': descriptionPratique,
+      'Competences (id persistant)': competences,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/tooling/domain-builder/factory/build-campaign-analysis.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-analysis.js
@@ -1,0 +1,13 @@
+const faker = require('faker');
+const CampaignAnalysis = require('../../../../lib/domain/models/CampaignAnalysis');
+
+module.exports = function buildCampaignAnalysis(
+  {
+    id = faker.random.number(),
+    campaignTubeRecommendations = [],
+  } = {}) {
+  return new CampaignAnalysis({
+    id,
+    campaignTubeRecommendations,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
@@ -1,0 +1,20 @@
+const CampaignTubeRecommendation = require('../../../../lib/domain/models/CampaignTubeRecommendation');
+
+module.exports = function buildCampaignTubeRecommendation(
+  {
+    campaignId,
+    competenceId,
+    competenceName,
+    tubeId,
+    tubePracticalTitle,
+    areaColor,
+  } = {}) {
+  return new CampaignTubeRecommendation({
+    campaignId,
+    tubeId,
+    competenceId,
+    competenceName,
+    tubePracticalTitle,
+    areaColor,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-skill-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill-airtable-data-object.js
@@ -5,7 +5,8 @@ module.exports = function({
   hintStatus = 'Validé',
   tutorialIds = ['receomyzL0AmpMFGw'],
   pixValue = 2.4,
-  competenceId = 'recABCD1234'
+  competenceId = 'recABCD1234',
+  tubeId = 'recEFGH5678',
 } = {}) {
 
   return {
@@ -16,5 +17,6 @@ module.exports = function({
     tutorialIds,
     pixValue,
     competenceId,
+    tubeId,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-skill.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill.js
@@ -7,6 +7,7 @@ const buildSkill = function buildSkill({
   pixValue = faker.random.number(4),
   competenceId = `rec${faker.random.uuid()}`,
   tutorialIds = [],
+  tubeId = `rec${faker.random.uuid()}`,
 } = {}) {
   return new Skill({
     id,
@@ -14,6 +15,7 @@ const buildSkill = function buildSkill({
     pixValue,
     competenceId,
     tutorialIds,
+    tubeId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -11,6 +11,7 @@ module.exports = function buildTube({
   practicalTitle = faker.random.word(),
   practicalDescription = faker.lorem.sentence(),
   skills = buildSkillCollection(),
+  competenceId = `rec${faker.random.uuid()}`,
 } = {}) {
   return new Tube({
     id,
@@ -19,6 +20,7 @@ module.exports = function buildTube({
     description,
     practicalTitle,
     practicalDescription,
-    skills
+    skills,
+    competenceId,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -13,6 +13,7 @@ module.exports = {
   buildCampaignParticipation: require('./build-campaign-participation'),
   buildCampaignParticipationResult: require('./build-campaign-participation-result'),
   buildCampaignReport: require('./build-campaign-report'),
+  buildCampaignTubeRecommendation: require('./build-campaign-tube-recommendation'),
   buildCertification: require('./build-certification'),
   buildCertificationCandidate: require('./build-certification-candidate'),
   buildCertificationReport: require('./build-certification-report'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -8,6 +8,7 @@ module.exports = {
   buildBadge: require('./build-badge'),
   buildBadgePartnerCompetence: require('./build-badge-partner-competence'),
   buildCampaign: require('./build-campaign'),
+  buildCampaignAnalysis: require('./build-campaign-analysis'),
   buildCampaignCollectiveResult: require('./build-campaign-collective-result'),
   buildCampaignCompetenceCollectiveResult: require('./build-campaign-competence-collective-result'),
   buildCampaignParticipation: require('./build-campaign-participation'),

--- a/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
@@ -8,6 +8,7 @@ module.exports = function SkillAirtableDataObjectFixture({
   competenceId = 'recofJCxg0NqTqTdP',
   pixValue = 2.4,
   status = 'actif',
+  tubeId = 'recofJCazertqTdP',
 } = {}) {
   return {
     id,
@@ -19,5 +20,6 @@ module.exports = function SkillAirtableDataObjectFixture({
     competenceId,
     pixValue,
     status,
+    tubeId,
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
@@ -27,6 +27,9 @@ module.exports = function skillRawAirTableFixture({ id } = { id: 'recTIddrkopID2
       ],
       'Tags': [
         'recdUq3RwhedQoRwS'
+      ],
+      'Tube (id persistant)': [
+        'recofJCazertqTdP'
       ]
     },
     'createdTime': '2018-01-31T12:41:07.000Z'

--- a/api/tests/tooling/fixtures/infrastructure/tubeAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/tubeAirtableDataObjectFixture.js
@@ -5,6 +5,7 @@ module.exports = function TubeAirtableDataObjectFixture({
   description = 'Connaître le fonctionnement d\'un moteur de recherche',
   practicalTitle = 'Outils d\'accès au web',
   practicalDescription = 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
+  competenceId = 'recsvLz0W2ShyfD63',
 } = {}) {
   return {
     id,
@@ -13,5 +14,6 @@ module.exports = function TubeAirtableDataObjectFixture({
     description,
     practicalTitle,
     practicalDescription,
+    competenceId,
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/tubeRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/tubeRawAirTableFixture.js
@@ -10,6 +10,9 @@ module.exports = function tubeRawAirTableFixture() {
       'Description': 'Connaître le fonctionnement d\'un moteur de recherche',
       'Titre pratique': 'Outils d\'accès au web',
       'Description pratique': 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
+      'Competences (id persistant)': [
+        'recsvLz0W2ShyfD63'
+      ],
     },
     'createdTime': '2018-01-31T12:41:07.000Z'
   });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -341,23 +341,6 @@ describe('Unit | Application | Controller | Campaign', () => {
       sinon.stub(campaignAnalysisSerializer, 'serialize');
     });
 
-    it('should return ok', async () => {
-      // given
-      usecases.computeCampaignAnalysis.resolves({});
-      campaignAnalysisSerializer.serialize.withArgs({}).returns('ok');
-
-      // when
-      const response = await campaignController.getAnalysis({
-        params: { id: campaignId },
-        auth: {
-          credentials: { userId }
-        }
-      });
-
-      // then
-      expect(response).to.be.equal('ok');
-    });
-
     it('should return an unauthorized error', async () => {
       // given
       const error = new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
@@ -375,7 +358,6 @@ describe('Unit | Application | Controller | Campaign', () => {
       // then
       expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntity);
     });
-
   });
 
   describe('archiveCampaign', async () => {

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -3,6 +3,7 @@ const { sinon, expect, domainBuilder, hFake, catchErr } = require('../../../test
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
 
 const campaignSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-serializer');
+const campaignAnalysisSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer');
 const campaignReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer');
 const campaignCollectiveResultSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-collective-result-serializer');
 
@@ -330,6 +331,53 @@ describe('Unit | Application | Controller | Campaign', () => {
 
   });
 
+  describe('#getAnalysis', () => {
+
+    const campaignId = 1;
+    const userId = 1;
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'computeCampaignAnalysis');
+      sinon.stub(campaignAnalysisSerializer, 'serialize');
+    });
+
+    it('should return ok', async () => {
+      // given
+      usecases.computeCampaignAnalysis.resolves({});
+      campaignAnalysisSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await campaignController.getAnalysis({
+        params: { id: campaignId },
+        auth: {
+          credentials: { userId }
+        }
+      });
+
+      // then
+      expect(response).to.be.equal('ok');
+    });
+
+    it('should return an unauthorized error', async () => {
+      // given
+      const error = new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+      const request = {
+        params: { id: campaignId },
+        auth: {
+          credentials: { userId }
+        }
+      };
+      usecases.computeCampaignAnalysis.rejects(error);
+
+      // when
+      const errorCatched = await catchErr(campaignController.getAnalysis)(request);
+
+      // then
+      expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntity);
+    });
+
+  });
+
   describe('archiveCampaign', async () => {
     let updatedCampaign;
     let serializedCampaign;
@@ -362,6 +410,7 @@ describe('Unit | Application | Controller | Campaign', () => {
     });
 
   });
+
   describe('unarchiveCampaign', async () => {
     let updatedCampaign;
     let serializedCampaign;

--- a/api/tests/unit/domain/models/CampaignTubeRecommendation_test.js
+++ b/api/tests/unit/domain/models/CampaignTubeRecommendation_test.js
@@ -1,0 +1,22 @@
+const CampaignTubeRecommendation = require('../../../../lib/domain/models/CampaignTubeRecommendation');
+const { expect } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | CampaignTubeRecommendation', () => {
+
+  describe('@id', () => {
+
+    it('should return a unique identifier that is the concatenation of "campaignId" and "tubeId"', () => {
+      // given
+      const campaignId = 123;
+      const tubeId = 'recTube';
+      const campaignTubeRecommendation = new CampaignTubeRecommendation({ campaignId, tubeId });
+
+      // when
+      const campaignTubeRecommendationId = campaignTubeRecommendation.id;
+
+      // then
+      expect(campaignTubeRecommendationId).to.equal('123_recTube');
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -1,0 +1,187 @@
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const { computeCampaignAnalysis } = require('../../../../lib/domain/usecases');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | compute-campaign-analysis', () => {
+
+  let campaignRepository;
+  let competenceRepository;
+  let targetProfileRepository;
+  let tubeRepository;
+
+  const userId = 1;
+  const campaignId = 'someCampaignId';
+  let area;
+  let competence;
+  let tube;
+  let targetProfile;
+  let skill;
+
+  beforeEach(() => {
+    campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
+    competenceRepository = { list: sinon.stub() };
+    targetProfileRepository = { getByCampaignId: sinon.stub() };
+    tubeRepository = { list: sinon.stub() };
+
+    area = domainBuilder.buildArea();
+    competence = domainBuilder.buildCompetence({ area });
+    skill = domainBuilder.buildSkill({ id: 'skillId', competenceId: competence.id, tubeId: 'tubeId' });
+    targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+    tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
+  });
+
+  context('User has access to this result', () => {
+
+    beforeEach(() => {
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+      targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+    });
+
+    it('should returns a single CampaignTubeRecommendation', async () => {
+      // given
+      competenceRepository.list.resolves([competence]);
+      tubeRepository.list.resolves([tube]);
+      const expectedCampaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+        campaignId,
+        tubeId : tube.id,
+        competenceId: competence.id,
+        competenceName: competence.name,
+        tubePracticalTitle: tube.practicalTitle,
+        areaColor: area.color,
+      });
+
+      const expectedResult = {
+        id: campaignId,
+        campaignTubeRecommendations: [expectedCampaignTubeRecommendation],
+      };
+
+      // when
+      const actualCampaignAnalysis = await computeCampaignAnalysis({
+        userId,
+        campaignId,
+        campaignRepository,
+        competenceRepository,
+        targetProfileRepository,
+        tubeRepository,
+      });
+
+      // then
+      expect(actualCampaignAnalysis).to.deep.equal(expectedResult);
+    });
+
+    context('With several skills', () => {
+      let skill2;
+      let campaignTubeRecommendation;
+
+      beforeEach(() => {
+        skill2 = domainBuilder.buildSkill({ id: 'skillId2', competenceId: competence.id, tubeId: 'otherTubeId' });
+        competenceRepository.list.resolves([competence]);
+
+        campaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+          campaignId,
+          tubeId : tube.id,
+          competenceId: competence.id,
+          competenceName: competence.name,
+          tubePracticalTitle: tube.practicalTitle,
+          areaColor: area.color,
+        });
+      });
+
+      it('should returns two CampaignTubeRecommendations', async () => {
+        // given
+        const largeTargetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
+        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(largeTargetProfile);
+
+        const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
+        tubeRepository.list.resolves([tube, otherTube]);
+
+        const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+          campaignId,
+          tubeId : otherTube.id,
+          competenceId: competence.id,
+          competenceName: competence.name,
+          tubePracticalTitle: otherTube.practicalTitle,
+          areaColor: area.color,
+        });
+
+        const expectedResult = {
+          id: campaignId,
+          campaignTubeRecommendations: [campaignTubeRecommendation, campaignOtherTubeRecommendation],
+        };
+
+        // when
+        const actualCampaignAnalysis = await computeCampaignAnalysis({
+          userId,
+          campaignId,
+          campaignRepository,
+          competenceRepository,
+          targetProfileRepository,
+          tubeRepository,
+        });
+
+        // then
+        expect(actualCampaignAnalysis).to.deep.equal(expectedResult);
+      });
+
+      it('should returns two CampaignTubeRecommendations but with two skills in the same tube', async () => {
+        // given
+        const skill3 = domainBuilder.buildSkill({ id: 'skillId3', competenceId: competence.id, tubeId: 'otherTubeId' });
+
+        const largeTargetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2, skill3] });
+        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(largeTargetProfile);
+
+        const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2, skill3] });
+        tubeRepository.list.resolves([tube, otherTube]);
+
+        const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+          campaignId,
+          tubeId : otherTube.id,
+          competenceId: competence.id,
+          competenceName: competence.name,
+          tubePracticalTitle: otherTube.practicalTitle,
+          areaColor: area.color,
+        });
+
+        const expectedResult = {
+          id: campaignId,
+          campaignTubeRecommendations: [campaignTubeRecommendation, campaignOtherTubeRecommendation],
+        };
+
+        // when
+        const actualCampaignAnalysis = await computeCampaignAnalysis({
+          userId,
+          campaignId,
+          campaignRepository,
+          competenceRepository,
+          targetProfileRepository,
+          tubeRepository,
+        });
+
+        // then
+        expect(actualCampaignAnalysis).to.deep.equal(expectedResult);
+      });
+    });
+  });
+
+  context('User does not belong to the organization', () => {
+    beforeEach(() => {
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
+    });
+
+    it('it should throw an UserNotAuthorizedToAccessEntity error', async () => {
+      // when
+      const result = await catchErr(computeCampaignAnalysis)({
+        userId,
+        campaignId,
+        campaignRepository,
+        competenceRepository,
+        targetProfileRepository,
+        tubeRepository,
+      });
+
+      // then
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+});

--- a/api/tests/unit/infrastructure/adapters/skill-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/skill-adapter_test.js
@@ -13,6 +13,7 @@ describe('Unit | Infrastructure | Adapter | skillAdapter', () => {
       pixValue: skillDataObject.pixValue,
       competenceId: skillDataObject.competenceId,
       tutorialIds: ['receomyzL0AmpMFGw'],
+      tubeId: skillDataObject.tubeId,
     });
 
     // when

--- a/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/target-profile-adapter_test.js
@@ -19,6 +19,7 @@ describe('Unit | Infrastructure | Adapter | targetSkillAdapter', () => {
       pixValue: skillAirtableDataObject.pixValue,
       competenceId: skillAirtableDataObject.competenceId,
       tutorialIds: ['receomyzL0AmpMFGw'],
+      tubeId: skillAirtableDataObject.tubeId,
     });
     const expectedTargetProfile = domainBuilder.buildTargetProfile({
       id: bookshelfTargetProfile.get('id'),

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -56,8 +56,16 @@ describe('Unit | Repository | challenge-repository', () => {
           });
           solution = domainBuilder.buildSolution();
           challengeDatasource.get.withArgs(challengeRecordId).resolves(challengeDataObject);
-          skillDatasource.get.withArgs('skillId_1').resolves(domainBuilder.buildSkillAirtableDataObject({ name: '@web1', competenceId: 'rec1' }));
-          skillDatasource.get.withArgs('skillId_2').resolves(domainBuilder.buildSkillAirtableDataObject({ name: '@url2', competenceId: 'rec1' }));
+          skillDatasource.get.withArgs('skillId_1').resolves(domainBuilder.buildSkillAirtableDataObject({
+            name: '@web1',
+            competenceId: 'rec1',
+            tubeId: 'recTube1',
+          }));
+          skillDatasource.get.withArgs('skillId_2').resolves(domainBuilder.buildSkillAirtableDataObject({
+            name: '@url2',
+            competenceId: 'rec1',
+            tubeId: 'recTube2',
+          }));
           solutionAdapter.fromChallengeAirtableDataObject.returns(solution);
 
           // when
@@ -114,8 +122,22 @@ describe('Unit | Repository | challenge-repository', () => {
           // then
           return promise.then((challenge) => {
             expect(challenge.skills).to.have.lengthOf(2);
-            expect(challenge.skills[0]).to.deep.equal(new Skill({ id: 'recTIddrkopID28Ep', name: '@web1', pixValue: 2.4, competenceId: 'rec1', tutorialIds: ['receomyzL0AmpMFGw'] }));
-            expect(challenge.skills[1]).to.deep.equal(new Skill({ id: 'recTIddrkopID28Ep', name: '@url2', pixValue: 2.4, competenceId: 'rec1', tutorialIds: ['receomyzL0AmpMFGw'] }));
+            expect(challenge.skills[0]).to.deep.equal(new Skill({
+              id: 'recTIddrkopID28Ep',
+              name: '@web1',
+              pixValue: 2.4,
+              competenceId: 'rec1',
+              tutorialIds: ['receomyzL0AmpMFGw'],
+              tubeId: 'recTube1',
+            }));
+            expect(challenge.skills[1]).to.deep.equal(new Skill({
+              id: 'recTIddrkopID28Ep',
+              name: '@url2',
+              pixValue: 2.4,
+              competenceId: 'rec1',
+              tutorialIds: ['receomyzL0AmpMFGw'],
+              tubeId: 'recTube2',
+            }));
           });
         });
         it('should call the solution-adapter to create the solution', () => {
@@ -179,19 +201,22 @@ describe('Unit | Repository | challenge-repository', () => {
         id: 'recSkillWeb1',
         name: '@web1',
         pixValue: 2,
-        competenceId: 'rec1'
+        competenceId: 'rec1',
+        tubeId: 'recTube1',
       });
       skillURL2 = domainBuilder.buildSkillAirtableDataObject({
         id: 'recSkillURL2',
         name: '@url2',
         pixValue: 3,
-        competenceId: 'rec1'
+        competenceId: 'rec1',
+        tubeId: 'recTube2',
       });
       skillURL3 = domainBuilder.buildSkillAirtableDataObject({
         id: 'recSkillURL3',
         name: '@url3',
         pixValue: 3,
-        competenceId: 'rec1'
+        competenceId: 'rec1',
+        tubeId: 'recTube3',
       });
       skills = [skillWeb1, skillURL2, skillURL3];
       sinon.stub(skillDatasource, 'get');
@@ -260,6 +285,7 @@ describe('Unit | Repository | challenge-repository', () => {
                 'pixValue': 2,
                 'competenceId': 'rec1',
                 'tutorialIds': ['receomyzL0AmpMFGw'],
+                'tubeId': 'recTube1',
               }
             ]);
             expect(challenges[1].skills).to.deep.equal([
@@ -269,6 +295,7 @@ describe('Unit | Repository | challenge-repository', () => {
                 'pixValue': 3,
                 'competenceId': 'rec1',
                 'tutorialIds': ['receomyzL0AmpMFGw'],
+                'tubeId': 'recTube2',
               },
               {
                 'id': 'recSkillURL3',
@@ -276,6 +303,7 @@ describe('Unit | Repository | challenge-repository', () => {
                 'pixValue': 3,
                 'competenceId': 'rec1',
                 'tutorialIds': ['receomyzL0AmpMFGw'],
+                'tubeId': 'recTube3',
               }
             ]);
           });

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -23,11 +23,13 @@ describe('Unit | Repository | skill-repository', function() {
           pixValue: 2.4,
           competenceId: 'rec1',
           tutorialIds: [1, 2, 3],
+          tubeId: 'tubeRec1',
         }, {
           id: 'recAcquix2',
           name: '@acquix2',
           pixValue: 2.4,
           competenceId: 'rec2',
+          tubeId: 'tubeRec2',
         },
         ]);
     });
@@ -42,8 +44,8 @@ describe('Unit | Repository | skill-repository', function() {
       expect(skills).to.have.lengthOf(2);
       expect(skills[0]).to.be.instanceof(DomainSkill);
       expect(skills).to.be.deep.equal([
-        { id: 'recAcquix1', name: '@acquix1', pixValue: 2.4, competenceId: 'rec1', tutorialIds: [1, 2, 3] },
-        { id: 'recAcquix2', name: '@acquix2', pixValue: 2.4, competenceId: 'rec2', tutorialIds: [] },
+        { id: 'recAcquix1', name: '@acquix1', pixValue: 2.4, competenceId: 'rec1', tutorialIds: [1, 2, 3], tubeId: 'tubeRec1' },
+        { id: 'recAcquix2', name: '@acquix2', pixValue: 2.4, competenceId: 'rec2', tutorialIds: [], tubeId: 'tubeRec2' },
       ]);
     });
   });

--- a/api/tests/unit/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/tube-repository_test.js
@@ -14,6 +14,7 @@ describe('Unit | Repository | tube-repository', () => {
       'Description': 'Connaître le fonctionnement d\'un moteur de recherche',
       'Titre pratique': 'Outils d\'accès au web',
       'Description pratique': 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
+      'Competences (id persistant)': [ 'recCompetence1' ],
     },
     'createdTime': '2018-01-31T12:41:07.000Z'
   });
@@ -26,6 +27,7 @@ describe('Unit | Repository | tube-repository', () => {
       'Description': 'Enregistrer un document',
       'Titre pratique': 'Enregistrement',
       'Description pratique': 'Enregistrer un document',
+      'Competences (id persistant)': [ 'recCompetence2' ],
     },
     'createdTime': '2018-01-31T12:48:07.000Z'
   });
@@ -37,6 +39,7 @@ describe('Unit | Repository | tube-repository', () => {
     description: 'Description',
     practicalTitle: 'Titre vulgarisé',
     practicalDescription: 'Description vulgarisée',
+    competenceId: 'recCompetence1',
   };
 
   const tubeData2 = {
@@ -46,6 +49,7 @@ describe('Unit | Repository | tube-repository', () => {
     description: 'Description',
     practicalTitle: 'Titre vulgarisé',
     practicalDescription: 'Description vulgarisée',
+    competenceId: 'recCompetence2',
   };
 
   beforeEach(() => {
@@ -66,6 +70,7 @@ describe('Unit | Repository | tube-repository', () => {
         description: 'Description 1',
         practicalTitle: 'Practical Title 1',
         practicalDescription: 'Practical Description 1',
+        competenceId: 'recCompetence1',
       };
       const tube2 = {
         id: 'recTube2',
@@ -74,6 +79,7 @@ describe('Unit | Repository | tube-repository', () => {
         description: 'Description 2',
         practicalTitle: 'Practical Title 2',
         practicalDescription: 'Practical Description 2',
+        competenceId: 'recCompetence2',
       };
 
       tubeDatasource.findByNames.withArgs(names).resolves([tube1, tube2]);
@@ -97,6 +103,7 @@ describe('Unit | Repository | tube-repository', () => {
           'practicalTitle': 'Practical Title 1',
           'skills': [],
           'title': 'Title 1',
+          'competenceId': 'recCompetence1',
         },
         {
           'description': 'Description 2',
@@ -106,6 +113,7 @@ describe('Unit | Repository | tube-repository', () => {
           'practicalTitle': 'Practical Title 2',
           'skills': [],
           'title': 'Title 2',
+          'competenceId': 'recCompetence2',
         },
       ]);
     });
@@ -128,6 +136,7 @@ describe('Unit | Repository | tube-repository', () => {
         description: 'Description',
         practicalTitle: 'Titre vulgarisé',
         practicalDescription: 'Description vulgarisée',
+        competenceId: 'recCompetence1',
       });
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
@@ -1,0 +1,60 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer');
+
+describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should return a serialized JSON data object', () => {
+      // given
+      const campaignId = 123;
+
+      const campaignAnalysis = domainBuilder.buildCampaignAnalysis({
+        id: campaignId,
+        campaignTubeRecommendations: [
+          domainBuilder.buildCampaignTubeRecommendation({
+            campaignId: campaignId,
+            tubeId: 'tubeRec1',
+            competenceId: 'rec1',
+            competenceName: 'Cuisson des legumes d’automne',
+            tubePracticalTitle: 'Savoir cuisiner des legumes d’automne à la perfection',
+            areaColor: 'jaffa',
+          }),
+        ]
+      });
+
+      const expectedSerializedResult = {
+        data: {
+          id: '123',
+          type: 'campaign-analyses',
+          attributes: {},
+          relationships: {
+            'campaign-tube-recommendations': {
+              data: [{
+                id: '123_tubeRec1',
+                type: 'campaignTubeRecommendations',
+              }]
+            },
+          },
+        },
+        included: [{
+          id: '123_tubeRec1',
+          type: 'campaignTubeRecommendations',
+          attributes: {
+            'competence-id': 'rec1',
+            'tube-id': 'tubeRec1',
+            'competence-name': 'Cuisson des legumes d’automne',
+            'tube-practical-title': 'Savoir cuisiner des legumes d’automne à la perfection',
+            'area-color': 'jaffa',
+          }
+        }]
+      };
+
+      // when
+      const result = serializer.serialize(campaignAnalysis);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedResult);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -70,6 +70,11 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
                 'links': {
                   'related': '/api/campaigns/5/collective-results'
                 }
+              },
+              'campaign-analysis': {
+                'links': {
+                  'related': '/api/campaigns/5/analyses'
+                }
               }
             }
           },
@@ -168,6 +173,11 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               'campaign-collective-result': {
                 'links': {
                   'related': '/api/campaigns/5/collective-results'
+                }
+              },
+              'campaign-analysis': {
+                'links': {
+                  'related': '/api/campaigns/5/analyses'
                 }
               }
             }

--- a/orga/app/models/campaign-analysis.js
+++ b/orga/app/models/campaign-analysis.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+const { hasMany, Model } = DS;
+
+export default class CampaignAnalysis extends Model {
+
+  @hasMany('CampaignTubeRecommendation') campaignTubeRecommendations;
+
+}

--- a/orga/app/models/campaign-tube-recommendation.js
+++ b/orga/app/models/campaign-tube-recommendation.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+const { belongsTo, Model, attr } = DS;
+
+export default class CampaignTubeRecommendation extends Model {
+
+  @attr() areaColor;
+  @attr() competenceName;
+  @attr() competenceId;
+  @attr() tubeId;
+  @attr() tubePracticalTitle;
+
+  @belongsTo('campaignAnalysis') campaignAnalysis;
+
+}

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -22,6 +22,7 @@ export default DS.Model.extend({
   targetProfile: DS.belongsTo('target-profile'),
   campaignReport: DS.belongsTo('campaign-report'),
   campaignCollectiveResult: DS.belongsTo('campaign-collective-result'),
+  campaignAnalysis: DS.belongsTo('campaign-analysis'),
 
   isTypeProfilesCollection: computed.equal('type', 'PROFILES_COLLECTION'),
   isTypeAssessment: computed.equal('type', 'ASSESSMENT'),

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -36,6 +36,7 @@ Router.map(function() {
       this.route('details', { path: '/:campaign_id' }, function() {
         this.route('parameters', { path: '/' });
         this.route('collective-results', { path: '/resultats-collectifs' });
+        this.route('analysis', { path: '/analyse' });
         this.route('participants', function() {
           this.route('results', { path: '/:campaign_participation_id' });
         });

--- a/orga/app/routes/authenticated/campaigns/details/analysis.js
+++ b/orga/app/routes/authenticated/campaigns/details/analysis.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+
+export default class CampaignAnalysisRoute extends Route {
+
+  model() {
+    const campaign = this.modelFor('authenticated.campaigns.details');
+    return campaign.belongsTo('campaignAnalysis').reload()
+      .then(() => campaign);
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -39,6 +39,7 @@
 @import "pages/authenticated/campaigns/new-item";
 @import "pages/authenticated/campaigns/list";
 @import "pages/authenticated/campaigns/no-campaign-panel";
+@import "pages/authenticated/campaigns/details/analysis";
 @import "pages/authenticated/campaigns/details/parameters";
 @import "pages/authenticated/campaigns/details/collective-results/success-indicator";
 @import "pages/authenticated/campaigns/details/participants";

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -17,6 +17,7 @@ $curious-blue: #2b89c8;
 $aqua: #388AFF;
 $dodger-blue: #3D68FF;
 $comet: #585F75;
+$blue-zodia: #505F79;
 $gun-powder: #414657;
 $heliotrope: #985FFF;
 $porcelain: #f2f3f4;

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -90,3 +90,38 @@
     }
   }
 }
+
+.campaign-details-table {
+  margin-bottom: 20px;
+
+  &__bullet {
+    font-size: 1.8rem;
+    margin-right: 12px;
+
+    &--jaffa {
+      color: $jaffa;
+    }
+
+    &--emerald {
+      color: $emerald;
+    }
+
+    &--cerulean {
+      color: $cerulean;
+    }
+
+    &--wild-strawberry {
+      color: $wild-strawberry;
+    }
+
+    &--butterfly-bush {
+      color: $butterfly-bush;
+    }
+  }
+
+  &__line-wrapper {
+    display: flex;
+    align-items: center;
+    height: inherit;
+  }
+}

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis.scss
@@ -1,0 +1,6 @@
+sub {
+  color: $blue-zodia;
+  font-family: $open-sans;
+  font-size: 0.6875rem;
+  font-weight: normal;
+}

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants/participant-results.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants/participant-results.scss
@@ -134,37 +134,3 @@
     padding: 10px;
   }
 }
-
-.participant-results-details {
-  &-competence__bullet {
-    font-size: 1.8rem;
-    margin-right: 12px;
-
-    &--jaffa {
-      color: $jaffa;
-    }
-
-    &--emerald {
-      color: $emerald;
-    }
-
-    &--cerulean {
-      color: $cerulean;
-    }
-
-    &--wild-strawberry {
-      color: $wild-strawberry;
-    }
-
-    &--butterfly-bush {
-      color: $butterfly-bush;
-    }
-  }
-
-  &__competence-wrapper {
-    display: flex;
-    align-items: center;
-    height: inherit;
-  }
-}
-

--- a/orga/app/templates/authenticated/campaigns/details/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/details/analysis.hbs
@@ -1,0 +1,2 @@
+<Routes::Authenticated::Campaigns::Details::AnalysisTab
+  @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}/>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
@@ -1,0 +1,25 @@
+<div class="panel panel--light-shadow content-text content-text--small campaign-details-table">
+
+  <table aria-label="Analyse par sujet">
+    <thead>
+    <tr>
+      <th class="table__column--wide">Sujets ({{ @campaignTubeRecommendations.length }})</th>
+    </tr>
+    </thead>
+
+      <tbody>
+      {{#each @campaignTubeRecommendations as |tubeRecommendation|}}
+        <tr aria-label="Sujet">
+          <td class="campaign-details-table__line-wrapper">
+            <span class="campaign-details-table__bullet campaign-details-table__bullet--{{tubeRecommendation.areaColor}}">
+              &#8226;
+            </span>
+            <span>{{tubeRecommendation.tubePracticalTitle}}<br/>
+              <sub>{{tubeRecommendation.competenceName}}</sub>
+            </span>
+          </td>
+        </tr>
+      {{/each}}
+      </tbody>
+  </table>
+</div>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
@@ -47,8 +47,8 @@
       <tbody>
       {{#each @campaignCollectiveResult.campaignCompetenceCollectiveResults as |competenceResult|}}
         <tr>
-          <td class="participant-results-details__competence-wrapper">
-            <span class="participant-results-details-competence__bullet participant-results-details-competence__bullet--{{competenceResult.areaColor}}">
+          <td class="campaign-details-table__line-wrapper">
+            <span class="campaign-details-table__bullet campaign-details-table__bullet--{{competenceResult.areaColor}}">
               &#8226;
             </span>
             <span>{{competenceResult.competenceName}}</span>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/participants/results-item.hbs
@@ -103,8 +103,8 @@
       <tbody>
       {{#each @campaignParticipation.campaignParticipationResult.competenceResults as |competence|}}
         <tr aria-label="Résultats par compétence">
-          <td class="participant-results-details__competence-wrapper">
-            <span class="participant-results-details-competence__bullet participant-results-details-competence__bullet--{{competence.areaColor}}">
+          <td class="campaign-details-table__line-wrapper">
+            <span class="campaign-details-table__bullet campaign-details-table__bullet--{{competence.areaColor}}">
               &#8226;
             </span>
             <span>{{competence.name}}</span>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -179,6 +179,12 @@ export default function() {
     return campaign.campaignCollectiveResult;
   });
 
+  this.get('/campaigns/:id/analyses', (schema, request) => {
+    const campaignId = request.params.id;
+    const campaign = schema.campaigns.find(campaignId);
+    return campaign.campaignAnalysis;
+  });
+
   this.get('/campaign-participations', (schema, request) => {
     const qp = request.queryParams;
     const campaignId = qp['filter[campaignId]'];

--- a/orga/mirage/factories/campaign-analysis.js
+++ b/orga/mirage/factories/campaign-analysis.js
@@ -1,0 +1,25 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  withTubeRecommendations: trait({
+    afterCreate(campaignAnalysis, server) {
+      const tubeRecommendation_1 = server.create('campaign-tube-recommendation', {
+        areaColor: 'jaffa',
+        competenceName: 'Competence A',
+        competenceId: 'recCompA',
+        tubeId: 'recTubeA',
+        tubePracticalTitle: 'Tube A',
+      });
+      const tubeRecommendation_2 = server.create('campaign-tube-recommendation', {
+        areaColor: 'emerald',
+        competenceName: 'Competence B',
+        competenceId: 'recCompB',
+        tubeId: 'recTubeB',
+        tubePracticalTitle: 'Tube B',
+      });
+      campaignAnalysis.campaignTubeRecommendations = [tubeRecommendation_1, tubeRecommendation_2];
+    }
+  })
+
+});

--- a/orga/mirage/serializers/campaign-analysis.js
+++ b/orga/mirage/serializers/campaign-analysis.js
@@ -1,0 +1,7 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+const relationshipsToInclude = ['campaignTubeRecommendations'];
+
+export default JSONAPISerializer.extend({
+  include: relationshipsToInclude
+});

--- a/orga/mirage/serializers/campaign.js
+++ b/orga/mirage/serializers/campaign.js
@@ -9,6 +9,9 @@ export default JSONAPISerializer.extend({
       },
       'campaignCollectiveResult': {
         related: `/api/campaigns/${campaign.id}/collective-results`
+      },
+      'campaignAnalysis': {
+        related: `/api/campaigns/${campaign.id}/analyses`
       }
     };
   }

--- a/orga/tests/acceptance/campaign-analysis-test.js
+++ b/orga/tests/acceptance/campaign-analysis-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Campaign Analysis', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let user;
+
+  hooks.beforeEach(async () => {
+    server.logging = true;
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
+    await authenticateSession({
+      user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
+    });
+    const campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations');
+    server.create('campaign', {
+      id: 1,
+      campaignAnalysis,
+    });
+  });
+
+  test('it should display campain analysis', async function(assert) {
+    // when
+    await visit('/campagnes/1/analyse');
+
+    // then
+    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (2)');
+  });
+});

--- a/orga/tests/acceptance/campaign-collective-result-test.js
+++ b/orga/tests/acceptance/campaign-collective-result-test.js
@@ -38,7 +38,7 @@ module('Acceptance | Campaign Collective Result', function(hooks) {
     // then
     assert.dom('.table__empty').doesNotExist();
 
-    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('participant-results-details-competence__bullet--jaffa');
+    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('campaign-details-table__bullet--jaffa');
     assert.dom('table tbody tr:first-child td:first-child span:nth-child(2)').hasText('Competence A');
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('50%');
     assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('5');

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis-tab-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/campaigns/details/analysis-tab', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+  let campaignTubeRecommendation_1;
+
+  hooks.beforeEach(function() {
+    store = this.owner.lookup('service:store');
+
+    campaignTubeRecommendation_1 = store.createRecord('campaign-tube-recommendation', {
+      id: '1_recTubeA',
+      tubeId: 'recTubeA',
+      competenceId: 'recCompA',
+      competenceName: 'Competence A',
+      tubePracticalTitle: 'Tube A',
+      areaColor: 'jaffa',
+    });
+
+    const campaignTubeRecommendation_2 = store.createRecord('campaign-tube-recommendation', {
+      id: '1_recTubeB',
+      tubeId: 'recTubeB',
+      competenceId: 'recCompB',
+      competenceName: 'Competence B',
+      tubePracticalTitle: 'Tube B',
+      areaColor: 'emerald',
+    });
+
+    this.set('campaignTubeRecommendations', [campaignTubeRecommendation_1, campaignTubeRecommendation_2]);
+  });
+
+  test('it should display the tube analysis list of the campaign', async function(assert) {
+    // when
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::AnalysisTab
+      @campaignTubeRecommendations={{campaignTubeRecommendations}}
+    />`);
+
+    // then
+    assert.dom('[aria-label="Sujet"]').exists({ count: 2 });
+  });
+
+  test('it should display tube details', async function(assert) {
+    // when
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::AnalysisTab
+      @campaignTubeRecommendations={{campaignTubeRecommendations}}
+    />`);
+
+    // then
+    const firstTube = '[aria-label="Sujet"]:first-child';
+    assert.dom(firstTube).containsText('•');
+    assert.dom(firstTube).containsText('Tube A');
+    assert.dom(firstTube).containsText('Competence A');
+  });
+});

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/collective-results-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/collective-results-tab-test.js
@@ -73,13 +73,13 @@ module('Integration | Component | routes/authenticated/campaign/details | collec
 
     // then
     assert.dom('.table__empty').doesNotExist();
-    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('participant-results-details-competence__bullet--jaffa');
+    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('campaign-details-table__bullet--jaffa');
     assert.dom('table tbody tr:first-child td:first-child span:nth-child(2)').hasText('Competence A');
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('33%');
     assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('10');
     assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('30');
 
-    assert.dom('table tbody tr:nth-child(2) td:first-child span:first-child').hasClass('participant-results-details-competence__bullet--emerald');
+    assert.dom('table tbody tr:nth-child(2) td:first-child span:first-child').hasClass('campaign-details-table__bullet--emerald');
     assert.dom('table tbody tr:nth-child(2) td:first-child span:nth-child(2)').hasText('Competence B');
     assert.dom('table tbody tr:nth-child(2) td:nth-child(2)').hasText('25%');
     assert.dom('table tbody tr:nth-child(2) td:nth-child(3)').hasText('12.5');

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/participants/results-item-test.js
@@ -95,7 +95,7 @@ module('Integration | Component | routes/authenticated/campaign/details/particip
     assert.dom('.participant-results-content__circle-chart-value').hasText('50%');
 
     assert.dom('table tbody tr').exists({ count: 1 });
-    assert.dom('table tbody tr td span:first-child').hasClass('participant-results-details-competence__bullet--jaffa');
+    assert.dom('table tbody tr td span:first-child').hasClass('campaign-details-table__bullet--jaffa');
     assert.dom('table tbody tr td span:nth-child(2)').hasText('Compétence 1');
     assert.dom('table tbody tr td:nth-child(2)').containsText('50%');
     assert.dom('table tbody tr td:nth-child(3)').hasText('5');


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs de Pix Orga veulent pouvoir voir une analyse détaillée des résultats des participants. Pour cela on va leur recommmander des sujets à travailler.

## :robot: Solution
Dans un premier temps, on a choisi de découper et de faire apparaître la liste des sujets uniquement, affichés avec le nom de la compétence à laquelle ils appartiennent, et la couleur des domaines correspondants.

## :rainbow: Remarques
C'est une nouvelle page non accessible pour l'instant.

/!\ PENSER À RECHARCHER LE CACHE EN FAISANT LA MEP

## :100: Pour tester
Saisir l'url `/campagnes/1/analyse`.
*Attention*, ce n'est valable que pour les campagnes d'évaluation (et non collecte de profils).
