### PR TITLE
[FEATURE] Affichage des tutoriels par sujets dans l'analyse de campagne (PO-408).

### DIFF
--- a/api/lib/domain/models/CampaignAnalysis.js
+++ b/api/lib/domain/models/CampaignAnalysis.js
@@ -11,21 +11,23 @@ class CampaignAnalysis {
     competences,
     skills,
     validatedKnowledgeElements,
-    participantsCount
+    participantsCount,
+    tutorials,
   } = {}) {
     this.id = campaignId;
     // attributes
-    this.campaignTubeRecommendations = this._buildCampaignTubeRecommandations(campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount);
+    this.campaignTubeRecommendations = this._buildCampaignTubeRecommandations({ campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount, tutorials });
   }
 
-  _buildCampaignTubeRecommandations(campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount) {
+  _buildCampaignTubeRecommandations({ campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount, tutorials }) {
     const { difficulty: maxSkillLevelInTargetProfile } =  _.maxBy(skills, 'difficulty');
     return tubes.map((tube) => {
       const competence = _.find(competences, { id: tube.competenceId });
       const tubeSkills = _.filter(skills, { tubeId: tube.id });
       const tubeSkillIds = _.map(tubeSkills, ({ id }) => id);
       const validatedKnowledgeElementsOfTube = _.filter(validatedKnowledgeElements, (knowledgeElement) => tubeSkillIds.includes(knowledgeElement.skillId));
-
+      const tutorialIds = _.uniq(_.flatMap(tubeSkills, 'tutorialIds'));
+      const tubeTutorials = _.filter(tutorials, (tutorial) => tutorialIds.includes(tutorial.id));
       return new CampaignTubeRecommendation({
         campaignId: campaignId,
         competence,
@@ -34,6 +36,7 @@ class CampaignAnalysis {
         validatedKnowledgeElements: validatedKnowledgeElementsOfTube,
         participantsCount,
         maxSkillLevelInTargetProfile,
+        tutorials: tubeTutorials,
       });
     });
   }

--- a/api/lib/domain/models/CampaignTubeRecommendation.js
+++ b/api/lib/domain/models/CampaignTubeRecommendation.js
@@ -12,7 +12,8 @@ class CampaignTubeRecommendation {
     skills,
     validatedKnowledgeElements,
     participantsCount,
-    maxSkillLevelInTargetProfile
+    maxSkillLevelInTargetProfile,
+    tutorials,
   } = {}) {
     // attributes
     this.campaignId = campaignId;
@@ -25,6 +26,7 @@ class CampaignTubeRecommendation {
     if (participantsCount) {
       this.averageScore = this._computeAverageScore(validatedKnowledgeElements, skills, participantsCount, maxSkillLevelInTargetProfile);
     }
+    this.tutorials = tutorials;
   }
 
   get id() {

--- a/api/lib/domain/usecases/compute-campaign-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-analysis.js
@@ -11,7 +11,8 @@ module.exports = async function computeCampaignAnalysis(
     targetProfileRepository,
     tubeRepository,
     knowledgeElementRepository,
-    campaignParticipationRepository
+    campaignParticipationRepository,
+    tutorialRepository,
   } = {}) {
 
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
@@ -20,12 +21,13 @@ module.exports = async function computeCampaignAnalysis(
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
   }
 
-  const [competences, tubes, targetProfile, validatedKnowledgeElements, participantsCount] = await Promise.all([
+  const [competences, tubes, targetProfile, validatedKnowledgeElements, participantsCount, tutorials] = await Promise.all([
     competenceRepository.list(),
     tubeRepository.list(),
     targetProfileRepository.getByCampaignId(campaignId),
     knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId),
-    campaignParticipationRepository.countSharedParticipationOfCampaign(campaignId)
+    campaignParticipationRepository.countSharedParticipationOfCampaign(campaignId),
+    tutorialRepository.list(),
   ]);
 
   const targetedTubeIds = _.map(targetProfile.skills, ({ tubeId }) => ({ id: tubeId }));
@@ -37,6 +39,7 @@ module.exports = async function computeCampaignAnalysis(
     competences,
     skills: targetProfile.skills,
     validatedKnowledgeElements,
-    participantsCount
+    participantsCount,
+    tutorials,
   });
 };

--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -12,6 +12,7 @@ module.exports = async function computeCampaignParticipationAnalysis(
     targetProfileRepository,
     tubeRepository,
     knowledgeElementRepository,
+    tutorialRepository,
   } = {}) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   const campaignId = campaignParticipation.campaignId;
@@ -25,11 +26,12 @@ module.exports = async function computeCampaignParticipationAnalysis(
     return null;
   }
 
-  const [competences, tubes, targetProfile, validatedKnowledgeElements] = await Promise.all([
+  const [competences, tubes, targetProfile, validatedKnowledgeElements, tutorials] = await Promise.all([
     competenceRepository.list(),
     tubeRepository.list(),
     targetProfileRepository.getByCampaignId(campaignId),
     knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId: campaignParticipation.userId }),
+    tutorialRepository.list(),
   ]);
 
   const targetedTubeIds = _.map(targetProfile.skills, ({ tubeId }) => ({ id: tubeId }));
@@ -41,6 +43,7 @@ module.exports = async function computeCampaignParticipationAnalysis(
     competences,
     skills: targetProfile.skills,
     validatedKnowledgeElements,
+    tutorials,
     participantsCount: 1
   });
 };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -25,6 +25,11 @@ module.exports = {
     }
   },
 
