### PR TITLE
[TECH] Retourner une réponse 204 lors de l'appel de rafraichissement du cache

### DIFF
--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -13,7 +13,7 @@ export default class ToolsController extends Controller {
     this.set('isLoading', true);
     try {
       await this.store.adapterFor('learning-content-cache').refreshCacheEntries();
-      this.notifications.success('Le cache a été rechargé avec succès.');
+      this.notifications.success('La demande de rechargement du cache a bien été prise en compte.');
     } catch (err) {
       this.notifications.error('Une erreur est survenue.');
     } finally {

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -3,9 +3,9 @@ const _ = require('lodash');
 
 module.exports = {
 
-  refreshCacheEntries() {
-    return Promise.all(_.map(AirtableDatasources, (datasource) => datasource.refreshAirtableCacheRecords()))
-      .then(() => null);
+  refreshCacheEntries(request, h) {
+    _.forEach(AirtableDatasources, (datasource) => datasource.refreshAirtableCacheRecords());
+    return h.response().code(204);
   },
 
   refreshCacheEntry(request) {

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -1,11 +1,16 @@
 const AirtableDatasources = require('../../infrastructure/datasources/airtable');
+const logger = require('../../infrastructure/logger');
 const _ = require('lodash');
 
 module.exports = {
 
   refreshCacheEntries(request, h) {
-    _.forEach(AirtableDatasources, (datasource) => datasource.refreshAirtableCacheRecords());
-    return h.response().code(204);
+    _.forEach(AirtableDatasources, (datasource) =>
+      datasource.refreshAirtableCacheRecords().catch((e) =>
+        logger.error(`Error while reloading cache for ${datasource}`, e)
+      )
+    );
+    return h.response({}).code(202);
   },
 
   refreshCacheEntry(request) {

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -47,16 +47,16 @@ describe('Unit | Controller | cache-controller', () => {
 
     const request = {};
 
-    it('should reply with null when there is no error', async () => {
+    it('should reply with http status 204 when there is no error', async () => {
       // given
-      _.map(AirtableDatasources, (datasource) => sinon.stub(datasource, 'refreshAirtableCacheRecords'));
+      _.forEach(AirtableDatasources, (datasource) => sinon.stub(datasource, 'refreshAirtableCacheRecords'));
 
       // when
       const response = await cacheController.refreshCacheEntries(request, hFake);
 
       // Then
-      _.map(AirtableDatasources, (datasource) => expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce);
-      expect(response).to.be.null;
+      _.forEach(AirtableDatasources, (datasource) => expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce);
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -48,42 +48,55 @@ describe('Unit | Controller | cache-controller', () => {
 
     const request = {};
 
-    it('should reply with http status 202', async () => {
-      // given
-      const numberOfDeletedKeys = 0;
-      _.forEach(AirtableDatasources, (datasource) => {
-        sinon.stub(datasource, 'refreshAirtableCacheRecords');
-        datasource.refreshAirtableCacheRecords.resolves(numberOfDeletedKeys);
+    context('nominal case', () => {
+      it('should reply with http status 202', async () => {
+        // given
+        const numberOfDeletedKeys = 0;
+        _.forEach(AirtableDatasources, (datasource) => {
+          sinon.stub(datasource, 'refreshAirtableCacheRecords');
+          datasource.refreshAirtableCacheRecords.resolves(numberOfDeletedKeys);
+        });
+
+        // when
+        const response = await cacheController.refreshCacheEntries(request, hFake);
+
+        // then
+        _.forEach(AirtableDatasources, (datasource) =>
+          expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce
+        );
+        expect(response.statusCode).to.equal(202);
       });
-
-      // when
-      const response = await cacheController.refreshCacheEntries(request, hFake);
-
-      // then
-      _.forEach(AirtableDatasources, (datasource) =>
-        expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce
-      );
-      expect(response.statusCode).to.equal(202);
     });
 
-    it('should also reply with http status 202 when there is an error', async () => {
-      // given
-      sinon.stub(logger, 'error');
-      const datasourcesCount = Object.keys(AirtableDatasources).length;
-      _.forEach(AirtableDatasources, (datasource) => {
-        sinon.stub(datasource, 'refreshAirtableCacheRecords');
-        datasource.refreshAirtableCacheRecords.rejects();
+    context('error case', () => {
+      let datasourcesCount, response;
+
+      beforeEach(async () => {
+        // given
+        sinon.stub(logger, 'error');
+        datasourcesCount = Object.keys(AirtableDatasources).length;
+        _.forEach(AirtableDatasources, (datasource) => {
+          sinon.stub(datasource, 'refreshAirtableCacheRecords');
+          datasource.refreshAirtableCacheRecords.rejects();
+        });
+
+        // when
+        response = await cacheController.refreshCacheEntries(request, hFake);
       });
 
-      // when
-      const response = await cacheController.refreshCacheEntries(request, hFake);
+      it('should reply with http status 202', async () => {
+        // then
+        expect(response.statusCode).to.equal(202);
+      });
 
-      // then
-      _.forEach(AirtableDatasources, (datasource) =>
-        expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce
-      );
-      expect(logger.error.callCount).to.equal(datasourcesCount);
-      expect(response.statusCode).to.equal(202);
+      it('should call log errors as many times as there are datasources', async () => {
+        // then
+        _.forEach(AirtableDatasources, (datasource) =>
+          expect(datasource.refreshAirtableCacheRecords).to.have.been.calledOnce
+        );
+        expect(logger.error.callCount).to.equal(datasourcesCount);
+      });
     });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On a un endpoint PATCH /api/cache qui lance le rechargement du cache, puis retourne null à l'appelant lorsque le traitement est terminé.
La durée de ce traitement dépasse le timeout de Scalingo, et la requête est retournée en erreur (le traitement dans api continue de tourner mais on a pas attendu la fin).

## :robot: Solution
Retourner un 204 sans attendre la fin du traitement.
EDIT: Finalement, c'est un 202 qui est retourné

## :100: Pour tester
Sur pix admin, reloader le cache.
Une notification apparaît immédiatement pour indiquer que la demande a été prise en compte.
