### PR TITLE
[FEATURE] Pouvoir s'assigner une session à traiter dans PixAdmin (PA-137)

### DIFF
--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -7,9 +7,14 @@ export default class SessionAdapter extends ApplicationAdapter {
     if (adapterOptions && adapterOptions.flagResultsAsSentToPrescriber)  {
       delete adapterOptions.flagResultsAsSentToPrescriber;
       return url + '/results-sent-to-prescriber';
-    } else if (adapterOptions && adapterOptions.updatePublishedCertifications)  {
+    }
+    if (adapterOptions && adapterOptions.updatePublishedCertifications)  {
       delete adapterOptions.updatePublishedCertifications;
       return url + '/publication';
+    }
+    if (adapterOptions && adapterOptions.certificationOfficerAssignment)  {
+      delete adapterOptions.certificationOfficerAssignment;
+      return url + '/certification-officer-assignment';
     }
     return url;
   }
@@ -17,9 +22,13 @@ export default class SessionAdapter extends ApplicationAdapter {
   updateRecord(store, type, snapshot) {
     if (snapshot.adapterOptions.flagResultsAsSentToPrescriber) {
       return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PUT');
-    } else if (snapshot.adapterOptions.updatePublishedCertifications) {
+    }
+    if (snapshot.adapterOptions.updatePublishedCertifications) {
       const data =  { data: { attributes: { toPublish: snapshot.adapterOptions.toPublish } } };
       return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PATCH', { data });
+    }
+    if (snapshot.adapterOptions.certificationOfficerAssignment) {
+      return this.ajax(this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot), 'PATCH');
     }
 
     return super.updateRecord(...arguments);

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -4,14 +4,10 @@ import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 
 export default class IndexController extends Controller {
-  @service
-  sessionInfoService;
+  @service sessionInfoService;
+  @service notifications;
 
-  @service
-  notifications;
-
-  @alias('model')
-  session;
+  @alias('model') session;
 
   @action
   downloadSessionResultFile() {
@@ -34,5 +30,15 @@ export default class IndexController extends Controller {
   @action
   async tagSessionAsSentToPrescriber() {
     await this.session.save({ adapterOptions: { flagResultsAsSentToPrescriber: true } });
+  }
+
+  @action
+  async assignSessionToCurrentUser() {
+    try {
+      await this.session.save({ adapterOptions: { certificationOfficerAssignment: true } });
+      this.notifications.success('La session vous a correctement été assignée');
+    } catch (err) {
+      this.notifications.error('Erreur lors de l\'assignation à la session');
+    }
   }
 }

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -16,10 +16,12 @@ function _formatHumanReadableLocaleDateTime(date, options) {
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const IN_PROCESS = 'in_process';
 export const PROCESSED = 'processed';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [IN_PROCESS]: 'En cours de traitement',
   [PROCESSED]: 'Résultats transmis par Pix',
 };
 
@@ -44,7 +46,9 @@ export default class Session extends Model {
 
   @computed('status')
   get isFinalized() {
-    return this.status === FINALIZED || this.status === PROCESSED;
+    return this.status === FINALIZED
+        || this.status === IN_PROCESS
+        || this.status === PROCESSED;
   }
 
   @computed('examinerGlobalComment')

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -83,18 +83,25 @@
 
   <div class="session-info__actions">
     <div class='row row--btn'>
-      <button class="btn btn-primary" {{action "downloadBeforeJuryFile"}} type="button">
+
+      {{#if this.session.finalizedAt}}
+        <button class="btn btn-primary" {{on 'click' this.assignSessionToCurrentUser}}>
+          M'assigner la session
+        </button>
+      {{/if}}
+
+      <button class="btn btn-primary" {{on 'click' this.downloadBeforeJuryFile}}>
         Récupérer le fichier avant jury
       </button>
 
-      <button class="btn btn-primary btn--right" {{action "downloadSessionResultFile"}} type="button">
+      <button class="btn btn-primary btn--right" {{on 'click' this.downloadSessionResultFile}}>
         Exporter les résultats
       </button>
 
       {{#if this.session.areResultsToBeSentToPrescriber}}
-      <button class="btn btn-primary" {{action "tagSessionAsSentToPrescriber"}} type="button">
-        Résultats transmis au prescripteur
-      </button>
+        <button class="btn btn-primary" {{on 'click' this.tagSessionAsSentToPrescriber}}>
+          Résultats transmis au prescripteur
+        </button>
       {{/if}}
     </div>
   </div>

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -63,9 +63,9 @@ module('Acceptance | Session page', function(hooks) {
       });
         // when
       await visit(`/sessions/${session.id}`);
-      await click('.session-info__actions button:nth-child(3)');
+      await click('.session-info__actions button:nth-child(4)');
         
-      assert.dom('.session-info__actions button:nth-child(3)').doesNotExist();
+      assert.dom('.session-info__actions button:nth-child(4)').doesNotExist();
     });
 
   });

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { FINALIZED } from 'pix-admin/models/session';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -30,8 +31,8 @@ module('Acceptance | Session pages', function(hooks) {
       session = server.create('session', {
         id: 1,
         certificationCenterName: 'Centre des Staranne',
+        status: FINALIZED,
         finalizedAt: new Date('2020-01-01T03:00:00Z'),
-        resultsSentToPrescriberAt: new Date('2020-02-01T03:00:00Z'),
         examinerGlobalComment: 'Commentaire du surveillant',
       });
     });
@@ -95,8 +96,19 @@ module('Acceptance | Session pages', function(hooks) {
         test('it show session informations', function(assert) {
           // then
           assert.dom('.session-info__details .row div:last-child').hasText(session.certificationCenterName);
-          assert.dom('[data-test-id="session-info__sent-to-prescriber-at"]').hasText(session.resultsSentToPrescriberAt.toLocaleString('fr-FR'));
+          assert.dom('[data-test-id="session-info__finalized-at"]').hasText(session.finalizedAt.toLocaleString('fr-FR'));
           assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
+        });
+      });
+
+      module('Buttons section', function() {
+
+        test('it show all buttons', function(assert) {
+          // then
+          assert.dom('.session-info__actions div button:first-child').hasText('M\'assigner la session');
+          assert.dom('.session-info__actions div button:nth-child(2)').hasText('Récupérer le fichier avant jury');
+          assert.dom('.session-info__actions div button:nth-child(3)').hasText('Exporter les résultats');
+          assert.dom('.session-info__actions div button:nth-child(4)').hasText('Résultats transmis au prescripteur');
         });
       });
     });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
@@ -81,8 +81,9 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
       assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
       assert.equal(find('[data-test-id="session-info__number-of-not-checked-end-screen"]'), undefined);
+      const firstButton = this.element.querySelector('.session-info__actions .row button:nth-child(1)');
+      assert.equal(firstButton.innerHTML.trim(), 'Récupérer le fichier avant jury');
     });
