### PR TITLE
[TECH] Renommer tubeName de Skill dans api

### DIFF
--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -139,14 +139,14 @@ function _enrichDirectKnowledgeElementsWithInferredKnowledgeElements({
   targetSkills,
   userId,
 }) {
-  const targetSkillsGroupedByTubeName = _.groupBy(targetSkills, (skill) => skill.tubeName);
+  const targetSkillsGroupedByTubeName = _.groupBy(targetSkills, (skill) => skill.tubeNameWithoutPrefix);
   const status = answer.isOk() ? statuses.VALIDATED : statuses.INVALIDATED;
 
   return directKnowledgeElements.reduce((totalKnowledgeElements, directKnowledgeElement) => {
 
     const directSkill = _findSkillByIdFromTargetSkills(directKnowledgeElement.skillId, targetSkills);
 
-    targetSkillsGroupedByTubeName[directSkill.tubeName]
+    targetSkillsGroupedByTubeName[directSkill.tubeNameWithoutPrefix]
       .filter(_skillIsNotAlreadyAssessed({ previouslyFailedSkills, previouslyValidatedSkills }))
       .forEach((skillToInfer) => {
 

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -28,11 +28,11 @@ class Skill {
   }
 
   get tubeName() {
-    return this.name.slice(1, -1);
+    return this.name.slice(0, -1);  //with skill'@sourceImage2', returns '@sourceImage'
   }
 
-  get tubeNameWithAt() {
-    return this.name.slice(0, -1);
+  get tubeNameWithoutPrefix() {
+    return this.tubeName.slice(1); //with skill '@sourceImage2', returns 'sourceImage'
   }
 
   static areEqual(oneSkill, otherSkill) {

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -29,7 +29,7 @@ class Tube {
     if (name) {
       this.name = name;
     } else if (skills.length > 0) {
-      this.name = skills[0].tubeName;
+      this.name = skills[0].tubeNameWithoutPrefix;
     } else {
       this.name = '';
     }

--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -85,7 +85,7 @@ function _probaOfCorrectAnswer(userEstimatedLevel, challengeDifficulty) {
 }
 
 function _getNewSkillsInfoIfSkillSolved(skillTested, tubes, knowledgeElements) {
-  let extraValidatedSkills = _findTubeByName(tubes, skillTested.tubeName)
+  let extraValidatedSkills = _findTubeByName(tubes, skillTested.tubeNameWithoutPrefix)
     .getEasierThan(skillTested)
     .filter(_skillNotTestedYet(knowledgeElements));
 
@@ -96,7 +96,7 @@ function _getNewSkillsInfoIfSkillSolved(skillTested, tubes, knowledgeElements) {
 }
 
 function _getNewSkillsInfoIfSkillUnsolved(skillTested, tubes, knowledgeElements) {
-  let extraFailedSkills =  _findTubeByName(tubes, skillTested.tubeName)
+  let extraFailedSkills =  _findTubeByName(tubes, skillTested.tubeNameWithoutPrefix)
     .getHarderThan(skillTested)
     .filter(_skillNotTestedYet(knowledgeElements));
 

--- a/api/lib/domain/services/tube-service.js
+++ b/api/lib/domain/services/tube-service.js
@@ -5,7 +5,7 @@ function computeTubesFromSkills(skills) {
   const tubes = [];
 
   skills.forEach((skill) => {
-    const tubeNameOfSkill = skill.tubeName;
+    const tubeNameOfSkill = skill.tubeNameWithoutPrefix;
     const existingTube = tubes.find((tube) => tube.name === tubeNameOfSkill);
     if (existingTube) {
       existingTube.addSkill(skill);

--- a/api/lib/domain/usecases/find-tutorials.js
+++ b/api/lib/domain/usecases/find-tutorials.js
@@ -39,7 +39,7 @@ module.exports = async function findTutorials({
 
 async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId) {
   return await Promise.all(_.map(easiestSkills, async (skill) => {
-    const tube = _.find(tubes, { name: skill.tubeNameWithAt });
+    const tube = _.find(tubes, { name: skill.tubeName });
     const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: skill.tutorialIds, userId });
     return _.map(tutorials, (tutorial) => {
       tutorial.tubeName = tube.name;
@@ -55,7 +55,7 @@ function _getEasiestSkills(skillsGroupByTube) {
 }
 
 function _getSkillsGroupedByTube(failedSkills) {
-  return _.groupBy(_(_.orderBy(failedSkills, 'difficulty')).uniq().value(), 'tubeNameWithAt');
+  return _.groupBy(_(_.orderBy(failedSkills, 'difficulty')).uniq().value(), 'tubeName');
 }
 
 function _getFailedSkills(skills, invalidatedDirectKnowledgeElements) {

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -13,23 +13,23 @@ describe('Unit | Domain | Models | Skill', () => {
     });
   });
 
-  describe('#TubeName', function() {
+  describe('#tubeNameWithoutPrefix', function() {
     it('should return the name of the tube', function() {
       // given
       const url1 = new Skill({ name: '@url1' });
 
       // then
-      expect(url1.tubeName).to.be.equal('url');
+      expect(url1.tubeNameWithoutPrefix).to.be.equal('url');
     });
   });
 
-  describe('#tubeNameWithAt', () => {
+  describe('#tubeName', () => {
     it('should have a property fromListOfSkill', () => {
       // when
       const skill = new Skill({ name: '@web3' });
 
       // then
-      expect(skill.tubeNameWithAt).to.equal('@web');
+      expect(skill.tubeName).to.equal('@web');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans Airtable, le nom du Skill est par exemple `@sourceImage2` et le nom du tube correspondant est `@sourceImage`.

Or, en examinant dans model/Skill.js, actuellement on a:
```
get tubeName() {
  return this.name.slice(1, -1); //avec le skill @sourceImage2, cette fonction retourne sourceImage
}

get tubeNameWithAt() {
  return this.name.slice(0, -1); //avec le skill @sourceImage2, cette fonction retourne @sourceImage
}
```
Ce que retourne `get tubeName()` n'est donc pas le nom du tube, car le nom du tube devrait avoir un '@'.

## :robot: Solution
`get tubeName` deviendrait `get tubeNameWithoutPrefix `
et `get tubeNameWithAt` deviendrait `get tubeName`

```
get tubeName() {
  return this.name.slice(0, -1);  //avec le skill ' @sourceImage2', cette fonction retourne '@sourceImage'
}

get tubeNameWithoutPrefix() {
  return this.tubeName.slice(1); //avec le skill ' @sourceImage2', cette fonction retourne 'sourceImage'
}
```