### PR TITLE
[BSR] Remplacer Promise.all par bluebird.mapSeries lors de la génération des résultats de certification d'une session entière (PA-209)

### DIFF
--- a/api/lib/domain/usecases/get-session-certifications.js
+++ b/api/lib/domain/usecases/get-session-certifications.js
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const bluebird = require('bluebird');
 const certificationService = require('../../domain/services/certification-service');
 
 module.exports = async function getSessionCertifications({
@@ -6,9 +6,5 @@ module.exports = async function getSessionCertifications({
   certificationCourseRepository,
 }) {
   const certificationCourseIds = await certificationCourseRepository.findIdsBySessionId(sessionId);
-  const certificationCourseIdsChunks = _.chunk(certificationCourseIds, 10);
-  const certificationResultsChunks = await Promise.all(_.map(certificationCourseIdsChunks, (certificationCourseIdsChunk) => {
-    return Promise.all(_.map(certificationCourseIdsChunk, certificationService.getCertificationResult));
-  }));
-  return _.flatten(certificationResultsChunks);
+  return bluebird.mapSeries(certificationCourseIds, certificationService.getCertificationResult);
 };


### PR DESCRIPTION
## :unicorn: Problème
La Laura du passé pensait avoir l'idée du siècle en faisant un morceau de code qui calcule les résultats de certification par tranche de 10 certifs afin d'éviter de bombarder le serveur BDD. La Laura du présent a appris que des `Promise.all` en cascade n'y changent rien, cela provoque toujours N promesses lancées dans le vent.

## :robot: Solution
On remplace l'usage de `Promise.all` par `bluebird.mapSeries`

## :rainbow: Remarques

## :100: Pour tester
De la non-régression sur l'affichage des certifications d'une session éventuellement sur PixAdmin
