### PR TITLE
[TECH] Ajout de tests E2E Cypress sur PixCertif (PC-142)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ jobs:
     docker:
       - image: circleci/node:12.14.0-browsers
         environment:
-          # See https://git.io/vdao3 for details.
           JOBS: 2
     working_directory: ~/pix/orga
     steps:
@@ -151,7 +150,6 @@ jobs:
     docker:
       - image: circleci/node:12.14.0-browsers
         environment:
-          # See https://git.io/vdao3 for details.
           JOBS: 2
     working_directory: ~/pix/certif
     steps:
@@ -172,7 +170,6 @@ jobs:
     docker:
       - image: circleci/node:12.14.0-browsers
         environment:
-          # See https://git.io/vdao3 for details.
           JOBS: 2
     working_directory: ~/pix/admin
     steps:
@@ -242,9 +239,20 @@ jobs:
             - v7-orga-npm-{{ checksum "~/pix/orga/cachekey" }}
       - run:
           environment:
-            # See https://git.io/vdao3 for details.
             JOBS: 2
           working_directory: ~/pix/orga
+          command: npm ci
+
+      - run:
+          working_directory: ~/pix/certif
+          command: cat package*.json > cachekey
+      - restore_cache:
+          keys:
+            - v7-certif-npm-{{ checksum "~/pix/certif/cachekey" }}
+      - run:
+          environment:
+            JOBS: 2
+          working_directory: ~/pix/certif
           command: npm ci
 
       - run:
@@ -264,8 +272,14 @@ jobs:
       - run:
           working_directory: ~/pix/orga
           environment:
-            # See https://git.io/vdao3 for details.
             JOBS: 2
+          background: true
+          command: npm start
+
+      - run:
+          working_directory: ~/pix/certif
+          environment:
+            JOBS: 1
           background: true
           command: npm start
 

--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -2,7 +2,8 @@
   "baseUrl": "http://localhost:4200",
   "env": {
     "API_URL": "http://localhost:3000",
-    "ORGA_URL": "http://localhost:4201"
+    "ORGA_URL": "http://localhost:4201",
+    "CERTIF_URL": "http://localhost:4203"
   },
   "video": false,
   "blacklistHosts": "*stats.pix.fr*"

--- a/high-level-tests/e2e/cypress/fixtures/certification-candidates.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-candidates.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "userId": null,
+    "sessionId": 1,
+    "lastName": "Berger",
+    "firstName": "Michel",
+    "birthdate": "1990-01-04",
+    "birthCity": "Perpignan",
+    "birthProvinceCode": "66",
+    "birthCountry": "France",
+    "externalId": "TEAMCERTIFDECHIRE",
+    "email": "michel.berger@example.net",
+    "extraTimePercentage": null
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/certification-candidates.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-candidates.json
@@ -12,5 +12,33 @@
     "externalId": "TEAMCERTIFDECHIRE",
     "email": "michel.berger@example.net",
     "extraTimePercentage": null
