### PR TITLE
[BUGFIX] Le temps d'attente (debounce) avant de lancer une requête de recherche ne marchait pas dans les listes paginées sur PixAdmin (PA-206)

### DIFF
--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -8,10 +8,34 @@
       <th>ID externe</th>
     </tr>
     <tr>
-      <th><Input class="table-admin-input" id="id" @value={{@id}} @key-up={{fn @triggerFiltering "id" @id}} /></th>
-      <th><Input class="table-admin-input" id="name" @value={{@name}} @key-up={{fn @triggerFiltering "name" @name}} /></th>
-      <th><Input class="table-admin-input" id="type" @value={{@type}} @key-up={{fn @triggerFiltering "type" @type}} /></th>
-      <th><Input class="table-admin-input" id="externalId" @value={{@externalId}} @key-up={{fn @triggerFiltering "externalId" @externalId}} /></th>
+      <th>
+        <input id="id"
+               type="text"
+               value={{@id}}
+               oninput={{perform @triggerFiltering 'id'}}
+               class="table-admin-input" />
+      </th>
+      <th>
+        <input id="name"
+               type="text"
+               value={{@name}}
+               oninput={{perform @triggerFiltering 'name'}}
+               class="table-admin-input" />
+      </th>
+      <th>
+        <input id="type"
+               type="text"
+               value={{@type}}
+               oninput={{perform @triggerFiltering 'type'}}
+               class="table-admin-input" />
+      </th>
+      <th>
+        <input id="externalId"
+               type="text"
+               value={{@externalId}}
+               oninput={{perform @triggerFiltering 'externalId'}}
+               class="table-admin-input" />
+      </th>
     </tr>
     </thead>
 

--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -9,22 +9,25 @@
         </tr>
         <tr>
           <th>
-            <Input id="name"
-                   @value={{@name}}
-                   @key-up={{fn @triggerFiltering "name" @name}}
+            <input id="name"
+                   type="text"
+                   value={{@name}}
+                   oninput={{perform @triggerFiltering 'name'}}
                    class="table-admin-input" />
           </th>
           <th>
-            <Input id="type"
-                   @value={{@type}}
-                   @key-up={{fn @triggerFiltering "type" @type}}
-                   class="table-admin-input"/>
+            <input id="type"
+                   type="text"
+                   value={{@type}}
+                   oninput={{perform @triggerFiltering 'type'}}
+                   class="table-admin-input" />
           </th>
           <th>
-            <Input id="externalId"
-                   @value={{@externalId}}
-                   @key-up={{fn @triggerFiltering "externalId" @externalId}}
-                   class="table-admin-input"/>
+            <input id="externalId"
+                   type="text"
+                   value={{@externalId}}
+                   oninput={{perform @triggerFiltering 'externalId'}}
+                   class="table-admin-input" />
           </th>
         </tr>
       </thead>

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -14,16 +14,17 @@
       </tr>
       <tr>
         <th>
-          <Input id="id"
-                 @value={{@id}}
-                 @key-up={{fn @triggerFiltering "id" @id}}
+          <input id="id"
+                 type="text"
+                 value={{@id}}
+                 oninput={{perform @triggerFiltering 'id'}}
                  class="table-admin-input" />
         </th>
         <th></th>
         <th></th>
         <th></th>
         <th>
-          <XSelect id='status' @value={{@status}} @onChange={{@setStatusFilter}} as |xs|>
+          <XSelect id='status' @value={{@status}} @onChange={{perform @triggerFiltering 'status'}} as |xs|>
             <xs.option @value={{@sessionStatusAndLabels.[0].status}}>{{@sessionStatusAndLabels.[0].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[1].status}}>{{@sessionStatusAndLabels.[1].label}}</xs.option>
             <xs.option @value={{@sessionStatusAndLabels.[2].status}}>{{@sessionStatusAndLabels.[2].label}}</xs.option>
@@ -35,7 +36,7 @@
         <th></th>
         <th></th>
         <th>
-          <XSelect id='resultsSentToPrescriberAt' @value={{@sessionResultsSentToPrescriberAtAndLabels.[0].value}} @onChange={{@setResultsSentToPrescriberAtFilter}} as |xs|>
+          <XSelect id='resultsSentToPrescriberAt' @value={{@resultsSentToPrescriberAt}} @onChange={{perform @triggerFiltering 'resultsSentToPrescriberAt'}} as |xs|>
             <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[0].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[0].label}}</xs.option>
             <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[1].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[1].label}}</xs.option>
             <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[2].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[2].label}}</xs.option>

