### PR TITLE
[CLEANUP] Extraire la logique de scoring de certification dans un Event Handler dédié (PF-1202)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -92,6 +92,7 @@ module.exports = {
 
     await DomainTransaction.execute(async (domainTransaction) => {
       const assessmentCompletedEvent = await usecases.completeAssessment({ domainTransaction, assessmentId });
+      await events.handleCertificationScoring({ assessmentCompletedEvent });
       await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent });
     });
 

--- a/api/lib/domain/events/AssessmentCompleted.js
+++ b/api/lib/domain/events/AssessmentCompleted.js
@@ -1,8 +1,10 @@
 class AssessmentCompleted {
-  constructor(userId, targetProfileId, campaignParticipationId) {
+  constructor(assessmentId, userId, targetProfileId, campaignParticipationId, isCertification) {
+    this.assessmentId = assessmentId;
     this.userId = userId;
     this.targetProfileId = targetProfileId;
     this.campaignParticipationId = campaignParticipationId;
+    this.isCertification = isCertification;
   }
 }
 

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -1,0 +1,97 @@
+const AssessmentResult = require('../models/AssessmentResult');
+const CompetenceMark = require('../models/CompetenceMark');
+const Promise = require('bluebird');
+const { UNCERTIFIED_LEVEL } = require('../constants');
+const {
+  CertificationComputeError,
+} = require('../errors');
+
+const handleCertificationScoring = async function({
+  assessmentCompletedEvent,
+  assessmentResultRepository,
+  certificationCourseRepository,
+  competenceMarkRepository,
+  scoringCertificationService,
+  assessmentRepository
+}) {
+  if (assessmentCompletedEvent.isCertification) {
+    await _calculateCertificationScore({ assessmentId:assessmentCompletedEvent.assessmentId, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService, assessmentRepository });
+  }
+};
+
+async function _calculateCertificationScore({
+  assessmentId,
+  assessmentResultRepository,
+  certificationCourseRepository,
+  competenceMarkRepository,
+  scoringCertificationService,
+  assessmentRepository
+}) {
+  const assessment = await assessmentRepository.get(assessmentId);
+  try {
+    const assessmentScore = await scoringCertificationService.calculateAssessmentScore(assessment);
+    await _saveResult({
+      assessment,
+      assessmentScore,
+      assessmentResultRepository,
+      certificationCourseRepository,
+      competenceMarkRepository,
+    });
+  }
+  catch (error) {
+    if (!(error instanceof CertificationComputeError)) {
+      throw error;
+    }
+    await _saveResultAfterCertificationComputeError({
+      assessment,
+      assessmentResultRepository,
+      certificationCourseRepository,
+      certificationComputeError: error,
+    });
+  }
+}
+
+async function _saveResult({
+  assessment,
+  assessmentScore,
+  assessmentResultRepository,
+  certificationCourseRepository,
+  competenceMarkRepository,
+}) {
+  const assessmentResult = await _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository });
+
+  await Promise.map(assessmentScore.competenceMarks, (competenceMark) => {
+    const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
+    return competenceMarkRepository.save(competenceMarkDomain);
+  });
+
+  return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date());
+}
+
+function _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository }) {
+  const assessmentStatus = _getAssessmentStatus(assessmentScore);
+  const assessmentResult = AssessmentResult.BuildStandardAssessmentResult(assessmentScore.level, assessmentScore.nbPix, assessmentStatus, assessment.id);
+  return assessmentResultRepository.save(assessmentResult);
+}
+
+function _getAssessmentStatus(assessmentScore) {
+  if (assessmentScore.nbPix === 0) {
+    assessmentScore.level = UNCERTIFIED_LEVEL;
+    return AssessmentResult.status.REJECTED;
+  } else {
+    return AssessmentResult.status.VALIDATED;
+  }
+}
+
+async function _saveResultAfterCertificationComputeError({
+  assessment,
+  assessmentResultRepository,
+  certificationCourseRepository,
+  certificationComputeError,
+}) {
+  const assessmentResult = AssessmentResult.BuildAlgoErrorResult(certificationComputeError, assessment.id);
+  await assessmentResultRepository.save(assessmentResult);
+  return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date());
+}
+
+module.exports = handleCertificationScoring;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -5,8 +5,14 @@ const dependencies = {
   badgeCriteriaService: require('../services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
   campaignParticipationResultRepository: require('../../infrastructure/repositories/campaign-participation-result-repository'),
+  assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
+  certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
+  competenceMarkRepository: require('../../infrastructure/repositories/competence-mark-repository'),
+  scoringCertificationService: require('../services/scoring/scoring-certification-service'),
+  assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
 };
 
 module.exports = injectDependencies({
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
+  handleCertificationScoring: require('./handle-certification-scoring'),
 }, dependencies);

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -236,6 +236,6 @@ module.exports = {
     result.listChallengesAndAnswers = _getChallengeInformation(matchingAnswers, certificationChallenges, allCompetences);
     return result;
   },
-  
+
   _computeAnswersSuccessRate,
 };

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -1,21 +1,12 @@
-const AssessmentResult = require('../models/AssessmentResult');
-const CompetenceMark = require('../models/CompetenceMark');
-const Promise = require('bluebird');
-const { UNCERTIFIED_LEVEL } = require('../constants');
 const AssessmentCompleted = require('../events/AssessmentCompleted');
 
 const {
   AlreadyRatedAssessmentError,
-  CertificationComputeError,
 } = require('../errors');
 
 module.exports = async function completeAssessment({
   assessmentId,
   assessmentRepository,
-  assessmentResultRepository,
-  certificationCourseRepository,
-  competenceMarkRepository,
-  scoringCertificationService,
   domainTransaction
 }) {
   const assessment = await assessmentRepository.get(assessmentId);
@@ -24,87 +15,13 @@ module.exports = async function completeAssessment({
     throw new AlreadyRatedAssessmentError();
   }
 
-  if (assessment.isCertification()) {
-    await _calculateCertificationScore({ assessment, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService });
-  }
   await assessmentRepository.completeByAssessmentId(domainTransaction, assessmentId);
 
   return new AssessmentCompleted(
+    assessmentId,
     assessment.userId,
     assessment.isSmartPlacement() ? assessment.campaignParticipation.campaign.targetProfileId : null,
     assessment.isSmartPlacement() ? assessment.campaignParticipation.id : null,
+    assessment.isCertification()
   );
 };
-
-async function _calculateCertificationScore({
-  assessment,
-  assessmentResultRepository,
-  certificationCourseRepository,
-  competenceMarkRepository,
-  scoringCertificationService,
-}) {
-  try {
-    const assessmentScore = await scoringCertificationService.calculateAssessmentScore(assessment);
-    await _saveResult({
-      assessment,
-      assessmentScore,
-      assessmentResultRepository,
-      certificationCourseRepository,
-      competenceMarkRepository,
-    });
-  }
-  catch (error) {
-    if (!(error instanceof CertificationComputeError)) {
-      throw error;
-    }
-    await _saveResultAfterCertificationComputeError({
-      assessment,
-      assessmentResultRepository,
-      certificationCourseRepository,
-      certificationComputeError: error,
-    });
-  }
-}
-
-async function _saveResult({
-  assessment,
-  assessmentScore,
-  assessmentResultRepository,
-  certificationCourseRepository,
-  competenceMarkRepository,
-}) {
-  const assessmentResult = await _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository });
-
-  await Promise.map(assessmentScore.competenceMarks, (competenceMark) => {
-    const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
-    return competenceMarkRepository.save(competenceMarkDomain);
-  });
-
-  return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date());
-}
-
-function _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository }) {
-  const assessmentStatus = _getAssessmentStatus(assessment, assessmentScore);
-  const assessmentResult = AssessmentResult.BuildStandardAssessmentResult(assessmentScore.level, assessmentScore.nbPix, assessmentStatus, assessment.id);
-  return assessmentResultRepository.save(assessmentResult);
-}
-
-function _getAssessmentStatus(assessment, assessmentScore) {
-  if (assessmentScore.nbPix === 0) {
-    assessmentScore.level = UNCERTIFIED_LEVEL;
-    return AssessmentResult.status.REJECTED;
-  } else {
-    return AssessmentResult.status.VALIDATED;
-  }
-}
-
-async function _saveResultAfterCertificationComputeError({
-  assessment,
-  assessmentResultRepository,
-  certificationCourseRepository,
-  certificationComputeError,
-}) {
-  const assessmentResult = AssessmentResult.BuildAlgoErrorResult(certificationComputeError, assessment.id);
-  await assessmentResultRepository.save(assessmentResult);
-  return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date());
-}

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -115,6 +115,7 @@ describe('Unit | Controller | assessment-controller', function() {
       usecases.completeAssessment.resolves(assessmentCompletedEvent);
 
       sinon.stub(events, 'handleBadgeAcquisition');
+      sinon.stub(events, 'handleCertificationScoring');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         transactionToBeExecuted = lambda;
       });
