### PR TITLE
[FEATURE] Ajouter des filtres concernant le statut et l'envoi des résultats au prescripteur sur la liste des sessions paginées (PA-205)

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -29,11 +29,18 @@
             <xs.option @value={{@sessionStatusAndLabels.[2].status}}>{{@sessionStatusAndLabels.[2].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[3].status}}>{{@sessionStatusAndLabels.[3].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[4].status}}>{{@sessionStatusAndLabels.[4].label}}</xs.option>
-          </XSelect></th>
+          </XSelect>
+        </th>
         <th></th>
         <th></th>
         <th></th>
-        <th></th>
+        <th>
+          <XSelect id='resultsSentToPrescriberAt' @value={{@sessionResultsSentToPrescriberAtAndLabels.[0].value}} @onChange={{@setResultsSentToPrescriberAtFilter}} as |xs|>
+            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[0].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[0].label}}</xs.option>
+            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[1].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[1].label}}</xs.option>
+            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[2].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[2].label}}</xs.option>
+          </XSelect>
+        </th>
       </tr>
     </thead>
 

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -22,6 +22,14 @@
         <th></th>
         <th></th>
         <th></th>
+        <th>
+          <XSelect id='status' @value={{@sessionStatusAndLabels.[0].status}} @onChange={{@setStatusFilter}} as |xs|>
+            <xs.option @value={{@sessionStatusAndLabels.[0].status}}>{{@sessionStatusAndLabels.[0].label}}</xs.option>
+            <xs.option @value={{@sessionStatusAndLabels.[1].status}}>{{@sessionStatusAndLabels.[1].label}}</xs.option>
+            <xs.option @value={{@sessionStatusAndLabels.[2].status}}>{{@sessionStatusAndLabels.[2].label}}</xs.option>
+            <xs.option @value={{@sessionStatusAndLabels.[3].status}}>{{@sessionStatusAndLabels.[3].label}}</xs.option>
+            <xs.option @value={{@sessionStatusAndLabels.[4].status}}>{{@sessionStatusAndLabels.[4].label}}</xs.option>
+          </XSelect></th>
         <th></th>
         <th></th>
         <th></th>

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -23,7 +23,7 @@
         <th></th>
         <th></th>
         <th>
