### PR TITLE
[TECH] Algorithme : changement du gain

### DIFF
--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -50,9 +50,9 @@ function findMaxRewardingSkills(...args) {
   )(...args);
 }
 
-function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements }) {
+function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements, numberOfRecentlyFailedAnswer }) {
   return _.reduce(availableSkills, (acc, skill) => {
-    const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements });
+    const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements, numberOfRecentlyFailedAnswer });
     if (skillReward > acc.maxReward) {
       acc.maxReward = skillReward;
       acc.maxRewardingSkills = [skill];
@@ -70,12 +70,12 @@ function _clearSkillsIfNotRewarding(skills) {
   return _.filter(skills, (skill) => skill.reward !== 0);
 }
 
-function _computeReward({ skill, predictedLevel, tubes, knowledgeElements }) {
+function _computeReward({ skill, predictedLevel, tubes, knowledgeElements, numberOfRecentlyFailedAnswer }) {
   const proba = _probaOfCorrectAnswer(predictedLevel, skill.difficulty);
   const extraSkillsIfSolvedCount = _getNewSkillsInfoIfSkillSolved(skill, tubes, knowledgeElements).length;
   const failedSkillsIfUnsolvedCount = _getNewSkillsInfoIfSkillUnsolved(skill, tubes, knowledgeElements).length;
 
-  return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount;
+  return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount + numberOfRecentlyFailedAnswer * proba;
 }
 
 // The probability P(gap) of giving the correct answer is given by the "logistic function"

--- a/api/lib/domain/services/smart-random/data-fetcher.js
+++ b/api/lib/domain/services/smart-random/data-fetcher.js
@@ -58,12 +58,14 @@ async function fetchForCompetenceEvaluations({
 
   const [
     lastAnswer,
+    allAnswers,
     targetSkills,
     challenges,
     knowledgeElements
 
   ] = await Promise.all([
     answerRepository.findLastByAssessment(assessment.id),
+    answerRepository.findByAssessment(assessment.id),
     skillRepository.findByCompetenceId(assessment.competenceId),
     challengeRepository.findByCompetenceId(assessment.competenceId),
     knowledgeElementRepository.findUniqByUserId({ userId: assessment.userId })]
@@ -71,6 +73,7 @@ async function fetchForCompetenceEvaluations({
 
   return {
     lastAnswer,
+    allAnswers,
     targetSkills,
     challenges,
     knowledgeElements,

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -736,5 +736,48 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       });
     });
 
+    context('when user has failed some answer before', () => {
+      it('should return a easier skill than a difficult', () => {
+        targetSkills = [url2, url3, url4, url5, url6, web1, web2, web3, web4, web5, info2];
+        challenges = [challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeWeb_1,
+          challengeWeb_2, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeInfo_2];
+        lastAnswer = [
+          domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.KO })
+        ];
+        const allAnswers =  [
+          domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeCnil_2.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeRechInfo_5.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeRechInfo_7.id, result: AnswerStatus.OK }),
+          domainBuilder.buildAnswer({ challengeId: challengeRechInfo_5.id, result: AnswerStatus.KO }),
+        ];
+        knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: web1.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'indirect'
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: info2.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'indirect'
+          })
+        ];
+
+        // when
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          lastAnswer,
+          allAnswers
+        });
+
+        // then
+        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[url3]);
+
+      });
+    });
+
   });
 });

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -77,6 +77,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
     beforeEach(() => {
       answerRepository = {
         findLastByAssessment: sinon.stub(),
+        findByAssessment: sinon.stub()
       };
       challengeRepository = {
         findByCompetenceId: sinon.stub(),
@@ -104,6 +105,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       const assessment = domainBuilder.buildAssessment.ofTypeSmartPlacement();
 
       answerRepository.findLastByAssessment.withArgs(assessment.id).resolves(answer);
+      answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
       challengeRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);


### PR DESCRIPTION
## :unicorn: Problème
Le gain de l’algorithme à proposer une épreuve est calculé pour maximiser les connaissances que l’algorithme pourra acquérir pour un utilisateur. Le gain calculé proposera donc des épreuves difficiles si cela lui permet d’invalider un grand nombre d’acquis pour un utilisateur.

Par conséquent, le gain ne cherche pas à être bienveillant envers l’utilisateur et à éviter de le mettre dans des situations trop difficile.

## :robot: Solution
Une première expérience pourrait être de modifier la fonction de gain pour prendre en compte un critère de bienveillance.

Pour plus de bienveillance, l’algorithme pourrait proposer plus facilement des épreuves que l’utilisateur a une forte probabilité de réussite lorsqu’il a enchaîné les défaites. Cet axe d’amélioration a été remonté lors de l’Open Lab de Janvier 2020.

Par conséquent, le gain passerait de : 
- Gain(épreuve E) = (NbrAcquisValidé(E) * ProbaRéussite(E)) + (NbrAcquisInvalidé(E) * (1 - ProbaRéussite(E))
à : 
- Gain(épreuve E) = (NbrAcquisValidé(E) * ProbaRéussite(E)) + (NbrAcquisInvalidé(E) * (1 - ProbaRéussite(E)) + NbrDeMauvaiseRéponseALaSuite * ProbaRéussite(E)

Nous ajoutons donc au gain la valeur NbrDeMauvaiseRéponseALaSuite * ProbaRéussite(E), qui augmentera fortement si l’utilisateur a une probabilité forte et un nombre de mauvaise réponses récente élevée.

## :rainbow: Remarques
- Ceci est un PoC, vous pouvez tester, commenter et proposer vos idées dans cette PR.
