### PR TITLE
[FEATURE] Créer des campagnes de type collecte de profils (PO-392).

### DIFF
--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -54,6 +54,14 @@ class Campaign {
     this.targetProfileId = targetProfileId;
     this.creatorId = creatorId;
   }
+
+  isAssessment() {
+    return this.type === types.ASSESSMENT;
+  }
+
+  isProfilesCollection() {
+    return this.type === types.PROFILES_COLLECTION;
+  }
 }
 
 Campaign.types = types;

--- a/api/lib/domain/usecases/create-campaign.js
+++ b/api/lib/domain/usecases/create-campaign.js
@@ -7,46 +7,38 @@ const { UserNotAuthorizedToCreateCampaignError } = require('../errors');
 module.exports = async function createCampaign({ campaign, campaignRepository, userRepository, organizationRepository, organizationService }) {
   campaignValidator.validate(campaign);
 
-  await _checkCreatorHasAccessToCampaignOrganization(campaign.creatorId, campaign.organizationId, userRepository);
+  await _checkIfUserCanCreateCampaign(campaign, userRepository, organizationRepository, organizationService);
 
-  if (campaign.isProfilesCollection()) {
-    await _checkOrganizationCanCollectProfiles(campaign.organizationId, organizationRepository);
-  }
-  if (campaign.isAssessment()) {
-    await _checkOrganizationHasAccessToTargetProfile(campaign.targetProfileId, campaign.organizationId, organizationService);
-  }
   const generatedCampaignCode = await campaignCodeGenerator.generate(campaignRepository);
   const campaignWithCode = new Campaign(campaign);
   campaignWithCode.code = generatedCampaignCode;
   return campaignRepository.save(campaignWithCode);
 };
 
-function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
-  return userRepository.getWithMemberships(userId)
-    .then((user) => {
-      if (user.hasAccessToOrganization(organizationId)) {
-        return Promise.resolve();
-      }
-      return Promise.reject(new UserNotAuthorizedToCreateCampaignError(`User does not have an access to the organization ${organizationId}`));
-    });
+async function _checkIfUserCanCreateCampaign(campaign, userRepository, organizationRepository, organizationService) {
+  if (!await _hasCreatorAccessToCampaignOrganization(campaign.creatorId, campaign.organizationId, userRepository)) {
+    throw new UserNotAuthorizedToCreateCampaignError(`User does not have an access to the organization ${campaign.organizationId}`);
+  }
+
+  if (campaign.isProfilesCollection() && !await _canOrganizationCollectProfiles(campaign.organizationId, organizationRepository)) {
+    throw new UserNotAuthorizedToCreateCampaignError('Organization can not create campaign with type PROFILES_COLLECTION');
+  }
+  if (campaign.isAssessment() && !await _hasOrganizationAccessToTargetProfile(campaign.targetProfileId, campaign.organizationId, organizationService)) {
+    throw new UserNotAuthorizedToCreateCampaignError(`Organization does not have an access to the profile ${campaign.targetProfileId}`);
+  }
 }
 
-function _checkOrganizationHasAccessToTargetProfile(targetProfileId, organizationId, organizationService) {
-  return organizationService.findAllTargetProfilesAvailableForOrganization(organizationId)
-    .then((targetProfiles) => {
-      if (_.find(targetProfiles, (targetProfile) => targetProfile.id === targetProfileId)) {
-        return Promise.resolve();
-      }
-      throw new UserNotAuthorizedToCreateCampaignError(`Organization does not have an access to the profile ${targetProfileId}`);
-    });
+async function _hasCreatorAccessToCampaignOrganization(userId, organizationId, userRepository) {
+  const user = await userRepository.getWithMemberships(userId);
+  return user.hasAccessToOrganization(organizationId);
 }
 
-function _checkOrganizationCanCollectProfiles(organizationId, organizationRepository) {
-  return organizationRepository.get(organizationId)
-    .then((organization) => {
-      if (organization.canCollectProfiles) {
-        return Promise.resolve();
-      }
-      throw new UserNotAuthorizedToCreateCampaignError('Organization can not create campaign with type PROFILES_COLLECTION');
-    });
+async function _hasOrganizationAccessToTargetProfile(targetProfileId, organizationId, organizationService) {
+  const targetProfiles = await organizationService.findAllTargetProfilesAvailableForOrganization(organizationId);
+  return _.find(targetProfiles, (targetProfile) => targetProfile.id === targetProfileId);
+}
+
+async function _canOrganizationCollectProfiles(organizationId, organizationRepository) {
+  const organization = await organizationRepository.get(organizationId);
+  return organization.canCollectProfiles;
 }

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -19,6 +19,7 @@ function _toDomain(bookshelfCampaign) {
     'customLandingPageText',
     'idPixLabel',
     'title',
+    'type',
     'archivedAt',
   ]));
 }
@@ -37,6 +38,7 @@ function _fromBookshelfCampaignWithReportDataToDomain(campaignWithReportData) {
     'customLandingPageText',
     'idPixLabel',
     'title',
+    'type',
     'archivedAt',
   ]);
 

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -119,7 +119,7 @@ module.exports = {
   },
 
   save(domainCampaign) {
-    const repositoryCampaign = _.omit(domainCampaign, ['createdAt', 'archivedAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator', 'campaignAnalysis' ]);
+    const repositoryCampaign = _.omit(domainCampaign, ['id', 'createdAt', 'archivedAt', 'organizationLogoUrl', 'organizationName', 'targetProfile', 'campaignReport', 'campaignCollectiveResult', 'isRestricted', 'creator', 'campaignAnalysis' ]);
     return new BookshelfCampaign(repositoryCampaign)
       .save()
       .then(_toDomain);

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -36,6 +36,7 @@ function _toMembershipsDomain(membershipsBookshelf) {
         name: membershipBookshelf.related('organization').get('name'),
         type: membershipBookshelf.related('organization').get('type'),
         isManagingStudents: Boolean(membershipBookshelf.related('organization').get('isManagingStudents')),
+        canCollectProfiles: Boolean(membershipBookshelf.related('organization').get('canCollectProfiles')),
         externalId: membershipBookshelf.related('organization').get('externalId')
       }),
     });
