### PR TITLE
[CLEANUP] Glimmerisation du composant pour gérer les simulateurs embarqués dans les épreuves (PF-1241).

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -9,7 +9,7 @@ export default class ChallengeEmbedSimulator extends Component {
   isLoadingEmbed = true;
 
   @tracked
-  isSimulatorNotYetLaunched = true;
+  isSimulatorLaunched = false;
 
   get embedDocumentHeightStyle() {
     if (this.args.embedDocument) {
@@ -20,7 +20,7 @@ export default class ChallengeEmbedSimulator extends Component {
 
   configureIframe(iframe, [embedUrl, thisComponent]) {
     thisComponent.isLoadingEmbed = true;
-    thisComponent.isSimulatorNotYetLaunched = true;
+    thisComponent.isSimulatorLaunched = false;
     iframe.onload = () => {
       if (embedUrl) {
         thisComponent.isLoadingEmbed = false;
@@ -35,7 +35,7 @@ export default class ChallengeEmbedSimulator extends Component {
     // TODO: use correct targetOrigin once the embeds are hosted behind our domain
     iframe.contentWindow.postMessage('launch', '*');
     iframe.focus();
-    this.isSimulatorNotYetLaunched = false;
+    this.isSimulatorLaunched = true;
   }
 
   @action

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -18,7 +18,10 @@ export default class ChallengeEmbedSimulator extends Component {
     return '';
   }
 
-  configureIframe(iframe, [embedUrl, thisComponent]) {
+  configureIframe(iframe, params) {
+    const embedUrl = params[0];
+    const thisComponent = params[1];
+
     thisComponent.isLoadingEmbed = true;
     thisComponent.isSimulatorLaunched = false;
     iframe.onload = () => {

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -1,70 +1,46 @@
-import Component from '@ember/component';
-import { attributeBindings, classNames } from '@ember-decorators/component';
-import { action, computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { htmlSafe } from '@ember/string';
-import classic from 'ember-classic-decorator';
 
-@classic
-@classNames('challenge-embed-simulator')
-@attributeBindings('embedDocumentHeightStyle:style')
 export default class ChallengeEmbedSimulator extends Component {
-  // Data props
-  embedDocument = null;
 
-  // CPs
-  @computed('embedDocument.height')
+  @tracked
+  isLoadingEmbed = true;
+
+  @tracked
+  isSimulatorNotYetLaunched = true;
+
   get embedDocumentHeightStyle() {
-    return htmlSafe(`height: ${this.get('embedDocument.height')}px`);
+    if (this.args.embedDocument) {
+      return htmlSafe(`height: ${this.args.embedDocument.height}px`);
+    }
+    return '';
+  }
+
+  configureIframe(iframe, [embedUrl, thisComponent]) {
+    thisComponent.isLoadingEmbed = true;
+    thisComponent.isSimulatorNotYetLaunched = true;
+    iframe.onload = () => {
+      if (embedUrl) {
+        thisComponent.isLoadingEmbed = false;
+      }
+    };
   }
 
   @action
-  launchSimulator() {
-    const iframe = this._getIframe();
+  launchSimulator(event) {
+    const iframe = this._getIframe(event);
 
     // TODO: use correct targetOrigin once the embeds are hosted behind our domain
     iframe.contentWindow.postMessage('launch', '*');
     iframe.focus();
-
-    this.toggleProperty('_isSimulatorNotYetLaunched');
-    this._unblurSimulator();
+    this.isSimulatorNotYetLaunched = false;
   }
 
   @action
-  rebootSimulator() {
-    this._rebootSimulator();
-  }
-
-  // Internals
-  _isSimulatorNotYetLaunched = true;
-
-  _hiddenSimulatorClass = null;
-
-  didUpdateAttrs() {
-    this.set('_isSimulatorNotYetLaunched', true);
-    this.set('_hiddenSimulatorClass', 'hidden-class');
-  }
-
-  didRender() {
-    super.didRender(...arguments);
-    const iframe = this._getIframe();
-    iframe.onload = () => {
-      this._removePlaceholder();
-    };
-  }
-
-  _removePlaceholder() {
-    if (this.embedDocument.url) {
-      this.set('_hiddenSimulatorClass', null);
-    }
-  }
-
-  _getIframe() {
-    return this.element.querySelector('.embed__iframe');
-  }
-
-  /* This method is not tested because it would be too difficult (add an observer on a complicated stubbed DOM API element!) */
-  _rebootSimulator() {
-    const iframe = this._getIframe();
+  rebootSimulator(event) {
+    const iframe = this._getIframe(event);
     const tmpSrc = iframe.src;
 
     // First onload: when we reset the iframe
@@ -79,8 +55,7 @@ export default class ChallengeEmbedSimulator extends Component {
     iframe.src = '';
   }
 
-  _unblurSimulator() {
-    const $simulatorPanel = this.element.getElementsByClassName('embed__simulator').item(0);
-    $simulatorPanel.classList.remove('blurred');
+  _getIframe(event) {
+    return event.currentTarget.parentElement.parentElement.querySelector('.embed__iframe');
   }
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -9,7 +9,7 @@
   position: relative;
   height: 100%;
 
-  &.hidden-class {
+  &.hidden-visibility {
     visibility: hidden;
   }
 
@@ -57,6 +57,7 @@
   text-transform: uppercase;
   height: 56px;
   padding: 0 36px;
+  cursor: pointer;
 }
 
 .embed__simulator {

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -8,7 +8,7 @@
   <div class="embed rounded-panel {{if this.isLoadingEmbed 'hidden-visibility' ''}}">
     {{#unless this.isSimulatorLaunched}}
       <div class="embed__acknowledgment-overlay">
-        <button class="embed__launch-simulator-button" {{on 'click' this.launchSimulator}}>Je lance l’application</button>
+        <button class="embed__launch-simulator-button" type="button" {{on 'click' this.launchSimulator}}>Je lance l’application</button>
       </div>
     {{/unless}}
 
@@ -23,7 +23,7 @@
   </div>
 
   <div class="embed__reboot">
-    <div class="link link--grey embed-reboot__content" {{on 'click' this.rebootSimulator}}>
+    <div class="link link--grey embed-reboot__content" role="button" {{on 'click' this.rebootSimulator}}>
       <FaIcon @icon="redo-alt"></FaIcon>
       <div class="embed-reboot-content__text"> Réinitialiser </div>
     </div>

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -6,13 +6,13 @@
   {{/if}}
 
   <div class="embed rounded-panel {{if this.isLoadingEmbed 'hidden-visibility' ''}}">
-    {{#if this.isSimulatorNotYetLaunched}}
+    {{#unless this.isSimulatorLaunched}}
       <div class="embed__acknowledgment-overlay">
         <button class="embed__launch-simulator-button" {{on 'click' this.launchSimulator}}>Je lance l’application</button>
       </div>
-    {{/if}}
+    {{/unless}}
 
-    <div class="embed__simulator {{if this.isSimulatorNotYetLaunched 'blurred'}}">
+    <div class="embed__simulator {{unless this.isSimulatorLaunched 'blurred'}}">
       <iframe class="embed__iframe"
               src="{{@embedDocument.url}}"
               title="{{@embedDocument.title}}"

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -1,27 +1,31 @@
-{{#if this._hiddenSimulatorClass}}
-  <div class="embed placeholder" aria-label="Chargement de l'application en cours">
-    <FaIcon @icon="image"></FaIcon>
-  </div>
-{{/if}}
-
-<div class="embed rounded-panel {{this._hiddenSimulatorClass}}">
-  {{#if this._isSimulatorNotYetLaunched}}
-    <div class="embed__acknowledgment-overlay">
-      <button class="embed__launch-simulator-button" {{action "launchSimulator"}}>Je lance l’application</button>
+<div class="challenge-embed-simulator" style="{{this.embedDocumentHeightStyle}}">
+  {{#if this.isLoadingEmbed}}
+    <div class="embed placeholder blurred" aria-label="Chargement de l'application en cours">
+      <FaIcon @icon="image"></FaIcon>
     </div>
   {{/if}}
 
-  <div class="embed__simulator blurred">
-    <iframe class="embed__iframe"
-            src="{{this.embedDocument.url}}"
-            title="{{this.embedDocument.title}}">
-    </iframe>
-  </div>
-</div>
+  <div class="embed rounded-panel {{if this.isLoadingEmbed 'hidden-visibility' ''}}">
+    {{#if this.isSimulatorNotYetLaunched}}
+      <div class="embed__acknowledgment-overlay">
+        <button class="embed__launch-simulator-button" {{on 'click' this.launchSimulator}}>Je lance l’application</button>
+      </div>
+    {{/if}}
 
-<div class="embed__reboot">
-  <div class="link link--grey embed-reboot__content" {{action "rebootSimulator"}}>
-    <FaIcon @icon="redo-alt"></FaIcon>
-    <div class="embed-reboot-content__text"> Réinitialiser </div>
+    <div class="embed__simulator {{if this.isSimulatorNotYetLaunched 'blurred'}}">
+      <iframe class="embed__iframe"
+              src="{{@embedDocument.url}}"
+              title="{{@embedDocument.title}}"
+        {{did-insert this.configureIframe @embedDocument.url this}}
+        {{did-update this.configureIframe @embedDocument.url this}}
+       />
+    </div>
+  </div>
+
+  <div class="embed__reboot">
+    <div class="link link--grey embed-reboot__content" {{on 'click' this.rebootSimulator}}>
+      <FaIcon @icon="redo-alt"></FaIcon>
+      <div class="embed-reboot-content__text"> Réinitialiser </div>
+    </div>
   </div>
 </div>

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
-import { describe, it, beforeEach } from 'mocha';
+import { beforeEach, describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
-import { click, find, findAll, render } from '@ember/test-helpers';
+import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Challenge Embed Simulator', function() {
@@ -13,7 +12,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should be displayed when component has just been rendered', async function() {
       // when
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
       expect(find('.embed__acknowledgment-overlay')).to.exist;
@@ -21,7 +20,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should contain a button to launch the simulator', async function() {
       // when
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
       expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button')).to.exist;
@@ -32,7 +31,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should have text "Je lance le simulateur"', async function() {
       // when
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
       expect(find('.embed__acknowledgment-overlay .embed__launch-simulator-button').textContent).to.equal('Je lance l’application');
@@ -40,7 +39,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should close the acknowledgment overlay when clicked', async function() {
       // given
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // when
       await click('.embed__launch-simulator-button');
@@ -54,23 +53,10 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should have text "Réinitialiser"', async function() {
       // when
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
       expect(find('.embed__reboot').textContent.trim()).to.equal('Réinitialiser');
-    });
-
-    it('should reload simulator when user clicked on button reload', async function() {
-      // given
-      const stubRebootSimulator = sinon.stub();
-      this.set('stubRebootSimulator', stubRebootSimulator);
-      await render(hbs`{{challenge-embed-simulator _rebootSimulator=stubRebootSimulator}}`);
-
-      // when
-      await click('.embed-reboot__content');
-
-      // then
-      sinon.assert.calledOnce(stubRebootSimulator);
     });
   });
 
@@ -78,52 +64,50 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
     it('should be active when component is first rendered', async function() {
       // when
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
-      expect(findAll('.embed__simulator')[0].classList.contains('blurred')).to.be.true;
+      expect(find('.embed__simulator').classList.contains('blurred')).to.be.true;
     });
 
     it('should be removed when simulator was launched', async function() {
       // given
-      await render(hbs`{{challenge-embed-simulator}}`);
+      await render(hbs`<ChallengeEmbedSimulator />`);
 
       // when
       await click('.embed__launch-simulator-button');
 
       // then
-      expect(findAll('.embed__simulator')[0].classList.contains('blurred')).to.be.false;
+      expect(find('.embed__simulator').classList.contains('blurred')).to.be.false;
     });
   });
 
   describe('Embed simulator', function() {
 
-    const embedDocument = {
-      url: 'http://embed-simulator.url',
-      title: 'Embed simulator',
-      height: 200
-    };
-
     beforeEach(async function() {
       // given
-      this.set('embedDocument', embedDocument);
+      this.set('embedDocument', {
+        url: 'http://embed-simulator.url',
+        title: 'Embed simulator',
+        height: 200
+      });
 
       // when
-      await render(hbs`{{challenge-embed-simulator embedDocument=embedDocument}}`);
+      await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
 
       // then
     });
 
     it('should have an height that is the one defined in the referential', function() {
-      expect(findAll('.challenge-embed-simulator')[0].style.cssText).to.equal('height: 200px;');
+      expect(find('.challenge-embed-simulator').style.cssText).to.equal('height: 200px;');
     });
 
     it('should define a title attribute on the iframe element that is the one defined in the referential for field "Embed title"', function() {
-      expect(findAll('.embed__iframe')[0].title).to.equal('Embed simulator');
+      expect(find('.embed__iframe').title).to.equal('Embed simulator');
     });
 
     it('should define a src attribute on the iframe element that is the one defined in the referential for field "Embed URL"', function() {
-      expect(findAll('.embed__iframe')[0].src).to.equal('http://embed-simulator.url/');
+      expect(find('.embed__iframe').src).to.equal('http://embed-simulator.url/');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Tout est parti d'une initiative d'ajout de la gestion des refresh_token, côté back/API. Pour ce faire, il "suffit" d'ajouter une propriété `expires_in` ou `expires_at` dans le retour de l'appel d'obtention d'un `access_token` (cf. `POST /api/token`).

Il s'avère qu'il existe [un bug](https://github.com/simplabs/ember-simple-auth/issues/2019) dans la version de l'addon Ember-Simple-Auth (ESA pour les intimes) actuellement utilisée dans mon-pix (v2.1.1). Ce bug est corrigé dans la version (mlajeure) suivante (3.0.0).

Pour rappel, avant les montées de version successives des apps Ember (pre-3.13), nous utilisions ESA v1.8.2. Lors de la montée de version de Pix App sous Ember 3.15, nous avons commencé par effectuer la montée de version des différentes dépendances. Nous avons rencontré un problème au moment de passer de ESA 1.8.2 à 3.0.0 (version courante). Des tests d'intégration relatifs au composant de gestion des _Embeds_ cassaient. Pour avancer, nous avons décidés de monter ESA dans sa version intermédiaire 2.1.1.

Moralité : pour avancer sur le sujet des `refresh_token`, nous devons corriger les problèmes de montée de version d'ESA, c'est-à-dire fixer les tests d'intégration qui cassent.

> PS : il semblerait au passage que plusieurs personnes rencontrent des soucis liés à ces mêmes tests quand elles les exécutent depuis leur navigateur.

## :robot: Solution

La solution que nous avons mise en œuvre consiste à [_glimmeriser_](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/) le composant `challenge-embed-simulator`, responsable d'afficher et gérer les _embed simulators_.

Cette PR se concentre sur la glimmerisation du composant. En soi ce changement est déjà un gain par rapport au code.

Conclusion : **l'hypothèse émise - ce composant empêche la montée de version d'ESA en 3.0.0 - était la bonne**. Suite à la glimmerisation du composant, il est possible d'effectuer l'upgrade d'ESA ! 🎉 

## ℹ️ Implémentation

**1/** Avec les composants Glimmer, on perd plus d'une trentaine de fonctionnalités riches ou pratiques proposées anciennement par Ember, notamment tous les hooks de cycle de vie d'un composant. Seules demeurent les hooks `constuctor` et `willDestroy`. 

Précedemment, on se servait du hook `didRender` pour gérer la fin du chargement du contenu de l'iframe utilisée pour afficher le simulateur. 

Pour reproduire ce mécanisme, il a fallu ajouter [l'addon ember-render-modifier](https://github.com/emberjs/ember-render-modifiers) qui propose un équivalent, tel que [recommandé par la doc d'Ember](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_lifecycle-hooks--modifiers).

Pour ce faire, il a fallu attacher à l'élement iframe les modifiers `did-insert` et `did-update` qui se déclenche lors de la création du composant (_insert_) ou lorsqu'il doit être mis à jour (_update_). Historiquement, dans Ember, la phase _render_ intervenait à la suite de chacune de ces phases.

**2/** Par ailleurs, avec Glimmer, il n'est plus possible d'accéder au DOM du composant, depuis le composant lui-même. En revanche il est possible d'accéder à l'élément du DOM qui déclenche un _event_, lors d'une `@action`. 

> En ce sens, on se rend compte qu'Ember a pris le parti de proposer moins de magie et de se rapprocher du développement d'application Web un peu plus bas niveau, plus proche de ce que propose nativement les nvavigateurs. Sûrement les core-maintainers Ember pensent-ils que le Web a suffisamment évolué et s'est suffisamment enrichi de ce point de vue là.

Quoiqu'il en soit, il est désormais plus difficile d'accéder au DOM et de le modifier. Il faut maintenant jouer sur les mécaniques de l'API DOM et en particulier démarrer de l'intelligence et des interactions depuis l'élément du DOM concerné.

C'est ce paradigme qui explique le changement d'implémentation de la méthode `_getIframe()`. C'est un peu moche dans le code, mais c'est plus proche de ce que  propose le navigateur 🤷‍♂️

**3/** On est obligé de passer `this` dans les modifiers `did-insert` et `did-update` dans le template du composant car la méthode de controller `configureIframe` ne permet pas _a priori_ de récupérer le contexte dans lequel elle est appelée, cf. [l'exemple dans la doc de l'addon](https://github.com/emberjs/ember-render-modifiers#user-content-example-ember-composability-tools-style-rendering). 

## :100: Pour tester

Passer le test de démo suivant : courses/recdOFxsOksc1FMCM.

Vérifications effectuées : 
- un placehodler apparaît lors du chargement de l'épreuve en lieu et place du simulateur
- dès que le simulateur est chargé, le placeholder laisse la place à un panneau avec le bouton "Lancer le simulateur"
- lorsque le simulateur n'est pas lancé, le _background_ de l'_iframe_ est _blurred_
- la succession de 2 embeds fonctionne correctement (cf. critères ci-dessus pour la seconde épreuve)
- en particulier le cas suivant : 
    - affichage de l'embed 1
    - lancement de l'embed 1
    - validation de l'épreuve
    - affichage de l'embed 2
    - lancement de l'embed 2

> Remarque : **des soucis ont été rencontrés lors de la gestion du "retour arrière" lorsque plusieurs onglets sont ouverts**, dont certains sur une épreuve contenant un simulateur
