### PR TITLE
[FEATURE] Rendre une épreuve multilangue (PF-1196)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -39,7 +39,7 @@ class Challenge {
    * @param validator
    * @param competenceId
    * @param format
-   * @param locale
+   * @param locales
    */
   constructor(
     {
@@ -57,7 +57,7 @@ class Challenge {
       status,
       timer,
       type,
-      locale,
+      locales,
       // includes
       answer,
       skills = [],
@@ -80,7 +80,7 @@ class Challenge {
     this.timer = timer;
     this.status = status;
     this.type = type;
-    this.locale = locale;
+    this.locales = locales;
     // includes
     this.skills = skills;
     this.validator = validator;

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -9,7 +9,7 @@ module.exports = {
     }
     const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
-    const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => challenge.locale === locale));
+    const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => _.includes(challenge.locales, locale)));
     if (_.isEmpty(localeChallenges)) {
       return _pickChallengeAtIndex(chosenSkill.challenges, key);
     }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -79,7 +79,7 @@ module.exports = datasource.extend({
       competenceId,
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
-      locales: _convertLanguesToLocales(airtableRecord.get('Langues') || [])
+      locales: _convertLanguagesToLocales(airtableRecord.get('Langues') || [])
     };
   },
 
@@ -102,12 +102,12 @@ module.exports = datasource.extend({
   },
 });
 
