### PR TITLE
[FEATURE] Générer un mot de passe à usage unique pour un élève dans Pix Orga (PO-321).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -149,7 +149,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SchoolingRegistrationAlreadyLinkedToUserError) {
     return new HttpErrors.ConflictError(error.message);
   }
-  if (error instanceof DomainErrors.UserNotAuthorizedToUpdateStudentPasswordError) {
+  if (error instanceof DomainErrors.UserNotAuthorizedToUpdatePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
   if (error instanceof DomainErrors.UserNotAuthorizedToCreateResourceError) {

--- a/api/lib/application/passwords/index.js
+++ b/api/lib/application/passwords/index.js
@@ -50,7 +50,7 @@ exports.register = async function(server) {
             data: {
               attributes: {
                 username: Joi.string().required(),
-                expiredPassword: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+                expiredPassword: Joi.string().required(),
                 newPassword: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
               },
               type: Joi.string()

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -1,8 +1,7 @@
 const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
 const securityController = require('../../interfaces/controllers/security-controller');
+const JSONAPIError = require('jsonapi-serializer').Error;
 const Joi = require('@hapi/joi');
-const { passwordValidationPattern } = require('../../config').account;
-const XRegExp = require('xregexp');
 
 exports.register = async function(server) {
   server.route([
@@ -36,11 +35,19 @@ exports.register = async function(server) {
             data: {
               attributes: {
                 'organization-id': Joi.number().required(),
-                'student-id': Joi.number().required(),
-                password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+                'schooling-registration-id': Joi.number().required()
               }
             }
-          })
+          }),
+          failAction: (request, h) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              code: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: 'The server could not understand the request due to invalid syntax.',
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          }
         },
         notes : [
           '- Met à jour le mot de passe d\'un utilisateur identifié par son identifiant élève\n' +

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -20,20 +20,27 @@ module.exports = {
     return h.response(userSerializer.serialize(createdUser)).created();
   },
 
-  async updatePassword(request) {
+  async updatePassword(request, h) {
     const payload = request.payload.data.attributes;
     const userId = parseInt(request.auth.credentials.userId);
     const organizationId = parseInt(payload['organization-id']);
-    const schoolingRegistrationId = parseInt(payload['student-id']);
-    const password = payload.password;
+    const schoolingRegistrationId = parseInt(payload['schooling-registration-id']);
 
-    const updatedUser = await usecases.updateSchoolingRegistrationDependentUserPassword({
+    const generatedPassword = await usecases.updateSchoolingRegistrationDependentUserPassword({
       userId,
       organizationId,
       schoolingRegistrationId,
-      password,
     });
 
-    return userSerializer.serialize(updatedUser);
+    const schoolingRegistrationWithGeneratedPasswordResponse = {
+      data: {
+        attributes: {
+          'generated-password': generatedPassword
+        },
+        type: 'schooling-registration-dependent-user'
+      }
+    };
+
+    return h.response(schoolingRegistrationWithGeneratedPasswordResponse).code(200);
   },
 };

--- a/api/lib/application/student-dependent-users/index.js
+++ b/api/lib/application/student-dependent-users/index.js
@@ -1,8 +1,4 @@
 const schoolingRegistrationDependentUserController = require('./../schooling-registration-dependent-users/schooling-registration-dependent-user-controller');
-const securityController = require('../../interfaces/controllers/security-controller');
-const Joi = require('@hapi/joi');
-const { passwordValidationPattern } = require('../../config').account;
-const XRegExp = require('xregexp');
 
 exports.register = async function(server) {
   server.route([
@@ -19,38 +15,7 @@ exports.register = async function(server) {
         ],
         tags: ['api', 'studentDependentUser']
       }
-    },
-    {
-      method: 'POST',
-      path: '/api/student-dependent-users/password-update',
-      config: {
-        pre: [{
-          method: securityController.checkUserBelongsToScoOrganizationAndManagesStudents,
-          assign: 'belongsToScoOrganizationAndManageStudents'
-        }],
-        handler: schoolingRegistrationDependentUserController.updatePassword,
-        validate: {
-          options: {
-            allowUnknown: true
-          },
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'organization-id': Joi.number().required(),
-                'student-id': Joi.number().required(),
-                password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
-              }
-            }
-          })
-        },
-        notes : [
-          '- Met à jour le mot de passe d\'un utilisateur identifié par son identifiant élève\n' +
-          '- La demande de modification du mot de passe doit être effectuée par un membre de l\'organisation à laquelle appartient l\'élève.' +
-          '- L\'utilisation de cette route est dépréciée. tiliser /api/schooling-registration-dependent-users à la place',
-        ],
-        tags: ['api', 'studentDependentUser'],
-      }
-    },
+    }
   ]);
 };
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -420,8 +420,8 @@ class UserNotAuthorizedToCertifyError extends DomainError {
   }
 }
 
