### PR TITLE
BUGFIX - Revert PF-1213 - Réparer l'envoi des mails d'invitation - (PF-1219)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,16 +1,12 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 
-const EMAIL_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
-const PIX_NAME = 'PIX - Ne pas répondre';
-const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
-
 function sendAccountCreationEmail(email) {
   return mailer.sendEmail({
     template: mailer.accountCreationTemplateId,
     to: email,
-    from: EMAIL_NO_RESPONSE,
-    fromName: PIX_NAME,
+    from: 'ne-pas-repondre@pix.fr',
+    fromName: 'PIX - Ne pas répondre',
     subject: 'Création de votre compte PIX'
   });
 }
@@ -19,8 +15,8 @@ function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
   return mailer.sendEmail({
     template: mailer.passwordResetTemplateId,
     to: email,
-    from: EMAIL_NO_RESPONSE,
-    fromName: PIX_NAME,
+    from: 'ne-pas-repondre@pix.fr',
+    fromName: 'PIX - Ne pas répondre',
     subject: 'Demande de réinitialisation de mot de passe PIX',
     variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }
   });
@@ -30,21 +26,19 @@ function sendOrganizationInvitationEmail({
   email,
   organizationName,
   organizationInvitationId,
-  code,
-  tags
+  code
 }) {
   const pixOrgaBaseUrl = settings.pixOrgaUrl;
   return mailer.sendEmail({
     template: mailer.organizationInvitationTemplateId,
     to: email,
-    from: EMAIL_NO_RESPONSE,
-    fromName: PIX_ORGA_NAME,
+    from: 'ne-pas-repondre@pix.fr',
+    fromName: 'Pix Orga - Ne pas répondre',
     subject: 'Invitation à rejoindre Pix Orga',
     variables: {
       organizationName,
       responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-    },
-    tags: tags || null
+    }
   });
 }
 

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -8,7 +8,7 @@ const _generateCode = () => {
 };
 
 const createOrganizationInvitation = async ({
-  organizationRepository, organizationInvitationRepository, organizationId, email, tags
+  organizationRepository, organizationInvitationRepository, organizationId, email
 }) => {
   let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
 
@@ -23,8 +23,7 @@ const createOrganizationInvitation = async ({
     email,
     organizationName,
     organizationInvitationId: organizationInvitation.id,
-    code: organizationInvitation.code,
-    tags
+    code: organizationInvitation.code
   });
 
   return organizationInvitation;

--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -17,7 +17,6 @@ function _formatPayload(options) {
       'content-type': 'application/json',
       'accept': 'application/json',
     },
-    tags: options.tags
   };
   if (options.variables) {
     payload.params = options.variables;

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -12,8 +12,6 @@ const organizationInvitationService = require('../lib/domain/services/organizati
 const organizationRepository = require('../lib/infrastructure/repositories/organization-repository');
 const organizationInvitationRepository = require('../lib/infrastructure/repositories/organization-invitation-repository');
 
-const TAGS = ['JOIN_ORGA'];
-
 async function getOrganizationByExternalId(externalId) {
   return BookshelfOrganization
     .where({ externalId })
@@ -38,14 +36,14 @@ async function prepareDataForSending(objectsFromFile) {
   });
 }
 
-async function sendJoinOrganizationInvitations(invitations, tags) {
+async function sendJoinOrganizationInvitations(invitations) {
   return bluebird.mapSeries(invitations, ({ organizationId, email }, index) => {
     if (require.main === module) {
       process.stdout.write(`${index}/${invitations.length}\r`);
     }
 
     return organizationInvitationService.createOrganizationInvitation({
-      organizationRepository, organizationInvitationRepository, organizationId, email, tags
+      organizationRepository, organizationInvitationRepository, organizationId, email
     });
   });
 }
@@ -55,9 +53,6 @@ async function main() {
 
   try {
     const filePath = process.argv[2];
-    const argTags = process.argv[3];
-
-    const tags = argTags ? [argTags] : TAGS;
 
     console.log('Reading and parsing csv file... ');
     const csvData = parseCsvWithHeader(filePath);
@@ -68,7 +63,7 @@ async function main() {
     console.log('ok');
 
     console.log('Sending invitations...');
-    await sendJoinOrganizationInvitations(invitations, tags);
+    await sendJoinOrganizationInvitations(invitations);
     console.log('\nDone.');
 
   } catch (error) {

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { expect, databaseBuilder, knex } = require('../../test-helper');
 
 const BookshelfOrganizationInvitation = require('../../../lib/infrastructure/data/organization-invitation');
+
 const {
   getOrganizationByExternalId, buildInvitation, prepareDataForSending, sendJoinOrganizationInvitations
 } = require('../../../scripts/send-invitations-to-sco-organizations');
@@ -98,12 +99,11 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
         });
 
       const numberBefore = await getNumberOfOrganizationInvitations();
-      const tags = ['test'];
 
       await databaseBuilder.commit();
 
       // when
-      await sendJoinOrganizationInvitations(objectsForInvitations, tags);
+      await sendJoinOrganizationInvitations(objectsForInvitations);
       const numberAfter = await getNumberOfOrganizationInvitations();
       const invitationsCreatedInDatabase = numberAfter - numberBefore;
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -1,5 +1,4 @@
 const { sinon } = require('../../../test-helper');
-
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const mailService = require('../../../../lib/domain/services/mail-service');
 
@@ -59,70 +58,30 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendOrganizationInvitationEmail', () => {
 
-    context('When tags property is not provided', () => {
+    it('should call Mailjet with pix-orga url, organization-invitation id and code', async () => {
+      // given
+      const email = 'user@organization.org';
+      const organizationName = 'Organization Name';
+      const pixOrgaBaseUrl = 'http://dev.pix-orga.fr';
+      const organizationInvitationId = 1;
+      const code = 'ABCDEFGH01';
 
-      it('should call mail provider with pix-orga url, organization-invitation id, code and null tags', async () => {
-        // given
-        const emailAddress = 'user@organization.org';
-        const organizationName = 'Organization Name';
-        const pixOrgaBaseUrl = 'http://dev.pix-orga.fr';
-        const organizationInvitationId = 1;
-        const code = 'ABCDEFGH01';
-
-        const expectedOptions = {
-          to: emailAddress,
-          template: 'test-organization-invitation-demand-template-id',
-          from: 'ne-pas-repondre@pix.fr',
-          fromName: 'Pix Orga - Ne pas répondre',
-          subject: 'Invitation à rejoindre Pix Orga',
-          variables: {
-            organizationName,
-            responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
-          },
-          tags: null
-        };
-
-        // when
-        await mailService.sendOrganizationInvitationEmail({
-          email: emailAddress, organizationName, organizationInvitationId, code
-        });
-
-        // then
-        sinon.assert.calledWith(mailer.sendEmail, expectedOptions);
+      // when
+      await mailService.sendOrganizationInvitationEmail({
+        email, organizationName, organizationInvitationId, code
       });
-    });
 
-    context('When tags property is provided', () => {
-
-      it('should call mail provider with correct tags', async () => {
-        // given
-        const email = 'user@organization.org';
-        const organizationName = 'Organization Name';
-        const pixOrgaBaseUrl = 'http://dev.pix-orga.fr';
-        const organizationInvitationId = 1;
-        const code = 'ABCDEFGH01';
-        const tags = ['JOIN_ORGA'];
-
-        const expectedOptions = {
-          to: email,
-          template: 'test-organization-invitation-demand-template-id',
-          from: 'ne-pas-repondre@pix.fr',
-          fromName: 'Pix Orga - Ne pas répondre',
-          subject: 'Invitation à rejoindre Pix Orga',
-          variables: {
-            organizationName,
-            responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
-          },
-          tags
-        };
-
-        // when
-        await mailService.sendOrganizationInvitationEmail({
-          email, organizationName, organizationInvitationId, code, tags
-        });
-
-        // then
-        sinon.assert.calledWith(mailer.sendEmail, expectedOptions);
+      // then
+      sinon.assert.calledWith(mailer.sendEmail, {
+        to: email,
+        template: 'test-organization-invitation-demand-template-id',
+        from: 'ne-pas-repondre@pix.fr',
+        fromName: 'Pix Orga - Ne pas répondre',
+        subject: 'Invitation à rejoindre Pix Orga',
+        variables: {
+          organizationName,
+          responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
+        }
       });
     });
   });

--- a/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
@@ -37,8 +37,6 @@ describe('Unit | Class | SendinblueProvider', () => {
 
           const from = 'no-reply@example.net';
           const email = recipient;
-          const tags = ['TEST'];
-
           const expectedPayload = {
             to: [{
               email,
@@ -52,8 +50,7 @@ describe('Unit | Class | SendinblueProvider', () => {
             headers: {
               'content-type': 'application/json',
               'accept': 'application/json',
-            },
-            tags
+            }
           };
 
           // when
@@ -62,8 +59,7 @@ describe('Unit | Class | SendinblueProvider', () => {
             to: email,
             fromName: 'Ne pas repondre',
             subject: 'Creation de compte',
-            template: '129291',
-            tags
+            template: '129291'
           });
 
           // then


### PR DESCRIPTION
Les mails d'invitation ne s'envoient plus sur notre environnement d'intégration et les RA à jour.
Les mails de création de compte et de réinitialisation de mot de passe ne sont pas impactés.

On pense que l'erreur vient d'une modification sur les tags des mails, liée à la PF-1213

L'erreur remontée est visible dans Jira