### PR TITLE
[TECH][FIX] Catégoriser les envois d'e-mail en alimentant la propriété TAGS (PF-1242).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,23 +1,27 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 
+const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
+const PIX_NAME = 'PIX - Ne pas répondre';
+const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
+
 function sendAccountCreationEmail(email) {
   return mailer.sendEmail({
-    template: mailer.accountCreationTemplateId,
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'PIX - Ne pas répondre',
-    subject: 'Création de votre compte PIX'
+    subject: 'Création de votre compte PIX',
+    template: mailer.accountCreationTemplateId,
   });
 }
 
 function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
   return mailer.sendEmail({
-    template: mailer.passwordResetTemplateId,
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'PIX - Ne pas répondre',
     subject: 'Demande de réinitialisation de mot de passe PIX',
+    template: mailer.passwordResetTemplateId,
     variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }
   });
 }
@@ -26,19 +30,21 @@ function sendOrganizationInvitationEmail({
   email,
   organizationName,
   organizationInvitationId,
-  code
+  code,
+  tags
 }) {
   const pixOrgaBaseUrl = settings.pixOrgaUrl;
   return mailer.sendEmail({
-    template: mailer.organizationInvitationTemplateId,
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_ORGA_NAME,
     to: email,
-    from: 'ne-pas-repondre@pix.fr',
-    fromName: 'Pix Orga - Ne pas répondre',
     subject: 'Invitation à rejoindre Pix Orga',
+    template: mailer.organizationInvitationTemplateId,
     variables: {
       organizationName,
       responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-    }
+    },
+    tags: tags || null
   });
 }
 

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -8,7 +8,7 @@ const _generateCode = () => {
 };
 
 const createOrganizationInvitation = async ({
-  organizationRepository, organizationInvitationRepository, organizationId, email
+  organizationRepository, organizationInvitationRepository, organizationId, email, tags
 }) => {
   let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
 
@@ -23,7 +23,8 @@ const createOrganizationInvitation = async ({
     email,
     organizationName,
     organizationInvitationId: organizationInvitation.id,
-    code: organizationInvitation.code
+    code: organizationInvitation.code,
+    tags
   });
 
   return organizationInvitation;

--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -1,4 +1,6 @@
+const _ = require ('lodash');
 const SibApiV3Sdk = require('sib-api-v3-sdk');
+
 const MailingProvider = require('./MailingProvider');
 const { mailing } = require('../../config');
 
@@ -18,9 +20,15 @@ function _formatPayload(options) {
       'accept': 'application/json',
     },
   };
+
   if (options.variables) {
     payload.params = options.variables;
   }
+
+  if (_.isArray(options.tags) && !_.isEmpty(options.tags)) {
+    payload.tags = options.tags;
+  }
+
   return payload;
 }
 

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 const { expect, databaseBuilder, knex } = require('../../test-helper');
 
 const BookshelfOrganizationInvitation = require('../../../lib/infrastructure/data/organization-invitation');
-
 const {
   getOrganizationByExternalId, buildInvitation, prepareDataForSending, sendJoinOrganizationInvitations
 } = require('../../../scripts/send-invitations-to-sco-organizations');
@@ -99,11 +98,12 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
         });
 
       const numberBefore = await getNumberOfOrganizationInvitations();
+      const tags = ['TEST'];
 
       await databaseBuilder.commit();
 
       // when
