### PR TITLE
[CLEANUP] Appliquer la règle eslint no-get dans PixApp (PF-1247).

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   rules: {
     'ember/avoid-leaking-state-in-ember-objects': 'off',
+    'ember/no-get': 'error',
     'ember/no-empty-attrs': 'error',
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   rules: {
     'ember/avoid-leaking-state-in-ember-objects': 'off',
-    'ember/no-get': 'error',
+    'ember/no-get': ['error', { ignoreNestedPaths : true }],
     'ember/no-empty-attrs': 'error',
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   rules: {
     'ember/avoid-leaking-state-in-ember-objects': 'off',
-    'ember/no-get': ['error', { ignoreNestedPaths : true }],
+    'ember/no-get': ['error'],
     'ember/no-empty-attrs': 'error',
     'ember/no-new-mixins': 'off',
     'ember/no-restricted-resolver-tests': 'off',
@@ -36,7 +36,7 @@ module.exports = {
         'multi-line-function',
       ]
     }],
-    /* Rules recommanded */
+    /* Recommended rules */
     'ember/no-mixins': 'off',
     'ember/no-jquery': 'off',
     'ember/require-computed-property-dependencies': 'off',

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -35,7 +35,14 @@ module.exports = {
         'single-line-function',
         'multi-line-function',
       ]
-    }]
+    }],
+    /* Rules recommanded */
+    'ember/no-mixins': 'off',
+    'ember/no-jquery': 'off',
+    'ember/require-computed-property-dependencies': 'off',
+    'ember/no-private-routing-service': 'off',
+    'ember/require-computed-macros': 'off',
+
   },
   overrides: [
     // node files

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -19,7 +19,7 @@ const ChallengeItemGeneric = Component.extend({
 
   init() {
     this._super(...arguments);
-    if (!_.isInteger(this.get('challenge.timer'))) {
+    if (!_.isInteger(this.challenge.timer)) {
       this._start();
     }
   },
@@ -51,7 +51,7 @@ const ChallengeItemGeneric = Component.extend({
   }),
 
   hasTimerDefined() {
-    return _.isInteger(this.get('challenge.timer'));
+    return _.isInteger(this.challenge.timer);
   },
 
   _getTimeout() {
@@ -86,16 +86,16 @@ const ChallengeItemGeneric = Component.extend({
         if (this._hasError()) {
 
           const errorMessage = this._getErrorMessage();
-          
+
           this.set('errorMessage', errorMessage);
 
           return;
         }
-        
+
         this.set('errorMessage', null);
         this.set('_isUserAwareThatChallengeIsTimed', false);
         this.set('isValidateButtonEnabled', false);
-        
+
         return this.answerValidated(this.challenge, this.assessment, this._getAnswerValue(), this._getTimeout(), this._getElapsedTime())
           .finally(() => this.set('isValidateButtonEnabled', true));
       }

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
+import _ from 'lodash';
 
 @classic
 @classNames('challenge-statement')
@@ -12,14 +13,15 @@ export default class ChallengeStatement extends Component {
 
   challenge = null;
   assessment = null;
+  selectedAttachmentUrl = null;
 
   didReceiveAttrs() {
-    this.set('selectedAttachmentUrl', this.get('challenge.attachments.firstObject'));
+    this.selectedAttachmentUrl =  _.get(this.challenge, 'attachments.firstObject');
   }
 
   @computed('challenge.instruction')
   get challengeInstruction() {
-    const instruction = this.get('challenge.instruction');
+    const instruction = this.challenge.instruction;
     if (!instruction) {
       return null;
     }
@@ -28,24 +30,25 @@ export default class ChallengeStatement extends Component {
 
   @computed('challenge.hasValidEmbedDocument')
   get challengeEmbedDocument() {
-    if (this.get('challenge.hasValidEmbedDocument')) {
+    if (this.challenge.hasValidEmbedDocument) {
       return {
-        url: this.get('challenge.embedUrl'),
-        title: this.get('challenge.embedTitle'),
-        height: this.get('challenge.embedHeight')
+        url: this.challenge.embedUrl,
+        title: this.challenge.embedTitle,
+        height: this.challenge.embedHeight
       };
     }
     return undefined;
   }
 
-  init() {
-    super.init(...arguments);
-    this.id = 'challenge_statement_' + this.get('challenge.id');
+  @computed('challenge.id')
+  get id() {
+    return 'challenge_statement_' + this.challenge.id;
+
   }
 
   @computed('challenge.attachments')
   get attachmentsData() {
-    return this.get('challenge.attachments');
+    return this.challenge.attachments;
   }
 
   @action
@@ -55,6 +58,6 @@ export default class ChallengeStatement extends Component {
 
   _formattedEmailForInstruction() {
     return this.mailGenerator
-      .generateEmail(this.get('challenge.id'), this.get('assessment.id'), window.location.hostname, config.environment);
+      .generateEmail(this.challenge.id, this.assessment.id, window.location.hostname, config.environment);
   }
 }

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -68,7 +68,7 @@ export default class ComparisonWindow extends Component {
   @computed('answer.result')
   get resultItem() {
     let resultItem = TEXT_FOR_RESULT['default'];
-    const answerStatus = this.get('answer.result');
+    const answerStatus = this.answer.result;
 
     if (answerStatus && (answerStatus in TEXT_FOR_RESULT)) {
       resultItem = TEXT_FOR_RESULT[answerStatus];
@@ -78,6 +78,6 @@ export default class ComparisonWindow extends Component {
 
   @computed('resultItem')
   get resultItemIcon() {
-    return resultIconUrl(this.get('resultItem.status'));
+    return resultIconUrl(this.resultItem.status);
   }
 }

--- a/mon-pix/app/components/learning-more-panel.js
+++ b/mon-pix/app/components/learning-more-panel.js
@@ -10,6 +10,6 @@ export default class LearningMorePanel extends Component {
 
   @computed('learningMoreTutorials.length')
   get hasLearningMoreItems() {
-    return this.get('learningMoreTutorials.length') > 0;
+    return this.learningMoreTutorials.length > 0;
   }
 }

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -36,15 +36,15 @@ export default class ProgressBar extends Component {
     'assessment.{hasCheckpoints,certificationCourse.nbChallenges,course.nbChallenges}'
   )
   get maxStepsNumber() {
-    if (this.get('assessment.hasCheckpoints')) {
+    if (this.assessment.hasCheckpoints) {
       return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
     }
 
     if (this.assessment.isCertification) {
-      return this.get('assessment.certificationCourse.nbChallenges');
+      return this.assessment.get('certificationCourse.nbChallenges');
     }
 
-    return this.get('assessment.course.nbChallenges');
+    return this.assessment.get('course.nbChallenges');
   }
 
   @computed('currentStepIndex')

--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -22,10 +22,10 @@ export default class QcmSolutionPanel extends Component {
 
   @computed('answer')
   get labeledCheckboxes() {
-    const answer = this.get('answer.value');
+    const answer = this.answer.value;
     let checkboxes  = [];
     if (_.isNonEmptyString(answer)) {
-      const proposals = this.get('challenge.proposals');
+      const proposals = this.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       checkboxes = labeledCheckboxes(proposalsArray, answerArray);

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -22,10 +22,10 @@ export default class QcuSolutionPanel extends Component {
 
   @computed('answer')
   get labeledRadios() {
-    const answer = this.get('answer.value');
+    const answer = this.answer.value;
     let radiosArray = [];
     if (_.isNonEmptyString(answer)) {
-      const proposals = this.get('challenge.proposals');
+      const proposals = this.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       radiosArray = labeledCheckboxes(proposalsArray, answerArray);

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -15,17 +15,17 @@ export default class QrocSolutionPanel extends Component {
 
   @computed('answer.result')
   get inputClass() {
-    return classByResultValue[this.get('answer.result')] || '';
+    return classByResultValue[this.answer.result] || '';
   }
 
   @computed('answer')
   get isResultOk() {
-    return this.get('answer.result') === 'ok';
+    return this.answer.result === 'ok';
   }
 
   @computed('answer')
   get answerToDisplay() {
-    const answer = this.get('answer.value');
+    const answer = this.answer.value;
     if (answer === '#ABAND#') {
       return 'Pas de réponse';
     }

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -18,9 +18,9 @@ const classByResultValue = {
 export default class QrocmDepSolutionPanel extends Component {
   @computed('challenge.proposals', 'answer.value')
   get inputFields() {
-    const escapedProposals = this.get('challenge.proposals').replace(/(\n\n|\n)/gm, '<br>');
+    const escapedProposals = this.challenge.proposals.replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.get('answer.value'), _.keys(labels));
+    const answers = answersAsObject(this.answer.value, _.keys(labels));
 
     return Object.keys(labels).map((key) => {
       const answerIsEmpty = answers[key] === '';

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -30,11 +30,11 @@ class QrocmIndSolutionPanel extends Component {
   @computed('challenge.proposals', 'answer.value', 'solution')
   get inputFields() {
 
-    const escapedProposals = this.get('challenge.proposals').replace(/(\n\n|\n)/gm, '<br>');
+    const escapedProposals = this.challenge.proposals.replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.get('answer.value'), _.keys(labels));
+    const answers = answersAsObject(this.answer.value, _.keys(labels));
     const solutions = solutionsAsObject(this.solution);
-    const resultDetails = resultDetailsAsObject(this.get('answer.resultDetails'));
+    const resultDetails = resultDetailsAsObject(this.answer.resultDetails);
 
     const inputFields = [];
 

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -32,7 +32,7 @@ export default class ResetPasswordForm extends Component {
 
   @action
   validatePassword() {
-    const password = this.get('user.password');
+    const password = this.user.password;
     const validationStatus = (isPasswordValid(password)) ? 'default' : 'error';
     this.set('validation', VALIDATION_MAP[validationStatus]);
   }

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -35,8 +35,8 @@ export default Component.extend({
   openComparison: null,
 
   resultItem: computed('answer.result', function() {
-    if (!this.get('answer.result')) return;
-    return contentReference[this.get('answer.result')];
+    if (!this.answer.result) return;
+    return contentReference[this.answer.result];
   }),
 
   resultTooltip: computed('resultItem', function() {
@@ -45,7 +45,7 @@ export default Component.extend({
 
   validationImplementedForChallengeType: computed('answer.challenge.type', function() {
     const implementedTypes = ['QCM', 'QROC', 'QCU', 'QROCM-ind', 'QROCM-dep'];
-    const challengeType = this.get('answer.challenge.type');
+    const challengeType = this.answer.get('challenge.type');
     return implementedTypes.includes(challengeType);
   }),
 

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -197,9 +197,9 @@ export default class RegisterForm extends Component {
     }
 
     if (this.loginWithUsername) {
-      await this._authenticate(this.get('studentDependentUser.username'), this.get('studentDependentUser.password'));
+      await this._authenticate(this.studentDependentUser.username, this.studentDependentUser.password);
     } else {
-      await this._authenticate(this.get('studentDependentUser.email'), this.get('studentDependentUser.password'));
+      await this._authenticate(this.studentDependentUser.email, this.studentDependentUser.password);
     }
 
     this.set('studentDependentUser.password', null);
@@ -263,7 +263,7 @@ export default class RegisterForm extends Component {
   }
 
   _updateInputsStatus() {
-    const errors = this.get('studentDependentUser.errors');
+    const errors = this.studentDependentUser.errors;
     errors.forEach(({ attribute, message }) => {
       const statusObject = 'validation.' + attribute + '.status';
       const messageObject = 'validation.' + attribute + '.message';

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -68,9 +68,9 @@ export default class RegisterForm extends Component {
 
   @computed('email', 'username', 'password')
   get isCreationFormNotValid() {
-    const isPasswordNotValid = !isPasswordValid(this.get('password'));
-    const isUsernameNotValid = !isStringValid(this.get('username'));
-    const isEmailNotValid = !isEmailValid(this.get('email'));
+    const isPasswordNotValid = !isPasswordValid(this.password);
+    const isUsernameNotValid = !isStringValid(this.username);
+    const isEmailNotValid = !isEmailValid(this.email);
     if (this.loginWithUsername) {
       return isUsernameNotValid || isPasswordNotValid;
     }
@@ -177,10 +177,10 @@ export default class RegisterForm extends Component {
     try {
       this.set('studentDependentUser.password', this.password);
       if (this.loginWithUsername) {
-        this.set('studentDependentUser.username', this.get('username'));
+        this.set('studentDependentUser.username', this.username);
         this.set('studentDependentUser.email', undefined);
       } else {
-        this.set('studentDependentUser.email', this.get('email'));
+        this.set('studentDependentUser.email', this.email);
         this.set('studentDependentUser.username', undefined);
       }
       await this.studentDependentUser.save({

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -17,27 +17,27 @@ export default class ScorecardDetails extends Component {
 
   @computed('scorecard.{level,isNotStarted}')
   get level() {
-    return this.get('scorecard.isNotStarted') ? null : this.get('scorecard.level');
+    return this.scorecard.isNotStarted ? null : this.scorecard.level;
   }
 
   @computed('scorecard.{isMaxLevel,isNotStarted,isFinished}')
   get isProgressable() {
-    return !(this.get('scorecard.isFinished') || this.get('scorecard.isMaxLevel') || this.get('scorecard.isNotStarted'));
+    return !(this.scorecard.isFinished || this.scorecard.isMaxLevel || this.scorecard.isNotStarted);
   }
 
   @computed('scorecard.remainingDaysBeforeReset')
   get displayWaitSentence() {
-    return this.get('scorecard.remainingDaysBeforeReset') > 0;
+    return this.scorecard.remainingDaysBeforeReset > 0;
   }
 
   @computed('scorecard.remainingDaysBeforeReset')
   get displayResetButton() {
-    return this.get('scorecard.remainingDaysBeforeReset') === 0;
+    return this.scorecard.remainingDaysBeforeReset === 0;
   }
 
   @computed('scorecard.remainingDaysBeforeReset')
   get remainingDaysText() {
-    const daysBeforeReset = this.get('scorecard.remainingDaysBeforeReset');
+    const daysBeforeReset = this.scorecard.remainingDaysBeforeReset;
     return `Remise à zéro disponible dans ${daysBeforeReset} ${daysBeforeReset <= 1 ? 'jour' : 'jours'}`;
   }
 
@@ -75,7 +75,7 @@ export default class ScorecardDetails extends Component {
 
   @action
   reset() {
-    this.scorecard.save({ adapterOptions: { resetCompetence: true, userId: this.currentUser.user.id, competenceId: this.get('scorecard.competenceId') } });
+    this.scorecard.save({ adapterOptions: { resetCompetence: true, userId: this.currentUser.user.id, competenceId: this.scorecard.competenceId } });
 
     this.set('showResetModal', false);
   }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -97,7 +97,7 @@ export default Component.extend({
   },
 
   _updateInputsStatus() {
-    const errors = this.get('user.errors');
+    const errors = this.user.errors;
     errors.forEach(({ attribute, message }) => {
       this._updateValidationStatus(attribute, 'error', message);
     });
@@ -143,7 +143,7 @@ export default Component.extend({
       this._trimNamesAndEmailOfUser();
 
       this.user.save().then(() => {
-        const credentials = { login: this.get('user.email'), password: this.get('user.password') };
+        const credentials = { login: this.user.email, password: this.user.password };
         this.authenticateUser(credentials);
         this.set('_tokenHasBeenUsed', true);
         this.set('user.password', null);

--- a/mon-pix/app/components/user-certifications-detail-area.js
+++ b/mon-pix/app/components/user-certifications-detail-area.js
@@ -10,6 +10,6 @@ export default class UserCertificationsDetailArea extends Component {
 
   @computed('area.resultCompetences.[]')
   get sortedCompetences() {
-    return this.get('area.resultCompetences').sortBy('index');
+    return this.area.resultCompetences.sortBy('index');
   }
 }

--- a/mon-pix/app/components/user-certifications-detail-profile.js
+++ b/mon-pix/app/components/user-certifications-detail-profile.js
@@ -10,6 +10,6 @@ export default class UserCertificationsDetailProfile extends Component {
 
   @computed('resultCompetenceTree.areas.[]')
   get sortedAreas() {
-    return this.get('resultCompetenceTree.areas').sortBy('code');
+    return this.resultCompetenceTree.areas.sortBy('code');
   }
 }

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -20,7 +20,7 @@ export default class UserLoggedMenu extends Component.extend(EmberKeyboardMixin)
 
   @computed('routing.currentRouteName')
   get canDisplayLinkToProfile() {
-    const currentRouteName = this.get('routing.currentRouteName');
+    const currentRouteName = this.routing.currentRouteName;
 
     return currentRouteName !== 'profile';
   }

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -24,12 +24,12 @@ export default class CheckpointController extends Controller {
 
   @computed('finalCheckpoint', 'model.progression.completionPercentage')
   get completionPercentage() {
-    return this.finalCheckpoint ? 100 : this.get('model.progression.completionPercentage');
+    return this.finalCheckpoint ? 100 : this.model.get('progression.completionPercentage');
   }
 
   @computed('model.answersSinceLastCheckpoints')
   get shouldDisplayAnswers() {
-    return !!this.get('model.answersSinceLastCheckpoints.length');
+    return !!this.model.answersSinceLastCheckpoints.length;
   }
 
   @computed('finalCheckpoint')

--- a/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
@@ -18,7 +18,7 @@ export default Controller.extend({
         this.set('isLoading', true);
         return this.start(this.model, participantExternalId);
       } else {
-        return this.set('errorMessage', `Merci de renseigner votre ${this.get('model.idPixLabel')}.`);
+        return this.set('errorMessage', `Merci de renseigner votre ${ this.model.idPixLabel }.`);
       }
     },
 

--- a/mon-pix/app/controllers/campaigns/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/send-profile.js
@@ -6,6 +6,7 @@ export default class SendProfileController extends Controller {
 
   @tracked isLoading = false;
   @tracked errorMessage = null;
+  pageTitle = 'Envoyer mon profil';
 
   @action
   async sendProfile() {
@@ -14,13 +15,14 @@ export default class SendProfileController extends Controller {
 
     const campaignParticipation = this.model.campaignParticipation;
     campaignParticipation.isShared = true;
-
-    try {
-      await campaignParticipation.save();
-    } catch (error) {
-      campaignParticipation.rollbackAttributes();
-      this.errorMessage = true;
-    }
-    this.isLoading = false;
+    return campaignParticipation.save()
+      .then(() => {
+        this.isLoading = false;
+      })
+      .catch(() => {
+        campaignParticipation.rollbackAttributes();
+        this.isLoading = false;
+        this.errorMessage = true;
+      });
   }
 }

--- a/mon-pix/app/controllers/campaigns/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/skill-review.js
@@ -14,8 +14,8 @@ export default class SkillReviewController extends Controller {
     'model.{campaignParticipation.campaignParticipationResult.badge,campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled}'
   )
   get shouldShowBadge() {
-    const badge = this.get('model.campaignParticipation.campaignParticipationResult.badge.content');
-    const areBadgeCriteriaFulfilled = this.get('model.campaignParticipation.campaignParticipationResult.areBadgeCriteriaFulfilled');
+    const badge = this.model.campaignParticipation.get('campaignParticipationResult.badge.content');
+    const areBadgeCriteriaFulfilled = this.model.campaignParticipation.get('campaignParticipationResult.areBadgeCriteriaFulfilled');
     return (!_.isEmpty(badge) && areBadgeCriteriaFulfilled);
   }
 
@@ -23,7 +23,7 @@ export default class SkillReviewController extends Controller {
   shareCampaignParticipation() {
     this.set('displayErrorMessage', false);
     this.set('displayLoadingButton', true);
-    const campaignParticipation = this.get('model.campaignParticipation');
+    const campaignParticipation = this.model.campaignParticipation;
     campaignParticipation.set('isShared', true);
     return campaignParticipation.save()
       .then(() => {
@@ -38,8 +38,8 @@ export default class SkillReviewController extends Controller {
 
   @action
   async improvementCampaignParticipation() {
-    const assessment = this.get('model.assessment');
-    const campaignParticipation = this.get('model.campaignParticipation');
+    const assessment = this.model.assessment;
+    const campaignParticipation = this.model.campaignParticipation;
     await campaignParticipation.save({ adapterOptions: { beginImprovement: true } });
     return this.transitionToRoute('campaigns.start-or-resume', assessment.get('codeCampaign'));
   }

--- a/mon-pix/app/routes/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/routes/campaigns/campaign-landing-page.js
@@ -27,6 +27,6 @@ export default class CampaignLandingPageRoute extends Route {
   }
 
   _userIsUnauthenticated() {
-    return this.get('session.isAuthenticated') === false;
+    return this.session.isAuthenticated === false;
   }
 }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -86,7 +86,7 @@ export default class StartOrResumeRoute extends Route.extend(AuthenticatedRouteM
   }
 
   _userIsUnauthenticated() {
-    return this.get('session.isAuthenticated') === false;
+    return this.session.isAuthenticated === false;
   }
 
   _thereIsNoAssessment(assessments) {

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -1,7 +1,10 @@
 import getCampaignParticipationResult from './routes/get-campaign-participation-result';
 import getCampaigns from './routes/get-campaigns';
+import getCertifications from './routes/get-certifications';
 import getChallenge from './routes/get-challenge';
 import getChallenges from './routes/get-challenges';
+import getCompetenceEvaluations from './routes/get-competence-evaluations';
+import getProgression from './routes/get-progression';
 import getScorecard from './routes/get-scorecard';
 import getScorecardsTutorials from './routes/get-scorecards-tutorials';
 import postCompetenceEvaluation from './routes/post-competence-evaluation';
@@ -43,15 +46,15 @@ export default function() {
 
   this.get('/campaign-participations/:id/campaign-participation-result', getCampaignParticipationResult);
 
-  this.get('/certifications');
+  this.get('/certifications', getCertifications);
 
   this.get('/challenges', getChallenges);
   this.get('/challenges/:id', getChallenge);
 
-  this.get('/competence-evaluations');
+  this.get('/competence-evaluations', getCompetenceEvaluations);
   this.post('/competence-evaluations/start-or-resume', postCompetenceEvaluation);
 
-  this.get('/progressions/:id');
+  this.get('/progressions/:id', getProgression);
 
   this.get('/scorecards/:id', getScorecard);
   this.get('/scorecards/:id/tutorials', getScorecardsTutorials);

--- a/mon-pix/mirage/routes/get-certifications.js
+++ b/mon-pix/mirage/routes/get-certifications.js
@@ -1,0 +1,3 @@
+export default function(schema) {
+  return schema.certifications.all();
+}

--- a/mon-pix/mirage/routes/get-competence-evaluations.js
+++ b/mon-pix/mirage/routes/get-competence-evaluations.js
@@ -1,0 +1,3 @@
+export default function(schema) {
+  return schema.competenceEvaluations.all();
+}

--- a/mon-pix/mirage/routes/get-progression.js
+++ b/mon-pix/mirage/routes/get-progression.js
@@ -1,0 +1,11 @@
+export default function(schema, request) {
+  const { id } = request.params;
+
+  let progression = schema.progression.find(id);
+
+  if (!progression) {
+    progression = schema.scorecards.create({});
+  }
+
+  return progression;
+}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -16648,9 +16648,9 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.13.0.tgz",
-      "integrity": "sha512-qIbw4uP0qUJoiWF4+7MTJWqwEN86RGmBNId0cwSoHoVNWtcw50R1ajYgxM1Q5FVUdoisVeSl9lKVRh5zkDFl+g==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-8.4.0.tgz",
+      "integrity": "sha512-jzSpyA3+aQrEHydo3Tz8cNAbgmtYVlp0eSe8X52OsHYLdVc7i4vzMwA+ptfO06dzpLQNHWW5ziprB5hoAEt95A==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -16648,9 +16648,9 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.8.1.tgz",
-      "integrity": "sha512-74Whm5MHV+llWv0LA/4b4IaLQxMTj5Jc1zoK11gYEPQbPIAviTF4JsRuzPM/x7QMo5pQZyTdfGYF5zVMbgQ2RA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.13.0.tgz",
+      "integrity": "sha512-qIbw4uP0qUJoiWF4+7MTJWqwEN86RGmBNId0cwSoHoVNWtcw50R1ajYgxM1Q5FVUdoisVeSl9lKVRh5zkDFl+g==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -95,7 +95,7 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.8.0",
-    "eslint-plugin-ember": "^7.8.1",
+    "eslint-plugin-ember": "^7.13.0",
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -95,7 +95,7 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.8.0",
-    "eslint-plugin-ember": "^7.13.0",
+    "eslint-plugin-ember": "^8.4.0",
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -187,7 +187,6 @@ describe('Acceptance | Certification | Start Certification Course', function() {
             it('should navigate to next challenge when we click pass', async function() {
               // when
               await click('.challenge-actions__action-skip-text');
-
               // then
               expect(currentURL().startsWith(`/assessments/${assessment.id}/challenges/rec`)).to.be.true;
             });

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -42,8 +42,10 @@ describe('Integration | Component | ChallengeStatement', function() {
     // Inspired from: https://github.com/emberjs/ember-mocha/blob/0790a78d7464655fee0c103d2fa960fa53a056ca/tests/setup-component-test-test.js#L118-L122
     it('should render challenge instruction if it exists', async function() {
       // given
+      addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {
-        instruction: 'La consigne de mon test'
+        instruction: 'La consigne de mon test',
+        id: 'rec_challenge'
       });
 
       // when
@@ -55,6 +57,7 @@ describe('Integration | Component | ChallengeStatement', function() {
 
     it('should not render challenge instruction if it does not exist', async function() {
       // given
+      addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {});
 
       // when
@@ -91,9 +94,11 @@ describe('Integration | Component | ChallengeStatement', function() {
       // given
       const challenge = {
         illustrationUrl: '/images/pix-logo.svg',
-        illustrationAlt: 'texte alternatif'
+        illustrationAlt: 'texte alternatif',
+        id: 'rec_challenge'
       };
       addChallengeToContext(this, challenge);
+      addAssessmentToContext(this, { id: '267845' });
 
       // when
       await renderChallengeStatement();
@@ -106,6 +111,7 @@ describe('Integration | Component | ChallengeStatement', function() {
     it('should not display challenge illustration if it does not exist', async function() {
       // given
       addChallengeToContext(this, {});
+      addAssessmentToContext(this, { id: '267845' });
 
       // when
       await renderChallengeStatement();
@@ -127,8 +133,10 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should not display attachements section', async function() {
         addChallengeToContext(this, {
           attachments: [],
-          hasAttachment: false
+          hasAttachment: false,
+          id: 'rec_challenge'
         });
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -146,8 +154,10 @@ describe('Integration | Component | ChallengeStatement', function() {
           attachments: ['http://challenge.file.url'],
           hasAttachment: true,
           hasSingleAttachment: true,
-          hasMultipleAttachments: false
+          hasMultipleAttachments: false,
+          id: 'rec_challenge'
         });
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -167,7 +177,8 @@ describe('Integration | Component | ChallengeStatement', function() {
         attachments: [file1, file2],
         hasAttachment: true,
         hasSingleAttachment: false,
-        hasMultipleAttachments: true
+        hasMultipleAttachments: true,
+        id: 'rec_challenge'
       };
 
       const challengeQROC = {
@@ -176,12 +187,14 @@ describe('Integration | Component | ChallengeStatement', function() {
         hasSingleAttachment: false,
         hasAttachment: true,
         hasMultipleAttachments: true,
-        attachments: ['http://dl.airtable.com/EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt', 'http://dl.airtable.com/VGAwZSilQji6Spm9C9Tf_PIX_parchemin.odp']
+        attachments: ['http://dl.airtable.com/EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt', 'http://dl.airtable.com/VGAwZSilQji6Spm9C9Tf_PIX_parchemin.odp'],
+        id: 'rec_challenge'
       };
 
       it('should display as many radio button as attachments', async function() {
         // given
         addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -193,6 +206,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should display radio buttons with right label', async function() {
         // given
         addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -206,6 +220,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should select first attachment as default selected radio button', async function() {
         // given
         addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -218,6 +233,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should select first attachment as default selected radio button when QROC', async function() {
         // given
         addChallengeToContext(this, challengeQROC);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -230,6 +246,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should display attachements paragraph text', async function() {
         // given
         addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -241,6 +258,7 @@ describe('Integration | Component | ChallengeStatement', function() {
       it('should display help icon next to attachements paragraph', async function() {
         // given
         addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
 
         // when
         await renderChallengeStatement();
@@ -262,7 +280,8 @@ describe('Integration | Component | ChallengeStatement', function() {
 
     it('should be displayed when the challenge has a valid Embed object', async function() {
       // given
-      addChallengeToContext(this, { hasValidEmbedDocument: true });
+      addChallengeToContext(this, { hasValidEmbedDocument: true, id: 'rec_challenge' });
+      addAssessmentToContext(this, { id: '267845' });
 
       // when
       await renderChallengeStatement();
@@ -273,7 +292,8 @@ describe('Integration | Component | ChallengeStatement', function() {
 
     it('should not be displayed when the challenge does not have a valid Embed object', async function() {
       // given
-      addChallengeToContext(this, { hasValidEmbedDocument: false });
+      addChallengeToContext(this, { hasValidEmbedDocument: false, id: 'rec_challenge' });
+      addAssessmentToContext(this, { id: '267845' });
 
       // when
       await renderChallengeStatement();

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -29,7 +29,7 @@ describe('Integration | Component | comparison-window', function() {
         '- 3eme possibilite\n' +
         '- 4eme possibilite'
       });
-      correction = EmberObject.create({ solution: '2,3' });
+      correction = EmberObject.create({ solution: '2,3', learningMoreTutorials: [], tutorials: [] });
 
       this.set('answer', answer);
       answer.set('challenge', challenge);
@@ -118,6 +118,7 @@ describe('Integration | Component | comparison-window', function() {
     it('should render a feedback panel already opened',async  function() {
       //when
       await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+
       //then
       expect(find('.comparison-window__feedback-panel')).to.exist;
       expect(find('.feedback-panel__form')).to.exist;
@@ -191,7 +192,7 @@ describe('Integration | Component | comparison-window', function() {
       });
     });
 
-    context('the correction has no hints nor tutoriasl at all', function() {
+    context('the correction has no hints nor tutorials at all', function() {
       it('should render “Bientot des tutos”', async function() {
         // given
         correction.setProperties({

--- a/mon-pix/tests/integration/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel-test.js
@@ -79,11 +79,11 @@ describe('Integration | Component | QROC solution panel', function() {
           // given
           const assessment = EmberObject.create({ id: 'assessment_id' });
           const challenge = EmberObject.create({ id: 'challenge_id', format: data.format });
-          const answer = EmberObject.create({ id: 'answer_id', result: 'ok', assessment, challenge });
+          const answer = EmberObject.create({ id: 'answer_id', result: 'ok', value: 'test', assessment, challenge });
 
           // when
-          await render(hbs`{{qroc-solution-panel answer=answer}}`);
           this.set('answer', answer);
+          await render(hbs`{{qroc-solution-panel answer=answer}}`);
         });
 
         it('should display the answer in bold green', async function() {

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -105,7 +105,7 @@ describe('Integration | Component | reset password form', function() {
           // then
           expect(isSaveMethodCalled).to.be.true;
           expect(saveMethodOptions).to.eql({ adapterOptions: { updatePassword: true, temporaryKey: 'temp-key' } });
-          expect(this.get('user.password')).to.eql(null);
+          expect(this.user.password).to.eql(null);
           expect(find(PASSWORD_INPUT_CLASS)).to.not.exist;
           expect(find('.password-reset-demand-form__body')).to.exist;
         });
@@ -126,7 +126,7 @@ describe('Integration | Component | reset password form', function() {
 
           // then
           expect(isSaveMethodCalled).to.be.true;
-          expect(this.get('user.password')).to.eql(validPassword);
+          expect(this.user.password).to.eql(validPassword);
           expect(find(PASSWORD_INPUT_CLASS).value).to.equal(validPassword);
           expect(find('.form-textfield__message--error')).to.exist;
         });

--- a/mon-pix/tests/unit/components/challenge-statement-test.js
+++ b/mon-pix/tests/unit/components/challenge-statement-test.js
@@ -14,7 +14,8 @@ describe('Unit | Component | challenge statement', function() {
         hasValidEmbedDocument: true,
         embedUrl: 'https://challenge-embed.url',
         embedTitle: 'Challenge embed document title',
-        embedHeight: 300
+        embedHeight: 300,
+        id: 'rec_123'
       });
 
       const component = this.owner.lookup('component:challenge-statement');

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import EmberObject from '@ember/object';
 
 describe('Unit | Controller | Assessments | Checkpoint', function() {
 
@@ -30,11 +31,11 @@ describe('Unit | Controller | Assessments | Checkpoint', function() {
 
     it('should equal the progression completionPercentage', function() {
       // when
-      const model = {
+      const model = EmberObject.create({
         progression: {
           completionPercentage: 73,
         },
-      };
+      });
       controller.set('model', model);
 
       // then

--- a/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/skill-review-test.js
@@ -16,19 +16,19 @@ describe('Unit | Controller | Campaigns | Skill Review', function() {
     const setStub = sinon.stub();
 
     controller.set('model', {
-      campaignParticipation: {
+      campaignParticipation: EmberObject.create({
         isShared: false,
         set: setStub,
         save: sinon.stub().resolves({}),
-        campaignParticipationResult: {
+        campaignParticipationResult: EmberObject.create({
           masteryPercentage: 50,
-        },
-        campaign: {
+        }),
+        campaign: EmberObject.create({
           targetProfile: {
             name: 'Cléa Numérique',
           }
-        }
-      },
+        })
+      }),
       assessment: {
         id: 'assessmentId',
         get: sinon.stub().withArgs('id').resolves('assessmentId'),


### PR DESCRIPTION
## :unicorn: Problème
Nous utilisons encore des `this.get('foo')` sur PixApp ce qui nous empêche d'avancer vers Octane.

## :robot: Solution
Appliquer la règle eslint [no-get](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-get.md) et le fix associé.

## ❓ Remarques et interrogations
- Le `this.get` d'Ember avait pour effet de ne pas tomber en erreur en cas d'impossibilité de récupéré la valeur demandé. Lorsqu'on retire the `.get`, si le chemin est parfois impossible, une erreur remonte.
- Passer par `this.a.b.c.d` fonctionne pour une majorité des cas. Mais dans le cas où on passe d'un objet ember à un autre, il faut mieux refaire un get (ex : `this.assessment.get('campaign')`)
- Des règles du `plugin:ember/recommended` ont été ignoré pour le moment.

- C'est un résultat en demi-teinte puisque la règle Octane [classic-decorator-no-classic-methods](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/classic-decorator-no-classic-methods.md) nous rapprocherait davantage de notre but. Elle est malheureusement trop permissive puisqu'elle autorise notamment les `get` et les `set` si les classes appelantes possèdent le décorateur `@classic`

- Ce dernier point soulève quelques interrogations : 
Est-il possible de se passer totalement des `get` et des `set` sans passer en composant Glimmer ?
Qu'en est-il de ce qui n'est pas composant ?
> On a appris avec la documentation eslint qu'il est possible de faire appel à `@tracked` même si la classe n'hérite pas de `glimmer/component`
