### PR TITLE
[BUG] Propriétés cgus incorrects lors de l'affichage de détail utilisateurs.(PA-208)

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -23,15 +23,15 @@
     <br>
     <div class="attribute cgu">
       <span class="attibute__label">CGU Pix App validé : </span>
-      <span class="attribute__value user__cgu">{{if @user.isPixTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+      <span class="attribute__value user__cgu">{{if @user.cgu 'OUI' 'NON'}}</span>
     </div>
     <div class="attribute pix-orga-terms-of-service-accepted">
       <span class="attibute__label">CGU Pix Orga validé : </span>
-      <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if @user.isPixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+      <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}</span>
     </div>
     <div class="attribute pix-certif-terms-of-service-accepted">
       <span class="attibute__label">CGU Pix Certif validé : </span>
-      <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if @user.isPixCertifTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+      <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}</span>
     </div>
   </div>
 </section>

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "OUI" when user accepted Pix App terms of service', async function(assert) {
-    this.set('user', { isPixTermsOfServiceAccepted: true });
+    this.set('user', { cgu: true });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -47,7 +47,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "NON" when user not accepted Pix App terms of service', async function(assert) {
-    this.set('user', { isPixTermsOfServiceAccepted: false });
+    this.set('user', { cgu: false });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -55,7 +55,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "OUI" when user accepted Pix Orga terms of service', async function(assert) {
-    this.set('user', { isPixOrgaTermsOfServiceAccepted: true });
+    this.set('user', { pixOrgaTermsOfServiceAccepted: true });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -63,7 +63,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "NON" when user not accepted Pix Orga terms of service', async function(assert) {
-    this.set('user', { isPixOrgaTermsOfServiceAccepted: false });
+    this.set('user', { pixOrgaTermsOfServiceAccepted: false });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -71,7 +71,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "OUI" when user accepted Pix Certif terms of service', async function(assert) {
-    this.set('user', { isPixCertifTermsOfServiceAccepted: true });
+    this.set('user', { pixCertifTermsOfServiceAccepted: true });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -79,7 +79,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
   });
 
   test('should display "NON" when user not accepted Pix Certif terms of service', async function(assert) {
-    this.set('user', { isPixCertifTermsOfServiceAccepted: false });
+    this.set('user', { pixCertifTermsOfServiceAccepted: false });
 
     await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 


### PR DESCRIPTION
## :unicorn: Problème
Les valeurs cgus dans la vue : détail utilisateur dans Pix Admin sont erronés.

## :robot: Solution
Les templates sont basé sur "computed property" qui ont été supprimés.

## :rainbow: Remarques
Les tests passaient car ces computed ont été stub dans les tests et aussi non supprimé du template.

## :100: Pour tester
Dans la vue 'utilisateurs dans Pix Admin' , clique sur la ligne du tableau des utilisateurs pour afficher le détail.