+  async list() {
+    const tutorialData = await tutorialDatasource.list();
+    return _.map(tutorialData, _toDomain);
+  },
+
 };
 
 function _toDomain(tutorialData) {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
@@ -1,4 +1,5 @@
 const { Serializer } = require('jsonapi-serializer');
+const tutorialAttributes = require('./tutorial-attributes');
 
 module.exports = {
   serialize(results) {
@@ -7,7 +8,8 @@ module.exports = {
       campaignTubeRecommendations: {
         ref: 'id',
         includes: true,
-        attributes: ['tubeId', 'competenceId', 'competenceName', 'tubePracticalTitle', 'areaColor', 'averageScore'],
+        attributes: ['tubeId', 'competenceId', 'competenceName', 'tubePracticalTitle', 'areaColor', 'averageScore', 'tutorials'],
+        tutorials: tutorialAttributes
       },
     }).serialize(results);
   },

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -169,18 +169,29 @@ describe('Acceptance | API | Campaign Controller', () => {
         campaignParticipationId: campaignParticipation.id
       });
 
-      databaseBuilder.factory.buildKnowledgeElement({ skillId: 'recSkillId1', status: 'validated', userId, assessmentId: assessment.id, competenceId: 'recCompetence1', createdAt: faker.date.past(10, campaignParticipation.sharedAt) });
+      databaseBuilder.factory.buildKnowledgeElement({
+        skillId: 'recSkillId1',
+        status: 'validated',
+        userId,
+        assessmentId: assessment.id,
+        competenceId: 'recCompetence1',
+        createdAt: faker.date.past(10, campaignParticipation.sharedAt)
+      });
 
       await databaseBuilder.commit();
 
       const area = airtableBuilder.factory.buildArea({ competenceIds: ['recCompetence1'], couleur: 'specialColor' });
-      const competence1 = airtableBuilder.factory.buildCompetence({ id: 'recCompetence1', titre: 'Fabriquer un meuble', domaineIds: [ area.id ] });
+      const competence1 = airtableBuilder.factory.buildCompetence({
+        id: 'recCompetence1',
+        titre: 'Fabriquer un meuble',
+        domaineIds: [area.id]
+      });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: [ 'recCompetence1' ] }),
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId2', ['compétenceViaTube']: [ 'recCompetence1' ] }),
+        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: ['recCompetence1'] }),
+        airtableBuilder.factory.buildSkill({ id: 'recSkillId2', ['compétenceViaTube']: ['recCompetence1'] }),
       ]).activate();
