### PR TITLE
[TECH] Catégoriser les envois d'e-mail en alimentant la propriété TAGS (PF-1213).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,12 +1,16 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 
+const EMAIL_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
+const PIX_NAME = 'PIX - Ne pas répondre';
+const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
+
 function sendAccountCreationEmail(email) {
   return mailer.sendEmail({
     template: mailer.accountCreationTemplateId,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'PIX - Ne pas répondre',
+    from: EMAIL_NO_RESPONSE,
+    fromName: PIX_NAME,
     subject: 'Création de votre compte PIX'
   });
 }
@@ -15,8 +19,8 @@ function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
   return mailer.sendEmail({
     template: mailer.passwordResetTemplateId,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'PIX - Ne pas répondre',
+    from: EMAIL_NO_RESPONSE,
+    fromName: PIX_NAME,
     subject: 'Demande de réinitialisation de mot de passe PIX',
     variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }
   });
@@ -26,19 +30,21 @@ function sendOrganizationInvitationEmail({
   email,
   organizationName,
   organizationInvitationId,
-  code
+  code,
+  tags
 }) {
   const pixOrgaBaseUrl = settings.pixOrgaUrl;
   return mailer.sendEmail({
     template: mailer.organizationInvitationTemplateId,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'Pix Orga - Ne pas répondre',
+    from: EMAIL_NO_RESPONSE,
+    fromName: PIX_ORGA_NAME,
     subject: 'Invitation à rejoindre Pix Orga',
     variables: {
       organizationName,
       responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-    }
+    },
+    tags: tags || null
   });
 }
 

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -8,7 +8,7 @@ const _generateCode = () => {
 };
 
 const createOrganizationInvitation = async ({
-  organizationRepository, organizationInvitationRepository, organizationId, email
+  organizationRepository, organizationInvitationRepository, organizationId, email, tags
 }) => {
   let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
 
@@ -23,7 +23,8 @@ const createOrganizationInvitation = async ({
     email,
     organizationName,
     organizationInvitationId: organizationInvitation.id,
-    code: organizationInvitation.code
+    code: organizationInvitation.code,
+    tags
   });
 
   return organizationInvitation;

--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -17,6 +17,7 @@ function _formatPayload(options) {
       'content-type': 'application/json',
       'accept': 'application/json',
     },
+    tags: options.tags
   };
   if (options.variables) {
     payload.params = options.variables;

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -12,6 +12,8 @@ const organizationInvitationService = require('../lib/domain/services/organizati
 const organizationRepository = require('../lib/infrastructure/repositories/organization-repository');
 const organizationInvitationRepository = require('../lib/infrastructure/repositories/organization-invitation-repository');
 
+const TAGS = ['JOIN_ORGA'];
+
 async function getOrganizationByExternalId(externalId) {
   return BookshelfOrganization
     .where({ externalId })
@@ -36,14 +38,14 @@ async function prepareDataForSending(objectsFromFile) {
   });
 }
 
-async function sendJoinOrganizationInvitations(invitations) {
+async function sendJoinOrganizationInvitations(invitations, tags) {
   return bluebird.mapSeries(invitations, ({ organizationId, email }, index) => {
     if (require.main === module) {
       process.stdout.write(`${index}/${invitations.length}\r`);
     }
 
     return organizationInvitationService.createOrganizationInvitation({
-      organizationRepository, organizationInvitationRepository, organizationId, email
+      organizationRepository, organizationInvitationRepository, organizationId, email, tags
     });
   });
 }
@@ -53,6 +55,9 @@ async function main() {
 
   try {
     const filePath = process.argv[2];
+    const argTags = process.argv[3];
+
+    const tags = argTags ? [argTags] : TAGS;
 
     console.log('Reading and parsing csv file... ');
     const csvData = parseCsvWithHeader(filePath);
@@ -63,7 +68,7 @@ async function main() {
     console.log('ok');
 
     console.log('Sending invitations...');
-    await sendJoinOrganizationInvitations(invitations);
+    await sendJoinOrganizationInvitations(invitations, tags);
     console.log('\nDone.');
 
   } catch (error) {

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 const { expect, databaseBuilder, knex } = require('../../test-helper');
 
 const BookshelfOrganizationInvitation = require('../../../lib/infrastructure/data/organization-invitation');
-
 const {
   getOrganizationByExternalId, buildInvitation, prepareDataForSending, sendJoinOrganizationInvitations
 } = require('../../../scripts/send-invitations-to-sco-organizations');
@@ -99,11 +98,12 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
         });
 
       const numberBefore = await getNumberOfOrganizationInvitations();
+      const tags = ['test'];
 
       await databaseBuilder.commit();
 
       // when
-      await sendJoinOrganizationInvitations(objectsForInvitations);
+      await sendJoinOrganizationInvitations(objectsForInvitations, tags);
       const numberAfter = await getNumberOfOrganizationInvitations();
       const invitationsCreatedInDatabase = numberAfter - numberBefore;
 

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -5,75 +5,89 @@ const { createOrganizationInvitation } = require('../../../../lib/domain/service
 
 describe('Unit | Service | Organization-Invitation Service', () => {
 
+  const organizationId = 1;
+  const organizationName = 'Organization Name';
+
+  const organizationInvitationId = 10;
+  const email = 'member@organization.org';
+  const code = 'ABCDEFGH01';
+
   let organizationInvitationRepository;
   let organizationRepository;
 
   beforeEach(() => {
     organizationInvitationRepository = {
       create: sinon.stub(),
-      findOnePendingByOrganizationIdAndEmail: sinon.stub(),
+      findOnePendingByOrganizationIdAndEmail: sinon.stub().resolves(null),
     };
     organizationRepository = {
-      get: sinon.stub()
+      get: sinon.stub().resolves({ name: organizationName })
     };
-    sinon.stub(mailService, 'sendOrganizationInvitationEmail');
+    sinon.stub(mailService, 'sendOrganizationInvitationEmail').resolves();
   });
 
   describe('#createOrganizationInvitation', () => {
 
-    it('should create a new organization-invitation and send an email with organizationId, email and code', async () => {
-      // given
-      organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves(null);
+    context('when organization-invitation does not exist', () => {
 
-      const organizationInvitationId = 10;
-      const code = 'ABCDEFGH01';
-
-      const organizationName = 'Organization Name';
-      organizationRepository.get.resolves({ name: organizationName });
-
-      mailService.sendOrganizationInvitationEmail.resolves();
-
-      const organizationId = 1;
-      const email = 'member@organization.org';
-      organizationInvitationRepository.create.withArgs({
-        organizationId, email, code: sinon.match.string
-      }).resolves({ id: organizationInvitationId, code });
-
-      // when
-      await createOrganizationInvitation({
-        organizationRepository, organizationInvitationRepository, organizationId, email
+      beforeEach(() => {
+        organizationInvitationRepository.create.withArgs({
+          organizationId, email, code: sinon.match.string
+        }).resolves({ id: organizationInvitationId, code });
       });
 
-      // then
-      expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith({
-        email, organizationName, organizationInvitationId, code
+      it('should create a new organization-invitation and send an email with organizationId, email and code', async () => {
+        // given
+        const expectedParameters = {
+          email, organizationName, organizationInvitationId, code, tags: undefined
+        };
+
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email
+        });
+
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+      });
+
+      it('should send an email with organizationId, email, code and tags', async () => {
+        // given
+        const tags = ['JOIN_ORGA'];
+        const expectedParameters = {
+          email, organizationName, organizationInvitationId, code, tags
+        };
+
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email, tags
+        });
+
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
       });
     });
 
-    it('should re-send an email with same code when organization-invitation already exist with status pending', async () => {
-      // given
-      const organizationId = 1;
-      const organizationName = 'Organization Name';
-      const organizationInvitationId = 100;
-      const email = 'member@organization.org';
-      const code = 'ABCDEFGH01';
-      const isPending = true;
+    context('when an organization-invitation with pending status already exists', () => {
 
-      organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves({
-        id: organizationInvitationId, isPending, code
-      });
-      organizationRepository.get.resolves({ name: organizationName });
+      it('should re-send an email with same code', async () => {
+        // given
+        const isPending = true;
+        const expectedParameters = {
+          email, organizationName, organizationInvitationId, code, tags: undefined
+        };
 
-      mailService.sendOrganizationInvitationEmail.resolves();
+        organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves({
+          id: organizationInvitationId, isPending, code
+        });
 
-      // when
-      await createOrganizationInvitation({
-        organizationRepository, organizationInvitationRepository, organizationId, email
-      });
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email
+        });
 
-      // then
-      expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith({
-        email, organizationName, organizationInvitationId, code
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
       });
     });
   });

--- a/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
@@ -37,6 +37,8 @@ describe('Unit | Class | SendinblueProvider', () => {
 
           const from = 'no-reply@example.net';
           const email = recipient;
+          const tags = ['TEST'];
+
           const expectedPayload = {
             to: [{
               email,
@@ -50,7 +52,8 @@ describe('Unit | Class | SendinblueProvider', () => {
             headers: {
               'content-type': 'application/json',
               'accept': 'application/json',
-            }
+            },
+            tags
           };
 
           // when
@@ -59,7 +62,8 @@ describe('Unit | Class | SendinblueProvider', () => {
             to: email,
             fromName: 'Ne pas repondre',
             subject: 'Creation de compte',
-            template: '129291'
+            template: '129291',
+            tags
           });
 
           // then


### PR DESCRIPTION
## :unicorn: Problème
Dans Sendinblue, après l'envoie d'e-mails (générés par un script ad hoc cf. `api/scripts/send-invitations-to-sco-organizations.js`), on veut faciliter le suivi de ces e-mails envoyés en masse.

Le dashbord Sendinblue propose une propriété "tags".
Actuellement les services e-mail de l'API ne l'utilisent pas.

## :rainbow: Remarques
On va exploiter cette propriété dans le mailService de l'API, et l'utiliser dans `api/scripts/send-invitations-to-sco-organizations.js`. 
