### PR TITLE
[FEATURE] afficher l id de certif dans le champ de recherche admin (PA-201)

### DIFF
--- a/admin/app/routes/authenticated/certifications/certification.js
+++ b/admin/app/routes/authenticated/certifications/certification.js
@@ -2,8 +2,13 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default class CertificationRoute extends Route {  
+export default class CertificationRoute extends Route {
   @service notifications
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    this.controllerFor('authenticated.certifications').inputId = model.id;
+  }
 
   @action
   error(anError) {

--- a/admin/tests/unit/routes/authenticated/certifications/certification-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification-test.js
@@ -5,6 +5,21 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/certifications/certification', function(hooks) {
   setupTest(hooks);
 
+  test('#setupController', function(assert) {
+    // given
+    const certifications = { inputId: 5 };
+    const id = Symbol('id');
+    const route = this.owner.lookup('route:authenticated/certifications/certification');
+    route.controllerFor = sinon.stub().returns(certifications);
+
+    // when
+    route.setupController(null, { id });
+
+    // then
+    assert.equal(certifications.inputId, id);
+    assert.ok(route.controllerFor.calledWith('authenticated.certifications'));
+  });
+
   test('#error', function(assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certifications/certification');

--- a/admin/tests/unit/routes/authenticated/sessions/session-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session-test.js
@@ -5,6 +5,21 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/sessions/session', function(hooks) {
   setupTest(hooks);
 
+  test('#setupController', function(assert) {
+    // given
+    const sessions = { inputId: 5 };
+    const id = Symbol('id');
+    const route = this.owner.lookup('route:authenticated/sessions/session');
+    route.controllerFor = sinon.stub().returns(sessions);
+
+    // when
+    route.setupController(null, { id });
+
+    // then
+    assert.equal(sessions.inputId, id);
+    assert.ok(route.controllerFor.calledWith('authenticated.sessions.session'));
+  });
+
   test('#error', function(assert) {
     // given
     const route = this.owner.lookup('route:authenticated/sessions/session');


### PR DESCRIPTION
## :unicorn: Problème
Le champs de recherche des certifs dans admin n'est pas reinitialisé quand on change de certification. 
On souhaite qu'il contienne toujours l'identifiant de la certification courante

## :robot: Solution
Passer au controller l'identifiant de la route ne cours

## :rainbow: Remarques
Cela ne correspond pas aux attentes UX. Cette solution est temporaire en attendant de trouver un affichage plus approprié de cet identifiant

## :100: Pour tester

1) Aucun ID affiché

> - dans Pix Admin, aller sur la liste des session et ouvrir une page de détails de session
> - cliquer sur l’onglet “Certifications” pour afficher la liste des certif de cette session
> - ouvrir la page de détails d’une des certif
> 
> Résultat attendu : l’ID de certif en question devrait être affiché dans la barre de recherche

2) Mauvais ID affiché

> - dans Pix Admin, cliquer sur le menu “Certifications”
> - entrer un ID de certif existant dans la barre de rechercher puis cliquer sur “Charger” : la page de détails de la certif s’affiche et l’ID de certif recherché reste indiqué dans la barre de recherche
> - cliquer sur le menu “Sessions” et ouvrir la page de détails d’une session
> - cliquer sur l’onglet “Certifications” puis sur un ID de certif pour afficher sa page de détails
> 
> Résultat attendu : je devrais voir le bon ID de certif dans la barre de recherche