+  },
+  {
+    "id": 2,
+    "userId": 1,
+    "sessionId": 2,
+    "lastName": "Gall",
+    "firstName": "France",
+    "birthdate": "1990-01-05",
+    "birthCity": "Montpellier",
+    "birthProvinceCode": "33",
+    "birthCountry": "France",
+    "externalId": "TOUTPIXDECHIRE",
+    "email": "france.gall@example.net",
+    "extraTimePercentage": 0.3
+  },
+  {
+    "id": 3,
+    "userId": 2,
+    "sessionId": 2,
+    "lastName": "Balavoine",
+    "firstName": "Daniel",
+    "birthdate": "1990-02-04",
+    "birthCity": "Toulouse",
+    "birthProvinceCode": "31",
+    "birthCountry": "France",
+    "externalId": "LAURADECHIRE",
+    "email": "daniel.balavoine@example.net",
+    "extraTimePercentage": null
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/certification-center-memberships.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-center-memberships.json
@@ -1,0 +1,6 @@
+[
+  {
+    "userId": 7,
+    "certificationCenterId": 1
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/certification-centers.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-centers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "type": "SCO",
+    "name": "Centre de certification Sco"
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/certification-courses.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-courses.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": 1,
+    "userId": 1,
+    "sessionId": 2,
+    "lastName": "Berger",
+    "firstName": "Michel",
+    "birthdate": "1990-01-04",
+    "birthplace": "Perpignan",
+    "externalId": "TEAMCERTIFDECHIRE",
+    "isV2Certification": true
+  },
+  {
+    "id": 2,
+    "userId": 2,
+    "sessionId": 2,
+    "lastName": "Balavoine",
+    "firstName": "Daniel",
+    "birthdate": "1990-02-04",
+    "birthplace": "Toulouse",
+    "externalId": "LAURADECHIRE",
+    "isV2Certification": true
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/sessions.json
+++ b/high-level-tests/e2e/cypress/fixtures/sessions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "certificationCenterId": 1,
+    "certificationCenter": "Centre de certification Sco",
+    "address": "4 rue du Pix En Folie",
+    "room": "Salle de la session 1",
+    "examiner": "AnneSophix",
+    "date": "2050-12-25",
+    "time": "15:00",
+    "description": "Session pas commencée avec aucun candidat inscrit",
+    "accessCode": "ANNE01"
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/sessions.json
+++ b/high-level-tests/e2e/cypress/fixtures/sessions.json
@@ -10,5 +10,17 @@
     "time": "15:00",
     "description": "Session pas commencée avec aucun candidat inscrit",
     "accessCode": "ANNE01"
+  },
+  {
+    "id": 2,
+    "certificationCenterId": 1,
+    "certificationCenter": "Centre de certification Sco",
+    "address": "4 rue du Pix En Folie",
+    "room": "Salle de la session 2",
+    "examiner": "AnneSophix",
+    "date": "2040-12-25",
+    "time": "14:00",
+    "description": "Session commencée pas encore finalisée",
+    "accessCode": "ANNE02"
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -47,5 +47,14 @@
     "email": "cersei.lannister@example.net",
     "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
     "cgu": true
+  },
+  {
+    "id": 7,
+    "firstName": "Certif",
+    "lastName": "Sco",
+    "email": "certif.sco@example.net",
+    "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
+    "cgu": true,
+    "pixCertifTermsOfServiceAccepted": true
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-candidates-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-candidates-management.feature
@@ -1,0 +1,24 @@
+#language: fr
+Fonctionnalité: Gestion des candidats inscrits à une session de certification
+
+  Contexte:
+    Étant donné que je vais sur Pix Certif
+    Et que les données de test sont chargées
+    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+    Lorsque je clique sur la session de certification dont la salle est "Salle de la session 1"
+    Et que je clique sur l'onglet des Candidats de la session de certification
+
+  Scénario: J'ajoute un candidat à la session de certification
+    Étant donné que je clique sur l'onglet des Candidats de la session de certification
+    Alors je vois la page des candidats de certification
+    Et je vois 1 candidat dans le tableau de candidats
+    Lorsque je clique sur "Ajouter un candidat"
+    Alors je vois un formulaire d'ajout de candidat apparaître en haut du tableau de candidats
+    Lorsque j'ajoute un candidat
+    Alors je vois 2 candidats dans le tableau de candidats
+
+  Scénario: Je supprime un candidat de la session de certification
+    Étant donné que je clique sur l'onglet des Candidats de la session de certification
+    Alors je vois 1 candidat dans le tableau de candidats
+    Lorsque je retire un candidat de la liste
+    Alors je vois 0 candidat dans le tableau de candidats

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-creation.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-creation.feature
@@ -1,0 +1,17 @@
+#language: fr
+Fonctionnalité: Création d'une session de certification
+
+  Contexte:
+    Étant donné que je vais sur Pix Certif
+    Et que les données de test sont chargées
+    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+
+  Scénario: Je confirme la création d'une session de certification
+    Lorsque je clique sur "Créer une session"
+    Alors je vois le formulaire de création de session de certification
+    Lorsque je remplis le formulaire de création de session de certification
+    Et je clique sur "Créer la session"
+    Alors je vois les détails d'une session de certification
+    Lorsque je clique sur le bouton de retour de la page de détails d'une session
+    Alors je vois la liste des sessions de certification
+    Et je vois 3 sessions de certification dans la liste

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-finalization.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-finalization.feature
@@ -1,0 +1,25 @@
+#language: fr
+Fonctionnalité: Finalisation d'une session de certification
+
+  Contexte:
+    Étant donné que je vais sur Pix Certif
+    Et que les données de test sont chargées
+    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+
+  Scénario: Je finalise une session de certification
+    Lorsque je clique sur la session de certification dont la salle est "Salle de la session 2"
+    Alors je vois les détails d'une session de certification
+    Lorsque je clique sur "Finaliser la session"
+    Alors je vois le formulaire de finalisation de session de certification
+    Et je vois 2 candidats à finaliser
+    Lorsque j'oublie de cocher une case d'Écran de fin de test vu
+    Lorsque je clique sur le bouton pour finaliser la session
+    Alors je vois une modale qui me signale 1 oubli de case Écran de fin test
+    Lorsque je clique sur "Annuler"
+    Alors je vois le formulaire de finalisation de session de certification
+    Lorsque je coche toutes les cases d'Écran de fin de test vu
+    Lorsque je clique sur le bouton pour finaliser la session
+    Alors je vois une modale qui me signale 0 oubli de case Écran de fin test
+    Lorsque je clique sur "Confirmer"
+    Alors je vois les détails d'une session de certification
+    Et je vois le bouton de finalisation désactivé

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-update.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-update.feature
@@ -1,0 +1,20 @@
+#language: fr
+Fonctionnalité: Modification d'une session de certification
+
+  Contexte:
+    Étant donné que je vais sur Pix Certif
+    Et que les données de test sont chargées
+    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+
+  Scénario: Je confirme la modification d'une session de certification
+    Lorsque je clique sur la session de certification dont la salle est "Salle de la session 1"
+    Alors je vois les détails d'une session de certification
+    Lorsque je clique sur "Modifier"
+    Alors je vois le formulaire de modification de session de certification
+    Lorsque je modifie l'adresse de la session de certification avec la valeur "Chemin des églantines"
+    Et je clique sur "Modifier la session"
+    Alors je vois les détails d'une session de certification
+    Et je lis la valeur "Chemin des églantines" à l'emplacement de l'adresse de la session
+    Lorsque je clique sur le bouton de retour de la page de détails d'une session
+    Alors je vois la liste des sessions de certification
+    Et je vois 2 sessions de certification dans la liste

--- a/high-level-tests/e2e/cypress/integration/pix-certif/login-logout-certif.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/login-logout-certif.feature
@@ -8,5 +8,6 @@ Fonctionnalité: Connexion - Déconnexion de Pix Certif
   Scénario: Je me connecte à Pix Certif
     Lorsque je me connecte avec le compte "certif.sco@example.net"
     Alors je suis redirigé vers le compte Certif de "Certif Sco"
+    Et je vois la liste des sessions de certification
     Lorsque je me déconnecte de Pix Certif
     Alors je suis redirigé vers la page "/connexion"

--- a/high-level-tests/e2e/cypress/integration/pix-certif/login-logout-certif.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/login-logout-certif.feature
@@ -1,0 +1,12 @@
+#language: fr
+Fonctionnalité: Connexion - Déconnexion de Pix Certif
+
+  Contexte:
+    Étant donné que je vais sur Pix Certif
+    Et que les données de test sont chargées
+
+  Scénario: Je me connecte à Pix Certif
+    Lorsque je me connecte avec le compte "certif.sco@example.net"
+    Alors je suis redirigé vers le compte Certif de "Certif Sco"
+    Lorsque je me déconnecte de Pix Certif
+    Alors je suis redirigé vers la page "/connexion"

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -80,11 +80,20 @@ Cypress.Commands.add('visitOrga', (url) => {
   return cy.visit(url, { app: 'orga' });
 });
 
+Cypress.Commands.add('visitCertif', (url) => {
+  return cy.visit(url, { app: 'certif' });
+});
+
 Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   const ORGA_URL = Cypress.env('ORGA_URL');
+  const CERTIF_URL = Cypress.env('CERTIF_URL');
 
   if (options.app === 'orga') {
     url = ORGA_URL + url;
+  }
+
+  if (options.app === 'certif') {
+    url = CERTIF_URL + url;
   }
 
   return originalFn(url, options);

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -13,6 +13,8 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'knowledge-elements');
   cy.task('db:fixture', 'users_pix_roles');
   cy.task('db:fixture', 'schooling-registrations');
+  cy.task('db:fixture', 'certification-centers');
+  cy.task('db:fixture', 'certification-center-memberships');
 });
 
 given('tous les comptes sont créés', () => {
@@ -25,6 +27,10 @@ given('je vais sur Pix', () => {
 
 given('je vais sur Pix Orga', () => {
   cy.visitOrga('/');
+});
+
+given('je vais sur Pix Certif', () => {
+  cy.visitCertif('/');
 });
 
 given('j\'accède à mon profil', () => {
@@ -45,6 +51,10 @@ given('je suis connecté à Pix en tant que {string}', (user) => {
 
 given('je suis connecté à Pix Orga', () => {
   cy.login('daenerys.targaryen@pix.fr', 'pix123');
+});
+
+given('je suis connecté à Pix Certif', () => {
+  cy.login('certif.sco@example.net', 'pix123');
 });
 
 given('je suis connecté à Pix en tant qu\'administrateur', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -15,6 +15,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'schooling-registrations');
   cy.task('db:fixture', 'certification-centers');
   cy.task('db:fixture', 'certification-center-memberships');
+  cy.task('db:fixture', 'sessions');
 });
 
 given('tous les comptes sont créés', () => {
@@ -53,8 +54,8 @@ given('je suis connecté à Pix Orga', () => {
   cy.login('daenerys.targaryen@pix.fr', 'pix123');
 });
 
-given('je suis connecté à Pix Certif', () => {
-  cy.login('certif.sco@example.net', 'pix123');
+given('je suis connecté à Pix Certif avec le mail {string}', (email) => {
+  cy.login(email, 'pix123');
 });
 
 given('je suis connecté à Pix en tant qu\'administrateur', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -17,6 +17,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'certification-center-memberships');
   cy.task('db:fixture', 'sessions');
   cy.task('db:fixture', 'certification-candidates');
+  cy.task('db:fixture', 'certification-courses');
 });
 
 given('tous les comptes sont créés', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -16,6 +16,7 @@ given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'certification-centers');
   cy.task('db:fixture', 'certification-center-memberships');
   cy.task('db:fixture', 'sessions');
+  cy.task('db:fixture', 'certification-candidates');
 });
 
 given('tous les comptes sont créés', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -52,6 +52,13 @@ then(`je suis redirigé vers le compte Orga de {string}`, (fullName) => {
   });
 });
 
+then(`je suis redirigé vers le compte Certif de {string}`, (fullName) => {
+  cy.url().should('include', '/sessions/list');
+  cy.get('.topbar__user-identification').should((userName) => {
+    expect(userName.text()).to.contains(fullName);
+  });
+});
+
 when(`je me déconnecte`, () => {
   cy.get('.logged-user-name__link').click();
   cy.get('.logged-user-menu__link:last-of-type').click();
@@ -60,6 +67,10 @@ when(`je me déconnecte`, () => {
 when(`je me déconnecte de Pix Orga`, () => {
   cy.get('.topbar__user-logged-menu').click();
   cy.get('.logged-user-menu-item:last-of-type').click();
+});
+
+when(`je me déconnecte de Pix Certif`, () => {
+  cy.contains('Se déconnecter').click();
 });
 
 then(`je suis redirigé vers la page {string}`, (pathname) => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -28,6 +28,23 @@ then(`je lis la valeur {string} à l'emplacement de l'adresse de la session`, (s
   cy.get('.session-details-row div:nth-child(2)').should('contain', sessionAddress);
 });
 
+then(`je vois la page des candidats de certification`, () => {
+  cy.url().should('match', /sessions\/[0-9]*\/candidats/);
+});
+
+then(`je vois un formulaire d'ajout de candidat apparaître en haut du tableau de candidats`, () => {
+  cy.get('table tbody tr:nth-child(1) td:nth-child(1)').should('have.attr', 'data-test-id', 'panel-candidate__lastName__add-staging');
+});
+
+then('je vois {int} candidat(s) dans le tableau de candidats', (candidateCount) => {
+  if(candidateCount === 0) {
+    cy.get('.table__empty').should('exist');
+    cy.get('.table__empty').should('contain', 'En attente de candidats');
+  } else {
+    cy.get('table tbody tr').should('have.length', candidateCount);
+  }
+});
+
 when('je remplis le formulaire de création de session de certification', () => {
   cy.get('#session-address').type('2 rue du Pix Zen');
   cy.get('#session-room').type('Salle suspendue');
@@ -47,4 +64,25 @@ when('je clique sur la session de certification dont la salle est {string}', (ro
 
 when(`je modifie l\'adresse de la session de certification avec la valeur {string}`, (newAddress) => {
   cy.get('#session-address').type(newAddress);
+});
+
+when(`je clique sur l'onglet des Candidats de la session de certification`, () => {
+  cy.get('nav a:nth-child(2)').click();
+});
+
+when(`j'ajoute un candidat`, () => {
+  cy.get('[data-test-id="panel-candidate__lastName__add-staging"] > div > input').type('Candidat');
+  cy.get('[data-test-id="panel-candidate__firstName__add-staging"] > div > input').type('Jean');
+  cy.get('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input').type('04011990');
+  cy.get('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input').type('Compète-Ville');
+  cy.get('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input').type('75');
+  cy.get('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input').type('Brésil');
+  cy.get('[data-test-id="panel-candidate__email__add-staging"] > div > input').type('jean.candidat@example.net');
+  cy.get('[data-test-id="panel-candidate__externalId__add-staging"] > div > input').type('ID123456AZ');
+  cy.get('[data-test-id="panel-candidate__extraTimePercentage__add-staging"] > div > input').type('30');
+  cy.contains('Enregistrer').click();
+});
+
+when('je retire un candidat de la liste', () => {
+  cy.get('.certification-candidates-actions__delete button').click();
 });

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -1,0 +1,50 @@
+then('je vois la liste des sessions de certification', () => {
+  cy.url().should('contain', '/sessions/list');
+  cy.get('.session-list-page').should('exist');
+});
+
+then('je vois {int} session(s) de certification dans la liste', (sessionCount) => {
+  cy.get('table tbody tr').should('have.length', sessionCount);
+});
+
+then(`je vois les détails d'une session de certification`, () => {
+  cy.url().should('match', /sessions\/[0-9]*/);
+  cy.get('.session-details-page').should('exist');
+});
+
+then(`je vois le formulaire de création de session de certification`, () => {
+  cy.url().should('contain', '/sessions/creation');
+  cy.get('.page__title').should('contain', `Création d'une session de certification`);
+  cy.get('form').should('exist');
+});
+
+then(`je vois le formulaire de modification de session de certification`, () => {
+  cy.url().should('match', /sessions\/[0-9]*\/modification/);
+  cy.get('.page__title').should('contain', `Modification d'une session de certification`);
+  cy.get('form').should('exist');
+});
+
+then(`je lis la valeur {string} à l'emplacement de l'adresse de la session`, (sessionAddress) => {
+  cy.get('.session-details-row div:nth-child(2)').should('contain', sessionAddress);
+});
+
+when('je remplis le formulaire de création de session de certification', () => {
+  cy.get('#session-address').type('2 rue du Pix Zen');
+  cy.get('#session-room').type('Salle suspendue');
+  cy.get('.flatpickr-day.today').click({ force: true });
+  cy.get('#session-time').click();
+  cy.get('#session-examiner').type('John Travolta');
+  cy.get('#session-description').type('Session créée par Cypress tout seul comme un grand !');
+});
+
+when(`je clique sur le bouton de retour de la page de détails d'une session`, () => {
+  cy.get('.session-details-content__return-button').click();
+});
+
+when('je clique sur la session de certification dont la salle est {string}', (roomLabel) => {
+  cy.contains(roomLabel).click();
+});
+
+when(`je modifie l\'adresse de la session de certification avec la valeur {string}`, (newAddress) => {
+  cy.get('#session-address').type(newAddress);
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -45,6 +45,19 @@ then('je vois {int} candidat(s) dans le tableau de candidats', (candidateCount) 
   }
 });
 
+then('je vois le formulaire de finalisation de session de certification', () => {
+  cy.url().should('match', /sessions\/[0-9]*\/finalisation/);
+  cy.get('.session-finalization-step-container').should('have.length', 3);
+});
+
+then('je vois {int} candidat(s) à finaliser', (candidateCount) => {
+  cy.get('table.session-finalization-reports-informations-step__table tbody tr').should('have.length', candidateCount);
+});
+
+then('je vois le bouton de finalisation désactivé', () => {
+  cy.get('.session-details-container div:nth-child(3) div:nth-child(2)').should('have.class', 'button--disabled');
+});
+
 when('je remplis le formulaire de création de session de certification', () => {
   cy.get('#session-address').type('2 rue du Pix Zen');
   cy.get('#session-room').type('Salle suspendue');
@@ -85,4 +98,38 @@ when(`j'ajoute un candidat`, () => {
 
 when('je retire un candidat de la liste', () => {
   cy.get('.certification-candidates-actions__delete button').click();
+});
+
+when(`j'oublie de cocher une case d'Écran de fin de test vu`, () => {
+  cy.get('table.session-finalization-reports-informations-step__table tbody tr').each(function ($element, index, collection) {
+    const checkBox = $element.find('td:nth-child(5) div');
+    if(index !== collection.length - 1 && checkBox.hasClass('checkbox--unchecked')) {
+      cy.wrap(checkBox).click();
+    } else if(index === collection.length - 1 && checkBox.hasClass('checkbox--checked')) {
+      cy.wrap(checkBox).click();
+    }
+  });
+});
+
+when(`je coche toutes les cases d'Écran de fin de test vu`, () => {
+  cy.get('table.session-finalization-reports-informations-step__table tbody tr').each(function ($element) {
+    const checkBox = $element.find('td:nth-child(5) div');
+    if(checkBox.hasClass('checkbox--unchecked')) {
+      cy.wrap(checkBox).click();
+    }
+  });
+});
+
+when(`je clique sur le bouton pour finaliser la session`, () => {
+  cy.get('.finalize__button').click();
+});
+
+when('je vois une modale qui me signale {int} oubli(s) de case Écran de fin test', (endTestForgottenCount) => {
+  cy.get('.pix-modal__container').should('exist');
+  if(endTestForgottenCount === 0) {
+    cy.get('div.app-modal-body__warning p').should('have.length', 1);
+  } else {
+    cy.get('div.app-modal-body__warning p').should('have.length', 2);
+    cy.get('.app-modal-body__contextual').should('contain', `La case "Écran de fin du test vu" n'est pas cochée pour ${endTestForgottenCount} candidat(s)`);
+  }
 });

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -18,15 +18,16 @@
     "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
     "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:run",
-    "cy:test": "run-p start:api start:mon-pix start:orga cy:run",
-    "cy:test:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga cy:run",
-    "cy:test:open": "run-p start:api start:mon-pix start:orga cy:open",
-    "cy:test:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga cy:open",
+    "cy:test": "run-p start:api start:mon-pix start:orga start:certif cy:run",
+    "cy:test:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga start:certif cy:run",
+    "cy:test:open": "run-p start:api start:mon-pix start:orga start:certif cy:open",
+    "cy:test:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga start:certif cy:open",
     "db:empty": "cd ../../api && npm run db:empty",
     "db:initialize": "cd ../../api && npm run db:prepare",
     "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
     "start:mon-pix": "cd ../../mon-pix && npx ember serve --proxy",
-    "start:orga": "cd ../../orga && npx ember serve --proxy"
+    "start:orga": "cd ../../orga && npx ember serve --proxy",
+    "start:certif": "cd ../../certif && npx ember serve --proxy"
   },
   "devDependencies": {
     "cypress": "^3.8.1",


### PR DESCRIPTION
## :unicorn: Problème
L'application PixCertif n'était pas encore couverte par des tests E2E sur Cypress. Ce qui est bien dommage, étant donné la faible quantité de features que présente pour le moment l'application.
De plus, de tels tests nous permettent d'apporter de la sérénité quant à la non-régression de features classiques/autoroutes.

## :robot: Solution
On ajoute des tests E2E dans les cas les plus classiques PixCertif :
- Connexion / Déconnexion PixCertif
- Création/Modification d'une session
- Gestion de candidats dans la liste des inscrits à la session
- Finalisation d'une session

## :rainbow: Remarques
Je veux bien des conseils pour ceux qui connaissent cypress, ce sont mes premiers tests ;)

## :100: Pour tester
Laissez la CI vous porter !!
