### PR TITLE
[FEATURE] Ajout d'une entrée Analyse dans la sous navigation du détails d'une campagne (PO-407).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -22,6 +22,10 @@ Fonctionnalité: Gestion des Campagnes
     Lorsque je reviens en arrière
     Et je clique sur "Résultats collectifs"
     Alors je vois la moyenne des résultats à 50%
+    Lorsque je clique sur "Analyse"
+    Alors je vois 2 sujets
+    Et je vois que le sujet "Capitales" est "Fortement recommandé"
+    Et je vois que le sujet "Philosophes" est "Assez recommandé"
 
   Scénario: Je consulte le détail d'une campagne de collecte de profils
     Étant donné que je suis connecté à Pix Orga

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -59,3 +59,11 @@ then(`je vois que j'ai partagé mon profil`, () => {
 then(`je vois que j'ai envoyé les résultats`, () => {
   cy.contains('Merci, vos résultats ont bien été envoyés !');
 });
+
+then(`je vois {int} sujets`, (tubeCount) => {
+  cy.get('[aria-label="Sujet"]').should('have.lengthOf', tubeCount);
+});
+
+then(`je vois que le sujet {string} est {string}`, (tubeName, recommendationLevel) => {
+  cy.contains(tubeName).closest('[aria-label="Sujet"]').get(`[aria-label="${recommendationLevel}"]`);
+});

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -55,6 +55,9 @@
       <LinkTo @route="authenticated.campaigns.details.collective-results" @model={{@campaign}} class="navbar-item">
         Résultats collectifs
       </LinkTo>
+      <LinkTo @route="authenticated.campaigns.details.analysis" class="navbar-item" @model={{@campaign}} >
+        Analyse
+      </LinkTo>
     {{/if}}
   </nav>
 

--- a/orga/tests/acceptance/campaign-details-test.js
+++ b/orga/tests/acceptance/campaign-details-test.js
@@ -40,54 +40,6 @@ module('Acceptance | Campaign Details', function(hooks) {
       });
     });
 
