### PR TITLE
[TECH] Rendre l'envoi de mail asynchrone de la requête API.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -124,6 +124,10 @@ module.exports = (function() {
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
       debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
     },
+
+    scheduledJobs: {
+      redisUrl: process.env.REDIS_URL,
+    }
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -64,6 +64,9 @@ module.exports = (function() {
           passwordResetTemplateId: process.env.SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID
         },
       },
+      logger: {
+        templates: {}
+      }
     },
 
     captcha: {
@@ -109,7 +112,7 @@ module.exports = (function() {
 
     features: {
       dayBeforeImproving: _getNumber(process.env.DAY_BEFORE_IMPROVING, 4),
-      dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2,7),
+      dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2, 7),
     },
 
     pixOrgaUrl: process.env.PIXORGA_URL,

--- a/api/lib/domain/usecases/create-user.js
+++ b/api/lib/domain/usecases/create-user.js
@@ -67,8 +67,8 @@ module.exports = async function createUser({
       return userWithEncryptedPassword;
     })
     .then(userRepository.create)
-    .then((savedUser) => {
-      mailService.sendAccountCreationEmail(savedUser.email);
+    .then(async (savedUser) => {
+      await mailService.sendAccountCreationEmail(savedUser.email);
       return savedUser;
     });
 };

--- a/api/lib/infrastructure/mailers/MockLogEmailProvider.js
+++ b/api/lib/infrastructure/mailers/MockLogEmailProvider.js
@@ -1,0 +1,11 @@
+const logger = require('../logger');
+const MailingProvider = require('./MailingProvider');
+
+class MockLogEmailProvider extends MailingProvider {
+
+  sendEmail(options) {
+    logger.info(`Faking email sending - ${JSON.stringify(options)}`);
+  }
+}
+
+module.exports = MockLogEmailProvider;

--- a/api/lib/infrastructure/mailers/send-email-job-processor.js
+++ b/api/lib/infrastructure/mailers/send-email-job-processor.js
@@ -1,0 +1,4 @@
+module.exports = function(job) {
+  const options = job.data;
+  return this._provider.sendEmail(options);
+};

--- a/api/lib/infrastructure/queued-jobs/create-send-email-queue-service.js
+++ b/api/lib/infrastructure/queued-jobs/create-send-email-queue-service.js
@@ -1,0 +1,22 @@
+const Queue = require('bull');
+const config = require('../../config');
+const logger = require('../logger');
+
+const sendEmailJobOptions = {
+  attempts: 3,
+  backoff: {
+    type: 'exponential',
+    delay: 1000 * 60,
+  },
+  removeOnComplete: true,
+  removeOnFail: 1,
+};
+
+function createSendEmailQueue(sendEmailProcessorName) {
+  const sendEmailQueue = new Queue('send-email-queue', config.scheduledJobs.redisUrl);
+  sendEmailQueue.on('error', (err) => logger.error(`Creating send email queue failed: ${err}`));
+  sendEmailQueue.process(sendEmailProcessorName);
+  return sendEmailQueue;
+}
+
+module.exports = { createSendEmailQueue, sendEmailJobOptions };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1323,6 +1323,35 @@
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
+    "bull": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/bull/-/bull-3.13.0.tgz",
+      "integrity": "sha512-nP8ICMNHGYDNt6cgPqBPm90n57xA+/Om2wI2EGEOIJtWutjrYt8JAWiiFYjZKrly9UkKlrfG9qgOCwFFdS5xaw==",
+      "requires": {
+        "cron-parser": "^2.13.0",
+        "debuglog": "^1.0.0",
+        "get-port": "^5.1.1",
+        "ioredis": "^4.14.1",
+        "lodash": "^4.17.15",
+        "p-timeout": "^3.2.0",
+        "promise.prototype.finally": "^3.1.2",
+        "semver": "^6.3.0",
+        "util.promisify": "^1.0.1",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "bunyan": {
       "version": "1.8.12",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
@@ -1710,6 +1739,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1900,6 +1934,15 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cron-parser": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.13.0.tgz",
+      "integrity": "sha512-UWeIpnRb0eyoWPVk+pD3TDpNx3KCFQeezO224oJIkktBrcW6RoAPOx5zIKprZGfk6vcYSmA8yQXItejSaDBhbQ==",
+      "requires": {
+        "is-nan": "^1.2.1",
+        "moment-timezone": "^0.5.25"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1946,6 +1989,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2007,7 +2055,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2080,6 +2127,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.1",
@@ -2227,7 +2279,6 @@
       "version": "1.17.0-next.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
       "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -2246,7 +2297,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3009,8 +3059,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3044,6 +3093,11 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -3369,7 +3423,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3382,8 +3435,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3731,6 +3783,50 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz",
       "integrity": "sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA=="
     },
+    "ioredis": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.16.2.tgz",
+      "integrity": "sha512-hlRK9q9K8pWpYIxUh079dWUWECiGNdI7+/AR21pgeqIBXQzjVKFnz0wXvmhEQZV3Hvv4saQpvJww9SkjwvPXZA==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.1.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "redis-commands": "1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "redis-commands": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+          "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+        },
+        "redis-parser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+          "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+          "requires": {
+            "redis-errors": "^1.0.0"
+          }
+        }
+      }
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -3786,8 +3882,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -3819,8 +3914,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3878,6 +3972,14 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-nan": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
+      "integrity": "sha512-z7bbREymOqt2CCaZVly8aC4ML3Xhfi0ekuOnjO2L8vKdl+CttdVoGZQhd4adMFAsxQ5VeRVwORs4tU8RH+HFtQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "is-npm": {
@@ -3943,7 +4045,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -3972,7 +4073,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -4586,6 +4686,16 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -5563,14 +5673,12 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5584,7 +5692,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -5607,7 +5714,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -5726,8 +5832,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.2.1",
@@ -5745,6 +5850,14 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -6131,6 +6244,16 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise.prototype.finally": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz",
+      "integrity": "sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0",
+        "function-bind": "^1.1.1"
+      }
+    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -6326,6 +6449,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
       "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-parser": {
       "version": "2.6.0",
@@ -7020,6 +7148,11 @@
         }
       }
     },