--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -10,21 +10,24 @@
       <tr>
         <th></th>
         <th>
-          <Input id="firstName"
-                 @value={{@firstName}}
-                 @key-up={{fn @triggerFiltering "firstName" @firstName}}
+          <input id="firstName"
+                 type="text"
+                 value={{@firstName}}
+                 oninput={{perform @triggerFiltering 'firstName'}}
                  class="table-admin-input" />
         </th>
         <th>
-          <Input id="lastName"
-                 @value={{@lastName}}
-                 @key-up={{fn @triggerFiltering "lastName" @lastName}}
+          <input id="lastName"
+                 type="text"
+                 value={{@lastName}}
+                 oninput={{perform @triggerFiltering 'lastName'}}
                  class="table-admin-input" />
         </th>
         <th>
-          <Input id="email"
-                 @value={{@email}}
-                 @key-up={{fn @triggerFiltering "email" @email}}
+          <input id="email"
+                 type="text"
+                 value={{@email}}
+                 oninput={{perform @triggerFiltering 'email'}}
                  class="table-admin-input" />
         </th>
       </tr>

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -1,13 +1,15 @@
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { debounce } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
+import { task, timeout } from 'ember-concurrency';
+import config from 'pix-admin/config/environment';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
 
   queryParams = ['pageNumber', 'pageSize', 'name', 'type', 'externalId'];