-    test('it should be accessible for an authenticated user', async function(assert) {
-      // given
-      server.create('campaign', { id: 1 });
-
-      // when
-      await visit('/campagnes/1');
-
-      // then
-      assert.equal(currentURL(), '/campagnes/1');
-    });
-
-    test('it should display by default parameters tab', async function(assert) {
-      // given
-      server.create('campaign', { id: 1 });
-
-      // when
-      await visit('/campagnes/1');
-
-      // then
-      assert.dom('.navbar-item.active').hasText('Détails');
-    });
-
-    test('it should redirect to participants page on click on participants tab', async function(assert) {
-      // given
-      server.create('campaign-report', { id: 1, participationsCount: 2 });
-      server.create('campaign', { id: 1, campaignReportId: 1, type: 'ASSESSMENT' });
-
-      // when
-      await visit('/campagnes/1');
-      await click('.navbar-item:nth-child(2)');
-
-      // then
-      assert.dom('.navbar-item.active').hasText('Participants (2)');
-      assert.equal(currentURL(), '/campagnes/1/participants');
-    });
-
-    test('it should redirect to update page on click on update button', async function(assert) {
-      // given
-      server.create('campaign', { id: 1, type: 'ASSESSMENT' });
-      await visit('/campagnes/1');
-
-      // when
-      await click('.campaign-details-content__update-button');
-
-      // then
-      assert.equal(currentURL(), '/campagnes/1/modification');
-    });
-
     test('it should redirect to update page on click on return button', async function(assert) {
       // given
       server.create('campaign', { id: 1 });
@@ -99,20 +51,5 @@ module('Acceptance | Campaign Details', function(hooks) {
       // then
       assert.equal(currentURL(), '/campagnes');
     });
-
-    test('it should redirect to collective results page on click on collective results tab', async function(assert) {
-      // given
-      const campaignCollectiveResult = server.create('campaign-collective-result', 'withCompetenceCollectiveResults');
-      server.create('campaign', { id: 1, campaignCollectiveResult, type: 'ASSESSMENT' });
-
-      // when
-      await visit('/campagnes/1');
-      await click('.navbar-item:nth-child(3)');
-
-      // then
-      assert.dom('.navbar-item.active').hasText('Résultats collectifs');
-      assert.equal(currentURL(), '/campagnes/1/resultats-collectifs');
-    });
-
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details-item-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module ('Integration | Component | routes/authenticated/campaign | details-item', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign | details-item', function(hooks) {
   setupRenderingTest(hooks);
 
   let store;
@@ -96,8 +96,8 @@ module ('Integration | Component | routes/authenticated/campaign | details-item'
       assert.dom('nav a[href="/campagnes/12"]').hasText('Détails');
     });
 
-    module('When campaign type is ASSESSMENT', function() {
-      test('it should display participation item', async function(assert) {
+    module('When campaign type is ASSESSMENT', function(hooks) {
+      hooks.beforeEach(async function() {
         const campaignReport = store.createRecord('campaignReport', {
           participationsCount: 10,
         });
@@ -110,55 +110,44 @@ module ('Integration | Component | routes/authenticated/campaign | details-item'
         this.set('campaign', campaign);
 
         await render(hbs`<Routes::Authenticated::Campaigns::DetailsItem @campaign={{campaign}}/>`);
+      });
 
+      test('it should display campaign analyse item', async function(assert) {
+        assert.dom('nav a[href="/campagnes/13/analyse"]').hasText('Analyse');
+      });
+
+      test('it should display participation item', async function(assert) {
         assert.dom('nav a[href="/campagnes/13/participants"]').hasText('Participants (10)');
       });
 
       test('it should display collective results item', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          id: 14,
-          type: 'ASSESSMENT',
-        });
-
-        this.set('campaign', campaign);
-
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::DetailsItem @campaign={{campaign}}/>`);
-        // then
-        assert.dom('nav a[href="/campagnes/14/resultats-collectifs"]').hasText('Résultats collectifs');
+        assert.dom('nav a[href="/campagnes/13/resultats-collectifs"]').hasText('Résultats collectifs');
       });
     });
 
-    module('When campaign type is PROFILES_COLLECTION', function() {
-      test('it should not display participation item', async function(assert) {
+    module('When campaign type is PROFILES_COLLECTION', function(hooks) {
+      hooks.beforeEach(async function() {
         // given
         const campaign = store.createRecord('campaign', {
-          id: 15,
+          id: 13,
           type: 'PROFILES_COLLECTION',
         });
 
         this.set('campaign', campaign);
 
-        // when
         await render(hbs`<Routes::Authenticated::Campaigns::DetailsItem @campaign={{campaign}}/>`);
-        // then
-        assert.dom('nav a[href="/campagnes/15/participants"]').doesNotExist();
+      });
+
+      test('it should not display participation item', async function(assert) {
+        assert.dom('nav a[href="/campagnes/13/participants"]').doesNotExist();
+      });
+
+      test('it should not display analyse item', async function(assert) {
+        assert.dom('nav a[href="/campagnes/13/analyse"]').doesNotExist();
       });
 
       test('it should not display collective results item', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          id: 16,
-          type: 'PROFILES_COLLECTION',
-        });
-
-        this.set('campaign', campaign);
-
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::DetailsItem @campaign={{campaign}}/>`);
-        // then
-        assert.dom('nav a[href="/campagnes/16/resultats-collectifs"]').doesNotExist();
+        assert.dom('nav a[href="/campagnes/13/resultats-collectifs"]').doesNotExist();
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La page d'analyse d'une campagne n'est pas accessible depuis l'interface utilisateur.

## :robot: Solution
On ajoute d'une entrée Analyse dans la sous navigation de la page de détails d'une campagne.


## :100: Pour tester
Aller sur la page de détails d'une campagne et constater la présence d'un nouvel onglet.
