### PR TITLE
[BUGFIX] Restreindre l'accès au détail d'une campagne dans Pix Orga (PO-357). 

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const securityController = require('../../interfaces/controllers/security-controller');
 const campaignController = require('./campaign-controller');
 
 exports.register = async function(server) {
@@ -32,9 +33,14 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/campaigns/{id}',
       config: {
+        pre: [{
+          method: securityController.checkUserCanAccessCampaign,
+          assign: 'userCanAccessCampaign'
+        }],
         handler: campaignController.getById,
         notes: [
           '- Récupération d\'une campagne par son id',
+          '- L‘utilisateur doit appartenir à l‘organisation ayant créé cette campagne',
         ],
         tags: ['api', 'campaign']
       }

--- a/api/lib/application/usecases/checkUserCanAccessCampaign.js
+++ b/api/lib/application/usecases/checkUserCanAccessCampaign.js
@@ -1,0 +1,15 @@
+const userRepository = require('../../infrastructure/repositories/user-repository');
+const campaignRepository = require('../../infrastructure/repositories/campaign-repository');
+const _ = require('lodash');
+
+module.exports = {
+
+  execute(userId, campaignId) {
+    return Promise.all([
+      userRepository.getWithMemberships(userId),
+      campaignRepository.get(campaignId)
+    ]).then(([user, campaign]) => {
+      return _.some(user.memberships, { organization: { id : campaign.organizationId } });
+    });
+  }
+};

--- a/api/lib/interfaces/controllers/security-controller.js
+++ b/api/lib/interfaces/controllers/security-controller.js
@@ -4,6 +4,7 @@ const checkUserHasRolePixMasterUseCase = require('../../application/usecases/che
 const checkUserIsAdminInOrganizationUseCase = require('../../application/usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase  = require('../../application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase  = require('../../application/usecases/checkUserBelongsToOrganization');
+const checkUserCanAccessCampaignUseCase  = require('../../application/usecases/checkUserCanAccessCampaign');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
 
@@ -29,6 +30,20 @@ function _replyWithAuthorizationError(h) {
       code: errorHttpStatusCode,
       title: 'Forbidden access',
       detail: 'Missing or insufficient permissions.'
+    });
+
+    return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+  });
+}
+
+function _replyWithBadRequestError(h) {
+  return Promise.resolve().then(() => {
+    const errorHttpStatusCode = 400;
+
+    const jsonApiError = new JSONAPIError({
+      code: errorHttpStatusCode,
+      title: 'Bad Request',
+      detail: 'Malformed request syntax.'
     });
 
     return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
@@ -186,6 +201,26 @@ async function checkUserIsAdminInScoOrganizationAndManagesStudents(request, h) {
   return _replyWithAuthorizationError(h);
 }
 
+async function checkUserCanAccessCampaign(request, h) {
+  if (!request.auth.credentials || !request.auth.credentials.userId) {
+    return _replyWithAuthorizationError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const campaignId = parseInt(request.params.id);
+
+  if (isNaN(campaignId)) {
+    return _replyWithBadRequestError(h);
+  }
+
+  const canAccessCampaign = await checkUserCanAccessCampaignUseCase.execute(userId, campaignId);
+  if (canAccessCampaign) {
+    return h.response(true);
+  }
+
+  return _replyWithAuthorizationError(h);
+}
+
 module.exports = {
   checkRequestedUserIsAuthenticatedUser,
   checkUserBelongsToOrganizationOrHasRolePixMaster,
@@ -195,4 +230,5 @@ module.exports = {
   checkUserIsAdminInOrganization,
   checkUserIsAdminInOrganizationOrHasRolePixMaster,
   checkUserIsAdminInScoOrganizationAndManagesStudents,
+  checkUserCanAccessCampaign,
 };

--- a/api/tests/acceptance/application/security-controller_test.js
+++ b/api/tests/acceptance/application/security-controller_test.js
@@ -332,4 +332,38 @@ describe('Acceptance | Interface | Controller | SecurityController', function() 
     });
   });
 
+  describe('#checkUserCanAccessCampaign', () => {
+    let userId;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is not allowed to access campaign', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaignId}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const jsonApiError = {
+        errors: [{
+          code: 403,
+          title: 'Forbidden access',
+          detail: 'Missing or insufficient permissions.'
+        }]
+      };
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError);
+    });
+  });
+
 });

