### PR TITLE
[TECH] Tester la présence d'un ID et pas sa valeur dans le test auto sur les tutos (PF-1244)

### DIFF
--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -62,7 +62,7 @@ describe('Acceptance | Controller | user-tutorial-controller', () => {
         // then
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.type).to.deep.equal(expectedUserTutorial.data.type);
-        expect(response.result.data.id).to.deep.equal(expectedUserTutorial.data.id);
+        expect(response.result.data.id).to.exist;
         expect(response.result.data.attributes['user-id']).to.deep.equal(expectedUserTutorial.data.attributes['user-id']);
         expect(response.result.data.attributes['tutorial-id']).to.deep.equal(expectedUserTutorial.data.attributes['tutorial-id']);
       });


### PR DESCRIPTION
## :unicorn: Problème
Le test ``should respond with a 201 and return user-tutorial created`` ne passe pas si on le lance plusieurs fois sans rafraîchir la base. 
Il teste la valeur d'un id généré par une séquence. 
Bien que la table soit vidée après chaque test, la séquence n'est pas réinitialisée.

## :robot: Solution
On teste la présence d'un id mais pas sa valeur elle-même. 

## :rainbow: Remarques
On pourrait continuer à tester la valeur de l'identifiant mais il faudrait pour cela réinitialiser la séquence ce qui nécessite une requête native PostgreSQL :
``return knex.raw('TRUNCATE TABLE "user_tutorials" RESTART IDENTITY');``

## :100: Pour tester
Lancer plusieurs fois le test sans relancer de db:reset
