### PR TITLE
[FEATURE] Ajout d'un commentaire en dessous des profils cibles lors de la création d'une campagne (PO-415).

### DIFF
--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { first } = require ('lodash');
 const { EntityValidationError } = require('../errors');
 const Campaign = require('../models/Campaign');
 
@@ -9,13 +10,17 @@ const campaignValidationJoiSchema = Joi.object({
   name: Joi.string()
     .required()
     .messages({
+      'string.base': 'Veuillez donner un nom à votre campagne.',
       'string.empty': 'Veuillez donner un nom à votre campagne.',
     }),
 
   type: Joi.string()
     .valid(Campaign.types.ASSESSMENT, Campaign.types.PROFILES_COLLECTION)
     .required()
+    .error((errors) => first(errors))
     .messages({
+      'any.required': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
+      'string.base': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
       'any.only': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
     }),
 
@@ -23,6 +28,7 @@ const campaignValidationJoiSchema = Joi.object({
     .integer()
     .required()
     .messages({
+      'any.required': 'Le créateur n’est pas renseigné.',
       'number.base': 'Le créateur n’est pas renseigné.',
     }),
 
@@ -30,6 +36,7 @@ const campaignValidationJoiSchema = Joi.object({
     .integer()
     .required()
     .messages({
+      'any.required': 'L‘organisation n’est pas renseignée.',
       'number.base': 'L‘organisation n’est pas renseignée.',
     }),
 
@@ -45,6 +52,7 @@ const campaignValidationJoiSchema = Joi.object({
     })
     .integer()
     .messages({
+      'any.required': 'Veuillez sélectionner un profil cible pour votre campagne.',
       'number.base': 'Veuillez sélectionner un profil cible pour votre campagne.',
       'any.unknown': 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
     }),
@@ -73,7 +81,10 @@ const campaignValidationJoiSchema = Joi.object({
 module.exports = {
 
   validate(campaign) {
-    const { error } = campaignValidationJoiSchema.validate(campaign, { ...validationConfiguration, context: { type: campaign.type } });
+    const { error } = campaignValidationJoiSchema.validate(campaign, {
+      ...validationConfiguration,
+      context: { type: campaign.type }
+    });
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }

--- a/api/tests/unit/domain/validations/campaign-validator_test.js
+++ b/api/tests/unit/domain/validations/campaign-validator_test.js
@@ -3,6 +3,7 @@ const campaignValidator = require('../../../../lib/domain/validators/campaign-va
 
 const MISSING_VALUE = null;
 const EMPTY_VALUE = '';
+const UNDEFINED_VALUE = undefined;
 
 function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
   expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
@@ -42,7 +43,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // when/then
             expect(campaignValidator.validate({
               ...campaign,
-              idPixLabel: null,
+              idPixLabel: MISSING_VALUE,
             })).to.not.throw;
           });
 
@@ -50,7 +51,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // when/then
             expect(campaignValidator.validate({
               ...campaign,
-              title: null,
+              title: MISSING_VALUE,
             })).to.not.throw;
           });
 
@@ -58,7 +59,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // when/then
             expect(campaignValidator.validate({
               ...campaign,
-              title: undefined,
+              title: UNDEFINED_VALUE,
             })).to.not.throw;
           });
 
@@ -78,7 +79,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  name: null,
+                  name: MISSING_VALUE,
                 });
                 expect.fail('should have thrown an error');
               } catch (entityValidationErrors) {
@@ -130,7 +131,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  creatorId: undefined,
+                  creatorId: UNDEFINED_VALUE,
                 });
                 expect.fail('should have thrown an error');
 
@@ -169,7 +170,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  organizationId: undefined,
+                  organizationId: UNDEFINED_VALUE,
                 });
                 expect.fail('should have thrown an error');
 
@@ -252,7 +253,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  type: undefined,
+                  type: UNDEFINED_VALUE,
                 });
                 expect.fail('should have thrown an error');
               } catch (entityValidationErrors) {
@@ -279,16 +280,15 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             }
           });
 