-      airtableBuilder.mockList({ tableName: 'Competences' }).returns([ competence1 ]).activate();
-      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([ area ]).activate();
+      airtableBuilder.mockList({ tableName: 'Competences' }).returns([competence1]).activate();
+      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([area]).activate();
     });
 
     afterEach(async () => {
@@ -261,9 +272,9 @@ describe('Acceptance | API | Campaign Controller', () => {
 
       await databaseBuilder.commit();
 
-      airtableBuilder.mockList({ tableName: 'Acquis' }).returns([ airtableBuilder.factory.buildSkill() ]).activate();
-      airtableBuilder.mockList({ tableName: 'Competences' }).returns([ airtableBuilder.factory.buildCompetence() ]).activate();
-      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([ airtableBuilder.factory.buildArea() ]).activate();
+      airtableBuilder.mockList({ tableName: 'Acquis' }).returns([airtableBuilder.factory.buildSkill()]).activate();
+      airtableBuilder.mockList({ tableName: 'Competences' }).returns([airtableBuilder.factory.buildCompetence()]).activate();
+      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([airtableBuilder.factory.buildArea()]).activate();
     });
 
     afterEach(async () => {
@@ -271,7 +282,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       return cache.flushAll();
     });
 
-    it('should return csv file with statusCode 200', async ()=> {
+    it('should return csv file with statusCode 200', async () => {
 
       // given
       const url = `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`;
@@ -316,9 +327,9 @@ describe('Acceptance | API | Campaign Controller', () => {
 
       await databaseBuilder.commit();
 
-      airtableBuilder.mockList({ tableName: 'Acquis' }).returns([ airtableBuilder.factory.buildSkill() ]).activate();
-      airtableBuilder.mockList({ tableName: 'Competences' }).returns([ airtableBuilder.factory.buildCompetence() ]).activate();
-      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([ airtableBuilder.factory.buildArea() ]).activate();
+      airtableBuilder.mockList({ tableName: 'Acquis' }).returns([airtableBuilder.factory.buildSkill()]).activate();
+      airtableBuilder.mockList({ tableName: 'Competences' }).returns([airtableBuilder.factory.buildCompetence()]).activate();
+      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([airtableBuilder.factory.buildArea()]).activate();
     });
 
     afterEach(async () => {
@@ -326,7 +337,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       return cache.flushAll();
     });
 
-    it('should return csv file with statusCode 200', async ()=> {
+    it('should return csv file with statusCode 200', async () => {
       // given
       const url = `/api/campaigns/${campaign.id}/csv-profiles-collection-results?accessToken=${accessToken}`;
       const request = {
@@ -372,14 +383,37 @@ describe('Acceptance | API | Campaign Controller', () => {
       await databaseBuilder.commit();
 
       const area = airtableBuilder.factory.buildArea({ competenceIds: ['recCompetence1'], couleur: 'specialColor' });
-      const competence1 = airtableBuilder.factory.buildCompetence({ id: 'recCompetence1', titre: 'Fabriquer un meuble', acquisViaTubes: [ 'recSkillId1' ], domaineIds: [ area.id ] });
+      const competence1 = airtableBuilder.factory.buildCompetence({
+        id: 'recCompetence1',
+        titre: 'Fabriquer un meuble',
+        acquisViaTubes: ['recSkillId1'],
+        domaineIds: [area.id]
+      });
+      const tutorial = airtableBuilder.factory.buildTutorial({
+        id: 'recTutorial1',
+        titre: 'Apprendre à vivre confiné',
+        format: '2 mois',
+        source: 'covid-19',
+        lien: 'www.liberez-moi.fr',
+        createdTime: '2020-03-16T14:38:03.000Z'
+      });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: [ 'recCompetence1' ], tube: ['recTube1'] }),
+        airtableBuilder.factory.buildSkill({
+          id: 'recSkillId1',
+          'compétenceViaTube': ['recCompetence1'],
+          tube: ['recTube1'],
+          comprendre: [tutorial.id]
+        }),
       ]).activate();
-      const tube1 = airtableBuilder.factory.buildTube({ id: 'recTube1', titrePratique: 'Monter une étagère', competences: [ 'recCompetence1' ] });
-      airtableBuilder.mockList({ tableName: 'Tubes' }).returns([ tube1 ]).activate();
-      airtableBuilder.mockList({ tableName: 'Competences' }).returns([ competence1 ]).activate();
-      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([ area ]).activate();
+      const tube1 = airtableBuilder.factory.buildTube({
+        id: 'recTube1',
+        titrePratique: 'Monter une étagère',
+        competences: ['recCompetence1']
+      });
+      airtableBuilder.mockList({ tableName: 'Tubes' }).returns([tube1]).activate();
+      airtableBuilder.mockList({ tableName: 'Competences' }).returns([competence1]).activate();
+      airtableBuilder.mockList({ tableName: 'Domaines' }).returns([area]).activate();
+      airtableBuilder.mockList({ tableName: 'Tutoriels' }).returns([tutorial]).activate();
     });
 
     afterEach(async () => {
@@ -410,6 +444,17 @@ describe('Acceptance | API | Campaign Controller', () => {
           },
         },
         included: [{
+          'id': 'recTutorial1',
+          'type': 'tutorials',
+          attributes: {
+            'duration': '00:03:31',
+            'format': '2 mois',
+            'id': 'recTutorial1',
+            'link': 'www.liberez-moi.fr',
+            'source': 'covid-19',
+            'title': 'Apprendre à vivre confiné'
+          },
+        }, {
           id: `${campaign.id}_recTube1`,
           type: 'campaignTubeRecommendations',
           attributes: {
@@ -420,6 +465,14 @@ describe('Acceptance | API | Campaign Controller', () => {
             'tube-practical-title': 'Monter une étagère',
             'average-score': 30
           },
+          relationships: {
+            tutorials: {
+              data: [{
+                'id': 'recTutorial1',
+                'type': 'tutorials',
+              }]
+            }
+          }
         }]
       };
 

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
@@ -43,13 +43,15 @@ describe('Acceptance | API | Campaign Participations | Analyses', () => {
 
       const area = airtableBuilder.factory.buildArea({ competenceIds: ['recCompetence1'], couleur: 'specialColor' });
       const competence1 = airtableBuilder.factory.buildCompetence({ id: 'recCompetence1', titre: 'Fabriquer un meuble', acquisViaTubes: [ 'recSkillId1' ], domaineIds: [ area.id ] });
+      const tutorial = airtableBuilder.factory.buildTutorial({ id: 'recTutorial1', titre: 'Apprendre à vivre confiné', format: '2 mois', source: 'covid-19', lien: 'www.liberez-moi.fr', createdTime: '2020-03-16T14:38:03.000Z' });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: [ 'recCompetence1' ], tube: ['recTube1'] }),
+        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', 'compétenceViaTube': ['recCompetence1'], tube: ['recTube1'], comprendre: [tutorial.id] }),
       ]).activate();
       const tube1 = airtableBuilder.factory.buildTube({ id: 'recTube1', titrePratique: 'Monter une étagère', competences: [ 'recCompetence1' ] });
       airtableBuilder.mockList({ tableName: 'Tubes' }).returns([ tube1 ]).activate();
       airtableBuilder.mockList({ tableName: 'Competences' }).returns([ competence1 ]).activate();
       airtableBuilder.mockList({ tableName: 'Domaines' }).returns([ area ]).activate();
+      airtableBuilder.mockList({ tableName: 'Tutoriels' }).returns([ tutorial ]).activate();
     });
 
     afterEach(async () => {
@@ -79,6 +81,17 @@ describe('Acceptance | API | Campaign Participations | Analyses', () => {
           },
         },
         included: [{
+          id: 'recTutorial1',
+          type: 'tutorials',
+          attributes: {
+            duration: '00:03:31',
+            format: '2 mois',
+            id: 'recTutorial1',
+            link: 'www.liberez-moi.fr',
+            source: 'covid-19',
+            title: 'Apprendre à vivre confiné'
+          }
+        }, {
           id: `${campaign.id}_recTube1`,
           type: 'campaignTubeRecommendations',
           attributes: {
@@ -89,6 +102,14 @@ describe('Acceptance | API | Campaign Participations | Analyses', () => {
             'tube-practical-title': 'Monter une étagère',
             'average-score': 30,
           },
+          relationships: {
+            tutorials: {
+              data: [{
+                id: 'recTutorial1',
+                type: 'tutorials',
+              }]
+            }
+          }
         }]
       };
 

--- a/api/tests/integration/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-analysis_test.js
@@ -10,6 +10,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
   let tubeRepository;
   let knowledgeElementRepository;
   let campaignParticipationRepository;
+  let tutorialRepository;
 
   const userId = 1;
   const campaignId = 'someCampaignId';
@@ -21,6 +22,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
     tubeRepository = { list: sinon.stub() };
     knowledgeElementRepository = { findByCampaignIdForSharedCampaignParticipation: sinon.stub() };
     campaignParticipationRepository = { countSharedParticipationOfCampaign: sinon.stub() };
+    tutorialRepository = { list: sinon.stub() };
   });
 
   context('User has access to this result', () => {
@@ -30,7 +32,8 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
       const competence = domainBuilder.buildCompetence({ area });
       const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
       const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
-      const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId' });
+      const tutorial = domainBuilder.buildTutorial({ id: 'recTuto1' });
+      const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId', tutorialIds: [tutorial.id] });
       const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
       const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
@@ -42,8 +45,9 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
         competence,
         validatedKnowledgeElements: [knowledgeElementSkill1],
         skills: [skill],
-        maxSkillLevelInTargetProfile:  2,
-        participantsCount:  1
+        maxSkillLevelInTargetProfile: 2,
+        participantsCount: 1,
+        tutorials: [tutorial],
       });
 
       const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
@@ -52,8 +56,9 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
         competence,
         validatedKnowledgeElements: [knowledgeElementSkill2],
         skills: [skill2],
-        maxSkillLevelInTargetProfile:  2,
-        participantsCount: 1
+        maxSkillLevelInTargetProfile: 2,
+        participantsCount: 1,
+        tutorials: [],
       });
 
       targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
@@ -63,6 +68,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
       tubeRepository.list.resolves([tube, otherTube]);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
       targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+      tutorialRepository.list.resolves([tutorial]);
 
       const expectedResult = {
         id: campaignId,
@@ -78,7 +84,8 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
         targetProfileRepository,
         tubeRepository,
         knowledgeElementRepository,
-        campaignParticipationRepository
+        campaignParticipationRepository,
+        tutorialRepository,
       });
 
       // then

--- a/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -10,6 +10,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
   let targetProfileRepository;
   let tubeRepository;
   let knowledgeElementRepository;
+  let tutorialRepository;
 
   const userId = 1;
   const campaignId = 'someCampaignId';
@@ -23,6 +24,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
     targetProfileRepository = { getByCampaignId: sinon.stub() };
     tubeRepository = { list: sinon.stub() };
     knowledgeElementRepository = { findByCampaignIdAndUserIdForSharedCampaignParticipation: sinon.stub() };
+    tutorialRepository = { list: sinon.stub() };
 
     campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId, isShared: true });
   });
