### PR TITLE
[TECH] Ajout et utilisation d'une route pour récupérer toutes les answers (PF-1195).

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -32,9 +32,9 @@ module.exports = {
 
   async find(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const challengeId = request.query.challenge;
-    const assessmentId = request.query.assessment;
-    let answers;
+    const challengeId = request.query.challengeId;
+    const assessmentId = request.query.assessmentId;
+    let answers = [];
     if (challengeId && assessmentId) {
       answers = await usecases.findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId });
     }

--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -30,13 +30,19 @@ module.exports = {
     return answerSerializer.serialize(answer);
   },
 
-  async findByChallengeAndAssessment(request) {
+  async find(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
     const challengeId = request.query.challenge;
     const assessmentId = request.query.assessment;
-    const answer = await usecases.findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId });
+    let answers;
+    if (challengeId && assessmentId) {
+      answers = await usecases.findAnswerByChallengeAndAssessment({ challengeId, assessmentId, userId });
+    }
+    if (assessmentId && !challengeId) {
+      answers = await usecases.findAnswerByAssessment({ assessmentId, userId });
+    }
 
-    return answerSerializer.serialize(answer);
+    return answerSerializer.serialize(answers);
   },
 
   async getCorrection(request) {

--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -46,7 +46,7 @@ exports.register = async function(server) {
       path: '/api/answers',
       config: {
         auth: false,
-        handler: answerController.findByChallengeAndAssessment,
+        handler: answerController.find,
         tags: ['api', 'answers'],
         notes: [
           '- **Cette route est accessible aux utilisateurs pour qui l\'answer appartient à leur assessment**\n' +

--- a/api/lib/domain/usecases/find-answer-by-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-assessment.js
@@ -1,0 +1,18 @@
+module.exports = async function findAnswerByAssessment(
+  {
+    assessmentId,
+    userId,
+    answerRepository,
+    assessmentRepository,
+  } = {}) {
+  const integerAssessmentId = parseInt(assessmentId);
+  if (!Number.isFinite(integerAssessmentId)) {
+    return [];
+  }
+
+  const assessment = await assessmentRepository.get(assessmentId);
+  if (assessment.userId !== userId) {
+    return [];
+  }
+  return answerRepository.findByAssessment(integerAssessmentId);
+};

--- a/api/lib/domain/usecases/find-answer-by-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-assessment.js
@@ -1,3 +1,5 @@
+const { UserNotAuthorizedToAccessEntity, EntityValidationError } = require('../errors');
+
 module.exports = async function findAnswerByAssessment(
   {
     assessmentId,
@@ -7,12 +9,12 @@ module.exports = async function findAnswerByAssessment(
   } = {}) {
   const integerAssessmentId = parseInt(assessmentId);
   if (!Number.isFinite(integerAssessmentId)) {
-    return [];
+    throw new EntityValidationError('This assessment ID is not valid.');
   }
 
   const assessment = await assessmentRepository.get(assessmentId);
-  if (assessment.userId !== userId) {
-    return [];
+  if (assessment.userId !== userId && assessment.userId) {
+    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this assessment.');
   }
   return answerRepository.findByAssessment(integerAssessmentId);
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -89,6 +89,7 @@ module.exports = injectDependencies({
   finalizeSession: require('./finalize-session'),
   updatePublicationSession: require('./update-publication-session'),
   findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),
+  findAnswerByAssessment: require('./find-answer-by-assessment'),
   findAssociationBetweenUserAndSchoolingRegistration: require('./find-association-between-user-and-schooling-registration'),
   findCampaignParticipationsRelatedToAssessment: require('./find-campaign-participations-related-to-assessment'),
   findCampaignParticipationsWithResults: require('./find-campaign-participations-with-results'),

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -52,6 +52,11 @@ module.exports = {
       ],
       answers: {
         ref: 'id',
+        relationshipLinks: {
+          related(record) {
+            return `/api/answers?assessment=${record.id}`;
+          }
+        }
       },
       course: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/assessment-serializer.js
@@ -54,7 +54,7 @@ module.exports = {
         ref: 'id',
         relationshipLinks: {
           related(record) {
-            return `/api/answers?assessment=${record.id}`;
+            return `/api/answers?assessmentId=${record.id}`;
           }
         }
       },

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -220,15 +220,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         const response = await server.inject(options);
 
         // given
-        expect(response.statusCode).to.equal(200);
-      });
-
-      it('should return no answer', async () => {
-        // when
-        const response = await server.inject(options);
-
-        // given
-        expect(response.result.data).to.deep.equal([]);
+        expect(response.statusCode).to.equal(403);
       });
     });
 

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -3,7 +3,7 @@ const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | answer-controller-find', () => {
 
-  describe('GET /api/answers?challengeId=Y&assessmentId=Z', () => {
+  describe('GET /api/answers?challenge=Y&assessment=Z', () => {
 
     let server;
     let options;
@@ -88,9 +88,9 @@ describe('Acceptance | Controller | answer-controller-find', () => {
       });
 
     });
-    
+
     context('when the assessment has an userId but the user is not the relevant user', () => {
-      
+
       beforeEach(async () => {
         server = await createServer();
         userId = databaseBuilder.factory.buildUser().id;
@@ -122,7 +122,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
     });
 
     context('when the assessment is demo and there is no userId', () => {
-      
+
       beforeEach(async () => {
         server = await createServer();
         const assessment = databaseBuilder.factory.buildAssessment({ userId: null, type: 'DEMO' });
@@ -143,4 +143,116 @@ describe('Acceptance | Controller | answer-controller-find', () => {
       });
     });
   });
+
+  describe('GET /api/answers?assessment=12323', () => {
+
+    let server;
+    let options;
+    let userId;
+    let answers;
+
+    context('when the assessment has an userId (is not a demo or preview)', () => {
+
+      beforeEach(async () => {
+        server = await createServer();
+        userId = databaseBuilder.factory.buildUser().id;
+        const assessment = databaseBuilder.factory.buildAssessment({ userId, type: 'COMPETENCE_EVALUATION' });
+        answers = [
+          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id }),
+          databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id })
+        ];
+        await databaseBuilder.commit();
+        options = {
+          method: 'GET',
+          url: `/api/answers?assessment=${assessment.id}`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return application/json', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        const contentType = response.headers['content-type'];
+        expect(contentType).to.contain('application/json');
+      });
+
+      it('should return required answers', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        const answerReceived = response.result.data;
+        expect(answerReceived.length).to.equal(2);
+        expect(answerReceived[0].type).to.equal('answers');
+        expect(answerReceived[1].type).to.equal('answers');
+        expect([answerReceived[0].id, answerReceived[1].id]).to.have.members([answers[0].id.toString(), answers[1].id.toString()]);
+      });
+
+    });
+
+    context('when the assessment has an userId but the user is not the relevant user', () => {
+
+      beforeEach(async () => {
+        server = await createServer();
+        userId = databaseBuilder.factory.buildUser().id;
+        const assessment = databaseBuilder.factory.buildAssessment({ userId, type: 'COMPETENCE_EVALUATION' });
+        answers = [databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id, value: '1.2', result: 'ok' })];
+        await databaseBuilder.commit();
+        options = {
+          method: 'GET',
+          url: `/api/answers?assessment=${assessment.id}`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId + 3) },
+        };
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return no answer', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.result.data).to.deep.equal([]);
+      });
+    });
+
+    context('when the assessment is demo and there is no userId', () => {
+
+      beforeEach(async () => {
+        server = await createServer();
+        const assessment = databaseBuilder.factory.buildAssessment({ userId: null, type: 'DEMO' });
+        databaseBuilder.factory.buildAnswer({ assessmentId: assessment.id, value: '1.2', result: 'ok' });
+        await databaseBuilder.commit();
+        options = {
+          method: 'GET',
+          url: `/api/answers?&assessment=${assessment.id}`,
+        };
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // given
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+
 });

--- a/api/tests/acceptance/application/answers/answer-controller-find_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-find_test.js
@@ -3,7 +3,7 @@ const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | answer-controller-find', () => {
 
-  describe('GET /api/answers?challenge=Y&assessment=Z', () => {
+  describe('GET /api/answers?challengeId=Y&assessmentId=Z', () => {
 
     let server;
     let options;
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?challenge=${challengeId}&assessment=salut`,
+          url: `/api/answers?challengeId=${challengeId}&assessmentId=salut`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         };
       });
@@ -52,7 +52,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?challenge=${challengeId}&assessment=${assessment.id}`,
+          url: `/api/answers?challengeId=${challengeId}&assessmentId=${assessment.id}`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         };
       });
@@ -99,7 +99,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?challenge=${challengeId}&assessment=${assessment.id}`,
+          url: `/api/answers?challengeId=${challengeId}&assessmentId=${assessment.id}`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId + 3) },
         };
       });
@@ -130,7 +130,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?challenge=${challengeId}&assessment=${assessment.id}`,
+          url: `/api/answers?challengeId=${challengeId}&assessmentId=${assessment.id}`,
         };
       });
 
@@ -164,7 +164,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?assessment=${assessment.id}`,
+          url: `/api/answers?assessmentId=${assessment.id}`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         };
       });
@@ -210,7 +210,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?assessment=${assessment.id}`,
+          url: `/api/answers?assessmentId=${assessment.id}`,
           headers: { authorization: generateValidRequestAuthorizationHeader(userId + 3) },
         };
       });