+  DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
@@ -15,18 +17,12 @@ export default class ListController extends Controller {
   @tracked type = null;
   @tracked externalId = null;
 
-  searchFilter = null;
-
-  setFieldName() {
-    this.set(this.searchFilter.fieldName, this.searchFilter.value);
+  @(task(function * (fieldName, event) {
+    const value = event.target.value;
+    yield timeout(this.DEBOUNCE_MS);
+    this[fieldName] = value;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
-  }
-
-  @action
-  triggerFiltering(fieldName, value) {
-    this.searchFilter = { fieldName, value };
-    debounce(this, this.setFieldName, 500);
-  }
+  }).restartable()) triggerFiltering;
 
   @action
   goToOrganizationPage(organizationId) {

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -1,54 +1,54 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { debounce } from '@ember/runloop';
+import { task, timeout } from 'ember-concurrency';
 import _ from 'lodash';
+import config from 'pix-admin/config/environment';
 import { statusToDisplayName, FINALIZED } from 'pix-admin/models/session';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class SessionListController extends Controller {
 
-  queryParams = ['pageNumber', 'pageSize', 'id'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'status', 'resultsSentToPrescriberAt'];
+  DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
   @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
-  searchFilter = null;
 
   sessionStatusAndLabels = [
-    { status: '', label: 'Tous' },
+    { status: null, label: 'Tous' },
     ..._.map(statusToDisplayName, (label, status) => ({ status, label })),
   ];
 
   sessionResultsSentToPrescriberAtAndLabels = [
-    { value: '', label: 'Tous' },
+    { value: null, label: 'Tous' },
     { value: 'true', label: 'Résultats diffusés' },
     { value: 'false', label: 'Résultats non diffusés' },
   ];
 
-  setFieldName() {
-    this.searchFilter.fieldName = this.searchFilter.value;
+  @(task(function * (fieldName, param) {
+    let value;
+    let debounceDuration = this.DEBOUNCE_MS;
+    switch (fieldName) {
+      case 'id':
+        value = param.target.value; // param is an InputEvent
+        break;
+      case 'status':
+        debounceDuration = 0;
+        value = param;
+        break;
+      case 'resultsSentToPrescriberAt':
+        debounceDuration = 0;
+        value = param;
+        break;
+      default:
+        return;
+    }
+    yield timeout(debounceDuration);
+    this[fieldName] = value;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
-  }
-
-  @action
-  setStatusFilter(status) {
-    this.status = status;
-    this.pageNumber = DEFAULT_PAGE_NUMBER;
-  }
-
-  @action
-  setResultsSentToPrescriberAtFilter(value) {
-    this.resultsSentToPrescriberAt = value;
-    this.pageNumber = DEFAULT_PAGE_NUMBER;
-  }
-
-  @action
-  triggerFiltering(fieldName, value) {
-    this.searchFilter = { fieldName, value };
-    debounce(this, this.setFieldName, 500);
-  }
+  }).restartable()) triggerFiltering;
 }

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -1,13 +1,15 @@
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { debounce } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
+import { task, timeout } from 'ember-concurrency';
+import config from 'pix-admin/config/environment';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
 
   queryParams = ['pageNumber', 'pageSize', 'firstName', 'lastName', 'email'];
+  DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
@@ -15,18 +17,12 @@ export default class ListController extends Controller {
   @tracked lastName = null;
   @tracked email = null;
 
-  searchFilter = null;
-
-  setFieldName() {
-    this.set(this.searchFilter.fieldName, this.searchFilter.value);
+  @(task(function * (fieldName, event) {
+    const value = event.target.value;
+    yield timeout(this.DEBOUNCE_MS);
+    this[fieldName] = value;
     this.pageNumber = DEFAULT_PAGE_NUMBER;
-  }
-
-  @action
-  triggerFiltering(fieldName, value) {
-    this.searchFilter = { fieldName, value };
-    debounce(this, this.setFieldName, 500);
-  }
+  }).restartable()) triggerFiltering;
 
   @action
   goToUserDetailPage(userId) {

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -5,11 +5,11 @@
 <main class="page-body">
   <section class="page-section">
     <CertificationCenters::ListItems
-            @id={{id}}
-            @certificationCenters={{@model}}
-            @name={{name}}
-            @type={{type}}
-            @externalId={{externalId}}
-            @triggerFiltering={{this.triggerFiltering}} />
+      @certificationCenters={{@model}}
+      @id={{this.id}}
+      @name={{this.name}}
+      @type={{this.type}}
+      @externalId={{this.externalId}}
+      @triggerFiltering={{this.triggerFiltering}} />
   </section>
 </main>

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -11,9 +11,9 @@
   <section class="page-section">
     <Organizations::ListItems
       @organizations={{@model}}
-      @name={{name}}
-      @type={{type}}
-      @externalId={{externalId}}
+      @name={{this.name}}
+      @type={{this.type}}
+      @externalId={{this.externalId}}
       @triggerFiltering={{this.triggerFiltering}}
       @goToOrganizationPage={{this.goToOrganizationPage}} />
   </section>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -9,9 +9,8 @@
         @id={{this.id}}
         @status={{this.status}}
         @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
-        @setStatusFilter={{this.setStatusFilter}}
+        @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}
         @sessionResultsSentToPrescriberAtAndLabels={{this.sessionResultsSentToPrescriberAtAndLabels}}
-        @setResultsSentToPrescriberAtFilter={{this.setResultsSentToPrescriberAtFilter}}
         @triggerFiltering={{this.triggerFiltering}} />
   </section>
 </main>

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -8,8 +8,10 @@
   <section class="page-section">
     <Users::ListItems
       @users={{@model}}
-      @firstName={{firstName}} @lastName={{lastName}} @email={{email}}
-      @triggerFiltering={{action "triggerFiltering"}}
+      @firstName={{this.firstName}}
+      @lastName={{this.lastName}}
+      @email={{this.email}}
+      @triggerFiltering={{this.triggerFiltering}}
       @goToUserDetailPage={{this.goToUserDetailPage}} />
   </section>
 </main>

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -76,6 +76,10 @@ module.exports = function(environment) {
       warnIfNoIconsIncluded: true,
     },
 
+    pagination: {
+      debounce: 250,
+    },
+
   };
 
   if (environment === 'development') {
@@ -103,6 +107,8 @@ module.exports = function(environment) {
     ENV['ember-cli-notifications'] = {
       clearDuration: 300
     };
+
+    ENV.pagination.debounce = 0;
   }
 
   ENV.APP.ODS_PARSING_URL = 'api/sessions/session_id/certifications/attendance-sheet-analysis';

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -9,11 +9,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    const setStatusFilter = sinon.stub();
-    const setResultsSentToPrescriberAtFilter = sinon.stub();
-    const triggerFiltering = function() {};
-    this.set('setStatusFilter', setStatusFilter);
-    this.set('setResultsSentToPrescriberAtFilter', setResultsSentToPrescriberAtFilter);
+    const triggerFiltering = { perform: sinon.stub() };
     this.set('triggerFiltering', triggerFiltering);
   });
 
@@ -44,7 +40,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     this.set('sessions', sessions);
 
     // when
-    await render(hbs`{{sessions/list-items sessions=sessions triggerFiltering=triggerFiltering setStatusFilter=setStatusFilter setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter}}`);
+    await render(hbs`{{sessions/list-items sessions=sessions triggerFiltering=triggerFiltering}}`);
 
     // then
     assert.dom('table tbody tr').exists({ count: sessions.length });
@@ -76,21 +72,21 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
     test('it should render a dropdown menu to filter on status', async function(assert) {
       // when
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionStatusAndLabels=sessionStatusAndLabels}}`);
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering sessionStatusAndLabels=sessionStatusAndLabels}}`);
 
       // then
       const option1 = find('table thead tr:nth-child(2) th:nth-child(5) select option:nth-child(1)');
       assert.dom(option1).hasText('label1');
     });
