### PR TITLE
[FEATURE] Ajout de la recommandation pour un participant à une campagne (PO-422)

### DIFF
--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -11,6 +11,7 @@ module.exports = async function computeCampaignParticipationAnalysis(
     competenceRepository,
     targetProfileRepository,
     tubeRepository,
+    knowledgeElementRepository,
   } = {}) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   const campaignId = campaignParticipation.campaignId;
@@ -20,10 +21,11 @@ module.exports = async function computeCampaignParticipationAnalysis(
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
   }
 
-  const [competences, tubes, targetProfile] = await Promise.all([
+  const [competences, tubes, targetProfile, validatedKnowledgeElements] = await Promise.all([
     competenceRepository.list(),
     tubeRepository.list(),
-    targetProfileRepository.getByCampaignId(campaignId)
+    targetProfileRepository.getByCampaignId(campaignId),
+    knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId: campaignParticipation.userId }),
   ]);
 
   const targetedTubeIds = _.map(targetProfile.skills, ({ tubeId }) => ({ id: tubeId }));
@@ -34,7 +36,7 @@ module.exports = async function computeCampaignParticipationAnalysis(
     tubes: targetedTubes,
     competences,
     skills: targetProfile.skills,
-    validatedKnowledgeElements: [],
+    validatedKnowledgeElements,
     participantsCount: 1
   });
 };

--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -21,6 +21,10 @@ module.exports = async function computeCampaignParticipationAnalysis(
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
   }
 
+  if (!campaignParticipation.isShared)  {
+    return null;
+  }
+
   const [competences, tubes, targetProfile, validatedKnowledgeElements] = await Promise.all([
     competenceRepository.list(),
     tubeRepository.list(),

--- a/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -24,69 +24,94 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
     tubeRepository = { list: sinon.stub() };
     knowledgeElementRepository = { findByCampaignIdAndUserIdForSharedCampaignParticipation: sinon.stub() };
 
-    campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+    campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId, isShared: true });
   });
 
   context('User has access to this result', () => {
-    it('should returns two CampaignTubeRecommendations but with two skills in the same tube', async () => {
-      // given
-      const area = domainBuilder.buildArea();
-      const competence = domainBuilder.buildCompetence({ area });
-      const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId' });
-      const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
-      const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
-      const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
+    context('Participant has shared its results', () => {
+      it('should returns two CampaignTubeRecommendations but with two skills in the same tube', async () => {
+        // given
+        const area = domainBuilder.buildArea();
+        const competence = domainBuilder.buildCompetence({ area });
+        const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId' });
+        const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
+        const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
+        const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
 
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
-      const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
-      const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
-      const campaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
-        campaignId,
-        tube,
-        competence,
-        validatedKnowledgeElements: [knowledgeElementSkill1],
-        skills: [skill],
-        maxSkillLevelInTargetProfile:  2,
-        participantsCount: 1
+        const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
+        const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
+        const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
+        const campaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+          campaignId,
+          tube,
+          competence,
+          validatedKnowledgeElements: [knowledgeElementSkill1],
+          skills: [skill],
+          maxSkillLevelInTargetProfile:  2,
+          participantsCount: 1
+        });
+
+        const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
+          campaignId,
+          tube: otherTube,
+          competence,
+          validatedKnowledgeElements: [knowledgeElementSkill2],
+          skills: [skill2],
+          maxSkillLevelInTargetProfile:  2,
+          participantsCount: 1
+        });
+
+        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+        competenceRepository.list.resolves([competence]);
+        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        tubeRepository.list.resolves([tube, otherTube]);
+        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+        knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation.withArgs({ campaignId, userId: campaignParticipation.userId }).resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
+
+        const expectedResult = {
+          id: campaignId,
+          campaignTubeRecommendations: [campaignTubeRecommendation, campaignOtherTubeRecommendation],
+        };
+
+        // when
+        const actualCampaignAnalysis = await computeCampaignParticipationAnalysis({
+          userId,
+          campaignParticipationId,
+          campaignRepository,
+          campaignParticipationRepository,
+          competenceRepository,
+          targetProfileRepository,
+          tubeRepository,
+          knowledgeElementRepository,
+        });
+
+        // then
+        expect(actualCampaignAnalysis).to.deep.equal(expectedResult);
       });
+    });
 