-
   });
 
   module('when the session is finalized', function() {
@@ -146,7 +147,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         await visit(`/sessions/${session.id}`);
 
         // then
-        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(3)');
+        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(4)');
         assert.equal(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
       });
       
@@ -161,7 +162,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         await visit(`/sessions/${session.id}`);
 
         // then
-        assert.dom('.session-info__actions .row button:nth-child(3)').doesNotExist();
+        assert.dom('.session-info__actions .row button:nth-child(4)').doesNotExist();
       });
 
     });

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -4,14 +4,13 @@ import sinon from 'sinon';
 
 module('Unit | Adapter | session', function(hooks) {
   setupTest(hooks);
-
   let adapter;
 
   hooks.beforeEach(function() {
     adapter = this.owner.lookup('adapter:session');
   });
 
-  module('#urlForUpdateRecord', () => {
+  module('#urlForUpdateRecord', function() {
     test('should build update url from session id', function(assert) {
       // when
       const options = { adapterOptions: {} };
@@ -38,11 +37,23 @@ module('Unit | Adapter | session', function(hooks) {
       assert.ok(url.endsWith('/sessions/123/publication'));
     });
 
-    module('#updateRecord', () => {
-      
-      [true, false].forEach((isTrue) => 
+    test('should build specific url to user assignment', function(assert) {
+      // when
+      const options = { adapterOptions: { certificationOfficerAssignment: true } };
+      const url = adapter.urlForUpdateRecord(123, 'session', options);
+
+      // then
+      assert.ok(url.endsWith('/sessions/123/certification-officer-assignment'));
+    });
+  });
+
+  module('#updateRecord', function() {
+
+    module('when updatePublishedCertification adapterOption is passed', function() {
+
+      [true, false].forEach(function(isTrue) {
         test(`should send a patch request with publish to ${isTrue}`, function(assert) {
-        // when
+          // when
           const snapshot = { id: 123, adapterOptions: { updatePublishedCertifications: true, toPublish: isTrue } };
           adapter.ajax = sinon.stub();
 
@@ -51,9 +62,31 @@ module('Unit | Adapter | session', function(hooks) {
           // then
           sinon.assert.calledWithExactly(adapter.ajax, 'http://localhost:3000/api/sessions/123/publication', 'PATCH', { data: { data: { attributes: { toPublish: isTrue } } } });
           assert.ok(adapter);
-        })
-      );
+        });
+      });
     });
 
+    module('when certificationOfficerAssignment adapterOption passed', function(hooks) {
+
+      hooks.beforeEach(function() {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function() {
+        adapter.ajax.restore();
+      });
+
+      test('should send a patch request to user assignment endpoint', async function(assert) {
+        // given
+        adapter.ajax.resolves();
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'session' }, { id: 123, adapterOptions: { certificationOfficerAssignment: true } });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/sessions/123/certification-officer-assignment', 'PATCH');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -6,28 +6,32 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
   setupTest(hooks);
 
   let controller;
-  let sessionInfoServiceStub;
   let model;
-  let error;
-  let downloadSessionExportFile;
-  let downloadJuryFile;
+  let err;
 
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/sessions/session/informations');
 
     // context for sessionInfoService stub
     model = { id: Symbol('an id'), certifications: [] };
-    error = { err : 'some error' };
+    err = { error : 'some error' };
 
     // sessionInfoService stub
-    downloadSessionExportFile = sinon.stub();
+    const downloadSessionExportFile = sinon.stub();
+    const downloadJuryFile = sinon.stub();
     downloadSessionExportFile.withArgs(model).returns();
-    downloadSessionExportFile.withArgs().throws(error);
-    downloadJuryFile = sinon.stub();
+    downloadSessionExportFile.withArgs().throws(err);
     downloadJuryFile.withArgs(model.id, model.certifications).returns();
-    downloadJuryFile.throws(error);
-    sessionInfoServiceStub = { downloadSessionExportFile, downloadJuryFile };
+    downloadJuryFile.throws(err);
+    const sessionInfoServiceStub = { downloadSessionExportFile, downloadJuryFile };
 
+    // notifications stub
+    const success = sinon.stub();
+    const error = sinon.stub();
+    success.returns();
+    error.returns();
+
+    controller.notifications = { success, error };
     controller.sessionInfoService = sessionInfoServiceStub;
   });
 
@@ -45,16 +49,12 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
 
     test('should throw an error', function(assert) {
-      // given
-      const notificationsStub = { error: sinon.stub() };
-      controller.notifications = notificationsStub;
-
       // when
       controller.actions.downloadSessionResultFile.call(controller);
 
       // then
       assert.ok(controller.sessionInfoService.downloadSessionExportFile.calledOnce);
-      assert.ok(controller.notifications.error.calledWithExactly(error));
+      assert.ok(controller.notifications.error.calledWithExactly(err));
     });
   });
 
@@ -75,8 +75,6 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
 
     test('should throw an error if service is called with wrongs parameters', function(assert) {
       // given
-      const notificationsStub = { error: sinon.stub() };
-      controller.notifications = notificationsStub;
       controller.model = 'wrong model';
 
       // when
@@ -84,7 +82,38 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
 
       // then
       assert.ok(controller.sessionInfoService.downloadJuryFile.calledOnce);
-      assert.ok(controller.notifications.error.calledWithExactly(error));
+      assert.ok(controller.notifications.error.calledWithExactly(err));
+    });
+  });
+
+  module('#assignSessionToCurrentUser', function() {
+
+    test('should assign the current session to user', async function(assert) {
+      // given
+      const save = sinon.stub();
+      save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
+      controller.session = { save };
+
+      // when
+      await controller.actions.assignSessionToCurrentUser.call(controller);
+
+      // then
+      assert.ok(controller.session.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
+      assert.ok(controller.notifications.success.calledWithExactly('La session vous a correctement été assignée'));
+    });
+
+    test('should throw an error if save is called with wrongs parameters', async function(assert) {
+      // given
+      const save = sinon.stub();
+      save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).rejects();
+      controller.session = { save };
+
+      // when
+      await controller.actions.assignSessionToCurrentUser.call(controller);
+
+      // then
+      assert.ok(controller.session.save.calledOnce);
+      assert.ok(controller.notifications.error.calledWithExactly('Erreur lors de l\'assignation à la session'));
     });
   });
 });

--- a/api/db/migrations/20200327225551_add-column-assignedCertificationOfficerId-column-table-sessions.js
+++ b/api/db/migrations/20200327225551_add-column-assignedCertificationOfficerId-column-table-sessions.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'sessions';
+const COLUMN_NAME = 'assignedCertificationOfficerId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.integer(COLUMN_NAME).references('users.id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -304,6 +304,22 @@ exports.register = async (server) => {
         ]
       }
     },
+    {
+      method: 'PATCH',
+      path: '/api/sessions/{id}/certification-officer-assignment',
+      config: {
+        pre: [{
+          method: securityController.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.assignCertificationOfficer,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle PixMaster**\n' +
+          '- Assigne la session à un membre du pôle certifification (certification-officer)'
+        ],
+        tags: ['api', 'session', 'assignment']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -158,4 +158,11 @@ module.exports = {
     return resultsFlaggedAsSent ? h.response(serializedSession).created() : serializedSession;
   },
 
+  async assignCertificationOfficer(request) {
+    const sessionId = request.params.id;
+    const certificationOfficerId = request.auth.credentials.userId;
+    const session = await usecases.assignCertificationOfficerToSession({ sessionId, certificationOfficerId });
+    return sessionSerializer.serialize(session);
+  },
+
 };

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -2,11 +2,13 @@ const _ = require('lodash');
 
 const CREATED = 'created';
 const FINALIZED = 'finalized';
+const IN_PROCESS = 'in_process';
 const PROCESSED = 'processed';
 
 const statuses = {
   CREATED,
   FINALIZED,
+  IN_PROCESS,
   PROCESSED,
 };
 
@@ -32,6 +34,7 @@ class Session {
     certificationCandidates,
     // references
     certificationCenterId,
+    assignedCertificationOfficerId,
   } = {}) {
     this.id = id;
     // attributes
@@ -51,6 +54,7 @@ class Session {
     this.certificationCandidates = certificationCandidates;
     // references
     this.certificationCenterId = certificationCenterId;
+    this.assignedCertificationOfficerId = assignedCertificationOfficerId;
   }
 
   areResultsFlaggedAsSent() {
@@ -60,6 +64,9 @@ class Session {
   get status() {
     if (this.publishedAt) {
       return statuses.PROCESSED;
+    }
+    if (this.assignedCertificationOfficerId) {
+      return statuses.IN_PROCESS;
     }
     if (this.finalizedAt) {
       return statuses.FINALIZED;

--- a/api/lib/domain/usecases/assign-certification-officer-to-session.js
+++ b/api/lib/domain/usecases/assign-certification-officer-to-session.js
@@ -1,0 +1,18 @@
+const { ObjectValidationError } = require('../errors');
+
+module.exports = async function assignCertificationOfficerToSession({
+  sessionId,
+  certificationOfficerId,
+  sessionRepository,
+} = {}) {
+  const integerSessionId = parseInt(sessionId);
+  if (!Number.isFinite(integerSessionId)) {
+    throw new ObjectValidationError(`L'id ${sessionId} n'est pas un id de session valide.`);
+  }
+  const integerCertificationOfficerId = parseInt(certificationOfficerId);
+  if (!Number.isFinite(integerCertificationOfficerId)) {
+    throw new ObjectValidationError(`L'id ${certificationOfficerId} n'est pas un id de chargé de certification valide.`);
+  }
+
+  return sessionRepository.assignCertificationOfficer({ id: integerSessionId, assignedCertificationOfficerId: integerCertificationOfficerId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -70,6 +70,7 @@ module.exports = injectDependencies({
   answerToOrganizationInvitation: require('./answer-to-organization-invitation'),
   attachTargetProfilesToOrganization: require('./attach-target-profiles-to-organization'),
   archiveCampaign: require('./archive-campaign'),
+  assignCertificationOfficerToSession: require('./assign-certification-officer-to-session'),
   authenticateUser: require('./authenticate-user'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
   completeAssessment: require('./complete-assessment'),

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -7,14 +7,14 @@ const { NotFoundError } = require('../../domain/errors');
 
 module.exports = {
 
-  save: async (sessionData) => {
+  async save(sessionData) {
     sessionData = _.omit(sessionData, ['certificationCandidates']);
 
     const newSession = await new BookshelfSession(sessionData).save();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, newSession);
   },
 
-  isSessionCodeAvailable: async (accessCode) => {
+  async isSessionCodeAvailable(accessCode) {
     const sessionWithAccessCode = await BookshelfSession
       .where({ accessCode })
       .fetch({});
@@ -22,7 +22,7 @@ module.exports = {
     return !sessionWithAccessCode;
   },
 
-  isFinalized: async (id) => {
+  async isFinalized(id) {
     const session = await BookshelfSession
       .query((qb) => {
         qb.where({ id });

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -4,6 +4,7 @@ const BookshelfSession = require('../data/session');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const Bookshelf = require('../bookshelf');
 const { NotFoundError } = require('../../domain/errors');
+const { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } = require('../../../db/pgsql-errors');
 
 module.exports = {
 
@@ -147,5 +148,19 @@ module.exports = {
       pagination,
     };
   },
+
+  async assignCertificationOfficer({ id, assignedCertificationOfficerId }) {
+    try {
+      let updatedSession = await new BookshelfSession({ id })
+        .save({ assignedCertificationOfficerId }, { method: 'update' });
+      updatedSession = await updatedSession.refresh();
+      return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, updatedSession);
+    } catch (bookshelfError) {
+      if (bookshelfError.code === PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR) {
+        throw new NotFoundError(`L'utilisateur d'id ${assignedCertificationOfficerId} n'existe pas`);
+      }
+      throw new NotFoundError(`La session d'id ${id} n'existe pas.`);
+    }
+  }
 
 };

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -28,6 +28,7 @@ module.exports = {
         'certificationCandidates',
         'certificationReports',
         'certificationCenter',
+        'assignedCertificationOfficer',
       ],
       certifications : {
         ref: 'id',
@@ -65,6 +66,15 @@ module.exports = {
           }
         }
       },
+      assignedCertificationOfficer: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current) {
+            return `/api/users/${current.id}`;
+          }
+        }
+      },
       transform(session) {
         const transformedSession = Object.assign({}, session);
         transformedSession.status = session.status;
@@ -75,9 +85,13 @@ module.exports = {
         if (session.certificationCenterId) {
           transformedSession.certificationCenter = { id: session.certificationCenterId };
         }
+        if (session.assignedCertificationOfficerId) {
+          transformedSession.assignedCertificationOfficer = { id: session.assignedCertificationOfficerId };
+        }
         return transformedSession;
       },
     }).serialize(sessions);
+
   },
 
   serializeForFinalization(sessions) {
@@ -104,6 +118,7 @@ module.exports = {
         'publishedAt',
         'certifications',
         'certificationCenter',
+        'assignedCertificationOfficer',
       ],
       certifications : {
         ref: 'id',
@@ -123,6 +138,15 @@ module.exports = {
           }
         }
       },
+      assignedCertificationOfficer: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        relationshipLinks: {
+          related(record, current) {
+            return `/api/users/${current.id}`;
+          }
+        }
+      },
       transform(session) {
         const transformedSession = Object.assign({}, session);
         transformedSession.status = session.status;
@@ -131,6 +155,9 @@ module.exports = {
         delete transformedSession.certificationCenter;
         if (session.certificationCenterId) {
           transformedSession.certificationCenter = { id: session.certificationCenterId };
+        }
+        if (session.assignedCertificationOfficerId) {
+          transformedSession.assignedCertificationOfficer = { id: session.assignedCertificationOfficerId };
         }
         return transformedSession;
       },

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -1,0 +1,109 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('PATCH /api/sessions/:id/certification-officer-assignment', () => {
+  let server;
+  const options = { method: 'PATCH' };
+  let certificationOfficerId;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  context('when user does not have the role PIX MASTER', () => {
+
+    beforeEach(() => {
+      certificationOfficerId = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return a 403 error code', async () => {
+      // given
+      options.url = '/api/sessions/any/certification-officer-assignment';
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+  });
+
+  context('when user has role PixMaster', () => {
+
+    beforeEach(() => {
+      // given
+      certificationOfficerId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
+      return databaseBuilder.commit();
+    });
+
+    context('when the session id has an invalid format', () => {
+
+      it('should return a 422 error code', async () => {
+        // given
+        options.url = '/api/sessions/any/certification-officer-assignment';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+    });
+
+    context('when the session id is a number', () => {
+
+      context('when the session does not exist', () => {
+
+        it('should return a 404 error code', async () => {
+          // given
+          options.url = '/api/sessions/1/certification-officer-assignment';
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+        });
+      });
+
+      context('when the session exists', () => {
+        let sessionId;
+
+        beforeEach(() => {
+          // given
+          sessionId = databaseBuilder.factory.buildSession().id;
+          return databaseBuilder.commit();
+        });
+
+        it('should return a 200 status code', async () => {
+          // given
+          options.url = `/api/sessions/${sessionId}/certification-officer-assignment`;
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
+
+        it('should return the serialized session with a link to the assigned user', async () => {
+          // given
+          options.url = `/api/sessions/${sessionId}/certification-officer-assignment`;
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          const linkToAssignedUser = response.result.data.relationships['assigned-certification-officer'].links.related;
+          expect(linkToAssignedUser).to.equal(`/api/users/${certificationOfficerId}`);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -585,4 +585,55 @@ describe('Integration | Repository | Session', function() {
       });
     });
   });
+
+  describe('#assignCertificationOfficer', () => {
+    let sessionId;
+    let assignedCertificationOfficerId;
+
+    beforeEach(() => {
+      sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: null }).id;
+      assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return an updated Session domain object', async () => {
+      // when
+      const updatedSession = await sessionRepository.assignCertificationOfficer({ id: sessionId, assignedCertificationOfficerId });
+
+      // then
+      expect(updatedSession).to.be.an.instanceof(Session);
+      expect(updatedSession.id).to.deep.equal(sessionId);
+      expect(updatedSession.assignedCertificationOfficerId).to.deep.equal(assignedCertificationOfficerId);
+      expect(updatedSession.status).to.deep.equal(statuses.IN_PROCESS);
+    });
+
+    context('when assignedCertificationOfficerId provided does not exist', () => {
+
+      it('should return a Not found error', async () => {
+        // given
+        const unknownUserId = assignedCertificationOfficerId + 1;
+
+        // when
+        const error = await catchErr(sessionRepository.assignCertificationOfficer)({ id: sessionId, assignedCertificationOfficerId: unknownUserId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+
+    context('when sessionId does not exist', () => {
+
+      it('should return a Not found error', async () => {
+        // given
+        const unknownSessionId = sessionId + 1;
+
+        // when
+        const error = await catchErr(sessionRepository.assignCertificationOfficer)({ id: unknownSessionId, assignedCertificationOfficerId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
 });

--- a/api/tests/tooling/database-builder/factory/build-session.js
+++ b/api/tests/tooling/database-builder/factory/build-session.js
@@ -20,6 +20,7 @@ module.exports = function buildSession({
   finalizedAt = null,
   resultsSentToPrescriberAt = null,
   publishedAt = null,
+  assignedCertificationOfficerId,
 } = {}) {
 
   if (_.isUndefined(certificationCenterId)) {
@@ -43,6 +44,7 @@ module.exports = function buildSession({
     finalizedAt,
     resultsSentToPrescriberAt,
     publishedAt,
+    assignedCertificationOfficerId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'sessions',

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -17,6 +17,7 @@ module.exports = function buildSession({
   finalizedAt = null,
   resultsSentToPrescriberAt = null,
   publishedAt = null,
+  assignedCertificationOfficerId,
 } = {}) {
   return new Session({
     id,
@@ -33,5 +34,6 @@ module.exports = function buildSession({
     finalizedAt,
     resultsSentToPrescriberAt,
     publishedAt,
+    assignedCertificationOfficerId,
   });
 };

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -367,6 +367,7 @@ describe('Unit | Application | Sessions | Routes', () => {
       expect(res.statusCode).to.equal(200);
     });
   });
+
   describe('PUT /api/sessions/{id}/results-sent-to-prescriber', () => {
     let sessionId;
 
@@ -381,6 +382,26 @@ describe('Unit | Application | Sessions | Routes', () => {
       sessionId = 3;
 
       const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/results-sent-to-prescriber` });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
+
+  describe('PATCH /api/sessions/{id}/certification-officer-assignment', () => {
+    let options;
+
+    beforeEach(() => {
+      sinon.stub(securityController, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
+      const sessionId = 1;
+      options = {
+        method: 'PATCH',
+        url: `/api/sessions/${sessionId}/certification-officer-assignment`,
+      };
+      return server.register(route);
+    });
+
+    it('should exist', async () => {
+      const res = await server.inject(options);
       expect(res.statusCode).to.equal(200);
     });
   });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -655,4 +655,35 @@ describe('Unit | Controller | sessionController', () => {
       expect(sessionSerializer.serializeForPaginatedFilteredResults).to.have.been.calledWithExactly(expectedResults, expectedPagination);
     });
   });
+
+  describe('#assignCertificationOfficer', () => {
+    let request;
+    const sessionId = 1;
+    const session = Symbol('session');
+    const sessionJsonApi = Symbol('someSessionSerialized');
+
+    beforeEach(() => {
+      // given
+      request = {
+        params: { id : sessionId },
+        auth: {
+          credentials : {
+            userId,
+          }
+        },
+      };
+      sinon.stub(usecases, 'assignCertificationOfficerToSession').withArgs({ sessionId, certificationOfficerId: userId }).resolves(session);
+      sinon.stub(sessionSerializer, 'serialize').withArgs(session).returns(sessionJsonApi);
+    });
+
+    it('should return updated session', async () => {
+      // when
+      const response = await sessionController.assignCertificationOfficer(request, hFake);
+
+      // then
+      expect(usecases.assignCertificationOfficerToSession).to.have.been.calledWithExactly({ sessionId, certificationOfficerId: userId });
+      expect(response).to.deep.equal(sessionJsonApi);
+    });
+
+  });
 });

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -18,6 +18,7 @@ const SESSION_PROPS = [
   'publishedAt',
   'certificationCandidates',
   'certificationCenterId',
+  'assignedCertificationOfficerId',
 ];
 
 describe('Unit | Domain | Models | Session', () => {
@@ -42,6 +43,7 @@ describe('Unit | Domain | Models | Session', () => {
       certificationCandidates: [],
       // references
       certificationCenterId: '',
+      assignedCertificationOfficerId: '',
     });
   });
 
@@ -100,28 +102,45 @@ describe('Unit | Domain | Models | Session', () => {
 
     context('when session publishedAt timestamp is not defined', () => {
 
-      context('when session finalizedAt timestamp is defined', () => {
+      context('when session assignedCertificationOfficerId is defined', () => {
 
-        it('should return FINALIZED', () => {
+        it('should return IN_PROCESS', () => {
           // given
-          session.finalizedAt = new Date();
+          session.assignedCertificationOfficerId = 123;
 
           // when
           const status = session.status;
 
           // then
-          expect(status).to.equal(Session.statuses.FINALIZED);
+          expect(status).to.equal(Session.statuses.IN_PROCESS);
         });
       });
 
-      context('when session finalizedAt timestamp is not defined', () => {
+      context('when session assignedCertificationOfficerId is not defined', () => {
+      
+        context('when session finalizedAt timestamp is defined', () => {
 
-        it('should return CREATED', () => {
-          // when
-          const status = session.status;
+          it('should return FINALIZED', () => {
+            // given
+            session.finalizedAt = new Date();
 
-          // then
-          expect(status).to.equal(Session.statuses.CREATED);
+            // when
+            const status = session.status;
+
+            // then
+            expect(status).to.equal(Session.statuses.FINALIZED);
+          });
+        });
+
+        context('when session finalizedAt timestamp is not defined', () => {
+
+          it('should return CREATED', () => {
+            // when
+            const status = session.status;
+
+            // then
+            expect(status).to.equal(Session.statuses.CREATED);
+          });
         });
       });
     });

--- a/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
+++ b/api/tests/unit/domain/usecases/assign-certification-officer-to-session_test.js
@@ -1,0 +1,66 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const assignCertificationOfficerToSession = require('../../../../lib/domain/usecases/assign-certification-officer-to-session');
+const { ObjectValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | assign-certification-officer-to-session', () => {
+  let sessionId;
+  let certificationOfficerId;
+  let sessionRepository;
+
+  beforeEach(() => {
+    sessionRepository = { assignCertificationOfficer: sinon.stub() };
+  });
+
+  context('when session id is not a number', () => {
+
+    it('should throw a NotFound error', async () => {
+      // given
+      sessionId = 'notANumber';
+
+      // when
+      const error = await catchErr(assignCertificationOfficerToSession)({ sessionId, certificationOfficerId, sessionRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(ObjectValidationError);
+    });
+  });
+
+  context('when session id is a number', () => {
+
+    beforeEach(() => {
+      sessionId = 1;
+    });
+
+    context('when certificationOfficerId is not a number', () => {
+
+      it('should throw a NotFound error', async () => {
+        // given
+        certificationOfficerId = 'notANumber';
+
+        // when
+        const error = await catchErr(assignCertificationOfficerToSession)({ sessionId, certificationOfficerId, sessionRepository });
+
+        // then
+        expect(error).to.be.an.instanceOf(ObjectValidationError);
+      });
+    });
+
+    context('when certificationOfficerId is a number', () => {
+      const returnedSession = Symbol('returnedSession');
+
+      beforeEach(() => {
+        certificationOfficerId = 2;
+        sessionRepository.assignCertificationOfficer.withArgs({ id: sessionId, assignedCertificationOfficerId: certificationOfficerId }).resolves(returnedSession);
+      });
+
+      it('should return the session after assigningUser to it', async () => {
+        // when
+        const actualSession = await assignCertificationOfficerToSession({ sessionId, certificationOfficerId, sessionRepository });
+
+        // then
+        expect(sessionRepository.assignCertificationOfficer).to.have.been.calledWith({ id: sessionId, assignedCertificationOfficerId: certificationOfficerId });
+        expect(actualSession).to.equal(returnedSession);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/flag-session-results-as-sent-to-prescriber_test.js
@@ -3,7 +3,7 @@ const flagSessionResultsAsSentToPrescriber = require('../../../../lib/domain/use
 const Session = require('../../../../lib/domain/models/Session');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
-describe('Unit | UseCase | set-date-of-sending-results-to-prescriber', () => {
+describe('Unit | UseCase | flag-session-results-as-sent-to-prescriber', () => {
   let sessionId;
   let sessionRepository;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -76,6 +76,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expect(json).to.deep.equal(expectedJsonApi);
       });
     });
+
     context('when session has a link to an existing certification center', () => {
 
       it('should convert a Session model object into JSON API data with a link to the certification center', function() {
@@ -89,6 +90,25 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expectedJsonApi.data.relationships['certification-center'] = {
           'links': {
             'related': '/api/certification-centers/13',
+          }
+        };
+        expect(json).to.deep.equal(expectedJsonApi);
+      });
+    });
+
+    context('when session has an assigned certification officer', () => {
+
+      it('should convert a Session model object into JSON API data with a link to the assigned certification officer', function() {
+        // given
+        modelSession.assignedCertificationOfficerId = 13;
+
+        // when
+        const json = serializer.serialize(modelSession);
+
+        // then
+        expectedJsonApi.data.relationships['assigned-certification-officer'] = {
+          'links': {
+            'related': '/api/users/13',
           }
         };
         expect(json).to.deep.equal(expectedJsonApi);
@@ -275,6 +295,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expect(json).to.deep.equal(expectedResult);
       });
     });
+
     context('when session has a link to an existing certification center', () => {
 
       it('should convert a Session model object into JSON API data with a link to the certification center', function() {
@@ -290,6 +311,27 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
         expectedResult.data.relationships['certification-center'] = {
           'links': {
             'related': '/api/certification-centers/13',
+          }
+        };
+        expect(json).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('when session has an assigned certification officer', () => {
+
+      it('should convert a Session model object into JSON API data with a link to the assigned certification officer', function() {
+        // given
+        modelSession.assignedCertificationOfficerId = 13;
+        const meta = { page: 1, pageSize: 10, rowCount: 6, pageCount: 1 };
+        const expectedResult = Object.assign(expectedJsonApi, { meta });
+
+        // when
+        const json = serializer.serializeForPaginatedFilteredResults(modelSession, meta);
+
+        // then
+        expectedResult.data.relationships['assigned-certification-officer'] = {
+          'links': {
+            'related': '/api/users/13',
           }
         };
         expect(json).to.deep.equal(expectedResult);

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -7,10 +7,12 @@ const { Model, attr, belongsTo, hasMany } = DS;
 
 export const CREATED = 'created';
 export const FINALIZED = 'finalized';
+export const IN_PROCESS = 'in_process';
 export const PROCESSED = 'processed';
 export const statusToDisplayName = {
   [CREATED]: 'Créée',
   [FINALIZED]: 'Finalisée',
+  [IN_PROCESS]: 'Finalisée', // we don't want to show "En cours de traitement" status in Pix Certif
   [PROCESSED]: 'Résultats transmis par Pix',
 };
 
@@ -31,7 +33,9 @@ export default class Session extends Model {
 
   @computed('status')
   get isFinalized() {
-    return this.status === FINALIZED || this.status === PROCESSED;
+    return this.status === FINALIZED
+        || this.status === IN_PROCESS
+        || this.status === PROCESSED;
   }
 
   @computed('certificationCandidates.@each.isLinked')


### PR DESCRIPTION
## ☕ Contexte
Un statut “Finalisée” a été implémenté pour permettre au pôle certif de savoir quelles sessions doivent être traitées et dans quel ordre (selon la date de finalisation de session).

## :unicorn: Problème
Le pôle certif est composé de plusieurs membres, il faut donc qu’un membre du pôle puisse savoir lorsqu’une session est en cours de traitement chez un autre membre afin d'éviter que plusieurs personnes traitent la même session au même moment.

## :robot: Solution
La solution se fait en 2 parties. Cette PR est la première partie :
Un bouton a été rajouté sur PixAdmin dans les informations d'une session afin de pouvoir s'assigner la session. 
Cette dernière passe donc au status "En cours de traitement" (uniquement sur Pix Admin, elle reste "finalisée" sur Pix Certif).

## :rainbow: Remarques
La partie 2 implémentera la possibilité de voir qui est assigné à quelle session. 

## :100: Pour tester
- Aller sur PixAdmin > Choisir une session > Constater le nouveau boutton "M'assigner la session" si la session est finalisée > Pouvoir cliquer dessus, une notification verte apparaît > On observe que la ligne "Status" a changé pour "En cours de traitement" (sauf pour les session déjà publiées). 
- Sur PixCertif > Observer dans la liste des sessions qu'aucune n'est au status "En cours de traitement"