### PR TITLE
[DOC] Ajouter des diagrammes de séquence sur la sécurité

### DIFF
--- a/docs/security/authenticate.puml
+++ b/docs/security/authenticate.puml
@@ -1,0 +1,22 @@
+@startuml
+actor User #blue
+participant MonPix
+participant API
+User -> MonPix : /connexion
+note left:  Connexion à app.pix.fr
+User -> MonPix : /connexion
+note left:  Saisie identifiant/email et mot de passe \net clic sur "Je me connecte"
+MonPix -> API : POST /api/token \ngrant_type=password\n&username=<USER_NAME>password=<PASSWORD>\n&scope=mon-pix
+API -> MonPix : 200 OK \n{ token_type: "bearer", \naccess_token: <JWT>\n user_id: <USER_ID> }
+MonPix -> MonPix: Stockage du token dans le LocalStorage \ndu navigateur
+MonPix -> API : GET /api/users/me\nHeaders: Authorization: Bearer <JWT>
+API -> MonPix : 200 OK \n{ data: \ntype: "users",\nid: <USER_ID>, \n attributes: { first-name: (…)} \n}
+User -> MonPix : /assesments
+note left: Clic sur "Commencer"
+MonPix -> API : GET /api/challenges\nHeaders: Authorization: Bearer <JWT>
+User -> MonPix : /deconnexion
+note left: Clic sur entrée de menu \n "Se déconnecter"
+MonPix -> API : POST /api/revoke \ntoken_type_hint:"access_token"\n&token=<JWT>
+API -> MonPix : 204 No content \n Note: La révocation n'est pas implémentée côté API
+MonPix -> MonPix: Suppression du token dans le LocalStorage \ndu navigateur
+@enduml

--- a/docs/security/reset_with_email.puml
+++ b/docs/security/reset_with_email.puml
@@ -1,0 +1,26 @@
+@startuml
+actor User #blue
+participant MonPix
+participant API
+participant ServiceMail
+User -> MonPix : /connexion
+note left: Connexion à app.pix.fr
+User -> MonPix : /mot-de-passe-oublie
+note left: Clic sur "Mot de passe oublié ?"
+User -> MonPix : /mot-de-passe-oublie ?
+MonPix -> API : POST /api/password-reset-demands
+API -> ServiceMail : <TOKEN>
+ServiceMail -> User: envoi mail
+API -> MonPix : 201 Created
+MonPix -> User : "Un e-mail contenant la démarche  \n à suivre (..) vous a été envoyé"
+User -> MonPix : /changer-mot-de-passe/<TOKEN>
+note left: Ouverture de l'email, clic sur \n "Définir un nouveau mot de passe"
+MonPix -> API : POST /api/password-reset-demands \n{ data: { \ntype: "password-reset-demands" \nattributes: { email: <EMAIL> }\n}}
+API -> MonPix : 201 Created \n { data: {\ntype: "password-reset-demands", \nid: <ID>, \nattributes: { email:<EMAIL>}\n}}
+User -> MonPix : /changer-mot-de-passe/<TOKEN>
+note left: Saisie nouveau mot de passe \nclic sur Envoyer
+MonPix -> API : PATCH /api/users/{id}/password-update\n&temporaryKey=<TOKEN>\n\n { data: { \ntype: "users", \nattributes: {  \nid: <ID>,  \nemail: <EMAIL>, \npassword:<PASSWORD>}\n}}
+API -> MonPix : 200 OK Created \n{ data: { \ntype: "users", \nattributes: (..)} \n}
+MonPix -> User : "Votre mot de passe a été modifié avec succès."
+note left: Clic sur connectez-vous
+@enduml


### PR DESCRIPTION
## :unicorn: Problème
Il y plusieurs ressources liées à l'authentification/autorisation, des scénarios métiers complexes (avec ou sans email, via le GAR), et il n'existe aucune vue d'ensemble.

## :robot: Solution
Fournir des diagrammes de séquence avec les utilisateurs, le front et l'API.

## :rainbow: Remarques
Le format PlantUML est du markdown qui peut être rendu par les IDE (eg. Intellij) et les gestionnaires de sources (eg. GitHub).