### PR TITLE
[FEATURE] Certif clea zone rouge (PF-1147)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -92,8 +92,14 @@ module.exports = {
 
     await DomainTransaction.execute(async (domainTransaction) => {
       const assessmentCompletedEvent = await usecases.completeAssessment({ domainTransaction, assessmentId });
-      await events.handleCertificationScoring({ domainTransaction, assessmentCompletedEvent });
+      const certificationScoringEvent = await events.handleCertificationScoring({ domainTransaction, assessmentCompletedEvent });
+
       await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent });
+
+      if (certificationScoringEvent) {
+        // TODO this condition should be done by the broker/event bus
+        await events.handleCertificationAcquisitionForPartner({ domainTransaction, certificationScoringEvent });
+      }
     });
 
     return null;

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -92,7 +92,7 @@ module.exports = {
 
     await DomainTransaction.execute(async (domainTransaction) => {
       const assessmentCompletedEvent = await usecases.completeAssessment({ domainTransaction, assessmentId });
-      await events.handleCertificationScoring({ assessmentCompletedEvent });
+      await events.handleCertificationScoring({ domainTransaction, assessmentCompletedEvent });
       await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent });
     });
 

--- a/api/lib/domain/events/CertificationScoringCompleted.js
+++ b/api/lib/domain/events/CertificationScoringCompleted.js
@@ -1,0 +1,10 @@
+class CertificationScoringCompleted {
+  constructor({ certificationCourseId, userId, percentageCorrectAnswers, isCertification }) {
+    this.certificationCourseId = certificationCourseId;
+    this.userId = userId;
+    this.percentageCorrectAnswers = percentageCorrectAnswers;
+    this.isCertification = isCertification;
+  }
+}
+
+module.exports = CertificationScoringCompleted;

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -11,10 +11,10 @@ const handleBadgeAcquisition = async function({
     if (isABadgeAssociatedToCampaign(badge)) {
       const campaignParticipationResult = await fetchCampaignParticipationResults(assessmentCompletedEvent, badge, campaignParticipationResultRepository);
       if (isBadgeAcquired(campaignParticipationResult, badgeCriteriaService)) {
-        await badgeAcquisitionRepository.create(domainTransaction, {
+        await badgeAcquisitionRepository.create({
           badgeId: badge.id,
           userId: assessmentCompletedEvent.userId
-        });
+        }, domainTransaction);
       }
     }
   }

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -1,82 +1,32 @@
 const Badge = require('../models/Badge');
 const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
-const Promise = require('bluebird');
-const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED, MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED } = require('../constants');
-
-const CERTIF_GREEN_ZONE = 'green_zone';
-const CERTIF_RED_ZONE = 'red_zone';
 
 async function handleCertificationAcquisitionForPartner({
-  assessmentCompletedEvent,
   certificationScoringEvent,
   domainTransaction,
   badgeAcquisitionRepository,
   certificationPartnerAcquisitionRepository,
 }) {
-  if (!assessmentCompletedEvent.isCertification) {
+  if (!certificationScoringEvent.isCertification) {
     return;
   }
+  const hasAcquiredBadgeClea = await _getHasAcquiredBadgeClea(badgeAcquisitionRepository, certificationScoringEvent.userId);
 
-  const partnerCertifications = await _getAcquiredPartnerCertifications({
-    badgeAcquisitionRepository,
-    userId: assessmentCompletedEvent.userId,
+  const cleaPartnerAcquisition = new CertificationPartnerAcquisition({
     certificationCourseId: certificationScoringEvent.certificationCourseId,
-    percentageCorrectAnswers: certificationScoringEvent.percentageCorrectAnswers,
+    partnerKey: Badge.keys.PIX_EMPLOI_CLEA,
   });
 
-  await _saveResult({
-    partnerCertifications,
-    domainTransaction,
-    certificationPartnerAcquisitionRepository,
-  });
+  if (cleaPartnerAcquisition.hasAcquiredCertification({ hasAcquiredBadge: hasAcquiredBadgeClea, percentageCorrectAnswers: certificationScoringEvent.percentageCorrectAnswers })) {
+    await certificationPartnerAcquisitionRepository.save(cleaPartnerAcquisition, domainTransaction);
+  }
 }
 
-async function _saveResult({
-  partnerCertifications,
-  domainTransaction,
-  certificationPartnerAcquisitionRepository,
-}) {
-  return await Promise.map(partnerCertifications, (partnerCertification) => {
-    return certificationPartnerAcquisitionRepository.save(partnerCertification, domainTransaction);
-  });
-}
-
-async function _getAcquiredPartnerCertifications({ badgeAcquisitionRepository, userId, certificationCourseId, percentageCorrectAnswers }) {
-  const partnerCertifications = [];
-  const hasAcquiredBadgeClea = await badgeAcquisitionRepository.hasAcquiredBadgeWithKey({
+async function _getHasAcquiredBadgeClea(badgeAcquisitionRepository, userId) {
+  return badgeAcquisitionRepository.hasAcquiredBadgeWithKey({
     badgeKey: Badge.keys.PIX_EMPLOI_CLEA,
-    userId
+    userId,
   });
-
-  if (_checkCriteriaFullfilledClea(hasAcquiredBadgeClea, percentageCorrectAnswers)) {
-    partnerCertifications.push(new CertificationPartnerAcquisition({
-      certificationCourseId,
-      partnerKey: Badge.keys.PIX_EMPLOI_CLEA
-    }));
-  }
-
-  return partnerCertifications;
-}
-
-function _checkCriteriaFullfilledClea(userHasBadgeClea, percentageCorrectAnswers) {
-  if (!userHasBadgeClea) return false;
-
-  switch (_getPartnerCertificationObtentionArea(percentageCorrectAnswers)) {
-    case CERTIF_GREEN_ZONE:
-      return true;
-    case CERTIF_RED_ZONE:
-      return false;
-  }
-}
-
-function _getPartnerCertificationObtentionArea(percentageCorrectAnswers) {
-  if (percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED) {
-    return CERTIF_GREEN_ZONE;
-  } else if (percentageCorrectAnswers <= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED) {
-    return CERTIF_RED_ZONE;
-  }
-
-  return null;
 }
 
 module.exports = handleCertificationAcquisitionForPartner;

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -1,0 +1,82 @@
+const Badge = require('../models/Badge');
+const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
+const Promise = require('bluebird');
+const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED, MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED } = require('../constants');
+
+const CERTIF_GREEN_ZONE = 'green_zone';
+const CERTIF_RED_ZONE = 'red_zone';
+
+async function handleCertificationAcquisitionForPartner({
+  assessmentCompletedEvent,
+  certificationScoringEvent,
+  domainTransaction,
+  badgeAcquisitionRepository,
+  certificationPartnerAcquisitionRepository,
+}) {
+  if (!assessmentCompletedEvent.isCertification) {
+    return;
+  }
+
+  const partnerCertifications = await _getAcquiredPartnerCertifications({
+    badgeAcquisitionRepository,
+    userId: assessmentCompletedEvent.userId,
+    certificationCourseId: certificationScoringEvent.certificationCourseId,
+    percentageCorrectAnswers: certificationScoringEvent.percentageCorrectAnswers,
+  });
+
+  await _saveResult({
+    partnerCertifications,
+    domainTransaction,
+    certificationPartnerAcquisitionRepository,
+  });
+}
+
+async function _saveResult({
+  partnerCertifications,
+  domainTransaction,
+  certificationPartnerAcquisitionRepository,
+}) {
+  return await Promise.map(partnerCertifications, (partnerCertification) => {
+    return certificationPartnerAcquisitionRepository.save(partnerCertification, domainTransaction);
+  });
+}
+
+async function _getAcquiredPartnerCertifications({ badgeAcquisitionRepository, userId, certificationCourseId, percentageCorrectAnswers }) {
+  const partnerCertifications = [];
+  const hasAcquiredBadgeClea = await badgeAcquisitionRepository.hasAcquiredBadgeWithKey({
+    badgeKey: Badge.keys.PIX_EMPLOI_CLEA,
+    userId
+  });
+
+  if (_checkCriteriaFullfilledClea(hasAcquiredBadgeClea, percentageCorrectAnswers)) {
+    partnerCertifications.push(new CertificationPartnerAcquisition({
+      certificationCourseId,
+      partnerKey: Badge.keys.PIX_EMPLOI_CLEA
+    }));
+  }
+
+  return partnerCertifications;
+}
+
+function _checkCriteriaFullfilledClea(userHasBadgeClea, percentageCorrectAnswers) {
+  if (!userHasBadgeClea) return false;
+
+  switch (_getPartnerCertificationObtentionArea(percentageCorrectAnswers)) {
+    case CERTIF_GREEN_ZONE:
+      return true;
+    case CERTIF_RED_ZONE:
+      return false;
+  }
+}
+
+function _getPartnerCertificationObtentionArea(percentageCorrectAnswers) {
+  if (percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED) {
+    return CERTIF_GREEN_ZONE;
+  } else if (percentageCorrectAnswers <= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED) {
+    return CERTIF_RED_ZONE;
+  }
+
+  return null;
+}
+
+module.exports = handleCertificationAcquisitionForPartner;

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -3,10 +3,13 @@ const Badge = require('../models/Badge');
 const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
 const CompetenceMark = require('../models/CompetenceMark');
 const Promise = require('bluebird');
-const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED, UNCERTIFIED_LEVEL } = require('../constants');
+const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED, MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED, UNCERTIFIED_LEVEL } = require('../constants');
 const {
   CertificationComputeError,
 } = require('../errors');
+
+const CERTIF_GREEN_ZONE = 'green_zone';
+const CERTIF_RED_ZONE = 'red_zone';
 
 const handleCertificationScoring = async function({
   assessmentCompletedEvent,
@@ -86,10 +89,25 @@ async function _saveResult({
 
 function _checkCriteriaFullfilledClea(hasBadgeClea, percentageCorrectAnswers) {
   if (hasBadgeClea) {
-    // Green zone
-    return percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED;
+    switch (_getPartnerCertificationObtentionZone(percentageCorrectAnswers)) {
+      case CERTIF_GREEN_ZONE:
+        return true;
+      case CERTIF_RED_ZONE:
+        return false;
+    }
   }
+
   return false;
+}
+
+function _getPartnerCertificationObtentionZone(percentageCorrectAnswers) {
+  if (percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED) {
+    return CERTIF_GREEN_ZONE;
+  } else if (percentageCorrectAnswers <= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED) {
+    return CERTIF_RED_ZONE;
+  }
+
+  return null;
 }
 
 function _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository }) {

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -1,17 +1,13 @@
 const AssessmentResult = require('../models/AssessmentResult');
-const Badge = require('../models/Badge');
-const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
+const CertificationScoringCompleted = require('./CertificationScoringCompleted.js');
 const CompetenceMark = require('../models/CompetenceMark');
 const bluebird = require('bluebird');
-const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED, MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED, UNCERTIFIED_LEVEL } = require('../constants');
+const { UNCERTIFIED_LEVEL } = require('../constants');
 const {
   CertificationComputeError,
 } = require('../errors');
 
-const CERTIF_GREEN_ZONE = 'green_zone';
-const CERTIF_RED_ZONE = 'red_zone';
-
-const handleCertificationScoring = async function({
+async function  handleCertificationScoring({
   assessmentCompletedEvent,
   domainTransaction,
   assessmentResultRepository,
@@ -23,11 +19,15 @@ const handleCertificationScoring = async function({
   certificationPartnerAcquisitionRepository,
 }) {
   if (assessmentCompletedEvent.isCertification) {
-    await _calculateCertificationScore({ assessmentId: assessmentCompletedEvent.assessmentId, domainTransaction, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService, assessmentRepository, badgeAcquisitionRepository, certificationPartnerAcquisitionRepository, });
+    return _calculateCertificationScore({ assessmentCompletedEvent, assessmentId: assessmentCompletedEvent.assessmentId, domainTransaction, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService, assessmentRepository, badgeAcquisitionRepository, certificationPartnerAcquisitionRepository, });
   }
-};
+
+  return null;
+
+}
 
 async function _calculateCertificationScore({
+  assessmentCompletedEvent,
   assessmentId,
   domainTransaction,
   assessmentResultRepository,
@@ -35,24 +35,21 @@ async function _calculateCertificationScore({
   competenceMarkRepository,
   scoringCertificationService,
   assessmentRepository,
-  badgeAcquisitionRepository,
-  certificationPartnerAcquisitionRepository,
 }) {
   const assessment = await assessmentRepository.get(assessmentId);
   try {
     const assessmentScore = await scoringCertificationService.calculateAssessmentScore(assessment);
-    const partnerCertifications = await _getAcquiredPartnerCertifications({ badgeAcquisitionRepository, assessment, assessmentScore });
     await _saveResult({
       assessment,
       assessmentScore,
-      partnerCertifications,
       domainTransaction,
       assessmentResultRepository,
       certificationCourseRepository,
       competenceMarkRepository,
-      badgeAcquisitionRepository,
-      certificationPartnerAcquisitionRepository,
     });
+
+    return new CertificationScoringCompleted({ userId: assessmentCompletedEvent.userId, isCertification: assessmentCompletedEvent.isCertification, certificationCourseId: assessment.certificationCourseId, percentageCorrectAnswers: assessmentScore.percentageCorrectAnswers });
+
   }
   catch (error) {
     if (!(error instanceof CertificationComputeError)) {
@@ -71,48 +68,24 @@ async function _calculateCertificationScore({
 async function _saveResult({
   assessment,
   assessmentScore,
-  partnerCertifications,
   domainTransaction,
   assessmentResultRepository,
   certificationCourseRepository,
-  certificationPartnerAcquisitionRepository,
   competenceMarkRepository,
 }) {
-  const assessmentResult = await _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository, domainTransaction });
+  const assessmentResult = await _createAssessmentResult({
+    assessment,
+    assessmentScore,
+    assessmentResultRepository,
+    domainTransaction
+  });
 
   await bluebird.mapSeries(assessmentScore.competenceMarks, (competenceMark) => {
     const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
     return competenceMarkRepository.save(competenceMarkDomain, domainTransaction);
   });
 
-  await bluebird.mapSeries(partnerCertifications, (partnerCertification) => {
-    return certificationPartnerAcquisitionRepository.save(partnerCertification, domainTransaction);
-  });
-
   return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date(), domainTransaction);
-}
-
-function _checkCriteriaFullfilledClea(hasBadgeClea, percentageCorrectAnswers) {
-  if (hasBadgeClea) {
-    switch (_getPartnerCertificationObtentionZone(percentageCorrectAnswers)) {
-      case CERTIF_GREEN_ZONE:
-        return true;
-      case CERTIF_RED_ZONE:
-        return false;
-    }
-  }
-
-  return false;
-}
-
-function _getPartnerCertificationObtentionZone(percentageCorrectAnswers) {
-  if (percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED) {
-    return CERTIF_GREEN_ZONE;
-  } else if (percentageCorrectAnswers <= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED) {
-    return CERTIF_RED_ZONE;
-  }
-
-  return null;
 }
 
 function _createAssessmentResult({ assessment, assessmentScore, assessmentResultRepository, domainTransaction }) {
@@ -140,23 +113,6 @@ async function _saveResultAfterCertificationComputeError({
   const assessmentResult = AssessmentResult.BuildAlgoErrorResult(certificationComputeError, assessment.id);
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(assessment.certificationCourseId, new Date(), domainTransaction);
-}
-
-async function _getAcquiredPartnerCertifications({ badgeAcquisitionRepository, assessment, assessmentScore }) {
-  const partnerCertifications = [];
-  const hasAcquiredBadgeClea = await badgeAcquisitionRepository.hasAcquiredBadgeWithKey({
-    badgeKey: Badge.keys.PIX_EMPLOI_CLEA,
-    userId: assessment.userId
-  });
-
-  if (_checkCriteriaFullfilledClea(hasAcquiredBadgeClea, assessmentScore.percentageCorrectAnswers)) {
-    partnerCertifications.push(new CertificationPartnerAcquisition({
-      certificationCourseId: assessment.certificationCourseId,
-      partnerKey: Badge.keys.PIX_EMPLOI_CLEA
-    }));
-  }
-
-  return partnerCertifications;
 }
 
 module.exports = handleCertificationScoring;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -16,4 +16,5 @@ const dependencies = {
 module.exports = injectDependencies({
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
   handleCertificationScoring: require('./handle-certification-scoring'),
+  handleCertificationAcquisitionForPartner: require('./handle-certification-partner'),
 }, dependencies);

--- a/api/lib/domain/models/CertificationPartnerAcquisition.js
+++ b/api/lib/domain/models/CertificationPartnerAcquisition.js
@@ -1,11 +1,42 @@
+const CERTIF_GREEN_ZONE = 'green_zone';
+const CERTIF_RED_ZONE = 'red_zone';
+
+const { MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED, MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED } = require('../constants');
+
 class CertificationPartnerAcquisition {
   constructor(
     {
       certificationCourseId,
-      partnerKey
+      partnerKey,
+
     } = {}) {
     this.certificationCourseId = certificationCourseId;
     this.partnerKey = partnerKey;
+  }
+
+  hasAcquiredCertification({
+    hasAcquiredBadge = false,
+    percentageCorrectAnswers = 0 }) {
+    if (!hasAcquiredBadge) return false;
+
+    switch (this._getPartnerCertificationObtentionZone(percentageCorrectAnswers)) {
+      case CERTIF_GREEN_ZONE:
+        return true;
+      case CERTIF_RED_ZONE:
+        return false;
+        // case ZONE_GRISE
+        // zone grise
+    }
+  }
+
+  _getPartnerCertificationObtentionZone(percentageCorrectAnswers) {
+    if (percentageCorrectAnswers >= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_TRUSTED) {
+      return CERTIF_GREEN_ZONE;
+    } else if (percentageCorrectAnswers <= MINIMUM_REPRODUCTIBILITY_RATE_TO_BE_CERTIFIED) {
+      return CERTIF_RED_ZONE;
+    }
+
+    return null;
   }
 }
 

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -15,7 +15,7 @@ module.exports = async function completeAssessment({
     throw new AlreadyRatedAssessmentError();
   }
 
-  await assessmentRepository.completeByAssessmentId(domainTransaction, assessmentId);
+  await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
 
   return new AssessmentCompleted(
     assessmentId,

--- a/api/lib/infrastructure/DomainTransaction.js
+++ b/api/lib/infrastructure/DomainTransaction.js
@@ -10,5 +10,9 @@ class DomainTransaction {
       return lambda(new DomainTransaction(trx));
     });
   }
+
+  static emptyTransaction() {
+    return new DomainTransaction(null);
+  }
 }
 module.exports = DomainTransaction;

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -17,7 +17,7 @@ module.exports = {
     id,
     juryId,
     assessmentId,
-  }) => {
+  }, domainTransaction = {}) => {
     return new BookshelfAssessmentResult({
       pixScore,
       level,
@@ -30,7 +30,7 @@ module.exports = {
       juryId,
       assessmentId,
     })
-      .save()
+      .save(null, { transacting: domainTransaction.knexTransaction })
       .then(_toDomain);
   },
 

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -1,9 +1,10 @@
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const BookshelfBadgeAcquisition = require('../../infrastructure/data/badge-acquisition');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
 
-  async create(domainTransaction, { badgeId, userId }) {
+  async create({ badgeId, userId }, domainTransaction = DomainTransaction.emptyTransaction()) {
     const result = await new BookshelfBadgeAcquisition({
       badgeId,
       userId

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -1,5 +1,6 @@
 const Bookshelf = require('../bookshelf');
 const CertificationChallenge = require('../../domain/models/CertificationChallenge');
+const DomainTransaction = require('../DomainTransaction');
 const CertificationChallengeBookshelf = require('../data/certification-challenge');
 const logger = require('../../infrastructure/logger');
 
@@ -23,7 +24,7 @@ function _toDomain(model) {
 
 module.exports = {
 
-  save({ certificationChallenge, domainTransaction = {} }) {
+  save({ certificationChallenge, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const certificationChallengeToSave = new CertificationChallengeBookshelf({
       challengeId: certificationChallenge.challengeId,
       competenceId: certificationChallenge.competenceId,

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -17,9 +17,9 @@ module.exports = {
     return _toDomain(savedCertificationCourse);
   },
 
-  async changeCompletionDate(certificationCourseId, completedAt = null) {
+  async changeCompletionDate(certificationCourseId, completedAt = null, domainTransaction = {}) {
     const certificationCourseBookshelf = new CertificationCourseBookshelf({ id: certificationCourseId, completedAt });
-    const savedCertificationCourse = await certificationCourseBookshelf.save();
+    const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting: domainTransaction.knexTransaction });
     return _toDomain(savedCertificationCourse);
   },
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -3,13 +3,14 @@ const { _ } = require('lodash');
 const CertificationCourseBookshelf = require('../data/certification-course');
 const AssessmentBookshelf = require('../data/assessment');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../DomainTransaction');
 const CertificationCourse = require('../../domain/models/CertificationCourse');
 const Assessment = require('../../domain/models/Assessment');
 const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
 
-  async save({ certificationCourse, domainTransaction = {} }) {
+  async save({ certificationCourse, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const certificationCourseToSave = _adaptModelToDb(certificationCourse);
     const options = { transacting : domainTransaction.knexTransaction };
     const savedCertificationCourse = await new CertificationCourseBookshelf(certificationCourseToSave).save(null, options);
@@ -36,7 +37,7 @@ module.exports = {
     }
   },
 
-  async findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId, domainTransaction = {} }) {
+  async findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const certificationCourse = await CertificationCourseBookshelf
       .where({ userId, sessionId })
       .orderBy('createdAt', 'desc')

--- a/api/lib/infrastructure/repositories/certification-partner-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/certification-partner-acquisition-repository.js
@@ -2,7 +2,7 @@ const CertificationPartnerAcquisitionBookshelf = require('../data/certification-
 
 module.exports = {
 
-  async save(certificationPartnerAcquisition) {
-    return await new CertificationPartnerAcquisitionBookshelf(certificationPartnerAcquisition).save();
+  async save(certificationPartnerAcquisition, domainTransaction = {}) {
+    return await new CertificationPartnerAcquisitionBookshelf(certificationPartnerAcquisition).save(null , { transacting: domainTransaction.knexTransaction });
   },
 };

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -6,9 +6,9 @@ function _toDomain(bookshelfCompetenceMark) {
 }
 
 module.exports = {
-  save: (competenceMark) => {
+  save: (competenceMark, domainTransaction = {}) => {
     return competenceMark.validate()
-      .then(() => new BookshelfCompetenceMark(competenceMark).save())
+      .then(() => new BookshelfCompetenceMark(competenceMark).save(null, { transacting: domainTransaction.knexTransaction }))
       .then((savedCompetenceMark) => savedCompetenceMark.toDomainEntity());
   },
 

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -632,7 +632,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     it('should complete an assessment if not already existing and commited', async () => {
       // when
       await DomainTransaction.execute(async (domainTransaction) => {
-        await assessmentRepository.completeByAssessmentId(domainTransaction, assessmentId);
+        await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
       });
 
       // then
@@ -644,7 +644,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
       // when
       await catchErr(async () => {
         await DomainTransaction.execute(async (domainTransaction) => {
-          await assessmentRepository.completeByAssessmentId(domainTransaction, assessmentId);
+          await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
           throw new Error('an error occurs within the domain transaction');
         });
       });

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -30,7 +30,7 @@ describe('Integration | Repository | Badge Acquisition', () => {
     it('should persist the badge acquisition in db', async () => {
       // when
       badgeAcquisition = await DomainTransaction.execute(async (domainTransaction) => {
-        return badgeAcquisitionRepository.create(domainTransaction, badgeAcquisitionToCreate);
+        return badgeAcquisitionRepository.create(badgeAcquisitionToCreate, domainTransaction);
       });
 
       // then
@@ -42,7 +42,7 @@ describe('Integration | Repository | Badge Acquisition', () => {
     it('should return the saved badge acquired', async () => {
       // when
       badgeAcquisition = await DomainTransaction.execute(async (domainTransaction) => {
-        return badgeAcquisitionRepository.create(domainTransaction, badgeAcquisitionToCreate);
+        return badgeAcquisitionRepository.create(badgeAcquisitionToCreate, domainTransaction);
       });
 
       // then

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -23,7 +23,6 @@ describe('Unit | Controller | assessment-controller', function() {
     const userId = 24504875;
 
     beforeEach(() => {
-
       sinon.stub(usecases, 'findSmartPlacementAssessments');
       sinon.stub(assessmentSerializer, 'serialize');
     });
@@ -107,6 +106,7 @@ describe('Unit | Controller | assessment-controller', function() {
   describe('#completeAssessment', () => {
     const assessmentId = 2;
     const assessmentCompletedEvent = Symbol('un événement de fin de test');
+    const certificationScoringEvent = Symbol('un événement de fin de scoring');
     const domainTransaction = Symbol('domain transaction');
     let transactionToBeExecuted;
 
@@ -116,6 +116,7 @@ describe('Unit | Controller | assessment-controller', function() {
 
       sinon.stub(events, 'handleBadgeAcquisition');
       sinon.stub(events, 'handleCertificationScoring');
+      sinon.stub(events, 'handleCertificationPartner');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         transactionToBeExecuted = lambda;
       });
@@ -148,13 +149,27 @@ describe('Unit | Controller | assessment-controller', function() {
     it('should pass the assessment completed event to the CertificationScoringHandler', async () => {
       /// given
       events.handleBadgeAcquisition.resolves({});
+      events.handleCertificationScoring.resolves({});
 
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent });
+      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent,  });
+    });
+
+    it('should pass the assessment completed event to the CertificationPartnerHandler', async () => {
+      /// given
+      events.handleBadgeAcquisition.resolves({});
+      events.handleCertificationScoring.resolves(certificationScoringEvent);
+
+      // when
+      await assessmentController.completeAssessment({ params: { id: assessmentId } });
+      await transactionToBeExecuted(domainTransaction);
+
+      // then
+      expect(events.handleCertificationPartner).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent, certificationScoringEvent });
     });
 
     it('should call usecase and handler within the transaction', async () => {
@@ -166,6 +181,7 @@ describe('Unit | Controller | assessment-controller', function() {
       expect(usecases.completeAssessment).to.not.have.been.called;
       expect(events.handleBadgeAcquisition).to.not.have.been.called;
       expect(events.handleCertificationScoring).to.not.have.been.called;
+      expect(events.handleCertificationPartner).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -8,7 +8,6 @@ const DomainTransaction = require('../../../../lib/infrastructure/DomainTransact
 describe('Unit | Controller | assessment-controller', function() {
 
   describe('#findByFilters', () => {
-
     const assessments = [{ id: 1 }, { id: 2 }];
     const assessmentsInJSONAPI = [{
       id: 1,
@@ -116,7 +115,7 @@ describe('Unit | Controller | assessment-controller', function() {
 
       sinon.stub(events, 'handleBadgeAcquisition');
       sinon.stub(events, 'handleCertificationScoring');
-      sinon.stub(events, 'handleCertificationPartner');
+      sinon.stub(events, 'handleCertificationAcquisitionForPartner');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         transactionToBeExecuted = lambda;
       });
@@ -169,7 +168,7 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleCertificationPartner).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent, certificationScoringEvent });
+      expect(events.handleCertificationAcquisitionForPartner).to.have.been.calledWithExactly({ domainTransaction, certificationScoringEvent });
     });
 
     it('should call usecase and handler within the transaction', async () => {
@@ -181,7 +180,7 @@ describe('Unit | Controller | assessment-controller', function() {
       expect(usecases.completeAssessment).to.not.have.been.called;
       expect(events.handleBadgeAcquisition).to.not.have.been.called;
       expect(events.handleCertificationScoring).to.not.have.been.called;
-      expect(events.handleCertificationPartner).to.not.have.been.called;
+      expect(events.handleCertificationAcquisitionForPartner).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -154,7 +154,7 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ assessmentCompletedEvent });
+      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent });
     });
 
     it('should call usecase and handler within the transaction', async () => {

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -63,17 +63,17 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).returns(true);
 
           // when
-          await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent, ...dependencies });
+          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly(domainTransaction, { badgeId, userId: assessmentCompletedEvent.userId });
+          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({ badgeId, userId: assessmentCompletedEvent.userId }, domainTransaction);
         });
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
           // given
           badgeCriteriaService.areBadgeCriteriaFulfilled.withArgs({ campaignParticipationResult }).returns(false);
           // when
-          await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent, ...dependencies });
+          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -93,7 +93,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           const assessmentCompletedEvent = new AssessmentCompleted(userId, targetProfileId);
 
           // when
-          await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent, ...dependencies });
+          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -111,7 +111,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         const assessmentCompletedEvent = new AssessmentCompleted(userId, targetProfileId);
 
         // when
-        await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent, ...dependencies });
+        await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
 
         // then
         expect(badgeAcquisitionRepository.create).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-certification-partner_test.js
+++ b/api/tests/unit/domain/events/handle-certification-partner_test.js
@@ -1,0 +1,127 @@
+const _ = require('lodash');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const events = require('../../../../lib/domain/events');
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+const Badge = require('../../../../lib/domain/models/Badge');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+
+describe('Unit | Domain | Events | handle-certification-partner', () => {
+  const scoringCertificationService = { calculateAssessmentScore: _.noop };
+  const assessmentRepository = { get: _.noop };
+  const assessmentResultRepository = { save: _.noop };
+  const badgeAcquisitionRepository = { hasAcquiredBadgeWithKey:  _.noop };
+  const certificationPartnerAcquisitionRepository = { save: _.noop };
+  const domainTransaction = {};
+
+  let assessmentCompletedEvent;
+  let certificationScoringEvent;
+
+  const dependencies = {
+    scoringCertificationService,
+    assessmentRepository,
+    badgeAcquisitionRepository,
+    certificationPartnerAcquisitionRepository,
+  };
+
+  context('when assessment is of type CERTIFICATION', () => {
+    let certificationAssessment;
+
+    beforeEach(() => {
+      certificationAssessment = _buildCertificationAssessment();
+      sinon.stub(assessmentRepository, 'get').withArgs(certificationAssessment.id).resolves(certificationAssessment);
+      assessmentCompletedEvent = new AssessmentCompleted(
+        certificationAssessment.id,
+        Symbol('userId'),
+        null, //Symbol('targetProfileId'),
+        null, //Symbol('campaignParticipationId'),
+        true,
+      );
+
+      certificationScoringEvent = {
+        percentageCorrectAnswers: null,
+        certificationCourseId: certificationAssessment.certificationCourseId
+      };
+
+    });
+
+    context('when scoring is successful', () => {
+      const assessmentResult = Symbol('AssessmentResult');
+      const assessmentResultId = 'assessmentResultId';
+      const savedAssessmentResult = { id: assessmentResultId };
+
+      beforeEach(() => {
+        sinon.stub(AssessmentResult, 'BuildStandardAssessmentResult').returns(assessmentResult);
+        sinon.stub(assessmentResultRepository, 'save').resolves(savedAssessmentResult);
+      });
+
+      context('when score is above 0', () => {
+        const assessmentScore = {
+          nbPix: null,
+          level: null,
+          competenceMarks: null,
+        };
+
+        beforeEach(() => {
+          sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
+          sinon.stub(badgeAcquisitionRepository, 'hasAcquiredBadgeWithKey').resolves(true);
+        });
+
+        context('when user has clea badge', () => {
+          [80, 90, 100].forEach((reproducabilityRate) =>
+            it(`for ${reproducabilityRate} it should obtain CleA certification`, async () => {
+              // given
+              sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();
+              certificationScoringEvent.percentageCorrectAnswers = reproducabilityRate;
+
+              // when
+              await events.handleCertificationAcquisitionForPartner({
+                assessmentCompletedEvent, certificationScoringEvent,  ...dependencies, domainTransaction
+              });
+
+              // then
+              expect(badgeAcquisitionRepository.hasAcquiredBadgeWithKey).to.have.been.called;
+              expect(certificationPartnerAcquisitionRepository.save).to.have.been.calledWithMatch(
+                {
+                  partnerKey: Badge.keys.PIX_EMPLOI_CLEA,
+                  certificationCourseId: certificationAssessment.certificationCourseId,
+                },
+                domainTransaction);
+            })
+          );
+
+          [1, 50].forEach((reproducabilityRate) =>
+            it(`for ${reproducabilityRate} it should not obtain CleA certification`, async () => {
+              // given
+              sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();
+              certificationScoringEvent.percentageCorrectAnswers = reproducabilityRate;
+
+              // when
+              await events.handleCertificationAcquisitionForPartner({
+                assessmentCompletedEvent, certificationScoringEvent, ...dependencies, domainTransaction
+              });
+
+              // then
+              expect(badgeAcquisitionRepository.hasAcquiredBadgeWithKey).to.have.been.called;
+              expect(certificationPartnerAcquisitionRepository.save).not.to.have.been.called;
+            })
+          );
+        });
+
+      });
+
+      context('when score is equal 0', () => {
+
+      });
+    });
+  });
+});
+
+function _buildCertificationAssessment() {
+  return domainBuilder.buildAssessment({
+    id: Symbol('assessmentId'),
+    certificationCourseId: Symbol('certificationCourseId'),
+    state: 'started',
+    type: Assessment.types.CERTIFICATION,
+  });
+}

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -16,6 +16,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
   const competenceMarkRepository = { save: _.noop };
   const badgeAcquisitionRepository = { hasAcquiredBadgeWithKey:  _.noop };
   const certificationPartnerAcquisitionRepository = { save: _.noop };
+  const domainTransaction = {};
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
   let assessmentCompletedEvent;
@@ -89,7 +90,8 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         // when
         await events.handleCertificationScoring({
           assessmentCompletedEvent,
-          ...dependencies
+          ...dependencies,
+          domainTransaction,
         });
 
         // then
@@ -102,7 +104,8 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         // when
         await events.handleCertificationScoring({
           assessmentCompletedEvent,
-          ...dependencies
+          ...dependencies,
+          domainTransaction,
         });
 
         // then
@@ -113,7 +116,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           errorAssessmentResult
         );
         expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
-          certificationAssessment.certificationCourseId, now
+          certificationAssessment.certificationCourseId, now, domainTransaction
         );
       });
     });
@@ -139,7 +142,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           level: originalLevel,
           competenceMarks: [competenceMarkData1, competenceMarkData2],
           reproducabilityRate: undefined,
-
         };
 
         beforeEach(() => {
@@ -150,7 +152,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         it('should left untouched the calculated level in the assessment score', async () => {
           // when
           await events.handleCertificationScoring({
-            assessmentCompletedEvent, ...dependencies
+            assessmentCompletedEvent, ...dependencies, domainTransaction
           });
 
           // then
@@ -160,7 +162,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         it('should build and save an assessment result with the expected arguments', async () => {
           // when
           await events.handleCertificationScoring({
-            assessmentCompletedEvent, ...dependencies
+            assessmentCompletedEvent, ...dependencies, domainTransaction
           });
 
           // then
@@ -170,9 +172,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
             AssessmentResult.status.VALIDATED,
             certificationAssessment.id
           );
-          expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
+          expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult, domainTransaction);
           expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
-            certificationAssessment.certificationCourseId, now
+            certificationAssessment.certificationCourseId, now, domainTransaction
           );
 
         });
@@ -186,7 +188,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
               // when
               await events.handleCertificationScoring({
-                assessmentCompletedEvent, ...dependencies
+                assessmentCompletedEvent, ...dependencies, domainTransaction
               });
 
               // then
@@ -206,7 +208,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
               // when
               await events.handleCertificationScoring({
-                assessmentCompletedEvent, ...dependencies
+                assessmentCompletedEvent, ...dependencies, domainTransaction
               });
 
               // then
@@ -219,7 +221,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         it('should build and save as many competence marks as present in the assessmentScore', async () => {
         // when
           await events.handleCertificationScoring({
-            assessmentCompletedEvent, ...dependencies
+            assessmentCompletedEvent, ...dependencies, domainTransaction
           });
 
           // then
@@ -241,7 +243,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         it('should change level of the assessmentScore', async () => {
           // when
           await events.handleCertificationScoring({
-            assessmentCompletedEvent, ...dependencies
+            assessmentCompletedEvent, ...dependencies, domainTransaction
           });
 
           // then
@@ -251,7 +253,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         it('should build and save an assessment result with the expected arguments', async () => {
           // when
           await events.handleCertificationScoring({
-            assessmentCompletedEvent, ...dependencies
+            assessmentCompletedEvent, ...dependencies, domainTransaction
           });
 
           // then
@@ -262,10 +264,10 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
             certificationAssessment.id
           );
           expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
-            assessmentResult
+            assessmentResult, domainTransaction
           );
           expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
-            certificationAssessment.certificationCourseId, now
+            certificationAssessment.certificationCourseId, now, domainTransaction
           );
         });
       });
@@ -285,7 +287,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       // when
       await events.handleCertificationScoring({
-        assessmentCompletedEvent, ...dependencies
+        assessmentCompletedEvent, ...dependencies, domainTransaction
       });
 
       expect(assessmentRepository.get).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -198,7 +198,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
             })
           );
 
-          [1, 79].forEach((reproducabilityRate) =>
+          [1, 50].forEach((reproducabilityRate) =>
             it(`for ${reproducabilityRate} it should not obtain CleA certification`, async () => {
               // given
               sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -3,10 +3,10 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 const events = require('../../../../lib/domain/events');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const Badge = require('../../../../lib/domain/models/Badge');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
 const { UNCERTIFIED_LEVEL } = require('../../../../lib/domain/constants');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+const CertificationScoringCompleted = require('../../../../lib/domain/events/CertificationScoringCompleted');
 
 describe('Unit | Domain | Events | handle-certification-scoring', () => {
   const scoringCertificationService = { calculateAssessmentScore: _.noop };
@@ -14,8 +14,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
   const assessmentResultRepository = { save: _.noop };
   const certificationCourseRepository = { changeCompletionDate: _.noop };
   const competenceMarkRepository = { save: _.noop };
-  const badgeAcquisitionRepository = { hasAcquiredBadgeWithKey:  _.noop };
-  const certificationPartnerAcquisitionRepository = { save: _.noop };
   const domainTransaction = {};
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
@@ -27,8 +25,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
     competenceMarkRepository,
     scoringCertificationService,
     assessmentRepository,
-    badgeAcquisitionRepository,
-    certificationPartnerAcquisitionRepository,
   };
 
   beforeEach(() => {
@@ -142,11 +138,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           level: originalLevel,
           competenceMarks: [competenceMarkData1, competenceMarkData2],
           reproducabilityRate: undefined,
+          percentageCorrectAnswers: 80
         };
 
         beforeEach(() => {
           sinon.stub(scoringCertificationService, 'calculateAssessmentScore').resolves(assessmentScore);
-          sinon.stub(badgeAcquisitionRepository, 'hasAcquiredBadgeWithKey').resolves(true);
         });
 
         it('should left untouched the calculated level in the assessment score', async () => {
@@ -176,46 +172,17 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
             certificationAssessment.certificationCourseId, now, domainTransaction
           );
-
         });
 
-        context('when user has clea badge', () => {
-          [80, 90, 100].forEach((reproducabilityRate) =>
-            it(`for ${reproducabilityRate} it should obtain CleA certification`, async () => {
-              // given
-              sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();
-              assessmentScore.percentageCorrectAnswers = reproducabilityRate;
+        it('should return a CertificationScoringCompleted', async () => {
+          // when
+          const  certificationScoringCompleted = await events.handleCertificationScoring({
+            assessmentCompletedEvent, ...dependencies, domainTransaction
+          });
 
-              // when
-              await events.handleCertificationScoring({
-                assessmentCompletedEvent, ...dependencies, domainTransaction
-              });
-
-              // then
-              expect(badgeAcquisitionRepository.hasAcquiredBadgeWithKey).to.have.been.called;
-              expect(certificationPartnerAcquisitionRepository.save).to.have.been.calledWithMatch({
-                partnerKey: Badge.keys.PIX_EMPLOI_CLEA,
-                certificationCourseId: certificationAssessment.certificationCourseId
-              });
-            })
-          );
-
-          [1, 50].forEach((reproducabilityRate) =>
-            it(`for ${reproducabilityRate} it should not obtain CleA certification`, async () => {
-              // given
-              sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();
-              assessmentScore.percentageCorrectAnswers = reproducabilityRate;
-
-              // when
-              await events.handleCertificationScoring({
-                assessmentCompletedEvent, ...dependencies, domainTransaction
-              });
-
-              // then
-              expect(badgeAcquisitionRepository.hasAcquiredBadgeWithKey).to.have.been.called;
-              expect(certificationPartnerAcquisitionRepository.save).not.to.have.been.called;
-            })
-          );
+          // then
+          expect(certificationScoringCompleted).to.be.instanceof(CertificationScoringCompleted);
+          expect(certificationScoringCompleted).to.deep.equal({ userId: assessmentCompletedEvent.userId, isCertification: assessmentCompletedEvent.isCertification, certificationCourseId: certificationAssessment.certificationCourseId, percentageCorrectAnswers: assessmentScore.percentageCorrectAnswers });
         });
 
         it('should build and save as many competence marks as present in the assessmentScore', async () => {
@@ -286,11 +253,12 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       sinon.stub(assessmentRepository, 'get').resolves();
 
       // when
-      await events.handleCertificationScoring({
+      const certificationScoringCompleted = await events.handleCertificationScoring({
         assessmentCompletedEvent, ...dependencies, domainTransaction
       });
 
       expect(assessmentRepository.get).to.not.have.been.called;
+      expect(certificationScoringCompleted).to.be.null;
     });
 
   });

--- a/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
+++ b/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
@@ -1,0 +1,58 @@
+const { expect } = require('../../../test-helper');
+const CertificationPartnerAcquisition = require('../../../../lib/domain/models/CertificationPartnerAcquisition');
+
+describe('Unit | Domain | Models | CertificationPartnerAcquisition', () => {
+  let certificationPartnerAcquisition;
+  describe('#hasAcquiredCertification', () => {
+
+    context('when user does not have badge', () => {
+      beforeEach(() => {
+        certificationPartnerAcquisition = new CertificationPartnerAcquisition(
+          Symbol('certificationCourseId'),
+          Symbol('partnerKey'),
+        );
+      });
+
+      [1, 50, 80, 90, 100].forEach((reproducabilityRate) =>
+        it(`for ${reproducabilityRate} reproducability rate, it should not obtain certification`, async () => {
+          // when
+          const hasAcquiredCertif = certificationPartnerAcquisition.hasAcquiredCertification({ percentageCorrectAnswers: reproducabilityRate, hasAcquiredBadge: false });
+
+          // then
+          expect(hasAcquiredCertif).to.be.false;
+        })
+      );
+    });
+
+    context('when user has badge', () => {
+      beforeEach(() => {
+        certificationPartnerAcquisition = new CertificationPartnerAcquisition({
+          certificationCourseId: Symbol('certificationCourseId'),
+          partnerKey: Symbol('partnerKey'),
+        });
+      });
+
+      [80, 90, 100].forEach((reproducabilityRate) =>
+        it(`for ${reproducabilityRate} reproducability rate, it should obtain certification`, async () => {
+          // when
+          const hasAcquiredCertif = certificationPartnerAcquisition.hasAcquiredCertification({ hasAcquiredBadge: true, percentageCorrectAnswers:reproducabilityRate });
+
+          // then
+          expect(hasAcquiredCertif).to.be.true;
+        })
+      );
+
+      [1, 50].forEach((reproducabilityRate) =>
+        it(`for ${reproducabilityRate} reproducability rate, it should not obtain certification`, async () => {
+          // when
+          const hasAcquiredCertif = certificationPartnerAcquisition.hasAcquiredCertification({ hasAcquiredBadge: true, percentageCorrectAnswers:reproducabilityRate });
+
+          // then
+          expect(hasAcquiredCertif).to.be.false;
+
+        })
+      );
+    });
+
+  });
+});

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -82,7 +82,7 @@ describe('Unit | UseCase | complete-assessment', () => {
             });
 
             // then
-            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(domainTransaction, assessment.id)).to.be.true;
+            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id, domainTransaction)).to.be.true;
           });
 
           it('should return a AssessmentCompleted event', async () => {

--- a/docs/adr/0009-transaction-metier.md
+++ b/docs/adr/0009-transaction-metier.md
@@ -86,7 +86,7 @@ class DomainTransaction {
 ```javascript
 completeAssessment({assessment, domainTransaction, assessmentRepository, badgeRepository}) {
     if (!assessment.isComplete()) {
-        await assessmentRepository.completeAssessment(domainTransaction, assessment.id);
+        await assessmentRepository.completeAssessment(assessment.id, domainTransaction);
         await badgeRepository.acquireBadge(domainTransaction);
     }
 }
@@ -94,7 +94,7 @@ completeAssessment({assessment, domainTransaction, assessmentRepository, badgeRe
 
 #### Repository :
 ```javascript
-  completeByAssessmentId(domainTransaction, assessmentId) {
+  completeByAssessmentId(assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
       const assessment = await BookshelfAssessment
           .where({ assessmentId })
           .save({ Assessment.states.COMPLETED }, { require: true, patch: true, transacting: domainTransaction.knexTransaction });


### PR DESCRIPTION
## 🦄 Problème

La certification Clea doit pouvoir être obtenue en fonction de critères précis.

## 🤖 Solution

Implémentation de la “zone rouge” => un candidat ayant son badge Pix Emploi et ayant obtenu sa certif Pix avec un taux de repro <= 50% n'obtient pas sa certif Cléa.

## 🌈 Remarques

Pas de changement visible (suite zone verte pas de certif pour repro < 80%).

Les changements métier sont très légers. On profite de ce ticket pour 
- ajouter les transactions métiers
- ajouter une `DomainTransaction` vide comme valeur par défaut pour les repos
- déplacer la logique depuis le handler vers l'objet métier `CertificationPartnerAcquisition`

## 💯 Pour tester
ℹ️L'utilisateur no. 106 `certif1@example.net` généré par les seeds a obtenu le badge Pix Emploi.