--- a/api/tests/unit/application/usecases/checkUserCanAccessCampaign_test.js
+++ b/api/tests/unit/application/usecases/checkUserCanAccessCampaign_test.js
@@ -1,0 +1,51 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const useCase = require('../../../../lib/application/usecases/checkUserCanAccessCampaign');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+
+describe('Unit | Application | Use Case | CheckUserCanAccessCampaign', () => {
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'getWithMemberships');
+    sinon.stub(campaignRepository, 'get');
+  });
+
+  context('When user can access campaign', () => {
+
+    it('should return true', async () => {
+      // given
+      const organization = domainBuilder.buildOrganization();
+      const campaign = domainBuilder.buildCampaign({ organizationId: organization.id });
+      const membership = domainBuilder.buildMembership({ organization });
+      const user = domainBuilder.buildUser({ memberships: [membership] });
+      userRepository.getWithMemberships.resolves(user);
+      campaignRepository.get.resolves(campaign);
+
+      // when
+      const response = await useCase.execute(user.id, campaign.id);
+
+      // then
+      expect(response).to.equal(true);
+    });
+  });
+
+  context('When user belongs to campaign\'s organization', () => {
+
+    it('should return false', async () => {
+      // given
+      const organization = domainBuilder.buildOrganization();
+      const campaign = domainBuilder.buildCampaign({ organizationId: organization.id });
+      const otherOrganization = domainBuilder.buildOrganization();
+      const membership = domainBuilder.buildMembership({ organization: otherOrganization });
+      const user = domainBuilder.buildUser({ memberships: [membership] });
+      userRepository.getWithMemberships.resolves(user);
+      campaignRepository.get.resolves(campaign);
+
+      // when
+      const response = await useCase.execute(user.id, campaign.id);
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+});

--- a/api/tests/unit/interfaces/controllers/security-controller_test.js
+++ b/api/tests/unit/interfaces/controllers/security-controller_test.js
@@ -7,6 +7,7 @@ const checkUserHasRolePixMasterUseCase = require('../../../../lib/application/us
 const checkUserIsAdminInOrganizationUseCase = require('../../../../lib/application/usecases/checkUserIsAdminInOrganization');
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('../../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('../../../../lib/application/usecases/checkUserBelongsToOrganization');
+const checkUserCanAccessCampaignUseCase = require('../../../../lib/application/usecases/checkUserCanAccessCampaign');
 
 describe('Unit | Interfaces | Controllers | SecurityController', () => {
 
@@ -676,4 +677,95 @@ describe('Unit | Interfaces | Controllers | SecurityController', () => {
     });
   });
 
+  describe('#checkUserCanAccessCampaign', () => {
+
+    let canAccessCampaignStub;
+
+    beforeEach(() => {
+      canAccessCampaignStub = sinon.stub(checkUserCanAccessCampaignUseCase, 'execute');
+    });
+
+    context('Successful case', () => {
+      const request = {
+        auth: {
+          credentials: {
+            accessToken: 'valid.access.token',
+            userId: 1234
+          }
+        },
+        params: { id: 5678 }
+      };
+
+      it('should authorize access to resource when the user is authenticated and can access campaign', async () => {
+        // given
+        canAccessCampaignStub.resolves(true);
+
+        // when
+        const response = await securityController.checkUserCanAccessCampaign(request, hFake);
+
+        // then
+        expect(response.source).to.equal(true);
+      });
+    });
+
+    context('Error cases', () => {
+      const request = {
+        auth: {
+          credentials: {
+            accessToken: 'valid.access.token',
+            userId: 1234
+          }
+        },
+      };
+
+      it('should return a 400 error if campaignId is not a number', async () => {
+        // given
+        request.params = {
+          id: 'not_a_number'
+        };
+
+        // when
+        const response = await securityController.checkUserCanAccessCampaign(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should forbid resource access when user was not previously authenticated', async () => {
+        // given
+        delete request.auth.credentials;
+
+        // when
+        const response = await securityController.checkUserCanAccessCampaign(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+
+      it('should forbid resource access when user does not have access to campaign', async () => {
+        // given
+        canAccessCampaignStub.resolves(false);
+
+        // when
+        const response = await securityController.checkUserCanAccessCampaign(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+
+      it('should forbid resource access when an error is thrown by use case', async () => {
+        // given
+        canAccessCampaignStub.rejects(new Error('Some error'));
+
+        // when
+        const response = await securityController.checkUserCanAccessCampaign(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.isTakeOver).to.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Depuis Pix Orga, il est possible d'accéder au détail de toutes les campagnes en modifiant l'id de la campagne dans l'url.

## :robot: Solution
Autoriser l'accès au détail d'une campagne uniquement pour les utilisateurs appartenant à l'organisation pour laquelle la campagne a été créée.