@@ -241,7 +241,7 @@ describe('Acceptance | Controller | answer-controller-find', () => {
         await databaseBuilder.commit();
         options = {
           method: 'GET',
-          url: `/api/answers?&assessment=${assessment.id}`,
+          url: `/api/answers?&assessmentId=${assessment.id}`,
         };
       });
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -177,7 +177,7 @@ describe('Acceptance | API | assessment-controller-get', () => {
             'answers': {
               'data': [],
               links: {
-                related: `/api/answers?assessment=${assessmentId}`,
+                related: `/api/answers?assessmentId=${assessmentId}`,
               }
             },
           },

--- a/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get_test.js
@@ -174,7 +174,12 @@ describe('Acceptance | API | assessment-controller-get', () => {
                 type: 'courses'
               }
             },
-            'answers': { 'data': [] },
+            'answers': {
+              'data': [],
+              links: {
+                related: `/api/answers?assessment=${assessmentId}`,
+              }
+            },
           },
         };
         const assessment = response.result.data;

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -10,7 +10,7 @@ describe('Unit | Router | answer-router', function() {
 
     sinon.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
     sinon.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
-    sinon.stub(AnswerController, 'findByChallengeAndAssessment').callsFake((request, h) => h.response().code(200));
+    sinon.stub(AnswerController, 'find').callsFake((request, h) => h.response().code(200));
     sinon.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
 
     server = Hapi.server();

--- a/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
@@ -1,0 +1,68 @@
+const { expect, sinon } = require('../../../test-helper');
+const findAnswerByAssessment = require('../../../../lib/domain/usecases/find-answer-by-assessment');
+
+describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
+
+  const assessmentId = 123;
+  const userId = 'userId';
+  let answerRepository, assessmentRepository, answers;
+
+  beforeEach(() => {
+    answers =
+      [{
+        id: 1,
+        assessmentId,
+      },
+      {
+        id: 2,
+        assessmentId,
+      }];
+    const assessment = {
+      id: assessmentId,
+      userId: userId,
+    };
+
+    answerRepository = {
+      findByAssessment: sinon.stub(),
+    };
+
+    assessmentRepository = {
+      get: sinon.stub(),
+    };
+
+    answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
+    assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
+  });
+
+  context('when the assessmentid passed is not an integer', () => {
+    it('should return empty array', async () => {
+      // when
+      const result = await findAnswerByAssessment({ assessmentId: 'salut', userId, answerRepository, assessmentRepository });
+
+      // then
+      return expect(result).to.deep.equal([]);
+    });
+  });
+
+  context('when user asked for answer is the user of the assessment', () => {
+    it('should get the answer', async () => {
+
+      // when
+      const resultAnswers = await findAnswerByAssessment({ assessmentId, userId, answerRepository, assessmentRepository });
+
+      // then
+      expect(resultAnswers).to.deep.equal(answers);
+    });
+  });
+
+  context('when user asked for answer is not the user of the assessment', () => {
+    it('should return empty array', async () => {
+      // when
+      const result = await findAnswerByAssessment({ assessmentId, userId: userId + 1 , answerRepository, assessmentRepository });
+
+      // then
+      return expect(result).to.deep.equal([]);
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
@@ -1,5 +1,6 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const findAnswerByAssessment = require('../../../../lib/domain/usecases/find-answer-by-assessment');
+const { UserNotAuthorizedToAccessEntity, EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
 
@@ -37,10 +38,10 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
   context('when the assessmentid passed is not an integer', () => {
     it('should return empty array', async () => {
       // when
-      const result = await findAnswerByAssessment({ assessmentId: 'salut', userId, answerRepository, assessmentRepository });
+      const result = await catchErr(findAnswerByAssessment)({ assessmentId: 'salut', userId, answerRepository, assessmentRepository });
 
       // then
-      return expect(result).to.deep.equal([]);
+      expect(result).to.be.instanceOf(EntityValidationError);
     });
   });
 
@@ -58,10 +59,10 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
   context('when user asked for answer is not the user of the assessment', () => {
     it('should return empty array', async () => {
       // when
-      const result = await findAnswerByAssessment({ assessmentId, userId: userId + 1 , answerRepository, assessmentRepository });
+      const result = await catchErr(findAnswerByAssessment)({ assessmentId, userId: userId + 1 , answerRepository, assessmentRepository });
 
       // then
-      return expect(result).to.deep.equal([]);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -28,7 +28,10 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
                   id: assessment.answers[0].id.toString(),
                   type: 'answers',
                 }
-              ]
+              ],
+              links: {
+                related: '/api/answers?assessment=' + assessment.id.toString()
+              }
             },
             course: {
               data: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/assessment-serializer_test.js
@@ -30,7 +30,7 @@ describe('Unit | Serializer | JSONAPI | assessment-serializer', function() {
                 }
               ],
               links: {
-                related: '/api/answers?assessment=' + assessment.id.toString()
+                related: '/api/answers?assessmentId=' + assessment.id.toString()
               }
             },
             course: {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -12,7 +12,7 @@ export default Route.extend({
     return RSVP.hash({
       assessment,
       challenge: store.findRecord('challenge', challengeId),
-      answer: store.queryRecord('answer', { assessment: assessment.id, challenge: challengeId }),
+      answer: store.queryRecord('answer', { assessmentId: assessment.id, challengeId: challengeId }),
     }).catch((err) => {
       const meta = ('errors' in err) ? err.errors.get('firstObject').meta : null;
       if (meta.field === 'authorization') {

--- a/mon-pix/mirage/routes/answers/get-answer-by-challenge-and-assessment.js
+++ b/mon-pix/mirage/routes/answers/get-answer-by-challenge-and-assessment.js
@@ -1,6 +1,6 @@
 export default function(schema, request) {
-  const assessmentId = request.queryParams.assessment;
-  const challengeId = request.queryParams.challenge;
+  const assessmentId = request.queryParams.assessmentId;
+  const challengeId = request.queryParams.challengeId;
 
   const answers = schema.answers.where({ assessmentId, challengeId });
 

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -68,8 +68,8 @@ describe('Unit | Route | Assessments | Challenge', function() {
       return promise.then(() => {
         sinon.assert.calledOnce(queryRecordStub);
         sinon.assert.calledWith(queryRecordStub, 'answer', {
-          assessment: assessment.id,
-          challenge: params.challenge_id
+          assessmentId: assessment.id,
+          challengeId: params.challenge_id
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
- Lorsqu'on reprend un assessment, il y a X appels à `/api/answers/:id` pour les X answers déjà enregistrés pour l'assessment

## :robot: Solution
- Ajout d'une route pour récupérer toutes les answers d'un assessment
- Cette route est précisé dans ce que renvoie le back pour l'assessment

## :rainbow: Remarques
- On a voulu éviter ces appels en front
- Supprimer la barre de progression qui semblait chercher les answers n'a pas modifié le comportement
- Actuellement, nous ne voyons pas où sont demandés ces answers
- Lorsqu'on ajoute `{ async: false}` dans le model Assessment pour les Answers coté front, on a un message d'erreur nous indiquant qu'il a besoin des answers (même quand la barre de progression n'est plus présente).

## :100: Pour tester
- Commencer une compétence
- Répondre à 2/3 questions
- Quitter pix/ vider le cache
- Revenir et reprendre la compétence
- AVANT : on observait dans le Network plusieurs appels pour les answers
- APRES : on observe un appel unique pour les answers.