### PR TITLE
[FEATURE] Invitation à Pix Orga depuis Pix Admin (PA-96).

### DIFF
--- a/admin/app/adapters/organization-invitation.js
+++ b/admin/app/adapters/organization-invitation.js
@@ -1,0 +1,17 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationInvitation extends ApplicationAdapter {
+
+  urlForCreateRecord(modelName, { adapterOptions }) {
+    const { organizationId } = adapterOptions;
+
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/invitations`;
+  }
+
+  createRecord() {
+    return super.createRecord(...arguments).then((response) => {
+      response.data = response.data[0];
+      return response;
+    });
+  }
+}

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -1,21 +1,50 @@
 <section class="page-section mb_10">
   <header class="page-section__header">
     <h2 class="page-section__title">Ajouter un membre</h2>
+    <h2 class="page-section__title">Inviter un membre</h2>
   </header>
-  <form aria-label="Ajouter un membre" class="organization__sub-form form">
-    <Input
-      id="userEmail"
-      aria-label="Adresse email"
-      @value={{@userEmail}}
-      class="organization-sub-form__input form-field__text form-control"
-      @placeholder="Adresse email de l'utilisateur à ajouter" />
-    <button
-      type="button"
-      {{on "click" @addMembership}}
-      class="organization-sub-form__validate-button btn btn-outline-default">
-      Valider
-    </button>
-  </form>
+
+  <div class="organization__forms-section">
+    <form aria-label="Ajouter un membre">
+      <div class="organization__sub-form">
+        <Input
+                id="userEmailToAdd"
+                aria-label="Adresse email"
+                @value={{@userEmailToAdd}}
+                class="organization-sub-form__input form-field__text form-control"
+                @placeholder="Adresse email de l'utilisateur à ajouter" />
+        <button
+                type="button"
+          {{on "click" @addMembership}}
+                class="organization-sub-form__validate-button btn btn-outline-default">
+          Valider
+        </button>
+      </div>
+    </form>
+
+    <form aria-label="Inviter un membre">
+      <div class="organization__sub-form">
+        <Input
+                id="userEmailToInvite"
+                aria-label="Adresse email"
+                @value={{@userEmailToInvite}}
+                class={{if @userEmailToInviteError "organization-sub-form__input organization-sub-form__input__error form-control" "organization-sub-form__input form-control"}}
+                @placeholder="Adresse email de l'utilisateur à inviter" />
+        {{#if @isLoading}}
+          <button type="button" class="organization-sub-form__validate-button btn btn-outline-default">
+            Inviter
+          </button>
+        {{else}}
+          <button type="button" {{on "click" @createOrganizationInvitation}} class="organization-sub-form__validate-button btn btn-outline-default">
+            Inviter
+          </button>
+        {{/if}}
+      </div>
+      {{#if @userEmailToInviteError}}
+        <div class="organization-sub-form__error-message">{{@userEmailToInviteError}}</div>
+      {{/if}}
+    </form>
+  </div>
 </section>
 
 <section class="page-section mb_10">

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -3,11 +3,15 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
+import isEmailValid from '../../../utils/email-validator';
 
 export default class GetController extends Controller {
 
-  @tracked userEmail = null;
+  @tracked userEmailToAdd = null;
+  @tracked userEmailToInvite = null;
+  @tracked userEmailToInviteError;
   @tracked targetProfilesToAttach = [];
+  @tracked isLoading = false;
 
   @service notifications;
 
@@ -39,7 +43,7 @@ export default class GetController extends Controller {
 
   @action
   async addMembership() {
-    const email = this.userEmail.trim();
+    const email = this.userEmailToAdd.trim();
     const organization = this.model;
     const matchingUsers = await this.store.query('user', { filter: { email } });
 
@@ -57,7 +61,7 @@ export default class GetController extends Controller {
     return this.store.createRecord('membership', { organization, user })
       .save()
       .then(async () => {
-        this.userEmail = null;
+        this.userEmailToAdd = null;
         this.notifications.success('Accès attribué avec succès.');
       })
       .catch(() => {
@@ -65,9 +69,43 @@ export default class GetController extends Controller {
       });
   }
 
+  @action
+  createOrganizationInvitation() {
+    this.isLoading = true;
+    if (!this._isEmailToInviteValid(this.userEmailToInvite)) {
+      this.isLoading = false;
+      return;
+    }
+    const email = this.userEmailToInvite.trim();
+
+    return this.store.createRecord('organization-invitation', { email })
+      .save({ adapterOptions: { organizationId: this.model.id } })
+      .then((organizationInvitation) => {
+        this.notifications.success(`Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`);
+        this.userEmailToInvite = null;
+      })
+      .catch(() => this.notifications.error('Une erreur s’est produite, veuillez réessayer.'))
+      .finally(() => this.isLoading = false);
+  }
+
   _toArrayWithUnique(targetProfilesToAttach) {
     const trimedTargetProfilesToAttach = targetProfilesToAttach.split(',').map((targetProfileId) => targetProfileId.trim());
     return _.uniq(trimedTargetProfilesToAttach);
+  }
+
+  _isEmailToInviteValid(email) {
+    if (!email || !email.trim()) {
+      this.userEmailToInviteError = 'Ce champ est requis.';
+      return false;
+    }
+
+    if (!isEmailValid(email)) {
+      this.userEmailToInviteError = 'L\'adresse email saisie n\'est pas valide.';
+      return false;
+    }
+
+    this.userEmailToInviteError = null;
+    return true;
   }
 
 }

--- a/admin/app/models/organization-invitation.js
+++ b/admin/app/models/organization-invitation.js
@@ -1,0 +1,15 @@
+import Model, { belongsTo, attr } from '@ember-data/model';
+import { equal } from '@ember/object/computed';
+
+export default class OrganizationInvitation extends Model {
+
+  @attr email;
+  @attr status;
+  @attr createdAt;
+  @attr organizationName;
+
+  @belongsTo('organization') organization;
+
+  @equal('status', 'pending') isPending;
+  @equal('status', 'accepted') isAccepted;
+}

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -47,19 +47,38 @@
     }
   }
 
-  .organization__sub-form {
-    display: flex;
+  .page-section__header {
+    justify-content: space-around;
+  }
 
-    .organization-sub-form__input {
-      border-right: none;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      width: 280px;
+  .organization__forms-section {
+    display: flex;
+    justify-content: space-around;
+
+    .organization__sub-form {
+      display: flex;
+
+      .organization-sub-form__input {
+        border-right: none;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        width: 280px;
+
+        &__error {
+          border-right: 1px solid $error;
+          border-color: $error;
+        }
+      }
+
+      .organization-sub-form__validate-button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
     }
 
-    .organization-sub-form__validate-button {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+    .organization-sub-form__error-message {
+      color: $error;
+      font-size: .85rem;
     }
   }
 }

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -18,7 +18,13 @@
 
   <OrganizationInformationSection @organization={{@model}} @onLogoUpdated={{this.updateOrganizationInformation}} />
 
-  <OrganizationMembersSection @organization={{@model}} @userEmail={{this.userEmail}} @addMembership={{this.addMembership}} />
+  <OrganizationMembersSection @organization={{@model}}
+                              @userEmailToAdd={{this.userEmailToAdd}}
+                              @userEmailToInvite={{this.userEmailToInvite}}
+                              @addMembership={{this.addMembership}}
+                              @createOrganizationInvitation={{this.createOrganizationInvitation}}
+                              @userEmailToInviteError={{this.userEmailToInviteError}}
+                              @isLoading={{this.isLoading}}/>
 
   <OrganizationTargetProfilesSection @targetProfiles={{@model.targetProfiles}} @targetProfilesToAttach={{this.targetProfilesToAttach}} @attachTargetProfiles={{this.attachTargetProfiles}} />
 

--- a/admin/app/utils/email-validator.js
+++ b/admin/app/utils/email-validator.js
@@ -1,0 +1,10 @@
+export default function isEmailValid(email) {
+
+  if (!email) {
+    return false;
+  }
+  // From http://stackoverflow.com/a/46181/5430854
+  // eslint-disable-next-line no-useless-escape
+  const emailPattern = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+  return emailPattern.test(email.trim());
+}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -61,4 +61,12 @@ export default function() {
       }];
   }));
 
+  this.post('/organizations/:id/invitations', (schema, request) => {
+    const params = JSON.parse(request.requestBody);
+    const email = params.data.attributes.email;
+
+    schema.organizationInvitations.create({ email });
+
+    return schema.organizationInvitations.where({ email });
+  });
 }

--- a/admin/tests/integration/components/organization-members-section-test.js
+++ b/admin/tests/integration/components/organization-members-section-test.js
@@ -9,8 +9,9 @@ module('Integration | Component | organization-members-section', function(hooks)
   test('it renders', async function(assert) {
 
     this.set('addMembership', () => true);
+    this.set('createOrganizationInvitation', () => true);
 
-    await render(hbs`{{organization-members-section addMembership=(action addMembership)}}`);
+    await render(hbs`{{organization-members-section addMembership=addMembership createOrganizationInvitation=createOrganizationInvitation}}`);
 
     assert.dom('.member-list').exists();
   });

--- a/admin/tests/unit/controllers/authenticated/organizations/get-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Controller | authenticated/organizations/list', function(hooks) {
+
+  setupTest(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/organizations/get');
+  });
+
+  module('#createOrganizationInvitation', function() {
+
+    test('it should create an organization-invitation if the email is valid', function(assert) {
+      const saveStub = sinon.stub().resolves();
+      const createRecordStub = sinon.stub().returns({
+        save: saveStub
+      });
+      controller.store = Service.create({ createRecord: createRecordStub });
+      controller.model = { id: 1 };
+
+      controller.userEmailToInvite = 'test@example.net';
+
+      controller.createOrganizationInvitation();
+
+      assert.ok(createRecordStub.calledWith('organization-invitation', { email: 'test@example.net' }));
+      assert.equal(saveStub.callCount, 1);
+    });
+
+    test('it should fail if userEmailToInvite is undefined', function(assert) {
+      controller.userEmailToInvite = undefined;
+
+      controller.createOrganizationInvitation();
+
+      assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
+    });
+
+    test('it should fail if userEmailToInvite is empty', function(assert) {
+      controller.userEmailToInvite = '';
+
+      controller.createOrganizationInvitation();
+
+      assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
+    });
+
+    test('it should fail if userEmailToInvite is not a valid email address', function(assert) {
+      controller.userEmailToInvite = 'not_valid_email';
+
+      controller.createOrganizationInvitation();
+
+      assert.equal(controller.userEmailToInviteError, 'L\'adresse email saisie n\'est pas valide.');
+    });
+  });
+});

--- a/admin/tests/unit/utils/email-validator-test.js
+++ b/admin/tests/unit/utils/email-validator-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import isEmailValid from 'pix-admin/utils/email-validator';
+
+module('Unit | Utils | email validator', function(hooks) {
+  setupTest(hooks);
+
+  module('Invalid emails', function() {
+    [
+      '',
+      ' ',
+      null,
+      'INVALID_EMAIL',
+      'INVALID_EMAIL@',
+      'INVALID_EMAIL@pix',
+      'INVALID_EMAIL@pix.',
+      '@pix.fr',
+      '@pix'
+    ].forEach(function(badEmail) {
+      test(`should return false when email is invalid: ${badEmail}`, function(assert) {
+        assert.equal(isEmailValid(badEmail), false);
+      });
+    });
+  });
+
+  module('Valid emails', function() {
+    [
+      'user@pix.fr',
+      'user@pix.fr ',
+      ' user@pix.fr',
+      ' user@pix.fr ',
+      ' user-beta@pix.fr ',
+      ' user_beta@pix.fr ',
+      'user+beta@pix.fr',
+      'user+beta@pix.gouv.fr',
+      'user+beta@pix.beta.gouv.fr'
+    ].forEach(function(validEmail) {
+      test(`should return true if provided email is valid: ${validEmail}`, function(assert) {
+        assert.equal(isEmailValid(validEmail), true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le processus actuel d'ajout du premier utilisateur à une organisation est long et nécessite de nombreuses étapes qui ne sont pas couvertes par l'application Pix Admin. 

## :robot: Solution
Il existe cependant, un processus d'invitation par email (présent uniquement dans Pix Orga) qui permet de réaliser ces opérations plus simplement. Il a donc été décidé d'ajouter un formulaire dans Pix Admin permettant d'envoyer des invitations à rejoindre une organisation. 

## :rainbow: Remarques
Le premier utilisateur à rejoindre un organisation possède automatiquement le rôle ADMIN. Les utilisateur suivants auront par défaut le rôle MEMBER (le rôle est modifiable depuis Pix Orga). 

## :100: Pour tester
- Aller sur la page de détail d'une organisation dans Pix Admin.
- Renseigner une adresse email dans le formulaire "Inviter un membre" et cliquer sur "Inviter".
-  Cliquer sur  le lien du mail et suivre la procédure de création de compte dans Pix Orga.
- Vérifier que l'on est bien administrateur ou membre de l'organisation que l'on vient de rejoindre.
