### PR TITLE
[BUGFIX] Affichage non correct du résumé des résultats collectifs de campagne d'évaluation (PO-432).

### DIFF
--- a/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/collective-results-tab.hbs
@@ -1,21 +1,21 @@
-<div class="panel participant-results-row">
+<div class="panel participant-row participant-row__result">
 
   <div class="participant-results-content__summary">
-    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-      <div class="label-text participant-results-content__label-text">Acquis validés</div>
+    <div class="participant-content participant-content--large participant-content--wide">
+      <div class="label-text participant-content__label-text">Acquis validés</div>
       <div class="content-text content-text--big">
         {{ @campaignCollectiveResult.averageValidatedSkillsSum }}
       </div>
     </div>
-    <div class="participant-results-content participant-results-content--large participant-results-content--wide">
-      <div class="label-text participant-results-content__label-text">Acquis évalués</div>
+    <div class="participant-content participant-content--large participant-content--wide">
+      <div class="label-text participant-content__label-text">Acquis évalués</div>
       <div class="content-text content-text--big">
         {{ @campaignCollectiveResult.totalSkills }}
       </div>
     </div>
   </div>
 
-  <div class="participant-results-content">
+  <div class="participant-content participant-results-content">
     <div aria-label="Moyenne des résultats" class="participant-results-content__score">
       <div class="content-text content-text--big content-text--bold">Résultat</div>
       <div class="participant-results-content__circle-chart">


### PR DESCRIPTION
## :unicorn: Problème
Le résumé des résultats collectifs s'affiche comme ceci :
![image](https://user-images.githubusercontent.com/23451175/79778515-1eb87100-8339-11ea-8633-d07bf0822804.png)

## :robot: Solution
Corriger cet affichage.
![image](https://user-images.githubusercontent.com/23451175/79778414-fb8dc180-8338-11ea-9f97-44a1d6a77455.png)

## :100: Pour tester
- Cliquer sur l'onglet "Résultats collectifs" d'une campagne d'évaluation et voir que le résumé s'affiche correctement.
