### PR TITLE
[BUGFIX] Supprime un logo de badge sur la page de résultat de certification

### DIFF
--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -12,15 +12,6 @@
   Il peut donc différer de votre nombre de Pix affiché dans votre profil.
 </div>
 
-
-
-{{#if true}}
-  <hr>
-  <h3 class="user-certifications-detail-result__title-comment-jury">Vous avez obtenu le badge</h3>
-  <img src="/images/badges/Pret-CleaNum.svg" alt="" class="user-certifications-detail-result__badge-clea">
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras efficitur dui quis nisl sollicitudin fringilla. Pellentesque vitae arcu purus. Ut ornare neque scelerisque lorem tincidunt, nec consectetur lorem sodales. Nunc eget elit leo. Suspendisse potenti. Donec tristique tortor et semper elementum.</p>
-{{/if}}
-
 <div>
   {{#if certification.commentForCandidate}}
     <hr>


### PR DESCRIPTION
## :unicorn: Problème

La PR #1151 a introduit un logo de badge sur la page de résultat de certification.

## :robot: Solution

Supprimer ce logo.

## :rainbow: Remarques

Comme quoi les branches qui durent longtemps c'est mal 🙈

## :100: Pour tester

- Aller sur Pix Admin, publier la session 4
- Se connecter en tant que Anne Success
- Afficher le résultat de certification publié
- Vérifier qu'il n'y a pas de logo de badge