@@ -33,7 +35,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         // given
         const area = domainBuilder.buildArea();
         const competence = domainBuilder.buildCompetence({ area });
-        const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId' });
+        const tutorial = domainBuilder.buildTutorial({ id: 'recTutorial1', duration: '00:01:30', format: 'video', link: 'https://youtube.fr', source: 'Youtube', title: 'Savoir regarder des vidéos youtube.' });
+        const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId', tutorialIds: [tutorial.id] });
         const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
         const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
         const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
@@ -48,7 +51,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           validatedKnowledgeElements: [knowledgeElementSkill1],
           skills: [skill],
           maxSkillLevelInTargetProfile:  2,
-          participantsCount: 1
+          participantsCount: 1,
+          tutorials: [tutorial],
         });
 
         const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
@@ -58,7 +62,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           validatedKnowledgeElements: [knowledgeElementSkill2],
           skills: [skill2],
           maxSkillLevelInTargetProfile:  2,
-          participantsCount: 1
+          participantsCount: 1,
+          tutorials: [],
         });
 
         targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
@@ -68,6 +73,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
         targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
         knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation.withArgs({ campaignId, userId: campaignParticipation.userId }).resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
+        tutorialRepository.list.resolves([tutorial]);
 
         const expectedResult = {
           id: campaignId,
@@ -84,6 +90,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           targetProfileRepository,
           tubeRepository,
           knowledgeElementRepository,
+          tutorialRepository,
         });
 
         // then
