### PR TITLE
[BUGFIX] Le menu "Élèves" ne s'affiche pas correctement lorsque l'on change d'organisation (PO-426).

### DIFF
--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -38,10 +38,6 @@ export default class CurrentUserService extends Service {
     }
   }
 
-  get isSCOManagingStudents() {
-    return this.organization.isSco && this.organization.isManagingStudents;
-  }
-
   async _getMembershipByUserOrgaSettings(memberships, userOrgaSettings) {
     const organization = await userOrgaSettings.get('organization');
     for (let i = 0; i < memberships.length; i++) {
@@ -66,7 +62,9 @@ export default class CurrentUserService extends Service {
   async _setOrganizationProperties(membership) {
     const organization = await membership.organization;
     const isAdminInOrganization = membership.isAdmin;
+    const isSCOManagingStudents = organization.isSco && organization.isManagingStudents;
     this.set('organization', organization);
     this.set('isAdminInOrganization', isAdminInOrganization);
+    this.set('isSCOManagingStudents', isSCOManagingStudents);
   }
 }

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -89,6 +89,16 @@ module('Acceptance | Switch Organization', function(hooks) {
           assert.equal(currentURL(), '/campagnes');
         });
       });
+
+      module('When user switch from a not managing student organization to a managing student organization', function() {
+
+        test('it should display student menu item', async function(assert) {
+          await click('.logged-user-summary__link');
+          await click('.logged-user-menu-item');
+
+          assert.dom('.sidebar').containsText('Élèves');
+        });
+      });
     });
   });
 });

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -59,7 +59,9 @@ export function createUserWithMultipleMemberships() {
 
   const secondOrganization = server.create('organization', {
     name: 'My Heaven Company',
-    externalId: 'HEAVEN'
+    externalId: 'HEAVEN',
+    type: 'SCO',
+    isManagingStudents: true,
   });
 
   const firstMembership = server.create('membership', {

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module.only('Unit | Model | campaign', function(hooks) {
+module('Unit | Model | campaign', function(hooks) {
   setupTest(hooks);
 
   test('it exists', function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Récemment une régression a été introduite n'affichant pas correctement le menu "Élèves" lorsque l'on change d'une organisation ne manageant pas d'élèves vers une organisation en manageant et inversement.

## :robot: Solution
Corriger la régression, ajouter un test qui vérifie cette non-régression.

## :rainbow: Remarques
Un .only trainait également, c'est enlevé (problème de linter ? 🤔)

## :100: Pour tester
1 - Aller sur une organisation non SCO
2 - Voir qu'il n'y a pas le menu "élèves"
3 - Changer d'organisation (sans changer d'utilisateur) vers une organisation SCO `isManagingStudents`
4 - Voir qu'il y a bien le menu "élèves"

Et inversement :
1 - Aller sur une organisation SCO
2 - Voir qu'il y a bien le menu "élèves"
3 - Changer d'organisation (sans changer d'utilisateur) vers une organisation non SCO
4 - Voir qu'il n'y a pas le menu "élèves"