+    "standard-as-callback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
+      "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7104,11 +7237,64 @@
         "strip-ansi": "^3.0.0"
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "string.prototype.trimleft": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimstart": "^1.0.0"
+          }
+        },
+        "string.prototype.trimright": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimend": "^1.0.0"
+          }
+        }
+      }
+    },
     "string.prototype.trimleft": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -7118,10 +7304,63 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "string.prototype.trimleft": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimstart": "^1.0.0"
+          }
+        },
+        "string.prototype.trimright": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimend": "^1.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -7731,6 +7970,62 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "string.prototype.trimleft": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimstart": "^1.0.0"
+          }
+        },
+        "string.prototype.trimright": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "string.prototype.trimend": "^1.0.0"
+          }
+        }
+      }
     },
     "uuid": {
       "version": "3.3.2",

--- a/api/package.json
+++ b/api/package.json
@@ -34,6 +34,7 @@
     "bookshelf-page": "^0.3.2",
     "bookshelf-validate": "^2.0.3",
     "boom": "^7.3.0",
+    "bull": "3.13.0",
     "bunyan": "^1.8.12",
     "catbox": "^10.0.6",
     "catbox-memory": "^4.0.1",

--- a/api/tests/unit/infrastructure/mailers/MailjetProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/MailjetProvider_test.js
@@ -1,8 +1,6 @@
 const nodeMailjet = require('node-mailjet');
 const { sinon } = require('../../../test-helper');
 const MailjetProvider = require('../../../../lib/infrastructure/mailers/MailjetProvider');
-const mailCheck = require('../../../../lib/infrastructure/mail-check');
-const { mailing } = require('../../../../lib/config');
 
 describe('Unit | Class | MailjetProvider', function() {
 
@@ -14,89 +12,74 @@ describe('Unit | Class | MailjetProvider', function() {
 
     const recipient = 'test@example.net';
 
-    context('when mail sending is enabled', () => {
+    it('should request with a payload', async () => {
+      // given
+      const from = 'no-reply@example.net';
+      const requestStub = sinon.stub().returns(Promise.resolve());
+      const postStub = sinon.stub().returns({ request: requestStub });
+      nodeMailjet.connect.returns({ post: postStub });
+      const mailingProvider = new MailjetProvider();
 
-      beforeEach(() => {
-        sinon.stub(mailing, 'enabled').value(true);
-        sinon.stub(mailing, 'provider').value('mailjet');
+      // when
+      await mailingProvider.sendEmail({
+        from,
+        to: recipient,
+        fromName: 'Ne Pas Repondre',
+        subject: 'Creation de compte',
+        template: '129291'
       });
 
-      context('when email check succeeds', () => {
+      // then
+      sinon.assert.calledWith(requestStub, {
+        'FromEmail': 'no-reply@example.net',
+        'FromName': 'Ne Pas Repondre',
+        'Subject': 'Creation de compte',
+        'MJ-TemplateID': '129291',
+        'MJ-TemplateLanguage': 'true',
+        'Recipients': [{ 'Email': recipient, 'Vars': {} }]
+      });
+    });
 
-        beforeEach(() => {
-          sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
-        });
+    it('should have default values', async () => {
+      // given
+      const requestStub = sinon.stub().returns(Promise.resolve());
+      const postStub = sinon.stub().returns({ request: requestStub });
+      nodeMailjet.connect.returns({ post: postStub });
+      const mailingProvider = new MailjetProvider();
 
-        it('should request with a payload', async () => {
-          // given
-          const from = 'no-reply@example.net';
-          const requestStub = sinon.stub().returns(Promise.resolve());
-          const postStub = sinon.stub().returns({ request: requestStub });
-          nodeMailjet.connect.returns({ post: postStub });
-          const mailingProvider = new MailjetProvider();
+      // when
+      await mailingProvider.sendEmail({ template: '129291', to: recipient });
 
-          // when
-          await mailingProvider.sendEmail({
-            from,
-            to: recipient,
-            fromName: 'Ne Pas Repondre',
-            subject: 'Creation de compte',
-            template: '129291'
-          });
+      // then
+      sinon.assert.calledWith(requestStub, {
+        'FromEmail': 'communaute@pix.fr',
+        'FromName': 'Communauté PIX',
+        'Subject': 'Bienvenue dans la communauté PIX',
+        'MJ-TemplateID': '129291',
+        'MJ-TemplateLanguage': 'true',
+        'Recipients': [{ 'Email': recipient, 'Vars': {} }]
+      });
+    });
 
-          // then
-          sinon.assert.calledWith(requestStub, {
-            'FromEmail': 'no-reply@example.net',
-            'FromName': 'Ne Pas Repondre',
-            'Subject': 'Creation de compte',
-            'MJ-TemplateID': '129291',
-            'MJ-TemplateLanguage': 'true',
-            'Recipients': [{ 'Email': recipient, 'Vars': {} }]
-          });
-        });
+    it('should set variables in values', async () => {
+      // given
+      const requestStub = sinon.stub().returns(Promise.resolve());
+      const postStub = sinon.stub().returns({ request: requestStub });
+      const variables = { resetUrl: 'token' };
+      nodeMailjet.connect.returns({ post: postStub });
+      const mailingProvider = new MailjetProvider();
 
-        it('should have default values', async () => {
-          // given
-          const requestStub = sinon.stub().returns(Promise.resolve());
-          const postStub = sinon.stub().returns({ request: requestStub });
-          nodeMailjet.connect.returns({ post: postStub });
-          const mailingProvider = new MailjetProvider();
+      // when
+      await mailingProvider.sendEmail({ template: '129291', to: recipient, variables });
 
-          // when
-          await mailingProvider.sendEmail({ template: '129291', to: recipient });
-
-          // then
-          sinon.assert.calledWith(requestStub, {
-            'FromEmail': 'communaute@pix.fr',
-            'FromName': 'Communauté PIX',
-            'Subject': 'Bienvenue dans la communauté PIX',
-            'MJ-TemplateID': '129291',
-            'MJ-TemplateLanguage': 'true',
-            'Recipients': [{ 'Email': recipient, 'Vars': {} }]
-          });
-        });
-
-        it('should set variables in values', async () => {
-          // given
-          const requestStub = sinon.stub().returns(Promise.resolve());
-          const postStub = sinon.stub().returns({ request: requestStub });
-          const variables = { resetUrl: 'token' };
-          nodeMailjet.connect.returns({ post: postStub });
-          const mailingProvider = new MailjetProvider();
-
-          // when
-          await mailingProvider.sendEmail({ template: '129291', to: recipient, variables });
-
-          // then
-          sinon.assert.calledWith(requestStub, {
-            'FromEmail': 'communaute@pix.fr',
-            'FromName': 'Communauté PIX',
-            'Subject': 'Bienvenue dans la communauté PIX',
-            'MJ-TemplateID': '129291',
-            'MJ-TemplateLanguage': 'true',
-            'Recipients': [{ 'Email': recipient, 'Vars': variables }]
-          });
-        });
+      // then
+      sinon.assert.calledWith(requestStub, {
+        'FromEmail': 'communaute@pix.fr',
+        'FromName': 'Communauté PIX',
+        'Subject': 'Bienvenue dans la communauté PIX',
+        'MJ-TemplateID': '129291',
+        'MJ-TemplateLanguage': 'true',
+        'Recipients': [{ 'Email': recipient, 'Vars': variables }]
       });
     });
   });

--- a/api/tests/unit/infrastructure/mailers/MockLogEmailProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/MockLogEmailProvider_test.js
@@ -5,6 +5,9 @@ const logger = require('../../../../lib/infrastructure/logger');
 describe('Unit | Class | MockLogEmailProvider', function() {
 
   describe('#sendEmail', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
 
     it('should log options to fake email sending', async () => {
       // given

--- a/api/tests/unit/infrastructure/mailers/MockLogEmailProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/MockLogEmailProvider_test.js
@@ -1,0 +1,26 @@
+const { sinon, expect } = require('../../../test-helper');
+const MockLogEmailProvider = require('../../../../lib/infrastructure/mailers/MockLogEmailProvider');
+const logger = require('../../../../lib/infrastructure/logger');
+
+describe('Unit | Class | MockLogEmailProvider', function() {
+
+  describe('#sendEmail', () => {
+
+    it('should log options to fake email sending', async () => {
+      // given
+      const options = {
+        some: 'email',
+        options: 'to-fake',
+      };
+      sinon.spy(logger, 'info');
+      const mailingProvider = new MockLogEmailProvider();
+
+      // when
+      await mailingProvider.sendEmail(options);
+
+      // then
+      expect(logger.info).to.be.calledWith(`Faking email sending - ${JSON.stringify(options)}`);
+    });
+
+  });
+});

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -22,19 +22,17 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
         sinon.stub(mailer, '_provider').value(mailingProvider);
       });
 
-      context('when email check succeed', () => {
+      context('when email check succeeds', () => {
 
         beforeEach(() => {
           sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
         });
 
-        it('should called email provider method _doSendEmail', async () => {
+        it('should add send Email job to queue', async () => {
           // given
-          const from = 'no-reply@example.net';
-          mailer._provider.sendEmail.resolves();
-
+          sinon.stub(mailer.sendEmailQueue, 'add');
           const options = {
-            from,
+            from:'no-reply@example.net',
             to: recipient,
             fromName: 'Ne Pas Repondre',
             subject: 'Creation de compte',
@@ -45,7 +43,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
           await mailer.sendEmail(options);
 
           // then
-          sinon.assert.calledWith(mailer._provider.sendEmail, options);
+          expect(mailer.sendEmailQueue.add).to.be.called;
         });
       });
 
@@ -67,27 +65,6 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
         });
       });
 
-      context('when emailing fails', () => {
-
-        let error;
-
-        beforeEach(() => {
-          error = new Error('fail');
-          sinon.stub(mailCheck, 'checkMail').resolves();
-          sinon.stub(logger, 'warn');
-        });
-
-        it('should log a warning', async () => {
-          // given
-          mailer._provider.sendEmail.rejects(error);
-
-          // when
-          await mailer.sendEmail({ to: recipient });
-
-          // then
-          expect(logger.warn).to.have.been.calledWith({ err: error }, 'Could not send email to \'test@example.net\'');
-        });
-      });
     });
   });
 

--- a/docs/adr/0010-ajout-d-une-file-de-job-asynchrone.md
+++ b/docs/adr/0010-ajout-d-une-file-de-job-asynchrone.md
@@ -1,0 +1,45 @@
+# 10. Ajout d'une file de jobs asynchrones gérée par la librairie Bull
+
+Date : 2020-04-21
+
+## État
+
+Proposition
+
+## Contexte
+
+Certaines opérations ne sont pas obligatoirement synchrones de l'appel API entrant.
+C'est le cas par exemple de l'envoi de mail.
+L'envoi de mail est délégué (via un appel API) à un fournisseur tiers (Sendinblue ou Mailjet).
+Pour la résilience de Pix, l'échec de l'envoi via le fournisseur ne doit pas entraîner l'échec de la création de compte.
+
+Actuellement, on fait un appel asynchrone non géré (i. e. on n'attend pas le retour de l'appel API). 
+Ce fonctionnement n'entraîne pas l'échec de la création de compte si le fournisseur d'envoi de mails rencontre
+des problèmes.
+En revanche, cela ne permet pas de stratégie de ré-essai en cas d'échec. 
+**Un mail en échec ne sera jamais envoyé plus tard.**
+
+## Décision
+
+L'utilisation d'une file de jobs asynchrones permet d'envoyer les mails en contrôlant la concurrence des appels API (vers le
+fournisseur d'envoi de mails), de ré-essayer un certain nombre de fois un envoi en échec, espacé d'un temps défini.
+
+L'implémentation proposée repose sur l'usage de [bull](https://github.com/OptimalBits/bull/).
+Cette dépendence tierce permet la création et la gestion simplifiée d'une file de jobs en se basant sur un serveur REDIS.
+
+Toutes les informations motivant cette décision sont disponibles ici : [https://1024pix.atlassian.net/wiki/x/AQBMUw](https://1024pix.atlassian.net/wiki/x/AQBMUw).
+
+## Conséquences
+
+Il faut créer une file de job dans un fichier dans le dossier `lib/infrastructure/queued-jobs`.
+Voir pour exemple le fichier `lib/infrastructure/queued-jobs/create-send-email-queue-service.js`.
+
+Ce fichier exporte une fonction de création de la file de job et les options du job.
+On recommande les options suivantes :
+- `removeOnComplete` à `true` afin de ne pas stocker les jobs réussis.
+- `removeOnFailed` à `1` afin de ne garder qu'une seule occurence d'un job échoué (pas de stockage des ré-essais en cas d'échec).
+
+Il faut créer un fichier `processor` dédié.
+Voir pour exemple le fichier `lib/infrastructure/mailers/send-email-job-processor.js`.
+
+Cela permet d'exécuter le job dans un nouveau process, et donc d'optimiser l'usage CPU et de ne pas bloquer le process parent (l'api).


### PR DESCRIPTION
## :unicorn: Problème
L'envoi de mail - lors de la création de compte notamment - est fait en appelant de manière synchrone l'API du provider de mail.
Cela a pour conséquence de bloquer la requête dans l'attente de la réponse de l'API du provider de mail.
De plus, si l'envoi du mail échoue, notre requête échoue également.

## :robot: Solution
La solution proposée dans cette PR est l'utilisation d'une file (queue) de jobs asynchrones.
Lors de l'envoi d'un mail, un job est ajouté à cette file.
La création et la gestion de la file est faite par le package https://github.com/OptimalBits/bull.

## :rainbow: Remarques
Afin de tester le processing de la file sans envoyer réellement de mail, un provider est créé (`MockLogEmailProvider`) qui log les paramètres du mail uniquement (pas d'envoi).

Discussion et étude :
https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1397489665/2020-04-27+tude+de+l+exploitation+de+Redis+d+autres+fins+que+le+stockage+du+Learning+Content

## :100: Pour tester
Sur la review app, les variables d'environnement ont été changées comme suit :
```
# Mailing
MAILING_ENABLED=true
MAILING_PROVIDER=logger
```

Sur pix app, déclencher un envoi de mail (création de compte ou perte de mot de passe).
Vérifier dans les logs de l'api la présence de la ligne suivante :
```
Faking email sending - ## contenu de l'email envoyé ##
````