### PR TITLE
[CLEANUP] Appliquer le codemod no-implicit-this sur PixApp (PF-1230).

### DIFF
--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -5,5 +5,5 @@
   {{outlet}}
 
   <!-- Preloading images -->
-  <img src="{{rootURL}}/images/loader-white.svg" alt="Chargement en cours" style="display: none">
+  <img src="{{this.rootURL}}/images/loader-white.svg" alt="Chargement en cours" style="display: none">
 </div>

--- a/mon-pix/app/templates/assessments.hbs
+++ b/mon-pix/app/templates/assessments.hbs
@@ -1,3 +1,3 @@
-{{title model.title}}
+{{title this.model.title}}
 
 {{outlet}}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -1,9 +1,9 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="background-banner-wrapper assessment-challenge">
 
   <div class="assessment-challenge__assessment-banner">
-    {{#if model.assessment.isCertification}}
+    {{#if this.model.assessment.isCertification}}
       <CertificationBanner @certificationNumber={{@model.assessment.certificationNumber}} />
     {{else}}
       <AssessmentBanner @title={{@model.assessment.title}} @displayHomeLink={{true}} />
@@ -13,16 +13,16 @@
   <div class="assessment-challenge__content rounded-panel--over-background-banner">
     <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}} @challengeId={{@model.challenge.id}} />
 
-    {{component (get-challenge-component-class model.challenge)
-                challenge=model.challenge
-                answer=model.answer
-                assessment=model.assessment
+    {{component (get-challenge-component-class this.model.challenge)
+                challenge=this.model.challenge
+                answer=this.model.answer
+                assessment=this.model.assessment
                 answerValidated=(route-action "saveAnswerAndNavigate")
                 resumeAssessment=(route-action "resumeAssessment")
     }}
   </div>
 </div>
 
-{{#if showLevelup}}
-  <LevelupNotif @level={{newLevel}} @competenceName={{competenceLeveled}} />
+{{#if this.showLevelup}}
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
 {{/if}}

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="background-banner-wrapper assessment-challenge">
 
@@ -8,10 +8,10 @@
 
   <div class="checkpoint__container rounded-panel--over-background-banner">
     <div class="checkpoint__header">
-      {{#if shouldDisplayAnswers}}
+      {{#if this.shouldDisplayAnswers}}
         <div class="checkpoint-progression-gauge-wrapper">
-          <ProgressionGauge @total={{100}} @value={{completionPercentage}} @progressionClass="progression-gauge--white progression-gauge--tooltip-left">
-            <p class="sr-only">Vous avez effectué</p>{{completionPercentage}}%<p
+          <ProgressionGauge @total={{100}} @value={{this.completionPercentage}} @progressionClass="progression-gauge--white progression-gauge--tooltip-left">
+            <p class="sr-only">Vous avez effectué</p>{{this.completionPercentage}}%<p
             class="sr-only"> de votre parcours.</p>
           </ProgressionGauge>
 
@@ -19,14 +19,14 @@
 
         </div>
         <div class="checkpoint__continue-wrapper">
-          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{nextPageButtonText}} />
+          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
         </div>
       {{/if}}
     </div>
 
 
     <div class="rounded-panel rounded-panel--strong checkpoint__content">
-      {{#if shouldDisplayAnswers}}
+      {{#if this.shouldDisplayAnswers}}
         <div class="rounded-panel-one-line-header">
           <h1 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-title--all-small-caps">
             vos réponses
@@ -34,11 +34,11 @@
         </div>
 
         <div class="assessment-results__list">
-          {{#each model.answersSinceLastCheckpoints as |answer|}}
+          {{#each this.model.answersSinceLastCheckpoints as |answer|}}
             <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{action "openComparisonWindow"}} />
           {{/each}}
         </div>
-        <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{nextPageButtonText}} />
+        <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
       {{else}}
         <div class="checkpoint-no-answer">
           <div class="checkpoint-no-answer__header">
@@ -47,18 +47,18 @@
           <div class="checkpoint-no-answer__info">
             Vous avez déjà répondu aux questions, lors de vos parcours précédents. Vous pouvez directement accéder à vos résultats.
           </div>
-          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{nextPageButtonText}} />
+          <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
         </div>
       {{/if}}
     </div>
   </div>
 
-  {{#if isShowingModal}}
-    <ComparisonWindow @answer={{answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
+  {{#if this.isShowingModal}}
+    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
   {{/if}}
 
 </div>
 
-{{#if showLevelup}}
-  <LevelupNotif @level={{newLevel}} @competenceName={{competenceLeveled}} />
+{{#if this.showLevelup}}
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
 {{/if}}

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="assessment-results">
 
@@ -12,13 +12,13 @@
     </p>
 
     <div class="assessment-results__list">
-      {{#each model.answers as |answer|}}
+      {{#each this.model.answers as |answer|}}
         <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{action "openComparisonWindow"}} />
       {{/each}}
     </div>
 
     <div class="assessment-results__index-link-container">
-      {{#if model.isDemo}}
+      {{#if this.model.isDemo}}
         <LinkTo @route="inscription" class="assessment-results__index-link__element assessment-results__index-a-link" @tagName="button">
           <span class="assessment-results__link-back">Continuer mon expérience Pix</span>
         </LinkTo>
@@ -30,8 +30,8 @@
     </div>
   </div>
 
-  {{#if isShowingModal}}
-    <ComparisonWindow @answer={{answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
+  {{#if this.isShowingModal}}
+    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
   {{/if}}
 
 </div>

--- a/mon-pix/app/templates/campaigns.hbs
+++ b/mon-pix/app/templates/campaigns.hbs
@@ -1,3 +1,3 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div>{{outlet}}</div>

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
@@ -7,9 +7,9 @@
     <div class="rounded-panel campaign-landing-page__container__start">
       <div class="campaign-landing-page__start__image__container">
         <div class="campaign-landing-page__pix-logo">
-          <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+          <img class="campaign-landing-page__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
         </div>
-        {{#if model.organizationLogoUrl}}
+        {{#if this.model.organizationLogoUrl}}
           <div class="campaign-landing-page__logo">
             <img class="campaign-landing-page__image" src="{{@model.organizationLogoUrl}}" alt="{{@model.organizationName}}">
           </div>
@@ -23,7 +23,7 @@
         </p>
 
         <form {{action "startCampaignParticipation" on="submit"}}>
-          {{#if isLoading}}
+          {{#if this.isLoading}}
               <button type="button" disabled class="campaign-landing-page__start-button button button--big">
                 <span class="loader-in-button ">&nbsp;</span>
               </button>
@@ -41,7 +41,7 @@
         </p>
       </div>
 
-      {{#if model.customLandingPageText}}
+      {{#if this.model.customLandingPageText}}
         <hr class="campaign-landing-page__dash-line">
 
         <div class="campaign-landing-page__start__custom-text">
@@ -58,7 +58,8 @@
 
         <div class="campaign-landing-page__details__measure__container">
           <img class="campaign-landing-page__details__article-image measure"
-               src="{{rootURL}}/images/landing-page/icon-mesurer.svg" alt="">
+               src="{{this.rootURL}}/images/landing-page/icon-mesurer.svg"
+               alt="">
           <div class="campaign-landing-page__details__article-side">
             <p class="campaign-landing-page__details__text article-title ">
               Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :
@@ -81,7 +82,7 @@
         <hr class="campaign-landing-page__dash-line">
 
         <div class="campaign-landing-page__details__measure__container">
-          <img src="{{rootURL}}/images/landing-page/icon-conseil.svg" alt="">
+          <img src="{{this.rootURL}}/images/landing-page/icon-conseil.svg" alt="">
           <div class="campaign-landing-page__details__article-side">
             <p class="campaign-landing-page__details__text article-title ">
               Découvrir vos résultats au fil du test et consulter des indices pour progresser.
@@ -95,7 +96,7 @@
         <hr class="campaign-landing-page__dash-line">
 
         <div class="campaign-landing-page__details__measure__container">
-          <img src="{{rootURL}}/images/landing-page/icon-certif.svg" alt="">
+          <img src="{{this.rootURL}}/images/landing-page/icon-certif.svg" alt="">
           <div class="campaign-landing-page__details__article-side">
             <p class="campaign-landing-page__details__text article-title ">
               Préparer une certification reconnue par l’État et le monde professionnel

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -14,12 +14,12 @@
         <form class="fill-in-campaign-code__form" autocomplete="off">
 
           <div class="fill-in-campaign-code__form-field">
-            <Input required @type="text" @id="campaign-code" @value={{campaignCode}} @maxlength="9" @key-down={{action "clearErrorMessage"}} />
+            <Input required @type="text" @id="campaign-code" @value={{this.campaignCode}} @maxlength="9" @key-down={{action "clearErrorMessage"}} />
           </div>
 
-          {{#if errorMessage}}
+          {{#if this.errorMessage}}
             <div class="fill-in-campaign-code__error" aria-live="polite">
-              {{ errorMessage }}
+              {{ this.errorMessage }}
             </div>
           {{/if}}
 

--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
@@ -21,7 +21,7 @@
           <button type="submit" class="button button--big">Continuer</button>
         {{/if}}
         {{#if this.errorMessage}}
-          <div class="fill-in-id-pix__form__error-message">{{errorMessage}}</div>
+          <div class="fill-in-id-pix__form__error-message">{{this.errorMessage}}</div>
         {{/if}}
       </div>
 

--- a/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
+++ b/mon-pix/app/templates/campaigns/join-restricted-campaign.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
@@ -14,15 +14,15 @@
           <Input
             @id="firstName"
             @type="text"
-            @value={{firstName}}
+            @value={{this.firstName}}
             placeholder="Prénom"
-            @readonly={{isDisabled}}
-            @disabled={{isDisabled}}
-            class={{if validation.firstName.message "input--error"}}
-            @focusOut={{action "triggerInputStringValidation" "firstName" firstName}}
+            @readonly={{this.isDisabled}}
+            @disabled={{this.isDisabled}}
+            class={{if this.validation.firstName.message "input--error"}}
+            @focusOut={{action "triggerInputStringValidation" "firstName" this.firstName}}
            />
-          <div class="{{if validation.firstName.message 'join-restricted-campaign__field-error'}}" role="alert">
-            {{validation.firstName.message}}
+          <div class="{{if this.validation.firstName.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{this.validation.firstName.message}}
           </div>
         </div>
 
@@ -31,40 +31,40 @@
           <Input
             @id="lastName"
             @type="text"
-            @value={{lastName}}
+            @value={{this.lastName}}
             placeholder="Nom"
-            @readonly={{isDisabled}}
-            @disabled={{isDisabled}}
-            class={{if validation.lastName.message "input--error"}}
-            @focusOut={{action "triggerInputStringValidation" "lastName" lastName}}
+            @readonly={{this.isDisabled}}
+            @disabled={{this.isDisabled}}
+            class={{if this.validation.lastName.message "input--error"}}
+            @focusOut={{action "triggerInputStringValidation" "lastName" this.lastName}}
            />
-          <div class="{{if validation.lastName.message 'join-restricted-campaign__field-error'}}" role="alert">
-            {{validation.lastName.message}}
+          <div class="{{if this.validation.lastName.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{this.validation.lastName.message}}
           </div>
         </div>
 
         <div class="join-restricted-campaign__row">
           <label class="join-restricted-campaign__label">Date de naissance</label>
           <div class="join-restricted-campaign__birthdate">
-            <Input @id="dayOfBirth" @type="text" @value={{dayOfBirth}} placeholder="JJ" class={{if validation.dayOfBirth.message "input--error"}} @focusOut={{action "triggerInputDayValidation" "dayOfBirth" dayOfBirth}} />
-            <Input @id="monthOfBirth" @type="text" @value={{monthOfBirth}} placeholder="MM" class={{if validation.monthOfBirth.message "input--error"}} @focusOut={{action "triggerInputMonthValidation" "monthOfBirth" monthOfBirth}} />
-            <Input @id="yearOfBirth" @type="text" @value={{yearOfBirth}} placeholder="AAAA" class={{if validation.yearOfBirth.message "input--error"}} @focusOut={{action "triggerInputYearValidation" "yearOfBirth" yearOfBirth}} />
+            <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder="JJ" class={{if this.validation.dayOfBirth.message "input--error"}} @focusOut={{action "triggerInputDayValidation" "dayOfBirth" this.dayOfBirth}} />
+            <Input @id="monthOfBirth" @type="text" @value={{this.monthOfBirth}} placeholder="MM" class={{if this.validation.monthOfBirth.message "input--error"}} @focusOut={{action "triggerInputMonthValidation" "monthOfBirth" this.monthOfBirth}} />
+            <Input @id="yearOfBirth" @type="text" @value={{this.yearOfBirth}} placeholder="AAAA" class={{if this.validation.yearOfBirth.message "input--error"}} @focusOut={{action "triggerInputYearValidation" "yearOfBirth" this.yearOfBirth}} />
           </div>
-          <div class="{{if validation.dayOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
-            {{validation.dayOfBirth.message}}
+          <div class="{{if this.validation.dayOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{this.validation.dayOfBirth.message}}
           </div>
-          <div class="{{if validation.monthOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
-            {{validation.monthOfBirth.message}}
+          <div class="{{if this.validation.monthOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{this.validation.monthOfBirth.message}}
           </div>
-          <div class="{{if validation.yearOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
-            {{validation.yearOfBirth.message}}
+          <div class="{{if this.validation.yearOfBirth.message 'join-restricted-campaign__field-error'}}" role="alert">
+            {{this.validation.yearOfBirth.message}}
           </div>
         </div>
 
-        {{#if errorMessage}}
-          <div class="join-restricted-campaign__error" aria-live="polite">{{errorMessage}}</div>
+        {{#if this.errorMessage}}
+          <div class="join-restricted-campaign__error" aria-live="polite">{{this.errorMessage}}</div>
         {{/if}}
-        {{#if isLoading}}
+        {{#if this.isLoading}}
           <button type="button" disabled class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
           <button type="submit" class="button button--big" {{action "attemptNext"}}>

--- a/mon-pix/app/templates/campaigns/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/send-profile.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">

--- a/mon-pix/app/templates/campaigns/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/skill-review.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="background-banner-wrapper">
   <div class="skill-review__banner">
@@ -7,7 +7,7 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner skill-review__result-container">
     {{#if this.shouldShowBadge}}
       <div class="skill-review-result__badge">
-        <img src="{{rootURL}}{{@model.campaignParticipation.campaignParticipationResult.badge.imageUrl}}"
+        <img src="{{this.rootURL}}{{@model.campaignParticipation.campaignParticipationResult.badge.imageUrl}}"
              alt="{{@model.campaignParticipation.campaignParticipationResult.badge.altMessage}}">
         <p class="skill-review-result__badge-information">{{@model.campaignParticipation.campaignParticipationResult.badge.message}}</p>
       </div>
@@ -22,7 +22,7 @@
         <br> des compétences testées.
       </h3>
       <div class="skill-review-result__share-container">
-        {{#if model.campaignParticipation.isShared}}
+        {{#if this.model.campaignParticipation.isShared}}
           <p class="skill-review-share__thanks">Merci, vos résultats ont bien été envoyés !</p>
           <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
         {{else}}
@@ -30,13 +30,13 @@
             Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.
           </p>
 
-          {{#if displayErrorMessage}}
+          {{#if this.displayErrorMessage}}
             <div class="skill-review-share__error" aria-live="polite">
               Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.
             </div>
           {{/if}}
 
-          {{#if displayLoadingButton}}
+          {{#if this.displayLoadingButton}}
             <button type="button" disabled class="button button--extra-big skill-review-share__button">
               <span class="loader-in-button">&nbsp;</span>
             </button>
@@ -47,8 +47,8 @@
           {{/if}}
         {{/if}}
       </div>
-      {{#if displayImprovementButton}}
-        {{#unless model.campaignParticipation.isShared}}
+      {{#if this.displayImprovementButton}}
+        {{#unless this.model.campaignParticipation.isShared}}
          <div class="skill-review-result__dash-line"></div>
          <div class="skill-review__begin-improvement">
            <div><h2 class="skill-review__subtitle">Envie d'améliorer vos résultats ?</h2>
@@ -62,7 +62,7 @@
       {{/if}}
     {{else}}
       <div class="skill-review__campaign-archived">
-        <img class="skill-reviw__campaign-archived-image "src="{{rootURL}}/images/bees/fat-bee.svg">
+        <img class="skill-reviw__campaign-archived-image "src="{{this.rootURL}}/images/bees/fat-bee.svg">
         <p class="skill-review__campaign-archived-text">Ce parcours a été archivé par l'organisateur.
         <br> L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.</p>
         <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
@@ -88,8 +88,8 @@
       </thead>
 
       <tbody>
-      {{#if model.campaignParticipation.campaignParticipationResult.partnerCompetenceResults}}
-        {{#each model.campaignParticipation.campaignParticipationResult.partnerCompetenceResults as |partnerCompetence|}}
+      {{#if this.model.campaignParticipation.campaignParticipationResult.partnerCompetenceResults}}
+        {{#each this.model.campaignParticipation.campaignParticipationResult.partnerCompetenceResults as |partnerCompetence|}}
           <tr>
             <td>
               <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}">&#8226;</span>
@@ -104,7 +104,7 @@
           </tr>
         {{/each}}
       {{else}}
-        {{#each model.campaignParticipation.campaignParticipationResult.competenceResults as |competence|}}
+        {{#each this.model.campaignParticipation.campaignParticipationResult.competenceResults as |competence|}}
           <tr>
             <td>
               <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}">&#8226;</span>

--- a/mon-pix/app/templates/campaigns/start-or-resume.hbs
+++ b/mon-pix/app/templates/campaigns/start-or-resume.hbs
@@ -1,9 +1,9 @@
-{{#if model.isLoading }}
+{{#if this.model.isLoading }}
   <div class="app-loader">
     <p class="app-loader__image"><img src="/images/interwind.gif"></p>
   </div>
 {{else}}
-  {{#if model.isArchived }}
+  {{#if this.model.isArchived }}
     <InaccessibleCampaign>
       La campagne a été archivée.
     </InaccessibleCampaign>

--- a/mon-pix/app/templates/campaigns/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/tutorial.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 
 <div class="campaign-tutorial">
   <div class="rounded-panel rounded-panel--strong campaign-tutorial__container">
@@ -8,20 +8,20 @@
     </div>
 
     <div class="campaign-tutorial__explanation-icon">
-      <img alt="" src="{{rootURL}}/images/tutorial-campaign/{{@model.icon}}">
+      <img alt="" src="{{this.rootURL}}/images/tutorial-campaign/{{@model.icon}}">
     </div>
 
 
     <div class="campaign-tutorial__explanation-text"><p>{{@model.explanation}}</p></div>
 
     <div class="campaign-tutorial__paging">
-      {{#each model.paging as |page-class|}}
+      {{#each this.model.paging as |page-class|}}
         <div class="dot <PageClass />"> </div>
       {{/each}}
 
     </div>
     <div class="campaign-tutorial__next-button">
-    {{#if model.showNextButton}}
+    {{#if this.model.showNextButton}}
       <button type="submit" class="button button--big campaign-tutorial__next-page-tutorial" {{action "next"}}>Suivant</button>
 
       <button {{action "submit"}} class="button button--big button--no-color campaign-tutorial__ignore-button">Ignorer</button>

--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,2 +1,2 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <CertificationResultsPage @certificationNumber={{@model}} />

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
@@ -6,7 +6,7 @@
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
 
-      {{#if model.isCertifiable}}
+      {{#if this.model.isCertifiable}}
         <div
           class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner certification-start-page__panel">
           <div class="certification-stepper">

--- a/mon-pix/app/templates/competences.hbs
+++ b/mon-pix/app/templates/competences.hbs
@@ -1,3 +1,3 @@
-{{title model.name}}
+{{title this.model.name}}
 
 {{outlet}}

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @class="navbar-header--white" @burger={{burger}} />

--- a/mon-pix/app/templates/competences/results.hbs
+++ b/mon-pix/app/templates/competences/results.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
@@ -9,7 +9,7 @@
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
         <div class="competence-results-panel__header">
-          {{#if model.scorecard.hasNotEarnAnything}}
+          {{#if this.model.scorecard.hasNotEarnAnything}}
             <div class="competence-results-panel-header__banner competence-results-panel-header__banner--too-bad">
               <img src="/images/banners/too-bad-text.svg" alt="Tant pix !"
                    class="competence-results-banner__title">
@@ -17,7 +17,7 @@
                 Manifestement, ce n’est pas votre jour mais vous ferez mieux la prochaine fois.
               </div>
             </div>
-          {{else if model.scorecard.hasNotReachLevelOne}}
+          {{else if this.model.scorecard.hasNotReachLevelOne}}
             <div class="competence-results-panel-header__banner competence-results-panel-header__banner--not-bad">
               <img src="/images/banners/not-bad-text.svg" alt="Pas mal, mais pas max !"
                    class="competence-results-banner__title competence-results-banner__title--tablet">
@@ -33,7 +33,7 @@
                 </div>
               </div>
             </div>
-          {{else if model.scorecard.hasReachAtLeastLevelOne}}
+          {{else if this.model.scorecard.hasReachAtLeastLevelOne}}
             <div class="competence-results-panel-header__banner competence-results-panel-header__banner--congrats">
               <img src="/images/banners/congrats-text.svg" alt="Félicitations !"
                    class="competence-results-banner__title">
@@ -50,7 +50,7 @@
             </div>
           {{/if}}
         </div>
-        {{#if model.scorecard}}
+        {{#if this.model.scorecard}}
           <ScorecardDetails @scorecard={{@model.scorecard}} />
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/certifications-list.hbs
+++ b/mon-pix/app/templates/components/certifications-list.hbs
@@ -8,7 +8,7 @@
   </div>
 
   <div class="certifications-list__table-body" role="tablist">
-  {{#each certifications as |certification|}}
+  {{#each this.certifications as |certification|}}
     <CertificationsListItem @certification={{certification}} />
   {{/each}}
   </div>

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,11 +1,11 @@
 {{#if @answer}}
   <span class="challenge-actions__already-answered">Vous avez déjà répondu à cette question</span>
-  <button class="button challenge-actions__action challenge-actions__action-continue" {{action resumeAssessment @assessment}}>
+  <button class="button challenge-actions__action challenge-actions__action-continue" {{action this.resumeAssessment @assessment}}>
     <span class="challenge-actions__action-continue-text">Poursuivre</span>
   </button>
 {{else}}
   {{#if this.isValidateButtonEnabled}}
-    <button class="button challenge-actions__action challenge-actions__action-validate" type="submit" {{action validateAnswer}}>
+    <button class="button challenge-actions__action challenge-actions__action-validate" type="submit" {{action this.validateAnswer}}>
       <span class="challenge-actions__action-validate-text">Je valide</span>
     </button>
   {{else}}
@@ -14,7 +14,7 @@
     </div>
   {{/if}}
   {{#if this.isSkipButtonEnabled}}
-    <button class="button challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}}>
+    <button class="button challenge-actions__action challenge-actions__action-skip" {{action this.skipChallenge}}>
       <span class="challenge-actions__action-skip-text">Je passe</span>
     </button>
   {{else}}

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,47 +1,47 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{this.challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if this.answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QcuProposals @answer={{answer}} @answerValue={{answer.value}} @proposals={{challenge.proposals}} @answerChanged={{action "answerChanged"}} />
+        <QcuProposals @answer={{this.answer}} @answerValue={{this.answer.value}} @proposals={{this.challenge.proposals}} @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if this.answer}}
         <div class="challenge-response__locked-overlay">
           {{fa-icon 'lock' class='challenge-response-locked__icon'}}
         </div>
       {{/if}}
       
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if this.challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{this.challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if this.assessment}}
+      <ChallengeActions @challenge={{this.challenge}} @answer={{this.answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{this.isValidateButtonEnabled}} @isSkipButtonEnabled={{this.isSkipButtonEnabled}} @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,47 +1,47 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{this.challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if this.answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QrocProposal @answer={{answer}} @format={{challenge.format}} @proposals={{challenge.proposals}} @answerValue={{answer.value}} @answerChanged={{action "answerChanged"}} />
+        <QrocProposal @answer={{this.answer}} @format={{this.challenge.format}} @proposals={{this.challenge.proposals}} @answerValue={{this.answer.value}} @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if this.answer}}
         <div class="challenge-response__locked-overlay">
           {{fa-icon 'lock' class='challenge-response-locked__icon'}}
         </div>
       {{/if}}
 
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if this.challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{this.challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if this.assessment}}
+      <ChallengeActions @challenge={{this.challenge}} @answer={{this.answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{this.isValidateButtonEnabled}} @isSkipButtonEnabled={{this.isSkipButtonEnabled}} @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,47 +1,47 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{this.challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{this.challenge}} @assessment={{this.assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if this.answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QrocmProposal @answer={{answer}} @format={{challenge.format}} @proposals={{challenge.proposals}} @answersValue={{answer._valuesAsMap}} @answerChanged={{action "answerChanged"}} />
+        <QrocmProposal @answer={{this.answer}} @format={{this.challenge.format}} @proposals={{this.challenge.proposals}} @answersValue={{this.answer._valuesAsMap}} @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if this.answer}}
         <div class="challenge-response__locked-overlay">
           {{fa-icon 'lock' class='challenge-response-locked__icon'}}
         </div>
       {{/if}}
 
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if this.challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{this.challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if this.assessment}}
+      <ChallengeActions @challenge={{this.challenge}} @answer={{this.answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{this.isValidateButtonEnabled}} @isSkipButtonEnabled={{this.isSkipButtonEnabled}} @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -1,28 +1,27 @@
-{{#if challengeInstruction}}
+{{#if this.challengeInstruction}}
   <div class="challenge-statement__instruction-section">
-    <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{challengeInstruction}} />
+    <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{this.challengeInstruction}} />
   </div>
 {{/if}}
 
-{{#if challenge.illustrationUrl}}
+{{#if this.challenge.illustrationUrl}}
   <div class="challenge-statement__illustration-section">
-    <ChallengeIllustration @src={{challenge.illustrationUrl}} @alt={{challenge.illustrationAlt}} />
+    <ChallengeIllustration @src={{this.challenge.illustrationUrl}} @alt={{this.challenge.illustrationAlt}} />
   </div>
 {{/if}}
 
-{{#if challenge.hasAttachment}}
+{{#if this.challenge.hasAttachment}}
   <div class="challenge-statement__attachments-section">
 
-    {{#if challenge.hasSingleAttachment}}
+    {{#if this.challenge.hasSingleAttachment}}
       <div class="challenge-statement__action">
-        <a class="challenge-statement__action-link" href="{{challenge.attachments.firstObject}}" target="_blank"
-           download>
+        <a class="challenge-statement__action-link" href="{{this.challenge.attachments.firstObject}}" target="_blank" download>
           <span class="challenge-statement__action-label">Télécharger</span>
         </a>
       </div>
     {{/if}}
 
-    {{#if challenge.hasMultipleAttachments}}
+    {{#if this.challenge.hasMultipleAttachments}}
       <p class="challenge-statement__text">
         <span class="challenge-statement__text-content">Choisissez le type de fichier que vous voulez utiliser</span>
       <div class="challenge-statement__help-icon">
@@ -33,7 +32,7 @@
       </div>
       </p>
       <ul class="challenge-statement__file-options">
-        {{#each attachmentsData as |attachmentUrl index|}}
+        {{#each this.attachmentsData as |attachmentUrl index|}}
           <li class="challenge-statement__file-option">
 
             {{!-- This radiobutton is hidden  - SVG displayed instead - but needed to handle behaviour. --}}
@@ -43,7 +42,7 @@
                    name="attachment_selector"
                    value="{{attachmentUrl}}"
                    onclick={{action "selectAttachementUrl" attachmentUrl}}
-                     checked="{{if (eq attachmentUrl selectedAttachmentUrl) "checked"}}">
+                   checked="{{if (eq attachmentUrl this.selectedAttachmentUrl) "checked"}}">
 
             <label class="label-checkbox-downloadable" for="attachment{{index}}">
               <span class="challenge-statement__file-option-label">fichier .{{extract-extension attachmentUrl}}</span>
@@ -53,7 +52,7 @@
         {{/each}}
       </ul>
       <div class="challenge-statement__action">
-        <a class="challenge-statement__action-link" href="{{selectedAttachmentUrl}}" target="_blank" download>
+        <a class="challenge-statement__action-link" href="{{this.selectedAttachmentUrl}}" target="_blank" download>
           <span class="challenge-statement__action-label">Télécharger</span>
         </a>
       </div>
@@ -61,6 +60,6 @@
   </div>
 {{/if}}
 
-{{#if challenge.hasValidEmbedDocument}}
-  <ChallengeEmbedSimulator @embedDocument={{challengeEmbedDocument}} />
+{{#if this.challenge.hasValidEmbedDocument}}
+  <ChallengeEmbedSimulator @embedDocument={{this.challengeEmbedDocument}} />
 {{/if}}

--- a/mon-pix/app/templates/components/checkpoint-continue.hbs
+++ b/mon-pix/app/templates/components/checkpoint-continue.hbs
@@ -1,4 +1,4 @@
-<LinkTo @route="assessments.resume" @model={{assessmentId}} @query={{hash hasSeenCheckpoint=true}} class="button button--link button--yellow checkpoint__continue-button">
-  {{nextPageButtonText}}
+<LinkTo @route="assessments.resume" @model={{this.assessmentId}} @query={{hash hasSeenCheckpoint=true}} class="button button--link button--yellow checkpoint__continue-button">
+  {{this.nextPageButtonText}}
   {{fa-icon 'long-arrow-alt-right'}}
 </LinkTo>

--- a/mon-pix/app/templates/components/circle-chart.hbs
+++ b/mon-pix/app/templates/components/circle-chart.hbs
@@ -1,11 +1,11 @@
-<svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " chartClass}}>
-  <path class={{concat "circle " thicknessClass}}
+<svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " this.chartClass}}>
+  <path class={{concat "circle " this.thicknessClass}}
         d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
   </path>
   <!-- wait for value to be ready in order to animate circle under safari -->
-  {{#if value}}
-    <path class={{concat "circle circle--slice circle--" sliceColor " " thicknessClass}}
-          stroke-dasharray="{{value}}, 100"
+  {{#if this.value}}
+    <path class={{concat "circle circle--slice circle--" this.sliceColor " " this.thicknessClass}}
+          stroke-dasharray="{{this.value}}, 100"
           d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
     </path>
   {{/if}}

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -1,6 +1,6 @@
-<PixModal @class="comparison-window-modal" @onClose={{closeComparisonWindow}}>
+<PixModal @class="comparison-window-modal" @onClose={{this.closeComparisonWindow}}>
 
-  <div class="pix-modal__close-link" aria-label="Fermer" {{action (action closeComparisonWindow)}}>
+  <div class="pix-modal__close-link" aria-label="Fermer" {{action (action this.closeComparisonWindow)}}>
     <span>Fermer</span>
     <FaIcon @icon="times-circle" class="logged-user-menu__icon"></FaIcon>
   </div>
@@ -9,12 +9,13 @@
 
     <div class="pix-modal-header comparison-window-header">
       <div class="comparison-window__title">
-        <div title="{{resultItem.tooltip}}">
-          <img class="comparison-window__result-icon comparison-window__result-icon--{{resultItem.status}}"
-               src={{resultItemIcon}} alt={{resultItem.tooltip}}>
+        <div title="{{this.resultItem.tooltip}}">
+          <img class="comparison-window__result-icon comparison-window__result-icon--{{this.resultItem.status}}"
+               src={{this.resultItemIcon}}
+               alt={{this.resultItem.tooltip}}>
         </div>
       </div>
-      <div class="comparison-window__title-text">{{resultItem.title}}</div>
+      <div class="comparison-window__title-text">{{this.resultItem.title}}</div>
     </div>
 
     <div class="comparison-window--content">
@@ -23,48 +24,48 @@
 
         <div class="rounded-panel comparison-window__instruction">
           <div class="rounded-panel__row ">
-            <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{answer.challenge.instruction}} />
+            <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{this.answer.challenge.instruction}} />
           </div>
 
-         {{#if answer.challenge.illustrationUrl}}
+         {{#if this.answer.challenge.illustrationUrl}}
             <div class="rounded-panel__row challenge-statement__illustration-section">
-              <ChallengeIllustration @src={{answer.challenge.illustrationUrl}} @alt={{answer.challenge.illustrationAlt}} />
+              <ChallengeIllustration @src={{this.answer.challenge.illustrationUrl}} @alt={{this.answer.challenge.illustrationAlt}} />
             </div>
          {{/if}}
         </div>
         <div class="comparison-window__corrected-answers">
-          {{#if isAssessmentChallengeTypeQcm}}
-            <QcmSolutionPanel @challenge={{answer.challenge}} @answer={{answer}} @solution={{answer.correction.solution}} />
+          {{#if this.isAssessmentChallengeTypeQcm}}
+            <QcmSolutionPanel @challenge={{this.answer.challenge}} @answer={{this.answer}} @solution={{this.answer.correction.solution}} />
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQcu}}
-            <QcuSolutionPanel @challenge={{answer.challenge}} @answer={{answer}} @solution={{answer.correction.solution}} />
+          {{#if this.isAssessmentChallengeTypeQcu}}
+            <QcuSolutionPanel @challenge={{this.answer.challenge}} @answer={{this.answer}} @solution={{this.answer.correction.solution}} />
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQroc}}
+          {{#if this.isAssessmentChallengeTypeQroc}}
             <div class="comparison-window__corrected-answers--qroc">
-              <QrocSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} />
+              <QrocSolutionPanel @answer={{this.answer}} @solution={{this.answer.correction.solution}} />
             </div>
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQrocmInd}}
+          {{#if this.isAssessmentChallengeTypeQrocmInd}}
             <div class="comparison-window__corrected-answers--qrocm">
-              <QrocmIndSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} @challenge={{answer.challenge}} />
+              <QrocmIndSolutionPanel @answer={{this.answer}} @solution={{this.answer.correction.solution}} @challenge={{this.answer.challenge}} />
             </div>
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQrocmDep}}
+          {{#if this.isAssessmentChallengeTypeQrocmDep}}
             <div class="comparison-window__corrected-answers--qrocm">
-              <QrocmDepSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} @challenge={{answer.challenge}} />
+              <QrocmDepSolutionPanel @answer={{this.answer}} @solution={{this.answer.correction.solution}} @challenge={{this.answer.challenge}} />
             </div>
           {{/if}}
         </div>
 
-        {{#if answer.isResultNotOk}}
-          {{#if answer.correction.noHintsNorTutorialsAtAll }}
+        {{#if this.answer.isResultNotOk}}
+          {{#if this.answer.correction.noHintsNorTutorialsAtAll }}
             <div class="comparison-windows__default-message-container">
               <div class="comparison-windows__default-message-picto-container">
-                <img src="{{rootURL}}/images/comparison-window/icon-tuto.svg"
+                <img src="{{this.rootURL}}/images/comparison-window/icon-tuto.svg"
                     alt=""
                     class="comparison-windows__default-message-picto">
               </div>
@@ -73,15 +74,15 @@
               </div>
             </div>
           {{else}}
-            <TutorialPanel @hint={{answer.correction.hint}} @tutorials={{answer.correction.tutorials}} />
+            <TutorialPanel @hint={{this.answer.correction.hint}} @tutorials={{this.answer.correction.tutorials}} />
           {{/if}}
         {{/if}}
-        <LearningMorePanel @learningMoreTutorials={{answer.correction.learningMoreTutorials}} />
+        <LearningMorePanel @learningMoreTutorials={{this.answer.correction.learningMoreTutorials}} />
       </div>
 
       <div class="pix-modal-footer">
         <div class="comparison-window__feedback-panel">
-          <FeedbackPanel @assessment={{answer.assessment}} @challenge={{answer.challenge}} @context="comparison-window" @answer={{answer}} @isFormOpened={{true}} />
+          <FeedbackPanel @assessment={{this.answer.assessment}} @challenge={{this.answer.challenge}} @context="comparison-window" @answer={{this.answer}} @isFormOpened={{true}} />
         </div>
       </div>
     </div>

--- a/mon-pix/app/templates/components/competence-card-desktop.hbs
+++ b/mon-pix/app/templates/components/competence-card-desktop.hbs
@@ -1,25 +1,25 @@
 <article class="competence-card">
-  <LinkTo @route="competences.details" @model={{scorecard.competenceId}}>
+  <LinkTo @route="competences.details" @model={{this.scorecard.competenceId}}>
     <header class="competence-card__header">
-      <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
-      <span class="competence-card__area-name">{{scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{scorecard.name}}</span>
+      <span class="competence-card__color competence-card__color--{{this.scorecard.area.color}}"></span>
+      <span class="competence-card__area-name">{{this.scorecard.area.title}}</span>
+      <span class="competence-card__competence-name">{{this.scorecard.name}}</span>
     </header>
 
     <div class="competence-card__body">
-      {{#if scorecard.isFinishedWithMaxLevel}}
+      {{#if this.scorecard.isFinishedWithMaxLevel}}
         <div class="competence-card__congrats competence-card__congrats--with-magnification">
           <div class="competence-card__level competence-card__level--congrats">
             <span class="score-label competence-card__score-label--congrats">Niveau</span>
-            <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{displayedLevel}}</span>
+            <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{this.displayedLevel}}</span>
           </div>
         </div>
       {{else}}
         <div class="competence-card__link">
-          <CircleChart @value={{scorecard.percentageAheadOfNextLevel}} @sliceColor={{scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
+          <CircleChart @value={{this.scorecard.percentageAheadOfNextLevel}} @sliceColor={{this.scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
             <div class="competence-card__level">
               <span class="score-label">Niveau</span>
-              <span class="score-value competence-card__score-value">{{replace-zero-by-dash displayedLevel}}</span>
+              <span class="score-value competence-card__score-value">{{replace-zero-by-dash this.displayedLevel}}</span>
               <span class="competence-card__score-details">détail</span>
             </div>
           </CircleChart>
@@ -28,16 +28,16 @@
     </div>
   </LinkTo>
 
-  {{#if scorecard.isFinishedWithMaxLevel}}
+  {{#if this.scorecard.isFinishedWithMaxLevel}}
     <footer class="competence-card__congrats-message">
       Bravo !
     </footer>
   {{else}}
     <footer class="competence-card__footer">
-      {{#unless scorecard.isFinished}}
-        <LinkTo @route="competences.resume" @model={{scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
+      {{#unless this.scorecard.isFinished}}
+        <LinkTo @route="competences.resume" @model={{this.scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
           <span class="competence-card-button__label">
-            {{#if scorecard.isStarted}}
+            {{#if this.scorecard.isStarted}}
               Reprendre
             {{else}}
               Commencer

--- a/mon-pix/app/templates/components/competence-card.hbs
+++ b/mon-pix/app/templates/components/competence-card.hbs
@@ -1,20 +1,20 @@
 <article class="competence-card">
-  <LinkTo @route="competences.details" @model={{scorecard.competenceId}} class="competence-card__link">
-    <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
+  <LinkTo @route="competences.details" @model={{this.scorecard.competenceId}} class="competence-card__link">
+    <span class="competence-card__color competence-card__color--{{this.scorecard.area.color}}"></span>
     <header class="competence-card__header">
-      <span class="competence-card__area-name">{{scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{scorecard.name}}</span>
+      <span class="competence-card__area-name">{{this.scorecard.area.title}}</span>
+      <span class="competence-card__competence-name">{{this.scorecard.name}}</span>
     </header>
     <div class="competence-card__body">
-      {{#if scorecard.isFinishedWithMaxLevel}}
+      {{#if this.scorecard.isFinishedWithMaxLevel}}
         <div class="competence-card__congrats competence-card__congrats--small">
-          <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{displayedLevel}}</span>
+          <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{this.displayedLevel}}</span>
         </div>
       {{else}}
         <div class="competence-card__body--white-background">
-          <CircleChart @value={{scorecard.percentageAheadOfNextLevel}} @sliceColor={{scorecard.area.color}} @chartClass="circle-chart__content--small" @thicknessClass="circle--thick">
+          <CircleChart @value={{this.scorecard.percentageAheadOfNextLevel}} @sliceColor={{this.scorecard.area.color}} @chartClass="circle-chart__content--small" @thicknessClass="circle--thick">
             <div class="competence-card__level">
-              <span class="score-value competence-card__score-value">{{replace-zero-by-dash displayedLevel}}</span>
+              <span class="score-value competence-card__score-value">{{replace-zero-by-dash this.displayedLevel}}</span>
             </div>
           </CircleChart>
         </div>

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -2,8 +2,8 @@
   <a class="feedback-panel__open-link" {{action "toggleFeedbackForm"}} href="#">Signaler un problème</a>
 </div>
 
-{{#if isFormOpened}}
-  {{#if _isSubmitted}}
+{{#if this.isFormOpened}}
+  {{#if this._isSubmitted}}
     <div class="feedback-panel__view feedback-panel__view--mercix">
       <p>Votre commentaire a bien été transmis à l’équipe du projet Pix.</p>
       <p>Mercix !</p>
@@ -20,34 +20,33 @@
             <div class="feedback-panel__category-selection">
               <select class="feedback-panel__dropdown" {{action "displayCategoryOptions" on="change"}}>
                 <option value="" disabled selected>J’ai un problème avec</option>
-                {{#each categories as |category|}}
+                {{#each this.categories as |category|}}
                   <option value={{category.value}}>{{category.name}}</option>
                 {{/each}}
               </select>
-              {{#if displayQuestionDropdown}}
+              {{#if this.displayQuestionDropdown}}
                 <select class="feedback-panel__dropdown" {{action "showFeedback" on="change"}}>
                   <option value="default" selected>Précisez</option>
-                  {{#each nextCategory as |question index|}}
+                  {{#each this.nextCategory as |question index|}}
                     <option value={{index}}>{{question.name}}</option>
                   {{/each}}
                 </select>
               {{/if}}
-              {{#if quickHelpInstructions}}
+              {{#if this.quickHelpInstructions}}
                 <div class="feedback-panel__quick-help">
                   {{fa-icon 'exclamation-circle' class="tuto-icon__warning"}}
-                  <p>{{{quickHelpInstructions}}}</p>
+                  <p>{{{this.quickHelpInstructions}}}</p>
                 </div>
               {{/if}}
             </div>
           </div>
-          {{#if displayTextBox}}
+          {{#if this.displayTextBox}}
             <div class="feedback-panel__group">
               <p>Votre message est limité à 10 000 caractères.</p>
-              <Textarea class="feedback-panel__field feedback-panel__field--content" @value={{_content}} placeholder="Précisez" @maxlength="10000" @rows={{5}} />
-            </div>
-            {{#if _error}}
+              <Textarea class="feedback-panel__field feedback-panel__field--content" @value={{this._content}} placeholder="Précisez" @maxlength="10000" @rows={{5}} />            </div>
+            {{#if this._error}}
               <div class="alert alert-danger" role="alert">
-                {{_error}}
+                {{this._error}}
               </div>
             {{/if}}
             <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>

--- a/mon-pix/app/templates/components/form-textfield-date.hbs
+++ b/mon-pix/app/templates/components/form-textfield-date.hbs
@@ -1,25 +1,25 @@
 <label class="form-textfield__label">
-  {{#if require}}<abbr title="obligatoire">*</abbr> {{/if}}
-  {{label}}
-  <br><span class="form-textfield__help">{{help}}</span>
+  {{#if this.require}}<abbr title="obligatoire">*</abbr> {{/if}}
+  {{this.label}}
+  <br><span class="form-textfield__help">{{this.help}}</span>
 </label>
 
 <div class="form-textfield__date">
-  <div class="form-textfield__input-field-container {{if disabled "form-textfield__input-container--disabled" dayInputContainerStatusClass}}">
+  <div class="form-textfield__input-field-container {{if this.disabled "form-textfield__input-container--disabled" this.dayInputContainerStatusClass}}">
     <Input @type="text"
-           @id={{dayTextfieldName}}
-           @name={{dayTextfieldName}}
-           @value={{dayInputBindingValue}}
-           @focus-out={{action onValidateDay dayTextfieldName}}
-           class="form-textfield__input {{dayInputValidationStatus}}"
-           @autocomplete={{autocomplete}}
+           @id={{this.dayTextfieldName}}
+           @name={{this.dayTextfieldName}}
+           @value={{this.dayInputBindingValue}}
+           @focus-out={{action this.onValidateDay this.dayTextfieldName}}
+           class="form-textfield__input {{this.dayInputValidationStatus}}"
+           @autocomplete={{this.autocomplete}}
            @ariaDescribedBy="dayValidationMessage"
-           required={{require}}
-           @disabled={{disabled}}
+           required={{this.require}}
+           @disabled={{this.disabled}}
            placeholder="JJ" />
     <div class="form-textfield__icon">
-      {{#if dayHasIcon}}
-        {{#if (eq dayValidationStatus 'error') }}
+      {{#if this.dayHasIcon}}
+        {{#if (eq this.dayValidationStatus 'error') }}
           <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
         {{else}}
           <img src="/images/icons/icon-success.svg"
@@ -29,21 +29,21 @@
     </div>
   </div>
 
-  <div class="form-textfield__input-field-container {{if disabled "form-textfield__input-container--disabled" monthInputContainerStatusClass}}">
+  <div class="form-textfield__input-field-container {{if this.disabled "form-textfield__input-container--disabled" this.monthInputContainerStatusClass}}">
     <Input @type="text"
-           @id={{monthTextfieldName}}
-           @name={{monthTextfieldName}}
-           @value={{monthInputBindingValue}}
-           @focus-out={{action onValidateMonth monthTextfieldName}}
-           class="form-textfield__input {{monthInputValidationStatus}}"
-           @autocomplete={{autocomplete}}
+           @id={{this.monthTextfieldName}}
+           @name={{this.monthTextfieldName}}
+           @value={{this.monthInputBindingValue}}
+           @focus-out={{action this.onValidateMonth this.monthTextfieldName}}
+           class="form-textfield__input {{this.monthInputValidationStatus}}"
+           @autocomplete={{this.autocomplete}}
            @ariaDescribedBy="monthValidationMessage"
-           required={{require}}
-           @disabled={{disabled}}
+           required={{this.require}}
+           @disabled={{this.disabled}}
            placeholder="MM" />
     <div class="form-textfield__icon">
-      {{#if monthHasIcon}}
-        {{#if (eq monthValidationStatus 'error') }}
+      {{#if this.monthHasIcon}}
+        {{#if (eq this.monthValidationStatus 'error') }}
           <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
         {{else}}
           <img src="/images/icons/icon-success.svg"
@@ -53,21 +53,21 @@
     </div>
   </div>
 
-  <div class="form-textfield__input-field-container {{if disabled "form-textfield__input-container--disabled" yearInputContainerStatusClass}}">
+  <div class="form-textfield__input-field-container {{if this.disabled "form-textfield__input-container--disabled" this.yearInputContainerStatusClass}}">
     <Input @type="text"
-           @id={{yearTextfieldName}}
-           @name={{yearTextfieldName}}
-           @value={{yearInputBindingValue}}
-           @focus-out={{action onValidateYear yearTextfieldName}}
-           class="form-textfield__input {{yearInputValidationStatus}}"
-           @autocomplete={{autocomplete}}
+           @id={{this.yearTextfieldName}}
+           @name={{this.yearTextfieldName}}
+           @value={{this.yearInputBindingValue}}
+           @focus-out={{action this.onValidateYear this.yearTextfieldName}}
+           class="form-textfield__input {{this.yearInputValidationStatus}}"
+           @autocomplete={{this.autocomplete}}
            @ariaDescribedBy="yearValidationMessage"
-           required={{require}}
-           @disabled={{disabled}}
+           required={{this.require}}
+           @disabled={{this.disabled}}
            placeholder="AAAA" />
     <div class="form-textfield__icon">
-      {{#if yearHasIcon}}
-        {{#if (eq yearValidationStatus 'error') }}
+      {{#if this.yearHasIcon}}
+        {{#if (eq this.yearValidationStatus 'error') }}
           <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
         {{else}}
           <img src="/images/icons/icon-success.svg"
@@ -78,17 +78,14 @@
   </div>
 </div>
 
-{{#if dayValidationMessage}}
-  <div id="dayValidationMessage" class="form-textfield__message {{dayValidationMessageClass}}"
-       role="alert">{{dayValidationMessage}}</div>
+{{#if this.dayValidationMessage}}
+  <div id="dayValidationMessage" class="form-textfield__message {{this.dayValidationMessageClass}}" role="alert">{{this.dayValidationMessage}}</div>
 {{/if}}
 
-{{#if monthValidationMessage}}
-<div id="monthValidationMessage" class="form-textfield__message {{monthValidationMessageClass}}"
-       role="alert">{{monthValidationMessage}}</div>
+{{#if this.monthValidationMessage}}
+<div id="monthValidationMessage" class="form-textfield__message {{this.monthValidationMessageClass}}" role="alert">{{this.monthValidationMessage}}</div>
 {{/if}}
 
-{{#if yearValidationMessage}}
-  <div id="yearValidationMessage" class="form-textfield__message {{yearValidationMessageClass}}"
-       role="alert">{{yearValidationMessage}}</div>
+{{#if this.yearValidationMessage}}
+  <div id="yearValidationMessage" class="form-textfield__message {{this.yearValidationMessageClass}}" role="alert">{{this.yearValidationMessage}}</div>
 {{/if}}

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -1,32 +1,32 @@
-<label for="{{textfieldName}}" class="form-textfield__label">
-  {{#if require}}<abbr title="obligatoire">*</abbr> {{/if}}
-  {{label}}
-    <br><span class="form-textfield__help">{{help}}</span>
+<label for="{{this.textfieldName}}" class="form-textfield__label">
+  {{#if this.require}}<abbr title="obligatoire">*</abbr> {{/if}}
+  {{this.label}}
+    <br><span class="form-textfield__help">{{this.help}}</span>
 </label>
 
-<div class="form-textfield__input-field-container {{if disabled "form-textfield__input-container--disabled" inputContainerStatusClass}}">
-  <Input @type={{textfieldType}}
-         @id={{textfieldName}}
-         @name={{textfieldName}}
-         @value={{inputBindingValue}}
-         @focus-out={{action onValidate textfieldName}}
-         class="form-textfield__input {{inputValidationStatus}}"
-         @autocomplete={{autocomplete}}
+<div class="form-textfield__input-field-container {{if this.disabled "form-textfield__input-container--disabled" this.inputContainerStatusClass}}">
+  <Input @type={{this.textfieldType}}
+         @id={{this.textfieldName}}
+         @name={{this.textfieldName}}
+         @value={{this.inputBindingValue}}
+         @focus-out={{action this.onValidate this.textfieldName}}
+         class="form-textfield__input {{this.inputValidationStatus}}"
+         @autocomplete={{this.autocomplete}}
          @ariaDescribedBy="validationMessage"
-         required={{require}}
-         @disabled={{disabled}} />
+         required={{this.require}}
+         @disabled={{this.disabled}} />
     <div class="form-textfield__icon">
-      {{#if isPassword}}
+      {{#if this.isPassword}}
           <button type="button" aria-label="rendre le mot de passe lisible" class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>
-            {{#if isPasswordVisible}}
+            {{#if this.isPasswordVisible}}
                 <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw form-textfield-icon-button__eye"}}</div>
             {{else}}
                 <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye-slash' class="fa-fw form-textfield-icon-button__eye"}}</div>
             {{/if}}
           </button>
       {{/if}}
-      {{#if hasIcon}}
-        {{#if (eq validationStatus 'error') }}
+      {{#if this.hasIcon}}
+        {{#if (eq this.validationStatus 'error') }}
             <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
         {{else}}
             <img src="/images/icons/icon-success.svg" class="form-textfield-icon__state form-textfield-icon__state--success">
@@ -35,6 +35,6 @@
     </div>
 
 </div>
-{{#if displayMessage}}
-    <div id="validationMessage" class="form-textfield__message {{validationMessageClass}} form-textfield__message-{{textfieldType}}" role="alert">{{validationMessage}}</div>
+{{#if this.displayMessage}}
+    <div id="validationMessage" class="form-textfield__message {{this.validationMessageClass}} form-textfield__message-{{this.textfieldType}}" role="alert">{{this.validationMessage}}</div>
 {{/if}}

--- a/mon-pix/app/templates/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/templates/components/inaccessible-campaign.hbs
@@ -3,11 +3,10 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
     <div class="campaign-landing-page__start__image__container">
       <div class="campaign-landing-page__pix-logo">
-        <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+        <img class="campaign-landing-page__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
       </div>
       <div class="campaign-landing-page__marianne-logo">
-        <img class="campaign-landing-page__image" src="{{rootURL}}/images/logo-de-la-republique-francaise.svg"
-             alt="République française">
+        <img class="campaign-landing-page__image" src="{{this.rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
       </div>
     </div>
     <div class="campaign-landing-page__error-text">

--- a/mon-pix/app/templates/components/learning-more-panel.hbs
+++ b/mon-pix/app/templates/components/learning-more-panel.hbs
@@ -1,11 +1,11 @@
-{{#if hasLearningMoreItems}}
+{{#if this.hasLearningMoreItems}}
   <div class="learning-more-panel__container">
     <header class="learning-more-panel__hint-container-header">
       <h4 class="learning-more-panel__hint-title"><span>Pour en apprendre davantage</span></h4>
     </header>
 
     <div class="learning-more-panel__list-container">
-      {{#each learningMoreTutorials as |learningMoreTutorial|}}
+      {{#each this.learningMoreTutorials as |learningMoreTutorial|}}
         <TutorialItem @tutorial={{learningMoreTutorial}} />
       {{/each}}
       <div class="learning-more-panel__tutorial-info">

--- a/mon-pix/app/templates/components/levelup-notif.hbs
+++ b/mon-pix/app/templates/components/levelup-notif.hbs
@@ -1,10 +1,10 @@
-{{#unless closeLevelup}}
+{{#unless this.closeLevelup}}
   <div class="levelup">
-    <img src="{{rootURL}}/images/levelup.svg">
-    <div class="levelup__icon-card-level">{{level}}</div>
+    <img src="{{this.rootURL}}/images/levelup.svg">
+    <div class="levelup__icon-card-level">{{this.level}}</div>
     <div class="levelup__competence">
-      <div class="levelup-competence__level">Niveau {{level}} gagné !</div>
-      <div class="levelup-competence__name">{{competenceName}}</div>
+      <div class="levelup-competence__level">Niveau {{this.level}} gagné !</div>
+      <div class="levelup-competence__name">{{this.competenceName}}</div>
     </div>
     <button role = "button"
             class="levelup__close"

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -1,11 +1,11 @@
 <div class="navbar-burger-menu navbar-burger-menu__user-info">
-  {{#if currentUser.user}}
+  {{#if this.currentUser.user}}
     <div class="navbar-burger-menu-user-info__item">
       <p class="navbar-burger-menu-user-info-item__name">
-        {{currentUser.user.fullName}}
+        {{this.currentUser.user.fullName}}
       </p>
       <p class="navbar-burger-menu-user-info-item__email">
-        {{currentUser.user.email}}
+        {{this.currentUser.user.email}}
       </p>
     </div>
   {{/if}}
@@ -21,7 +21,7 @@
   </LinkTo>
 </div>
 
-{{#unless isInRouteWithoutLinksInHeader}}
+{{#unless this.isInRouteWithoutLinksInHeader}}
   <div class="navbar-burger-menu navbar-burger-menu__navigation">
     <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
       Profil

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -5,12 +5,12 @@
       <PixLogo />
     </div>
     <div class="navbar-desktop-header-logo__marianne">
-      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
+      <img src="{{this.rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
     </div>
   </div>
 
-  {{#unless isInRouteWithoutLinksInHeader}}
-    {{#if isUserLogged}}
+  {{#unless this.isInRouteWithoutLinksInHeader}}
+    {{#if this.isUserLogged}}
       <div class="navbar-desktop-header-container__menu">
         <LinkTo @route="profile" class="navbar-desktop-header-menu__item">
           Profil
@@ -30,9 +30,9 @@
 
   <!-- Links (right) -->
   <div class="navbar-desktop-header-right">
-    <NavbarDesktopMenu @menu={{menu}} />
+    <NavbarDesktopMenu @menu={{this.menu}} />
 
-    {{#if isUserLogged}}
+    {{#if this.isUserLogged}}
       <UserLoggedMenu />
     {{/if}}
   </div>

--- a/mon-pix/app/templates/components/navbar-desktop-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-menu.hbs
@@ -1,6 +1,6 @@
 <div class="navbar-desktop-menu-links">
   <ul class="navbar-desktop-menu-links__list">
-    {{#each menu as |item|}}
+    {{#each this.menu as |item|}}
       <li class="navbar-desktop-menu-links__item">
         <LinkTo @route={{item.link}} class="navbar-desktop-menu-links__link {{item.class}}">{{item.name}}</LinkTo>
       </li>

--- a/mon-pix/app/templates/components/navbar-header.hbs
+++ b/mon-pix/app/templates/components/navbar-header.hbs
@@ -1,5 +1,5 @@
 {{#if (media 'isDesktop')}}
   <NavbarDesktopHeader />
 {{else}}
-  <NavbarMobileHeader @burger={{burger}} />
+  <NavbarMobileHeader @burger={{this.burger}} />
 {{/if}}

--- a/mon-pix/app/templates/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/templates/components/navbar-mobile-header.hbs
@@ -1,8 +1,8 @@
 <div class="navbar-mobile-header__container">
-  {{#if burger}}
-    {{#if isUserLogged}}
-      <span class="navbar-mobile-header__burger-icon" {{action burger.state.actions.toggle}}>
-        {{#if burger.state.open}}
+  {{#if this.burger}}
+    {{#if this.isUserLogged}}
+      <span class="navbar-mobile-header__burger-icon" {{action this.burger.state.actions.toggle}}>
+        {{#if this.burger.state.open}}
           {{fa-icon 'times'}}
         {{else}}
           {{fa-icon 'bars'}}
@@ -20,7 +20,7 @@
       <PixLogo />
     </div>
     <div class="navbar-mobile-header-logo__marianne">
-      <img src="{{rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
+      <img src="{{this.rootURL}}/images/logo-de-la-republique-francaise.svg" alt="République française">
     </div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -1,11 +1,11 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
-    <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+  <a href={{this.urlHome}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
+    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
   <div class="sign-form__header">
-    {{#unless _displaySuccessMessage}}
+    {{#unless this._displaySuccessMessage}}
       <h1 class="sign-form-title">Mot de passe oublié ?</h1>
       <div class="sign-form-header__instruction sign-form-header__instruction--short sign-form-subtitle">
         Entrez votre adresse e-mail ci-dessous, et c'est repartix
@@ -13,17 +13,17 @@
     {{/unless}}
   </div>
 
-  {{#if _displayErrorMessage}}
+  {{#if this._displayErrorMessage}}
     <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
       Cette adresse e-mail ne correspond à aucun compte
     </div>
   {{/if}}
 
-  {{#unless _displaySuccessMessage}}
+  {{#unless this._displaySuccessMessage}}
     <form {{action "savePasswordResetDemand" on="submit"}} class="sign-form__body">
 
       <div class="sign-form-body__input">
-        <FormTextfield @label="Adresse e-mail" @textfieldName="email" @validationStatus="default" @inputBindingValue={{email}} />
+        <FormTextfield @label="Adresse e-mail" @textfieldName="email" @validationStatus="default" @inputBindingValue={{this.email}} />
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
@@ -37,17 +37,17 @@
     </form>
   {{/unless}}
 
-  {{#if _displaySuccessMessage}}
+  {{#if this._displaySuccessMessage}}
     <div class="sign-form-header__instruction sign-form-subtitle">Demande de réinitialisation de mot de passe</div>
 
     <div class="password-reset-demand-form__body" aria-live="polite">
       <span class="password-reset-demand-body__text sign-form-text">Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe
-        vous a été envoyé à l’adresse e-mail {{email}}.</span>
+        vous a été envoyé à l’adresse e-mail {{this.email}}.</span>
       <span class="password-reset-demand-body__text sign-form-text">Si vous ne recevez pas cet e-mail, vérifiez vos courriers indésirables.</span>
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{urlHome}} class="link" title="Lien vers la page d'accueil de Pix">Retour à l'accueil</a>
+      <a href={{this.urlHome}} class="link" title="Lien vers la page d'accueil de Pix">Retour à l'accueil</a>
     </div>
   {{/if}}
 

--- a/mon-pix/app/templates/components/pix-logo.hbs
+++ b/mon-pix/app/templates/components/pix-logo.hbs
@@ -1,3 +1,3 @@
 <LinkTo @route="index" class="pix-logo__link" @title="Lien vers la page d'accueil de Pix">
-  <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+  <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
 </LinkTo>

--- a/mon-pix/app/templates/components/pix-toggle.hbs
+++ b/mon-pix/app/templates/components/pix-toggle.hbs
@@ -1,6 +1,6 @@
 
 <div class="pix-toggle">
-<span class="{{firstButtonClass}}" onToggle={{action "onToggle" "firstButtonClass" on="click"}}>{{valueFirstLabel}}</span>
-<span class="{{secondButtonClass}}" onToggle={{action "onToggle" "secondButtonClass" on="click"}}>{{valueSecondLabel}}</span>
+<span class="{{this.firstButtonClass}}" onToggle={{action "onToggle" "firstButtonClass" on="click"}}>{{this.valueFirstLabel}}</span>
+<span class="{{this.secondButtonClass}}" onToggle={{action "onToggle" "secondButtonClass" on="click"}}>{{this.valueSecondLabel}}</span>
 </div>
 {{yield}}

--- a/mon-pix/app/templates/components/progress-bar.hbs
+++ b/mon-pix/app/templates/components/progress-bar.hbs
@@ -1,8 +1,8 @@
-{{#if showProgressBar}}
+{{#if this.showProgressBar}}
   <div class="progress-bar-container">
     <div class="progress-bar-stepnums"
          role="progressbar"
-         aria-valuenow={{currentStepNumber}}
+         aria-valuenow={{this.currentStepNumber}}
          aria-valuemin="1"
          aria-valuemax="5"
       >
@@ -13,7 +13,7 @@
 
     <div class="progress-bar-background"></div>
 
-    <div class="progress-bar-progression" style={{progressionWidth}}></div>
+    <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
 
     <div class="progress-bar-steps">
       {{#each this.steps as |step|}}
@@ -25,7 +25,7 @@
   <div class="assessment-progress">
     <div class="assessment-progress__label">Question</div>
     <div class="assessment-progress__value">
-      {{currentStepNumber}} / {{maxStepsNumber}}
+      {{this.currentStepNumber}} / {{this.maxStepsNumber}}
     </div>
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/progression-gauge.hbs
+++ b/mon-pix/app/templates/components/progression-gauge.hbs
@@ -1,7 +1,7 @@
-<div class={{concat "progression-gauge " progressionClass}} style={{totalGaugeStyle}}>
-  <div class="progression-gauge__marker" style={{valueGaugeStyle}}></div>
+<div class={{concat "progression-gauge " this.progressionClass}} style={{this.totalGaugeStyle}}>
+  <div class="progression-gauge__marker" style={{this.valueGaugeStyle}}></div>
 
-  <div class="progression-gauge__tooltip-wrapper" style={{valueGaugeStyle}}>
+  <div class="progression-gauge__tooltip-wrapper" style={{this.valueGaugeStyle}}>
     <div class="progression-gauge__tooltip">{{yield}}</div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -1,4 +1,4 @@
-{{#each labeledCheckboxes as |labeledCheckbox index|}}
+{{#each this.labeledCheckboxes as |labeledCheckbox index|}}
 <p class="proposal-paragraph">
 
   {{!-- Checkbox button : hidden  - SVG displayed instead - but needed. --}}
@@ -7,7 +7,7 @@
          checked={{labeledCheckbox.[1]}}
          name="{{inc index}}"
          onclick={{action "checkboxClicked"}}
-         disabled={{if answer true}}>
+         disabled={{if this.answer true}}>
 
   {{!-- Surrounding label --}}
   <label for="checkbox_{{inc index}}"

--- a/mon-pix/app/templates/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcm-solution-panel.hbs
@@ -1,13 +1,13 @@
 <div class="qcm-panel__proposals rounded-panel">
   <div class="rounded-panel__row qcm-panel__proposal-list">
-    {{#each labeledCheckboxes as |labeledCheckbox index|}}
+    {{#each this.labeledCheckboxes as |labeledCheckbox index|}}
       <p class="qcm-panel__proposal-item">
         <label class="qcm-panel__proposal-label qcm-proposal-label">
 
           <input type="checkbox" class="qcm-panel__proposal-checkbox" checked={{if labeledCheckbox.[1] 'checked' ''}} disabled="disabled">
 
           <span class="qcm-proposal-label__oracle"
-                data-goodness="{{if (get solutionArray (concat index)) 'good' 'bad'}}"
+                data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
                 data-checked={{if labeledCheckbox.[1] 'yes' 'no'}}>
             {{labeledCheckbox.[0]}}
           </span>

--- a/mon-pix/app/templates/components/qcu-proposals.hbs
+++ b/mon-pix/app/templates/components/qcu-proposals.hbs
@@ -1,5 +1,5 @@
 <form onchange="{{action "radioClicked"}}">
-{{#each labeledRadios as |labeledRadio index|}}
+{{#each this.labeledRadios as |labeledRadio index|}}
 <p class="proposal-paragraph">
 
   {{!-- Radio button --}}
@@ -10,7 +10,7 @@
          id="radio_{{inc index}}"
          checked={{labeledRadio.[1]}}
          onclick={{action "radioClicked" index}}
-         disabled={{if answer true}}>
+         disabled={{if this.answer true}}>
 
   {{!-- Surrounding label --}}
   <label for="radio_{{inc index}}"

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -1,6 +1,6 @@
 <div class="qcu-panel__proposals rounded-panel">
   <div class="rounded-panel__row qcu-panel__proposal-list">
-    {{#each labeledRadios as |labeledItemRadio index|}}
+    {{#each this.labeledRadios as |labeledItemRadio index|}}
       <p class="qcu-panel__proposal-item">
 
         <label class="qcu-panel__proposal-label qcu-proposal-label">
@@ -27,7 +27,8 @@
           {{/if}}
 
           <span class="qcu-proposal-label__oracle"
-                data-goodness="{{if (get solutionArray (concat index)) 'good' 'bad'}}" data-checked={{if
+                data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
+                data-checked={{if
             labeledItemRadio.[1] 'yes' 'no'}}>
             {{labeledItemRadio.[0]}}
           </span>

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -1,42 +1,41 @@
-{{#each _blocks as |block|}}
+{{#each this._blocks as |block|}}
 
   {{#if block.text}}
     <label for="qroc_input">{{block.text}}</label>
   {{/if}}
 
   {{#if block.input}}
-    {{#if (eq format 'paragraphe')}}
+    {{#if (eq this.format 'paragraphe')}}
       <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
                 rows="5"
                 id="qroc_input"
                 name={{block.input}}
                 placeholder={{block.placeholder}}
                 autocomplete="off"
-                value="{{userAnswer}}"
+                value="{{this.userAnswer}}"
                 data-uid="qroc-proposal-uid"
-                disabled={{if answer true}}>
-      </textarea>
-    {{else if (eq format 'phrase')}}
+                disabled={{if this.answer true}}>      </textarea>
+    {{else if (eq this.format 'phrase')}}
       <input class="challenge-response__proposal challenge-response__proposal--sentence"
              type="text"
              id="qroc_input"
              name={{block.input}}
              placeholder={{block.placeholder}}
              autocomplete="off"
-             value="{{userAnswer}}"
+             value="{{this.userAnswer}}"
              data-uid="qroc-proposal-uid"
-             disabled={{if answer true}}>
+             disabled={{if this.answer true}}>
     {{else}}
       <input class="challenge-response__proposal"
-             size="{{get-qroc-input-size format}}"
+             size="{{get-qroc-input-size this.format}}"
              type="text"
              id="qroc_input"
              name={{block.input}}
              placeholder={{block.placeholder}}
              autocomplete="off"
-             value="{{userAnswer}}"
+             value="{{this.userAnswer}}"
              data-uid="qroc-proposal-uid"
-             disabled={{if answer true}}>
+             disabled={{if this.answer true}}>
     {{/if}}
   {{/if}}
 

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -2,31 +2,30 @@
   <div class="rounded-panel__row ">
 
     <div class="correction-qroc-box__answer">
-      {{#if (eq answer.challenge.format 'paragraphe')}}
-        <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{inputClass}}"
+      {{#if (eq this.answer.challenge.format 'paragraphe')}}
+        <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{this.inputClass}}"
                   rows="5"
-                  value="{{answerToDisplay}}"
+                  value="{{this.answerToDisplay}}"
                   ariaLabel="réponse donnée"
-                  disabled>
-        </textarea>
-      {{else if (eq answer.challenge.format 'phrase')}}
-        <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{inputClass}}"
-               value="{{answerToDisplay}}"
+                  disabled>        </textarea>
+      {{else if (eq this.answer.challenge.format 'phrase')}}
+        <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{this.inputClass}}"
+               value="{{this.answerToDisplay}}"
                ariaLabel="réponse donnée"
                disabled>
       {{else}}
-        <input class="correction-qroc-box-answer {{inputClass}}"
-               size="{{get-qroc-input-size answer.challenge.format}}"
-               value="{{answerToDisplay}}"
+        <input class="correction-qroc-box-answer {{this.inputClass}}"
+               size="{{get-qroc-input-size this.answer.challenge.format}}"
+               value="{{this.answerToDisplay}}"
                ariaLabel="réponse donnée"
                disabled>
       {{/if}}
     </div>
 
-    {{#unless isResultOk}}
+    {{#unless this.isResultOk}}
       <div class="correction-qroc-box__solution">
         <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
-        <div class="correction-qroc-box__solution-text">{{solutionToDisplay}}</div>
+        <div class="correction-qroc-box__solution-text">{{this.solutionToDisplay}}</div>
       </div>
     {{/unless}}
   </div>

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -1,16 +1,16 @@
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each inputFields as |field|}}
+    {{#each this.inputFields as |field|}}
       {{{field.label}}}
 
-      {{#if (eq challenge.format 'paragraphe')}}
+      {{#if (eq this.challenge.format 'paragraphe')}}
         <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
                   rows="5"
                   value="{{field.answer}}"
                   id="{{field.label}}"
                   disabled>
         </textarea>
-      {{else if (eq challenge.format 'phrase')}}
+      {{else if (eq this.challenge.format 'phrase')}}
         <input value="{{field.answer}}"
                class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
                id="{{field.label}}"
@@ -18,17 +18,17 @@
       {{else}}
         <div class="correction-qrocm__answer-wrapper">
           <input value="{{field.answer}}"
-                 size="{{get-qroc-input-size challenge.format}}"
+                 size="{{get-qroc-input-size this.challenge.format}}"
                  class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
                  id="{{field.label}}"
                  disabled>
         </div>
       {{/if}}
     {{/each}}
-    {{#unless answerIsCorrect}}
+    {{#unless this.answerIsCorrect}}
       <div class="correction-qrocm__solution">
         <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
-        <div class="correction-qrocm__solution-text">{{expectedAnswers}}</div>
+        <div class="correction-qrocm__solution-text">{{this.expectedAnswers}}</div>
       </div>
     {{/unless}}
   </div>

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,9 +1,9 @@
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each inputFields as |field|}}
+    {{#each this.inputFields as |field|}}
       {{{field.label}}}
 
-      {{#if (eq challenge.format 'paragraphe')}}
+      {{#if (eq this.challenge.format 'paragraphe')}}
         <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
                   rows="5"
                   value="{{field.answer}}"
@@ -16,9 +16,9 @@
                 <div class="correction-qrocm__solution-text">{{field.solution}}</div>
             </div>
         {{/if}}
-      {{else if (eq challenge.format 'phrase')}}
+      {{else if (eq this.challenge.format 'phrase')}}
         <input value="{{field.answer}}"
-               size="{{get-qroc-input-size challenge.format}}"
+               size="{{get-qroc-input-size this.challenge.format}}"
                class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
                id="{{field.label}}"
                disabled>
@@ -31,7 +31,7 @@
       {{else}}
         <div class="correction-qrocm__answer-wrapper">
           <input value="{{field.answer}}"
-                 size="{{get-qroc-input-size challenge.format}}"
+                 size="{{get-qroc-input-size this.challenge.format}}"
                  class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
                  id="{{field.label}}"
                  disabled>

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,11 +1,11 @@
-{{#each _blocks as |block|}}
+{{#each this._blocks as |block|}}
 
   {{#if block.showText}}
     <span>{{block.text}}</span>
   {{/if}}
 
   {{#if block.input}}
-    {{#if (eq format 'paragraphe')}}
+    {{#if (eq this.format 'paragraphe')}}
       {{#if block.text}}
         <label for="{{block.text}}">{{block.text}}</label>
       {{/if}}
@@ -15,12 +15,11 @@
                 placeholder={{block.placeholder}}
                 autocomplete="off"
                 id="{{block.text}}"
-                value={{property-of answersValue block.input}}
-                disabled={{answer}}
+                value={{property-of this.answersValue block.input}}
+                disabled={{this.answer}}
                 aria-label={{block.ariaLabel}}
-                onkeydown={{action 'onInputChange'}}>
-      </textarea>
-    {{else if (eq format 'phrase')}}
+                onkeydown={{action 'onInputChange'}}>      </textarea>
+    {{else if (eq this.format 'phrase')}}
       {{#if block.text}}
         <label for="{{block.text}}">{{block.text}}</label>
       {{/if}}
@@ -30,8 +29,8 @@
              placeholder={{block.placeholder}}
              autocomplete="off"
              id="{{block.text}}"
-             value={{property-of answersValue block.input}}
-             disabled={{answer}}
+             value={{property-of this.answersValue block.input}}
+             disabled={{this.answer}}
              aria-label={{block.ariaLabel}}
              onkeydown={{action 'onInputChange'}}>
     {{else}}
@@ -39,14 +38,14 @@
         <label for="{{block.text}}">{{block.text}}</label>
       {{/if}}
       <input class="challenge-response__proposal"
-             size="{{get-qroc-input-size format}}"
+             size="{{get-qroc-input-size this.format}}"
              type="text"
              name={{block.input}}
              placeholder={{block.placeholder}}
              autocomplete="off"
              id="{{block.text}}"
-             value={{property-of answersValue block.input}}
-             disabled={{answer}}
+             value={{property-of this.answersValue block.input}}
+             disabled={{this.answer}}
              aria-label={{block.ariaLabel}}
              onkeydown={{action 'onInputChange'}}>
     {{/if}}

--- a/mon-pix/app/templates/components/result-item.hbs
+++ b/mon-pix/app/templates/components/result-item.hbs
@@ -1,13 +1,13 @@
-<div class="result-item__icon" title="{{resultItem.title}}">
-  {{fa-icon resultItem.icon class=(concat 'result-item__icon--' resultItem.color)}}
+<div class="result-item__icon" title="{{this.resultItem.title}}">
+  {{fa-icon this.resultItem.icon class=(concat 'result-item__icon--' this.resultItem.color)}}
 </div>
 
 <div class="result-item__instruction">
-  {{strip-instruction (convert-to-html answer.challenge.instruction) textLength}}
+  {{strip-instruction (convert-to-html this.answer.challenge.instruction) this.textLength}}
 </div>
 
 <div class="result-item__correction">
-  {{#if validationImplementedForChallengeType}}
-    <button {{action openAnswerDetails answer}} class="result-item__correction-button link js-correct-answer">Réponses et tutos</button>
+  {{#if this.validationImplementedForChallengeType}}
+    <button {{action this.openAnswerDetails this.answer}} class="result-item__correction-button link js-correct-answer">Réponses et tutos</button>
   {{/if}}
 </div>

--- a/mon-pix/app/templates/components/resume-campaign-banner.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner.hbs
@@ -1,19 +1,19 @@
-{{#if campaignToResumeOrShare}}
+{{#if this.campaignToResumeOrShare}}
   <div class="resume-campaign-banner__container">
-    {{#if campaignToResumeOrShare.assessment.isCompleted}}
-      {{#if campaignToResumeOrShare.title}}
-        <span class="resume-campaign-banner__title">Parcours "{{campaignToResumeOrShare.title}}" terminé ! Envoyez vos résultats.</span>
+    {{#if this.campaignToResumeOrShare.assessment.isCompleted}}
+      {{#if this.campaignToResumeOrShare.title}}
+        <span class="resume-campaign-banner__title">Parcours "{{this.campaignToResumeOrShare.title}}" terminé ! Envoyez vos résultats.</span>
       {{else}}
         <span class="resume-campaign-banner__title">Parcours terminé ! Envoyez vos résultats.</span>
       {{/if}}
-      <LinkTo @route="campaigns.start-or-resume" @model={{campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>
+      <LinkTo @route="campaigns.start-or-resume" @model={{this.campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>
     {{else}}
-      {{#if campaignToResumeOrShare.title}}
-        <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{campaignToResumeOrShare.title}}"</span>
+      {{#if this.campaignToResumeOrShare.title}}
+        <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{this.campaignToResumeOrShare.title}}"</span>
       {{else}}
         <span class="resume-campaign-banner__title">Vous n'avez pas terminé votre parcours</span>
       {{/if}}
-      <LinkTo @route="campaigns.start-or-resume" @model={{campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Reprendre</LinkTo>
+      <LinkTo @route="campaigns.start-or-resume" @model={{this.campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Reprendre</LinkTo>
     {{/if}}
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/routes/login-form.hbs
+++ b/mon-pix/app/templates/components/routes/login-form.hbs
@@ -1,5 +1,5 @@
 <div class="login-form">
-  {{#if isErrorMessagePresent}}
+  {{#if this.isErrorMessagePresent}}
     <div id="login-form-error-message" class="login-form__error-message error-message">L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects</div>
   {{/if}}
 
@@ -9,7 +9,7 @@
       <FormTextfield @label="Adresse e-mail ou identifiant"
                      @textfieldName="login"
                      @validationStatus="default"
-                     @inputBindingValue={{login}}
+                     @inputBindingValue={{this.login}}
                      @autocomplete="username" />
     </div>
 
@@ -17,12 +17,12 @@
       <FormTextfield @label="Mot de passe"
                      @textfieldName="password"
                      @validationStatus="default"
-                     @inputBindingValue={{password}}
+                     @inputBindingValue={{this.password}}
                      @autocomplete="current-password" />
     </div>
 
     <div class="login-button-container">
-      {{#if isLoading}}
+      {{#if this.isLoading}}
         <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
         <button id="submit-connexion" type="submit" class="button button--uppercase">Je me connecte</button>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -9,75 +9,75 @@
 
 <div class="scorecard-details__content">
   <div class="scorecard-details-content__left">
-    <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{scorecard.area.color}}">
-      {{scorecard.area.title}}
+    <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{this.scorecard.area.color}}">
+      {{this.scorecard.area.title}}
     </div>
     <h3 class="scorecard-details-content-left__name">
-      {{scorecard.name}}
+      {{this.scorecard.name}}
     </h3>
     <div class="scorecard-details-content-left__description">
-      {{scorecard.description}}
+      {{this.scorecard.description}}
     </div>
   </div>
 
   <div class="scorecard-details-content__right">
 
-    {{#unless scorecard.isNotStarted}}
+    {{#unless this.scorecard.isNotStarted}}
       <div class="scorecard-details-content-right__score-container">
-        {{#if scorecard.isFinishedWithMaxLevel}}
+        {{#if this.scorecard.isFinishedWithMaxLevel}}
           <div class="competence-card__congrats">
             <div class="competence-card__level competence-card__level--congrats">
               <span class="score-label competence-card__score-label--congrats">Niveau</span>
-              <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{level}}</span>
+              <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{this.level}}</span>
             </div>
           </div>
         {{else}}
-          <CircleChart @value={{scorecard.percentageAheadOfNextLevel}}
-                       @sliceColor={{scorecard.area.color}}
+          <CircleChart @value={{this.scorecard.percentageAheadOfNextLevel}}
+                       @sliceColor={{this.scorecard.area.color}}
                        @chartClass="circle-chart__content--big"
                        @thicknessClass="circle--thick">
             <div class="competence-card__level">
               <span class="score-label">Niveau</span>
-              <span class="score-value">{{replace-zero-by-dash level}}</span>
+              <span class="score-value">{{replace-zero-by-dash this.level}}</span>
             </div>
           </CircleChart>
         {{/if}}
 
         <div class="scorecard-details-content-right-score-container__pix-earned">
           <div class="score-label">pix</div>
-          <div class="score-value">{{replace-zero-by-dash scorecard.earnedPix}}</div>
+          <div class="score-value">{{replace-zero-by-dash this.scorecard.earnedPix}}</div>
         </div>
       </div>
     {{/unless}}
 
-    {{#if isProgressable}}
+    {{#if this.isProgressable}}
       <div class="scorecard-details-content-right__level-info">
-        {{scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc scorecard.level}}
+        {{this.scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc this.scorecard.level}}
       </div>
     {{/if}}
 
-    {{#unless scorecard.isFinished}}
+    {{#unless this.scorecard.isFinished}}
       <LinkTo @route="competences.resume"
-              @model={{scorecard.competenceId}}
-              class={{concat "button button--big button--thin button--round button--link button--green " (if scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
-        {{#if scorecard.isStarted}}
-          Reprendre <div class="sr-only">la compétence "{{scorecard.name}}"</div>
+              @model={{this.scorecard.competenceId}}
+              class={{concat "button button--big button--thin button--round button--link button--green " (if this.scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
+        {{#if this.scorecard.isStarted}}
+          Reprendre <div class="sr-only">la compétence "{{this.scorecard.name}}"</div>
         {{else}}
-          Commencer <div class="sr-only">la compétence "{{scorecard.name}}"</div>
+          Commencer <div class="sr-only">la compétence "{{this.scorecard.name}}"</div>
         {{/if}}
       </LinkTo>
     {{/unless}}
-    {{#if displayResetButton}}
+    {{#if this.displayResetButton}}
       <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
         Remettre à zéro
-        <div class="sr-only">la compétence "{{scorecard.name}}"</div>
+        <div class="sr-only">la compétence "{{this.scorecard.name}}"</div>
       </button>
-    {{else if displayWaitSentence}}
-      <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
+    {{else if this.displayWaitSentence}}
+      <p class="scorecard-details-content-right__reset-message">{{this.remainingDaysText}}</p>
     {{/if}}
   </div>
 </div>
-{{#if tutorialsGroupedByTubeName}}
+{{#if this.tutorialsGroupedByTubeName}}
 <div class="scorecard-details__content">
   <div class="tutorials">
     <div class="tutorials__header">
@@ -85,7 +85,7 @@
       <p class="tutorials-header__description">Voici une sélection de tutos qui pourront vous aider à gagner des Pix.</p>
     </div>
     <div class="tutorial__list">
-      {{#each tutorialsGroupedByTubeName as |tube|}}
+      {{#each this.tutorialsGroupedByTubeName as |tube|}}
         <div class="tube">
           <h4 class="tube__title">{{tube.practicalTitle}}</h4>
           <div class="tube__content">
@@ -99,7 +99,7 @@
   </div>
 </div>
 {{/if}}
-{{#if showResetModal}}
+{{#if this.showResetModal}}
   <PixModal @containerClass="scorecard-details__reset-modal pix-modal-dialog--wide" @onClose={{action "closeModal"}}>
     <div class="pix-modal__close-link" aria-label="Fermer" {{action "closeModal"}}>
       <span>Fermer</span>
@@ -110,15 +110,15 @@
     <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
       <div class="pix-modal-header">
         <h1 class="pix-modal-header__title pix-modal-header__title--thin">Remise à zéro de la compétence</h1>
-        <h2 class="pix-modal-header__subtitle">{{scorecard.name}}</h2>
+        <h2 class="pix-modal-header__subtitle">{{this.scorecard.name}}</h2>
       </div>
 
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="scorecard-details-reset-modal__important-message">
-          {{#if scorecard.hasNotReachLevelOne}}
-            Vos {{scorecard.earnedPix}} Pix vont être supprimés.
-          {{else if scorecard.hasReachAtLeastLevelOne}}
-            Votre niveau {{scorecard.level}} et vos {{scorecard.earnedPix}} Pix vont être supprimés.
+          {{#if this.scorecard.hasNotReachLevelOne}}
+            Vos {{this.scorecard.earnedPix}} Pix vont être supprimés.
+          {{else if this.scorecard.hasReachAtLeastLevelOne}}
+            Votre niveau {{this.scorecard.level}} et vos {{this.scorecard.earnedPix}} Pix vont être supprimés.
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Page d'accueil de Pix">
-    <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+  <a href={{this.urlHome}} class="pix-logo__link" title="Page d'accueil de Pix">
+    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
   <div class="sign-form__header">
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  {{#if displayErrorMessage}}
+  {{#if this.displayErrorMessage}}
     <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
       L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects
     </div>
@@ -24,14 +24,16 @@
       <FormTextfield @label="Adresse e-mail ou identifiant"
                      @textfieldName="login"
                      @validationStatus="default"
-                     @inputBindingValue={{username}} @autocomplete="username" />
+                     @inputBindingValue={{this.username}}
+                     @autocomplete="username" />
     </div>
 
     <div class="sign-form-body__input">
       <FormTextfield @label="Mot de passe"
                      @textfieldName="password"
                      @validationStatus="default"
-                     @inputBindingValue={{password}} @autocomplete="current-password" />
+                     @inputBindingValue={{this.password}}
+                     @autocomplete="current-password" />
     </div>
 
     <LinkTo @route="password-reset-demand" class="link link--grey sign-form-link sign-form-body__forgotten-password-link">

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
-  <a href={{urlHome}} class="pix-logo__link" title="Page d'accueil">
-    <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+  <a href={{this.urlHome}} class="pix-logo__link" title="Page d'accueil">
+    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
   <div class="sign-form__header">
@@ -12,9 +12,9 @@
     </div>
   </div>
 
-  {{#if _notificationMessage}}
+  {{#if this._notificationMessage}}
     <div class="sign-form__notification-message sign-form__notification-message--success" aria-live="polite">
-      {{_notificationMessage}}
+      {{this._notificationMessage}}
     </div>
   {{/if}}
 
@@ -24,10 +24,10 @@
     <div class="sign-form-body__input">
       <FormTextfield @label="Prénom"
                      @textfieldName="firstName"
-                     @inputBindingValue={{user.firstName}}
+                     @inputBindingValue={{this.user.firstName}}
                      @onValidate={{action "validateInput"}}
-                     @validationStatus={{validation.firstName.status}}
-                     @validationMessage={{validation.firstName.message}}
+                     @validationStatus={{this.validation.firstName.status}}
+                     @validationMessage={{this.validation.firstName.message}}
                      @autocomplete="given-name"
                      @require={{true}} />
     </div>
@@ -35,32 +35,34 @@
     <div class="sign-form-body__input">
       <FormTextfield @label="Nom"
                      @textfieldName="lastName"
-                     @inputBindingValue={{user.lastName}}
+                     @inputBindingValue={{this.user.lastName}}
                      @onValidate={{action "validateInput"}}
-                     @validationStatus={{validation.lastName.status}}
-                     @validationMessage={{validation.lastName.message}}
-                     @autocomplete="family-name" @require={{true}} />
+                     @validationStatus={{this.validation.lastName.status}}
+                     @validationMessage={{this.validation.lastName.message}}
+                     @autocomplete="family-name"
+                     @require={{true}} />
     </div>
 
     <div class="sign-form-body__input">
       <FormTextfield @label="Adresse e-mail"
                      @help="(ex: nom@exemple.fr)"
                      @textfieldName="email"
-                     @validationStatus={{validation.email.status}}
+                     @validationStatus={{this.validation.email.status}}
                      @onValidate={{action "validateInputEmail"}}
-                     @inputBindingValue={{user.email}}
-                     @validationMessage={{validation.email.message}}
-                     @autocomplete="email" @require={{true}} />
+                     @inputBindingValue={{this.user.email}}
+                     @validationMessage={{this.validation.email.message}}
+                     @autocomplete="email"
+                     @require={{true}} />
     </div>
 
     <div class="sign-form-body__input">
       <FormTextfield @label="Mot de passe"
                      @help="(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)"
                      @textfieldName="password"
-                     @validationStatus={{validation.password.status}}
+                     @validationStatus={{this.validation.password.status}}
                      @onValidate={{action "validateInputPassword"}}
-                     @inputBindingValue={{user.password}}
-                     @validationMessage={{validation.password.message}}
+                     @inputBindingValue={{this.user.password}}
+                     @validationMessage={{this.validation.password.message}}
                      @autocomplete="new-password"
                      @require={{true}} />
     </div>
@@ -68,29 +70,29 @@
     <div class="signup-form__cgu-container">
       <label for="pix-cgu" class="signup-form__cgu-label">
         <div class="signup-form__cgu">
-          <Input @type="checkbox" @id="pix-cgu" @checked={{user.cgu}} />
+          <Input @type="checkbox" @id="pix-cgu" @checked={{this.user.cgu}} />
            <abbr title="obligatoire">*</abbr> J'accepte les <a href="https://pix.fr/conditions-generales-d-utilisation" class="link" target="_blank">conditions d'utilisation de Pix</a>
         </div>
 
-        {{#if user.errors.cgu}}
+        {{#if this.user.errors.cgu}}
           <div class="sign-form__validation-error">
-            {{user.errors.cgu.firstObject.message}}
+            {{this.user.errors.cgu.firstObject.message}}
           </div>
         {{/if}}
       </label>
     </div>
 
-    {{#if isRecaptchaEnabled}}
+    {{#if this.isRecaptchaEnabled}}
       <div class="signup-form__captcha-container">
-        {{#if user.errors.recaptchaToken}}
-          <div class="sign-form__validation-error">{{user.errors.recaptchaToken.firstObject.message}}</div>
+        {{#if this.user.errors.recaptchaToken}}
+          <div class="sign-form__validation-error">{{this.user.errors.recaptchaToken.firstObject.message}}</div>
         {{/if}}
-        <GRecaptcha @recaptchaToken={{user.recaptchaToken}} @tokenHasBeenUsed={{_tokenHasBeenUsed}} />
+        <GRecaptcha @recaptchaToken={{this.user.recaptchaToken}} @tokenHasBeenUsed={{this._tokenHasBeenUsed}} />
       </div>
     {{/if}}
 
-    <div class="sign-form-body__bottom-button {{if isRecaptchaEnabled "" "sign-form-body__bottom-button--margin-top"}}">
-      {{#if isLoading}}
+    <div class="sign-form-body__bottom-button {{if this.isRecaptchaEnabled "" "sign-form-body__bottom-button--margin-top"}}">
+      {{#if this.isLoading}}
         <button type="button" disabled class="button button--uppercase button--thin button--round button--big">
           <span class="loader-in-button">&nbsp;</span>
         </button>

--- a/mon-pix/app/templates/components/stepper.hbs
+++ b/mon-pix/app/templates/components/stepper.hbs
@@ -1,7 +1,7 @@
 <div class="stepper">
   <section>
     {{#component this.activeComponentName as |Active|}}
-      <Active.main @success={{action "didMove"}} @stepsData={{stepsData}} />
+      <Active.main @success={{action "didMove"}} @stepsData={{this.stepsData}} />
     {{/component}}
   </section>
 </div>

--- a/mon-pix/app/templates/components/timeout-jauge.hbs
+++ b/mon-pix/app/templates/components/timeout-jauge.hbs
@@ -1,17 +1,17 @@
 <div class="timeout-jauge">
   <div class="timeout-jauge-container">
     <div class="timeout-jauge-clock">
-      {{#if hasFinished}}
+      {{#if this.hasFinished}}
         <img class="svg-timeout-clock-red" src="/images/icon-timeout-red.svg" alt="Icône indiquant que le temps alloué est dépassé">
       {{else}}
         <img class="svg-timeout-clock-black" src="/images/icon-timeout-black.svg" alt="Icône indiquant qu'il reste du temps pour accomplir l'épreuve">
       {{/if}}
       <div>&nbsp;</div>
-      <div class="timeout-jauge-remaining" data-spent="{{remainingSeconds}}">
-        {{remainingTime}}
+      <div class="timeout-jauge-remaining" data-spent="{{this.remainingSeconds}}">
+        {{this.remainingTime}}
       </div>
     </div>
-    <div class="timeout-jauge-progress" style={{jaugeWidthStyle}}>
+    <div class="timeout-jauge-progress" style={{this.jaugeWidthStyle}}>
     </div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -1,18 +1,15 @@
 <div class="tutorial-item">
   <div class="tutorial__content">
-    <a target="_blank" rel="noopener noreferrer" href="{{tutorial.link}}"
-       class="tutorial-content__title">{{tutorial.title}}</a>
+    <a target="_blank" rel="noopener noreferrer" href="{{this.tutorial.link}}" class="tutorial-content__title">{{this.tutorial.title}}</a>
     <div class="tutorial-content__description">
-      <span class="tutorial-content__source">Par {{tutorial.source}}</span>
-      • <span class="tutorial-content__format">{{tutorial.format}}</span>
-      • <span class="tutorial-content__duration">{{moment-duration tutorial.duration}}</span>
+      <span class="tutorial-content__source">Par {{this.tutorial.source}}</span>
+      • <span class="tutorial-content__format">{{this.tutorial.format}}</span>
+      • <span class="tutorial-content__duration">{{moment-duration this.tutorial.duration}}</span>
     </div>
     {{#if this.currentUser.user}}
-      <button class="tutorial-content__save-tutorial" title={{this.buttonTitle}}
-        {{on 'click' (if this.isSaved this.removeTutorial this.saveTutorial)}}
-              disabled={{this.isButtonDisabled}}>
+      <button class="tutorial-content__save-tutorial" title={{this.buttonTitle}} {{on 'click' (if this.isSaved this.removeTutorial this.saveTutorial)}} disabled={{this.isButtonDisabled}}>
         <FaIcon @prefix={{if this.isSaved 'fas' 'far'}} @icon='bookmark'></FaIcon>
-        {{buttonText}}
+        {{this.buttonText}}
       </button>
     {{/if}}
   </div>

--- a/mon-pix/app/templates/components/tutorial-panel.hbs
+++ b/mon-pix/app/templates/components/tutorial-panel.hbs
@@ -1,22 +1,22 @@
-{{#if shouldDisplayHintOrTuto}}
+{{#if this.shouldDisplayHintOrTuto}}
   <div class="tutorial-panel__hint-container">
     <header class="tutorial-panel__hint-container-header">
       <h3 class="tutorial-panel__hint-title"><span>Pour réussir la prochaine fois</span></h3>
     </header>
-    {{#if shouldDisplayHint}}
+    {{#if this.shouldDisplayHint}}
       <div class="tutorial-panel__hint-container-body">
         <div class="tutorial-panel__hint-picto-container">
-          <img src="{{rootURL}}/images/comparison-window/icon-lampe.svg"
+          <img src="{{this.rootURL}}/images/comparison-window/icon-lampe.svg"
                 alt=""
                 class="tutorial-panel__hint-picto">
         </div>
-        <MarkdownToHtml @class="tutorial-panel__hint-content" @markdown={{hint}} />
+        <MarkdownToHtml @class="tutorial-panel__hint-content" @markdown={{this.hint}} />
       </div>
     {{/if}}
 
-    {{#if shouldDisplayTutorial}}
+    {{#if this.shouldDisplayTutorial}}
       <div class="tutorial-panel__tutorials-container">
-        {{#each limitedTutorials as |tutorial|}}
+        {{#each this.limitedTutorials as |tutorial|}}
           <TutorialItem @tutorial={{tutorial}} />
         {{/each}}
       </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-area.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-area.hbs
@@ -1,8 +1,8 @@
 <div>
   <div class="user-certifications-detail-area__box-name">
-    {{area.title}}
+    {{this.area.title}}
   </div>
-  {{#each sortedCompetences as |competence index|}}
+  {{#each this.sortedCompetences as |competence index|}}
 
     <UserCertificationsDetailCompetence @competence={{competence}} />
 

--- a/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
@@ -1,14 +1,14 @@
 <div class="user-certifications-detail-competence__box-name">
-  <span class="user-certifications-detail-competence__box-name-label">{{competence.name}}</span>
-  {{#if (gte competence.level 1)}}
-    <div class="user-certifications-detail-competence__box-level">{{competence.level}}</div>
+  <span class="user-certifications-detail-competence__box-name-label">{{this.competence.name}}</span>
+  {{#if (gte this.competence.level 1)}}
+    <div class="user-certifications-detail-competence__box-level">{{this.competence.level}}</div>
   {{/if}}
 
 </div>
 
 <div class="user-certifications-detail-competence__levels-bar-block">
-  {{#each levels as |level index|}}
-    {{#if (gte competence.level level)}}
+  {{#each this.levels as |level index|}}
+    {{#if (gte this.competence.level level)}}
       <div class="user-certifications-detail-competence__validate-level user-certifications-detail-competence__level-bar"></div>
     {{else}}
       <div class="user-certifications-detail-competence__not-validate-level user-certifications-detail-competence__level-bar"></div>

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -1,18 +1,18 @@
-<img src="{{rootURL}}/images/icons/icon-certification.svg"
+<img src="{{this.rootURL}}/images/icons/icon-certification.svg"
      alt=""
      class="user-certifications-detail-header__icon">
 
 <div class="user-certifications-detail-header__data-box">
-  {{#if certification.date}}
+  {{#if this.certification.date}}
     <p class="user-certifications-detail-header__data-box-title">
       <span class="user-certifications-detail-header__data-box-title-big">CERTIFICAT</span>
-      obtenu le {{moment-format certification.date 'LL' locale='fr' allow-empty=true}}
+      obtenu le {{moment-format this.certification.date 'LL' locale='fr' allow-empty=true}}
     </p>
-    <p>Nom : {{certification.firstName}} {{certification.lastName}}</p>
-    <p>Date de naissance : {{moment-format certification.birthdate 'LL' locale='fr' allow-empty=true}}</p>
-    <p>Lieu de naissance : {{certification.birthplace}}</p>
-    {{#if certification.certificationCenter}}
-      <p>Centre de certification : {{certification.certificationCenter}}</p>
+    <p>Nom : {{this.certification.firstName}} {{this.certification.lastName}}</p>
+    <p>Date de naissance : {{moment-format this.certification.birthdate 'LL' locale='fr' allow-empty=true}}</p>
+    <p>Lieu de naissance : {{this.certification.birthplace}}</p>
+    {{#if this.certification.certificationCenter}}
+      <p>Centre de certification : {{this.certification.certificationCenter}}</p>
     {{/if}}
   {{/if}}
 </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-profile.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-profile.hbs
@@ -1,5 +1,5 @@
 <div>
-{{#each sortedAreas as |area index|}}
+{{#each this.sortedAreas as |area index|}}
 
   <UserCertificationsDetailArea @area={{area}} />
 

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,6 +1,6 @@
 <div class="user-certifications-detail-result__pix-score">
   <div class="user-certifications-detail-result__badge-pix-score">
-    <span>{{ certification.pixScore }}</span>
+    <span>{{ this.certification.pixScore }}</span>
   </div>
   <div class="user-certifications-detail-result__pix-certified">
     Pix certifiés
@@ -13,11 +13,11 @@
 </div>
 
 <div>
-  {{#if certification.commentForCandidate}}
+  {{#if this.certification.commentForCandidate}}
     <hr>
     <div class="user-certifications-detail-result__title-comment-jury">Intervention du jury</div>
     <div class="user-certifications-detail-result__comment-jury">
-      {{certification.commentForCandidate}}
+      {{this.certification.commentForCandidate}}
     </div>
   {{/if}}
 </div>

--- a/mon-pix/app/templates/components/user-certifications-panel.hbs
+++ b/mon-pix/app/templates/components/user-certifications-panel.hbs
@@ -1,6 +1,6 @@
-{{#if certifications}}
+{{#if this.certifications}}
   <div class="user-certifications-panel__certifications-list">
-    <CertificationsList @certifications={{certifications}} />
+    <CertificationsList @certifications={{this.certifications}} />
   </div>
 {{else}}
   <div class="user-certifications-panel__no-certification-panel">

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -1,17 +1,17 @@
-{{#if currentUser.user}}
-  <div class="logged-user-name" aria-haspopup="true" aria-expanded="{{_canDisplayMenu}}">
+{{#if this.currentUser.user}}
+  <div class="logged-user-name" aria-haspopup="true" aria-expanded="{{this._canDisplayMenu}}">
     <a href="#" class="logged-user-name__link" {{action 'toggleUserMenu'}}>
-      {{currentUser.user.firstName}}
+      {{this.currentUser.user.firstName}}
       <span class="caret"></span>
     </a>
   </div>
 
-  {{#if _canDisplayMenu}}
+  {{#if this._canDisplayMenu}}
     <ClickOutside @action={{action "closeMenu"}}>
       <div class="logged-user-menu">
         <div class="logged-user-menu__details">
-          <div class="logged-user-menu-details__fullname">{{currentUser.user.fullName}}</div>
-          <div class="logged-user-menu-details__identifier">{{displayedIdentifier}}</div>
+          <div class="logged-user-menu-details__fullname">{{this.currentUser.user.fullName}}</div>
+          <div class="logged-user-menu-details__identifier">{{this.displayedIdentifier}}</div>
         </div>
         <LinkTo @route="user-tutorials" class="logged-user-menu__link">
           Mes tutos

--- a/mon-pix/app/templates/components/warning-banner.hbs
+++ b/mon-pix/app/templates/components/warning-banner.hbs
@@ -1,4 +1,4 @@
-{{#if isEnabled}}
+{{#if this.isEnabled}}
   <div class="warning-banner">
     <a class="warning-banner__text" href="https://app.pix.fr">
       {{fa-icon 'exclamation-triangle'}}

--- a/mon-pix/app/templates/components/warning-page.hbs
+++ b/mon-pix/app/templates/components/warning-page.hbs
@@ -1,6 +1,6 @@
 <div class="challenge-item-warning">
   <div class="challenge-item-warning__instruction-primary">
-    Vous disposerez de <span class="challenge-item-warning__instruction-time">{{allocatedHumanTime}}</span> pour réussir la question suivante.
+    Vous disposerez de <span class="challenge-item-warning__instruction-time">{{this.allocatedHumanTime}}</span> pour réussir la question suivante.
   </div>
 
   <div class="challenge-item-warning__intruction-secondary">
@@ -9,10 +9,10 @@
   <div class="challenge-item-warning__allocated-time">
     <div class="challenge__allocated-time__jauge">
       <img class="challenge__allocated-time__warning-icon" src="/images/icon-timed-challenge.svg" alt="Message d'avertissement">
-      <span class="challenge__allocated-time__value">{{allocatedTime}}</span>
+      <span class="challenge__allocated-time__value">{{this.allocatedTime}}</span>
     </div>
   </div>
   <div class="challenge-item-warning__action">
-    <button {{action hasUserConfirmWarning}} class="challenge-item-warning__confirm-btn">Commencer</button>
+    <button {{action this.hasUserConfirmWarning}} class="challenge-item-warning__confirm-btn">Commencer</button>
   </div>
 </div>

--- a/mon-pix/app/templates/inscription.hbs
+++ b/mon-pix/app/templates/inscription.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="sign-form-page">
   <SignupForm @user={{@model}} @refresh="refresh" @authenticateUser={{route-action "authenticateUser"}} />
 </div>

--- a/mon-pix/app/templates/login.hbs
+++ b/mon-pix/app/templates/login.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="sign-form-page">
   <SigninForm @authenticateUser={{route-action "authenticate"}} />
 </div>

--- a/mon-pix/app/templates/not-connected.hbs
+++ b/mon-pix/app/templates/not-connected.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="not-connected">
   <div class="rounded-panel not-connected__container">
     <img class="pix-logo__image not-connected__logo" src="/images/pix-logo.svg" alt="Pix">

--- a/mon-pix/app/templates/password-reset-demand.hbs
+++ b/mon-pix/app/templates/password-reset-demand.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="sign-form-page">
   <PasswordResetDemandForm />
 </div>

--- a/mon-pix/app/templates/profile.hbs
+++ b/mon-pix/app/templates/profile.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     {{#if @model.campaignParticipations}}

--- a/mon-pix/app/templates/reset-password.hbs
+++ b/mon-pix/app/templates/reset-password.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <div class="sign-form-page">
   <ResetPasswordForm @user={{@model.user}} @temporaryKey={{@model.temporaryKey}} />
 </div>

--- a/mon-pix/app/templates/user-certifications.hbs
+++ b/mon-pix/app/templates/user-certifications.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @class="navbar-header--white" @burger={{burger}} />

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -1,10 +1,10 @@
-{{title pageTitle}}
+{{title this.pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
     <header role="banner" class="background-banner">
       <div class="user-tutorials-banner">
-        <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt=""/>
+        <img src="{{this.rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt="" />
         <h3 class="user-tutorials-banner__title">Mes tutos</h3>
         <p class="user-tutorials-banner__description">
           Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.
@@ -23,8 +23,8 @@
     {{else}}
       <article aria-label="tutoriels" class="rounded-panel user-tutorials-no-tutorial">
         <div class="user-tutorials-no-tutorial__illustration">
-          <img src="{{rootURL}}/images/user-tutorials/illustration.svg"
-               alt="Cliquez sur l'icône enregistrer sur un tutoriel pour le retrouver sur cette page"/>
+          <img src="{{this.rootURL}}/images/user-tutorials/illustration.svg"
+               alt="Cliquez sur l'icône enregistrer sur un tutoriel pour le retrouver sur cette page" />
         </div>
         <div class="user-tutorials-no-tutorial__instructions">
           <h4 class="user-tutorials-no-tutorial-instructions__title">Vous n'avez encore rien enregistré</h4>


### PR DESCRIPTION
## :unicorn: Problème
Le passage à Octane recommande l'utilisation du `this` explicite. 

> Using own properties
> 
> If a property is defined in the JavaScript file for this component's template, use a "this" when you refer to it. There's no change in behavior. Learn more about features and using codemods to update your existing components. 
> 
> Classic 
> `{{answer}} is the answer.`
> Octane
> `{{this.answer}} is the answer.`

Ref — https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates

## :robot: Solution
Exécuter le [codemod no-implicit-this](https://github.com/ember-codemods/ember-no-implicit-this-codemod)