### PR TITLE
[CLEANUP] Refacto autour du modèle CertificationChallenge (PF-1229)

### DIFF
--- a/api/db/migrations/20200408135742_drop_column_associated-skill-id_table_certification-challenges.js
+++ b/api/db/migrations/20200408135742_drop_column_associated-skill-id_table_certification-challenges.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-challenges';
+const COLUMN_NAME = 'associatedSkillId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20200408140122_rename_column_course-id_into_certification-course-id_table_certification-challenges.js
+++ b/api/db/migrations/20200408140122_rename_column_course-id_into_certification-course-id_table_certification-challenges.js
@@ -1,0 +1,11 @@
+const TABLE_NAME = 'certification-challenges';
+const OLD_COLUMN_NAME = 'courseId';
+const NEW_COLUMN_NAME = 'certificationCourseId';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (t) => t.renameColumn(OLD_COLUMN_NAME, NEW_COLUMN_NAME));
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (t) => t.renameColumn(NEW_COLUMN_NAME, OLD_COLUMN_NAME));
+};

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -54,7 +54,7 @@ function _buildCertificationCourse(databaseBuilder, { assessmentId, userId, sess
     campaignParticipationId: null, isImproving: false, createdAt,
   });
   _.each(CERTIFICATION_CHALLENGES_DATA, (challenge) => {
-    databaseBuilder.factory.buildCertificationChallenge({ ...challenge, courseId: certificationCourseId, associatedSkillId: null, createdAt });
+    databaseBuilder.factory.buildCertificationChallenge({ ...challenge, courseId: certificationCourseId, createdAt });
   });
 }
 

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -6,7 +6,7 @@ class CertificationChallenge {
     // includes
     // references
     challengeId,
-    courseId,
+    certificationCourseId,
     competenceId,
   } = {}) {
     this.id = id;
@@ -16,7 +16,7 @@ class CertificationChallenge {
     // references
     this.challengeId = challengeId;
     this.competenceId = competenceId;
-    this.courseId = courseId;
+    this.certificationCourseId = certificationCourseId;
   }
 }
 

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -2,7 +2,7 @@ class CertificationChallenge {
   constructor({
     id,
     // attributes
-    associatedSkillName,
+    associatedSkill,
     // includes
     // references
     associatedSkillId,
@@ -12,7 +12,7 @@ class CertificationChallenge {
   } = {}) {
     this.id = id;
     // attributes
-    this.associatedSkillName = associatedSkillName;
+    this.associatedSkill = associatedSkill;
     // includes
     // references
     this.associatedSkillId = associatedSkillId;

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -5,7 +5,6 @@ class CertificationChallenge {
     associatedSkill,
     // includes
     // references
-    associatedSkillId,
     challengeId,
     courseId,
     competenceId,
@@ -15,7 +14,6 @@ class CertificationChallenge {
     this.associatedSkill = associatedSkill;
     // includes
     // references
-    this.associatedSkillId = associatedSkillId;
     this.challengeId = challengeId;
     this.competenceId = competenceId;
     this.courseId = courseId;

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -16,7 +16,7 @@ class CertificationCourse {
       isV2Certification = false,
       // includes
       assessment,
-      challenges,
+      certificationChallenges,
       // references
       userId,
       sessionId,
@@ -36,7 +36,7 @@ class CertificationCourse {
     this.isV2Certification = isV2Certification;
     // includes
     this.assessment = assessment;
-    this.challenges = challenges;
+    this.certificationChallenges = certificationChallenges;
     // references
     this.userId = userId;
     this.sessionId = sessionId;

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -3,16 +3,16 @@ const certificationChallengeRepository = require('../../infrastructure/repositor
 module.exports = {
 
   saveChallenges(userCompetences, certificationCourse) {
-    const saveChallengePromises = [];
+    const saveCertificationChallengePromises = [];
     userCompetences.forEach((userCompetence) => {
       userCompetence.challenges.forEach((challenge) => {
-        saveChallengePromises.push(certificationChallengeRepository.save(challenge, certificationCourse));
+        saveCertificationChallengePromises.push(certificationChallengeRepository.save(challenge, certificationCourse));
       });
     });
 
-    return Promise.all(saveChallengePromises)
+    return Promise.all(saveCertificationChallengePromises)
       .then((certificationChallenges) => {
-        certificationCourse.challenges = certificationChallenges;
+        certificationCourse.certificationChallenges = certificationChallenges;
         return certificationCourse;
       });
   }

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -169,7 +169,7 @@ function _getChallengeInformation(listAnswers, certificationChallenges, competen
       value: answer.value,
       challengeId: answer.challengeId,
       competence: competenceValidatedByCertifChallenge.index || '',
-      skill: certificationChallengeRelatedToAnswer.associatedSkillName || '',
+      skill: certificationChallengeRelatedToAnswer.associatedSkill || '',
     };
   });
 }

--- a/api/lib/infrastructure/data/certification-course.js
+++ b/api/lib/infrastructure/data/certification-course.js
@@ -20,7 +20,7 @@ module.exports = Bookshelf.model('CertificationCourse', {
     return this.hasOne('Assessment', 'certificationCourseId');
   },
 
-  challenges() {
+  certificationChallenges() {
     return this.hasMany('CertificationChallenge', 'certificationCourseId');
   },
 

--- a/api/lib/infrastructure/data/certification-course.js
+++ b/api/lib/infrastructure/data/certification-course.js
@@ -21,7 +21,7 @@ module.exports = Bookshelf.model('CertificationCourse', {
   },
 
   challenges() {
-    return this.hasMany('CertificationChallenge', 'courseId');
+    return this.hasMany('CertificationChallenge', 'certificationCourseId');
   },
 
   session() {

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -17,7 +17,7 @@ module.exports = {
       challengeId: challenge.id,
       competenceId: challenge.competenceId,
       associatedSkill: challenge.testedSkill,
-      courseId: certificationCourse.id,
+      certificationCourseId: certificationCourse.id,
     });
 
     return certificationChallenge.save()
@@ -28,19 +28,19 @@ module.exports = {
 
   findByCertificationCourseId(certificationCourseId) {
     return CertificationChallengeBookshelf
-      .where({ courseId: certificationCourseId })
+      .where({ certificationCourseId })
       .fetchAll()
       .then((challenges) => bookshelfToDomainConverter.buildDomainObjects(CertificationChallengeBookshelf, challenges));
   },
 
-  getNonAnsweredChallengeByCourseId(assessmentId, courseId) {
+  getNonAnsweredChallengeByCourseId(assessmentId, certificationCourseId) {
 
     const answeredChallengeIds = Bookshelf.knex('answers')
       .select('challengeId')
       .where({ assessmentId });
 
     return CertificationChallengeBookshelf
-      .where({ courseId })
+      .where({ certificationCourseId })
       .query((knex) => knex.whereNotIn('challengeId', answeredChallengeIds))
       .fetch()
       .then((certificationChallenge) => {

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -15,7 +15,7 @@ function _toDomain(model) {
     id: model.get('id'),
     challengeId: model.get('challengeId'),
     competenceId: model.get('competenceId'),
-    associatedSkillName: model.get('associatedSkill'),
+    associatedSkill: model.get('associatedSkill'),
     associatedSkillId: model.get('associatedSkillId'),
     courseId: model.get('courseId'),
   });

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -17,7 +17,6 @@ module.exports = {
       challengeId: challenge.id,
       competenceId: challenge.competenceId,
       associatedSkill: challenge.testedSkill,
-      associatedSkillId: undefined,
       courseId: certificationCourse.id,
     });
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -25,7 +25,7 @@ module.exports = {
     try {
       const certificationCourse = await CertificationCourseBookshelf
         .where({ id })
-        .fetch({ require: true, withRelated: ['assessment', 'challenges'] });
+        .fetch({ require: true, withRelated: ['assessment', 'certificationChallenges'] });
       return _toDomain(certificationCourse);
     } catch (bookshelfError) {
       if (bookshelfError instanceof CertificationCourseBookshelf.NotFoundError) {
@@ -40,7 +40,7 @@ module.exports = {
       const certificationCourse = await CertificationCourseBookshelf
         .where({ userId, sessionId })
         .orderBy('createdAt', 'desc')
-        .fetch({ require: true, withRelated: ['assessment', 'challenges'] });
+        .fetch({ require: true, withRelated: ['assessment', 'certificationChallenges'] });
       return _toDomain(certificationCourse);
     } catch (err) {
       if (err instanceof CertificationCourseBookshelf.NotFoundError) {
@@ -85,7 +85,7 @@ function _toDomain(bookshelfCertificationCourse) {
   return new CertificationCourse({
     type: Assessment.types.CERTIFICATION,
     assessment,
-    challenges: bookshelfCertificationCourse.related('challenges').toJSON(),
+    certificationChallenges: bookshelfCertificationCourse.related('certificationChallenges').toJSON(),
     ..._.pick(dbCertificationCourse, [
       'id',
       'userId',
@@ -108,7 +108,7 @@ function _toDomain(bookshelfCertificationCourse) {
 function _adaptModelToDb(certificationCourse) {
   return _.omit(certificationCourse, [
     'assessment',
-    'challenges',
+    'certificationChallenges',
     'createdAt',
   ]);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
     return new Serializer('certification-course', {
       transform(currentCertificationCourse) {
         const certificationCourse = Object.assign({}, currentCertificationCourse);
-        certificationCourse.nbChallenges = currentCertificationCourse.challenges ? currentCertificationCourse.challenges.length : 0;
+        certificationCourse.nbChallenges = currentCertificationCourse.certificationChallenges ? currentCertificationCourse.certificationChallenges.length : 0;
 
         return certificationCourse;
       },

--- a/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -45,12 +45,9 @@ describe('Integration | Repository | Certification Challenge', function() {
           challengeId: 'chal123ABC',
           competenceId: 'comp456DEF',
           associatedSkill: '@url6',
-          courseId: certificationCourseId,
+          certificationCourseId,
         });
-      databaseBuilder.factory.buildCertificationChallenge(
-        {
-          courseId: certificationCourseId,
-        });
+      databaseBuilder.factory.buildCertificationChallenge({ certificationCourseId });
       databaseBuilder.factory.buildCertificationChallenge(
         {
           challengeId: 'chal789GHI',
@@ -94,7 +91,7 @@ describe('Integration | Repository | Certification Challenge', function() {
         const challenge = databaseBuilder.factory.buildCertificationChallenge(
           {
             challengeId: 'recChallenge1',
-            courseId: certificationCourseId,
+            certificationCourseId,
             associatedSkill: '@brm7',
             competenceId: 'recCompetenceId1',
           });
@@ -132,14 +129,14 @@ describe('Integration | Repository | Certification Challenge', function() {
         const answeredChallenge = databaseBuilder.factory.buildCertificationChallenge(
           {
             challengeId: 'recChallenge1',
-            courseId: certificationCourseId,
+            certificationCourseId,
             associatedSkill: '@brm7',
             competenceId: 'recCompetenceId1',
           });
         unansweredChallenge =
           {
             challengeId: 'recChallenge2',
-            courseId: certificationCourseId,
+            certificationCourseId,
             associatedSkill: '@brm24',
             competenceId: 'recCompetenceId2',
           };

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -96,9 +96,9 @@ describe('Integration | Repository | Certification Course', function() {
         });
       anotherCourseId = databaseBuilder.factory.buildCertificationCourse({ userId }).id;
       _.each([
-        { courseId: expectedCertificationCourse.id },
-        { courseId: expectedCertificationCourse.id },
-        { courseId: anotherCourseId },
+        { certificationCourseId: expectedCertificationCourse.id },
+        { certificationCourseId: expectedCertificationCourse.id },
+        { certificationCourseId: anotherCourseId },
       ], (certificationChallenge) => {
         databaseBuilder.factory.buildCertificationChallenge(certificationChallenge);
       });

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -127,7 +127,7 @@ describe('Integration | Repository | Certification Course', function() {
         const thisCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
 
         // then
-        expect(thisCertificationCourse.challenges.length).to.equal(2);
+        expect(thisCertificationCourse.certificationChallenges.length).to.equal(2);
       });
 
       context('When the certification course has one assessment', () => {

--- a/api/tests/tooling/database-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-challenge.js
@@ -8,19 +8,19 @@ module.exports = function buildCertificationChallenge({
   associatedSkill = '@twi8',
   challengeId = `rec${faker.random.uuid()}`,
   competenceId = `rec${faker.random.uuid()}`,
-  courseId,
+  certificationCourseId,
   createdAt = faker.date.past(),
   updatedAt = faker.date.recent(),
 } = {}) {
 
-  courseId = _.isUndefined(courseId) ? buildCertificationCourse().id : courseId;
+  certificationCourseId = _.isUndefined(certificationCourseId) ? buildCertificationCourse().id : certificationCourseId;
 
   const values = {
     id,
     associatedSkill,
     challengeId,
     competenceId,
-    courseId,
+    certificationCourseId,
     createdAt,
     updatedAt,
   };

--- a/api/tests/tooling/database-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-challenge.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 module.exports = function buildCertificationChallenge({
   id,
   associatedSkill = '@twi8',
-  associatedSkillId = `rec${faker.random.uuid()}`,
   challengeId = `rec${faker.random.uuid()}`,
   competenceId = `rec${faker.random.uuid()}`,
   courseId,
@@ -19,7 +18,6 @@ module.exports = function buildCertificationChallenge({
   const values = {
     id,
     associatedSkill,
-    associatedSkillId,
     challengeId,
     competenceId,
     courseId,

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
@@ -7,7 +7,6 @@ module.exports = function buildCertificationChallenge({
   challengeId = `rec${faker.random.uuid()}`,
   competenceId = `rec${faker.random.uuid()}`,
   courseId = faker.random.number(),
-  associatedSkillId = buildSkill().id,
   associatedSkill = buildSkill().name,
 } = {}) {
 
@@ -16,7 +15,6 @@ module.exports = function buildCertificationChallenge({
     challengeId,
     competenceId,
     courseId,
-    associatedSkillId,
     associatedSkill,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
@@ -6,7 +6,7 @@ module.exports = function buildCertificationChallenge({
   id = faker.random.number(),
   challengeId = `rec${faker.random.uuid()}`,
   competenceId = `rec${faker.random.uuid()}`,
-  courseId = faker.random.number(),
+  certificationCourseId = faker.random.number(),
   associatedSkill = buildSkill().name,
 } = {}) {
 
@@ -14,7 +14,7 @@ module.exports = function buildCertificationChallenge({
     id,
     challengeId,
     competenceId,
-    courseId,
+    certificationCourseId,
     associatedSkill,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
@@ -8,7 +8,7 @@ module.exports = function buildCertificationChallenge({
   competenceId = `rec${faker.random.uuid()}`,
   courseId = faker.random.number(),
   associatedSkillId = buildSkill().id,
-  associatedSkillName = buildSkill().name,
+  associatedSkill = buildSkill().name,
 } = {}) {
 
   return new CertificationChallenge({
@@ -17,6 +17,6 @@ module.exports = function buildCertificationChallenge({
     competenceId,
     courseId,
     associatedSkillId,
-    associatedSkillName,
+    associatedSkill,
   });
 };

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -75,7 +75,7 @@ describe('Unit | Service | Certification Challenge Service', function() {
       return promise.then((certificationCourse) => {
         expect(certificationCourse).to.deep.equal({
           id :'certification-course-id',
-          challenges : ['challenge', 'challenge'],
+          certificationChallenges : ['challenge', 'challenge'],
         });
       });
     });

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -102,18 +102,18 @@ const challengesFromAirTable = _.map([
 ], domainBuilder.buildChallenge);
 
 const challenges = _.map([
-  { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1' },
-  { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1' },
-  { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1' },
-  { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeD_2' },
-  { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeE_2' },
-  { challengeId: 'challenge_F_for_competence_2', competenceId: 'competence_2', associatedSkillName: '@skillChallengeF_2' },
-  { challengeId: 'challenge_G_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeG_3' },
-  { challengeId: 'challenge_H_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeH_3' },
-  { challengeId: 'challenge_I_for_competence_3', competenceId: 'competence_3', associatedSkillName: '@skillChallengeI_3' },
-  { challengeId: 'challenge_J_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeJ_4' },
-  { challengeId: 'challenge_K_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeK_4' },
-  { challengeId: 'challenge_L_for_competence_4', competenceId: 'competence_4', associatedSkillName: '@skillChallengeL_4' },
+  { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeA_1' },
+  { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeC_1' },
+  { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeB_1' },
+  { challengeId: 'challenge_D_for_competence_2', competenceId: 'competence_2', associatedSkill: '@skillChallengeD_2' },
+  { challengeId: 'challenge_E_for_competence_2', competenceId: 'competence_2', associatedSkill: '@skillChallengeE_2' },
+  { challengeId: 'challenge_F_for_competence_2', competenceId: 'competence_2', associatedSkill: '@skillChallengeF_2' },
+  { challengeId: 'challenge_G_for_competence_3', competenceId: 'competence_3', associatedSkill: '@skillChallengeG_3' },
+  { challengeId: 'challenge_H_for_competence_3', competenceId: 'competence_3', associatedSkill: '@skillChallengeH_3' },
+  { challengeId: 'challenge_I_for_competence_3', competenceId: 'competence_3', associatedSkill: '@skillChallengeI_3' },
+  { challengeId: 'challenge_J_for_competence_4', competenceId: 'competence_4', associatedSkill: '@skillChallengeJ_4' },
+  { challengeId: 'challenge_K_for_competence_4', competenceId: 'competence_4', associatedSkill: '@skillChallengeK_4' },
+  { challengeId: 'challenge_L_for_competence_4', competenceId: 'competence_4', associatedSkill: '@skillChallengeL_4' },
 ], domainBuilder.buildCertificationChallenge);
 
 const competence_1 = domainBuilder.buildCompetence({ id: 'competence_1', index: '1.1', area: { code: '1' }, name: 'Mener une recherche' });
@@ -685,9 +685,9 @@ describe('Unit | Service | Certification Result Service', function() {
               ], domainBuilder.buildAnswer);
 
               const challenges = _.map([
-                { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1' },
-                { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeB_1' },
-                { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeC_1' },
+                { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeA_1' },
+                { challengeId: 'challenge_B_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeB_1' },
+                { challengeId: 'challenge_C_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeC_1' },
               ], domainBuilder.buildCertificationChallenge);
 
               const userCompetences = [
@@ -1081,11 +1081,11 @@ describe('Unit | Service | Certification Result Service', function() {
           ];
 
           const challenges = _.map([
-            { challengeId: 'challenge_A_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeA_5' },
-            { challengeId: 'challenge_B_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeB_5' },
-            { challengeId: 'challenge_A_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeA_6' },
-            { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeB_6' },
-            { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeC_6' },
+            { challengeId: 'challenge_A_for_competence_5', competenceId: 'competence_5', associatedSkill: '@skillChallengeA_5' },
+            { challengeId: 'challenge_B_for_competence_5', competenceId: 'competence_5', associatedSkill: '@skillChallengeB_5' },
+            { challengeId: 'challenge_A_for_competence_6', competenceId: 'competence_6', associatedSkill: '@skillChallengeA_6' },
+            { challengeId: 'challenge_B_for_competence_6', competenceId: 'competence_6', associatedSkill: '@skillChallengeB_6' },
+            { challengeId: 'challenge_C_for_competence_6', competenceId: 'competence_6', associatedSkill: '@skillChallengeC_6' },
           ], domainBuilder.buildCertificationChallenge);
 
           challengeRepository.list.resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
@@ -1185,10 +1185,10 @@ describe('Unit | Service | Certification Result Service', function() {
 
         beforeEach(() => {
           challenges = _.map([
-            { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkillName: '@skillChallengeA_1' },
+            { challengeId: 'challenge_A_for_competence_1', competenceId: 'competence_1', associatedSkill: '@skillChallengeA_1' },
 
-            { challengeId: 'challenge_M_for_competence_5', competenceId: 'competence_5', associatedSkillName: '@skillChallengeM_5' },
-            { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkillName: '@skillChallengeN_6' },
+            { challengeId: 'challenge_M_for_competence_5', competenceId: 'competence_5', associatedSkill: '@skillChallengeM_5' },
+            { challengeId: 'challenge_N_for_competence_6', competenceId: 'competence_6', associatedSkill: '@skillChallengeN_6' },
           ], domainBuilder.buildCertificationChallenge);
 
           certificationChallengesRepository.findByCertificationCourseId.resolves(challenges);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -16,7 +16,7 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
       const certificationCourse = new CertificationCourse({
         id: 'certification_id',
         assessment: assessment,
-        challenges: ['challenge1', 'challenge2'],
+        certificationChallenges: ['challenge1', 'challenge2'],
         'examinerComment': 'Signalement de l\'examinateur',
         'hasSeenEndTestScreen': true,
       });


### PR DESCRIPTION
## :unicorn: Problème
Parfois, on se ballade dans le code, et on voit des choses. Donc on veut les réparer, mais en dehors de notre PR courante. Du coup, à cette effet, on fait une PR de cleanup ;)

Ici il s'agit en particulier d'un petit nettoyage autour du CertificationChallenge, histoire de dissiper + éviter les confusions au sein de lexique métier (courseId/certificationCourseId, challenge/certificationChallenge).

## :robot: Solution
On fait le coup de balai !
Chirurgie en 4 points :
- Renommage du champ `associatedSkillName` en `associatedSkill` dans le code, pour qu'il colle avec son nom dans la BDD ----> ainsi, on peut utiliser le `bookshelfToDomainConverter` dans le repo ! :+1: 
- Retrait de la colonne associatedSkillId dans la table certification-challenges, et en conséquence sa mention dans le code. Je rappelle que cette colonne est toujours NULL, dans tous les enregistrements en PROD. Elle n'a jamais été alimentée depuis son introduction (merci @Krysthalia pour la recherche : -> https://github.com/1024pix/pix/pull/173)
- Renommage de la colonne `courseId` en `certificationCourseId`, puis dans le code. Essentiel pour éviter la confusion entre deux choses différentes. `courseId` fait référence à une démo, `certificationCourseId` fait référence à un test de certification.
- Renommage du champ `challenges` en `certificationChallenges` dans le modèle `CertificationCourse`. Idem, on cherche à éviter la confusion entre un objet crée par l'équipe contenu, et le concept de la question posée à un candidat spécifique pendant son test de certification.

## :rainbow: Remarques

## :100: Pour tester
L'essentiel c'est de tester la non-régression d'un lancement d'un test de certification, ainsi que le scoring (donc consulter une certif sur PixAdmin par exemple).
