### PR TITLE
[INFRA] Ajout d'en-têtes HTTP pour la sécurité

### DIFF
--- a/admin/nginx.conf.erb
+++ b/admin/nginx.conf.erb
@@ -45,3 +45,7 @@ location /api/ {
 }
 
 <% end %>
+
+add_header X-Content-Type-Options "nosniff";
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection 1;

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -45,3 +45,7 @@ location /api/ {
 }
 
 <% end %>
+
+add_header X-Content-Type-Options "nosniff";
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection 1;

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -45,3 +45,7 @@ location /api/ {
 }
 
 <% end %>
+
+add_header X-Content-Type-Options "nosniff";
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection 1;

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -5,3 +5,7 @@ location ~ ^/(?<app>[^/]+)/.*$ {
 
   expires -1;
 }
+
+add_header X-Content-Type-Options "nosniff";
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection 1;

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -45,3 +45,7 @@ location /api/ {
 }
 
 <% end %>
+
+add_header X-Content-Type-Options "nosniff";
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection 1;


### PR DESCRIPTION
## :unicorn: Problème
Sur nos différentes plateformes, nous utilisons pas les en-têtes HTTP de sécurité. Celles-ci sont donc produites par le serveur nginx  et les fournit au navigateur. Sans leurs utilisations, on permet certaines failles de sécurité côté client.  Voici [ici](https://infosec.mozilla.org/guidelines/web_security) une documentation plus détaillée. 

## :robot: Solution
Ajouter aux différents fichiers `nginx.conf.erb` ces en-têtes de sécurité : 
- [X-Content-Type-Option](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/X-Content-Type-Options) : bloque les attaques qui utilisent le "reniflement" (_sniffing_) pour modifier le type MIME d'une ressource (rendre exécutable un type MIME non exécutable). Ex : empêche la conversion d'un type MIME `text` en type MIME `application/javascript`.
- [X-Frame-Option](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/X-Frame-Options) : bloque les attaques de type [clickjacking](https://fr.wikipedia.org/wiki/D%C3%A9tournement_de_clic) en empêchant l'application de se charger dans une iframe en dehors du domaine
- [X-XSS-Protection](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/X-XSS-Protection) : bloque les attaques de type [XSS](https://fr.wikipedia.org/wiki/Cross-site_scripting) en vérifiant et empêchant le chargement de ressources en dehors de domaines autorisés ; c'est une alternative à la définition et l'emploi d'une [politique de sécurité de contenu](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Content-Security-Policy)
## :taco: Remarques
Ces 3 en-têtes de sécurité, nous permettent de gagner 35 points sur : https://observatory.mozilla.org/

## :100: Pour tester
Recette globale