@@ -43,7 +44,7 @@ function _toMembershipsDomain(membershipsBookshelf) {
 }
 
 function _toUserOrgaSettingsDomain(userOrgaSettingsBookshelf) {
-  const { id, code, name, type, isManagingStudents, externalId } = userOrgaSettingsBookshelf.related('currentOrganization').attributes;
+  const { id, code, name, type, isManagingStudents, canCollectProfiles, externalId } = userOrgaSettingsBookshelf.related('currentOrganization').attributes;
   return new UserOrgaSettings({
     id: userOrgaSettingsBookshelf.get('id'),
     currentOrganization: new Organization({
@@ -52,6 +53,7 @@ function _toUserOrgaSettingsDomain(userOrgaSettingsBookshelf) {
       name,
       type,
       isManagingStudents: Boolean(isManagingStudents),
+      canCollectProfiles: Boolean(canCollectProfiles),
       externalId
     }),
   });

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -67,7 +67,11 @@ module.exports = {
     return new Deserializer({ keyForAttribute: 'camelCase' })
       .deserialize(json)
       .then((campaign) => {
-        campaign.targetProfileId = parseInt(_.get(json.data, ['relationships', 'target-profile', 'data', 'id']));
+        campaign.organizationId = parseInt(_.get(json.data, ['attributes', 'organization-id']));
+        const targetProfileId = _.get(json.data, ['relationships', 'target-profile', 'data', 'id']);
+        if (targetProfileId) {
+          campaign.targetProfileId = parseInt(targetProfileId);
+        }
         return new Campaign(campaign);
       });
   }

--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -20,7 +20,7 @@ module.exports = {
       organization: {
         ref: 'id',
         included: true,
-        attributes: ['code', 'name', 'type', 'isManagingStudents', 'externalId', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+        attributes: ['code', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
         campaigns: {
           ref: 'id',
           ignoreRelationshipData: true,

--- a/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
@@ -22,7 +22,7 @@ module.exports = {
       organization: {
         ref: 'id',
         included: true,
-        attributes: ['code', 'name', 'type', 'isManagingStudents', 'externalId', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+        attributes: ['code', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'campaigns', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
         campaigns: {
           ref: 'id',
           ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1,7 +1,7 @@
 const faker = require('faker');
 const jwt = require('jsonwebtoken');
 const createServer = require('../../../server');
-const { expect, databaseBuilder, airtableBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect, databaseBuilder, airtableBuilder, knex, generateValidRequestAuthorizationHeader } = require('../../test-helper');
 const settings = require('../../../lib/config');
 const Membership = require('../../../lib/domain/models/Membership');
 const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
@@ -9,30 +9,22 @@ const cache = require('../../../lib/infrastructure/caches/learning-content-cache
 describe('Acceptance | API | Campaign Controller', () => {
 
   let campaign;
-  let campaignWithoutOrga;
   let organization;
   let targetProfile;
   let server;
 
   beforeEach(async () => {
     server = await createServer();
-    organization = databaseBuilder.factory.buildOrganization({ isManagingStudents: true });
-    targetProfile = databaseBuilder.factory.buildTargetProfile({
-      organizationId: organization.id,
-      name: '+Profile 2'
-    });
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
-    campaign = databaseBuilder.factory.buildCampaign({
-      name: '@Campagne de Test N°2',
-      organizationId: organization.id,
-      targetProfileId: targetProfile.id,
-      idPixLabel: '+Identifiant entreprise'
-    });
-    campaignWithoutOrga = databaseBuilder.factory.buildCampaign({ organizationId: null });
-    await databaseBuilder.commit();
   });
 
   describe('GET /api/campaign', function() {
+
+    let campaignWithoutOrga;
+
+    beforeEach(async () => {
+      campaignWithoutOrga = databaseBuilder.factory.buildCampaign({ organizationId: null });
+      await databaseBuilder.commit();
+    });
 
     it('should return one NotFoundError if there is no campaign link to the code', async () => {
       // given
@@ -131,6 +123,18 @@ describe('Acceptance | API | Campaign Controller', () => {
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
+      organization = databaseBuilder.factory.buildOrganization();
+      targetProfile = databaseBuilder.factory.buildTargetProfile({
+        organizationId: organization.id,
+        name: 'Profile 2'
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
+      campaign = databaseBuilder.factory.buildCampaign({
+        name: 'Campagne de Test N°2',
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        idPixLabel: 'Identifiant entreprise'
+      });
 
       databaseBuilder.factory.buildMembership({
         userId,
@@ -246,6 +250,18 @@ describe('Acceptance | API | Campaign Controller', () => {
 
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser({ firstName: '@Jean', lastName: '=Bono' });
+      organization = databaseBuilder.factory.buildOrganization();
+      targetProfile = databaseBuilder.factory.buildTargetProfile({
+        organizationId: organization.id,
+        name: '+Profile 2'
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
+      campaign = databaseBuilder.factory.buildCampaign({
+        name: '@Campagne de Test N°2',
+        organizationId: organization.id,
+        targetProfileId: targetProfile.id,
+        idPixLabel: '+Identifiant entreprise'
+      });
       userId = user.id;
       accessToken = _createTokenWithAccessId(userId);
 
@@ -330,6 +346,7 @@ describe('Acceptance | API | Campaign Controller', () => {
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
+      organization = databaseBuilder.factory.buildOrganization();
 
       databaseBuilder.factory.buildMembership({
         userId,
@@ -408,6 +425,118 @@ describe('Acceptance | API | Campaign Controller', () => {
       // then
       expect(response.statusCode).to.equal(200, response.payload);
       expect(response.result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('POST /api/campaign', () => {
+
+    let options, payload;
+
+    beforeEach(async () => {
+      const userId = databaseBuilder.factory.buildUser().id;
+      organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
+      targetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: organization.id });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkill1' });
+      await databaseBuilder.commit();
+
+      const skill = airtableBuilder.factory.buildSkill({ id: 'recSkill1' });
+
+      airtableBuilder
+        .mockList({ tableName: 'Acquis' })
+        .returns([skill])
+        .activate();
+
+      payload = {
+        data: {
+          type: 'campaign',
+          attributes: {
+            'name': 'Campagne collège',
+            'type': 'ASSESSMENT',
+            'organization-id': `${organization.id}`,
+          },
+          relationships: {
+            'target-profile': {
+              data: {
+                type: 'target-profiles',
+                id: `${targetProfile.id}`
+              }
+            }
+          }
+        }
+      };
+      options = {
+        method: 'POST',
+        url: '/api/campaigns',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload
+      };
+    });
+
+    afterEach(async () => {
+      await knex('campaigns').delete();
+      await airtableBuilder.cleanAll();
+      return cache.flushAll();
+    });
+
+    it('should return 201 status code and the campaign created with type ASSESSMENT', async () => {
+      // when
+      const response = await server.inject(options, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.attributes.name).to.equal('Campagne collège');
+      expect(response.result.data.attributes.type).to.equal('ASSESSMENT');
+    });
+
+    it('should return 201 status code and the campaign created with type PROFILES_COLLECTION', async () => {
+      // given
+      payload = {
+        data: {
+          type: 'campaign',
+          attributes: {
+            'name': 'Campagne lycée',
+            'type': 'PROFILES_COLLECTION',
+            'organization-id': `${organization.id}`,
+          },
+          relationships: {
+            'target-profile': {
+              data: {
+                type: 'target-profiles',
+                id: undefined,
+              }
+            }
+          }
+        }
+      };
+      options.payload = payload;
+
+      // when
+      const response = await server.inject(options, payload);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.attributes.name).to.equal('Campagne lycée');
+      expect(response.result.data.attributes.type).to.equal('PROFILES_COLLECTION');
+    });
+
+    it('should return 403 status code when the user does not have access', async () => {
+      // given
+      const anotherUserId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'POST',
+        url: '/api/campaigns',
+        headers: { authorization: generateValidRequestAuthorizationHeader(anotherUserId) },
+        payload
+      };
+
+      // when
+      const response = await server.inject(options, payload);
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
   });
 });

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -434,7 +434,7 @@ describe('Acceptance | API | Campaign Controller', () => {
 
     beforeEach(async () => {
       const userId = databaseBuilder.factory.buildUser().id;
-      organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true });
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
       targetProfile = databaseBuilder.factory.buildTargetProfile({ organizationId: organization.id });
       databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkill1' });

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -88,6 +88,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
                 type: organization.type,
                 'external-id': organization.externalId,
                 'is-managing-students': organization.isManagingStudents,
+                'can-collect-profiles': organization.canCollectProfiles,
               },
               relationships: {
                 campaigns: {

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const organizationService = require('../../../../lib/domain/services/organization-service');
 
 const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
@@ -16,7 +17,7 @@ describe('Integration | UseCases | create-campaign', () => {
   let targetProfileId;
 
   beforeEach(async () => {
-    organizationId = databaseBuilder.factory.buildOrganization().id;
+    organizationId = databaseBuilder.factory.buildOrganization({ canCollectProfiles: true }).id;
     userId = databaseBuilder.factory.buildUser().id;
 
     targetProfileId = databaseBuilder.factory.buildTargetProfile({ organizationId }).id;
@@ -49,7 +50,7 @@ describe('Integration | UseCases | create-campaign', () => {
       'organizationLogoUrl', 'organizationName', 'targetProfileId' ];
 
     // when
-    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationService });
+    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationRepository, organizationService });
 
     // then
     expect(result).to.be.an.instanceOf(Campaign);
@@ -69,7 +70,7 @@ describe('Integration | UseCases | create-campaign', () => {
       'organizationLogoUrl', 'organizationName', 'targetProfile', 'targetProfileId' ];
 
     // when
-    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationService });
+    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationRepository, organizationService });
 
     // then
     expect(result).to.be.an.instanceOf(Campaign);

--- a/api/tests/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/integration/domain/usecases/create-campaign_test.js
@@ -1,0 +1,83 @@
+const { expect, databaseBuilder, domainBuilder, airtableBuilder, knex } = require('../../../test-helper');
+const _ = require('lodash');
+
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const organizationService = require('../../../../lib/domain/services/organization-service');
+
+const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
+
+const Campaign = require('../../../../lib/domain/models/Campaign');
+
+describe('Integration | UseCases | create-campaign', () => {
+
+  let userId;
+  let organizationId;
+  let targetProfileId;
+
+  beforeEach(async () => {
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    userId = databaseBuilder.factory.buildUser().id;
+
+    targetProfileId = databaseBuilder.factory.buildTargetProfile({ organizationId }).id;
+
+    databaseBuilder.factory.buildMembership({
+      organizationId, userId,
+    });
+
+    await databaseBuilder.commit();
+
+    const skill = airtableBuilder.factory.buildSkill({ id: 'recSkill1' });
+
+    airtableBuilder
+      .mockList({ tableName: 'Acquis' })
+      .returns([skill])
+      .activate();
+  });
+
+  afterEach(async () => {
+    await knex('campaigns').delete();
+    return airtableBuilder.cleanAll();
+  });
+
+  it('should save a new campaign of type ASSESSMENT', async () => {
+    // given
+    const campaign = domainBuilder.buildCampaign.ofTypeAssessment({ creatorId: userId, organizationId, targetProfileId });
+
+    const expectedAttributes = ['type', 'title', 'idPixLabel', 'name', 'organizationId',
+      'creatorId', 'isRestricted', 'customLandingPageText', 'archivedAt', 'campaignCollectiveResult', 'campaignReport',
+      'organizationLogoUrl', 'organizationName', 'targetProfileId' ];
+
+    // when
+    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationService });
+
+    // then
+    expect(result).to.be.an.instanceOf(Campaign);
+
+    expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
+
+    expect('code').to.be.ok;
+    expect('id').to.be.ok;
+  });
+
+  it('should save a new campaign of type PROFILES_COLLECTION', async () => {
+    // given
+    const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection({ creatorId: userId, organizationId });
+
+    const expectedAttributes = ['type', 'title', 'idPixLabel', 'name', 'organizationId',
+      'creatorId', 'isRestricted', 'customLandingPageText', 'archivedAt', 'campaignCollectiveResult', 'campaignReport',
+      'organizationLogoUrl', 'organizationName', 'targetProfile', 'targetProfileId' ];
+
+    // when
+    const result = await createCampaign({ campaign, campaignRepository, userRepository, organizationService });
+
+    // then
+    expect(result).to.be.an.instanceOf(Campaign);
+
+    expect(_.pick(result, expectedAttributes)).to.deep.equal(_.pick(campaign, expectedAttributes));
+
+    expect('code').to.be.ok;
+    expect('id').to.be.ok;
+
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-campaign.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign.js
@@ -83,7 +83,6 @@ buildCampaign.ofTypeProfilesCollection = function({
   id = 1,
   name = faker.company.companyName(),
   code = 'AZERTY123',
-  title = null,
   idPixLabel = faker.random.word(),
   customLandingPageText = faker.lorem.text(),
   archivedAt,
@@ -92,8 +91,6 @@ buildCampaign.ofTypeProfilesCollection = function({
   creatorId = faker.random.number(2),
   creator = buildUser({ id: creatorId }),
   organizationId = faker.random.number(2),
-  targetProfileId = null,
-  targetProfile = null,
   isRestricted = false,
   organizationLogoUrl
 } = {}) {
@@ -101,7 +98,6 @@ buildCampaign.ofTypeProfilesCollection = function({
     id,
     name,
     code,
-    title,
     idPixLabel,
     customLandingPageText,
     archivedAt,
@@ -110,8 +106,6 @@ buildCampaign.ofTypeProfilesCollection = function({
     creatorId,
     creator,
     organizationId,
-    targetProfileId,
-    targetProfile,
     isRestricted,
     organizationLogoUrl
   });

--- a/api/tests/tooling/domain-builder/factory/build-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-membership.js
@@ -23,6 +23,7 @@ function _buildOrganization() {
     type: 'PRO',
     externalId: 'EXTID',
     isManagingStudents: false,
+    canCollectProfiles: false,
   });
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-user-orga-settings.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-orga-settings.js
@@ -24,6 +24,7 @@ function _buildOrganization() {
     code: 'ABCD12',
     externalId: 'EXTID',
     isManagingStudents: false,
+    canCollectProfiles: false,
   });
 }
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const { sinon, expect, domainBuilder, hFake, catchErr } = require('../../../test-helper');
 
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
@@ -37,10 +39,11 @@ describe('Unit | Application | Controller | Campaign', () => {
 
       // then
       expect(usecases.createCampaign).to.have.been.calledOnce;
-      const createCampaignArgs = usecases.createCampaign.firstCall.args[0];
-      expect(createCampaignArgs.campaign).to.have.property('name', deserializedCampaign.name);
-      expect(createCampaignArgs.campaign).to.have.property('creatorId', connectedUserId);
-      expect(createCampaignArgs.campaign).to.have.property('organizationId', deserializedCampaign.organizationId);
+      const { campaign } = usecases.createCampaign.firstCall.args[0];
+      expect(campaign).to.include({
+        ..._.pick(deserializedCampaign, ['name', 'type', 'organizationId']),
+        creatorId: connectedUserId,
+      });
     });
 
     it('should return a serialized campaign when the campaign has been successfully created', async () => {

--- a/api/tests/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/unit/domain/usecases/create-campaign_test.js
@@ -1,8 +1,9 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const createCampaign = require('../../../../lib/domain/usecases/create-campaign');
 const campaignCodeGenerator = require('../../../../lib/domain/services/campaigns/campaign-code-generator');
 const campaignValidator = require('../../../../lib/domain/validators/campaign-validator');
 const { EntityValidationError, UserNotAuthorizedToCreateCampaignError } = require('../../../../lib/domain/errors');
+const _ = require('lodash');
 
 describe('Unit | UseCase | create-campaign', () => {
 
@@ -30,31 +31,31 @@ describe('Unit | UseCase | create-campaign', () => {
     sinon.stub(organizationService, 'findAllTargetProfilesAvailableForOrganization');
   });
 
-  it('should throw an EntityValidationError if campaign is not valid', () => {
+  it('should throw an EntityValidationError if campaign is not valid', async () => {
     // given
     campaignValidator.validate.throws(new EntityValidationError({ invalidAttributes: [] }));
 
     // when
-    const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
+    const error = await catchErr(createCampaign)({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
 
     // then
-    return expect(promise).to.be.rejectedWith(EntityValidationError);
+    expect(error).to.be.instanceOf(EntityValidationError);
   });
 
-  it('should throw an error if user do not have an access to the campaign organization', () => {
+  it('should throw an error if user do not have an access to the campaign organization', async () => {
     // given
     const organizationIdDifferentFromCampaign = 98437;
     campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(organizationIdDifferentFromCampaign);
 
     // when
-    const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService  });
+    const error = await catchErr(createCampaign)({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
 
     // then
-    return expect(promise).to.be.rejectedWith(UserNotAuthorizedToCreateCampaignError);
+    expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
   });
 
-  it('should generate a new code to the campaign', () => {
+  it('should generate a new code to the campaign', async () => {
     // given
     campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
@@ -62,16 +63,13 @@ describe('Unit | UseCase | create-campaign', () => {
     campaignRepository.save.resolves(savedCampaign);
 
     // when
-    const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
+    await createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
 
     // then
-    return promise.then(() => {
-      expect(campaignCodeGenerator.generate).to.have.been.called;
-    });
-
+    expect(campaignCodeGenerator.generate).to.have.been.called;
   });
 
-  it('should save the campaign with name, userId, organizationId and generated code', () => {
+  it('should save the campaign with name, type, userId, organizationId and generated code', async () => {
     // given
     campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
@@ -79,21 +77,18 @@ describe('Unit | UseCase | create-campaign', () => {
     campaignRepository.save.resolves(savedCampaign);
 
     // when
-    const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
+    await createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
 
     // then
-    return promise.then(() => {
-      expect(campaignRepository.save).to.have.been.called;
+    const [campaignToCreateWithCode] = campaignRepository.save.firstCall.args;
 
-      const campaignToCreateWithCode = campaignRepository.save.firstCall.args[0];
-      expect(campaignToCreateWithCode.name).to.equal(campaignToCreate.name);
-      expect(campaignToCreateWithCode.code).to.equal(availableCampaignCode);
-      expect(campaignToCreateWithCode.userId).to.equal(campaignToCreate.userId);
-      expect(campaignToCreateWithCode.organizationId).to.equal(campaignToCreate.organizationId);
+    expect(campaignToCreateWithCode).to.deep.include({
+      ..._.pick(campaignToCreate, ['name', 'userId', 'type', 'organizationId']),
+      code: availableCampaignCode
     });
   });
 
-  it('should return the newly created campaign', () => {
+  it('should return the newly created campaign', async () => {
     // given
     campaignValidator.validate.returns();
     _stubGetUserWithOrganizationsAccesses(campaignToCreate.organizationId);
@@ -101,12 +96,10 @@ describe('Unit | UseCase | create-campaign', () => {
     campaignRepository.save.resolves(savedCampaign);
 
     // when
-    const promise = createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
+    const campaign = await createCampaign({ campaign: campaignToCreate, campaignRepository, userRepository, organizationService });
 
     // then
-    return promise.then((campaign) => {
-      expect(campaign).to.deep.equal(savedCampaign);
-    });
+    expect(campaign).to.deep.equal(savedCampaign);
   });
 
 });

--- a/api/tests/unit/domain/validations/campaign-validator_test.js
+++ b/api/tests/unit/domain/validations/campaign-validator_test.js
@@ -10,188 +10,301 @@ function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedErro
 
 describe('Unit | Domain | Validators | campaign-validator', function() {
 
-  let campaign;
+  const campaignOfTypeProfilesCollection = domainBuilder.buildCampaign.ofTypeProfilesCollection({
+    name: 'campagne de collecte de profils',
+    creatorId: 4,
+    organizationId: 12,
+    idPixLabel: 'Mail Pro',
+  });
 
-  beforeEach(() => {
-    campaign = domainBuilder.buildCampaign({
-      name: 'campagne de test',
-      creatorId: 4,
-      organizationId: 12,
-      idPixLabel: 'Mail Pro',
-      targetProfileId: 44,
-    });
+  const campaignOfTypeAssessment = domainBuilder.buildCampaign.ofTypeAssessment({
+    name: 'campagne d\'évaluation',
+    title: 'Campagne d\'évaluation',
+    creatorId: 4,
+    organizationId: 12,
+    idPixLabel: 'Mail Pro',
+    targetProfileId: 44,
   });
 
   describe('#validate', () => {
 
-    context('when validation is successful', () => {
+    [campaignOfTypeAssessment, campaignOfTypeProfilesCollection].forEach((campaign) => {
 
-      it('should not throw any error', () => {
-        expect(campaignValidator.validate(campaign)).to.not.throw;
+      context(`when campaign is of type ${campaign.type}`, () => {
+        context('when validation is successful', () => {
+
+          it('should not throw any error', () => {
+            expect(campaignValidator.validate(campaign)).to.not.throw;
+          });
+
+          it('should resolve when idPixLabel is null', () => {
+            // when/then
+            expect(campaignValidator.validate({
+              ...campaign,
+              idPixLabel: null,
+            })).to.not.throw;
+          });
+
+          it('should resolve when title is null', () => {
+            // when/then
+            expect(campaignValidator.validate({
+              ...campaign,
+              title: null,
+            })).to.not.throw;
+          });
+
+          it('should resolve when title is not provided', () => {
+            // when/then
+            expect(campaignValidator.validate({
+              ...campaign,
+              title: undefined,
+            })).to.not.throw;
+          });
+
+        });
+
+        context('when campaign data validation fails', () => {
+
+          context('on name attribute', () => {
+
+            it('should reject with error when name is missing', () => {
+              // given
+              const expectedError = {
+                attribute: 'name',
+                message: 'Veuillez donner un nom à votre campagne.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  name: MISSING_VALUE,
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+          });
+
+          context('on creatorId attribute', () => {
+
+            it('should reject with error when creatorId is missing', () => {
+              // given
+              const expectedError = {
+                attribute: 'creatorId',
+                message: 'Le créateur n’est pas renseigné.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  creatorId: MISSING_VALUE,
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+          });
+
+          context('on organizationId attribute', () => {
+
+            it('should reject with error when organizationId is missing', () => {
+              // given
+              const expectedError = {
+                attribute: 'organizationId',
+                message: 'L‘organisation n’est pas renseignée.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  organizationId: MISSING_VALUE,
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+          });
+
+          context('on idPixLabel attribute', () => {
+            it('should reject with error when idPixLabel is an empty string', () => {
+              // given
+              const expectedError = {
+                attribute: 'idPixLabel',
+                message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  idPixLabel: MISSING_VALUE,
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+            it('should reject with error when idPixLabel length is under 3 characters', () => {
+              // given
+              const expectedError = {
+                attribute: 'idPixLabel',
+                message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  idPixLabel: 'AZ',
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+          });
+
+          context('on type attribute', () => {
+
+            it('should reject with error when type is a wrong type', () => {
+              // given
+              const expectedError = {
+                attribute: 'type',
+                message: 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.'
+              };
+
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  type: 'WRONG_TYPE',
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+          });
+
+          it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
+            try {
+              // when
+              campaignValidator.validate({
+                ...campaign,
+                name: MISSING_VALUE,
+                creatorId: MISSING_VALUE,
+                organizationId: MISSING_VALUE,
+              });
+              expect.fail('should have thrown an error');
+
+            } catch (entityValidationErrors) {
+              // then
+              expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(3);
+            }
+          });
+
+        });
       });
-
-      it('should resolve when idPixLabel is null', () => {
-        // given
-        campaign.idPixLabel = null;
-
-        // when/then
-        expect(campaignValidator.validate(campaign)).to.not.throw;
-      });
-
     });
 
-    context('when campaign data validation fails', () => {
-
-      context('on name attribute', () => {
-
-        it('should reject with error when name is missing', () => {
-          // given
-          const expectedError = {
-            attribute: 'name',
-            message: 'Veuillez donner un nom à votre campagne.'
-          };
-          campaign.name = MISSING_VALUE;
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-      });
-
-      context('on creatorId attribute', () => {
-
-        it('should reject with error when creatorId is missing', () => {
-          // given
-          const expectedError = {
-            attribute: 'creatorId',
-            message: 'Le créateur n’est pas renseigné.'
-          };
-          campaign.creatorId = MISSING_VALUE;
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-      });
-
-      context('on organizationId attribute', () => {
-
-        it('should reject with error when organizationId is missing', () => {
-          // given
-          const expectedError = {
-            attribute: 'organizationId',
-            message: 'L‘organisation n’est pas renseignée.'
-          };
-          campaign.organizationId = MISSING_VALUE;
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-      });
-
-      context('on idPixLabel attribute', () => {
-        it('should reject with error when idPixLabel is an empty string', () => {
-          // given
-          const expectedError = {
-            attribute: 'idPixLabel',
-            message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.'
-          };
-          campaign.idPixLabel = '';
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-        it('should reject with error when idPixLabel length is under 3 characters', () => {
-          // given
-          const expectedError = {
-            attribute: 'idPixLabel',
-            message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.'
-          };
-          campaign.idPixLabel = 'AZ';
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-      });
-
-      context('on targetProfileId attribute', () => {
-
-        it('should reject with error when targetProfileId is missing', () => {
-          // given
-          const expectedError = {
-            attribute: 'targetProfileId',
-            message: 'Veuillez sélectionner un profil cible pour votre campagne.'
-          };
-          campaign.targetProfileId = MISSING_VALUE;
-
-          try {
-            // when
-            campaignValidator.validate(campaign);
-            expect.fail('should have thrown an error');
-
-          } catch (entityValidationErrors) {
-            // then
-            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-          }
-        });
-
-      });
-
-      it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
+    context('on targetProfileId attribute', () => {
+      it('should reject with error when targetProfileId is provided and campaign type is PROFILES_COLLECTION', () => {
         // given
-        campaign.name = MISSING_VALUE;
-        campaign.creatorId = MISSING_VALUE;
-        campaign.organizationId = MISSING_VALUE;
-        campaign.targetProfileId = MISSING_VALUE;
+        const expectedError = {
+          attribute: 'targetProfileId',
+          message: 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
+        };
 
         try {
           // when
-          campaignValidator.validate(campaign);
+          campaignValidator.validate({
+            ...campaignOfTypeProfilesCollection,
+            targetProfileId: '1',
+          });
           expect.fail('should have thrown an error');
 
         } catch (entityValidationErrors) {
           // then
-          expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(4);
+          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
         }
       });
 
+      it('should reject with error when targetProfileId is missing and campaign type is ASSESSMENT', () => {
+        // given
+        const expectedError = {
+          attribute: 'targetProfileId',
+          message: 'Veuillez sélectionner un profil cible pour votre campagne.'
+        };
+
+        try {
+          // when
+          campaignValidator.validate({
+            ...campaignOfTypeAssessment,
+            targetProfileId: MISSING_VALUE,
+          });
+          expect.fail('should have thrown an error');
+
+        } catch (entityValidationErrors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+        }
+      });
+
+    });
+
+    context('when a title is provided', () => {
+      it('should reject with error when campaign type is PROFILES_COLLECTION', () => {
+        // given
+        const expectedError = {
+          attribute: 'title',
+          message: 'Le titre du parcours n’est pas autorisé pour les campagnes de collecte de profils.'
+        };
+
+        try {
+          // when
+          campaignValidator.validate({
+            ...campaignOfTypeProfilesCollection,
+            title: 'Titre du parcours',
+          });
+          expect.fail('should have thrown an error');
+
+        } catch (entityValidationErrors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+        }
+      });
+
+      it('should resolve when campaign type is ASSESSMENT', () => {
+        // given
+        const campaign = {
+          ...campaignOfTypeAssessment,
+          title: 'Titre du parcours',
+        };
+
+        // when/then
+        expect(campaignValidator.validate(campaign)).to.not.throw;
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -243,7 +243,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
 
   describe('#deserialize', function() {
 
-    it('should convert JSON API campaign data into a Campaign model object', function() {
+    it('should convert JSON API campaign data into a Campaign model object', async function() {
       // given
       const organizationId = 10293;
       const targetProfileId = '23';
@@ -265,16 +265,45 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
       };
 
       // when
-      const promise = serializer.deserialize(jsonAnswer);
+      const campaign = await serializer.deserialize(jsonAnswer);
 
       // then
-      return expect(promise).to.be.fulfilled
-        .then((campaign) => {
-          expect(campaign).to.be.instanceOf(Campaign);
-          expect(campaign.name).to.equal(jsonAnswer.data.attributes.name);
-          expect(campaign.organizationId).to.equal(organizationId);
-          expect(campaign.targetProfileId).to.equal(23);
-        });
+      expect(campaign).to.be.instanceOf(Campaign);
+      expect(campaign.name).to.equal(jsonAnswer.data.attributes.name);
+      expect(campaign.organizationId).to.equal(organizationId);
+      expect(campaign.targetProfileId).to.equal(23);
+    });
+
+    context('when no targetProfileId', () => {
+      it('should convert JSON API campaign data into a Campaign model object', async function() {
+        // given
+        const organizationId = 10293;
+        const jsonAnswer = {
+          data: {
+            type: 'campaign',
+            attributes: {
+              name: 'My super campaign',
+              'organization-id': organizationId,
+            },
+            relationships: {
+              'target-profile': {
+                data: {
+                  id: undefined,
+                }
+              }
+            }
+          }
+        };
+
+        // when
+        const campaign = await serializer.deserialize(jsonAnswer);
+
+        // then
+        expect(campaign).to.be.instanceOf(Campaign);
+        expect(campaign.name).to.equal(jsonAnswer.data.attributes.name);
+        expect(campaign.organizationId).to.equal(organizationId);
+        expect(campaign.targetProfileId).to.equal(undefined);
+      });
     });
 
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -100,7 +100,8 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
         'name': 'ACME',
         'type': 'PRO',
         'external-id': 'EXTID',
-        'is-managing-students': false
+        'is-managing-students': false,
+        'can-collect-profiles': false,
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
@@ -97,7 +97,8 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
         'name': 'ACME',
         'type': 'PRO',
         'external-id': 'EXTID',
-        'is-managing-students': false
+        'is-managing-students': false,
+        'can-collect-profiles': false,
       });
     });
 

--- a/high-level-tests/e2e/cypress/fixtures/organizations.json
+++ b/high-level-tests/e2e/cypress/fixtures/organizations.json
@@ -2,7 +2,8 @@
   {
     "id": 1,
     "type": "PRO",
-    "name": "Dragon & Co"
+    "name": "Dragon & Co",
+    "canCollectProfiles": true
   },
   {
     "id": 2,

--- a/high-level-tests/e2e/cypress/integration/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/campaign-management.feature
@@ -23,11 +23,21 @@ Fonctionnalité: Gestion des Campagnes
     Et je clique sur "Résultats collectifs"
     Alors je vois la moyenne des résultats à 50%
 
-  Scénario: Je créé une campagne
+  Scénario: Je créé une campagne d'évaluation
     Étant donné que je suis connecté à Pix Orga
     Lorsque je clique sur "Créer une campagne"
     Et je saisis "Campagne du Nord" dans le champ "Nom de la campagne"
+    Et je clique sur "Évaluer les participants"
     Et je sélectionne "Compétences pour un Mestre" dans le champ "Que souhaitez-vous tester ?"
     Et je clique sur "Non"
     Et je clique sur "Créer la campagne"
     Alors je vois le détail de la campagne "Campagne du Nord"
+
+  Scénario: Je créé une campagne de collecte de profils
+    Étant donné que je suis connecté à Pix Orga
+    Lorsque je clique sur "Créer une campagne"
+    Et je saisis "Campagne de l'Ouest" dans le champ "Nom de la campagne"
+    Et je clique sur "Collecter les profils Pix des participants"
+    Et je clique sur "Non"
+    Et je clique sur "Créer la campagne"
+    Alors je vois le détail de la campagne "Campagne de l'Ouest"

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -1,11 +1,13 @@
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class NewItem extends Component {
 
   campaign = null;
   targetProfiles = null;
   wantIdPix = false;
+  @tracked isCampaignGoalAssessment = null;
 
   @computed('wantIdPix')
   get notWantIdPix() {
@@ -29,5 +31,15 @@ export default class NewItem extends Component {
     const selectedTargetProfile = this.targetProfiles
       .find((targetProfile) => targetProfile.get('id') === event.target.value);
     this.campaign.set('targetProfile', selectedTargetProfile);
+  }
+
+  @action
+  setCampaignGoal(event) {
+    if (event.target.value === 'collect-participants-profile') {
+      this.isCampaignGoalAssessment = false;
+      return this.campaign.type = 'PROFILES_COLLECTION';
+    }
+    this.isCampaignGoalAssessment = true;
+    return this.campaign.type = 'ASSESSMENT';
   }
 }

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -47,6 +47,8 @@ export default class NewItem extends Component {
   setCampaignGoal(event) {
     if (event.target.value === 'collect-participants-profile') {
       this.isCampaignGoalAssessment = false;
+      this.campaign.title = null;
+      this.campaign.targetProfile = null;
       return this.campaign.type = 'PROFILES_COLLECTION';
     }
     this.isCampaignGoalAssessment = true;

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -1,13 +1,23 @@
+import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class NewItem extends Component {
+  @service currentUser;
 
-  campaign = null;
+  campaign = {};
   targetProfiles = null;
   wantIdPix = false;
   @tracked isCampaignGoalAssessment = null;
+
+  init() {
+    super.init(...arguments);
+    if (!this.currentUser.organization.canCollectProfiles) {
+      this.isCampaignGoalAssessment = true;
+      this.campaign.type = 'ASSESSMENT';
+    }
+  }
 
   @computed('wantIdPix')
   get notWantIdPix() {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -1,60 +1,102 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import ENV from 'pix-orga/config/environment';
+const { Model, attr, belongsTo } = DS;
 
 const PROFILES_COLLECTION_TEXT = 'Collecte de profils';
 const ASSESSMENT_TEXT = 'Évaluation';
 
-export default DS.Model.extend({
-  name: DS.attr('string'),
-  code: DS.attr('string'),
-  type: DS.attr('string'),
-  title: DS.attr('string'),
-  createdAt: DS.attr('date'),
-  creator: DS.belongsTo('user'),
-  archivedAt: DS.attr('date'),
-  idPixLabel: DS.attr('string'),
-  customLandingPageText: DS.attr('string'),
+export default class Campaign extends Model {
+  @attr('string')
+  name;
+
+  @attr('string')
+  code;
+
+  @attr('string')
+  type;
+
+  @attr('string')
+  title;
+
+  @attr('date')
+  createdAt;
+
+  @belongsTo('user')
+  creator;
+
+  @attr('date')
+  archivedAt;
+
+  @attr('string')
+  idPixLabel;
+
+  @attr('string')
+  customLandingPageText;
+
   // TODO remove organizationId and work only with the relationship
-  organizationId: DS.attr('number'),
-  organization: DS.belongsTo('organization'),
-  tokenForCampaignResults: DS.attr('string'),
-  targetProfile: DS.belongsTo('target-profile'),
-  campaignReport: DS.belongsTo('campaign-report'),
-  campaignCollectiveResult: DS.belongsTo('campaign-collective-result'),
-  campaignAnalysis: DS.belongsTo('campaign-analysis'),
 
-  isTypeProfilesCollection: computed.equal('type', 'PROFILES_COLLECTION'),
-  isTypeAssessment: computed.equal('type', 'ASSESSMENT'),
+  @attr('number')
+  organizationId;
 
-  readableType: computed('isTypeProfilesCollection', function() {
+  @belongsTo('organization')
+  organization;
+
+  @attr('string')
+  tokenForCampaignResults;
+
+  @belongsTo('target-profile')
+  targetProfile;
+
+  @belongsTo('campaign-report')
+  campaignReport;
+
+  @belongsTo('campaign-collective-result')
+  campaignCollectiveResult;
+
+  @belongsTo('campaign-analysis')
+  campaignAnalysis;
+
+  @equal('type', 'PROFILES_COLLECTION')
+  isTypeProfilesCollection;
+
+  @equal('type', 'ASSESSMENT')
+  isTypeAssessment;
+
+  @computed('isTypeProfilesCollection')
+  get readableType() {
     return this.isTypeProfilesCollection ? PROFILES_COLLECTION_TEXT : ASSESSMENT_TEXT;
-  }),
+  }
 
-  url: computed('code', function() {
+  @computed('code')
+  get url() {
     const code = this.code;
     return `${ENV.APP.CAMPAIGNS_ROOT_URL}${code}`;
-  }),
+  }
 
-  urlToResult: computed('id', 'tokenForCampaignResults', function() {
+  @computed('id', 'tokenForCampaignResults')
+  get urlToResult() {
     return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csvResults?accessToken=${this.tokenForCampaignResults}`;
-  }),
+  }
 
-  isArchived: computed('archivedAt', function() {
+  @computed('archivedAt')
+  get isArchived() {
     return Boolean(this.archivedAt);
-  }),
+  }
 
-  canBeArchived: computed('isTypeAssessment', 'isArchived', function() {
+  @computed('isTypeAssessment', 'isArchived')
+  get canBeArchived() {
     return this.isTypeAssessment && ! this.isArchived;
-  }),
+  }
 
   async archive() {
     await this.store.adapterFor('campaign').archive(this);
     return this.store.findRecord('campaign', this.id, { include: 'targetProfile' });
-  },
+  }
 
   async unarchive() {
     await this.store.adapterFor('campaign').unarchive(this);
     return this.store.findRecord('campaign', this.id, { include: 'targetProfile' });
   }
-});
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -18,18 +18,20 @@
     {{/each}}
   </div>
 
-  <div class="form__field">
-    <label class="label">Quel est l'objectif de votre campagne ?</label>
-    <div>
-      <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" {{on "change" this.setCampaignGoal}}>
-      <label for="assess-participants">Évaluer les participants</label>
-    <div>
+  {{#if this.currentUser.organization.canCollectProfiles}}
+    <div class="form__field">
+      <label class="label">Quel est l'objectif de votre campagne ?</label>
+      <div>
+        <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" {{on "change" this.setCampaignGoal}}>
+        <label for="assess-participants">Évaluer les participants</label>
+      <div>
 
+      </div>
+        <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" {{on "change" this.setCampaignGoal}}>
+        <label for="collect-participants-profile">Collecter les profils Pix des participants</label>
+      </div>
     </div>
-      <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" {{on "change" this.setCampaignGoal}}>
-      <label for="collect-participants-profile">Collecter les profils Pix des participants</label>
-    </div>
-  </div>
+  {{/if}}
 
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field">

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -21,14 +21,18 @@
   {{#if this.currentUser.organization.canCollectProfiles}}
     <div class="form__field">
       <label class="label">Quel est l'objectif de votre campagne ?</label>
-      <div>
-        <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" {{on "change" this.setCampaignGoal}}>
-        <label for="assess-participants">Évaluer les participants</label>
-      <div>
-
+      <div class="form__sub-label" role="button">
+        <label>
+          <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" class="radio-button" {{on "change" this.setCampaignGoal}}>
+          <span class="radio-button-span"></span>Évaluer les participants
+        </label>
       </div>
-        <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" {{on "change" this.setCampaignGoal}}>
-        <label for="collect-participants-profile">Collecter les profils Pix des participants</label>
+
+      <div class="form__sub-label" role="button">
+        <label>
+          <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" class="radio-button" {{on "change" this.setCampaignGoal}}>
+          <span class="radio-button-span"></span>Collecter les profils Pix des participants
+        </label>
       </div>
     </div>
   {{/if}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -19,19 +19,34 @@
   </div>
 
   <div class="form__field">
-    <label for="campaign-target-profile" class="label">Que souhaitez-vous tester ?</label>
-    <select class="select" id="campaign-target-profile" {{on "change" this.setSelectedTargetProfile}}>
-      <option value="" disabled="disabled" selected></option>
-      {{#each @targetProfiles as |targetProfile|}}
-        <option value="{{targetProfile.id}}">{{targetProfile.name}}</option>
-      {{/each}}
-    </select>
-    {{#each @campaign.errors.targetProfile as |error|}}
-      <div class='form__error error-message'>
-        {{error.message}}
-      </div>
-    {{/each}}
+    <label class="label">Quel est l'objectif de votre campagne ?</label>
+    <div>
+      <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" {{on "change" this.setCampaignGoal}}>
+      <label for="assess-participants">Évaluer les participants</label>
+    <div>
+
+    </div>
+      <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" {{on "change" this.setCampaignGoal}}>
+      <label for="collect-participants-profile">Collecter les profils Pix des participants</label>
+    </div>
   </div>
+
+  {{#if this.isCampaignGoalAssessment}}
+    <div class="form__field">
+      <label for="campaign-target-profile" class="label">Que souhaitez-vous tester ?</label>
+      <select class="select" id="campaign-target-profile" {{on "change" this.setSelectedTargetProfile}}>
+        <option value="" disabled="disabled" selected></option>
+        {{#each @targetProfiles as |targetProfile|}}
+          <option value="{{targetProfile.id}}">{{targetProfile.name}}</option>
+        {{/each}}
+      </select>
+      {{#each @campaign.errors.targetProfile as |error|}}
+        <div class='form__error error-message'>
+          {{error.message}}
+        </div>
+      {{/each}}
+    </div>
+  {{/if}}
 
   <div class="form__field">
     <div class="campaign-form_id-pix">
@@ -79,17 +94,19 @@
     {{/if}}
   </div>
 
-  <div class="form__field">
-    <label for="campaign-title" class="label">Titre du parcours</label>
-    <Input
-      @id="campaign-title"
-      @name="campaign-title"
-      @type="text"
-      @class="input"
-      @maxlength="50"
-      @value={{@campaign.title}}
-    />
-  </div>
+  {{#if this.isCampaignGoalAssessment}}
+    <div class="form__field">
+      <label for="campaign-title" class="label">Titre du parcours</label>
+      <Input
+        @id="campaign-title"
+        @name="campaign-title"
+        @type="text"
+        @class="input"
+        @maxlength="50"
+        @value={{@campaign.title}}
+      />
+    </div>
+  {{/if}}
 
   <div class="form__field">
     <label for="custom-landing-page-text" class="label">Texte de la page d'accueil</label>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -163,7 +163,21 @@ export default function() {
     return schema.targetProfiles.all();
   });
 
-  this.post('/campaigns');
+  this.post('/campaigns', (schema, request) => {
+    const body = JSON.parse(request.requestBody);
+    const campaign = {
+      ...body.data.attributes,
+      customLandingPageText: body.data.attributes['custom-landing-page-text'],
+      idPixLabel: body.data.attributes['id-pix-label'],
+    };
+    if (campaign.type === 'PROFILES_COLLECTION') {
+      return schema.campaigns.create(campaign);
+    } else if (campaign.type === 'ASSESSMENT') {
+      const targetProfileId = body.data.relationships['target-profile'].data.id;
+      return schema.campaigns.create({ ...campaign, targetProfileId });
+    }
+    return new Response(422);
+  });
 
   this.get('/campaigns/:id/campaign-report', (schema, request) => {
     const campaignId = request.params.id;

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -2,11 +2,12 @@ import { module, test } from 'qunit';
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+import { createUserWithMembershipAndTermsOfServiceAccepted, createUserThatCanCollectProfiles } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | Campaign Creation', function(hooks) {
+  let availableTargetProfiles;
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -19,20 +20,15 @@ module('Acceptance | Campaign Creation', function(hooks) {
     assert.equal(currentURL(), '/connexion');
   });
 
+  hooks.beforeEach(() => {
+    availableTargetProfiles = server.createList('target-profile', 2);
+  });
+
   module('when the user is authenticated', (hooks) => {
-
-    let availableTargetProfiles;
-    let user;
-
     hooks.beforeEach(async function() {
-      user = createUserWithMembershipAndTermsOfServiceAccepted();
-      availableTargetProfiles = server.createList('target-profile', 2);
-      await authenticateSession({
-        user_id: user.id,
-        access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
-        expires_in: 3600,
-        token_type: 'Bearer token type',
-      });
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      await authenticateUser(user.id);
+      await visit('/campagnes/creation');
     });
 
     hooks.afterEach(function() {
@@ -41,25 +37,18 @@ module('Acceptance | Campaign Creation', function(hooks) {
     });
 
     test('it should be accessible for an authenticated user', async function(assert) {
-      // when
-      await visit('/campagnes/creation');
-
       // then
       assert.equal(currentURL(), '/campagnes/creation');
       assert.dom('.page__title').hasText('Création d\'une campagne');
     });
 
     test('it should not display gdpr footnote', async function(assert) {
-      // when
-      await visit('/campagnes/creation');
-
       // then
       assert.dom('.new-item-form__gdpr-information').isNotVisible();
     });
 
     test('it should display gdpr footnote', async function(assert) {
       // when
-      await visit('/campagnes/creation');
       await click('#askLabelIdPix');
 
       // then
@@ -69,11 +58,9 @@ module('Acceptance | Campaign Creation', function(hooks) {
       );
     });
 
-    test('it should allow to create a campaign and redirect to the newly created campaign', async function(assert) {
+    test('it should allow to create a campaign of type ASSESSMENT by default and redirect to the newly created campaign', async function(assert) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
-
-      await visit('/campagnes/creation');
       await fillIn('#campaign-target-profile', expectedTargetProfileId);
       await fillIn('#campaign-name', 'Ma Campagne');
       await click('#askLabelIdPix');
@@ -85,39 +72,92 @@ module('Acceptance | Campaign Creation', function(hooks) {
       await click('button[type="submit"]');
 
       // then
-      assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
-      assert.equal(server.db.campaigns[0].title, 'Savoir rechercher');
-      assert.equal(server.db.campaigns[0].targetProfileId, expectedTargetProfileId);
-      assert.equal(server.db.campaigns[0].customLandingPageText, 'Texte personnalisé');
+      const firstCampaign = server.db.campaigns[0];
+      assert.equal(firstCampaign.name, 'Ma Campagne');
+      assert.equal(firstCampaign.title, 'Savoir rechercher');
+      assert.equal(firstCampaign.targetProfileId, expectedTargetProfileId);
+      assert.equal(firstCampaign.customLandingPageText, 'Texte personnalisé');
+      assert.equal(firstCampaign.idPixLabel, 'Mail Pro');
       assert.equal(currentURL(), '/campagnes/1');
-    });
-
-    test('it should display a list of target profiles', async function(assert) {
-      // given
-      const nbTargetProfiles = availableTargetProfiles.length;
-
-      // when
-      await visit('/campagnes/creation');
-
-      // then
-      assert.dom('select#campaign-target-profile').exists();
-      assert.dom('select[id=campaign-target-profile] option:not(:disabled)').exists({ count: nbTargetProfiles });
-      assert.dom(`select[id=campaign-target-profile] option[value="${availableTargetProfiles.get(0).id}"]`).hasText(availableTargetProfiles.get(0).name);
-      assert.dom(`select[id=campaign-target-profile] option[value="${availableTargetProfiles.get(1).id}"]`).hasText(availableTargetProfiles.get(1).name);
     });
 
     test('it should display error on global form when error 500 is returned from backend', async function(assert) {
       // given
       server.post('/campaigns', {}, 500);
-      await visit('/campagnes/creation');
 
       // when
       await click('button[type="submit"]');
 
       // then
       assert.equal(currentURL(), '/campagnes/creation');
-      assert.dom('[data-test-notification-message="error"]').exists();
       assert.dom('[data-test-notification-message="error"]').hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
     });
   });
+
+  module('when user is authenticated and can collect profiles', (hooks) => {
+    hooks.beforeEach(async function() {
+      const user = createUserThatCanCollectProfiles();
+      await authenticateUser(user.id);
+      await visit('/campagnes/creation');
+    });
+
+    test('it should allow to create a campaign of type ASSESSMENT and redirect to the newly created campaign', async function(assert) {
+      // given
+      const expectedTargetProfileId = availableTargetProfiles[1].id;
+      await click('#assess-participants');
+      await fillIn('#campaign-target-profile', expectedTargetProfileId);
+      await fillIn('#campaign-name', 'Ma Campagne');
+      await click('#doNotAskLabelIdPix');
+
+      // when
+      await click('button[type="submit"]');
+
+      // then
+      const firstCampaign = server.db.campaigns[0];
+      assert.equal(firstCampaign.name, 'Ma Campagne');
+      assert.equal(firstCampaign.targetProfileId, expectedTargetProfileId);
+      assert.equal(currentURL(), '/campagnes/1');
+    });
+
+    test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function(assert) {
+      // given
+      await click('#collect-participants-profile');
+      await fillIn('#campaign-name', 'Ma Campagne');
+      await click('#doNotAskLabelIdPix');
+
+      // when
+      await click('button[type="submit"]');
+
+      // then
+      assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
+      assert.equal(currentURL(), '/campagnes/1');
+    });
+
+    test('it should create campaign if user changes type after filling the form', async function(assert) {
+      // given
+      const expectedTargetProfileId = availableTargetProfiles[1].id;
+      await click('#assess-participants');
+      await fillIn('#campaign-target-profile', expectedTargetProfileId);
+      await fillIn('#campaign-name', 'Ma Campagne');
+      await fillIn('#campaign-title', 'Savoir rechercher');
+      await click('#doNotAskLabelIdPix');
+      await click('#collect-participants-profile');
+
+      // when
+      await click('button[type="submit"]');
+
+      // then
+      assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
+      assert.equal(currentURL(), '/campagnes/1');
+    });
+  });
 });
+
+function authenticateUser(userId) {
+  return authenticateSession({
+    user_id: userId,
+    access_token: 'aaa.' + btoa(`{"user_id":${userId},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+    expires_in: 3600,
+    token_type: 'Bearer token type',
+  });
+}

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -1,25 +1,8 @@
-export function createUserWithMembership() {
-  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': false });
-
-  const organization = server.create('organization', {
-    name: 'BRO & Evil Associates'
-  });
-
-  const memberships = server.create('membership', {
-    organizationId: organization.id,
-    userId: user.id
-  });
-
-  user.memberships = [memberships];
-  return user;
-}
-
-export function createUserWithMembershipAndTermsOfServiceAccepted() {
-  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': true });
-
+function _addUserToOrganization(user, { externalId, canCollectProfiles } = {}) {
   const organization = server.create('organization', {
     name: 'BRO & Evil Associates',
-    externalId: 'EXTBRO'
+    externalId,
+    canCollectProfiles,
   });
 
   const memberships = server.create('membership', {
@@ -30,6 +13,22 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
   user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
   user.memberships = [memberships];
   return user;
+}
+
+export function createUserWithMembership() {
+  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': false });
+
+  return _addUserToOrganization(user);
+}
+
+export function createUserWithMembershipAndTermsOfServiceAccepted() {
+  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': true });
+  return _addUserToOrganization(user, { externalId: 'EXTBRO' });
+}
+
+export function createUserThatCanCollectProfiles() {
+  const user = server.create('user', { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', 'pixOrgaTermsOfServiceAccepted': true });
+  return _addUserToOrganization(user, { canCollectProfiles: true });
 }
 
 export function createUserMembershipWithRole(organizationRole) {


### PR DESCRIPTION
## :unicorn: Problème
On a ajouté un nouveau type de campagnes pour collecter des profils mais on ne pouvait pas en créer dans l'application

## :robot: Solution
Rajouter le champ type de campagne dans le formulaire de création de campagnes

## :rainbow: Remarques
Seules les organisations avec canCollectProfiles à true peuvent créer ces campagnes

## :100: Pour tester
Il faut essayer de créer une campagne de type collecte de profils avec le compte pro@example.net.
Il faut vérifier qu'avec le compte sup@example.net on ne peut pas créer de campagnes de type collecte de profils.