-    
-    test('it should call setStatusFilter callback with appropriate arguments', async function(assert) {
+
+    test('it should call triggerFiltering task for the status field', async function(assert) {
       // given
       const xselect = new XSelectInteractor('#status');
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionStatusAndLabels=sessionStatusAndLabels}}`);
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering sessionStatusAndLabels=sessionStatusAndLabels}}`);
 
       // when
       await xselect.select('label3').when(() => {
-        sinon.assert.calledWith(this.get('setStatusFilter'), 'status3');
+        sinon.assert.calledWith(this.get('triggerFiltering').perform, 'status', 'status3');
         assert.equal(xselect.options(2).isSelected, true);
       });
     });
@@ -109,21 +105,21 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
 
     test('it should render a dropdown menu to filter on resultsSentToPrescriberAt', async function(assert) {
       // when
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
 
       // then
       const option1 = find('table thead tr:nth-child(2) th:nth-child(9) select option:nth-child(1)');
       assert.dom(option1).hasText('label1');
     });
 
-    test('it should call setResultsSentToPrescriberAtFilter callback with appropriate arguments', async function(assert) {
+    test('it should call triggerFiltering task for resultsSentToPrescriberAt field', async function(assert) {
       // given
       const xselect = new XSelectInteractor('#resultsSentToPrescriberAt');
-      await render(hbs`{{sessions/list-items setStatusFilter=setStatusFilter triggerFiltering=triggerFiltering setResultsSentToPrescriberAtFilter=setResultsSentToPrescriberAtFilter sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
 
       // when
       await xselect.select('label3').when(() => {
-        sinon.assert.calledWith(this.get('setResultsSentToPrescriberAtFilter'), 'value3');
+        sinon.assert.calledWith(this.get('triggerFiltering').perform, 'resultsSentToPrescriberAt', 'value3');
         assert.equal(xselect.options(2).isSelected, true);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/list-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/certification-centers/list', function(hooks) {
+  setupTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated.certification-centers.list');
+  });
+
+  module('#triggerFiltering task', function() {
+
+    module('updating id', function() {
+
+      test('it should update controller id field', async function(assert) {
+        // given
+        controller.id = 'someId';
+        const expectedValue = 'someOtherId';
+
+        // when
+        await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.id, expectedValue);
+      });
+    });
+
+    module('updating name', function() {
+
+      test('it should update controller name field', async function(assert) {
+        // given
+        controller.name = 'someName';
+        const expectedValue = 'someOtherName';
+
+        // when
+        await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.name, expectedValue);
+      });
+    });
+
+    module('updating type', function() {
+
+      test('it should update controller type field', async function(assert) {
+        // given
+        controller.type = 'someType';
+        const expectedValue = 'someOtherType';
+
+        // when
+        await controller.triggerFiltering.perform('type', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.type, expectedValue);
+      });
+    });
+
+    module('updating externalId', function() {
+
+      test('it should update controller externalId field', async function(assert) {
+        // given
+        controller.externalId = 'someExternalId';
+        const expectedValue = 'someOtherExternalId';
+
+        // when
+        await controller.triggerFiltering.perform('externalId', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.externalId, expectedValue);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/list-test.js
@@ -2,46 +2,58 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Controller | authenticated/organizations/list', function(hooks) {
-
   setupTest(hooks);
+  let controller;
 
-  module('#setFieldName', function() {
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated.organizations.list');
+  });
 
-    test('it should set name', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/organizations/list');
-      controller.searchFilter = { fieldName: 'name', value: 'sav' };
+  module('#triggerFiltering task', function() {
 
-      // when
-      controller.setFieldName();
+    module('updating name', function() {
 
-      // then
-      assert.equal(controller.get('name'), 'sav');
+      test('it should update controller name field', async function(assert) {
+        // given
+        controller.name = 'someName';
+        const expectedValue = 'someOtherName';
+        
+        // when
+        await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.name, expectedValue);
+      });
     });
 
-    test('it should set type', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/organizations/list');
-      controller.set('searchFilter', { fieldName: 'type', value: 'SCO' });
+    module('updating type', function() {
 
-      // when
-      controller.setFieldName();
+      test('it should update controller type field', async function(assert) {
+        // given
+        controller.type = 'someType';
+        const expectedValue = 'someOtherType';
 
-      // then
-      assert.equal(controller.get('type'), 'SCO');
+        // when
+        await controller.triggerFiltering.perform('type', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.type, expectedValue);
+      });
     });
 
-    test('it should reset pageNumber', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/organizations/list');
-      controller.set('searchFilter', { fieldName: 'name', value: 'random thing' });
-      controller.set('pageNumber', 3);
+    module('updating externalId', function() {
 
-      // when
-      controller.setFieldName();
+      test('it should update controller externalId field', async function(assert) {
+        // given
+        controller.externalId = 'someExternalId';
+        const expectedValue = 'someOtherExternalId';
 
-      // then
-      assert.equal(controller.get('pageNumber'), 1);
+        // when
+        await controller.triggerFiltering.perform('externalId', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.externalId, expectedValue);
+      });
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/sessions/list', function(hooks) {
+  setupTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated.sessions.list');
+  });
+
+  module('#triggerFiltering task', function() {
+
+    module('when fieldName is id', function() {
+
+      test('it should update controller id field', async function(assert) {
+        // given
+        controller.id = 'someId';
+
+        // when
+        const expectedValue = 'someOtherId';
+        await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.id, expectedValue);
+      });
+    });
+
+    module('when fieldName is status', function() {
+
+      test('it should update controller status field', async function(assert) {
+        // given
+        controller.status = 'someStatus';
+
+        // when
+        const expectedValue = 'someOtherStatus';
+        await controller.triggerFiltering.perform('status', expectedValue);
+
+        // then
+        assert.equal(controller.status, expectedValue);
+      });
+    });
+
+    module('when fieldName is resultsSentToPrescriberAt', function() {
+
+      test('it should update controller resultsSentToPrescriberAt field', async function(assert) {
+        // given
+        controller.resultsSentToPrescriberAt = 'someValue';
+
+        // when
+        const expectedValue = 'someOtherValue';
+        await controller.triggerFiltering.perform('resultsSentToPrescriberAt', expectedValue);
+
+        // then
+        assert.equal(controller.resultsSentToPrescriberAt, expectedValue);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/users/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/users/list-test.js
@@ -3,56 +3,57 @@ import { setupTest } from 'ember-qunit';
 
 module('Unit | Controller | authenticated/users/list', function(hooks) {
   setupTest(hooks);
+  let controller;
 
-  module('#setFieldName', function() {
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated.users.list');
+  });
 
-    test('it should set firstName', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/users/list');
-      controller.set('searchFilter', { fieldName: 'firstName', value: 'Emilie' });
+  module('#triggerFiltering task', function() {
 
-      // when
-      controller.setFieldName();
+    module('updating firstName', function() {
 
-      // then
-      assert.equal(controller.get('firstName'), 'Emilie');
+      test('it should update controller firstName field', async function(assert) {
+        // given
+        controller.firstName = 'someFirstName';
+        const expectedValue = 'someOtherFirstName';
+
+        // when
+        await controller.triggerFiltering.perform('firstName', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.firstName, expectedValue);
+      });
     });
 
-    test('it should set lastName', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/users/list');
-      controller.set('searchFilter', { fieldName: 'lastName', value: 'Duval' });
+    module('updating lastName', function() {
 
-      // when
-      controller.setFieldName();
+      test('it should update controller lastName field', async function(assert) {
+        // given
+        controller.lastName = 'someLastName';
+        const expectedValue = 'someOtherLastName';
 
-      // then
-      assert.equal(controller.get('lastName'), 'Duval');
+        // when
+        await controller.triggerFiltering.perform('lastName', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.lastName, expectedValue);
+      });
     });
 
-    test('it should set email', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/users/list');
-      controller.set('searchFilter', { fieldName: 'email', value: 'emilie.duval' });
+    module('updating email', function() {
 
-      // when
-      controller.setFieldName();
+      test('it should update controller email field', async function(assert) {
+        // given
+        controller.email = 'someEmail';
+        const expectedValue = 'someOtherEmail';
 
-      // then
-      assert.equal(controller.get('email'), 'emilie.duval');
-    });
+        // when
+        await controller.triggerFiltering.perform('email', { target: { value: expectedValue } });
 
-    test('it should reset pageNumber', function(assert) {
-      // given
-      const controller = this.owner.lookup('controller:authenticated/users/list');
-      controller.set('searchFilter', { fieldName: 'firstName', value: 'random name' });
-      controller.set('pageNumber', 3);
-
-      // when
-      controller.setFieldName();
-
-      // then
-      assert.equal(controller.get('pageNumber'), 1);
+        // then
+        assert.equal(controller.email, expectedValue);
+      });
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/certification-centers/list', function(hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/certification-centers/list');
+  });
+
+  module('#model', function(hooks) {
+    const params = {};
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function() {
+      route.store.query = sinon.stub().resolves();
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    module('when queryParams filters are falsy', function() {
+
+      test('it should call store.query with no filters on name, type and externalId', async function(assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          id: '',
+          name: '',
+          type: '',
+          externalId: '',
+        };
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'certification-center', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are  truthy', function() {
+
+      test('it should call store.query with filters containing trimmed values', async function(assert) {
+        // given
+        params.id = 'someId';
+        params.name = ' someName';
+        params.type = 'someType ';
+        params.externalId = 'someExternalId';
+        expectedQueryArgs.filter = {
+          id: 'someId',
+          name: 'someName',
+          type: 'someType',
+          externalId: 'someExternalId',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'certification-center', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+  });
+
+  module('#resetController', function(hooks) {
+    let controller;
+
+    hooks.beforeEach(function() {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+        id: 'someId',
+        name: 'someName',
+        type: 'someType',
+        externalId: 'someExternalId',
+      };
+    });
+
+    module('when route is exiting', function() {
+
+      test('it should reset controller', function(assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.equal(controller.pageNumber, 1);
+        assert.equal(controller.pageSize, 10);
+        assert.equal(controller.id, null);
+        assert.equal(controller.name, null);
+        assert.equal(controller.type, null);
+        assert.equal(controller.externalId, null);
+      });
+    });
+
+    module('when route is not exiting', function() {
+
+      test('it should not reset controller', function(assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.equal(controller.pageNumber, 'somePageNumber');
+        assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.id, 'someId');
+        assert.equal(controller.name, 'someName');
+        assert.equal(controller.type, 'someType');
+        assert.equal(controller.externalId, 'someExternalId');
+      });
+    });
+
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list-test.js
@@ -1,12 +1,112 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated/organizations/list', function(hooks) {
   setupTest(hooks);
+  let route;
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:authenticated/organizations/list');
-    assert.ok(route);
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/organizations/list');
   });
 
+  module('#model', function(hooks) {
+    const params = {};
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function() {
+      route.store.query = sinon.stub().resolves();
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    module('when queryParams filters are falsy', function() {
+
+      test('it should call store.query with no filters on name, type and externalId', async function(assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          name: '',
+          type: '',
+          externalId: '',
+        };
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'organization', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are  truthy', function() {
+
+      test('it should call store.query with filters containing trimmed values', async function(assert) {
+        // given
+        params.name = ' someName';
+        params.type = 'someType ';
+        params.externalId = 'someExternalId';
+        expectedQueryArgs.filter = {
+          name: 'someName',
+          type: 'someType',
+          externalId: 'someExternalId',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'organization', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+  });
+
+  module('#resetController', function(hooks) {
+    let controller;
+
+    hooks.beforeEach(function() {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+        name: 'someName',
+        type: 'someType',
+        externalId: 'someExternalId',
+      };
+    });
+
+    module('when route is exiting', function() {
+
+      test('it should reset controller', function(assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.equal(controller.pageNumber, 1);
+        assert.equal(controller.pageSize, 10);
+        assert.equal(controller.name, null);
+        assert.equal(controller.type, null);
+        assert.equal(controller.externalId, null);
+      });
+    });
+
+    module('when route is not exiting', function() {
+
+      test('it should not reset controller', function(assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.equal(controller.pageNumber, 'somePageNumber');
+        assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.name, 'someName');
+        assert.equal(controller.type, 'someType');
+        assert.equal(controller.externalId, 'someExternalId');
+      });
+    });
+
+  });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -1,0 +1,151 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sessions/list', function(hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/sessions/list');
+  });
+
+  module('#model', function(hooks) {
+    let params;
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function() {
+      route.store.query = sinon.stub().resolves();
+      params = {};
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    module('when queryParams are undefined', function() {
+
+      test('it should call store.query with no filters', async function(assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          id: undefined,
+          status: undefined,
+          resultsSentToPrescriberAt: undefined,
+        };
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams id is truthy', function() {
+
+      test('it should call store.query with a filter with trimmed id', async function(assert) {
+        // given
+        params.id = ' someId';
+        expectedQueryArgs.filter = {
+          id: 'someId',
+          status: undefined,
+          resultsSentToPrescriberAt: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams status is truthy', function() {
+
+      test('it should call store.query with a filter with trimmed status', async function(assert) {
+        // given
+        params.status = ' someStatus';
+        expectedQueryArgs.filter = {
+          id: undefined,
+          status: 'someStatus',
+          resultsSentToPrescriberAt: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams resultsSentToPrescriberAt is truthy', function() {
+
+      test('it should call store.query with a filter with trimmed resultsSentToPrescriberAt', async function(assert) {
+        // given
+        params.resultsSentToPrescriberAt = ' someValue';
+        expectedQueryArgs.filter = {
+          id: undefined,
+          status: undefined,
+          resultsSentToPrescriberAt: 'someValue',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+  });
+
+  module('#resetController', function(hooks) {
+    let controller;
+
+    hooks.beforeEach(function() {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+        id: 'someId',
+        status: 'someStatus',
+        resultsSentToPrescriberAt: 'someValue',
+      };
+    });
+
+    module('when route is exiting', function() {
+
+      test('it should reset controller', function(assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.equal(controller.pageNumber, 1);
+        assert.equal(controller.pageSize, 10);
+        assert.equal(controller.id, null);
+        assert.equal(controller.status, 'finalized');
+        assert.equal(controller.resultsSentToPrescriberAt, null);
+      });
+    });
+
+    module('when route is not exiting', function() {
+
+      test('it should not reset controller', function(assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.equal(controller.pageNumber, 'somePageNumber');
+        assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.id, 'someId');
+        assert.equal(controller.status, 'someStatus');
+        assert.equal(controller.resultsSentToPrescriberAt, 'someValue');
+      });
+    });
+
+  });
+});

--- a/admin/tests/unit/routes/authenticated/users/list-test.js
+++ b/admin/tests/unit/routes/authenticated/users/list-test.js
@@ -1,11 +1,112 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | authenticated/users/list', function(hooks) {
   setupTest(hooks);
+  let route;
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:authenticated/users/list');
-    assert.ok(route);
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/users/list');
+  });
+
+  module('#model', function(hooks) {
+    const params = {};
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function() {
+      route.store.query = sinon.stub().resolves();
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    module('when queryParams filters are falsy', function() {
+
+      test('it should call store.query with no filters on name, type and externalId', async function(assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          firstName: '',
+          lastName: '',
+          email: '',
+        };
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'user', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are  truthy', function() {
+
+      test('it should call store.query with filters containing trimmed values', async function(assert) {
+        // given
+        params.firstName = ' someFirstName';
+        params.lastName = 'someLastName ';
+        params.email = 'someEmail';
+        expectedQueryArgs.filter = {
+          firstName: 'someFirstName',
+          lastName: 'someLastName',
+          email: 'someEmail',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'user', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+  });
+
+  module('#resetController', function(hooks) {
+    let controller;
+
+    hooks.beforeEach(function() {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+        firstName: 'someFirstName',
+        lastName: 'someLastName',
+        email: 'someEmail',
+      };
+    });
+
+    module('when route is exiting', function() {
+
+      test('it should reset controller', function(assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.equal(controller.pageNumber, 1);
+        assert.equal(controller.pageSize, 10);
+        assert.equal(controller.firstName, null);
+        assert.equal(controller.lastName, null);
+        assert.equal(controller.email, null);
+      });
+    });
+
+    module('when route is not exiting', function() {
+
+      test('it should not reset controller', function(assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.equal(controller.pageNumber, 'somePageNumber');
+        assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.firstName, 'someFirstName');
+        assert.equal(controller.lastName, 'someLastName');
+        assert.equal(controller.email, 'someEmail');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque, dans une liste avec filtres, on a des champs de recherche, il est commode d'attendre un peu de temps après saisie dans les champs de recherche afin de ne pas envoyer une requête par touche de clavier frappée.
La volonté de mettre un tel temps d'attente était bien présente dans les listes paginées sur PixAdmin, mais n'était malheureusement pas fonctionnel.

## :detective: Mon explication
Le code en place pour debounce correctement marchait bien, jusqu'à la mise à jour vers _Ember Octane_ sur **PixAdmin**.

Mise en place :
Deux choses à savoir pour la suite. D'une part, c'est le controller qui porte les `queryParams`. De fait, dès lors qu'un attribut marqué comme étant `queryParam` est modifié, il déclenche le lancement de la requête XHR avec les filtres appropriés. D'autre part, les champs input permettant à l'utilisateur d'interagir avec les filtres de recherche sont bindés aux attributs `queryParams` du controller. Ces champs utilisent le build-in component <Input> d'Ember, qui garantit un **`two-way binding`** d'une variable avec l'affichage. On garde ces deux choses en tête et on y va.

Avant :
Afin de modifier un EmberObject correctement afin de déclencher tous les triggers subséquents, il faut passer par `myObject.set('attribute', <value>);`. Faire directement `myObject.attribute = <value>;` ne PROVOQUE PAS les triggers. De même, malgré la propriété `two-way binding` du component <Input>, il semblerait que ce dernier ne déclenche pas non plus les triggers. Ceci étant dit, le mécanisme a donc été conçu ainsi, en deux temps :
```js
  searchFilter = null;

  @action
  triggerFiltering(fieldName, value) {
    this.searchFilter = { fieldName, value }; // On retient la nouvelle valeur
    debounce(this, this.setFieldName, 500); // On délaye la mise à jour effective
  }

  setFieldName() {
    // On met effectivement à jour le controller, ainsi on déclenche la nouvelle requête XHR de recherche
    this.set(this.searchFilter.fieldName, this.searchFilter.value);
    this.pageNumber = DEFAULT_PAGE_NUMBER;
  }
```
Après:
Mise à jour vers **EmberOctane**, et donc plusieurs fichiers sont réécrits afin de présenter des classes natives JS. Le plus cool dans tout ça, et c'est Ember qui le dit, plus besoin de passer par 
`myObject.set('attribute', <value>);`, on peut faire `myObject.attribute = <value>;` et ça déclenche quand même tous les triggers, chance ! Enfin.... sauf pour la pagination ! En conséquence, le two-way binding du component <Input> marche du feu de dieu, met à jour directement l'attribut `queryParam` du controller qui n'attend plus le debounce...

## :robot: Solution
Dans un premier temps, la solution pour faire marcher l'ensemble consiste à remplacer l'usage du bu
ilt-in component `<Input>` d'Ember par le classique `<input>`, qui ne présente pas de two-way binding sur la value passée en paramètre.
Ensuite, pour simplifier à mon sens le code, j'ai décidé d'utiliser **ember-concurrency**. Ca réduit le nombre de fonctions à écrire à 1 au lieu de 2, ça gère bien le debounce et le restart du debouce.

## :rainbow: Remarques
AVANT :
![gilbert1](https://user-images.githubusercontent.com/48727874/79838947-194c3c80-83b4-11ea-8809-7840ae7272e8.png)

APRES :
![gilbert2](https://user-images.githubusercontent.com/48727874/79838955-1d785a00-83b4-11ea-9bde-f3867dc83e6c.png)

## :100: Pour tester
Pour n'importe quelle liste paginée, rendez-vous sur cette RA + une autre RA pour comparer.
Dans les deux cas, connectez-vous à PixAdmin et, dans la liste de votre choix, tapez une recherche dans un champ. Constater le bombardement de requêtes dans un cas et pas dans l'autre.