-      await sendJoinOrganizationInvitations(objectsForInvitations);
+      await sendJoinOrganizationInvitations(objectsForInvitations, tags);
       const numberAfter = await getNumberOfOrganizationInvitations();
       const invitationsCreatedInDatabase = numberAfter - numberBefore;
 

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -5,75 +5,94 @@ const { createOrganizationInvitation } = require('../../../../lib/domain/service
 
 describe('Unit | Service | Organization-Invitation Service', () => {
 
+  const organizationId = 1;
+  const organizationName = 'Organization Name';
+
+  const organizationInvitationId = 10;
+  const userEmailAddress = 'user@example.net';
+  const code = 'ABCDEFGH01';
+
   let organizationInvitationRepository;
   let organizationRepository;
 
   beforeEach(() => {
     organizationInvitationRepository = {
       create: sinon.stub(),
-      findOnePendingByOrganizationIdAndEmail: sinon.stub(),
+      findOnePendingByOrganizationIdAndEmail: sinon.stub().resolves(null),
     };
     organizationRepository = {
-      get: sinon.stub()
+      get: sinon.stub().resolves({ name: organizationName })
     };
-    sinon.stub(mailService, 'sendOrganizationInvitationEmail');
+    sinon.stub(mailService, 'sendOrganizationInvitationEmail').resolves();
   });
 
   describe('#createOrganizationInvitation', () => {
 
-    it('should create a new organization-invitation and send an email with organizationId, email and code', async () => {
-      // given
-      organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves(null);
+    context('when organization-invitation does not exist', () => {
 
-      const organizationInvitationId = 10;
-      const code = 'ABCDEFGH01';
-
-      const organizationName = 'Organization Name';
-      organizationRepository.get.resolves({ name: organizationName });
-
-      mailService.sendOrganizationInvitationEmail.resolves();
-
-      const organizationId = 1;
-      const email = 'member@organization.org';
-      organizationInvitationRepository.create.withArgs({
-        organizationId, email, code: sinon.match.string
-      }).resolves({ id: organizationInvitationId, code });
-
-      // when
-      await createOrganizationInvitation({
-        organizationRepository, organizationInvitationRepository, organizationId, email
+      beforeEach(() => {
+        organizationInvitationRepository.create.withArgs({
+          organizationId, email: userEmailAddress, code: sinon.match.string
+        }).resolves({ id: organizationInvitationId, code });
       });
 
-      // then
-      expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith({
-        email, organizationName, organizationInvitationId, code
+      it('should create a new organization-invitation and send an email with organizationId, email and code', async () => {
+        // given
+        const tags = undefined;
+
+        const expectedParameters = {
+          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+        };
+
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress
+        });
+
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+      });
+
+      it('should send an email with organizationId, email, code and tags', async () => {
+        // given
+        const tags = ['JOIN_ORGA'];
+
+        const expectedParameters = {
+          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+        };
+
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress, tags
+        });
+
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
       });
     });
 
-    it('should re-send an email with same code when organization-invitation already exist with status pending', async () => {
-      // given
-      const organizationId = 1;
-      const organizationName = 'Organization Name';
-      const organizationInvitationId = 100;
-      const email = 'member@organization.org';
-      const code = 'ABCDEFGH01';
-      const isPending = true;
+    context('when an organization-invitation with pending status already exists', () => {
 
-      organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves({
-        id: organizationInvitationId, isPending, code
-      });
-      organizationRepository.get.resolves({ name: organizationName });
+      it('should re-send an email with same code', async () => {
+        // given
+        const tags = undefined;
+        const isPending = true;
 
-      mailService.sendOrganizationInvitationEmail.resolves();
+        organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves({
+          id: organizationInvitationId, isPending, code
+        });
 
-      // when
-      await createOrganizationInvitation({
-        organizationRepository, organizationInvitationRepository, organizationId, email
-      });
+        const expectedParameters = {
+          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+        };
 
-      // then
-      expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith({
-        email, organizationName, organizationInvitationId, code
+        // when
+        await createOrganizationInvitation({
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress
+        });
+
+        // then
+        expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
       });
     });
   });

--- a/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
@@ -1,7 +1,9 @@
 const { sinon, expect, nock } = require('../../../test-helper');
-const SendinblueProvider = require('../../../../lib/infrastructure/mailers/SendinblueProvider');
+
 const mailCheck = require('../../../../lib/infrastructure/mail-check');
 const { mailing } = require('../../../../lib/config');
+
+const SendinblueProvider = require('../../../../lib/infrastructure/mailers/SendinblueProvider');
 
 describe('Unit | Class | SendinblueProvider', () => {
 
@@ -13,40 +15,48 @@ describe('Unit | Class | SendinblueProvider', () => {
 
   describe('#sendEmail', () => {
 
-    const recipient = 'test@example.net';
+    const senderEmailAddress = 'no-reply@example.net';
+    const userEmailAddress = 'user@example.net';
+    const templateId = 129291;
+
+    let stubbedSendinblueSMTPApi;
+    let mailingProvider;
 
     context('when mail sending is enabled', () => {
 
       beforeEach(() => {
         sinon.stub(mailing, 'enabled').value(true);
         sinon.stub(mailing, 'provider').value('sendinblue');
+
+        sinon.stub(SendinblueProvider, 'createSendinblueSMTPApi');
+        sinon.stub(mailCheck, 'checkMail').withArgs(userEmailAddress).resolves();
+
+        stubbedSendinblueSMTPApi = { sendTransacEmail: sinon.stub() };
+        SendinblueProvider.createSendinblueSMTPApi.returns(stubbedSendinblueSMTPApi);
+
+        mailingProvider = new SendinblueProvider();
       });
 
       context('when email check succeeds', () => {
 
-        beforeEach(() => {
-          sinon.stub(SendinblueProvider, 'createSendinblueSMTPApi');
-          sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
-        });
-
         it('should call the given sendinblue api instance', async () => {
           // given
-          const stubbedSibSMTPApi = { sendTransacEmail: sinon.stub() };
-          SendinblueProvider.createSendinblueSMTPApi.returns(stubbedSibSMTPApi);
-          const mailingProvider = new SendinblueProvider();
+          const options = {
+            from: senderEmailAddress, to: userEmailAddress,
+            fromName: 'Ne pas repondre', subject: 'Creation de compte',
+            template: templateId
+          };
 
-          const from = 'no-reply@example.net';
-          const email = recipient;
           const expectedPayload = {
             to: [{
-              email,
+              email: userEmailAddress,
             }],
             sender: {
               name: 'Ne pas repondre',
-              email: from,
+              email: senderEmailAddress,
             },
             subject: 'Creation de compte',
-            templateId: 129291,
+            templateId,
             headers: {
               'content-type': 'application/json',
               'accept': 'application/json',
@@ -54,16 +64,80 @@ describe('Unit | Class | SendinblueProvider', () => {
           };
 
           // when
-          await mailingProvider.sendEmail({
-            from,
-            to: email,
-            fromName: 'Ne pas repondre',
-            subject: 'Creation de compte',
-            template: '129291'
-          });
+          await mailingProvider.sendEmail(options);
 
           // then
-          expect(stubbedSibSMTPApi.sendTransacEmail).to.have.been.calledWithExactly(expectedPayload);
+          expect(stubbedSendinblueSMTPApi.sendTransacEmail).to.have.been.calledWithExactly(expectedPayload);
+        });
+
+        context('when tags property is given', () => {
+
+          it('should add tags when it is not a empty array', async () => {
+            // given
+            const tags = ['TEST'];
+
+            const options = {
+              from: senderEmailAddress, to: userEmailAddress,
+              fromName: 'Ne pas repondre', subject: 'Creation de compte',
+              template: templateId, tags
+            };
+
+            const expectedPayload = {
+              to: [{
+                email: userEmailAddress,
+              }],
+              sender: {
+                name: 'Ne pas repondre',
+                email: senderEmailAddress,
+              },
+              subject: 'Creation de compte',
+              templateId,
+              headers: {
+                'content-type': 'application/json',
+                'accept': 'application/json',
+              },
+              tags
+            };
+
+            // when
+            await mailingProvider.sendEmail(options);
+
+            // then
+            expect(stubbedSendinblueSMTPApi.sendTransacEmail).to.have.been.calledWithExactly(expectedPayload);
+          });
+
+          it('should not add tags when it is empty', async () => {
+            // given
+            const tags = null;
+
+            const options = {
+              from: senderEmailAddress, to: userEmailAddress,
+              fromName: 'Ne pas repondre', subject: 'Creation de compte',
+              template: templateId, tags
+            };
+
+            const expectedPayload = {
+              to: [{
+                email: userEmailAddress,
+              }],
+              sender: {
+                name: 'Ne pas repondre',
+                email: senderEmailAddress,
+              },
+              subject: 'Creation de compte',
+              templateId,
+              headers: {
+                'content-type': 'application/json',
+                'accept': 'application/json',
+              }
+            };
+
+            // when
+            await mailingProvider.sendEmail(options);
+
+            // then
+            expect(stubbedSendinblueSMTPApi.sendTransacEmail).to.have.been.calledWithExactly(expectedPayload);
+          });
         });
       });
     });


### PR DESCRIPTION
## 🦄 Problème
Dans Sendinblue, après l'envoie d'e-mails (générés par un script ad hoc cf. api/scripts/send-invitations-to-sco-organizations.js), on veut faciliter le suivi de ces e-mails envoyés en masse.

Le dashbord Sendinblue propose une propriété "tags".
Actuellement les services e-mail de l'API ne l'utilisent pas.

## 📫 Solution
On va exploiter cette propriété dans le mailService de l'API, et l'utiliser dans api/scripts/send-invitations-to-sco-organizations.js.

## 🌈 Remarques
Cette implémentation intègre le correctif de la PF-1213.