### PR TITLE
[BUGFIX] Messages d'erreurs d'authentifications erronés dans pix-certif (PC-143)

### DIFF
--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
 import { tracked } from '@glimmer/tracking';
+import _ from 'lodash';
 
 export default class LoginForm extends Component {
 
@@ -25,10 +26,11 @@ export default class LoginForm extends Component {
     }
   }
 
-  _manageErrorsApi(response) {
-    const { responseJSON } = response || {};
-    if (responseJSON && responseJSON.errors && responseJSON.errors.length > 0) {
-      const firstError = responseJSON.errors[0];
+  _manageErrorsApi(response = {}) {
+
+    const nbErrors = _.get(response, 'responseJSON.errors.length', 0);
+    if (nbErrors > 0) {
+      const firstError = response.responseJSON.errors[0];
       const messageError = this._showErrorMessages(firstError.status, firstError.detail);
       this.errorMessage = messageError;
     } else {

--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -26,7 +26,7 @@ export default class LoginForm extends Component {
   }
 
   _manageErrorsApi(response) {
-    const { responseJSON } = response;
+    const { responseJSON } = response || {};
     if (responseJSON && responseJSON.errors && responseJSON.errors.length > 0) {
       const firstError = responseJSON.errors[0];
       const messageError = this._showErrorMessages(firstError.status, firstError.detail);

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -39,8 +39,9 @@ export default class LoginForm extends Component {
 
   _manageErrorsApi(response) {
 
-    if (response && response.errors && response.errors.length > 0) {
-      const firstError = response.errors[0];
+    const errors = (response.responseJSON || {}).errors;
+    if ((errors || {}).length > 0) {
+      const firstError = response.responseJSON.errors[0];
       const messageError = this._showErrorMessages(firstError.status, firstError.detail);
       this.errorMessage = messageError;
     } else {
@@ -48,7 +49,7 @@ export default class LoginForm extends Component {
     }
   }
 
-  _showErrorMessages(statusCode, error) {
+  _showErrorMessages(statusCode,error) {
     const httpStatusCodeMessages = {
 
       '400': ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-certif/config/environment';
+import _ from 'lodash';
 
 export default class LoginForm extends Component {
 
@@ -37,10 +38,11 @@ export default class LoginForm extends Component {
     this.isPasswordVisible = !this.isPasswordVisible;
   }
 
-  _manageErrorsApi(response) {
+  _manageErrorsApi(response = {}) {
 
-    const errors = (response.responseJSON || {}).errors;
-    if ((errors || {}).length > 0) {
+    const nbErrors = _.get(response, 'responseJSON.errors.length', 0);
+
+    if (nbErrors > 0) {
       const firstError = response.responseJSON.errors[0];
       const messageError = this._showErrorMessages(firstError.status, firstError.detail);
       this.errorMessage = messageError;
@@ -49,7 +51,7 @@ export default class LoginForm extends Component {
     }
   }
 
-  _showErrorMessages(statusCode,error) {
+  _showErrorMessages(statusCode,apiError) {
     const httpStatusCodeMessages = {
 
       '400': ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
@@ -57,8 +59,8 @@ export default class LoginForm extends Component {
       '422': ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
       '502': ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
       '504': ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
-      '401': error,
-      '403': error,
+      '401': apiError,
+      '403': apiError,
       'default': ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
 
     };

--- a/certif/tests/integration/components/login-form-test.js
+++ b/certif/tests/integration/components/login-form-test.js
@@ -61,9 +61,9 @@ module('Integration | Component | login-form', function(hooks) {
     assert.equal(sessionServiceObserver.scope, 'pix-certif');
   });
 
-  test('it should display an error message when authentication fails with unauthorized acces', async function(assert) {
+  test('it should display an invalid credentials message if authentication failed', async function(assert) {
     // given
-    const msgErrorInvalidCredentiel = {
+    const invalidCredentialsErrorMessage = {
       responseJSON: {
         'errors': [{
           'status': '401',
@@ -73,7 +73,7 @@ module('Integration | Component | login-form', function(hooks) {
       }
     };
 
-    sessionStub.prototype.authenticate = () => reject(msgErrorInvalidCredentiel);
+    sessionStub.prototype.authenticate = () => reject(invalidCredentialsErrorMessage);
     await render(hbs`{{login-form}}`);
     await fillIn('#login-email', 'pix@example.net');
     await fillIn('#login-password', 'Mauvais mot de passe');
@@ -89,13 +89,13 @@ module('Integration | Component | login-form', function(hooks) {
   test('it should display an not linked certification message when authentication fails with Forbidden Access', async function(assert) {
 
     // given
-    const msgErrorNotLinkedCertification = {
+    const notLinkedToOrganizationErrorMessage = {
       responseJSON: {
         'errors': [{ 'status': '403', 'title': 'Unauthorized', 'detail': errorMessages.NOT_LINKED_CERTIFICATION_MSG }]
       }
     };
 
-    sessionStub.prototype.authenticate = () => reject(msgErrorNotLinkedCertification);
+    sessionStub.prototype.authenticate = () => reject(notLinkedToOrganizationErrorMessage);
     await render(hbs`{{login-form}}`);
     await fillIn('#login-email', 'pix@example.net');
     await fillIn('#login-password', 'JeMeLoggue1024');
@@ -111,7 +111,7 @@ module('Integration | Component | login-form', function(hooks) {
   test('it should display a 504 message when authentication fails with gateway Timeout', async function(assert) {
 
     // given
-    const msgErrorGatewayTimeout = {
+    const gatewayTimeoutErrorMessage = {
       responseJSON: {
         'errors': [{
           'status': ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.CODE,
@@ -121,7 +121,7 @@ module('Integration | Component | login-form', function(hooks) {
       }
     };
 
-    sessionStub.prototype.authenticate = () => reject(msgErrorGatewayTimeout);
+    sessionStub.prototype.authenticate = () => reject(gatewayTimeoutErrorMessage);
     await render(hbs`{{login-form}}`);
     await fillIn('#login-email', 'pix@example.net');
     await fillIn('#login-password', 'JeMeLoggue1024');

--- a/certif/tests/integration/components/login-form-test.js
+++ b/certif/tests/integration/components/login-form-test.js
@@ -63,8 +63,14 @@ module('Integration | Component | login-form', function(hooks) {
 
   test('it should display an error message when authentication fails with unauthorized acces', async function(assert) {
     // given
-    const msgErrorInvalidCredentiel =  {
-      'errors' : [{ 'status' : '401', 'title' : 'Unauthorized' , 'detail' : ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.MESSAGE }]
+    const msgErrorInvalidCredentiel = {
+      responseJSON: {
+        'errors': [{
+          'status': '401',
+          'title': 'Unauthorized',
+          'detail': ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.MESSAGE
+        }]
+      }
     };
 
     sessionStub.prototype.authenticate = () => reject(msgErrorInvalidCredentiel);
@@ -83,8 +89,10 @@ module('Integration | Component | login-form', function(hooks) {
   test('it should display an not linked certification message when authentication fails with Forbidden Access', async function(assert) {
 
     // given
-    const msgErrorNotLinkedCertification =  {
-      'errors' : [{ 'status' : '403', 'title' : 'Unauthorized' , 'detail' : errorMessages.NOT_LINKED_CERTIFICATION_MSG }]
+    const msgErrorNotLinkedCertification = {
+      responseJSON: {
+        'errors': [{ 'status': '403', 'title': 'Unauthorized', 'detail': errorMessages.NOT_LINKED_CERTIFICATION_MSG }]
+      }
     };
 
     sessionStub.prototype.authenticate = () => reject(msgErrorNotLinkedCertification);
@@ -103,8 +111,14 @@ module('Integration | Component | login-form', function(hooks) {
   test('it should display a 504 message when authentication fails with gateway Timeout', async function(assert) {
 
     // given
-    const msgErrorGatewayTimeout =  {
-      'errors' : [{ 'status' : ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.CODE, 'title' : 'Gateway Timeout' , 'detail' : ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE }]
+    const msgErrorGatewayTimeout = {
+      responseJSON: {
+        'errors': [{
+          'status': ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.CODE,
+          'title': 'Gateway Timeout',
+          'detail': ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE
+        }]
+      }
     };
 
     sessionStub.prototype.authenticate = () => reject(msgErrorGatewayTimeout);

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -1,6 +1,7 @@
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import _ from 'lodash';
 
 export default class LoginForm extends Component {
 
@@ -50,12 +51,14 @@ export default class LoginForm extends Component {
   _authenticate(password, email) {
     const scope = 'pix-orga';
     return this.session.authenticate('authenticator:oauth2', email, password, scope)
-      .catch((error) => {
+      .catch((response) => {
         this.set('isErrorMessagePresent', true);
-        if (error && error.errors && error.errors.length > 0) {
-          this.set('errorMessage', error.errors[0].detail);
+
+        const nbErrors = _.get(response, 'errors.length', 0);
+        if (nbErrors > 0) {
+          this.set('errorMessage', response.errors[0].detail);
         } else {
-          this.set('errorMessage','L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.');
+          this.set('errorMessage','Le service est momentanément indisponible. Veuillez réessayer ultérieurement.');
         }
       })
       .finally(() => {

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -180,6 +180,14 @@ module('Acceptance | join', function(hooks) {
 
       test('it should remain on join page', async function(assert) {
         // given
+        server.post('/token', {
+          errors: [{
+            detail: 'L\'adresse e-mail et/ou le mot de passe saisis sont incorrects.',
+            status: '4O1',
+            title: 'Unauthorized',
+          }]
+        }, 401);
+
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
         await fillIn('#login-email', user.email);

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
       await fillIn('#login-email', 'pix@example.net');
       await fillIn('#login-password', 'JeMeLoggue1024');
 
-      //  when
+      // when
       await click('.button');
 
       // then
@@ -114,8 +114,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
   test('it should display an invalid credentiels message when authentication fails', async function(assert) {
 
     // given
-    const msgErrorInvalidCredentiel =  {
-      'errors' : [{ 'status' : '401', 'title' : 'Unauthorized' , 'detail' : errorMessages.INVALID_CREDENTIEL_MSG  }]
+    const msgErrorInvalidCredentiel = {
+      'errors': [{ 'status': '401', 'title': 'Unauthorized', 'detail': errorMessages.INVALID_CREDENTIEL_MSG }]
     };
 
     sessionStub.prototype.authenticate = () => reject(msgErrorInvalidCredentiel);
@@ -135,8 +135,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
   test('it should display an not linked organisation message when authentication fails', async function(assert) {
 
     // given
-    const msgErrorNotLinkedOrganization =  {
-      'errors' : [{ 'status' : '403', 'title' : 'Unauthorized' , 'detail' : errorMessages.NOT_LINKED_ORGANIZATION_MSG }]
+    const msgErrorNotLinkedOrganization = {
+      'errors': [{ 'status': '403', 'title': 'Unauthorized', 'detail': errorMessages.NOT_LINKED_ORGANIZATION_MSG }]
     };
 
     sessionStub.prototype.authenticate = () => reject(msgErrorNotLinkedOrganization);


### PR DESCRIPTION
## :unicorn: Problème

Bug suite à la montée de la version de ember-simple-auth dans pix-certif et pix-admin. 
Il concerne les messages d'erreurs liées à l'authentification dans pix-certif.
 Peu importe l’erreur lors la connexion dans Pix Certif, je vois toujours le même message d’erreur unique: 'Le service est momentanément indisponible. Veuillez réessayer ultérieurement'.

## :robot: Solution
 La strutcture de l'objet error response qui stocke la réponse d'api à change.
 Pour accéder aux errors, il faut maintenant passer par la propriété response.responseJson.errors.

