### PR TITLE
[DRAFT] Pouvoir s'assigner une session à traiter dans PixAdmin (PA-137)

### DIFF
--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -10,6 +10,9 @@ export default class SessionAdapter extends ApplicationAdapter {
     } else if (adapterOptions && adapterOptions.updatePublishedCertifications)  {
       delete adapterOptions.updatePublishedCertifications;
       return url + '/publication';
+    } else if (adapterOptions && adapterOptions.userAssignment)  {
+      delete adapterOptions.userAssignment;
+      return url + '/user-assignment';
     }
     return url;
   }
@@ -20,6 +23,8 @@ export default class SessionAdapter extends ApplicationAdapter {
     } else if (snapshot.adapterOptions.updatePublishedCertifications) {
       const data =  { data: { attributes: { toPublish: snapshot.adapterOptions.toPublish } } };
       return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PATCH', { data });
+    } else if (snapshot.adapterOptions.userAssignment) {
+      return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PATCH');
     }
 
     return super.updateRecord(...arguments);

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -4,14 +4,10 @@ import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 
 export default class IndexController extends Controller {
-  @service
-  sessionInfoService;
+  @service sessionInfoService;
+  @service notifications;
 
-  @service
-  notifications;
-
-  @alias('model')
-  session;
+  @alias('model') session;
 
   @action
   downloadSessionResultFile() {
@@ -34,5 +30,15 @@ export default class IndexController extends Controller {
   @action
   async tagSessionAsSentToPrescriber() {
     await this.session.save({ adapterOptions: { flagResultsAsSentToPrescriber: true } });
+  }
+
+  @action
+  async assignSessionToCurrentUser() {
+    try {
+      await this.session.save({ adapterOptions: { userAssignment: true } });
+      this.notifications.success('La session vous a correctement été assignée');
+    } catch (err) {
+      this.notifications.error('Erreur lors de l\'assignation à la session');
+    }
   }
 }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -16,10 +16,12 @@ function _formatHumanReadableLocaleDateTime(date, options) {
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const ONGOING = 'ongoing';
 export const PROCESSED = 'processed';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [ONGOING]: 'En cours de traitement',
   [PROCESSED]: 'Résultats transmis par Pix',
 };
 
@@ -44,7 +46,9 @@ export default class Session extends Model {
 
   @computed('status')
   get isFinalized() {
-    return this.status === FINALIZED || this.status === PROCESSED;
+    return this.status === FINALIZED
+        || this.status === ONGOING
+        || this.status === PROCESSED;
   }
 
   @computed('examinerGlobalComment')

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -83,18 +83,23 @@
 
   <div class="session-info__actions">
     <div class='row row--btn'>
-      <button class="btn btn-primary" {{action "downloadBeforeJuryFile"}} type="button">
+
+      <button class="btn btn-primary" {{on 'click' this.assignSessionToCurrentUser}}>
+        M'assigner la session
+      </button>
+
+      <button class="btn btn-primary" {{on 'click' this.downloadBeforeJuryFile}}>
         Récupérer le fichier avant jury
       </button>
 
-      <button class="btn btn-primary btn--right" {{action "downloadSessionResultFile"}} type="button">
+      <button class="btn btn-primary btn--right" {{on 'click' this.downloadSessionResultFile}}>
         Exporter les résultats
       </button>
 
       {{#if this.session.areResultsToBeSentToPrescriber}}
-      <button class="btn btn-primary" {{action "tagSessionAsSentToPrescriber"}} type="button">
-        Résultats transmis au prescripteur
-      </button>
+        <button class="btn btn-primary" {{on 'click' this.tagSessionAsSentToPrescriber}}>
+          Résultats transmis au prescripteur
+        </button>
       {{/if}}
     </div>
   </div>

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -63,9 +63,9 @@ module('Acceptance | Session page', function(hooks) {
       });
         // when
       await visit(`/sessions/${session.id}`);
-      await click('.session-info__actions button:nth-child(3)');
+      await click('.session-info__actions button:nth-child(4)');
         
-      assert.dom('.session-info__actions button:nth-child(3)').doesNotExist();
+      assert.dom('.session-info__actions button:nth-child(4)').doesNotExist();
     });
 
   });

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { FINALIZED } from 'pix-admin/models/session';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -30,8 +31,8 @@ module('Acceptance | Session pages', function(hooks) {
       session = server.create('session', {
         id: 1,
         certificationCenterName: 'Centre des Staranne',
+        status: FINALIZED,
         finalizedAt: new Date('2020-01-01T03:00:00Z'),
-        resultsSentToPrescriberAt: new Date('2020-02-01T03:00:00Z'),
         examinerGlobalComment: 'Commentaire du surveillant',
       });
     });
@@ -95,8 +96,19 @@ module('Acceptance | Session pages', function(hooks) {
         test('it show session informations', function(assert) {
           // then
           assert.dom('.session-info__details .row div:last-child').hasText(session.certificationCenterName);
-          assert.dom('[data-test-id="session-info__sent-to-prescriber-at"]').hasText(session.resultsSentToPrescriberAt.toLocaleString('fr-FR'));
+          assert.dom('[data-test-id="session-info__finalized-at"]').hasText(session.finalizedAt.toLocaleString('fr-FR'));
           assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
+        });
+      });
+
+      module('Buttons section', function() {
+
+        test('it show all buttons', function(assert) {
+          // then
+          assert.dom('.session-info__actions div button:first-child').hasText('M\'assigner la session');
+          assert.dom('.session-info__actions div button:nth-child(2)').hasText('Récupérer le fichier avant jury');
+          assert.dom('.session-info__actions div button:nth-child(3)').hasText('Exporter les résultats');
+          assert.dom('.session-info__actions div button:nth-child(4)').hasText('Résultats transmis au prescripteur');
         });
       });
     });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