-function _convertLanguesToLocales(langues) {
-  return langues.map((langue) => _convertLangueToLocale(langue));
+function _convertLanguagesToLocales(languages) {
+  return languages.map((language) => _convertLanguageToLocale(language));
 }
 
-function _convertLangueToLocale(langue) {
-  switch (langue) {
+function _convertLanguageToLocale(language) {
+  switch (language) {
     case 'Francophone':
       return FRENCH_SPOKEN;
     case 'Franco Français':

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -79,7 +79,7 @@ module.exports = datasource.extend({
       competenceId,
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
-      locale: _convertLanguesToLocales(airtableRecord.get('Langues') || [])
+      locales: _convertLanguesToLocales(airtableRecord.get('Langues') || [])
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -32,7 +32,7 @@ module.exports = datasource.extend({
     'Embed height',
     'Texte alternatif illustration',
     'Format',
-    'Langue',
+    'Langues',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -79,7 +79,7 @@ module.exports = datasource.extend({
       competenceId,
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
-      locale: _convertLangueToLocale(airtableRecord.get('Langue'))
+      locale: _convertLanguesToLocales(airtableRecord.get('Langues') || [])
     };
   },
 
@@ -102,8 +102,12 @@ module.exports = datasource.extend({
   },
 });
 
-function _convertLangueToLocale(Langue) {
-  switch (Langue) {
+function _convertLanguesToLocales(langues) {
+  return langues.map((langue) => _convertLangueToLocale(langue));
+}
+
+function _convertLangueToLocale(langue) {
+  switch (langue) {
     case 'Francophone':
       return FRENCH_SPOKEN;
     case 'Franco Français':

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -92,6 +92,6 @@ function _adaptChallengeFromDataObjects({ challengeDataObject, skillDataObjects 
     competenceId: challengeDataObject.competenceId,
     illustrationAlt: challengeDataObject.illustrationAlt,
     format: challengeDataObject.format,
-    locale: challengeDataObject.locale,
+    locales: challengeDataObject.locales,
   });
 }

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -33,7 +33,7 @@ const frenchChallenge = airtableBuilder.factory.buildChallenge.untimed({
   statut: 'validé',
   acquix: [skillWeb2.id],
   acquis: [skillWeb2.name],
-  langue: 'Franco Français',
+  langues: ['Franco Français'],
 });
 
 const frenchSpokenChallengeId = 'recFrenchSpokenChallengeId';
@@ -44,7 +44,7 @@ const frenchSpokenChallenge = airtableBuilder.factory.buildChallenge.untimed({
   statut: 'validé',
   acquix: [skillWeb2.id],
   acquis: [skillWeb2.name],
-  langue: 'Francophone',
+  langues: ['Francophone'],
 });
 
 describe('Acceptance | API | assessment-controller-get-next-challenge-locale-management', () => {

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -103,7 +103,9 @@ const buildChallenge = function buildChallenge({
   createdTime = '2016-08-24T11:59:02.000Z',
   format = 'mots',
   illustrationAlt = 'texte alternatif à l\'image',
-  langue = 'Francophone',
+  langues = [
+    'Francophone'
+  ],
 } = {}) {
 
   return rawBuildChallenge({
@@ -139,7 +141,7 @@ const buildChallenge = function buildChallenge({
     createdTime,
     illustrationAlt,
     format,
-    langue,
+    langues,
   });
 };
 
@@ -319,7 +321,7 @@ function rawBuildChallenge({
   createdTime,
   illustrationAlt,
   format,
-  langue,
+  langues,
 }) {
 
   return {
@@ -356,7 +358,7 @@ function rawBuildChallenge({
       'domaines': domaines,
       'Texte alternatif illustration': illustrationAlt,
       'format': format,
-      'Langue': langue,
+      'Langue': langues,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -23,7 +23,7 @@ module.exports = function buildChallengeAirtableDataObject({
   embedHeight = 500,
   format = 'petit',
   illustrationAlt = 'texte alternatif à l\'image',
-  locale = 'fr',
+  locales = ['fr'],
 } = {}) {
 
   return {
@@ -48,6 +48,6 @@ module.exports = function buildChallengeAirtableDataObject({
     embedHeight,
     illustrationAlt,
     format,
-    locale,
+    locales,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -18,7 +18,7 @@ module.exports = function buildChallenge(
     status = 'validé',
     timer,
     type = Challenge.Type.QCM,
-    locale = ['fr'],
+    locales = ['fr'],
     // includes
     answer,
     validator = new Validator(),
@@ -41,7 +41,7 @@ module.exports = function buildChallenge(
     status,
     timer,
     type,
-    locale,
+    locales,
     // includes
     answer,
     validator,

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -18,7 +18,7 @@ module.exports = function buildChallenge(
     status = 'validé',
     timer,
     type = Challenge.Type.QCM,
-    locale = 'fr',
+    locale = ['fr'],
     // includes
     answer,
     validator = new Validator(),

--- a/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
@@ -23,7 +23,7 @@ module.exports = function ChallengeAirtableDataObjectFixture({
   embedTitle = 'Epreuve de selection de dossier',
   embedHeight = 500,
   format = 'petit',
-  locale = 'fr',
+  locales = ['fr'],
 } = {}) {
   return {
     id,
@@ -47,6 +47,6 @@ module.exports = function ChallengeAirtableDataObjectFixture({
     embedTitle,
     embedHeight,
     format,
-    locale,
+    locales,
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
@@ -124,7 +124,9 @@ module.exports = function challengeRawAirTableFixture({ id, fields } = { id: 're
         'recsvLz0W2ShyfD63',
       ],
       'Format': 'petit',
-      'Langue': 'Francophone'
+      'Langues': [
+        'Francophone'
+      ]
     }, fields),
     'createdTime': '2016-08-24T11:59:02.000Z',
   });

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -29,7 +29,7 @@ describe('Unit | Domain | Models | Challenge', () => {
         competenceId: 'recsvLz0W2ShyfD63',
         illustrationAlt: 'Texte alternatif à l\'image',
         format: 'phrase',
-        locale: 'fr',
+        locales: ['fr'],
       };
 
       // when

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -6,9 +6,9 @@ const _ = require('lodash');
 describe('Unit | Service | PickChallengeService', () => {
 
   describe('#pickChallenge', () => {
-    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locale: FRENCH_SPOKEN });
-    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locale: FRENCH_SPOKEN });
-    const frenchChallenge = domainBuilder.buildChallenge({ locale: FRENCH_FRANCE });
+    const frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
+    const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
+    const frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
     const randomSeed = 'some-random-seed';
 
     context('when challenge in selected locale exists', () => {

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -116,9 +116,9 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
   describe('#fromAirTableObject', () => {
 
     describe('when Languages is only Francophone', () => {
-      it('should create a Challenge from the AirtableRecord with locale set to [\'fr\']', () => {
+      it('should create a Challenge from the AirtableRecord with locales set to [\'fr\']', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_SPOKEN] });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locales: [FRENCH_SPOKEN] });
         const frenchSpokenChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Francophone'] } });
 
         // when
@@ -130,9 +130,9 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     });
 
     describe('when Languages is only Franco Français', () => {
-      it('should create a Challenge from the AirtableRecord with locale set to [\'fr-fr\']', () => {
+      it('should create a Challenge from the AirtableRecord with locales set to [\'fr-fr\']', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_FRANCE] });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locales: [FRENCH_FRANCE] });
         const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Franco Français'] } });
 
         // when
@@ -144,9 +144,9 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     });
 
     describe('when Languages is both Franco Français and Francophone', () => {
-      it('should create a Challenge from the AirtableRecord with locale set to [\'fr-fr\', \'fr\']', () => {
+      it('should create a Challenge from the AirtableRecord with locales set to [\'fr-fr\', \'fr\']', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_FRANCE, FRENCH_SPOKEN] });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locales: [FRENCH_FRANCE, FRENCH_SPOKEN] });
         const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Franco Français', 'Francophone'] } });
 
         // when

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -115,11 +115,11 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
   describe('#fromAirTableObject', () => {
 
-    describe('when Language is Francophone', () => {
-      it('should create a Challenge from the AirtableRecord with locale set to \'fr\'', () => {
+    describe('when Languages is only Francophone', () => {
+      it('should create a Challenge from the AirtableRecord with locale set to [\'fr\']', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: FRENCH_SPOKEN });
-        const frenchSpokenChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Francophone' } });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_SPOKEN] });
+        const frenchSpokenChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Francophone'] } });
 
         // when
         const challenge = challengeDatasource.fromAirTableObject(frenchSpokenChallenge);
@@ -129,11 +129,25 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       });
     });
 
-    describe('when Language is Franco Français', () => {
-      it('should create a Challenge from the AirtableRecord with locale set to \'fr-fr\'', () => {
+    describe('when Languages is only Franco Français', () => {
+      it('should create a Challenge from the AirtableRecord with locale set to [\'fr-fr\']', () => {
         // given
-        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: FRENCH_FRANCE });
-        const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langue: 'Franco Français' } });
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_FRANCE] });
+        const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Franco Français'] } });
+
+        // when
+        const challenge = challengeDatasource.fromAirTableObject(frenchChallenge);
+
+        // then
+        expect(challenge).to.deep.equal(expectedChallenge);
+      });
+    });
+
+    describe('when Languages is both Franco Français and Francophone', () => {
+      it('should create a Challenge from the AirtableRecord with locale set to [\'fr-fr\', \'fr\']', () => {
+        // given
+        const expectedChallenge = challengeAirtableDataObjectFixture({ locale: [FRENCH_FRANCE, FRENCH_SPOKEN] });
+        const frenchChallenge = challengeRawAirTableFixture({ id: 'recwWzTquPlvIl4So', fields: { Langues: ['Franco Français', 'Francophone'] } });
 
         // when
         const challenge = challengeDatasource.fromAirTableObject(frenchChallenge);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement un épreuve ne peut avoir qu'une seule langue (représentée colonne "Langue" dans Airtable). Or, on voudrait qu'une épreuve puisse en avoir plusieurs.
Par exemple, si une épreuve est ['Franco Français', 'Francophone'], on voudrait pourvoir y accéder à la fois depuis app.pix.fr et app.pix.digital.

## :robot: Solution
1. Dans un premier temps, renommer la colonne de Airtable 'Langue' => 'Langue**s**' et changer son type pour avoir une liste
2. Il faut aussi adapter le choix de la question pour choisir une épreuve par rapport à ses langues et son point d'entrée (.fr ou .digital)

## :100: Pour tester

Sur la review app:

* En passant par https://app-pr1252.review.pix.fr on ne doit voir que des épreuves Franco Françaises dont les id (visibles dans l'URL) sont :
```
recq9fXA6JylP1FaI
recRuRbNVtaFGJ5fn
rec27USdd7UOQ1CTL //présente aussi sur les épreuves francophones
```

* En passant par https://app-pr1252.review.pix.digital on ne doit voir que des épreuves Francophones dont les id (visibles dans l'URL) sont :

```
recluyogInt8pIHmf
recW9ntswD6AUsIoL
rec27USdd7UOQ1CTL //présente aussi sur les épreuves franco-françaises
```

## :100: Pour tester en développement

Si vous souhaiter tester sur votre machine en local:

Ajouter ces 2 lignes dans le fichier `/etc/hosts`
```
127.0.0.1 localhost.fr
127.0.0.1 localhost.digital 
```

1. Aller sur `localhost.fr:4200`, se connecter et vérifier dans les outils d'inspection, onglet `Network`, que le header `Accept-Language` vaut `fr-fr` dans les requêtes vers l'API.

1. Aller sur `localhost.digital:4200`, se connecter et vérifier dans les outils d'inspection, onglet `Network`, que le header `Accept-Language` vaut `fr` dans les requêtes vers l'API.

# 🌈 Remarques

La review app est pluggée sur une copy du Airtable de prod: PIX - Prod for i18n, où:
- la colonne `Langue` a été remplacée par `Langues`
- j'ai attribué des langues aléatoirement à certaines épreuves

Sur le Airtable de Prod, deux colonnes `Langue` et `Langues` existent actuellement. Une fois cette PR + celles de Pix Editor mergées, la colonne `Langue` sera supprimée. Seule `Langues` existera.