### PR TITLE
[CLEANUP] Ajout de tests end-to-end pour la fonctionnalité de sauvegarde de tutoriels

### DIFF
--- a/high-level-tests/e2e/cypress/integration/user-tutorials.feature
+++ b/high-level-tests/e2e/cypress/integration/user-tutorials.feature
@@ -1,0 +1,30 @@
+#language: fr
+Fonctionnalité: Connexion - Déconnexion
+
+  Contexte:
+    Étant donné que tous les comptes sont créés
+
+  Scénario: Je n'ai pas sauvegardé de tutoriel
+    Étant donné que je vais sur Pix
+    Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque je vais sur la page "/mes-tutos"
+    Alors je vois le titre de la page "Mes tutos | Pix"
+    Et la page mes-tutos est vide
+
+
+  Scénario: Je sauvegarde un tutoriel depuis la page de compétence puis le retire
+    Étant donné que je vais sur Pix
+    Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"
+    Alors je suis redirigé vers le profil de "Daenerys"
+    Lorsque je clique sur le rond de niveau de la compétence "Mathématiques"
+    Et je clique sur "Commencer"
+    Et je clique sur "Je passe"
+    Et je clique sur "Je passe"
+    Et je clique sur "Réponses et tutos"
+    Et j‘enregistre le tutoriel "Ne pas confondre le web et Internet"
+    Alors le titre du bouton du tutoriel "Ne pas confondre le web et Internet" est "Retirer"
+    Et je vais sur la page "/mes-tutos"
+    Alors je vois le tutoriel "Ne pas confondre le web et Internet"
+    Lorsque je retire le tutoriel "Ne pas confondre le web et Internet"
+    Alors la page mes-tutos est vide

--- a/high-level-tests/e2e/cypress/support/step_definitions/user-tutorials.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/user-tutorials.js
@@ -1,0 +1,22 @@
+when(`j‘enregistre le tutoriel {string}`, (tutorialName) => {
+  cy.contains('.tutorial__content', tutorialName).find('.tutorial-content__save-tutorial').click();
+});
+
+when(`je retire le tutoriel {string}`, (tutorialName) => {
+  cy.contains('.tutorial__content', tutorialName).find('.tutorial-content__save-tutorial').click();
+});
+
+when(`le titre du bouton du tutoriel {string} est {string}`, (tutorialName, buttonTitle) => {
+  cy.contains('.tutorial__content', tutorialName).find('.tutorial-content__save-tutorial')
+    .should('contain', buttonTitle);
+});
+
+then(`je vois le tutoriel {string}`, (tutorialName) => {
+  cy.contains('.tutorial__content', tutorialName);
+});
+
+
+then('la page mes-tutos est vide', () => {
+  cy.get('.user-tutorials-no-tutorial-instructions__title')
+    .should('contain', 'Vous n\'avez encore rien enregistré');
+});


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité d'enregistrement et de retrait de tutoriels n'est pas couverte par des tests end-to-end.

## :robot: Solution
Ajouter des tests end-to-end sur cette fonctionnalité.

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer les tests cypress contenus dans le fichier `user-tutorials.feature`.