-      const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
-        campaignId,
-        tube: otherTube,
-        competence,
-        validatedKnowledgeElements: [knowledgeElementSkill2],
-        skills: [skill2],
-        maxSkillLevelInTargetProfile:  2,
-        participantsCount: 1
+    context('Participant has not shared its results', () => {
+      it('should returns null', async () => {
+        // given
+        campaignParticipation.isShared = false;
+        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+
+        // when
+        const actualCampaignAnalysis = await computeCampaignParticipationAnalysis({
+          userId,
+          campaignParticipationId,
+          campaignRepository,
+          campaignParticipationRepository,
+          competenceRepository,
+          targetProfileRepository,
+          tubeRepository
+        });
+
+        // then
+        expect(actualCampaignAnalysis).to.be.null;
       });
-
-      targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
-      competenceRepository.list.resolves([competence]);
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-      tubeRepository.list.resolves([tube, otherTube]);
-      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
-      knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation.withArgs({ campaignId, userId: campaignParticipation.userId }).resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
-
-      const expectedResult = {
-        id: campaignId,
-        campaignTubeRecommendations: [campaignTubeRecommendation, campaignOtherTubeRecommendation],
-      };
-
-      // when
-      const actualCampaignAnalysis = await computeCampaignParticipationAnalysis({
-        userId,
-        campaignParticipationId,
-        campaignRepository,
-        campaignParticipationRepository,
-        competenceRepository,
-        targetProfileRepository,
-        tubeRepository,
-        knowledgeElementRepository,
-      });
-
-      // then
-      expect(actualCampaignAnalysis).to.deep.equal(expectedResult);
     });
   });
 

--- a/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -9,6 +9,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
   let competenceRepository;
   let targetProfileRepository;
   let tubeRepository;
+  let knowledgeElementRepository;
 
   const userId = 1;
   const campaignId = 'someCampaignId';
@@ -21,6 +22,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
     competenceRepository = { list: sinon.stub() };
     targetProfileRepository = { getByCampaignId: sinon.stub() };
     tubeRepository = { list: sinon.stub() };
+    knowledgeElementRepository = { findByCampaignIdAndUserIdForSharedCampaignParticipation: sinon.stub() };
 
     campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
   });
@@ -32,6 +34,9 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
       const competence = domainBuilder.buildCompetence({ area });
       const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId' });
       const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
+      const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
+      const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
+
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
       const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
       const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
@@ -39,17 +44,17 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         campaignId,
         tube,
         competence,
-        validatedKnowledgeElements: [],
+        validatedKnowledgeElements: [knowledgeElementSkill1],
         skills: [skill],
         maxSkillLevelInTargetProfile:  2,
-        participantsCount:  1
+        participantsCount: 1
       });
 
       const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
         campaignId,
         tube: otherTube,
         competence,
-        validatedKnowledgeElements: [],
+        validatedKnowledgeElements: [knowledgeElementSkill2],
         skills: [skill2],
         maxSkillLevelInTargetProfile:  2,
         participantsCount: 1
@@ -61,6 +66,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
       tubeRepository.list.resolves([tube, otherTube]);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
       targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+      knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation.withArgs({ campaignId, userId: campaignParticipation.userId }).resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
 
       const expectedResult = {
         id: campaignId,
@@ -75,7 +81,8 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         campaignParticipationRepository,
         competenceRepository,
         targetProfileRepository,
-        tubeRepository
+        tubeRepository,
+        knowledgeElementRepository,
       });
 
       // then

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -322,6 +322,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       // given
       databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
       databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 2 });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 3 });
       const otherUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
@@ -349,6 +350,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
         id: 3,
         status: 'validated',
         userId: otherUserId,
+        skillId: 3,
       });
       await databaseBuilder.commit();
 
@@ -417,5 +419,59 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.deep.equal([1]);
     });
+  });
+
+  describe('findByCampaignIdAndUserIdForSharedCampaignParticipation', () => {
+    let userId, targetProfileId, campaignId;
+
+    beforeEach(() => {
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      userId = databaseBuilder.factory.buildUser().id;
+      campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+    });
+
+    it('should return a list of knowledge elements for a given user', async () => {
+      // given
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 2 });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 3 });
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        campaignId,
+        isShared: true
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        userId: otherUserId,
+        campaignId,
+        isShared: true
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        id: 1,
+        status: 'validated',
+        userId,
+        skillId: 1
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        id: 2,
+        status: 'validated',
+        userId,
+        skillId: 2,
+      });
+      databaseBuilder.factory.buildKnowledgeElement({
+        id: 3,
+        status: 'validated',
+        userId: otherUserId,
+        skillId: 3,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
+
+      // then
+      expect(_.map(actualKnowledgeElements, 'id')).to.have.members([1,2]);
+    });
+
   });
 });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -358,7 +358,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