@@ -132,7 +133,7 @@ describe('Unit | Controller | assessment-controller', function() {
       expect(usecases.completeAssessment).to.have.been.calledWithExactly({ domainTransaction, assessmentId });
     });
 
-    it('should pass the assessment completed event to the CleaBadgeCreationHandler', async () => {
+    it('should pass the assessment completed event to the BadgeAcquisitionHandler', async () => {
       /// given
       events.handleBadgeAcquisition.resolves({});
 
@@ -144,14 +145,27 @@ describe('Unit | Controller | assessment-controller', function() {
       expect(events.handleBadgeAcquisition).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent });
     });
 
+    it('should pass the assessment completed event to the CertificationScoringHandler', async () => {
+      /// given
+      events.handleBadgeAcquisition.resolves({});
+
+      // when
+      await assessmentController.completeAssessment({ params: { id: assessmentId } });
+      await transactionToBeExecuted(domainTransaction);
+
+      // then
+      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ assessmentCompletedEvent });
+    });
+
     it('should call usecase and handler within the transaction', async () => {
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
       // and transactionToBeExecuted is not executed
 
       // then
-      expect(events.handleBadgeAcquisition).to.not.have.been.called;
       expect(usecases.completeAssessment).to.not.have.been.called;
+      expect(events.handleBadgeAcquisition).to.not.have.been.called;
+      expect(events.handleCertificationScoring).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -1,0 +1,255 @@
+const _ = require('lodash');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const events = require('../../../../lib/domain/events');
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+const { CertificationComputeError } = require('../../../../lib/domain/errors');
+const { UNCERTIFIED_LEVEL } = require('../../../../lib/domain/constants');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+
+describe('Unit | Domain | Events | handle-certification-scoring', () => {
+  const scoringCertificationService = { calculateAssessmentScore: _.noop };
+  const assessmentRepository = { get: _.noop };
+  const assessmentResultRepository = { save: _.noop };
+  const certificationCourseRepository = { changeCompletionDate: _.noop };
+  const competenceMarkRepository = { save: _.noop };
+  const now = new Date('2019-01-01T05:06:07Z');
+  let clock;
+  let assessmentCompletedEvent;
+
+  const dependencies = {
+    assessmentResultRepository,
+    certificationCourseRepository,
+    competenceMarkRepository,
+    scoringCertificationService,
+    assessmentRepository
+  };
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  context('when assessment is of type CERTIFICATION', () => {
+    let certificationAssessment;
+
+    beforeEach(() => {
+      certificationAssessment = _buildCertificationAssessment();
+      sinon.stub(assessmentRepository, 'get').withArgs(certificationAssessment.id).resolves(certificationAssessment);
+      assessmentCompletedEvent = new AssessmentCompleted(
+        certificationAssessment.id,
+        Symbol('userId'),
+        Symbol('targetProfileId'),
+        Symbol('campaignParticipationId'),
+        true,
+      );
+    });
+
+    context('when an error different from a compute error happens', () => {
+      const otherError = new Error();
+      beforeEach(() => {
+        sinon.stub(scoringCertificationService, 'calculateAssessmentScore').rejects(otherError);
+        sinon.stub(AssessmentResult, 'BuildAlgoErrorResult');
+        sinon.stub(assessmentResultRepository, 'save');
+        sinon.stub(certificationCourseRepository, 'changeCompletionDate');
+      });
+
+      it('should not save any results', async () => {
+        // when
+        await catchErr(events.handleCertificationScoring)({
+          assessmentCompletedEvent, ...dependencies
+        });
+
+        // then
+        expect(AssessmentResult.BuildAlgoErrorResult).to.not.have.been.called;
+        expect(assessmentResultRepository.save).to.not.have.been.called;
+        expect(certificationCourseRepository.changeCompletionDate).to.not.have.been.called;
+      });
+    });
+
+    context('when an error of type CertificationComputeError happens while scoring the assessment', () => {
+      const errorAssessmentResult = Symbol('ErrorAssessmentResult');
+      const computeError = new CertificationComputeError();
+      beforeEach(() => {
+        sinon.stub(scoringCertificationService, 'calculateAssessmentScore').rejects(computeError);
+        sinon.stub(AssessmentResult, 'BuildAlgoErrorResult').returns(errorAssessmentResult);
+        sinon.stub(assessmentResultRepository, 'save').resolves();
+        sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
+      });
+
+      it('should call the scoring service with the right arguments', async () => {
+        // when
+        await events.handleCertificationScoring({
+          assessmentCompletedEvent,
+          ...dependencies
+        });
+
+        // then
+        expect(scoringCertificationService.calculateAssessmentScore).to.have.been.calledWithExactly(
+          certificationAssessment
+        );
+      });
+
+      it('should save the error result appropriately', async () => {
+        // when
+        await events.handleCertificationScoring({
+          assessmentCompletedEvent,
+          ...dependencies
+        });
+
+        // then
+        expect(AssessmentResult.BuildAlgoErrorResult).to.have.been.calledWithExactly(
+          computeError, certificationAssessment.id
+        );
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
+          errorAssessmentResult
+        );
+        expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
+          certificationAssessment.certificationCourseId, now
+        );
+      });
+    });
+
+    context('when scoring is successful', () => {
+      const competenceMarkData1 = { dummyAttr: 'cm1' };
+      const competenceMarkData2 = { dummyAttr: 'cm2' };
+      const assessmentResult = Symbol('AssessmentResult');
+      const assessmentResultId = 'assessmentResultId';
+      const savedAssessmentResult = { id: assessmentResultId };
+
+      beforeEach(() => {
+        sinon.stub(AssessmentResult, 'BuildStandardAssessmentResult').returns(assessmentResult);
+        sinon.stub(assessmentResultRepository, 'save').resolves(savedAssessmentResult);
+        sinon.stub(competenceMarkRepository, 'save').resolves();
+        sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
+      });
+
+      context('when score is above 0', () => {
+        const originalLevel = Symbol('originalLevel');
+        const assessmentScore = {
+          nbPix: 1,
+          level: originalLevel,
+          competenceMarks: [competenceMarkData1, competenceMarkData2]
+        };
+        beforeEach(() => {
+          sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
+        });
+
+        it('should left untouched the calculated level in the assessment score', async () => {
+          // when
+          await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies
+          });
+
+          // then
+          expect(assessmentScore.level).to.deep.equal(originalLevel);
+        });
+
+        it('should build and save an assessment result with the expected arguments', async () => {
+          // when
+          await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies
+          });
+
+          // then
+          expect(AssessmentResult.BuildStandardAssessmentResult).to.have.been.calledWithExactly(
+            originalLevel,
+            assessmentScore.nbPix,
+            AssessmentResult.status.VALIDATED,
+            certificationAssessment.id
+          );
+          expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
+          expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
+            certificationAssessment.certificationCourseId, now
+          );
+        });
+
+        it('should build and save as many competence marks as present in the assessmentScore', async () => {
+          // when
+          await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies
+          });
+
+          // then
+          expect(competenceMarkRepository.save.callCount).to.equal(assessmentScore.competenceMarks.length);
+        });
+      });
+
+      context('when score is equal 0', () => {
+        const originalLevel = Symbol('originalLevel');
+        const assessmentScore = {
+          nbPix: 0,
+          level: originalLevel,
+          competenceMarks: [competenceMarkData1, competenceMarkData2]
+        };
+        beforeEach(() => {
+          sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
+        });
+
+        it('should change level of the assessmentScore', async () => {
+          // when
+          await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies
+          });
+
+          // then
+          expect(assessmentScore.level).to.deep.equal(UNCERTIFIED_LEVEL);
+        });
+
+        it('should build and save an assessment result with the expected arguments', async () => {
+          // when
+          await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies
+          });
+
+          // then
+          expect(AssessmentResult.BuildStandardAssessmentResult).to.have.been.calledWithExactly(
+            UNCERTIFIED_LEVEL,
+            assessmentScore.nbPix,
+            AssessmentResult.status.REJECTED,
+            certificationAssessment.id
+          );
+          expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
+            assessmentResult
+          );
+          expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
+            certificationAssessment.certificationCourseId, now
+          );
+        });
+      });
+    });
+  });
+  context('when completed assessment is not of type CERTIFICATION', () => {
+    it('should not do anything', async () => {
+      // given
+      const assessmentCompletedEvent = new AssessmentCompleted(
+        Symbol('an assessment Id'),
+        Symbol('userId'),
+        Symbol('targetProfileId'),
+        Symbol('campaignParticipationId'),
+        false,
+      );
+      sinon.stub(assessmentRepository, 'get').resolves();
+
+      // when
+      await events.handleCertificationScoring({
+        assessmentCompletedEvent, ...dependencies
+      });
+
+      expect(assessmentRepository.get).to.not.have.been.called;
+    });
+
+  });
+});
+
+function _buildCertificationAssessment() {
+  return domainBuilder.buildAssessment({
+    id: Symbol('assessmentId'),
+    certificationCourseId: Symbol('certificationCourseId'),
+    state: 'started',
+    type: Assessment.types.CERTIFICATION,
+  });
+}

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -1,10 +1,8 @@
 const _ = require('lodash');
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const completeAssessment = require('../../../../lib/domain/usecases/complete-assessment');
-const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { AlreadyRatedAssessmentError, CertificationComputeError } = require('../../../../lib/domain/errors');
-const { UNCERTIFIED_LEVEL } = require('../../../../lib/domain/constants');
+const { AlreadyRatedAssessmentError } = require('../../../../lib/domain/errors');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
 describe('Unit | UseCase | complete-assessment', () => {
@@ -59,7 +57,8 @@ describe('Unit | UseCase | complete-assessment', () => {
   context('when assessment is not yet completed', () => {
     [
       _buildCompetenceEvaluationAssessment(),
-      _buildSmartPlacementAssessment()
+      _buildSmartPlacementAssessment(),
+      _buildCertificationAssessment()
     ]
       .forEach((assessment) => {
 
@@ -100,6 +99,8 @@ describe('Unit | UseCase | complete-assessment', () => {
 
             // then
             expect(result).to.be.an.instanceof(AssessmentCompleted);
+            expect(result.userId).to.equal(assessment.userId);
+            expect(result.assessmentId).to.equal(assessment.id);
           });
         });
       });
@@ -122,254 +123,32 @@ describe('Unit | UseCase | complete-assessment', () => {
         });
 
         // then
-        expect(result).to.deep.equal({
-          userId: assessment.userId,
-          targetProfileId: assessment.campaignParticipation.campaign.targetProfileId,
-          campaignParticipationId: assessment.campaignParticipation.id
-        });
+        expect(result.targetProfileId).to.equal(
+          assessment.campaignParticipation.campaign.targetProfileId
+        );
+        expect(result.campaignParticipationId).to.equal(assessment.campaignParticipation.id);
       });
     });
 
     context('when assessment is of type CERTIFICATION', () => {
-      let certificationAssessment;
-
-      beforeEach(() => {
+      it('should return a AssessmentCompleted event with certification flag', async () => {
         const assessment = _buildCertificationAssessment();
-        certificationAssessment = assessment;
-        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(certificationAssessment);
+
+        sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
-      });
-
-      context('when an error different from a compute error happens', () => {
-        const otherError = new Error();
-        beforeEach(() => {
-          sinon.stub(scoringCertificationService, 'calculateAssessmentScore').rejects(otherError);
-          sinon.stub(AssessmentResult, 'BuildAlgoErrorResult');
-          sinon.stub(assessmentResultRepository, 'save');
-          sinon.stub(certificationCourseRepository, 'changeCompletionDate');
+        // when
+        const result = await completeAssessment({
+          assessmentId: assessment.id,
+          assessmentRepository,
+          assessmentResultRepository,
+          certificationCourseRepository,
+          competenceMarkRepository,
+          scoringCertificationService,
+          domainTransaction
         });
 
-        it('should not save any results', async () => {
-          // when
-          await catchErr(completeAssessment)({
-            assessmentId: certificationAssessment.id,
-            assessmentRepository,
-            assessmentResultRepository,
-            certificationCourseRepository,
-            competenceMarkRepository,
-            scoringCertificationService,
-            domainTransaction
-          });
-
-          // then
-          expect(AssessmentResult.BuildAlgoErrorResult).to.not.have.been.called;
-          expect(assessmentResultRepository.save).to.not.have.been.called;
-          expect(certificationCourseRepository.changeCompletionDate).to.not.have.been.called;
-        });
-      });
-
-      context('when an error of type CertificationComputeError happens while scoring the assessment', () => {
-        const errorAssessmentResult = Symbol('ErrorAssessmentResult');
-        const computeError = new CertificationComputeError();
-        beforeEach(() => {
-          sinon.stub(scoringCertificationService, 'calculateAssessmentScore').rejects(computeError);
-          sinon.stub(AssessmentResult, 'BuildAlgoErrorResult').returns(errorAssessmentResult);
-          sinon.stub(assessmentResultRepository, 'save').resolves();
-          sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
-        });
-
-        it('should call the scoring service with the right arguments', async () => {
-          // when
-          await completeAssessment({
-            assessmentId: certificationAssessment.id,
-            assessmentRepository,
-            assessmentResultRepository,
-            certificationCourseRepository,
-            competenceMarkRepository,
-            scoringCertificationService,
-            domainTransaction,
-          });
-
-          // then
-          expect(scoringCertificationService.calculateAssessmentScore.calledWithExactly(certificationAssessment)).to.be.true;
-        });
-
-        it('should save the error result appropriately', async () => {
-          // when
-          await completeAssessment({
-            assessmentId: certificationAssessment.id,
-            assessmentRepository,
-            assessmentResultRepository,
-            certificationCourseRepository,
-            competenceMarkRepository,
-            scoringCertificationService,
-            domainTransaction,
-          });
-
-          // then
-          expect(AssessmentResult.BuildAlgoErrorResult.calledWithExactly(computeError, certificationAssessment.id)).to.be.true;
-          expect(assessmentResultRepository.save.calledWithExactly(errorAssessmentResult)).to.be.true;
-          expect(certificationCourseRepository.changeCompletionDate.calledWithExactly(certificationAssessment.certificationCourseId, now)).to.be.true;
-        });
-
-        it('should still complete the assessment', async () => {
-          // when
-          await completeAssessment({
-            assessmentId: certificationAssessment.id,
-            assessmentRepository,
-            assessmentResultRepository,
-            certificationCourseRepository,
-            competenceMarkRepository,
-            scoringCertificationService,
-            domainTransaction,
-          });
-
-          // then
-          expect(assessmentRepository.completeByAssessmentId)
-            .to.have.been.calledWithExactly(domainTransaction, certificationAssessment.id);
-        });
-      });
-
-      context('when scoring is successful', () => {
-        const competenceMarkData1 = { dummyAttr: 'cm1' };
-        const competenceMarkData2 = { dummyAttr: 'cm2' };
-        const assessmentResult = Symbol('AssessmentResult');
-        const assessmentResultId = 'assessmentResultId';
-        const savedAssessmentResult = { id: assessmentResultId };
-
-        beforeEach(() => {
-          sinon.stub(AssessmentResult, 'BuildStandardAssessmentResult').returns(assessmentResult);
-          sinon.stub(assessmentResultRepository, 'save').resolves(savedAssessmentResult);
-          sinon.stub(competenceMarkRepository, 'save').resolves();
-          sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
-        });
-
-        context('when score is above 0', () => {
-          const originalLevel = Symbol('originalLevel');
-          const assessmentScore = {
-            nbPix: 1,
-            level: originalLevel,
-            competenceMarks: [competenceMarkData1, competenceMarkData2]
-          };
-          beforeEach(() => {
-            sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
-          });
-
-          it('should left untouched the calculated level in the assessment score', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction,
-            });
-
-            // then
-            expect(assessmentScore.level).to.deep.equal(originalLevel);
-          });
-
-          it('should build and save an assessment result with the expected arguments', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction,
-            });
-
-            // then
-            expect(AssessmentResult.BuildStandardAssessmentResult.calledWithExactly(originalLevel, assessmentScore.nbPix, AssessmentResult.status.VALIDATED, certificationAssessment.id))
-              .to.be.true;
-            expect(assessmentResultRepository.save.calledWithExactly(assessmentResult)).to.be.true;
-            expect(certificationCourseRepository.changeCompletionDate.calledWithExactly(certificationAssessment.certificationCourseId, now)).to.be.true;
-          });
-
-          it('should build and save as many competence marks as present in the assessmentScore', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction,
-            });
-
-            // then
-            expect(competenceMarkRepository.save.callCount).to.equal(assessmentScore.competenceMarks.length);
-          });
-
-          it('should still complete the assessment', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction,
-            });
-
-            // then
-            expect(assessmentRepository.completeByAssessmentId)
-              .to.have.been.calledWithExactly(domainTransaction, certificationAssessment.id);
-          });
-        });
-
-        context('when score is equal 0', () => {
-          const originalLevel = Symbol('originalLevel');
-          const assessmentScore = {
-            nbPix: 0,
-            level: originalLevel,
-            competenceMarks: [competenceMarkData1, competenceMarkData2]
-          };
-          beforeEach(() => {
-            sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
-          });
-
-          it('should change level of the assessmentScore', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction
-            });
-
-            // then
-            expect(assessmentScore.level).to.deep.equal(UNCERTIFIED_LEVEL);
-          });
-
-          it('should build and save an assessment result with the expected arguments', async () => {
-            // when
-            await completeAssessment({
-              assessmentId: certificationAssessment.id,
-              assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
-              domainTransaction,
-            });
-
-            // then
-            expect(AssessmentResult.BuildStandardAssessmentResult.calledWithExactly(UNCERTIFIED_LEVEL, assessmentScore.nbPix, AssessmentResult.status.REJECTED, certificationAssessment.id))
-              .to.be.true;
-            expect(assessmentResultRepository.save.calledWithExactly(assessmentResult)).to.be.true;
-            expect(certificationCourseRepository.changeCompletionDate.calledWithExactly(certificationAssessment.certificationCourseId, now)).to.be.true;
-          });
-        });
+        // then
+        expect(result.isCertification).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

La logique de scoring de la certification (contexte "Certification") transpire dans celle de la completion de l'assessment (contexte "Evaluation") : les fonctions contenant cette logique se trouvent dans le usecase `complete-assessment` qui est déclenché sur tous les assessments (évaluation de compétence, campagne et certification).

## :robot: Solution
Déplacer la logique de scoring de certification dans un *Event handler* qui réagit à l'évènement `AssessmentCompleted`.

## :rainbow: Remarques
Voir le dernier commit seulement.

## :100: Pour tester
Non régression sur la fin d'un parcours de certification.
