### PR TITLE
[FEATURE] Ajout d'informations sur la méthode de calcul des recommandations (PO-405).

### DIFF
--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -41,6 +41,7 @@
 @import "pages/authenticated/campaigns/list";
 @import "pages/authenticated/campaigns/no-campaign-panel";
 @import "pages/authenticated/campaigns/details/analysis";
+@import "pages/authenticated/campaigns/details/analysis/analysis-tab";
 @import "pages/authenticated/campaigns/details/parameters";
 @import "pages/authenticated/campaigns/details/collective-results/success-indicator";
 @import "pages/authenticated/campaigns/details/participants";

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis/analysis-tab.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis/analysis-tab.scss
@@ -1,0 +1,20 @@
+.campaign-details-analysis {
+  color: $grey-90;
+  font-weight: normal;
+  letter-spacing: 0;
+
+  &__header {
+    font-weight: normal;
+    font-family: $open-sans;
+    font-size: 1.25rem;
+    margin: 4px 0 0 0;
+    line-height: 1.688rem;
+  }
+
+  &__text {
+    font-family: $roboto;
+    margin: 2px 0 29px 0;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+  }
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
@@ -1,3 +1,12 @@
+<h4 class="campaign-details-analysis campaign-details-analysis__header">Recommandation de sujets à travailler</h4>
+<p class="campaign-details-analysis campaign-details-analysis__text">
+  En fonction du référentiel testé et des résultats de la campagne,
+  Pix vous recommande ces sujets à travailler, classés par degré de pertinence (
+  <svg height="10" width="10">
+      <circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble"/>
+  </svg>
+  )
+</p>
 <div class="panel panel--light-shadow content-text content-text--small campaign-details-table">
 
   <table aria-label="Analyse par sujet">


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur va voit un indicateur sans réelle explication de comment il a été calculé par pix.

## :robot: Solution
Ajouter un titre et une phrase d’explication au dessus de la liste des recommendations.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix Orga.
Se rendre sur le détail d'une campagne.
Ajouter `/analyse` à l'url pour afficher l'analyse de la campagne.
Une phrase d'explication des recommendations doit s'afficher au dessus du tableau de recommendations.