### PR TITLE
[TECH] Problème de script npm start en développement. 

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -84,7 +84,6 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.APP.API_HOST = process.env.API_HOST || 'http://localhost:3000';
     ENV.matomo.url = 'https://stats.pix.fr/js/container_x4fRiAXl_dev_a6c96fc927042b6f6e773267.js';
     ENV.matomo.debug = true;
   }

--- a/admin/package.json
+++ b/admin/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint .",
     "preinstall": "test \"$(npm --version)\" = 6.13.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
-    "start": "ember serve --proxy",
+    "start": "ember serve --proxy http://localhost:3000",
     "test": "ember exam",
     "test:watch": "ember exam --serve --reporter dot"
   },

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -83,7 +83,6 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.APP.API_HOST = 'http://localhost:3000';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/certif/package.json
+++ b/certif/package.json
@@ -28,7 +28,7 @@
     "lint:hbs": "ember-template-lint .",
     "preinstall": "test \"$(npm --version)\" = 6.13.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
-    "start": "ember serve --proxy",
+    "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"
   },
   "devDependencies": {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -95,7 +95,6 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
-    ENV.APP.API_HOST = process.env.API_HOST || 'http://localhost:3000';
     ENV.APP.HOME_HOST = process.env.HOME_HOST || '/';
     ENV.matomo.url = 'https://stats.pix.fr/js/container_jKDD76j4_dev_179474167add1104d6c8a92b.js';
     ENV.matomo.debug = true;

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -30,7 +30,7 @@
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "preinstall": "test \"$(npm --version)\" = 6.13.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
-    "start": "ember server --proxy",
+    "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -68,7 +68,6 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;

--- a/orga/package.json
+++ b/orga/package.json
@@ -28,7 +28,7 @@
     "lint:hbs": "ember-template-lint .",
     "preinstall": "test \"$(npm --version)\" = 6.13.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
-    "start": "ember serve --proxy",
+    "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"
   },
   "devDependencies": {


### PR DESCRIPTION
## :unicorn: Problème
Nous utilisons mal l'option `--proxy` de la commande `ember serve`.
L'option `--proxy` nécessite un argument : l'URL à utiliser comme proxy, seulement nous ne lui en fournissons pas. 
La commande marche en partie car juste le fait d'avoir l'option `--proxy` [permet de désactiver mirage](https://github.com/miragejs/ember-cli-mirage/blob/e4b94da31b84eecb0ed0903291a1b2894b3ca40b/config/environment.js#L6), mais le proxy lui [n'est pas actif car l'URL est vide](https://github.com/ember-cli/ember-cli/blob/00a63f2daf5e560558ae2aa41a7a704b31441af5/lib/tasks/server/middleware/proxy-server/index.js#L17).

## :robot: Solution
- Ajouter `http://localhost:3000` comme argument à l'option de la commande 
- Suppression de la surcharge de la variable d'environnement `ENV.APP.API_HOST` en environnement de développement qui devient inutile.

## :rainbow: Remarques
Cela apporte en plus le fait de supprimer les requêtes `OPTIONS` en développement. 

## :100: Pour tester
Voir que le proxy fonctionne en allant par exemple dans le network et en voyant les requêtes API qui vont sur `localhost:420X/api/…`.
Constater qu'il n'y a plus de requêtes `OPTIONS` (en utilisant Firefox ; Chrome n'affiche plus les requêtes `OPTIONS` dans l'inspecteur Web depuis qu'ils ont [déplacé ce traitement dans une autre couche](https://www.chromium.org/Home/loading/oor-cors))