-class UserNotAuthorizedToUpdateStudentPasswordError extends DomainError {
-  constructor(message = 'Cet utilisateur n\'est pas autorisé à mettre à jour le mot de passe de l\'étudiant.') {
+class UserNotAuthorizedToUpdatePasswordError extends DomainError {
+  constructor(message = 'L\'utilisateur n\'est pas autorisé à mettre à jour ce mot de passe.') {
     super(message);
   }
 }
@@ -511,8 +511,8 @@ module.exports = {
   UserNotAuthorizedToGetCampaignResultsError,
   UserNotAuthorizedToGetCertificationCoursesError,
   UserNotAuthorizedToUpdateCampaignError,
+  UserNotAuthorizedToUpdatePasswordError,
   UserNotAuthorizedToUpdateResourceError,
-  UserNotAuthorizedToUpdateStudentPasswordError,
   UserNotFoundError,
   UserNotMemberOfOrganizationError,
   UserOrgaSettingsCreationError,

--- a/api/lib/domain/services/password-generator.js
+++ b/api/lib/domain/services/password-generator.js
@@ -1,0 +1,11 @@
+const randomString = require('randomstring');
+const _ = require('lodash');
+
+module.exports = {
+
+  generate() {
+    const letterPart = randomString.generate({ length: 6, charset: 'abcdefghjkmnpqrstuvwxyz', capitalization: 'lowercase' });
+    const numberPart = _.padStart(_.random(99), 2, '0');
+    return `${letterPart}${numberPart}`;
+  }
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -38,6 +38,7 @@ const dependencies = {
   organizationService: require('../../domain/services/organization-service'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
+  passwordGenerator: require('../../domain/services/password-generator'),
   pickChallengeService: require('../services/pick-challenge-service'),
   resetPasswordService: require('../../domain/services/reset-password-service'),
   reCaptchaValidator: require('../../infrastructure/validators/grecaptcha-validator'),

--- a/api/lib/domain/usecases/update-schooling-registration-dependent-user-password.js
+++ b/api/lib/domain/usecases/update-schooling-registration-dependent-user-password.js
@@ -1,26 +1,32 @@
 const _ = require('lodash');
-
-const { UserNotAuthorizedToUpdateStudentPasswordError } = require('../errors');
+const { UserNotAuthorizedToUpdatePasswordError } = require('../errors');
 
 module.exports = async function updateSchoolingRegistrationDependentUserPassword({
-  userId, organizationId, schoolingRegistrationId, password,
+  userId,
+  organizationId,
+  schoolingRegistrationId,
+  passwordGenerator,
   encryptionService,
-  userRepository, schoolingRegistrationRepository
+  userRepository,
+  schoolingRegistrationRepository
 }) {
-
   const userWithMemberships = await userRepository.getWithMemberships(userId);
   const schoolingRegistration = await schoolingRegistrationRepository.get(schoolingRegistrationId);
 
   if (!userWithMemberships.hasAccessToOrganization(organizationId) || schoolingRegistration.organizationId !== organizationId) {
-    throw new UserNotAuthorizedToUpdateStudentPasswordError(`Cet utilisateur ${schoolingRegistration.userId} ne peut pas modifier le mot de passe de l'éleve car il n'appartient pas à l'organisation ${organizationId}`);
+    throw new UserNotAuthorizedToUpdatePasswordError(`L'utilisateur ${userId} n'est pas autorisé à modifier le mot de passe des élèves de l'organisation ${organizationId} car il n'y appartient pas.`);
   }
 
   const userStudent = await userRepository.get(schoolingRegistration.userId);
   if (_.isEmpty(userStudent.username) && _.isEmpty(userStudent.email)) {
-    throw new UserNotAuthorizedToUpdateStudentPasswordError(`\`Le changement de mot de passe n'est possible que si l'utilisateur ${schoolingRegistration.userId} utilise les méthodes d'authentification email ou identifiant\``);
+    throw new UserNotAuthorizedToUpdatePasswordError(`Le changement de mot de passe n'est possible que si l'élève (utilisateur:  ${schoolingRegistration.userId}) utilise les méthodes d'authentification email ou identifiant.`);
   }
 
-  const hashedPassword = await encryptionService.hashPassword(password);
+  const generatedPassword = passwordGenerator.generate();
+  const hashedPassword = await encryptionService.hashPassword(generatedPassword);
 
-  return userRepository.updatePassword(schoolingRegistration.userId, hashedPassword);
+  await userRepository.updatePasswordThatShouldBeChanged(userStudent.id, hashedPassword);
+
+  return generatedPassword;
 };
+

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -377,6 +377,19 @@ module.exports = {
     return username;
   },
 
+  updatePasswordThatShouldBeChanged(id, hashedPassword) {
+    return BookshelfUser
+      .where({ id })
+      .save({ password: hashedPassword, shouldChangePassword: true }, { patch: true, method: 'update' })
+      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .catch((err) => {
+        if (err instanceof BookshelfUser.NoRowsUpdatedError) {
+          throw new UserNotFoundError(`User not found for ID ${id}`);
+        }
+        throw err;
+      });
+  },
+
   async updateExpiredPassword({ userId, hashedNewPassword }) {
     return BookshelfUser
       .where({ id: userId })

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -394,9 +394,9 @@ describe('Integration | Utils | Error Manager', function() {
       expect(result.statusCode).to.equal(400);
     });
 
-    it('should return 403 on domain UserNotAuthorizedToUpdateStudentPasswordError', function() {
+    it('should return 403 on domain UserNotAuthorizedToUpdatePasswordError', function() {
       // given
-      const error = new DomainErrors.UserNotAuthorizedToUpdateStudentPasswordError();
+      const error = new DomainErrors.UserNotAuthorizedToUpdatePasswordError();
 
       // when
       const result = handle(hFake, error);

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -51,9 +51,8 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
       const payload = {
         data: {
           attributes: {
-            'student-id': 1,
-            'organization-id': 3,
-            'password': 'P@ssw0rd'
+            'schooling-registration-id': 1,
+            'organization-id': 3
           }
         }
       };

--- a/api/tests/integration/application/student-dependent-users/index_test.js
+++ b/api/tests/integration/application/student-dependent-users/index_test.js
@@ -4,14 +4,13 @@ const schoolingRegistrationDependentUserController = require('../../../../lib/ap
 const moduleUnderTest = require('../../../../lib/application/student-dependent-users');
 const securityController = require('../../../../lib/interfaces/controllers/security-controller');
 
-describe('Integration | Application | Route | schooling-registration-dependent-users', () => {
+describe('Integration | Application | Route | student-dependent-users', () => {
 
   let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(securityController, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
     sinon.stub(schoolingRegistrationDependentUserController, 'createAndAssociateUserToSchoolingRegistration').callsFake((request, h) => h.response('ok').code(201));
-    sinon.stub(schoolingRegistrationDependentUserController, 'updatePassword').callsFake((request, h) => h.response('ok').code(200));
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -41,29 +40,4 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
       expect(response.statusCode).to.equal(201);
     });
   });
-
-  describe('POST /api/student-dependent-users/password-update', () => {
-
-    it('should succeed', async () => {
-      // given
-      const method = 'POST';
-      const url = '/api/student-dependent-users/password-update';
-      const payload = {
-        data: {
-          attributes: {
-            'student-id': 1,
-            'organization-id': 3,
-            'password': 'P@ssw0rd'
-          }
-        }
-      };
-
-      // when
-      const response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -666,6 +666,41 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
   });
 
+  describe('#updateTemporaryPassword', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser(userToInsert);
+      await databaseBuilder.commit();
+    });
+
+    it('should save the user', async () => {
+      // given
+      const generatedPassword = '1235Pix!';
+
+      // when
+      const updatedUser = await userRepository.updatePasswordThatShouldBeChanged(userInDb.id, generatedPassword);
+
+      // then
+      expect(updatedUser).to.be.an.instanceOf(User);
+      expect(updatedUser.password).to.equal(generatedPassword);
+      expect(updatedUser.shouldChangePassword).to.be.true;
+    });
+
+    it('should throw UserNotFoundError when user id not found', async () => {
+      // given
+      const wrongUserId = 0;
+      const generatedPassword = '1235Pix!';
+
+      // when
+      const error = await catchErr(userRepository.updatePasswordThatShouldBeChanged)(wrongUserId, generatedPassword);
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+  });
+
   describe('#isUserExistingByEmail', () => {
     const email = 'shi@fu.fr';
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -63,8 +63,8 @@ describe('Unit | Domain | Errors', () => {
     expect(errors.CampaignAlreadyArchivedError).to.exist;
   });
 
-  it('should export a UserNotAuthorizedToUpdateStudentPassword', () => {
-    expect(errors.UserNotAuthorizedToUpdateStudentPasswordError).to.exist;
+  it('should export a UserNotAuthorizedToUpdatePasswordError', () => {
+    expect(errors.UserNotAuthorizedToUpdatePasswordError).to.exist;
   });
 
   it('should export a UserNotAuthorizedToUpdateCampaignError', () => {

--- a/api/tests/unit/domain/services/password-generator_test.js
+++ b/api/tests/unit/domain/services/password-generator_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const service = require('../../../../lib/domain/services/password-generator');
+
+describe('Unit | Service | password-generator', () => {
+
+  let generatedPassword;
+
+  beforeEach(() => {
+    generatedPassword = service.generate();
+  });
+
+  it('should have a length of 8 characters', function() {
+    expect(generatedPassword.length).to.equal(8);
+  });
+
+  it('should not contains hard to read characters', function() {
+    const hardToReadCharacters = '[ilo]';
+    expect(RegExp(hardToReadCharacters).test(generatedPassword)).to.be.false;
+  });
+
+  it('should contains 6 lowercase letters and two digits', function() {
+    expect(RegExp('^[a-z]{6}[0-9]{2}$').test(generatedPassword)).to.be.true;
+  });
+
+});

--- a/high-level-tests/e2e/cypress/fixtures/schooling-registrations.json
+++ b/high-level-tests/e2e/cypress/fixtures/schooling-registrations.json
@@ -9,5 +9,13 @@
     "birthdate": "1986-10-23",
     "organizationId": 2,
     "userId": null
+  },
+  {
+    "id": 2,
+    "firstName": "user",
+    "lastName": "name",
+    "birthdate": "1986-10-23",
+    "organizationId": 2,
+    "userId": 8
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -22,7 +22,8 @@
     "lastName": "Snow",
     "email": "john.snow@pix.fr",
     "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
-    "cgu": true
+    "cgu": true,
+    "pixOrgaTermsOfServiceAccepted": true
   },
   {
     "id": 4,

--- a/high-level-tests/e2e/cypress/integration/pix-orga/student-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/student-management.feature
@@ -1,0 +1,18 @@
+#language: fr
+Fonctionnalité: Génération du mot de passe à usage unique
+
+  Contexte:
+    Étant donné que les données de test sont chargées
+
+  Scénario: Je suis un élève et je veux changer mon mot de passe
+    Étant donné que je vais sur Pix Orga
+    Lorsque je me connecte avec le compte "john.snow@pix.fr"
+    Alors je suis redirigé vers le compte Orga de "John Snow"
+    Lorsque je clique sur "Élèves"
+    Alors je suis redirigé vers la page "/eleves"
+    Lorsque je clique sur l'engrenage
+    Alors je vois la modal de gestion du compte de l'élève
+    Lorsque je clique sur "Réinitialiser le mot de passe"
+    Alors je vois le mot de passe généré
+
+

--- a/high-level-tests/e2e/cypress/support/step_definitions/student.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/student.js
@@ -1,0 +1,11 @@
+when(`je clique sur l'engrenage`, () => {
+  cy.get('table > tbody > tr:nth-child(1) > td.list-students-page__password-reset-cell > div > button').click();
+});
+
+then(`je vois la modal de gestion du compte de l'élève`, () => {
+  cy.contains('Gestion du compte de l\'élève');
+});
+
+then('je vois le mot de passe généré', () => {
+  cy.contains('Mot de passe à usage unique');
+});

--- a/orga/app/adapters/schooling-registration-dependent-user.js
+++ b/orga/app/adapters/schooling-registration-dependent-user.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class StudentDependentUser extends ApplicationAdapter {
+
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/schooling-registration-dependent-users/password-update`;
+  }
+}

--- a/orga/app/components/password-reset-window.js
+++ b/orga/app/components/password-reset-window.js
@@ -1,77 +1,35 @@
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-
-import isPasswordValid from '../utils/password-validator';
-
-const ERROR_PASSWORD_MESSAGE =
-  'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 export default class PasswordResetWindow extends Component {
 
   @service store;
   @service notifications;
 
-  isLoading = false;
-  isPasswordVisible = false;
+  isUniquePasswordVisible = false;
 
-  @computed('isPasswordVisible')
-  get passwordInputType() {
-    return this.isPasswordVisible ? 'text' : 'password';
-  }
-
-  student = null;
-  isShowingModal = null;
-  studentUser = null;
-
-  init() {
-    super.init(...arguments);
-    this.studentUser = this.store.createRecord('student-dependent-user', {
-      organizationId: this.student.organization.get('id'),
-      studentId: this.student.id,
-      password: null
-    });
-    this.set('validation', {
-      password: {
-        message: null
-      }
-    });
-  }
+  generatedPassword = null;
 
   @action
-  async updatePassword(event) {
+  async resetPassword(event) {
     event.preventDefault();
-    if (isPasswordValid(this.studentUser.password)) {
-      this.set('isLoading', true);
-      try {
-        await this.studentUser.save();
-        this.closePasswordReset();
-        this.notifications.sendSuccess('Mot de passe modifié !');
-      } catch (e) {
-        this.closePasswordReset();
-        this.notifications.sendError('Quelque chose s\'est mal passé. Veuillez réessayer.');
-      } finally {
-        this.set('isLoading', false);
-      }
+    const schoolingRegistrationDependentUser = this.store.createRecord('schooling-registration-dependent-user', {
+      organizationId: this.student.organization.get('id'),
+      schoolingRegistrationId: this.student.id
+    });
+
+    try {
+      await schoolingRegistrationDependentUser.save();
+      this.generatedPassword = schoolingRegistrationDependentUser.generatedPassword;
+      this.toggleProperty('isUniquePasswordVisible');
+    } catch (e) {
+      this.notifications.sendError('Quelque chose s\'est mal passé. Veuillez réessayer.');
     }
   }
 
   @action
-  togglePasswordVisibility() {
-    this.toggleProperty('isPasswordVisible');
-  }
-
-  @action
-  validateInputPassword() {
-    const isInvalidInput = !isPasswordValid(this.studentUser.password);
-    const message = isInvalidInput ? ERROR_PASSWORD_MESSAGE : '';
-    this.set('validation.password.message', message);
-  }
-
-  @action
   closePasswordReset() {
-    this.set('studentUser', null);
-    this.set('validation', null);
     this.set('isShowingModal', false);
   }
 }

--- a/orga/app/models/schooling-registration-dependent-user.js
+++ b/orga/app/models/schooling-registration-dependent-user.js
@@ -1,0 +1,9 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class SchoolingRegistrationDependentUser extends Model {
+
+  @attr() organizationId;
+  @attr() schoolingRegistrationId;
+  @attr() generatedPassword;
+
+}

--- a/orga/app/styles/globals/pix-modal.scss
+++ b/orga/app/styles/globals/pix-modal.scss
@@ -71,32 +71,38 @@
         border-radius: 8px 8px 4px 4px;
         padding: 24px;
 
-        &__title {
-          color: $white;
-          margin-bottom: 22px;
-        }
-
         button {
           font-weight: 600;
-        }
-
-        .input-password__icon {
-          &:hover, &:focus, &:active {
-            background-color: inherit;
-          }
+          margin-bottom: 16px;
         }
 
         .label {
           color: $white;
         }
 
-        .alert-input {
-          text-align: left;
+        &__warning {
+          display: flex;
+          color: $white;
+          font-size: .875rem;
+
+          .warning-icon {
+            color: $information-light;
+          }
+
+          span {
+            margin-left: 10px;
+          }
         }
 
-        .help {
-          font-size: .85rem;
-          font-weight: 400;
+        &__informations {
+          display: flex;
+          color: $white;
+          flex-direction: column;
+          font-size: .875rem;
+
+          span {
+            margin: 4px 0;
+          }
         }
       }
     }

--- a/orga/app/templates/components/password-reset-window.hbs
+++ b/orga/app/templates/components/password-reset-window.hbs
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <form {{on 'submit' this.updatePassword}}>
+    <form>
       <div class="pix-modal-body">
           {{#if @student.hasUsername}}
               <div class="input-container">
@@ -42,43 +42,35 @@
           {{/if}}
       </div>
       <div class="pix-modal-footer">
-        <div class="pix-modal-footer__title">L'élève saisit ici son nouveau mot de passe</div>
-        <div class="input-container">
-          <label for="password" class="label">Nouveau mot de passe
-            <br>
-            <span class="help">
-            (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)
-          </span>
-          </label>
-          <div class="{{if this.validation.password.message 'alert-input alert-input--error'}}" role="alert">{{this.validation.password.message}}</div>
-          <div class="input-password {{if this.validation.password.message 'input-password--error'}}">
-            <Input
-              id="update-password"
-              @name="password"
-              @type={{this.passwordInputType}}
-              @class="input"
-              @value={{this.studentUser.password}}
-              required="required"
-              @autocomplete="current-password"
-              @focusOut={{this.validateInputPassword}}
-            />
-            <button type="button" aria-label="rendre le mot de passe lisible" class="button input-password__icon" {{on 'click' this.togglePasswordVisibility}} >
-              {{#if this.isPasswordVisible}}
-                <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}>
-                  <FaIcon @icon='eye' @class="fa-fw input-password-icon__eye" />
-                </div>
-              {{else}}
-                <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}>
-                  <FaIcon @icon='eye-slash' @class="fa-fw input-password-icon__eye" />
-                </div>
-              {{/if}}
-            </button>
+        {{#unless this.isUniquePasswordVisible}}
+          <div>
+            <button type="button" class="button" {{on 'click' this.resetPassword}}>Réinitialiser le mot de passe</button>
+
+            <div class="pix-modal-footer__warning">
+              <FaIcon @icon='exclamation-triangle' @class="fa-fw warning-icon" />
+              <span>Réinitialiser supprime le mot de passe actuel de l’élève</span>
+            </div>
           </div>
-        </div>
-        {{#if this.isLoading}}
-          <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
-        {{else}}
-          <button type="submit" class="button">Modifier le mot de passe</button>
+        {{/unless}}
+        {{#if this.isUniquePasswordVisible}}
+          <div>
+            <div class="input-container">
+              <label for="generated-password" class="label">Mot de passe à usage unique</label>
+              <Input
+                id="generated-password"
+                @name="generated-password"
+                @class="input"
+                @value={{this.generatedPassword}}
+                @disabled="true"
+              />
+            </div>
+
+            <div class="pix-modal-footer__informations">
+              <span>1. Communiquez ce mot de passe à votre élève</span>
+              <span>2. L'élève se connecte avec ce mot de passe à usage unique</span>
+              <span>3. Pix lui demande de choisir un nouveau mot de passe</span>
+            </div>
+          </div>
         {{/if}}
       </div>
     </form>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -228,18 +228,10 @@ export default function() {
 
   this.get('/campaign-participation-results/:id');
 
-  this.post('/student-dependent-users/password-update', (schema, request) => {
-    const passwordForFailure = 'passwordFor01Failure';
-
-    const requestBody = JSON.parse(request.requestBody);
-    const { password } = requestBody.data.attributes;
-    if (password === passwordForFailure) {
-      return new Response(500, {}, { errors: [ { status: '500', detail: '' } ] });
-    }
-
-    const user = schema.users.find(1);
-    user.modelName = 'student-dependent-users';
-    return user;
+  this.post('/schooling-registration-dependent-users/password-update', (schema) => {
+    const schoolingRegistrationDependentUser = schema.schoolingRegistrationDependentUsers.create();
+    schoolingRegistrationDependentUser.generatedPassword = 'Passw0rd';
+    return schoolingRegistrationDependentUser;
   });
 
   this.post('/user-orga-settings', (schema, request) => {

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { find, currentURL, triggerEvent, visit, click, fillIn } from '@ember/test-helpers';
+import { find, currentURL, triggerEvent, visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -122,7 +122,7 @@ module('Acceptance | Student List', function(hooks) {
 
       module('when student authenticated by username and email', async function() {
 
-        test('it should display password update button for student', async function(assert) {
+        test('it should display password reset modal button for student', async function(assert) {
           // when
           await visit('/eleves');
 
@@ -130,34 +130,30 @@ module('Acceptance | Student List', function(hooks) {
           assert.dom('.table tbody tr:nth-child(6) td:last-child button .fa-cog').exists();
         });
 
-        test('it should update password and close modal window', async function(assert) {
+        test('it should open modal and display password reset button', async function(assert) {
           // given
           await visit('/eleves');
-          await click('.table tbody tr:nth-child(6) td:last-child button');
 
           // when
-          await fillIn('#update-password', 'Pix12345');
-          await click('button[type="submit"]');
+          await click('.table tbody tr:nth-child(6) td:last-child button');
 
           // then
-          assert.dom('.pix-modal-overlay').doesNotExist();
-          assert.dom('[data-test-notification-message="success"]').exists();
+          assert.dom('.pix-modal-overlay').exists();
+          assert.dom('.pix-modal-footer button').exists();
+          assert.dom('.pix-modal-footer button').hasText('Réinitialiser le mot de passe');
         });
 
-        test('it should close modal window when update password failed', async function(assert) {
+        test('it should display unique password input when reset button is clicked', async function(assert) {
           // given
-          const passwordForFailure = 'passwordFor01Failure';
-
           await visit('/eleves');
           await click('.table tbody tr:nth-child(6) td:last-child button');
 
           // when
-          await fillIn('#update-password', passwordForFailure);
-          await click('button[type="submit"]');
+          await click('.pix-modal-footer div button');
 
           // then
-          assert.dom('.pix-modal-overlay').doesNotExist();
-          assert.dom('[data-test-notification-message="error"]').exists();
+          assert.dom('.pix-modal-footer div button').doesNotExist();
+          assert.dom('#generated-password').exists();
         });
 
         test('it should open password modal window with email and username value', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
La procédure standard pour réinitialiser un mot de passe oublié nécessite l'envoi d'un email à l'utilisateur or, les étudiants, ne possèdent pas forcément d'adresse email. Il a été décidé de permettre, dans un premier temps, un changement de mot de passe depuis l'application Pix Orga. Cette version posant plusieurs soucis (besoin d'être en présence physique de son professeur, devoir changer son mot de passe depuis l'ordinateur du professeur), une version plus pérenne a été mise en place.   

## :robot: Solution
Depuis Pix Orga, le professeur a maintenant la possibilité de générer, pour l'élève, un nouveau mot de passe à usage unique. Ce mot de passe généré remplace l'ancien mot de passe de l'élève. Néanmoins, à la première connexion de l'élève grâce à ce mot de passe généré, ce dernier devra impérativement le modifier s'il souhaite accéder au reste de l'application (traité dans la PR https://github.com/1024pix/pix/pull/1199) 

## :rainbow: Remarques
La génération du mot de passe à usage unique s'effectue grâce à la lib randomString. Le mot de passe généré est composé de 6 lettres minuscules (hormis les lettres i, o et l) et 2 chiffres. Ce dernier ne respecte pas les standards de Pix pour les raisons suivantes:
- Plus grande facilité pour communiquer ce mot de passe à l'élève.
- Garantit que ce mot de passe temporaire ne deviendra pas le nouveau mot de passe de l'élève. 
 
## :100: Pour tester
- Se connecter à Pix Orga sur une organisation gérant des élèves.
- Aller dans l'onglet "Élèves", cliquer sur l'engrenage afin de faire apparaître la modal de gestion de compte de l'élève.
- Cliquer sur "Réinitialiser le mot de passe" afin de générer un nouveau mot de passe.
- Se connecter à l'application Pix  avec l'email/identifiant de l'élève et son mot de passe généré.
- S'assurer que l'on arrive bien sur la page de changement de mot de passe.