### PR TITLE
[FEATURE] Appliquer une recherche stricte sur le filtre de la colonne ID dans la liste des sessions sur PixAdmin (PA-202)

### DIFF
--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -135,7 +135,7 @@ module.exports = {
       .query((qb) => {
         const { id } = filters;
         if (id) {
-          qb.whereRaw('CAST(id as TEXT) LIKE ?', `%${id.toString()}%`);
+          qb.where({ id });
         }
       })
       .fetchPage({ page: page.number, pageSize: page.size });

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -51,7 +51,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should return a 200 status code with paginated and filtered data', async () => {
         // given
-        options.url = '/api/sessions?filter[id]=2&page[number]=1&page[size]=2';
+        options.url = '/api/sessions?filter[id]=121&page[number]=1&page[size]=2';
         const expectedMetaData = { page: 1, pageSize: 2, rowCount: 1, pageCount: 1 };
 
         // when

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -538,9 +538,9 @@ describe('Integration | Repository | Session', function() {
           return databaseBuilder.commit();
         });
 
-        it('should apply the filter and return the appropriate results', async () => {
+        it('should apply the strict filter and return the appropriate results', async () => {
           // given
-          const filters = { id: 2 };
+          const filters = { id: expectedSession.id };
           const page = { number: 1, size: 10 };
           const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
 


### PR DESCRIPTION
## :unicorn: Problème
Le filtre sur la colonne ID de la liste des sessions paginée est un filtre "lâche" de type `LIKE %<value>%`.
Cela ne s'avère pas très pratique, car en général quand on recherche par id, on a un id fixe ( :laughing: ) et on se retrouve avec une liste de sessions qui comprend des résultats non voulus. Typiquement, sur une liste de 5000 sessions, si on souhaite rechercher la session d'ID 22, on se retrouve avec toutes les sessions dont l'id contient 22....

## :robot: Solution
Une recherche stricte sur le champ ID dans la méthode de repo !

## :rainbow: Remarques
Sans parler du petit gain en perf sur cette recherche.... Une recherche sur un LIKE '%..%' c'est forcément en Scan séquentiel, alors que la recherche direct par ID en revanche... :+1: 

## :100: Pour tester
Connectez-vous sur PixAdmin via le compte PixMaster, et testez la recherche sur le champ ID dans la liste des sessions. Je vais m'assurer d'ajouter suffisamment de sessions pour pouvoir correctement tester la modification.
