### PR TITLE
[TECH] Log des payloads des requêtes vers datadog 

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -42,6 +42,7 @@ module.exports = (function() {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
       logLevel: (process.env.LOG_LEVEL || 'info'),
+      logRequestPayload: (process.env.LOG_REQUEST_PAYLOAD),
     },
 
     mailing: {

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -61,6 +61,9 @@ const plugins = [
   {
     plugin: require('good'),
     options: {
+      includes: {
+        request: (settings.logging.logRequestPayload ? [settings.logging.logRequestPayload] : []),
+      },
       reporters: {
         console: consoleReporters,
       }


### PR DESCRIPTION
## :unicorn: Problème
Quand un problème survient en production, on ne sait pas quelles sont les données qui ont déclenché le bug afin de le reproduire.

## :robot: Solution
Inclure l'option du plugin Good pour activer le logs des payloads de [requêtes, responses, headers] dans l'événement response de Hapi. 
En production, l'objet de cet événement sera enrichi selon la configuration des options dans le plugin good.
Il sera donc visible par défault dans datadog, vu que les logs sont déjà indexés.
L'activation est piloté par une variable d'environnement.

## :rainbow: Remarques
Pour info: la durée de rétention des logs est de de 15j.
Datadog facture par évenement, du coup la taille des logs ne rajoute pas de frais supplémentaire.
La taille maximum par ligne d'événement autorisé est de 25KB.
On va se contenter d'activer les payload de request en premier pour l'instant.
Selon le besoin, on pourrait rajouter les headers et les payloads de la response.

## Point d'attention en cours

- Vérifier la Limite scalingo par rapport à la taille du payload. 
- En cas d'import de fichier, il vérifier si le binaire téléchargé ne sera pas tracé.
- Ajouter une protection pour ne pas dépasser la taille maximum.
- Ajouter un LogDataTransformer pour proposer un système de whitelist des endpoint à logguer.