@@ -146,7 +146,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         await visit(`/sessions/${session.id}`);
 
         // then
-        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(3)');
+        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(4)');
         assert.equal(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
       });
       
@@ -161,7 +161,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         await visit(`/sessions/${session.id}`);
 
         // then
-        assert.dom('.session-info__actions .row button:nth-child(3)').doesNotExist();
+        assert.dom('.session-info__actions .row button:nth-child(4)').doesNotExist();
       });
 
     });

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -4,14 +4,13 @@ import sinon from 'sinon';
 
 module('Unit | Adapter | session', function(hooks) {
   setupTest(hooks);
-
   let adapter;
 
   hooks.beforeEach(function() {
     adapter = this.owner.lookup('adapter:session');
   });
 
-  module('#urlForUpdateRecord', () => {
+  module('#urlForUpdateRecord', function() {
     test('should build update url from session id', function(assert) {
       // when
       const options = { adapterOptions: {} };
@@ -38,11 +37,23 @@ module('Unit | Adapter | session', function(hooks) {
       assert.ok(url.endsWith('/sessions/123/publication'));
     });
 
-    module('#updateRecord', () => {
-      
-      [true, false].forEach((isTrue) => 
+    test('should build specific url to user assignment', function(assert) {
+      // when
+      const options = { adapterOptions: { userAssignment: true } };
+      const url = adapter.urlForUpdateRecord(123, 'session', options);
+
+      // then
+      assert.ok(url.endsWith('/sessions/123/user-assignment'));
+    });
+  });
+
+  module('#updateRecord', function() {
+
+    module('when updatePublishedCertification adapterOption is passed', function() {
+
+      [true, false].forEach(function(isTrue) {
         test(`should send a patch request with publish to ${isTrue}`, function(assert) {
-        // when
+          // when
           const snapshot = { id: 123, adapterOptions: { updatePublishedCertifications: true, toPublish: isTrue } };
           adapter.ajax = sinon.stub();
 
@@ -51,9 +62,31 @@ module('Unit | Adapter | session', function(hooks) {
           // then
           sinon.assert.calledWithExactly(adapter.ajax, 'http://localhost:3000/api/sessions/123/publication', 'PATCH', { data: { data: { attributes: { toPublish: isTrue } } } });
           assert.ok(adapter);
-        })
-      );
+        });
+      });
     });
 
+    module('when userAssignment adapterOption passed', function(hooks) {
+
+      hooks.beforeEach(function() {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function() {
+        adapter.ajax.restore();
+      });
+
+      test('should send a patch request to user assignment endpoint', async function(assert) {
+        // given
+        adapter.ajax.resolves();
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'session' }, { id: 123, adapterOptions: { userAssignment: true } });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/sessions/123/user-assignment', 'PATCH');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
   });
 });

--- a/api/db/migrations/20200327225551_add-column-assignedUserId-column-table-sessions.js
+++ b/api/db/migrations/20200327225551_add-column-assignedUserId-column-table-sessions.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'assignedUserId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).references('users.id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -304,6 +304,22 @@ exports.register = async (server) => {
         ]
       }
     },
+    {
+      method: 'PATCH',
+      path: '/api/sessions/{id}/user-assignment',
+      config: {
+        pre: [{
+          method: securityController.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.assignUser,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle PixMaster**\n' +
+          '- Assigne la session à un utilisateur PixMaster'
+        ],
+        tags: ['api', 'session', 'assignment']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -158,4 +158,11 @@ module.exports = {
     return resultsFlaggedAsSent ? h.response(serializedSession).created() : serializedSession;
   },
 
+  async assignUser(request) {
+    const sessionId = request.params.id;
+    const userId = request.auth.credentials.userId;
+    const session = await usecases.assignUserToSession({ sessionId, userId });
+    return sessionSerializer.serialize(session);
+  },
+
 };

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -3,11 +3,13 @@ const _ = require('lodash');
 const CREATED = 'created';
 const FINALIZED = 'finalized';
 const PROCESSED = 'processed';
+const ONGOING = 'ongoing';
 
 const statuses = {
   CREATED,
   FINALIZED,
   PROCESSED,
+  ONGOING,
 };
 
 const NO_EXAMINER_GLOBAL_COMMENT = null;
@@ -32,6 +34,7 @@ class Session {
     certificationCandidates,
     // references
     certificationCenterId,
+    assignedUserId,
   } = {}) {
     this.id = id;
     // attributes
@@ -51,6 +54,7 @@ class Session {
     this.certificationCandidates = certificationCandidates;
     // references
     this.certificationCenterId = certificationCenterId;
+    this.assignedUserId = assignedUserId;
   }
 
   areResultsFlaggedAsSent() {
@@ -60,6 +64,9 @@ class Session {
   get status() {
     if (this.publishedAt) {
       return statuses.PROCESSED;
+    }
+    if (this.assignedUserId) {
+      return statuses.ONGOING;
     }
     if (this.finalizedAt) {
       return statuses.FINALIZED;

--- a/api/lib/domain/usecases/assign-user-to-session.js
+++ b/api/lib/domain/usecases/assign-user-to-session.js
@@ -1,0 +1,16 @@
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = async function assignUserToSession({
+  sessionId,
+  userId,
+  sessionRepository,
+} = {}) {
+  const ERROR_MESSAGE = `La session ${sessionId} n'existe pas.`;
+  const integerSessionId = parseInt(sessionId);
+  if (!Number.isFinite(integerSessionId)) {
+    throw new NotFoundError(ERROR_MESSAGE);
+  }
+
+  const { id } = await sessionRepository.get(sessionId);
+  return sessionRepository.assignUser({ id, assignedUserId: userId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -69,6 +69,7 @@ module.exports = injectDependencies({
   answerToOrganizationInvitation: require('./answer-to-organization-invitation'),
   attachTargetProfilesToOrganization: require('./attach-target-profiles-to-organization'),
   archiveCampaign: require('./archive-campaign'),
+  assignUserToSession: require('./assign-user-to-session'),
   authenticateUser: require('./authenticate-user'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
   completeAssessment: require('./complete-assessment'),

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -146,4 +146,11 @@ module.exports = {
     };
   },
 
+  async assignUser({ id, assignedUserId }) {
+    let updatedSession = await new BookshelfSession({ id })
+      .save({ assignedUserId }, { method: 'update' });
+    updatedSession = await updatedSession.refresh();
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, updatedSession);
+  }
+
 };

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -7,14 +7,14 @@ const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
 
-  save: async (sessionData) => {
+  async save(sessionData) {
     sessionData = _.omit(sessionData, ['certificationCandidates']);
 
     const newSession = await new BookshelfSession(sessionData).save();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, newSession);
   },
 
-  isSessionCodeAvailable: async (accessCode) => {
+  async isSessionCodeAvailable(accessCode) {
     const sessionWithAccessCode = await BookshelfSession
       .where({ accessCode })
       .fetch({});
@@ -22,7 +22,7 @@ module.exports = {
     return !sessionWithAccessCode;
   },
 
-  isFinalized: async (id) => {
+  async isFinalized(id) {
     const session = await BookshelfSession
       .query((qb) => {
         qb.where({ id });

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -28,6 +28,7 @@ module.exports = {
         'certificationCandidates',
         'certificationReports',
         'certificationCenter',
+        'assignedUser',
       ],
       certifications : {
         ref: 'id',
@@ -65,6 +66,15 @@ module.exports = {
           }
         }
       },
+      assignedUser: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current) {
+            return `/api/users/${current.id}`;
+          }
+        }
+      },
       transform(session) {
         const transformedSession = Object.assign({}, session);
         transformedSession.status = session.status;
@@ -75,9 +85,13 @@ module.exports = {
         if (session.certificationCenterId) {
           transformedSession.certificationCenter = { id: session.certificationCenterId };
         }
+        if (session.assignedUserId) {
+          transformedSession.assignedUser = { id: session.assignedUserId };
+        }
         return transformedSession;
       },
     }).serialize(sessions);
+
   },
 
   serializeForFinalization(sessions) {
@@ -103,6 +117,7 @@ module.exports = {
         'publishedAt',
         'certifications',
         'certificationCenter',
+        'assignedUser',
       ],
       certifications : {
         ref: 'id',
@@ -122,6 +137,15 @@ module.exports = {
           }
         }
       },
+      assignedUser: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current) {
+            return `/api/users/${current.id}`;
+          }
+        }
+      },
       transform(session) {
         const transformedSession = Object.assign({}, session);
         transformedSession.status = session.status;
@@ -130,6 +154,9 @@ module.exports = {
         delete transformedSession.certificationCenter;
         if (session.certificationCenterId) {
           transformedSession.certificationCenter = { id: session.certificationCenterId };
+        }
+        if (session.assignedUserId) {
+          transformedSession.assignedUser = { id: session.assignedUserId };
         }
         return transformedSession;
       },

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -1,0 +1,109 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('PATCH /api/sessions/:id/user-assignment', () => {
+  let server;
+  const options = { method: 'PATCH' };
+  let userId;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  context('when user does not have the role PIX MASTER', () => {
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return a 403 error code', async () => {
+      // given
+      options.url = '/api/sessions/any/user-assignment';
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+  });
+
+  context('when user has role PixMaster', () => {
+
+    beforeEach(() => {
+      // given
+      userId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+      return databaseBuilder.commit();
+    });
+
+    context('when the session id has an invalid format', () => {
+
+      it('should return a 404 error code', async () => {
+        // given
+        options.url = '/api/sessions/any/user-assignment';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    context('when the session id is a number', () => {
+
+      context('when the session does not exist', () => {
+
+        it('should return a 404 error code', async () => {
+          // given
+          options.url = '/api/sessions/1/user-assignment';
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
+
+      context('when the session exists', () => {
+        let sessionId;
+
+        beforeEach(() => {
+          // given
+          sessionId = databaseBuilder.factory.buildSession().id;
+          return databaseBuilder.commit();
+        });
+
+        it('should return a 200 status code', async () => {
+          // given
+          options.url = `/api/sessions/${sessionId}/user-assignment`;
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
+
+        it('should return the serialized session with a link to the assigned user', async () => {
+          // given
+          options.url = `/api/sessions/${sessionId}/user-assignment`;
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const linkToAssignedUser = response.result.data.relationships['assigned-user'].links.related;
+          expect(linkToAssignedUser).to.equal(`/api/users/${userId}`);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -554,4 +554,27 @@ describe('Integration | Repository | Session', function() {
       });
     });
   });
+
+  describe('#assignUser', () => {
+    let id;
+    let assignedUserId;
+
+    beforeEach(() => {
+      id = databaseBuilder.factory.buildSession({ assignedUserId: null }).id;
+      assignedUserId = databaseBuilder.factory.buildUser().id;
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return an updated Session domain object', async () => {
+      // when
+      const updatedSession = await sessionRepository.assignUser({ id, assignedUserId });
+
+      // then
+      expect(updatedSession).to.be.an.instanceof(Session);
+      expect(updatedSession.id).to.deep.equal(id);
+      expect(updatedSession.assignedUserId).to.deep.equal(assignedUserId);
+      expect(updatedSession.status).to.deep.equal(statuses.ONGOING);
+    });
+  });
 });

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -20,6 +20,7 @@ module.exports = function buildSession({
   finalizedAt = null,
   resultsSentToPrescriberAt = null,
   publishedAt = null,
+  assignedUserId,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -43,6 +44,7 @@ module.exports = function buildSession({
     finalizedAt,
     resultsSentToPrescriberAt,
     publishedAt,
+    assignedUserId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -17,6 +17,7 @@ module.exports = function buildSession({
   finalizedAt = null,
   resultsSentToPrescriberAt = null,
   publishedAt = null,
+  assignedUserId,
 } = {}) {
   return new Session({
     id,
@@ -33,5 +34,6 @@ module.exports = function buildSession({
     finalizedAt,
     resultsSentToPrescriberAt,
     publishedAt,
+    assignedUserId,
   });
 };

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -367,6 +367,7 @@ describe('Unit | Application | Sessions | Routes', () => {
       expect(res.statusCode).to.equal(200);
     });
   });
+
   describe('PUT /api/sessions/{id}/results-sent-to-prescriber', () => {
     let sessionId;
 
@@ -381,6 +382,26 @@ describe('Unit | Application | Sessions | Routes', () => {
       sessionId = 3;
 
       const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/results-sent-to-prescriber` });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
+
+  describe('PATCH /api/sessions/{id}/user-assignment', () => {
+    let options;
+
+    beforeEach(() => {
+      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'assignUser').returns('ok');
+      const sessionId = 1;
+      options = {
+        method: 'PATCH',
+        url: `/api/sessions/${sessionId}/user-assignment`,
+      };
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject(options);
       expect(res.statusCode).to.equal(200);
     });
   });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -655,4 +655,34 @@ describe('Unit | Controller | sessionController', () => {
       expect(sessionSerializer.serializeForPaginatedFilteredResults).to.have.been.calledWithExactly(expectedResults, expectedPagination);
     });
   });
+
+  describe('#assignUser ', () => {
+    let request;
+    const sessionId = 1;
+    const session = Symbol('session');
+    const sessionJsonApi = Symbol('someSessionSerialized');
+
+    beforeEach(() => {
+      // given
+      request = {
+        params: { id : sessionId },
+        auth: {
+          credentials : {
+            userId,
+          }
+        },
+      };
+      sinon.stub(usecases, 'assignUserToSession').withArgs({ sessionId, userId }).resolves(session);
+      sinon.stub(sessionSerializer, 'serialize').withArgs(session).returns(sessionJsonApi);
+    });
+
+    it('should return updated session', async () => {
+      // when
+      const response = await sessionController.assignUser(request, hFake);
+
+      // then
+      expect(response).to.deep.equal(sessionJsonApi);
+    });
+
+  });
 });

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -18,6 +18,7 @@ const SESSION_PROPS = [
   'publishedAt',
   'certificationCandidates',
   'certificationCenterId',
+  'assignedUserId',
 ];
 
 describe('Unit | Domain | Models | Session', () => {
@@ -42,6 +43,7 @@ describe('Unit | Domain | Models | Session', () => {
       certificationCandidates: [],
       // references
       certificationCenterId: '',
+      assignedUserId: '',
     });
   });
 
@@ -100,28 +102,45 @@ describe('Unit | Domain | Models | Session', () => {
 
     context('when session publishedAt timestamp is not defined', () => {
 
-      context('when session finalizedAt timestamp is defined', () => {
+      context('when session assignedUserId is defined', () => {
 
-        it('should return FINALIZED', () => {
+        it('should return ONGOING', () => {
           // given
-          session.finalizedAt = new Date();
+          session.assignedUserId = Symbol('123');
 
           // when
           const status = session.status;
 
           // then
-          expect(status).to.equal(Session.statuses.FINALIZED);
+          expect(status).to.equal(Session.statuses.ONGOING);
         });
       });
 
-      context('when session finalizedAt timestamp is not defined', () => {
+      context('when session assignedUserId is not defined', () => {
+      
+        context('when session finalizedAt timestamp is defined', () => {
 
-        it('should return CREATED', () => {
-          // when
-          const status = session.status;
+          it('should return FINALIZED', () => {
+            // given
+            session.finalizedAt = new Date();
 
-          // then
-          expect(status).to.equal(Session.statuses.CREATED);
+            // when
+            const status = session.status;
+
+            // then
+            expect(status).to.equal(Session.statuses.FINALIZED);
+          });
+        });
+
+        context('when session finalizedAt timestamp is not defined', () => {
+
+          it('should return CREATED', () => {
+            // when
+            const status = session.status;
+
+            // then
+            expect(status).to.equal(Session.statuses.CREATED);
+          });
         });
       });
     });

--- a/api/tests/unit/domain/usecases/assign-user-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-user-to-session_test.js
@@ -1,0 +1,46 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const assignUserToSession = require('../../../../lib/domain/usecases/assign-user-to-session');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | assign-user-to-session', () => {
+  let sessionId;
+  const userId = 'someUserId';
+  let sessionRepository;
+
+  beforeEach(() => {
+    sessionRepository = { assignUser: sinon.stub(), get: sinon.stub() };
+  });
+
+  context('when session id is not a number', () => {
+
+    it('should throw a NotFound error', async () => {
+      // given
+      sessionId = 'notANumber';
+
+      // when
+      const error = await catchErr(assignUserToSession)({ sessionId, userId, sessionRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when session id is a number', () => {
+    const returnedSession = Symbol('returnedSession');
+
+    beforeEach(() => {
+      sessionId = 1;
+      sessionRepository.get.withArgs(sessionId).resolves({ id: sessionId });
+      sessionRepository.assignUser.withArgs({ id: sessionId, assignedUserId: userId }).resolves(returnedSession);
+    });
+
+    it('should return the session after assigningUser to it', async () => {
+      // when
+      const actualSession = await assignUserToSession({ sessionId, userId, sessionRepository });
+
+      // then
+      expect(sessionRepository.assignUser).to.have.been.calledWith({ id: sessionId, assignedUserId: userId });
+      expect(actualSession).to.equal(returnedSession);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
@@ -3,7 +3,7 @@ const flagSessionResultsAsSentToPrescriber = require('../../../../lib/domain/use
 const Session = require('../../../../lib/domain/models/Session');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
-describe('Unit | UseCase | set-date-of-sending-results-to-prescriber', () => {
+describe('Unit | UseCase | flag-session-results-as-sent-to-prescriber', () => {
   let sessionId;
   let sessionRepository;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -76,6 +76,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expect(json).to.deep.equal(expectedJsonApi);
       });
     });
+
     context('when session has a link to an existing certification center', () => {
 
       it('should convert a Session model object into JSON API data with a link to the certification center', function() {
@@ -89,6 +90,25 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expectedJsonApi.data.relationships['certification-center'] = {
           'links': {
             'related': '/api/certification-centers/13',
+          }
+        };
+        expect(json).to.deep.equal(expectedJsonApi);
+      });
+    });
+
+    context('when session has an assigned user', () => {
+
+      it('should convert a Session model object into JSON API data with a link to the assigned user', function() {
+        // given
+        modelSession.assignedUserId = 13;
+
+        // when
+        const json = serializer.serialize(modelSession);
+
+        // then
+        expectedJsonApi.data.relationships['assigned-user'] = {
+          'links': {
+            'related': '/api/users/13',
           }
         };
         expect(json).to.deep.equal(expectedJsonApi);
@@ -289,6 +309,27 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expectedResult.data.relationships['certification-center'] = {
           'links': {
             'related': '/api/certification-centers/13',
+          }
+        };
+        expect(json).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('when session has an assigned user', () => {
+
+      it('should convert a Session model object into JSON API data with a link to the assigned user', function() {
+        // given
+        modelSession.assignedUserId = 13;
+        const meta = { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 };
+        const expectedResult = Object.assign(expectedJsonApi, { meta });
+
+        // when
+        const json = serializer.serializeForPaginatedFilteredResults(modelSession, meta);
+
+        // then
+        expectedResult.data.relationships['assigned-user'] = {
+          'links': {
+            'related': '/api/users/13',
           }
         };
         expect(json).to.deep.equal(expectedResult);

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -7,10 +7,12 @@ const { Model, attr, belongsTo, hasMany } = DS;
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const ONGOING = 'ongoing';
 export const PROCESSED = 'processed';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [ONGOING]: 'Finalisée',
   [PROCESSED]: 'Résultats transmis par Pix',
 };
 
@@ -31,7 +33,9 @@ export default class Session extends Model {
 
   @computed('status')
   get isFinalized() {
-    return this.status === FINALIZED || this.status === PROCESSED;
+    return this.status === FINALIZED
+        || this.status === ONGOING
+        || this.status === PROCESSED;
   }
 
   @computed('certificationCandidates.@each.isLinked')


### PR DESCRIPTION
Ceci est un draft destiné à disparaître au profit de la [PA-137](https://github.com/1024pix/pix/pull/1239/commits/4ee89c36466db6de7f0582006d1d1d3c2c060ea2). 

J'ai créé ce draft pour avoir un historique rapidement consultable et visuel sur mes commits.