### PR TITLE
[FEATURE] Ajout de la date de diffusion au prescripteur dans la liste des sessions sur PixAdmin (PA-189)

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -10,6 +10,7 @@
         <th>Date de finalisation</th>
         <th>Nombre de certifications publiées</th>
         <th>Date de publication</th>
+        <th>Date de diffusion au prescripteur</th>
       </tr>
       <tr>
         <th>
@@ -18,6 +19,7 @@
                  @key-up={{fn @triggerFiltering "id" @id}}
                  class="table-admin-input" />
         </th>
+        <th></th>
         <th></th>
         <th></th>
         <th></th>
@@ -43,6 +45,7 @@
           <td>{{session.displayFinalizationDate}}</td>
           <td>{{session.countPublishedCertifications}}</td>
           <td>{{session.displayPublishedAtDate}}</td>
+          <td>{{session.displayResultsSentToPrescriberDate}}</td>
         </tr>
       {{/each}}
       </tbody>

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -15,14 +15,19 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     const sessions = [
       { id: 1, certificationCenterName: 'Centre A', certificationCenter: { type: 'SUP' },
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 0, displayFinalizationDate: '', displayPublishedAtDate: ''
+        displayStatus, countPublishedCertifications: 0, displayFinalizationDate: '', displayPublishedAtDate: '',
+        displayResultsSentToPrescriberDate: '',
       },
       { id: 2, certificationCenterName: 'Centre B', certificationCenter: { type: null },
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate' },
+        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
+        displayResultsSentToPrescriberDate: 'SomeRDate',
+      },
       { id: 3, certificationCenterName: 'Centre C',
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate' },
+        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
+        displayResultsSentToPrescriberDate: 'SomeRDate',
+      },
     ];
 
     sessions.meta = { rowCount: 3 };
@@ -44,6 +49,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(6)`).hasText(sessions[i].displayFinalizationDate);
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(7)`).hasText(sessions[i].countPublishedCertifications.toString());
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(8)`).hasText(sessions[i].displayPublishedAtDate);
+      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(9)`).hasText(sessions[i].displayResultsSentToPrescriberDate);
     }
     assert.dom('table tbody tr:nth-child(1) td:nth-child(3)').hasText(sessions[0].certificationCenter.type);
     assert.dom('table tbody tr:nth-child(2) td:nth-child(3)').hasText('-');

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -100,6 +100,7 @@ module.exports = {
         'time',
         'status',
         'finalizedAt',
+        'resultsSentToPrescriberAt',
         'publishedAt',
         'certifications',
         'certificationCenter',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-serializer_test.js
@@ -233,6 +233,7 @@ describe('Unit | Serializer | JSONAPI | session-serializer', function() {
             status: statuses.PROCESSED,
             'finalized-at': new Date('2020-02-17T14:23:56Z'),
             'published-at': new Date('2020-02-21T14:23:56Z'),
+            'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
           },
           relationships: {
             certifications: {


### PR DESCRIPTION
## :unicorn: Contexte
Le pôle certification souhaite pouvoir lire la date d'envoi des résultats au prescripteur par session depuis la liste des sessions paginées sur PixAdmin

## :robot: Solution
Ajouter la colonne !

## :rainbow: Remarques

## :100: Pour tester
Rendez-vous sur PixAdmin ETQ pixmaster@example.net pix123, puis sur la liste des sessions et constater l'apparition de la date pour les sessions dont les résultats ont été marqués comme envoyés au prescripteur. Pour mettre une session dans cet état là, rendez-vous sur la page de détails d'une session finalisée mais qui n'a pas encore de date d'envoi des résultats au prescripteur, cliquer sur le bouton **Résultats transmis au prescripteur** et constater l'apparition de la valeur dans la colonne appropriée sur la liste paginée.
