### PR TITLE
[DESIGN SYSTEM] Ajout d'une tooltip custom

### DIFF
--- a/pix-ui/addon/components/pix-tooltip.js
+++ b/pix-ui/addon/components/pix-tooltip.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+import layout from '../templates/components/pix-tooltip';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  layout,
+  getPosition: computed('position', function() {
+    const correctsPosition = ['top', 'right', 'bottom', 'left'];
+    return correctsPosition.includes(this.position) ? this.position : 'top';
+  })
+});

--- a/pix-ui/addon/styles/_pix-tooltip.scss
+++ b/pix-ui/addon/styles/_pix-tooltip.scss
@@ -1,0 +1,80 @@
+.pix-tooltip {
+  position: relative;
+  display: inline-block;
+
+  & > *:nth-child(2):hover {
+    cursor: help;
+  }
+  &:hover .pix-tooltip__content {
+    opacity: 1;
+  }
+}
+
+.pix-tooltip__content {
+  opacity: 0;
+  background-color: $black;
+  position: absolute;
+  z-index: 100;
+  margin: 0; padding: 0 1rem;
+  left: auto;
+  height: 2rem;
+  line-height: 2rem;
+  color: $white;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  border-radius: 4px;
+  transition: opacity 0.3s;
+
+  &::before {
+    content: "";
+    position: absolute;
+    border-width: 5px;
+    border-style: solid;
+  }
+}
+
+.pix-tooltip__content--right {
+  top: calc(50% - 1rem); // -1rem is half of the height of tooltip
+  left: calc(100% + 10px);
+
+  &::before {
+    top: calc(50% - 5px); // -5px is half of the height of ::before elmt
+    left: -10px; // 10px is width of the ::before elmt
+    border-color: transparent $black transparent transparent;
+  }
+}
+
+.pix-tooltip__content--top {
+  bottom: calc(100% + 10px);
+  left: 50%; // 50% here is the parent width
+  transform: translate(-50%); // 50% here is the width of this current element
+
+  &::before {
+    top: 100%;
+    left: calc(50% - 5px);
+    border-color: $black transparent transparent transparent;
+  }
+}
+
+.pix-tooltip__content--bottom {
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translate(-50%);
+
+  &::before {
+    top: -10px;
+    left: calc(50% - 5px);
+    border-color: transparent transparent $black transparent;
+  }
+}
+
+.pix-tooltip__content--left {
+  top: calc(50% - 1rem);
+  right: calc(100% + 10px);
+
+  &::before {
+    top: calc(50% - 5px);
+    right: -10px;
+    border-color: transparent transparent transparent $black;
+  }
+}

--- a/pix-ui/addon/styles/addon.scss
+++ b/pix-ui/addon/styles/addon.scss
@@ -3,6 +3,7 @@
 
 @import 'pix-h1';
 @import 'pix-buttons';
+@import 'pix-tooltip';
 
 html {
   font-size: 16px;

--- a/pix-ui/addon/templates/components/pix-tooltip.hbs
+++ b/pix-ui/addon/templates/components/pix-tooltip.hbs
@@ -1,0 +1,9 @@
+<div class='pix-tooltip'>
+
+  <span class='pix-tooltip__content pix-tooltip__content--{{this.getPosition}}'>
+    {{@text}}
+  </span>
+
+  {{yield}}
+
+</div>

--- a/pix-ui/app/components/pix-tooltip.js
+++ b/pix-ui/app/components/pix-tooltip.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-tooltip';

--- a/pix-ui/stories/tooltip.stories.js
+++ b/pix-ui/stories/tooltip.stories.js
@@ -1,0 +1,16 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default { title: 'Tooltip' };
+
+export const pixTooltip = () => {
+  return {
+    template: hbs`
+      <br><br>
+      <PixTooltip
+        @text='In accumsan scelerisque sapien, et lacinia nisi efficitur a.'
+        @position='right'>
+        <button>Hover me!</button>
+      </PixTooltip>
+    `,
+  }
+};

--- a/pix-ui/tests/integration/components/pix-tooltip-test.js
+++ b/pix-ui/tests/integration/components/pix-tooltip-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | pix-tooltip', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders default tooltip', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+    this.set('text', 'Une explication toolpixdienne');
+
+    await render(hbs`
+      <PixTooltip>
+        <p>I can be anything, go hover me to see the tooltip</p>
+      </PixTooltip>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'I can be anything, go hover me to see the tooltip');
+    assert.dom('pix-tooltip__content').hasText('Une explication toolpixdienne')
+  });
+
+  test('it renders tooltip at the right', async function(assert) {
+    await render(hbs`
+      <PixTooltip
+        @text='Jaime les mangues'
+        @position='right'>
+        <button>Hover me!</button>
+      </PixTooltip>
+    `);
+
+    assert.dom('pix-tooltip__content--right').exists();
+  });
+});


### PR DESCRIPTION
Cette PR est bloquée tant qu'on a pas décidé où et comment, serait mis en place le dossier de design system.

## :unicorn: Problème
Les tooltips ne sont pas les mêmes entre toutes les app. Certaines utilisent encore du ember-bootstrap que l'on souhaite enlever. 

## :robot: Solution
Créer notre propre pix-tooltip. 
Pour le moment la tooltip prend 2 paramètres (le second facultatif) : 
- un contenu (du texte)
- une position (top, right, bottom, left)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
TODO

TODO : 
- [ ] : finirs correctement les tests
- [ ] : voir le rendu intégré dans une app (avec un autre contexte que les stories)
- [ ] : améliorer le composant aux besoins (à voir)
