### PR TITLE
[FEATURE] Ajout d'un composant pour représenter les différents niveaux de recommandation des sujets (PO-403).

### DIFF
--- a/orga/app/components/recommendation-indicator.js
+++ b/orga/app/components/recommendation-indicator.js
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+
+const RECOMMENDED = 75;
+const HIGHLY_RECOMMENDED = 50;
+const STRONGLY_RECOMMENDED = 25;
+
+export default class RecommendationIndicator extends Component {
+
+  get bubblesCount() {
+    const value = this.args.value;
+    if (value <= STRONGLY_RECOMMENDED) return 4;
+    if (value <= HIGHLY_RECOMMENDED) return 3;
+    if (value <= RECOMMENDED) return 2;
+    return 1;
+  }
+
+  get bubbles() {
+    return new Array(this.bubblesCount);
+  }
+
+  get label() {
+    const value = this.args.value;
+    if (value <= STRONGLY_RECOMMENDED) return 'Fortement recommandé';
+    if (value <= HIGHLY_RECOMMENDED) return 'Très recommandé';
+    if (value <= RECOMMENDED) return 'Recommandé';
+    return 'Assez recommandé';
+  }
+
+  get bubbleWidth() {
+    return 12 * this.bubblesCount;
+  }
+
+  get xBubbleCoordinate() {
+    return 5 * this.bubbles.length;
+  }
+}

--- a/orga/app/helpers/multiply.js
+++ b/orga/app/helpers/multiply.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import _ from 'lodash';
+
+export function multiply(numbers) {
+  return _.reduce(numbers,(a, b) => Number(a) * Number(b));
+}
+
+export default helper(multiply);

--- a/orga/app/helpers/sum.js
+++ b/orga/app/helpers/sum.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import _ from 'lodash';
+
+export function sum(numbers) {
+  return _.reduce(numbers,(a, b) => Number(a) + Number(b));
+}
+
+export default helper(sum);

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -24,6 +24,7 @@
 @import "components/current-organization";
 @import "components/pagination-control";
 @import "components/progression-gauge";
+@import "components/recommendation-indicator";
 @import "components/register-form";
 @import "components/search-input";
 @import "components/sidebar-menu";

--- a/orga/app/styles/components/recommendation-indicator.scss
+++ b/orga/app/styles/components/recommendation-indicator.scss
@@ -1,0 +1,9 @@
+.recommendation-indicator {
+  display: flex;
+  justify-content: center;
+
+  &__bubble {
+    padding: 2px;
+    fill: $blue;
+  }
+}

--- a/orga/app/templates/components/recommendation-indicator.hbs
+++ b/orga/app/templates/components/recommendation-indicator.hbs
@@ -1,0 +1,7 @@
+<div class="recommendation-indicator">
+  <svg height="10" width={{this.bubbleWidth}} aria-label={{this.label}}>
+    {{#each this.bubbles as |bubble index|}}
+      <circle cx={{sum (multiply 12 index) 5}} cy="5" r="5" class="recommendation-indicator__bubble"/>
+    {{/each}}
+  </svg>
+</div>

--- a/orga/tests/integration/components/recommendation-indicator-test.js
+++ b/orga/tests/integration/components/recommendation-indicator-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | recommendation-indicator', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('should display recommendation indicator with a level of 4 for value 0', async function(assert) {
+    // given
+    this.set('value', 0);
+
+    // when
+    await render(hbs`<RecommendationIndicator @value={{value}} />`);
+
+    // then
+    assert.dom('[aria-label="Fortement recommandé"]').exists();
+  });
+
+  test('should display recommendation indicator with a level of 4 for value 25', async function(assert) {
+    // given
+    this.set('value', 25);
+
+    // when
+    await render(hbs`<RecommendationIndicator @value={{value}} />`);
+
+    // then
+    assert.dom('[aria-label="Fortement recommandé"]').exists();
+  });
+
+  test('should display recommendation indicator with a level of 3 for value 50', async function(assert) {
+    // given
+    this.set('value', 50);
+
+    // when
+    await render(hbs`<RecommendationIndicator @value={{value}} />`);
+
+    // then
+    assert.dom('[aria-label="Très recommandé"]').exists();
+  });
+
+  test('should display recommendation indicator with a level of 2 for value 75', async function(assert) {
+    // given
+    this.set('value', 75);
+
+    // when
+    await render(hbs`<RecommendationIndicator @value={{value}} />`);
+
+    // then
+    assert.dom('[aria-label="Recommandé"]').exists();
+  });
+
+  test('should display recommendation indicator with a level of 1 for value 100', async function(assert) {
+    // given
+    this.set('value', 100);
+
+    // when
+    await render(hbs`<RecommendationIndicator @value={{value}} />`);
+
+    // then
+    assert.dom('[aria-label="Assez recommandé"]').exists();
+  });
+});

--- a/orga/tests/unit/helpers/multiply-test.js
+++ b/orga/tests/unit/helpers/multiply-test.js
@@ -1,0 +1,17 @@
+import { multiply } from 'pix-orga/helpers/multiply';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | multiply', function(hooks) {
+  setupTest(hooks);
+
+  module('multiply', () => {
+    test('it multiply 10 by 2', function(assert) {
+      assert.equal(multiply([10, 2]), 20);
+    });
+
+    test('it multiply 10 by 2 by 20', function(assert) {
+      assert.equal(multiply([10, 2, 20]), 400);
+    });
+  });
+});

--- a/orga/tests/unit/helpers/sum-test.js
+++ b/orga/tests/unit/helpers/sum-test.js
@@ -1,0 +1,17 @@
+import { sum } from 'pix-orga/helpers/sum';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | sum', function(hooks) {
+  setupTest(hooks);
+
+  module('sum', () => {
+    test('it sum 10 and 2', function(assert) {
+      assert.equal(sum([10, 2]), 12);
+    });
+
+    test('it sum 10 and 2 and 20', function(assert) {
+      assert.equal(sum([10, 2, 20]), 32);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pix ne souhaite pas afficher le score de recommandation exact pour les sujets.

## :robot: Solution
Afficher la recommandation sous forme de niveaux de recommandation (1 - 2 - 3 - 4) sous forme de bulles bleues.

## :rainbow: Remarques
Ce composant n'est pas utilisé pour l'instant mais le sera quand la recommandation arrivera côté front (User Story en cours).

## :100: Pour tester
Tirer la branche en local et afficher le composant n'importe où.
Cela ressemblera à ça : 
![image](https://user-images.githubusercontent.com/23451175/78916215-6f081700-7a8d-11ea-81ad-aa3c6cc21392.png)