@@ -106,7 +113,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           campaignParticipationRepository,
           competenceRepository,
           targetProfileRepository,
-          tubeRepository
+          tubeRepository,
+          tutorialRepository
         });
 
         // then
@@ -130,7 +138,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         campaignParticipationRepository,
         competenceRepository,
         targetProfileRepository,
-        tubeRepository
+        tubeRepository,
+        tutorialRepository,
       });
 
       // then

--- a/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
@@ -8,7 +8,8 @@ module.exports = function buildCampaignTubeRecommendation(
     skills,
     validatedKnowledgeElements,
     maxSkillLevelInTargetProfile,
-    participantsCount
+    participantsCount,
+    tutorials,
   } = {}) {
   return new CampaignTubeRecommendation({
     campaignId,
@@ -17,6 +18,7 @@ module.exports = function buildCampaignTubeRecommendation(
     skills,
     validatedKnowledgeElements,
     maxSkillLevelInTargetProfile,
-    participantsCount
+    participantsCount,
+    tutorials,
   });
 };

--- a/api/tests/unit/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/tutorial-repository_test.js
@@ -152,4 +152,32 @@ describe('Unit | Repository | tutorial-repository', () => {
     });
   });
 
+  describe('#list', () => {
+
+    context('when tutorials are found', () => {
+      beforeEach(() => {
+        // given
+        sinon.stub(tutorialDatasource, 'list')
+          .resolves([tutorialData1, tutorialData2]);
+      });
+
+      it('should return a lits of domain Tutorial objects', async () => {
+        // when
+        const fetchedTutorialList = await tutorialRepository.list();
+
+        // then
+        const expectedTutorialList = [
+          expectedTutorial,
+          expectedTutorial2
+        ];
+
+        expect(fetchedTutorialList[0]).to.be.an.instanceOf(Tutorial);
+        expect(fetchedTutorialList[1]).to.be.an.instanceOf(Tutorial);
+        expect(fetchedTutorialList).to.deep.equal(expectedTutorialList);
+      });
+
+    });
+
+  });
+
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
@@ -20,6 +20,14 @@ describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
             tubePracticalTitle: 'Savoir cuisiner des legumes d’automne à la perfection',
             areaColor: 'jaffa',
             averageScore: 11,
+            tutorials: [{
+              id: 'recTutorial1',
+              duration: '00:03:30',
+              format: 'video',
+              link: 'https://youtube.fr',
+              source: 'Youtube',
+              title: 'Savoir regarder des vidéos youtube.',
+            }]
           }
         ]
       };
@@ -39,6 +47,17 @@ describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
           },
         },
         included: [{
+          id: 'recTutorial1',
+          type: 'tutorials',
+          attributes: {
+            id: 'recTutorial1',
+            duration: '00:03:30',
+            format: 'video',
+            link: 'https://youtube.fr',
+            source: 'Youtube',
+            title: 'Savoir regarder des vidéos youtube.'
+          }
+        }, {
           id: '123_tubeRec1',
           type: 'campaignTubeRecommendations',
           attributes: {
@@ -48,7 +67,16 @@ describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
             'tube-practical-title': 'Savoir cuisiner des legumes d’automne à la perfection',
             'area-color': 'jaffa',
             'average-score': 11,
-
+          },
+          relationships: {
+            tutorials: {
+              data: [
+                {
+                  id: 'recTutorial1',
+                  type: 'tutorials'
+                }
+              ]
+            }
           }
         }]
       };

--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -26,6 +26,8 @@ Fonctionnalité: Gestion des Campagnes
     Alors je vois 2 sujets
     Et je vois que le sujet "Capitales" est "Fortement recommandé"
     Et je vois que le sujet "Philosophes" est "Assez recommandé"
+    Lorsque j'ouvre le sujet "Capitales"
+    Alors je vois 1 tutoriel
 
   Scénario: Je consulte le détail d'une campagne de collecte de profils
     Étant donné que je suis connecté à Pix Orga

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -6,6 +6,12 @@ when(`je vais sur la campagne {string} avec l'identifiant {string}`, (campaignCo
   cy.visitMonPix(`/campagnes/${campaignCode}?participantExternalId=${participantExternalId}`);
 });
 
