### PR TITLE
[BUGFIX] [EXPEDITE] Correction de l'affichage des boutons sur la page de détails d'une campagne (PO-402).

### DIFF
--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -43,7 +43,7 @@ export default DS.Model.extend({
     return Boolean(this.archivedAt);
   }),
 
-  canBeArchived: computed('campaign', function() {
+  canBeArchived: computed('isTypeTestGiven', 'isArchived', function() {
     return this.isTypeTestGiven && ! this.isArchived;
   }),
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -48,23 +48,25 @@
     <LinkTo @route="authenticated.campaigns.details.parameters" class="navbar-item" @model={{@campaign}} >
       Détails
     </LinkTo>
-    {{# if @campaign.isTypeTestGiven}}
+    {{#if @campaign.isTypeTestGiven}}
       <LinkTo @route="authenticated.campaigns.details.participants" @model={{@campaign}} class="navbar-item">
         Participants ({{@campaign.campaignReport.participationsCount}})
       </LinkTo>
-      <LinkTo @route="authenticated.campaigns.details.collective-results" @model={{@campaign}}   class="navbar-item">
+      <LinkTo @route="authenticated.campaigns.details.collective-results" @model={{@campaign}} class="navbar-item">
         Résultats collectifs
       </LinkTo>
     {{/if}}
   </nav>
 
-  <div class="campaign-details-controls__export-button">
-    <a class="button button--link button--with-icon" href="{{@campaign.urlToResult}}" target="_blank"
-       rel="noopener noreferrer" download>
-      Exporter résultats (.csv)
-      <FaIcon @icon='file-download'></FaIcon>
-    </a>
-  </div>
+  {{#if @campaign.isTypeTestGiven}}
+    <div class="campaign-details-controls__export-button">
+      <a class="button button--link button--with-icon" href="{{@campaign.urlToResult}}" target="_blank"
+         rel="noopener noreferrer" download>
+        Exporter résultats (.csv)
+        <FaIcon @icon='file-download'></FaIcon>
+      </a>
+    </div>
+  {{/if}}
 </div>
 
 {{outlet}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -47,18 +47,18 @@
   </div>
 
   {{#if @campaign.canBeArchived}}
-      <div class="campaign-details-row">
-        <div class="campaign-details-content campaign-details-content--button campaign-details--button">
-          <LinkTo @route="authenticated.campaigns.update" @model={{@campaign.id}} class="button button--grey button--regular button--link campaign-details-content__update-button" aria-label="Modifier">
-            Modifier
-          </LinkTo>
-        </div>
-        <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
-          <button type="button" {{on 'click' (fn this.archiveCampaign @campaign.id)}}
-                     class="button button--grey button--regular button--link" aria-label="Archiver">
-            Archiver
-          </button>
-        </div>
+    <div class="campaign-details-row">
+      <div class="campaign-details-content campaign-details-content--button campaign-details--button">
+        <LinkTo @route="authenticated.campaigns.update" @model={{@campaign.id}} class="button button--grey button--regular button--link campaign-details-content__update-button" aria-label="Modifier">
+          Modifier
+        </LinkTo>
+      </div>
+      <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
+        <button type="button" {{on 'click' (fn this.archiveCampaign @campaign.id)}}
+                   class="button button--grey button--regular button--link" aria-label="Archiver">
+          Archiver
+        </button>
+      </div>
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Parfois, il est impossible de modifier ou archiver une campagne d'évaluation.

## :robot: Solution
Corriger la computed property pour la faire observer les bons trucs.

## :rainbow: Remarques
Le bouton d'export est lui aussi affiché conditionnellement.

## :100: Pour tester
- Aller le voir le détail d'une campagne d'évaluation.
