### PR TITLE
[BUGFIX] Campagnes non affichées sur IE (PO-398).

### DIFF
--- a/orga/README.md
+++ b/orga/README.md
@@ -21,8 +21,8 @@ You will need the following things properly installed on your computer.
 ## Running / Development
 
 * `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+* Visit your app at [http://localhost:4201](http://localhost:4201).
+* Visit your tests at [http://localhost:4201/tests](http://localhost:4201/tests).
 
 ### Code Generators
 

--- a/orga/app/styles/pages/authenticated/campaigns/list.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/list.scss
@@ -34,6 +34,7 @@
     outline: none;
     font-family: $roboto;
     border-radius: 4px;
+    border: none;
     &:hover {
       background: $grey-20;
       opacity: .8;

--- a/orga/app/styles/pages/authenticated/campaigns/list.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/list.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  width: 100%;
 
   &__header-page {
     display: flex;

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -3,10 +3,8 @@
     <Routes::Authenticated::Campaigns::NoCampaignPanel />
   {{else}}
     <div class="list-campaigns-page__header-page">
-      <ul role="tablist" class="list-campaigns-page__campaigns-status" aria-label="Filtre des campagnes par statut">
-        <li role="tab" type="submit" class="list-campaigns-page__tab {{unless this.isArchived  'list-campaigns-page__tab--active' }}" aria-selected="{{ not this.isArchived }}" {{on 'click' (fn this.updateCampaignStatus null)}}>Actives</li>
-        <li role="tab" type="submit" class="list-campaigns-page__tab {{if this.isArchived 'list-campaigns-page__tab--active' }}" aria-selected="{{ this.isArchived }}" {{on 'click' (fn this.updateCampaignStatus 'archived')}}>Archivées</li>
-      </ul>
+      <button role="tab" type="submit" class="list-campaigns-page__tab {{unless this.isArchived  'list-campaigns-page__tab--active' }}" aria-selected="{{ not this.isArchived }}" aria-label="Afficher les campagnes actives" {{on 'click' (fn this.updateCampaignStatus null)}}>Actives</button>
+      <button role="tab" type="submit" class="list-campaigns-page__tab {{if this.isArchived 'list-campaigns-page__tab--active' }}" aria-selected="{{ this.isArchived }}" aria-label="Afficher les campagnes archivées" {{on 'click' (fn this.updateCampaignStatus 'archived')}}>Archivées</button>
       <div role="tabpanel" class="list-campaigns-page__create-campaign-button">
         <LinkTo @route="authenticated.campaigns.new" class="button button--link">Créer une campagne</LinkTo>
       </div>


### PR DESCRIPTION
## :unicorn: Problème
Sur IE, les campagnes ne sont pas affichées (page blanche).
Après investigation, c'est l'ajout d'un `onclick` sur les items de liste (balise `li`) qui entraine une erreur sur IE, rendant l'affichage de la page impossible.

## :robot: Solution
Ne pas utiliser de `li` mais des `buttons`.
D'autre part, cela permet de naviguer au clavier ce qui améliore l'accessibilité de la page.

## :rainbow: Remarques
RAS

## :100: Pour tester
Ouvrir pix-orga avec IE (utiliser lambdatest dans un environnement non Windows).
Se connecter (par exemple avec `sup@example.net`)
Vérifier que la liste des campagnes est affichées.
Cliquer sur l'onglet `Archivées`.
La liste affiche les campagnes archivées.
Cliquer sur l'onglet `Actives`.
La liste affiche les campagnes actives.