-          // {"name":null,"code":null,"type":null,"title":null,"created-at":null,"archived-at":null,"id-pix-label":null,"custom-landing-page-text":null,"organization-id":1,"token-for-campaign-results":null}
           context('more complex case', () => {
             it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
               // given
               const campaign = {
-                name: null,
-                code: null,
-                type: null,
-                title: null,
-                idPixLabel: null,
+                name: MISSING_VALUE,
+                code: MISSING_VALUE,
+                type: MISSING_VALUE,
+                title: MISSING_VALUE,
+                idPixLabel: MISSING_VALUE,
                 organizationId: 1,
               };
 
@@ -362,7 +362,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
           // when
           campaignValidator.validate({
             ...campaignOfTypeAssessment,
-            targetProfileId: undefined,
+            targetProfileId: UNDEFINED_VALUE,
           });
           expect.fail('should have thrown an error');
 

--- a/api/tests/unit/domain/validations/campaign-validator_test.js
+++ b/api/tests/unit/domain/validations/campaign-validator_test.js
@@ -1,7 +1,8 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const campaignValidator = require('../../../../lib/domain/validators/campaign-validator');
 
-const MISSING_VALUE = '';
+const MISSING_VALUE = null;
+const EMPTY_VALUE = '';
 
 function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
   expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
@@ -66,19 +67,32 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         context('when campaign data validation fails', () => {
 
           context('on name attribute', () => {
+            // given
+            const expectedError = {
+              attribute: 'name',
+              message: 'Veuillez donner un nom à votre campagne.'
+            };
 
             it('should reject with error when name is missing', () => {
-              // given
-              const expectedError = {
-                attribute: 'name',
-                message: 'Veuillez donner un nom à votre campagne.'
-              };
-
               try {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  name: MISSING_VALUE,
+                  name: null,
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+            it('should reject with error when name is empty', () => {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  name: EMPTY_VALUE,
                 });
                 expect.fail('should have thrown an error');
               } catch (entityValidationErrors) {
@@ -90,14 +104,13 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
           });
 
           context('on creatorId attribute', () => {
+            // given
+            const expectedError = {
+              attribute: 'creatorId',
+              message: 'Le créateur n’est pas renseigné.'
+            };
 
             it('should reject with error when creatorId is missing', () => {
-              // given
-              const expectedError = {
-                attribute: 'creatorId',
-                message: 'Le créateur n’est pas renseigné.'
-              };
-
               try {
                 // when
                 campaignValidator.validate({
@@ -112,17 +125,31 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
               }
             });
 
+            it('should reject with error when creatorId is undefined', () => {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  creatorId: undefined,
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
           });
 
           context('on organizationId attribute', () => {
+            // given
+            const expectedError = {
+              attribute: 'organizationId',
+              message: 'L‘organisation n’est pas renseignée.'
+            };
 
             it('should reject with error when organizationId is missing', () => {
-              // given
-              const expectedError = {
-                attribute: 'organizationId',
-                message: 'L‘organisation n’est pas renseignée.'
-              };
-
               try {
                 // when
                 campaignValidator.validate({
@@ -137,10 +164,25 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
               }
             });
 
+            it('should reject with error when organizationId is undefined', () => {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  organizationId: undefined,
+                });
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
           });
 
           context('on idPixLabel attribute', () => {
-            it('should reject with error when idPixLabel is an empty string', () => {
+            it('should reject with error when idPixLabel is empty', () => {
               // given
               const expectedError = {
                 attribute: 'idPixLabel',
@@ -151,7 +193,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
                 // when
                 campaignValidator.validate({
                   ...campaign,
-                  idPixLabel: MISSING_VALUE,
+                  idPixLabel: EMPTY_VALUE,
                 });
                 expect.fail('should have thrown an error');
 
@@ -185,19 +227,32 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
           });
 
           context('on type attribute', () => {
+            // given
+            const expectedError = {
+              attribute: 'type',
+              message: 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.'
+            };
 
             it('should reject with error when type is a wrong type', () => {
-              // given
-              const expectedError = {
-                attribute: 'type',
-                message: 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.'
-              };
-
               try {
                 // when
                 campaignValidator.validate({
                   ...campaign,
                   type: 'WRONG_TYPE',
+                });
+                expect.fail('should have thrown an error');
+              } catch (entityValidationErrors) {
+                // then
+                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+              }
+            });
+
+            it('should reject with error when type is undefined', () => {
+              try {
+                // when
+                campaignValidator.validate({
+                  ...campaign,
+                  type: undefined,
                 });
                 expect.fail('should have thrown an error');
               } catch (entityValidationErrors) {
@@ -222,6 +277,31 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
               // then
               expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(3);
             }
+          });
+
+          // {"name":null,"code":null,"type":null,"title":null,"created-at":null,"archived-at":null,"id-pix-label":null,"custom-landing-page-text":null,"organization-id":1,"token-for-campaign-results":null}
+          context('more complex case', () => {
+            it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
+              // given
+              const campaign = {
+                name: null,
+                code: null,
+                type: null,
+                title: null,
+                idPixLabel: null,
+                organizationId: 1,
+              };
+
+              try {
+                // when
+                campaignValidator.validate(campaign);
+                expect.fail('should have thrown an error');
+
+              } catch (entityValidationErrors) {
+                // then
+                expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(3);
+              }
+            });
           });
 
         });
@@ -271,6 +351,27 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         }
       });
 
+      it('should reject with error when targetProfileId is undefined and campaign type is ASSESSMENT', () => {
+        // given
+        const expectedError = {
+          attribute: 'targetProfileId',
+          message: 'Veuillez sélectionner un profil cible pour votre campagne.'
+        };
+
+        try {
+          // when
+          campaignValidator.validate({
+            ...campaignOfTypeAssessment,
+            targetProfileId: undefined,
+          });
+          expect.fail('should have thrown an error');
+
+        } catch (entityValidationErrors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+        }
+      });
+
     });
 
     context('when a title is provided', () => {
@@ -306,5 +407,6 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         expect(campaignValidator.validate(campaign)).to.not.throw;
       });
     });
+
   });
 });

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -23,10 +23,6 @@ export default class NewItem extends Component {
     return !this.wantIdPix;
   }
 
-  get shallDisplayComment() {
-    return this.currentUser.organization.isSCO && this.currentUser.organization.isManagingStudents;
-  }
-
   @action
   askLabelIdPix() {
     this.set('wantIdPix', true);

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import Component from '@ember/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -8,7 +8,7 @@ export default class NewItem extends Component {
 
   campaign = {};
   targetProfiles = null;
-  wantIdPix = false;
+  @tracked wantIdPix = false;
   @tracked isCampaignGoalAssessment = null;
 
   init() {
@@ -19,9 +19,12 @@ export default class NewItem extends Component {
     }
   }
 
-  @computed('wantIdPix')
   get notWantIdPix() {
     return !this.wantIdPix;
+  }
+
+  get shallDisplayComment() {
+    return this.currentUser.organization.isSCO && this.currentUser.organization.isManagingStudents;
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaigns/new-item.js
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.js
@@ -37,9 +37,9 @@ export default class NewItem extends Component {
 
   @action
   setSelectedTargetProfile(event) {
-    const selectedTargetProfile = this.targetProfiles
+    this.campaign.targetProfile = this.targetProfiles
       .find((targetProfile) => targetProfile.get('id') === event.target.value);
-    this.campaign.set('targetProfile', selectedTargetProfile);
+    this.campaign.errors.remove('targetProfile');
   }
 
   @action

--- a/orga/app/routes/authenticated/students.js
+++ b/orga/app/routes/authenticated/students.js
@@ -7,7 +7,7 @@ export default class StudentsRoute extends Route {
 
   beforeModel() {
     super.beforeModel(...arguments);
-    if (!this.currentUser.canAccessStudentsPage) {
+    if (!this.currentUser.isSCOManagingStudents) {
       return this.replaceWith('application');
     }
   }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -38,6 +38,10 @@ export default class CurrentUserService extends Service {
     }
   }
 
+  get isSCOManagingStudents() {
+    return this.organization.isSco && this.organization.isManagingStudents;
+  }
+
   async _getMembershipByUserOrgaSettings(memberships, userOrgaSettings) {
     const organization = await userOrgaSettings.get('organization');
     for (let i = 0; i < memberships.length; i++) {
@@ -62,9 +66,7 @@ export default class CurrentUserService extends Service {
   async _setOrganizationProperties(membership) {
     const organization = await membership.organization;
     const isAdminInOrganization = membership.isAdmin;
-    const canAccessStudentsPage = organization.isSco && organization.isManagingStudents;
     this.set('organization', organization);
     this.set('isAdminInOrganization', isAdminInOrganization);
-    this.set('canAccessStudentsPage', canAccessStudentsPage);
   }
 }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -27,6 +27,11 @@
   &__information {
     margin-top: 7px;
   }
+
+  &__comment {
+    font-weight: 400;
+    font-style: italic;
+  }
 }
 
 .label {

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -58,6 +58,14 @@
           {{error.message}}
         </div>
       {{/each}}
+      {{#if this.shallDisplayComment}}
+        <label class="label" id="campaign-target-profile-comment-label">
+          Si vous souhaitez avoir plus d'information, consultez
+          <a href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"
+             target="_blank"
+             rel="noopener noreferrer"> la documentation correspondante</a>.
+        </label>
+      {{/if}}
     </div>
   {{/if}}
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -61,7 +61,8 @@
       {{#if this.currentUser.isSCOManagingStudents}}
         <label class="label" id="campaign-target-profile-comment-label">
           Si vous souhaitez avoir plus d'information, consultez
-          <a href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"
+          <a class="link"
+             href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"
              target="_blank"
              rel="noopener noreferrer"> la documentation correspondante</a>.
         </label>

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -34,6 +34,13 @@
           <span class="radio-button-span"></span>Collecter les profils Pix des participants
         </label>
       </div>
+
+      {{#each @campaign.errors.type as |error|}}
+        <div class='form__error error-message'>
+          {{error.message}}
+        </div>
+      {{/each}}
+
     </div>
   {{/if}}
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -59,13 +59,13 @@
         </div>
       {{/each}}
       {{#if this.currentUser.isSCOManagingStudents}}
-        <label class="label" id="campaign-target-profile-comment-label">
+        <p class="form__comment" id="campaign-target-profile-comment-label">
           Si vous souhaitez avoir plus d'information, consultez
           <a class="link"
              href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"
              target="_blank"
              rel="noopener noreferrer"> la documentation correspondante</a>.
-        </label>
+        </p>
       {{/if}}
     </div>
   {{/if}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/new-item.hbs
@@ -58,7 +58,7 @@
           {{error.message}}
         </div>
       {{/each}}
-      {{#if this.shallDisplayComment}}
+      {{#if this.currentUser.isSCOManagingStudents}}
         <label class="label" id="campaign-target-profile-comment-label">
           Si vous souhaitez avoir plus d'information, consultez
           <a href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"

--- a/orga/app/templates/components/sidebar-menu.hbs
+++ b/orga/app/templates/components/sidebar-menu.hbs
@@ -7,12 +7,12 @@
       Équipe
     </LinkTo>
   {{/if}}
-  {{#if this.currentUser.canAccessStudentsPage}}
+  {{#if this.currentUser.isSCOManagingStudents}}
     <LinkTo @route="authenticated.students" class="sidebar-menu__item sidebar--padding-left sidebar--padding-right">
       Élèves
     </LinkTo>
   {{/if}}
-  {{#if this.currentUser.canAccessStudentsPage}}
+  {{#if this.currentUser.isSCOManagingStudents}}
     <div class="sidebar-menu__documentation-item">
       <a class="sidebar-menu-documentation-item__button" href="https://bit.ly/ressourcespixorga"
          target="_blank" rel="noopener noreferrer">

--- a/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
@@ -98,6 +98,55 @@ module('Integration | Component | routes/authenticated/campaign | new-item', fun
     });
   });
 
+  module('when user‘s organization is SCO and is managing student', function() {
+
+    test('it should display comment for target profile selection', async function(assert) {
+      // given
+      this.currentUser = this.owner.lookup('service:current-user');
+      this.set('currentUser.organization.isSCO', true);
+      this.set('currentUser.organization.isManagingStudents', true);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);
+
+      // then
+      assert.dom('#campaign-target-profile-comment-label').exists();
+    });
+  });
+
+  module('when user‘s organization is SCO but is not managing student', function() {
+
+    test('it should not display comment for target profile selection', async function(assert) {
+      // given
+      this.currentUser = this.owner.lookup('service:current-user');
+      this.set('currentUser.organization.isSCO', true);
+      this.set('currentUser.organization.isManagingStudents', false);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);
+
+      // then
+      assert.dom('#campaign-target-profile-comment-label').doesNotExist();
+    });
+  });
+
+  module('when user‘s organization is not SCO but is managing student', function() {
+
+    /* eslint-disable-next-line mocha/no-identical-title */
+    test('it should not display comment for target profile selection', async function(assert) {
+      // given
+      this.currentUser = this.owner.lookup('service:current-user');
+      this.set('currentUser.organization.isSCO', false);
+      this.set('currentUser.organization.isManagingStudents', true);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);
+
+      // then
+      assert.dom('#campaign-target-profile-comment-label').doesNotExist();
+    });
+  });
+
   test('it should send campaign creation action when submitted', async function(assert) {
     // given
     this.set('model', EmberObject.create({}));

--- a/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
@@ -103,8 +103,7 @@ module('Integration | Component | routes/authenticated/campaign | new-item', fun
     test('it should display comment for target profile selection', async function(assert) {
       // given
       this.currentUser = this.owner.lookup('service:current-user');
-      this.set('currentUser.organization.isSCO', true);
-      this.set('currentUser.organization.isManagingStudents', true);
+      this.set('currentUser.isSCOManagingStudents', true);
 
       // when
       await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);
@@ -114,30 +113,12 @@ module('Integration | Component | routes/authenticated/campaign | new-item', fun
     });
   });
 
-  module('when user‘s organization is SCO but is not managing student', function() {
+  module('when user‘s organization is not (SCO and managing student)', function() {
 
     test('it should not display comment for target profile selection', async function(assert) {
       // given
       this.currentUser = this.owner.lookup('service:current-user');
-      this.set('currentUser.organization.isSCO', true);
-      this.set('currentUser.organization.isManagingStudents', false);
-
-      // when
-      await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);
-
-      // then
-      assert.dom('#campaign-target-profile-comment-label').doesNotExist();
-    });
-  });
-
-  module('when user‘s organization is not SCO but is managing student', function() {
-
-    /* eslint-disable-next-line mocha/no-identical-title */
-    test('it should not display comment for target profile selection', async function(assert) {
-      // given
-      this.currentUser = this.owner.lookup('service:current-user');
-      this.set('currentUser.organization.isSCO', false);
-      this.set('currentUser.organization.isManagingStudents', true);
+      this.set('currentUser.isSCOManagingStudents', false);
 
       // when
       await render(hbs`<Routes::Authenticated::Campaigns::NewItem @createCampaign={{action createCampaignSpy}} @cancel={{action cancelSpy}}/>`);

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -101,7 +101,7 @@ module('Unit | Service | current-user', function(hooks) {
         assert.equal(currentUserService.isAdminInOrganization, true);
       });
 
-      test('should set canAccessStudentsPage to true when type is SCO', async function(assert) {
+      test('should set isSCOManagingStudents to true when type is SCO', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: true, isSco: true });
         const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
@@ -112,10 +112,10 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.canAccessStudentsPage, true);
+        assert.equal(currentUserService.isSCOManagingStudents, true);
       });
 
-      test('should set canAccessStudentsPage to false when type is PRO', async function(assert) {
+      test('should set isSCOManagingStudents to false when type is PRO', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'PRO', isManagingStudents: true, isSco: false });
         const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
@@ -126,10 +126,10 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.canAccessStudentsPage, false);
+        assert.equal(currentUserService.isSCOManagingStudents, false);
       });
 
-      test('should set canAccessStudentsPage to false when isManagingStudents is false', async function(assert) {
+      test('should set isSCOManagingStudents to false when isManagingStudents is false', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
         const membership = Object.create({ organization, organizationRole: 'ADMIN', isAdmin: true });
@@ -140,7 +140,7 @@ module('Unit | Service | current-user', function(hooks) {
         await currentUserService.load();
 
         // then
-        assert.equal(currentUserService.canAccessStudentsPage, false);
+        assert.equal(currentUserService.isSCOManagingStudents, false);
       });
 
       test('should prefer organization from userOrgaSettings rather than first membership', async function(assert) {
@@ -208,12 +208,12 @@ module('Unit | Service | current-user', function(hooks) {
           assert.equal(currentUserService.isAdminInOrganization, true);
         });
 
-        test('should set canAccessStudentsPage', async function(assert) {
+        test('should set isSCOManagingStudents', async function(assert) {
           // when
           await currentUserService.load();
 
           // then
-          assert.equal(currentUserService.canAccessStudentsPage, false);
+          assert.equal(currentUserService.isSCOManagingStudents, false);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Il y a beaucoup de questions et de frustrations des professeurs concernant le contenu des profils cibles.
Une vingtaine de retours nous a été fait, et certains professeurs au vu du manque d’information sur les contenus des parcours ont décidé de ne pas utiliser Pix.

## :robot: Solution
Ajout d'un commentaire en dessous du choix de la liste des profils cibles pour les organisations SCO gérant des étudiants (`isManagingStudents === true`) uniquement avec un lien vers https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga.

## :rainbow: Remarques
En passant sur l'écran, certains messages d'erreur étaient en anglais.
De plus certains messages n'étaient jamais affichées.
Cette PR inclue également ces correctifs (premiers commits) 

## :100: Pour tester
Se connecter à une organisation de type SCO gérant des étudiants.
Se rendre sur le formulaire de création de campagne.
Sélectionner l'objectif de campagne `Évaluer les participants`.
Vérifier que le commentaire `Si vous souhaitez avoir plus d'information, consultez la documentation correspondante.` est affiché.
Vérifier que `documentation correspondante` est un lien.
Vérifier que le clic sur le lien ouvre un nouvel onglet sur l'adresse  "https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"