### PR TITLE
[TECH] Simplification de la génération de CSV de campagne d'évaluation (PO-427).

### DIFF
--- a/api/lib/domain/services/campaign-csv-export-service.js
+++ b/api/lib/domain/services/campaign-csv-export-service.js
@@ -1,0 +1,28 @@
+const CampaignAssessmentCsvLine = require('../../infrastructure/utils/CampaignAssessmentCsvLine');
+const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
+const campaignParticipationService = require('../services/campaign-participation-service');
+
+module.exports = {
+  createOneCsvLine,
+};
+
+function createOneCsvLine({
+  organization,
+  campaign,
+  competences,
+  campaignParticipationResultData,
+  targetProfile,
+  participantKnowledgeElements,
+}) {
+  const line = new CampaignAssessmentCsvLine({
+    organization,
+    campaign,
+    competences,
+    campaignParticipationResultData,
+    targetProfile,
+    participantKnowledgeElements,
+    campaignParticipationService,
+  });
+
+  return csvSerializer.serializeLine(line.toCsvLine());
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -13,6 +13,7 @@ const dependencies = {
   campaignRepository: require('../../infrastructure/repositories/campaign-repository'),
   certificationCandidatesOdsService: require('../../domain/services/certification-candidates-ods-service'),
   certificationsOdsService: require('../../domain/services/certifications-ods-service'),
+  campaignCsvExportService: require('../../domain/services/campaign-csv-export-service'),
   certificationCandidateRepository: require('../../infrastructure/repositories/certification-candidate-repository'),
   certificationReportRepository: require('../../infrastructure/repositories/certification-report-repository'),
   certificationChallengesService: require('../../domain/services/certification-challenges-service'),

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -1,5 +1,3 @@
-const campaignParticipationService = require('../services/campaign-participation-service');
-
 const _ = require('lodash');
 const moment = require('moment');
 const bluebird = require('bluebird');
@@ -19,6 +17,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
     campaignParticipationRepository,
     organizationRepository,
     knowledgeElementRepository,
+    campaignCsvExportService,
   }) {
 
   const campaign = await campaignRepository.get(campaignId);
@@ -54,7 +53,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
       limitDate: campaignParticipationResultData.sharedAt,
     });
 