+when(`j'ouvre le sujet {string}`, (tubeName) => {
+  cy.contains(tubeName).closest('[aria-label="Sujet"]').within(() => {
+    cy.get('button').click();
+  });
+});
+
 then(`je vois la page \(d'\)/\(de \){string} de la campagne`, (page) => {
   cy.url().should('include', page);
 });
@@ -20,8 +26,12 @@ when(`je saisis la date de naissance {int}-{int}-{int}`, (dayOfBirth, monthOfBir
   cy.get('input#yearOfBirth').type(yearOfBirth);
 });
 
-then(`je vois {int} campagne\(s\)`, (numberOfCampaigns) => {
-  cy.get('[aria-label="Campagne"]').should('have.lengthOf', numberOfCampaigns);
+then(`je vois {int} campagne\(s\)`, (campaignsCount) => {
+  cy.get('[aria-label="Campagne"]').should('have.lengthOf', campaignsCount);
+});
+
+then(`je vois {int} tutoriel\(s\)`, (tutorialsCount) => {
+  cy.get('[aria-label="Tutoriel"]').should('have.lengthOf', tutorialsCount);
 });
 
 when(`je recherche une campagne avec le nom {string}`, (campaignSearchName) => {

--- a/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.js
+++ b/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.js
@@ -7,7 +7,7 @@ export default class TubeRecommendationRowComponent extends Component {
   isOpen = false;
 
   @action
-  toggle() {
+  toggleTutorialsSection() {
     this.isOpen = !this.isOpen;
   }
 }

--- a/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.js
+++ b/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.js
@@ -1,0 +1,13 @@
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+
+export default class TubeRecommendationRowComponent extends Component {
+  @tracked
+  isOpen = false;
+
+  @action
+  toggle() {
+    this.isOpen = !this.isOpen;
+  }
+}

--- a/orga/app/models/campaign-tube-recommendation.js
+++ b/orga/app/models/campaign-tube-recommendation.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-const { belongsTo, Model, attr } = DS;
+const { belongsTo, hasMany, Model, attr } = DS;
 
 export default class CampaignTubeRecommendation extends Model {
 
@@ -12,4 +12,5 @@ export default class CampaignTubeRecommendation extends Model {
 
   @belongsTo('campaignAnalysis') campaignAnalysis;
 
+  @hasMany('tutorial') tutorials;
 }

--- a/orga/app/models/tutorial.js
+++ b/orga/app/models/tutorial.js
@@ -1,0 +1,9 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Tutorial extends Model {
+
+  // attributes
+  @attr('string') title;
+  @attr('string') link;
+
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -42,6 +42,7 @@
 @import "pages/authenticated/campaigns/no-campaign-panel";
 @import "pages/authenticated/campaigns/details/analysis";
 @import "pages/authenticated/campaigns/details/analysis/analysis-tab";
+@import "pages/authenticated/campaigns/details/analysis/tube-recommendation-row";
 @import "pages/authenticated/campaigns/details/parameters";
 @import "pages/authenticated/campaigns/details/collective-results/success-indicator";
 @import "pages/authenticated/campaigns/details/participants";

--- a/orga/app/styles/components/recommendation-indicator.scss
+++ b/orga/app/styles/components/recommendation-indicator.scss
@@ -4,6 +4,6 @@
 
   &__bubble {
     padding: 2px;
-    fill: $blue;
+    fill: lighten($blue, 10%);
   }
 }

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -38,7 +38,7 @@ tbody {
 tr {
   width: 100%;
   height: 60px;
-  border-top: 2px solid $grey-10;
+  border-top: 1px solid $grey-15;
 }
 
 td, th {
@@ -61,10 +61,21 @@ td, th {
     width: 25%;
   }
 
+  &--right {
+    text-align: right;
+    padding-right: 24px;
+  }
+
   &--truncated {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+.table__row {
+  &--small {
+    height: 40px;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
@@ -1,0 +1,47 @@
+.tube-recommendation-title {
+  font-family: $open-sans;
+  color: $grey-80;
+  font-weight: 600;
+  font-size: 0.875rem;
+
+  &--open {
+    color: $grey-100;
+    font-weight: 700;
+  }
+}
+
+.tube-recommendation-subtitle {
+  font-family: $open-sans;
+  color: $grey-35;
+  font-weight: 400;
+  font-size: 0.75rem;
+
+  &--open {
+    color: $grey-60;
+  }
+}
+
+.tube-recommendation-tutorial {
+  &__column {
+    padding-left: 52px;
+    padding-right: 52px;
+  }
+
+  &__title {
+    font-weight: 400;
+    font-family: $open-sans;
+    font-size: 1rem;
+  }
+}
+
+.tube-recommendation-tutorial-table {
+  margin-bottom: 10px;
+
+  &__row {
+    padding-left: 0;
+
+    a {
+      font-weight: 500;
+    }
+  }
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
@@ -15,25 +15,16 @@
       <th class="table__column--wide">Sujets ({{if @displayAnalysis
                                                   @campaignTubeRecommendations.length '-' }})</th>
       <th class="table__column--small table__column--center">Pertinence</th>
+      <th class="table__column--small table__column--center"></th>
     </tr>
     </thead>
 
     {{#if @displayAnalysis }}
       <tbody>
       {{#each @campaignTubeRecommendations as |tubeRecommendation|}}
-        <tr aria-label="Sujet">
-          <td class="campaign-details-table__line-wrapper">
-            <span class="campaign-details-table__bullet campaign-details-table__bullet--{{tubeRecommendation.areaColor}}">
-              &#8226;
-            </span>
-            <span>{{tubeRecommendation.tubePracticalTitle}}<br/>
-              <sub>{{tubeRecommendation.competenceName}}</sub>
-            </span>
-          </td>
-          <td>
-            <RecommendationIndicator @value={{tubeRecommendation.averageScore}} />
-          </td>
-        </tr>
+        <Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+          @tubeRecommendation={{tubeRecommendation}}
+        />
       {{/each}}
       </tbody>
     {{/if}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
@@ -1,0 +1,39 @@
+<tr aria-label="Sujet">
+  <td class="campaign-details-table__line-wrapper">
+    <span class="campaign-details-table__bullet campaign-details-table__bullet--{{@tubeRecommendation.areaColor}}">
+      &#8226;
+    </span>
+    <span>{{@tubeRecommendation.tubePracticalTitle}}<br />
+      <sub>{{@tubeRecommendation.competenceName}}</sub>
+    </span>
+  </td>
+  <td>
+    <RecommendationIndicator @value={{@tubeRecommendation.averageScore}} />
+  </td>
+  <td>
+    <button type="button" class="icon-button" {{on 'click' this.toggle}} aria-expanded={{this.isOpen}}>
+      {{#if this.isOpen}}
+      <FaIcon @icon="chevron-up" />
+      {{else}}
+      <FaIcon @icon="chevron-down" />
+      {{/if}}
+    </button>
+  </td>
+</tr>
+{{#if this.isOpen}}
+<tr>
+  <td colspan="3">
+    <h3>Tutos recommandés par la communauté Pix</h3>
+    <table>
+      <tbody>
+        <tr>
+          <td>Tuto 1</td>
+        </tr>
+        <tr>
+          <td>Tuto 2</td>
+        </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+{{/if}}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
@@ -3,37 +3,53 @@
     <span class="campaign-details-table__bullet campaign-details-table__bullet--{{@tubeRecommendation.areaColor}}">
       &#8226;
     </span>
-    <span>{{@tubeRecommendation.tubePracticalTitle}}<br />
-      <sub>{{@tubeRecommendation.competenceName}}</sub>
+    <span class={{concat "tube-recommendation-title " (if this.isOpen "tube-recommendation-title--open")}}>
+      {{@tubeRecommendation.tubePracticalTitle}}<br />
+      <sub class={{concat "tube-recommendation-subtitle " (if this.isOpen "tube-recommendation-subtitle--open")}}>
+        {{@tubeRecommendation.competenceName}}
+      </sub>
     </span>
   </td>
   <td>
     <RecommendationIndicator @value={{@tubeRecommendation.averageScore}} />
   </td>
-  <td>
-    <button type="button" class="icon-button" {{on 'click' this.toggle}} aria-expanded={{this.isOpen}}>
+  <td class="table__column--right">
+    <button type="button" class="icon-button" {{on 'click' this.toggleTutorialsSection}} aria-expanded="{{this.isOpen}}">
       {{#if this.isOpen}}
-      <FaIcon @icon="chevron-up" />
+        <FaIcon @icon="chevron-up" />
       {{else}}
-      <FaIcon @icon="chevron-down" />
+        <FaIcon @icon="chevron-down" />
       {{/if}}
     </button>
   </td>
 </tr>
 {{#if this.isOpen}}
-<tr>
-  <td colspan="3">
-    <h3>Tutos recommandés par la communauté Pix</h3>
-    <table>
-      <tbody>
-        <tr>
-          <td>Tuto 1</td>
-        </tr>
-        <tr>
-          <td>Tuto 2</td>
-        </tr>
-      </tbody>
-    </table>
-  </td>
-</tr>
+  <tr>
+    <td colspan="3" class="tube-recommendation-tutorial__column">
+      {{#if (eq @tubeRecommendation.tutorials.length 0)}}
+        <h3 class="tube-recommendation-tutorial__title">Aucun tuto recommandé pour ce sujet.</h3>
+      {{else}}
+        <h3 class="tube-recommendation-tutorial__title">
+          {{#if (eq @tubeRecommendation.tutorials.length 1)}}
+            1 tuto recommandé par la communauté Pix
+          {{else}}
+            {{@tubeRecommendation.tutorials.length}} tutos recommandés par la communauté Pix
+          {{/if}}
+        </h3>
+        <table class="tube-recommendation-tutorial-table">
+          <tbody>
+            {{#each @tubeRecommendation.tutorials as |tutorial|}}
+              <tr aria-label="Tutoriel" class="table__row--small">
+                <td class="tube-recommendation-tutorial-table__row">
+                  <a href={{tutorial.link}} class="link" target="_blank" rel="noopener noreferrer">
+                    {{tutorial.title}}
+                  </a>
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{/if}}
+    </td>
+  </tr>
 {{/if}}

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -34,7 +34,7 @@ module.exports = function(environment) {
 
     googleFonts: [
       'Roboto:300,400,500,700,900', // main font
-      'Open+Sans:300,600',
+      'Open+Sans:300,400,600,700',
     ],
 
     fontawesome: {

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row-test.js
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/campaigns/details/analysis/tube-recommendation-row', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+  let tubeRecommendation;
+  let tutorial1;
+  let tutorial2;
+
+  hooks.beforeEach(function() {
+    store = this.owner.lookup('service:store');
+
+    tutorial1 = store.createRecord('tutorial', {
+      title: 'tutorial1',
+      link: 'http://link.to.tuto.1',
+    });
+
+    tutorial2 = store.createRecord('tutorial', {
+      title: 'tutorial2',
+      link: 'http://link.to.tuto.2',
+    });
+
+    tubeRecommendation = store.createRecord('campaign-tube-recommendation', {
+      id: '1_recTubeA',
+      tubeId: 'recTubeA',
+      competenceId: 'recCompA',
+      competenceName: 'Competence A',
+      tubePracticalTitle: 'Tube A',
+      areaColor: 'jaffa',
+    });
+
+    this.set('tubeRecommendation', tubeRecommendation);
+  });
+
+  test('it should display tube details', async function(assert) {
+    // when
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+
+    // then
+    const firstTube = '[aria-label="Sujet"]';
+    assert.dom(firstTube).containsText('•');
+    assert.dom(firstTube).containsText('Tube A');
+    assert.dom(firstTube).containsText('Competence A');
+  });
+
+  test('it should expand and display one tutorial in the list', async function(assert) {
+    // given
+    tubeRecommendation.tutorials = [tutorial1];
+
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+
+    // when
+    await click('[data-icon="chevron-down"]');
+
+    // then
+    assert.dom('h3').containsText('1 tuto recommandé par la communauté Pix');
+    assert.dom('[aria-label="Tutoriel"]:first-child').containsText('tutorial1');
+    assert.dom('[aria-expanded="true"]').exists();
+  });
+
+  test('it should expand and display 2 tutorials in the list', async function(assert) {
+    // given
+    tubeRecommendation.tutorials = [tutorial1, tutorial2];
+
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+
+    // when
+    await click('[data-icon="chevron-down"]');
+
+    // then
+    assert.dom('h3').containsText('2 tutos recommandés par la communauté Pix');
+  });
+
+  test('it should collapse and hide tube tutorials list', async function(assert) {
+    // given
+    tubeRecommendation.tutorials = [tutorial1, tutorial2];
+
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+    await click('[data-icon="chevron-down"]');
+
+    // when
+    await click('[data-icon="chevron-up"]');
+
+    // then
+    assert.dom('h3').doesNotExist();
+    assert.dom('[aria-expanded="false"]').exists();
+  });
+
+  test('it should display a "no data" message when tutorials are empty', async function(assert) {
+    // given
+    tubeRecommendation.tutorials = [];
+
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::Analysis::TubeRecommendationRow
+      @tubeRecommendation={{tubeRecommendation}}
+    />`);
+
+    // when
+    await click('[data-icon="chevron-down"]');
+
+    // then
+    assert.dom('h3').containsText('Aucun tuto recommandé pour ce sujet.');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le prescripteur ne voit pas quel resource il peut fournir pour aider à améliorer les acquis des sujets les plus recommandés

## :robot: Solution
Pour chaque sujet, proposer de voir les tutoriels le plus pertinents à travailler pour s'améliorer.

## :rainbow: Remarques
L'affichage des tutoriels par sujet fonctionne pour:
1. Les analyses collectives de campagne
2. Les analyses de campagne par participant
Cela a été résolu "automatiquement" grâce à l'utilisation de routes, modèles et de composants pour les 2 types d'analyse.

## :100: Pour tester
**Test d'une analyse collective de campagne :**
1. Se connecter sur pix-orga
2. Aller sur une campagne
3. Cliquer sur l'onglet "analyse"
4. Cliquer sur le chevron d'un sujet pour afficher les tutoriels recommandés

**Test d'une analyse de campagne par participant :**
1. Se connecter sur pix-orga
2. Aller sur une campagne
3. Cliquer sur l'onglet "participants"
4. Cliquer sur un participant
5. Ajouter `/analyse` à l'URL
4. Cliquer sur le chevron d'un sujet pour afficher les tutoriels recommandés