### PR TITLE
[BUGFIX] Correction du design du formulaire de rattachement de profils cibles (PA-200).

### DIFF
--- a/admin/app/components/organization-target-profiles-section.hbs
+++ b/admin/app/components/organization-target-profiles-section.hbs
@@ -2,19 +2,21 @@
   <header class="page-section__header">
     <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
   </header>
-  <form aria-label="Rattacher un ou plusieurs profil(s) cible(s)" class="organization__sub-form form">
-    <Input
-      aria-label="ID du ou des profil(s) cible(s)"
-      @value={{@targetProfilesToAttach}}
-      class="organization-sub-form__input form-field__text form-control"
-      @placeholder="1, 2" />
-    <button
-      type="button"
-      {{on "click" @attachTargetProfiles}}
-      class="organization-sub-form__validate-button btn btn-outline-default">
-      Valider
-    </button>
-  </form>
+  <div class="organization__forms-section">
+    <form aria-label="Rattacher un ou plusieurs profil(s) cible(s)" class="organization__sub-form form">
+      <Input
+        aria-label="ID du ou des profil(s) cible(s)"
+        @value={{@targetProfilesToAttach}}
+        class="organization-sub-form__input form-field__text form-control"
+        @placeholder="1, 2" />
+      <button
+        type="button"
+        {{on "click" @attachTargetProfiles}}
+        class="organization-sub-form__validate-button btn btn-outline-default">
+        Valider
+      </button>
+    </form>
+  </div>
 </section>
 
 <section class="page-section mb_10">


### PR DESCRIPTION
## :unicorn: Problème
Suite à la PR https://github.com/1024pix/pix/pull/1254, le design du formulaire de rattachement de profils cibles a été cassé. 

## :robot: Solution
Correction de l'affichage du formulaire.

![Capture d’écran de 2020-04-06 16-37-30](https://user-images.githubusercontent.com/1216570/78570202-f3a42c80-7824-11ea-9761-9f98dceb530a.png)

