### PR TITLE
[TECH] Algorithme : limiter le nombre de réponse utilisé pour le niveau dans l'algo

### DIFF
--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -26,7 +26,8 @@ function _enumerateCatLevels() {
 
 function _probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills) {
   const directKnowledgeElements = _.filter(knowledgeElements, (ke) => ke.source === 'direct');
-  const extraAnswers = directKnowledgeElements.map((ke) => {
+  const recentDirectKnowledgeElements = _.slice(directKnowledgeElements, 0, 5);
+  const extraAnswers = recentDirectKnowledgeElements.map((ke) => {
     const skill = skills.find((skill) => skill.id === ke.skillId);
     const maxDifficulty = skill.difficulty || 2;
     const binaryOutcome = (ke.status === KnowledgeElement.StatusType.VALIDATED) ? 1 : 0;

--- a/api/lib/domain/services/smart-random/smart-random.js
+++ b/api/lib/domain/services/smart-random/smart-random.js
@@ -13,6 +13,7 @@ function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targ
   const knowledgeElementsOfTargetSkills = knowledgeElements.filter((ke) => {
     return targetSkills.find((skill) => skill.id === ke.skillId);
   });
+
   const filteredChallenges = _removeUnpublishedChallenges(challenges);
   targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour calculer le niveau de l’utilisateur utilisé dans l’algorithme de choix d'épreuve, nous utilisons toutes les connaissances que nous avons de lui.Par conséquent, si cet utilisateur a eu des difficultés en début d'évaluation, et a appris durant celle-ci, via les tutoriels par ensemble, ces premières erreurs sont prises en compte pour le calcul de son niveau dans l’algorithme.

## :robot: Solution
- Lors du calcul du niveau de l'utilisateur, ne récupérer que les 5 dernières réponses pour effectuer ce calcul.

## :rainbow: Remarques
Ceci est un PoC, vous pouvez tester, commenter et proposer vos idées dans cette PR.