-    const csvLine = _createOneLineOfCSV({
+    const csvLine = campaignCsvExportService.createOneCsvLine({
       organization,
       campaign,
       competences,
@@ -124,68 +123,6 @@ function _createHeaderOfCSV(skills, competences, idPixLabel) {
   ];
 }
 
-function _totalValidatedSkills(knowledgeElements) {
-  const sumValidatedSkills = _.reduce(knowledgeElements, function(validatedSkill, knowledgeElement) {
-    if (knowledgeElement.isValidated) {
-      return validatedSkill + 1;
-    }
-    return validatedSkill;
-  }, 0);
-  return sumValidatedSkills;
-}
-
-function _percentageSkillsValidated(knowledgeElements, targetProfile) {
-  return _.round(_totalValidatedSkills(knowledgeElements) / targetProfile.skills.length, 2);
-}
-
-function _stateOfSkill(skillId, knowledgeElements) {
-  const knowledgeElementForSkill = _.findLast(knowledgeElements,
-    (knowledgeElement) => knowledgeElement.skillId === skillId);
-  if (knowledgeElementForSkill) {
-    return knowledgeElementForSkill.isValidated ? 'OK' : 'KO';
-  } else {
-    return 'Non testé';
-  }
-}
-
-function _getSkillsOfCompetenceByTargetProfile(competence, targetProfile) {
-  const skillsOfProfile = targetProfile.skills;
-  const skillsOfCompetences = competence.skillIds;
-  return skillsOfProfile
-    .filter((skillOfProfile) => skillsOfCompetences.some((skill) => skill === skillOfProfile.id));
-}
-
-function _getSkillsValidatedForCompetence(skills, knowledgeElements) {
-  const sumValidatedSkills = _.reduce(knowledgeElements, function(validatedSkill, knowledgeElement) {
-    if (knowledgeElement.isValidated && skills.find((skill) => skill.id === knowledgeElement.skillId)) {
-      return validatedSkill + 1;
-    }
-    return validatedSkill;
-  }, 0);
-  return sumValidatedSkills;
-
-}
-
-function _createOneLineOfCSV({
-  organization,
-  campaign,
-  competences,
-  campaignParticipationResultData,
-  targetProfile,
-  participantKnowledgeElements,
-}) {
-  const line = new CsvLine({
-    organization,
-    campaign,
-    competences,
-    campaignParticipationResultData,
-    targetProfile,
-    participantKnowledgeElements,
-  });
-
-  return csvSerializer.serializeLine(line.toCsvLine());
-}
-
 function _extractCompetences(allCompetences, skills) {
   return _(skills)
     .map('competenceId')
@@ -204,98 +141,3 @@ function _extractAreas(competences) {
   return _.uniqBy(competences.map((competence) => competence.area), 'code');
 }
 
-class CsvLine {
-  constructor({
-    organization,
-    campaign,
-    competences,
-    campaignParticipationResultData,
-    targetProfile,
-    participantKnowledgeElements,
-  }) {
-
-    this.organization = organization;
-    this.campaign = campaign;
-    this.competences = competences;
-    this.campaignParticipationResultData = campaignParticipationResultData;
-    this.targetProfile = targetProfile;
-    this.participantKnowledgeElements = participantKnowledgeElements;
-    this.isShared = campaignParticipationResultData.isShared;
-    this.knowledgeElements = participantKnowledgeElements
-      .filter((ke) => _.find(targetProfile.skills, { id: ke.skillId }));
-
-    this._makeStatsColumns = this._makeStatsColumns.bind(this);
-    this._makeAreaColumns  = this._makeAreaColumns.bind(this);
-    this._makeCommonColumns = this._makeCommonColumns.bind(this);
-    this._getStatsForCompetence = this._getStatsForCompetence.bind(this);
-  }
-
-  toCsvLine() {
-    return [
-      ...this._makeCommonColumns(),
-      ...this._makeCompetenceColumns(),
-      ...this._makeAreaColumns(),
-      ..._.map(this.targetProfile.skills, ({ id }) => this.isShared ? _stateOfSkill(id, this.knowledgeElements) : 'NA')
-    ];
-  }
-
-  _makeStatsColumns({ skillCount, validatedSkillCount }) {
-    if (!this.isShared) return ['NA', 'NA', 'NA'];
-    return [
-      _.round(validatedSkillCount / skillCount, 2),
-      skillCount,
-      validatedSkillCount,
-    ];
-  }
-
-  _getStatsForCompetence(competence) {
-    const skillsForThisCompetence = _getSkillsOfCompetenceByTargetProfile(competence, this.targetProfile);
-    return {
-      skillCount: skillsForThisCompetence.length,
-      validatedSkillCount: _getSkillsValidatedForCompetence(skillsForThisCompetence, this.knowledgeElements)
-    };
-  }
-
-  _makeCompetenceColumns() {
-    return _.flatMap(this.competences, (competence) => this._makeStatsColumns({
-      id: competence.id,
-      ...this._getStatsForCompetence(competence),
-    }));
-  }
-
-  _makeAreaColumns() {
-    const areas = _extractAreas(this.competences);
-    return _.flatMap(areas, ({ id }) => {
-      const areaCompetenceStats = _.filter(this.competences, (competence) => competence.area.id === id)
-        .map(this._getStatsForCompetence);
-
-      const skillCount = _.sumBy(areaCompetenceStats, 'skillCount');
-      const validatedSkillCount = _.sumBy(areaCompetenceStats, 'validatedSkillCount');
-
-      return this._makeStatsColumns({
-        id,
-        skillCount,
-        validatedSkillCount,
-      });
-    });
-  }
-
-  _makeCommonColumns() {
-    const { participantFirstName, participantLastName } = this.campaignParticipationResultData;
-    return [
-      this.organization.name,
-      this.campaign.id,
-      this.campaign.name,
-      this.targetProfile.name,
-      participantLastName,
-      participantFirstName,
-      this.campaign.idPixLabel ? this.campaignParticipationResultData.participantExternalId : 'NA',
-      campaignParticipationService.progress(this.campaignParticipationResultData.isCompleted, this.knowledgeElements.length, this.targetProfile.skills.length),
-      moment.utc(this.campaignParticipationResultData.createdAt).format('YYYY-MM-DD'),
-      this.isShared ? 'Oui' : 'Non',
-      this.isShared ? moment.utc(this.campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : 'NA',
-      this.isShared ? _percentageSkillsValidated(this.knowledgeElements, this.targetProfile) : 'NA',
-    ];
-  }
-
-}

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -1,0 +1,148 @@
+const moment = require('moment');
+const _ = require('lodash');
+
+function _stateOfSkill(skillId, knowledgeElements) {
+  const knowledgeElementForSkill = _.findLast(knowledgeElements,
+    (knowledgeElement) => knowledgeElement.skillId === skillId);
+  if (knowledgeElementForSkill) {
+    return knowledgeElementForSkill.isValidated ? 'OK' : 'KO';
+  } else {
+    return 'Non testé';
+  }
+}
+
+function _getSkillsOfCompetenceByTargetProfile(competence, targetProfile) {
+  const skillsOfProfile = targetProfile.skills;
+  const skillsOfCompetences = competence.skillIds;
+  return skillsOfProfile
+    .filter((skillOfProfile) => skillsOfCompetences.some((skill) => skill === skillOfProfile.id));
+}
+
+function _getSkillsValidatedForCompetence(skills, knowledgeElements) {
+  const sumValidatedSkills = _.reduce(knowledgeElements, function(validatedSkill, knowledgeElement) {
+    if (knowledgeElement.isValidated && skills.find((skill) => skill.id === knowledgeElement.skillId)) {
+      return validatedSkill + 1;
+    }
+    return validatedSkill;
+  }, 0);
+  return sumValidatedSkills;
+
+}
+
+function _extractAreas(competences) {
+  return _.uniqBy(competences.map((competence) => competence.area), 'code');
+}
+
+function _totalValidatedSkills(knowledgeElements) {
+  const sumValidatedSkills = _.reduce(knowledgeElements, function(validatedSkill, knowledgeElement) {
+    if (knowledgeElement.isValidated) {
+      return validatedSkill + 1;
+    }
+    return validatedSkill;
+  }, 0);
+  return sumValidatedSkills;
+}
+
+function _percentageSkillsValidated(knowledgeElements, targetProfile) {
+  return _.round(_totalValidatedSkills(knowledgeElements) / targetProfile.skills.length, 2);
+}
+
+class CampaignAssessmentCsvLine {
+  constructor({
+    organization,
+    campaign,
+    competences,
+    campaignParticipationResultData,
+    targetProfile,
+    participantKnowledgeElements,
+    campaignParticipationService,
+  }) {
+
+    this.organization = organization;
+    this.campaign = campaign;
+    this.competences = competences;
+    this.campaignParticipationResultData = campaignParticipationResultData;
+    this.targetProfile = targetProfile;
+    this.participantKnowledgeElements = participantKnowledgeElements;
+    this.isShared = campaignParticipationResultData.isShared;
+    this.knowledgeElements = participantKnowledgeElements
+      .filter((ke) => _.find(targetProfile.skills, { id: ke.skillId }));
+    this.campaignParticipationService = campaignParticipationService;
+
+    this._makeStatsColumns = this._makeStatsColumns.bind(this);
+    this._makeAreaColumns  = this._makeAreaColumns.bind(this);
+    this._makeCommonColumns = this._makeCommonColumns.bind(this);
+    this._getStatsForCompetence = this._getStatsForCompetence.bind(this);
+  }
+
+  toCsvLine() {
+    return [
+      ...this._makeCommonColumns(),
+      ...this._makeCompetenceColumns(),
+      ...this._makeAreaColumns(),
+      ..._.map(this.targetProfile.skills, ({ id }) => this.isShared ? _stateOfSkill(id, this.knowledgeElements) : 'NA')
+    ];
+  }
+
+  _makeStatsColumns({ skillCount, validatedSkillCount }) {
+    if (!this.isShared) return ['NA', 'NA', 'NA'];
+    return [
+      _.round(validatedSkillCount / skillCount, 2),
+      skillCount,
+      validatedSkillCount,
+    ];
+  }
+
+  _getStatsForCompetence(competence) {
+    const skillsForThisCompetence = _getSkillsOfCompetenceByTargetProfile(competence, this.targetProfile);
+    return {
+      skillCount: skillsForThisCompetence.length,
+      validatedSkillCount: _getSkillsValidatedForCompetence(skillsForThisCompetence, this.knowledgeElements)
+    };
+  }
+
+  _makeCompetenceColumns() {
+    return _.flatMap(this.competences, (competence) => this._makeStatsColumns({
+      id: competence.id,
+      ...this._getStatsForCompetence(competence),
+    }));
+  }
+
+  _makeAreaColumns() {
+    const areas = _extractAreas(this.competences);
+    return _.flatMap(areas, ({ id }) => {
+      const areaCompetenceStats = _.filter(this.competences, (competence) => competence.area.id === id)
+        .map(this._getStatsForCompetence);
+
+      const skillCount = _.sumBy(areaCompetenceStats, 'skillCount');
+      const validatedSkillCount = _.sumBy(areaCompetenceStats, 'validatedSkillCount');
+
+      return this._makeStatsColumns({
+        id,
+        skillCount,
+        validatedSkillCount,
+      });
+    });
+  }
+
+  _makeCommonColumns() {
+    const { participantFirstName, participantLastName } = this.campaignParticipationResultData;
+    return [
+      this.organization.name,
+      this.campaign.id,
+      this.campaign.name,
+      this.targetProfile.name,
+      participantLastName,
+      participantFirstName,
+      this.campaign.idPixLabel ? this.campaignParticipationResultData.participantExternalId : 'NA',
+      this.campaignParticipationService.progress(this.campaignParticipationResultData.isCompleted, this.knowledgeElements.length, this.targetProfile.skills.length),
+      moment.utc(this.campaignParticipationResultData.createdAt).format('YYYY-MM-DD'),
+      this.isShared ? 'Oui' : 'Non',
+      this.isShared ? moment.utc(this.campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : 'NA',
+      this.isShared ? _percentageSkillsValidated(this.knowledgeElements, this.targetProfile) : 'NA',
+    ];
+  }
+
+}
+
+module.exports = CampaignAssessmentCsvLine;

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -11,6 +11,7 @@ const knowledgeElementRepository = require('../../../../lib/infrastructure/repos
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 
@@ -175,6 +176,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         organizationRepository,
         campaignParticipationRepository,
         knowledgeElementRepository,
+        campaignCsvExportService
       });
 
       const csv = await csvPromise;

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -3,6 +3,7 @@ const moment = require('moment');
 
 const { expect, sinon, domainBuilder, streamToPromise } = require('../../../test-helper');
 
+const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 const startWritingCampaignAssessmentResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-assessment-results-to-stream');
 const Area = require('../../../../lib/domain/models/Area');
 
@@ -164,6 +165,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
         organizationRepository,
         campaignParticipationRepository,
         knowledgeElementRepository,
+        campaignCsvExportService
       });
 
       const csv = await csvPromise;
@@ -225,6 +227,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           organizationRepository,
           campaignParticipationRepository,
           knowledgeElementRepository,
+          campaignCsvExportService
         });
 
         const csv = await csvPromise;
@@ -291,6 +294,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           organizationRepository,
           campaignParticipationRepository,
           knowledgeElementRepository,
+          campaignCsvExportService
         });
 
         const csv = await csvPromise;
@@ -357,6 +361,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           organizationRepository,
           campaignParticipationRepository,
           knowledgeElementRepository,
+          campaignCsvExportService
         });
 
         const csv = await csvPromise;
@@ -437,6 +442,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           organizationRepository,
           campaignParticipationRepository,
           knowledgeElementRepository,
+          campaignCsvExportService
         });
 
         const csv = await csvPromise;
@@ -507,6 +513,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           organizationRepository,
           campaignParticipationRepository,
           knowledgeElementRepository,
+          campaignCsvExportService
         });
 
         const csv = await csvPromise;


### PR DESCRIPTION
## :unicorn: Problème
L'utilisation d'une collection contenant des objets `{ title: '', property: '' }` nous a semblé compliqué pour générer les csv. On pense qu'il est possible de simplifier ce code en utilisant des tableaux.

## :robot: Solution
On a réussi à supprimer l'utilisation de ces collections pour des simples tableaux. De fil en aiguille nous avons migré le code vers un objet `CsvLine` pour la génération du contenu. On pourrait aller plus loin encore mais on pense que dans l'état le code est plus maintenable. Il faudrait faire la même évolution pour les campagnes de types collecte de profils.
