### PR TITLE
[BUGFIX] Correction du design du loader dans Pix Orga (PO-413).

### DIFF
--- a/orga/app/styles/globals/pix-modal.scss
+++ b/orga/app/styles/globals/pix-modal.scss
@@ -112,3 +112,11 @@
   align-items: center;
 }
 
+.ember-modal-overlay.translucent {
+  background-color: rgba(red($grey-200), green($grey-200), blue($grey-200), 0.2);
+}
+
+.pix-modal__translucent {
+  background-color: transparent;
+  box-shadow: none;
+}


### PR DESCRIPTION
## :unicorn: Problème
Suite au ticket https://1024pix.atlassian.net/browse/PO-382#icft=PO-382, le design des loader dans Pix Orga avaient été cassé.  

## :robot: Solution
Réparer le design des loader.

## :rainbow: Remarques
Suite au merge de la PR de design system dans Pix Orga, le design final n'est pas identique à celui qui existait avant.  