-      expect(_.map(actualKnowledgeElements, 'id')).to.have.members([1,2]);
+      expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1,2]);
     });
 
     it('should return a list of knowledge elements when there are validated knowledge elements', async () => {
@@ -388,7 +388,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
-      expect(_.map(actualKnowledgeElements, 'id')).to.deep.equal([1]);
+      expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
     });
 
     it('should return a list of knowledge elements whose its skillId is included in the campaign target profile', async () => {
@@ -417,7 +417,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
-      expect(_.map(actualKnowledgeElements, 'id')).to.deep.equal([1]);
+      expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
     });
   });
 
@@ -470,7 +470,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
 
       // then
-      expect(_.map(actualKnowledgeElements, 'id')).to.have.members([1,2]);
+      expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1,2]);
     });
 
   });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -147,6 +147,25 @@ function compareDatabaseObject(evaluatedObject, expectedObject) {
 
 }
 
+chai.use(function(chai) {
+  const Assertion = chai.Assertion;
+
+  Assertion.addMethod('exactlyContain', function(expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain [${expectedElements}]`;
+    new Assertion(this._obj, errorMessage).to.have.members(expectedElements);
+  });
+});
+
+chai.use(function(chai) {
+  const Assertion = chai.Assertion;
+
+  Assertion.addMethod('exactlyContainInOrder', function(expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain in order [${expectedElements}]`;
+
+    new Assertion(this._obj, errorMessage).to.deep.equal(expectedElements);
+  });
+});
+
 module.exports = {
   EMPTY_BLANK_AND_NULL,
   airtableBuilder,

--- a/orga/app/templates/authenticated/campaigns/details/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/details/analysis.hbs
@@ -1,2 +1,3 @@
 <Routes::Authenticated::Campaigns::Details::AnalysisTab
-  @campaignTubeRecommendations={{@model.campaignAnalysis.sortedCampaignTubeRecommendations}}/>
+  @campaignTubeRecommendations={{@model.campaignAnalysis.sortedCampaignTubeRecommendations}}
+  @displayAnalysis={{gt @model.campaignReport.sharedParticipationsCount 0}}/>

--- a/orga/app/templates/authenticated/campaigns/details/participants/participant/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/details/participants/participant/analysis.hbs
@@ -1,2 +1,2 @@
 <Routes::Authenticated::Campaigns::Details::AnalysisTab
-  @campaignTubeRecommendations={{@model.campaignParticipation.campaignAnalysis.campaignTubeRecommendations}}/>
+  @campaignTubeRecommendations={{@model.campaignParticipation.campaignAnalysis.sortedCampaignTubeRecommendations}}/>

--- a/orga/app/templates/authenticated/campaigns/details/participants/participant/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/details/participants/participant/analysis.hbs
@@ -1,2 +1,3 @@
 <Routes::Authenticated::Campaigns::Details::AnalysisTab
-  @campaignTubeRecommendations={{@model.campaignParticipation.campaignAnalysis.sortedCampaignTubeRecommendations}}/>
+        @campaignTubeRecommendations={{@model.campaignParticipation.campaignAnalysis.sortedCampaignTubeRecommendations}}
+        @displayAnalysis={{@model.campaignParticipation.isShared}} />

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/analysis-tab.hbs
@@ -3,7 +3,7 @@
   En fonction du référentiel testé et des résultats de la campagne,
   Pix vous recommande ces sujets à travailler, classés par degré de pertinence (
   <svg height="10" width="10">
-      <circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble"/>
+    <circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble"/>
   </svg>
   )
 </p>
@@ -12,11 +12,13 @@
   <table aria-label="Analyse par sujet">
     <thead>
     <tr>
-      <th class="table__column--wide">Sujets ({{ @campaignTubeRecommendations.length }})</th>
+      <th class="table__column--wide">Sujets ({{if @displayAnalysis
+                                                  @campaignTubeRecommendations.length '-' }})</th>
       <th class="table__column--small table__column--center">Pertinence</th>
     </tr>
     </thead>
 
+    {{#if @displayAnalysis }}
       <tbody>
       {{#each @campaignTubeRecommendations as |tubeRecommendation|}}
         <tr aria-label="Sujet">
@@ -28,9 +30,15 @@
               <sub>{{tubeRecommendation.competenceName}}</sub>
             </span>
           </td>
-          <td><RecommendationIndicator @value={{tubeRecommendation.averageScore}} /></td>
+          <td>
+            <RecommendationIndicator @value={{tubeRecommendation.averageScore}} />
+          </td>
         </tr>
       {{/each}}
       </tbody>
+    {{/if}}
   </table>
+  {{#unless @displayAnalysis }}
+    <div class="table__empty content-text">En attente de résultats</div>
+  {{/unless}}
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -220,6 +220,12 @@ export default function() {
 
   this.get('/campaign-participations/:id');
 
+  this.get('/campaign-participations/:id/analyses', (schema, request) => {
+    const campaignParticipationId = request.params.id;
+    const campaignParticipation = schema.campaignParticipations.find(campaignParticipationId);
+    return campaignParticipation.campaignAnalysis;
+  });
+
   this.get('/campaign-participation-results/:id');
 
   this.post('/student-dependent-users/password-update', (schema, request) => {

--- a/orga/mirage/serializers/campaign-participation.js
+++ b/orga/mirage/serializers/campaign-participation.js
@@ -1,0 +1,12 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+
+  links(campaignParticipation) {
+    return {
+      'campaignAnalysis': {
+        related: `/api/campaign-participations/${campaignParticipation.id}/analyses`
+      }
+    };
+  }
+});

--- a/orga/tests/acceptance/campaign-participants-individual-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results-test.js
@@ -6,7 +6,7 @@ import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/te
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Participants Details', function(hooks) {
+module('Acceptance | Campaign Participants Individual Results', function(hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/campaign-participants-indivual-analysis-test.js
+++ b/orga/tests/acceptance/campaign-participants-indivual-analysis-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Campaign Participants Individual Analysis', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let user, campaignAnalysis, participant;
+
+  hooks.beforeEach(async () => {
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
+    await authenticateSession({
+      user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
+    });
+    server.create('campaign', { id: 1 });
+
+    participant = server.create('user', { firstName: 'Jack', lastName: 'Doe' });
+    campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations');
+  });
+
+  test('it should display individual analysis when participation is shared', async function(assert) {
+    // given
+    server.create('campaign-participation', { campaignId: 1, userId: participant.id, campaignAnalysis, isShared: true });
+
+    // when
+    await visit('/campagnes/1/participants/1/analyse');
+
+    // then
+    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (2)');
+  });
+
+  test('it should not display individual analysis when participation is not shared', async function(assert) {
+    // given
+    server.create('campaign-participation', { campaignId: 1, userId: participant.id, campaignAnalysis, isShared: false });
+
+    // when
+    await visit('/campagnes/1/participants/1/analyse');
+
+    // then
+    assert.dom('[aria-label="Analyse par sujet"]').containsText('Sujets (-)');
+  });
+});

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis-tab-test.js
@@ -37,6 +37,7 @@ module('Integration | Component | routes/authenticated/campaigns/details/analysi
     // when
     await render(hbs`<Routes::Authenticated::Campaigns::Details::AnalysisTab
       @campaignTubeRecommendations={{campaignTubeRecommendations}}
+      @displayAnalysis={{true}}
     />`);
 
     // then
@@ -47,6 +48,7 @@ module('Integration | Component | routes/authenticated/campaigns/details/analysi
     // when
     await render(hbs`<Routes::Authenticated::Campaigns::Details::AnalysisTab
       @campaignTubeRecommendations={{campaignTubeRecommendations}}
+      @displayAnalysis={{true}}
     />`);
 
     // then
@@ -54,5 +56,17 @@ module('Integration | Component | routes/authenticated/campaigns/details/analysi
     assert.dom(firstTube).containsText('•');
     assert.dom(firstTube).containsText('Tube A');
     assert.dom(firstTube).containsText('Competence A');
+  });
+
+  test('it should not display tube details when display', async function(assert) {
+    // when
+    await render(hbs`<Routes::Authenticated::Campaigns::Details::AnalysisTab
+      @campaignTubeRecommendations={{campaignTubeRecommendations}}
+      @displayAnalysis={{false}}
+    />`);
+
+    // then
+    assert.dom('[aria-label="Sujet"]').doesNotExist;
+    assert.dom('.table__empty').containsText('En attente de résultats');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On ne voit le score de recommandation de sujet pour un participant dans l'analyse de la campagne de participation.

## :robot: Solution
Ajouter la colonne recommandation et calculer le score pour un participant.
Réutilisation des composants fronts utilisés dans l'analyse de campagne

## :rainbow: Remarques
Ajout de la gestion des résultats de campagne non partagés par un participant (tableau d'analyse vide et message associé)

## :100: Pour tester
Test de l'affichage des scores:
1. Se connecter `PIX ORGA`
2. Aller sur une campagne d'évaluation avec des participants
3. Cliquer sur un participant avec des résultats partagés
4. Ajouter `/analyse` dans l'URL
5. Vérifier que les scores sont correctement affichés et triés

Test de l'affichage des résultats non partagés:
1. Se connecter `PIX ORGA`
2. Aller sur une campagne d'évaluation avec des participants
3. Cliquer sur un participant avec des résultats partagés
4. Ajouter `/analyse` dans l'URL
5. Vérifier que la liste des recommandations est vide et qu'un message "En attente de résultat" soit affiché.

