### PR TITLE
[FEATURE] Ordonner la liste des sessions paginée dans PixAdmin de sorte à remonter les sessions à traiter en premier par le pôle certification (PA-178)

### DIFF
--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -85,6 +85,28 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     finalizedAt: new Date('2020-05-05T15:00:34Z'),
     publishedAt: new Date('2020-06-05T15:00:34Z'),
   });
+
+  // Some sessions to illustrate paginated sessions list order in PixAdmin
+  databaseBuilder.factory.buildSession({
+    certificationCenter, certificationCenterId, address, room, examiner, date , time,
+    finalizedAt: null,
+    publishedAt: null,
+  });
+  databaseBuilder.factory.buildSession({
+    certificationCenter, certificationCenterId,
+    finalizedAt: new Date('2018-01-01T00:00:00Z'),
+    publishedAt: null,
+  });
+  databaseBuilder.factory.buildSession({
+    certificationCenter, certificationCenterId,
+    finalizedAt: new Date('2018-01-02T00:00:00Z'),
+    publishedAt: null,
+  });
+  databaseBuilder.factory.buildSession({
+    certificationCenter, certificationCenterId, address, room, examiner, date , time,
+    finalizedAt: new Date('2018-01-02T00:00:00Z'),
+    publishedAt: new Date('2018-01-03T00:00:00Z'),
+  });
 }
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -137,6 +137,8 @@ module.exports = {
         if (id) {
           qb.where({ id });
         }
+        qb.orderByRaw('?? ASC NULLS FIRST', 'publishedAt');
+        qb.orderByRaw('?? ASC', 'finalizedAt');
       })
       .fetchPage({ page: page.number, pageSize: page.size });
 

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -502,6 +502,37 @@ describe('Integration | Repository | Session', function() {
       });
     });
 
+    context('orders', () => {
+      let firstSessionId;
+      let secondSessionId;
+      let thirdSessionId;
+      let fourthSessionId;
+
+      beforeEach(() => {
+        firstSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-01T00:00:00Z'), resultsSentToPrescriberAt: null }).id;
+        secondSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-02T00:00:00Z'), resultsSentToPrescriberAt: null }).id;
+        thirdSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-02T00:00:00Z'), resultsSentToPrescriberAt: new Date('2020-01-03T00:00:00Z') }).id;
+        fourthSessionId = databaseBuilder.factory.buildSession({ finalizedAt: null, resultsSentToPrescriberAt: null }).id;
+
+        return databaseBuilder.commit();
+      });
+
+      it('should order sessions by returning first finalized but not published, then neither of those, and finally the processed ones', async () => {
+        // given
+        const filters = {};
+        const page = { number: 1, size: 10 };
+
+        // when
+        const { sessions: matchingSessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+        // then
+        expect(matchingSessions[0].id).to.equal(firstSessionId);
+        expect(matchingSessions[1].id).to.equal(secondSessionId);
+        expect(matchingSessions[2].id).to.equal(thirdSessionId);
+        expect(matchingSessions[3].id).to.equal(fourthSessionId);
+      });
+    });
+
     context('filters', () => {
 
       context('when there are ignored filters', () => {


### PR DESCRIPTION
## :unicorn: Contexte
L'idée générale de l'EPIX de gestion des sessions dans PixAdmin est d'éviter au pôle certification de multiplier les outils et les interfaces quant à leur tâche de traitement des sessions de certification. L'objectif principal de l'EPIX en cours est de complètement ANNIHILER l'usage d'un google sheet partagé au sein du pôle certif qui permet le suivi des sessions de certification.

Afin de faciliter le traitement des sessions, on souhaite présenter les sessions de certification, au sein de la liste paginée, selon l'ordre suivant :
Faire remonter les sessions finalisées mais NON publiées, de la session la plus anciennement finalisée à la plus récente.

## :robot: Solution
Mettre en place les clauses `ORDER BY` adéquates dans la méthode de répo.
Le plus important ici est d'être attentif sur l'ordre des valeurs NULLs.

## :rainbow: Remarques

## :100: Pour tester
RDV sur PixAdmin dans la liste des sessions paginée. On constate que les sessions finalisées non publiées sont remontées dans la liste, en ordre selon leur date de finalisation.
