### PR TITLE
[TECH] Éviter de générer des _heap dumps_ lors de l'utilisation de `nodemon`

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -113,7 +113,7 @@
     "scalingo-postbuild": "echo 'nothing to do'",
     "scalingo-post-ra-creation": "npm run postdeploy && npm run db:seed",
     "start": "node bin/www",
-    "start:watch": "nodemon --signal SIGTERM bin/www",
+    "start:watch": "nodemon bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "npm run test:api:path -- tests",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
@@ -123,5 +123,8 @@
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:lint": "npm test && npm run lint"
+  },
+  "nodemonConfig": {
+    "signal": "SIGTERM"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Quand on lance l'API en tapant :

```
$ nodemon bin/www
```

À chaque changement de code `nodemon` arrête le processus en lui envoyant le signal `SIGUSR2`. Malheureusement comme expliqué dans #514 ce signal est aussi utilisé par le module `heapdump` et par conséquent à chaque tentative de redémarrage de `nodemon` on a un _dump_ qui est créé.

Si on utilise `npm run start:watch` l'option `--signal SIGTERM` est bien passée à `nodemon` pour éviter le problème en utilisant un autre signal. Mais on a parfois envie d'utiliser `nodemon` directement, par exemple pour lui passer l'option `--inspect` afin de pouvoir utiliser un débogueur.

## :robot: Solution

Au lieu d'ajouter l'option `--signal` sur la ligne de commande de `start:watch` on ajoute une section `nodemonConfig` dans `package.json` avec une entrée `"signal": SIGTERM`. Ainsi toute invocation de `nodemon` dans le répertoire `api` prendra cette option en compte, qu'on passe par `npm` ou non.

## :100: Pour tester

Lancer l'API en tapant `nodemon bin/www`. Taper ensuite `rs` pour forcer `nodemon` à redémarrer le processus, ou modifier un fichier pour un redémarrage automatique. Constater qu'aucun fichier `*.heapsnapshot` n'est créé.

## :rainbow: Remarques
Merci à @aceol d'avoir signalé le problème.