-          <XSelect id='status' @value={{@sessionStatusAndLabels.[0].status}} @onChange={{@setStatusFilter}} as |xs|>
+          <XSelect id='status' @value={{@status}} @onChange={{@setStatusFilter}} as |xs|>
             <xs.option @value={{@sessionStatusAndLabels.[0].status}}>{{@sessionStatusAndLabels.[0].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[1].status}}>{{@sessionStatusAndLabels.[1].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[2].status}}>{{@sessionStatusAndLabels.[2].label}}</xs.option>

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -15,12 +15,19 @@ export default class SessionListController extends Controller {
   @tracked pageSize = 10;
   @tracked id = null;
   @tracked status = null;
+  @tracked resultsSentToPrescriberAt = null;
+  searchFilter = null;
 
   sessionStatusAndLabels = [
     { status: '', label: 'Tous' },
     ..._.map(statusToDisplayName, (label, status) => ({ status, label })),
   ];
-  searchFilter = null;
+
+  sessionResultsSentToPrescriberAtAndLabels = [
+    { value: '', label: 'Tous' },
+    { value: 'true', label: 'Résultats diffusés' },
+    { value: 'false', label: 'Résultats non diffusés' },
+  ];
 
   setFieldName() {
     this.searchFilter.fieldName = this.searchFilter.value;
@@ -30,6 +37,12 @@ export default class SessionListController extends Controller {
   @action
   setStatusFilter(status) {
     this.status = status;
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }
+
+  @action
+  setResultsSentToPrescriberAtFilter(value) {
+    this.resultsSentToPrescriberAt = value;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -2,6 +2,8 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
+import _ from 'lodash';
+import { statusToDisplayName } from 'pix-admin/models/session';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -12,11 +14,22 @@ export default class SessionListController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
+  @tracked status = null;
 
+  sessionStatusAndLabels = [
+    { status: '', label: 'Tous' },
+    ..._.map(statusToDisplayName, (label, status) => ({ status, label })),
+  ];
   searchFilter = null;
 
   setFieldName() {
     this.searchFilter.fieldName = this.searchFilter.value;
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }
+
+  @action
+  setStatusFilter(status) {
+    this.status = status;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
 import _ from 'lodash';
-import { statusToDisplayName } from 'pix-admin/models/session';
+import { statusToDisplayName, FINALIZED } from 'pix-admin/models/session';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -14,7 +14,7 @@ export default class SessionListController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
-  @tracked status = null;
+  @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
   searchFilter = null;
 

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { FINALIZED } from 'pix-admin/models/session';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   queryParams: {
@@ -29,7 +30,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.pageNumber = 1;
       controller.pageSize = 10;
       controller.id = null;
-      controller.status = null;
+      controller.status = FINALIZED;
       controller.resultsSentToPrescriberAt = null;
     }
   }

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -7,6 +7,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
     status: { refreshModel: true },
+    resultsSentToPrescriberAt: { refreshModel: true },
   },
 
   model(params) {
@@ -14,6 +15,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       filter: {
         id: params.id ? params.id.trim() : undefined,
         status: params.status ? params.status.trim() : undefined,
+        resultsSentToPrescriberAt: params.resultsSentToPrescriberAt ? params.resultsSentToPrescriberAt.trim() : undefined,
       },
       page: {
         number: params.pageNumber,
@@ -28,6 +30,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.pageSize = 10;
       controller.id = null;
       controller.status = null;
+      controller.resultsSentToPrescriberAt = null;
     }
   }
 });

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -3,21 +3,17 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 export default Route.extend(AuthenticatedRouteMixin, {
   queryParams: {
-    pageNumber: {
-      refreshModel: true,
-    },
-    pageSize: {
-      refreshModel: true,
-    },
-    id: {
-      refreshModel: true,
-    },
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    id: { refreshModel: true },
+    status: { refreshModel: true },
   },
 
   model(params) {
     return this.store.query('session', {
       filter: {
-        id: params.id ? params.id.trim() : '',
+        id: params.id ? params.id.trim() : undefined,
+        status: params.status ? params.status.trim() : undefined,
       },
       page: {
         number: params.pageNumber,
@@ -31,6 +27,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.pageNumber = 1;
       controller.pageSize = 10;
       controller.id = null;
+      controller.status = null;
     }
   }
 });

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -6,7 +6,8 @@
   <section class="page-section">
       <Sessions::ListItems
         @sessions={{@model}}
-        @id={{id}}
+        @id={{this.id}}
+        @status={{this.status}}
         @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
         @setStatusFilter={{this.setStatusFilter}}
         @sessionResultsSentToPrescriberAtAndLabels={{this.sessionResultsSentToPrescriberAtAndLabels}}

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -7,6 +7,8 @@
       <Sessions::ListItems
         @sessions={{@model}}
         @id={{id}}
+        @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
+        @setStatusFilter={{this.setStatusFilter}}
         @triggerFiltering={{this.triggerFiltering}} />
   </section>
 </main>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -9,6 +9,8 @@
         @id={{id}}
         @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
         @setStatusFilter={{this.setStatusFilter}}
+        @sessionResultsSentToPrescriberAtAndLabels={{this.sessionResultsSentToPrescriberAtAndLabels}}
+        @setResultsSentToPrescriberAtFilter={{this.setResultsSentToPrescriberAtFilter}}
         @triggerFiltering={{this.triggerFiltering}} />
   </section>
 </main>

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -10,8 +10,10 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
   hooks.beforeEach(function() {
     const setStatusFilter = sinon.stub();
+    const setResultsSentToPrescriberAtFilter = sinon.stub();
     const triggerFiltering = function() {};
     this.set('setStatusFilter', setStatusFilter);
+    this.set('setResultsSentToPrescriberAtFilter', setResultsSentToPrescriberAtFilter);
     this.set('triggerFiltering', triggerFiltering);
   });
 
@@ -42,7 +44,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     this.set('sessions', sessions);
 
     // when
-    await render(hbs`{{sessions/list-items sessions=sessions triggerFiltering=triggerFiltering setStatusFilter=setStatusFilter}}`);
+    await render(hbs`{{sessions/list-items sessions=sessions triggerFiltering=triggerFiltering setStatusFilter=setStatusFilter setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter}}`);
 
     // then
     assert.dom('table tbody tr').exists({ count: sessions.length });
@@ -74,7 +76,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
     test('it should render a dropdown menu to filter on status', async function(assert) {
       // when
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering sessionStatusAndLabels=sessionStatusAndLabels}}`);
+      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionStatusAndLabels=sessionStatusAndLabels}}`);
 
       // then
       const option1 = find('table thead tr:nth-child(2) th:nth-child(5) select option:nth-child(1)');
@@ -84,11 +86,44 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     test('it should call setStatusFilter callback with appropriate arguments', async function(assert) {
       // given
       const xselect = new XSelectInteractor('#status');
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering sessionStatusAndLabels=sessionStatusAndLabels}}`);
+      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionStatusAndLabels=sessionStatusAndLabels}}`);
 
       // when
       await xselect.select('label3').when(() => {
         sinon.assert.calledWith(this.get('setStatusFilter'), 'status3');
+        assert.equal(xselect.options(2).isSelected, true);
+      });
+    });
+  });
+
+  module('Dropdown menu for resultsSentToPrescriberAt filtering', function(hooks) {
+
+    hooks.beforeEach(function() {
+      const statusList = [
+        { value: 'value1', label: 'label1' },
+        { value: 'value2', label: 'label2' },
+        { value: 'value3', label: 'label3' },
+      ];
+      this.set('sessionResultsSentToPrescriberAtAndLabels', statusList);
+    });
+
+    test('it should render a dropdown menu to filter on resultsSentToPrescriberAt', async function(assert) {
+      // when
+      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
+
+      // then
+      const option1 = find('table thead tr:nth-child(2) th:nth-child(9) select option:nth-child(1)');
+      assert.dom(option1).hasText('label1');
+    });
+
+    test('it should call setResultsSentToPrescriberAtFilter callback with appropriate arguments', async function(assert) {
+      // given
+      const xselect = new XSelectInteractor('#resultsSentToPrescriberAt');
+      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
+
+      // when
+      await xselect.select('label3').when(() => {
+        sinon.assert.calledWith(this.get('setResultsSentToPrescriberAtFilter'), 'value3');
         assert.equal(xselect.options(2).isSelected, true);
       });
     });

--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -101,6 +101,7 @@ function certificationSessionsBuilder({ databaseBuilder }) {
     certificationCenter, certificationCenterId,
     finalizedAt: new Date('2018-01-02T00:00:00Z'),
     publishedAt: null,
+    resultsSentToPrescriberAt: new Date('2018-01-04T00:00:00Z'),
   });
   databaseBuilder.factory.buildSession({
     certificationCenter, certificationCenterId, address, room, examiner, date , time,

--- a/api/lib/domain/usecases/find-paginated-filtered-sessions.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-sessions.js
@@ -1,3 +1,18 @@
+const sessionValidator = require('../validators/session-validator');
+
 module.exports = async function findPaginatedFilteredSessions({ filters, page, sessionRepository }) {
+  try {
+    sessionValidator.validateFilters(filters);
+  } catch (err) {
+    return {
+      sessions: [],
+      pagination: {
+        page: page.number,
+        pageSize: page.size,
+        rowCount: 0, 
+        pageCount: 0,
+      },
+    };
+  }
   return sessionRepository.findPaginatedFiltered({ filters, page });
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { statuses } = require('../models/Session');
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
@@ -40,10 +41,24 @@ const sessionValidationJoiSchema = Joi.object({
 
 });
 
+const sessionFiltersValidationSchema = Joi.object({
+  id: Joi.number().integer().optional(),
+  status: Joi.string()
+    .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
+  resultsSentToPrescriberAt: Joi.string().valid('true', 'false').optional(),
+});
+
 module.exports = {
 
   validate(session) {
     const { error } = sessionValidationJoiSchema.validate(session, validationConfiguration);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  },
+
+  validateFilters(sessionFilters) {
+    const { error } = sessionFiltersValidationSchema.validate(sessionFilters, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -135,9 +135,15 @@ module.exports = {
   async findPaginatedFiltered({ filters = {}, page = {} }) {
     const { models, pagination } = await BookshelfSession
       .query((qb) => {
-        const { id, status } = filters;
+        const { id, status, resultsSentToPrescriberAt } = filters;
         if (id) {
           qb.where({ id });
+        }
+        if (resultsSentToPrescriberAt === 'true') {
+          qb.whereNotNull('resultsSentToPrescriberAt');
+        }
+        if (resultsSentToPrescriberAt === 'false') {
+          qb.whereNull('resultsSentToPrescriberAt');
         }
         if (status === statuses.CREATED) {
           qb.whereNull('finalizedAt');

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -5,6 +5,7 @@ const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-convert
 const Bookshelf = require('../bookshelf');
 const { NotFoundError } = require('../../domain/errors');
 const { PGSQL_UNIQUE_CONSTRAINT_VIOLATION_ERROR } = require('../../../db/pgsql-errors');
+const { statuses } = require('../../domain/models/Session');
 
 module.exports = {
 
@@ -131,12 +132,29 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, publishedSession);
   },
 
-  async findPaginatedFiltered({ filters, page }) {
+  async findPaginatedFiltered({ filters = {}, page = {} }) {
     const { models, pagination } = await BookshelfSession
       .query((qb) => {
-        const { id } = filters;
+        const { id, status } = filters;
         if (id) {
           qb.where({ id });
+        }
+        if (status === statuses.CREATED) {
+          qb.whereNull('finalizedAt');
+          qb.whereNull('publishedAt');
+        }
+        if (status === statuses.FINALIZED) {
+          qb.whereNotNull('finalizedAt');
+          qb.whereNull('assignedCertificationOfficerId');
+          qb.whereNull('publishedAt');
+        }
+        if (status === statuses.IN_PROCESS) {
+          qb.whereNotNull('finalizedAt');
+          qb.whereNotNull('assignedCertificationOfficerId');
+          qb.whereNull('publishedAt');
+        }
+        if (status === statuses.PROCESSED) {
+          qb.whereNotNull('publishedAt');
         }
         qb.orderByRaw('?? ASC NULLS FIRST', 'publishedAt');
         qb.orderByRaw('?? ASC', 'finalizedAt');

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -584,7 +584,7 @@ describe('Integration | Repository | Session', function() {
         });
       });
 
-      context('when there are filters regarding session status', () => {
+      context('when there is a filter regarding session status', () => {
         context('when there is a filter on created sessions', () => {
           let expectedSessionId;
 
@@ -604,6 +604,7 @@ describe('Integration | Repository | Session', function() {
             const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
+            expect(sessions).to.have.length(1);
             expect(sessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -628,6 +629,7 @@ describe('Integration | Repository | Session', function() {
             const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
+            expect(sessions).to.have.length(1);
             expect(sessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -653,6 +655,7 @@ describe('Integration | Repository | Session', function() {
             const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
+            expect(sessions).to.have.length(1);
             expect(sessions[0].id).to.equal(expectedSessionId);
           });
         });
@@ -677,7 +680,81 @@ describe('Integration | Repository | Session', function() {
             const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
 
             // then
+            expect(sessions).to.have.length(1);
             expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+      });
+
+      context('when there is a filter regarding resultsSentToPrescriberAt state', () => {
+
+        context('when there is a filter on sessions which results have been sent to prescriber', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            expectedSessionId = databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z') }).id;
+            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { resultsSentToPrescriberAt: 'true' };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions).to.have.length(1);
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+
+        context('when there is a filter on sessions which results have not been sent to prescriber', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z') });
+            expectedSessionId = databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null }).id;
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { resultsSentToPrescriberAt: 'false' };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions).to.have.length(1);
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+
+        context('when there is no filter on whether session results has been sent to prescriber or not', () => {
+
+          beforeEach(() => {
+            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: new Date('2020-01-01T00:00:00Z') });
+            databaseBuilder.factory.buildSession({ resultsSentToPrescriberAt: null });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = {};
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions).to.have.length(2);
           });
         });
       });

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -583,6 +583,105 @@ describe('Integration | Repository | Session', function() {
           expect(sessions[0].id).to.equal(expectedSession.id);
         });
       });
+
+      context('when there are filters regarding session status', () => {
+        context('when there is a filter on created sessions', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            expectedSessionId = databaseBuilder.factory.buildSession({ finalizedAt: null, publishedAt: null }).id;
+            databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-01T00:00:00Z') });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { status: statuses.CREATED };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+
+        context('when there is a filter on finalized sessions', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            const someDate = new Date('2020-01-01T00:00:00Z');
+            expectedSessionId = databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: null, assignedCertificationOfficerId: null }).id;
+            databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: someDate, assignedCertificationOfficerId: null });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { status: statuses.FINALIZED };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+
+        context('when there is a filter on in process sessions', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            const someDate = new Date('2020-01-01T00:00:00Z');
+            const assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+            expectedSessionId = databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: null, assignedCertificationOfficerId }).id;
+            databaseBuilder.factory.buildSession({ publishedAt: someDate, assignedCertificationOfficerId });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { status: statuses.IN_PROCESS };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+
+        context('when there is a filter on published sessions', () => {
+          let expectedSessionId;
+
+          beforeEach(() => {
+            const someDate = new Date('2020-01-01T00:00:00Z');
+            expectedSessionId = databaseBuilder.factory.buildSession({ publishedAt: someDate }).id;
+            databaseBuilder.factory.buildSession({ publishedAt: null });
+
+            return databaseBuilder.commit();
+          });
+
+          it('should apply the strict filter and return the appropriate results', async () => {
+            // given
+            const filters = { status: statuses.PROCESSED };
+            const page = { number: 1, size: 10 };
+
+            // when
+            const { sessions } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+            // then
+            expect(sessions[0].id).to.equal(expectedSessionId);
+          });
+        });
+      });
+
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-sessions_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-sessions_test.js
@@ -1,28 +1,64 @@
 const { expect, sinon } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
+const sessionValidator = require('../../../../lib/domain/validators/session-validator');
 
 describe('Unit | UseCase | find-paginated-filtered-sessions', () => {
   let sessionRepository;
+  let restoreValidateFilters;
 
   beforeEach(() => {
     sessionRepository = {
       findPaginatedFiltered: sinon.stub(),
     };
+    restoreValidateFilters = sessionValidator.validateFilters;
+    sessionValidator.validateFilters = sinon.stub();
   });
 
-  it('should result sessions with filtering and pagination', async () => {
-    // given
-    const filters = 'someFilters';
-    const page = 'somePageConfiguration';
-    const resolvedPagination = 'pagination';
-    const matchingSessions = 'listOfMatchingSessions';
-    sessionRepository.findPaginatedFiltered.withArgs({ filters, page }).resolves({ sessions: matchingSessions, pagination: resolvedPagination });
+  afterEach(() => {
+    sessionValidator.validateFilters = restoreValidateFilters;
+  });
 
-    // when
-    const response = await usecases.findPaginatedFilteredSessions({ filters, page, sessionRepository });
+  context('when filters are valid', () => {
 
-    // then
-    expect(response.sessions).to.equal(matchingSessions);
-    expect(response.pagination).to.equal(resolvedPagination);
+    it('should result sessions with filtering and pagination', async () => {
+      // given
+      const filters = 'someFilters';
+      const page = 'somePageConfiguration';
+      const resolvedPagination = 'pagination';
+      const matchingSessions = 'listOfMatchingSessions';
+      sessionValidator.validateFilters.withArgs(filters).returns();
+      sessionRepository.findPaginatedFiltered.withArgs({ filters, page }).resolves({ sessions: matchingSessions, pagination: resolvedPagination });
+
+      // when
+      const response = await usecases.findPaginatedFilteredSessions({ filters, page, sessionRepository });
+
+      // then
+      expect(response.sessions).to.equal(matchingSessions);
+      expect(response.pagination).to.equal(resolvedPagination);
+    });
+  });
+
+  context('when filters are not valid', () => {
+
+    it('should result empty list of session with basic pagination', async () => {
+      // given
+      const filters = 'someFilters';
+      const page = { number: 'aNumber', size: 'aSize' };
+      const basicPagination = {
+        page: 'aNumber',
+        pageSize: 'aSize',
+        rowCount: 0,
+        pageCount: 0,
+      };
+      sessionValidator.validateFilters.withArgs(filters).throws();
+
+      // when
+      const response = await usecases.findPaginatedFilteredSessions({ filters, page, sessionRepository });
+
+      // then
+      expect(sessionRepository.findPaginatedFiltered.notCalled).to.be.true;
+      expect(response.pagination).to.deep.equal(basicPagination);
+      expect(response.sessions).to.be.empty;
+    });
   });
 });

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -1,4 +1,6 @@
-const { expect, domainBuilder } = require('../../../test-helper');
+const { expect, domainBuilder, catchErr } = require('../../../test-helper');
+const { statuses } = require('../../../../lib/domain/models/Session');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
 
 const MISSING_VALUE = '';
@@ -155,6 +157,120 @@ describe('Unit | Domain | Validators | session-validator', () => {
           }
         });
 
+      });
+
+    });
+  });
+
+  describe('#validateFilters', () => {
+
+    context('when validating id', () => {
+
+      context('when id not in submitted filters', () => {
+
+        it('should not throw any error', () => {
+          expect(sessionValidator.validateFilters({})).to.not.throw;
+        });
+      });
+
+      context('when id is in submitted filters', () => {
+
+        context('when id is not an integer', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ id: 'salut' });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when id is an integer', () => {
+
+          it('should not throw any error in form of a string', () => {
+            expect(sessionValidator.validateFilters({ id: '123' })).to.not.throw;
+          });
+
+          it('should not throw any error', () => {
+            expect(sessionValidator.validateFilters({ id: 123 })).to.not.throw;
+          });
+        });
+      });
+
+    });
+
+    context('when validating status', () => {
+
+      context('when status not in submitted filters', () => {
+
+        it('should not throw any error', () => {
+          expect(sessionValidator.validateFilters({})).to.not.throw;
+        });
+      });
+
+      context('when status is in submitted filters', () => {
+
+        context('when status is not an string', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ status: 123 });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when status is not in the statuses list', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ status: 'SomeOtherStatus' });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when status is in the statuses list', () => {
+
+          it('should not throw an error', async () => {
+            expect(sessionValidator.validateFilters({ status: statuses.CREATED })).to.not.throw;
+            expect(sessionValidator.validateFilters({ status: statuses.FINALIZED })).to.not.throw;
+            expect(sessionValidator.validateFilters({ status: statuses.IN_PROCESS })).to.not.throw;
+            expect(sessionValidator.validateFilters({ status: statuses.PROCESSED })).to.not.throw;
+          });
+        });
+      });
+
+    });
+
+    context('when validating resultsSentToPrescriberAt', () => {
+
+      context('when resultsSentToPrescriberAt not in submitted filters', () => {
+
+        it('should not throw any error', () => {
+          expect(sessionValidator.validateFilters({})).to.not.throw;
+        });
+      });
+
+      context('when resultsSentToPrescriberAt is in submitted filters', () => {
+
+        context('when resultsSentToPrescriberAt is not an string', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ resultsSentToPrescriberAt: 123 });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when resultsSentToPrescriberAt is not in the resultsSentToPrescriberAt list', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ resultsSentToPrescriberAt: 'SomeOtherValue' });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when resultsSentToPrescriberAt is string true or false', () => {
+
+          it('should not throw an error', async () => {
+            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: 'true' })).to.not.throw;
+            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: 'false' })).to.not.throw;
+          });
+        });
       });
 
     });


### PR DESCRIPTION
## :unicorn: Problème
Toujours dans l'objectif final de permettre au pôle certif de se passer de l'usage d'un google sheet afin de faire un suivi du traitement des sessions de certif, on cherche à rendre la liste des sessions paginées sur PixAdmin manipulable et exploitable selon l'usage du pôle certif.
Les membres du pôle certif ont besoin de pouvoir rapidement visualiser et filtrer les sessions selon :
1) Le statut
2) Selon si les résultats ont été envoyés au prescripteur ou pas

## :robot: Solution
Ajouter deux menus déroulants sous chaque colonne correspondante

## :rainbow: Remarques

## :100: Pour tester
Se balader dans PixAdmin et jouer avec les filtres positionnés sur la liste des sessions paginées
