### PR TITLE
[CLEANUP] Convertir les font-size exprimées en px en rem et aligner la valeur du rem de Pix App sur les autres fronts.

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -112,10 +112,6 @@
   box-sizing: border-box;
 }
 
-html {
-  font-size: 10px;
-}
-
 body {
   font-family: $font-roboto;
   background-color: $porcelain-grey;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -131,7 +131,7 @@ input:invalid {
 }
 
 input {
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   font-family: $font-roboto;
 }
 

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -20,7 +20,7 @@
 }
 
 .assessment-banner__title {
-  font-size: 1.75rem;
+  font-size: 1.094rem;
   font-weight: $font-light;
   margin: 0;
 
@@ -46,8 +46,8 @@
 
 .assessment-banner__home-link {
   font-family: $font-roboto;
-  font-size: 1.6rem;
-  letter-spacing: 0.025rem;
+  font-size: 1rem;
+  letter-spacing: 0.016rem;
   font-weight: $font-medium;
   margin-left: auto;
   text-align: right;

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -23,7 +23,7 @@
  }
 
  &__value {
-   font-size: 3rem;
+   font-size: 1.875rem;
    font-weight: bold;
  }
 }

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -6,7 +6,7 @@
   &__label {
     color: rgb(88, 95, 117);
     font-family: $font-roboto;
-    font-size: 15px;
+    font-size: 1.5rem;
     font-weight: 500;
     height: 18px;
     width: 130px;

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -6,7 +6,7 @@
   &__label {
     color: rgb(88, 95, 117);
     font-family: $font-roboto;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     font-weight: 500;
     height: 18px;
     width: 130px;
@@ -15,7 +15,7 @@
   &__title {
     color: $nero;
     font-family: $font-open-sans;
-    font-size: 4.2rem;
+    font-size: 2.625rem;
     font-weight: $font-light;
     text-align: center;
     margin-bottom: 32px;

--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -24,7 +24,7 @@
 .certification-not-certifiable__text {
   font-family: $font-open-sans;
   text-align: center;
-  font-size: 1.6rem;
+  font-size: 1rem;
   line-height: 27px;
   margin-top: 0;
 

--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -6,7 +6,7 @@
   max-width: 990px;
   width: 100%;
   margin: -150px auto;
-  line-height: 3rem;
+  line-height: 1.875rem;
   background-color: $white;
   padding-top: 10px;
 
@@ -18,22 +18,22 @@
 .result-content__panel-title {
   color: $grayish-grey;
   font-family: $font-open-sans;
-  font-size: 2.5rem;
+  font-size: 1.563rem;
   font-weight: $font-bold;
-  line-height: 4rem;
+  line-height: 2.5rem;
   text-align: center;
   margin-top: 11px;
 
   @include device-is('tablet') {
-    font-size: 3rem;
+    font-size: 1.875rem;
   }
 }
 
 .result-content__panel-description {
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 2rem;
-  line-height: 3rem;
+  font-size: 1.25rem;
+  line-height: 1.875rem;
   text-align: center;
   margin-top: 21px;
   padding: 0 3px;
@@ -42,25 +42,25 @@
 
 .result-content__panel-description-supervisor {
   color: $pure-orange;
-  font-size: 2rem;
+  font-size: 1.25rem;
   font-weight: bold;
-  line-height: 3rem;
+  line-height: 1.875rem;
   text-align: center;
   margin-top: 21px;
   padding: 0 3px;
 }
 
 .result-content__warning-container {
-  padding-top: 5rem;
+  padding-top: 3.125rem;
   text-align: center;
 }
 
 .result-content__warning-text {
   text-align: center;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   color: $charcoal-grey;
   line-height: normal;
-  padding-left: 1rem;
+  padding-left: 0.625rem;
   padding-bottom: 30px;
 }
 
@@ -71,7 +71,7 @@
 .result-content__button {
   border: none;
   display: block;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   text-transform: uppercase;
   font-weight: $font-bold;
   text-align: center;

--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -25,7 +25,7 @@
   margin-top: 11px;
 
   @include device-is('tablet') {
-    font-size: 30px;
+    font-size: 3rem;
   }
 }
 

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -8,7 +8,7 @@
   color: $charcoal-grey;
   font-family: $font-open-sans;
   font-weight: $font-light;
-  font-size: 2rem;
+  font-size: 1.25rem;
   line-height: 28px;
   text-align: center;
   margin-top: 5px;
@@ -17,7 +17,7 @@
 
 .certification-course-page__cgu {
   color: $charcoal-grey;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   line-height: 18px;
   text-align: justify;
   margin: 5px 30px 5px 30px;
@@ -50,7 +50,7 @@
     $silver-grey 1ch,
     transparent 0,
     transparent 1ch + $space-between-dashes) 0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
-  font-size: 3rem;
+  font-size: 1.875rem;
   font-family: $font-roboto-mono;
   letter-spacing: $space-between-dashes;
   background-position-x: 0.5ch;
@@ -83,7 +83,7 @@
 
 .certification-course-page__errors {
   color: $pure-orange;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   text-align: center;
   margin: 5px 5px 5px 5px;
 }

--- a/mon-pix/app/styles/components/_certifications-list-item.scss
+++ b/mon-pix/app/styles/components/_certifications-list-item.scss
@@ -43,7 +43,7 @@
 
   @include device-is('tablet') {
     height: 60px;
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 }
 
@@ -68,7 +68,7 @@
   padding: 10px 0;
   border-top: 1px solid $alto-grey;
 
-  font-size: 1.6rem;
+  font-size: 1rem;
   color: $dove-gray;
   text-align: left;
 }
@@ -120,11 +120,11 @@
     letter-spacing: -1px;
     color: $tundora-grey;
 
-    font-size: 0.8rem;
+    font-size: 0.5rem;
     font-weight: 300;
 
     @include device-is('tablet') {
-      font-size: 1.4rem;
+      font-size: 0.875rem;
       font-weight: 500;
     }
   }
@@ -143,14 +143,14 @@
   justify-content: left;
 
   .certifications-list-item__cell-detail-button {
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     color: $pix-blue;
     border: none;
     background: none;
   }
 
   .certifications-list-item__cell-detail-link {
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     color: $pix-blue;
     border: none;
     background: none;

--- a/mon-pix/app/styles/components/_certifications-list-item.scss
+++ b/mon-pix/app/styles/components/_certifications-list-item.scss
@@ -43,7 +43,7 @@
 
   @include device-is('tablet') {
     height: 60px;
-    font-size: 16px;
+    font-size: 1.6rem;
   }
 }
 
@@ -68,7 +68,7 @@
   padding: 10px 0;
   border-top: 1px solid $alto-grey;
 
-  font-size: 16px;
+  font-size: 1.6rem;
   color: $dove-gray;
   text-align: left;
 }
@@ -120,11 +120,11 @@
     letter-spacing: -1px;
     color: $tundora-grey;
 
-    font-size: 8px;
+    font-size: 0.8rem;
     font-weight: 300;
 
     @include device-is('tablet') {
-      font-size: 14px;
+      font-size: 1.4rem;
       font-weight: 500;
     }
   }
@@ -143,14 +143,14 @@
   justify-content: left;
 
   .certifications-list-item__cell-detail-button {
-    font-size: 13px;
+    font-size: 1.3rem;
     color: $pix-blue;
     border: none;
     background: none;
   }
 
   .certifications-list-item__cell-detail-link {
-    font-size: 13px;
+    font-size: 1.3rem;
     color: $pix-blue;
     border: none;
     background: none;

--- a/mon-pix/app/styles/components/_certifications-list.scss
+++ b/mon-pix/app/styles/components/_certifications-list.scss
@@ -2,12 +2,12 @@
 
   background-color: transparent;
   justify-content: space-around;
-  font-size: 10px;
+  font-size: 1rem;
   color: $charcoal-grey;
   font-family: $font-open-sans;
 
   @include device-is('tablet') {
-    font-size: 14px;
+    font-size: 1.4rem;
   }
 }
 

--- a/mon-pix/app/styles/components/_certifications-list.scss
+++ b/mon-pix/app/styles/components/_certifications-list.scss
@@ -2,12 +2,12 @@
 
   background-color: transparent;
   justify-content: space-around;
-  font-size: 1rem;
+  font-size: 0.625rem;
   color: $charcoal-grey;
   font-family: $font-open-sans;
 
   @include device-is('tablet') {
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 }
 

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -47,11 +47,11 @@
 .challenge-actions__action-skip-text {
   text-align: center;
   flex-grow: 1;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-semi-bold;
   color: $slate-grey;
   text-transform: uppercase;
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.031rem;
 }
 .challenge-actions__action-skip__loader {
   margin-right: 15px;
@@ -99,10 +99,10 @@
 .challenge-actions__action-validate-text {
   width: 76px;
   flex-grow: 1;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
-  letter-spacing: 0.15rem;
+  letter-spacing: 0.094rem;
   color: white;
   text-decoration: none;
 }
@@ -130,10 +130,10 @@
 
 .challenge-actions__already-answered {
   font-family: $font-roboto;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: 600;
   color: $tundora-grey;
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.031rem;
   margin-right: 20px;
 }
 
@@ -164,10 +164,10 @@
   width: 76px;
   padding: 0;
   font-family: $font-roboto;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
-  letter-spacing: 0.15rem;
+  letter-spacing: 0.094rem;
   color: white;
   text-decoration: none;
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -19,7 +19,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 7rem;
+    font-size: 4.375rem;
     color: $raven-grey;
   }
 
@@ -51,7 +51,7 @@
   border: none;
   border-radius: 5px;
   font-family: $font-roboto;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-weight: bold;
   text-align: center;
   text-transform: uppercase;
@@ -94,5 +94,5 @@
 
 .embed-reboot-content__text {
   font-family: $font-roboto;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
 }

--- a/mon-pix/app/styles/components/_challenge-illustration.scss
+++ b/mon-pix/app/styles/components/_challenge-illustration.scss
@@ -7,7 +7,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 7rem;
+    font-size: 4.375rem;
     color: $raven-grey;
   }
 

--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -1,5 +1,5 @@
 .challenge-response {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   background-color: $porcelain-grey;
   margin: 6px;
 
@@ -8,7 +8,7 @@
   }
 
   @include device-is('desktop') {
-    font-size: 2rem;
+    font-size: 1.25rem;
   }
 
   &__proposal {
@@ -18,7 +18,7 @@
 }
 
 .challenge-response__proposal {
-  font-size: 2rem;
+  font-size: 1.25rem;
   color: $charcoal-grey;
 
   &--paragraph {
@@ -44,7 +44,7 @@
   width: 100%;
   word-wrap: break-word;
   overflow-wrap: break-word;
-  line-height: 2.6rem;
+  line-height: 1.625rem;
 }
 
 form .challenge-response {
@@ -78,7 +78,7 @@ form .challenge-response.challenge-response--locked {
 
 form .challenge-response-locked {
   &__icon {
-    font-size: 5rem;
+    font-size: 3.125rem;
     opacity: 1;
 
     &:hover {

--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -1,5 +1,5 @@
 .challenge-response {
-  font-size: 15px;
+  font-size: 1.5rem;
   background-color: $porcelain-grey;
   margin: 6px;
 
@@ -8,7 +8,7 @@
   }
 
   @include device-is('desktop') {
-    font-size: 20px;
+    font-size: 2rem;
   }
 
   &__proposal {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -27,7 +27,7 @@
 }
 
 .challenge-statement__instruction-section {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-family: $font-open-sans;
   margin-bottom: 20px;
 
@@ -37,7 +37,7 @@
   }
 
   @include device-is('desktop') {
-    font-size: 2rem;
+    font-size: 1.25rem;
   }
 }
 
@@ -60,7 +60,7 @@
 }
 
 .challenge-statement__text {
-  font-size: 1.6rem;
+  font-size: 1rem;
 }
 
 .challenge-statement__help-icon {
@@ -122,7 +122,7 @@
 }
 
 .challenge-statement__help-text {
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   color: $charcoal-grey;
 }
 
@@ -148,7 +148,7 @@
 }
 
 .challenge-statement__file-option-label {
-  font-size: 1.6rem;
+  font-size: 1rem;
   line-height: 10px;
   font-weight: $font-normal;
 }
@@ -177,7 +177,7 @@
 .challenge-statement__action-label {
   width: 76px;
   line-height: 46px;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-heavy;
   text-transform: uppercase;
 }

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -27,7 +27,7 @@
 }
 
 .challenge-statement__instruction-section {
-  font-size: 15px;
+  font-size: 1.5rem;
   font-family: $font-open-sans;
   margin-bottom: 20px;
 
@@ -37,7 +37,7 @@
   }
 
   @include device-is('desktop') {
-    font-size: 20px;
+    font-size: 2rem;
   }
 }
 
@@ -60,7 +60,7 @@
 }
 
 .challenge-statement__text {
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .challenge-statement__help-icon {
@@ -122,7 +122,7 @@
 }
 
 .challenge-statement__help-text {
-  font-size: 14px;
+  font-size: 1.4rem;
   color: $charcoal-grey;
 }
 
@@ -148,7 +148,7 @@
 }
 
 .challenge-statement__file-option-label {
-  font-size: 16px;
+  font-size: 1.6rem;
   line-height: 10px;
   font-weight: $font-normal;
 }
@@ -177,7 +177,7 @@
 .challenge-statement__action-label {
   width: 76px;
   line-height: 46px;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: $font-heavy;
   text-transform: uppercase;
 }

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -40,7 +40,7 @@
 }
 
 .checkpoint-legend {
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   font-weight: $font-light;
   color: $white;
   margin: 6px 0;
@@ -107,16 +107,16 @@
   text-align: center;
 
   &__header {
-    font-size: 4.2rem;
-    line-height: 4.8rem;
+    font-size: 2.625rem;
+    line-height: 3rem;
     font-weight: $font-light;
     margin-bottom: 60px;
   }
 
   &__info {
     color: $dove-gray;
-    font-size: 2.4rem;
-    line-height: 3.3rem;
+    font-size: 1.5rem;
+    line-height: 2.063rem;
     font-weight: $font-light;
     margin-bottom: 60px;
     max-width: 100%;

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -81,7 +81,7 @@
   & > svg {
     margin-left: 30px;
     padding-top: 6px;
-    font-size: 1.5em;
+    font-size: 0.938em;
     position: relative;
     left: 0;
     transition: all 0.25s ease-in-out;

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -28,7 +28,7 @@
 
 .comparison-window__instruction {
   margin: 15px;
-  font-size: 16px;
+  font-size: 1.6rem;
 
   @include device-is('desktop') {
     margin: 20px 40px 0 40px;
@@ -51,7 +51,7 @@
   right: -10px; /*XXX : right alignment, found no other way to achieve it;*/
   margin-right: 0;
   height: 17px;
-  font-size: 14px;
+  font-size: 1.4rem;
   border: none;
   background-color: transparent;
   color: $white;
@@ -82,7 +82,7 @@
   margin-left: 9px;
   max-width: 618.5px;
   font-family: $font-open-sans;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: $font-heavy;
   color: $charcoal-grey;
 }
@@ -118,14 +118,14 @@
 
 .comparison-windows__default-message-title {
   font-family: $font-open-sans;
-  font-size: 17px;
+  font-size: 1.7rem;
   text-align: center;
   color: $black;
   font-weight: $font-semi-bold;
   margin-top: 10.2px;
 
   @include device-is('desktop') {
-    font-size: 22px;
+    font-size: 2.2rem;
     line-height: 26px;
   }
 }

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -28,7 +28,7 @@
 
 .comparison-window__instruction {
   margin: 15px;
-  font-size: 1.6rem;
+  font-size: 1rem;
 
   @include device-is('desktop') {
     margin: 20px 40px 0 40px;
@@ -51,7 +51,7 @@
   right: -10px; /*XXX : right alignment, found no other way to achieve it;*/
   margin-right: 0;
   height: 17px;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   border: none;
   background-color: transparent;
   color: $white;
@@ -82,7 +82,7 @@
   margin-left: 9px;
   max-width: 618.5px;
   font-family: $font-open-sans;
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   font-weight: $font-heavy;
   color: $charcoal-grey;
 }
@@ -118,14 +118,14 @@
 
 .comparison-windows__default-message-title {
   font-family: $font-open-sans;
-  font-size: 1.7rem;
+  font-size: 1.063rem;
   text-align: center;
   color: $black;
   font-weight: $font-semi-bold;
   margin-top: 10.2px;
 
   @include device-is('desktop') {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
     line-height: 26px;
   }
 }

--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -43,11 +43,11 @@
   }
 
   .competence-card__area-name {
-    font-size: 0.9rem;
+    font-size: 0.563rem;
   }
 
   .competence-card__competence-name {
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 
   .competence-card__competence-name {
@@ -145,7 +145,7 @@
 
   .competence-card__score-value--congrats {
     color: $white;
-    font-size: 4.5rem;
+    font-size: 2.813rem;
     font-weight: $font-bold;
   }
 
@@ -159,9 +159,9 @@
     height: 34px;
     color: $pix-grey-hover;
     font-family: $font-open-sans;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     font-weight: $font-bold;
-    letter-spacing: 0.1rem;
+    letter-spacing: 0.063rem;
     text-transform: uppercase;
   }
 
@@ -172,7 +172,7 @@
     color: $dusty-grey;
     opacity: 0;
     text-transform: uppercase;
-    font-size: 1rem;
+    font-size: 0.625rem;
     transition: opacity 0.1s linear;
     letter-spacing: 0.5px;
   }

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -67,8 +67,8 @@
 }
 
 .competence-card__area-name {
-  font-size: 1.1rem;
-  letter-spacing: 0.05rem;
+  font-size: 0.688rem;
+  letter-spacing: 0.031rem;
   opacity: 0.8;
   text-transform: uppercase;
   position: relative;
@@ -76,7 +76,7 @@
 }
 
 .competence-card__competence-name {
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   font-weight: $font-medium;
   position: relative;
 }
@@ -120,7 +120,7 @@
 
 .competence-card__score-value {
   min-height: 44px;
-  font-size: 3.5rem;
+  font-size: 2.188rem;
 
   &--congrats {
     color: $white;

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -31,7 +31,7 @@
   color: $porcelain-grey;
   font-weight: $font-normal;
   font-family: $font-open-sans;
-  line-height: 1.4em;
-  font-size: 2.4em;
+  line-height: 0.875em;
+  font-size: 1.5em;
   text-align: center;
 }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -19,7 +19,7 @@
   right: 10px;
   left: auto;
   bottom: auto;
-  font-size: 1em;
+  font-size: 0.625rem;
   cursor: pointer;
   opacity: .5;
   &:hover, &:active {

--- a/mon-pix/app/styles/components/_corner-ribbon.scss
+++ b/mon-pix/app/styles/components/_corner-ribbon.scss
@@ -25,7 +25,7 @@
   color: $white;
   display: block;
   font-weight: $font-bold;
-  font-size: 2rem;
+  font-size: 1.25rem;
   margin: 1px 0;
   padding: 3px 0;
   text-align: center;

--- a/mon-pix/app/styles/components/_corner-ribbon.scss
+++ b/mon-pix/app/styles/components/_corner-ribbon.scss
@@ -25,7 +25,7 @@
   color: $white;
   display: block;
   font-weight: $font-bold;
-  font-size: 20px;
+  font-size: 2rem;
   margin: 1px 0;
   padding: 3px 0;
   text-align: center;

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,6 +1,6 @@
 .feedback-panel {
   color: $charcoal-grey;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   margin-top: -18px;
 }
 
@@ -12,7 +12,7 @@
   color: $dusty-grey;
   font-family: $font-roboto;
   font-weight: $font-medium;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   line-height: 20px;
 }
 
@@ -27,12 +27,12 @@
 
 .feedback-panel__form-description {
   margin-bottom: 20px;
-  font-size: 2rem;
+  font-size: 1.25rem;
 }
 
 .feedback-panel__form-description p {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-family: $font-open-sans;
 }
 
@@ -55,7 +55,7 @@
   border: solid 1px $alto-grey;
   box-sizing: border-box;
   padding: 8px;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
 }
 
 .feedback-panel__category-selection {
@@ -65,7 +65,7 @@
 
 .feedback-panel__dropdown {
   font-family: $font-roboto;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   color: $charcoal-grey;
 
   margin: 5px 0;
@@ -76,7 +76,7 @@
 }
 
 .feedback-panel__quick-help {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   margin-top: 20px;
   font-weight: bold;
   text-align: justify;
@@ -124,7 +124,7 @@
   border-top: 1px solid $alto-grey;
 
   & p {
-    font-size: 1.2rem;
+    font-size: 0.75rem;
   }
 }
 
@@ -133,7 +133,7 @@
 
 .feedback-panel__view--mercix {
   text-align: center;
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   color: $charcoal-grey;
   padding-top: 20px;
   padding-bottom: 10px;

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -4,10 +4,10 @@
 }
 
 .form-textfield__label {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-weight: $font-medium;
   color: $charcoal-grey;
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.031rem;
 }
 
 .form-textfield__help {
@@ -90,7 +90,7 @@
 
 
 .form-textfield__message {
-  font-size: 1.4rem;
+  font-size: 0.875rem;
 }
 
 .form-textfield__message--error {
@@ -151,7 +151,7 @@
   &__eye {
     color: $dove-gray;
     transition: .5s;
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     margin-top: 1px;
 
     &:hover {

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -13,20 +13,20 @@
 @mixin hexagon-score-title {
   color: $nero;
   font-family: $font-roboto;
-  font-size: 1.4rem;
-  letter-spacing: 0.35rem;
+  font-size: 0.875rem;
+  letter-spacing: 0.219rem;
 }
 
 @mixin hexagon-score-pix-score {
   color: $black;
   font-family: $font-open-sans;
-  font-size: 4.6rem;
+  font-size: 2.875rem;
 }
 
 @mixin hexagon-score-pix-total {
   color: $dove-gray;
   font-family: $font-roboto;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   border-top: 1px solid $dusty-grey;
 }
 
@@ -101,8 +101,8 @@
 
 .hexagon-score-information__text {
   font-family: $font-open-sans;
-  font-size: 1.6rem;
-  line-height: 2.2rem;
+  font-size: 1rem;
+  line-height: 1.375rem;
 
   &--strong {
     font-weight: $font-bold;
@@ -110,7 +110,7 @@
 }
 .hexagon-score-information__close {
   float: right;
-  font-size: 2rem;
+  font-size: 1.25rem;
   padding: 10px;
   margin-top: -10px;
   @include device-is('desktop') {

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -21,8 +21,8 @@
 
 .learning-more-panel__tutorial-info {
   color: $raven-grey;
-  font-size: 1.3rem;
-  line-height: 2rem;
+  font-size: 0.813rem;
+  line-height: 1.25rem;
   margin: 5px;
 }
 

--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -21,7 +21,7 @@
     position: absolute;
     top: 31px;
     left: 40px;
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     font-family: $font-open-sans;
     font-weight: $font-bold;
   }
@@ -37,7 +37,7 @@
     background-color: transparent;
     cursor: pointer;
     color: $slate-grey;
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     width: 70px;
     border: none;
     border-left: 1px solid $alto-grey;
@@ -57,24 +57,24 @@
 
 .levelup-competence {
   &__level {
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-weight: $font-bold;
     font-family: $font-open-sans;
     text-transform: uppercase;
     margin-bottom: 2px;
 
     @include device-is('mobile') {
-      font-size: 1.4rem;
+      font-size: 0.875rem;
     }
   }
 
   &__name {
-    font-size: 1.4rem;
-    line-height: 1.8rem;
+    font-size: 0.875rem;
+    line-height: 1.125rem;
     font-family: $font-roboto;
 
     @include device-is('mobile') {
-      font-size: 1.3rem;
+      font-size: 0.813rem;
     }
   }
 }

--- a/mon-pix/app/styles/components/_login-form.scss
+++ b/mon-pix/app/styles/components/_login-form.scss
@@ -7,12 +7,12 @@
   &__error-message {
     color: red;
     font-family: $font-roboto;
-    font-size: 1.2rem;
+    font-size: 0.75rem;
     margin-bottom: 10px;
   }
 
   &__forgotten-password {
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     margin: 8px;
     text-align: center;
   }

--- a/mon-pix/app/styles/components/_login-or-register.scss
+++ b/mon-pix/app/styles/components/_login-or-register.scss
@@ -38,7 +38,7 @@
 
   &__invitation {
     font-family: $font-roboto;
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: 500;
     color: $dove-gray;
     text-align: center;
@@ -98,7 +98,7 @@
 .form-title {
   color: $nero;
   font-family: $font-open-sans;
-  font-size: 3rem;
+  font-size: 1.875rem;
   font-weight: $font-light;
   margin-bottom: 20px;
 }

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -24,7 +24,7 @@
     margin: 5px 0;
     padding: 6px 32px;
     color: $white;
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-family: $font-open-sans;
 
     &.active,
@@ -37,7 +37,7 @@
 
 .navbar-burger-menu-user-info-item {
   &__name {
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: $font-semi-bold;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -45,7 +45,7 @@
   }
 
   &__email {
-    font-size: 1.2rem;
+    font-size: 0.75rem;
     font-weight: $font-light;
     padding: 0;
     text-overflow: ellipsis;
@@ -54,7 +54,7 @@
   }
 
   &__logout {
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     text-decoration: underline;
     margin: 10px 0;
 
@@ -72,7 +72,7 @@
     margin: 5px 0;
     padding: 10px 32px;
     color: $gray;
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     font-family: $font-roboto;
 
     &.active {

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -23,7 +23,7 @@
     margin-right: 20px;
     padding-top: 5px;
     padding-bottom: 5px;
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-family: $font-roboto;
     color: $dove-gray;
     text-decoration: none;

--- a/mon-pix/app/styles/components/_navbar-desktop-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-menu.scss
@@ -36,13 +36,13 @@
 .navbar-desktop-menu-links__item:first-child {
   background: transparent;
   padding: 0;
-  font-size: 13px;
+  font-size: 1.3rem;
   justify-content: normal;
 }
 
 .navbar-desktop-menu-links__link {
   text-transform: uppercase;
-  font-size: 13px;
+  font-size: 1.3rem;
   padding-left: 0;
   width: 100%;
   color: inherit;
@@ -58,7 +58,7 @@
 
 .navbar-menu-signup-link {
   border-radius: 20px;
-  font-size: 13px;
+  font-size: 1.3rem;
   text-align: center;
   color: $white;
   border: 2px solid $white;

--- a/mon-pix/app/styles/components/_navbar-desktop-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-menu.scss
@@ -36,13 +36,13 @@
 .navbar-desktop-menu-links__item:first-child {
   background: transparent;
   padding: 0;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   justify-content: normal;
 }
 
 .navbar-desktop-menu-links__link {
   text-transform: uppercase;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   padding-left: 0;
   width: 100%;
   color: inherit;
@@ -58,7 +58,7 @@
 
 .navbar-menu-signup-link {
   border-radius: 20px;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   text-align: center;
   color: $white;
   border: 2px solid $white;

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -12,7 +12,7 @@
   &__burger-icon {
     padding: 0;
     color: $pix-grey-hover;
-    font-size: 2.6rem;
+    font-size: 1.625rem;
     display: inline-flex;
     cursor: pointer;
   }

--- a/mon-pix/app/styles/components/_no-certification-panel.scss
+++ b/mon-pix/app/styles/components/_no-certification-panel.scss
@@ -6,11 +6,11 @@
   background-color: white;
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 17px;
+  font-size: 1.7rem;
 
   @include device-is('tablet') {
     margin: 0 50px;
-    font-size: 20px;
+    font-size: 2rem;
 
   }
 

--- a/mon-pix/app/styles/components/_no-certification-panel.scss
+++ b/mon-pix/app/styles/components/_no-certification-panel.scss
@@ -6,11 +6,11 @@
   background-color: white;
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 1.7rem;
+  font-size: 1.063rem;
 
   @include device-is('tablet') {
     margin: 0 50px;
-    font-size: 2rem;
+    font-size: 1.25rem;
 
   }
 

--- a/mon-pix/app/styles/components/_pix-toggle.scss
+++ b/mon-pix/app/styles/components/_pix-toggle.scss
@@ -1,6 +1,6 @@
 .pix-toggle {
   font-family: $font-roboto;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-medium;
   letter-spacing: 0.45px;
   color: $pix-grey;
@@ -15,7 +15,7 @@
   span {
     width: 50%;
     vertical-align: middle;
-    line-height: 4.4rem;
+    line-height: 2.75rem;
     border-radius: 10px;
   }
 

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -8,7 +8,7 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   padding: 0px 4px;
 }
 
@@ -63,7 +63,7 @@
   }
 
   &__value {
-    font-size: 3rem;
+    font-size: 1.875rem;
     font-weight: bold;
   }
 }

--- a/mon-pix/app/styles/components/_progression-gauge.scss
+++ b/mon-pix/app/styles/components/_progression-gauge.scss
@@ -67,7 +67,7 @@
   color: $white;
   border-radius: 5px;
   font-family: $font-roboto;
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   font-weight: $font-normal;
   text-align: center;
   right: -18px;

--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -1,6 +1,6 @@
 .qcm-panel__proposals {
   margin: 0 0 15px;
-  font-size: 1.6rem;
+  font-size: 1rem;
 }
 
 .qcm-panel__proposal-item {

--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -1,6 +1,6 @@
 .qcm-panel__proposals {
   margin: 0 0 15px;
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .qcm-panel__proposal-item {

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -1,5 +1,5 @@
 .qcu-panel__proposals {
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .qcu-panel__proposal-item {

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -1,5 +1,5 @@
 .qcu-panel__proposals {
-  font-size: 1.6rem;
+  font-size: 1rem;
 }
 
 .qcu-panel__proposal-item {

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -4,13 +4,13 @@
 
 .correction-qroc-box-answer {
   height: 26px;
-  line-height: 2.4rem;
+  line-height: 1.5rem;
   border-radius: 3px;
   background-color: $white;
   box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
   border: solid 1px $alto-grey;
   padding: 0 10px;
-  font-size: 1.6rem;
+  font-size: 1rem;
 
   &--paragraph {
     width: 100%;
@@ -45,7 +45,7 @@
 }
 
 .correction-qroc-box__solution-text {
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-bold;
   color: $caribbean-green;
   display: flex;

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -1,13 +1,13 @@
 .correction-qrocm {
   &__text {
     display: inline-block;
-    font-size: 1.6rem;
-    line-height: 2.8rem;
+    font-size: 1rem;
+    line-height: 1.75rem;
     color: $charcoal-grey;
   }
 
   &__answer {
-    line-height: 2.6rem;
+    line-height: 1.625rem;
     border-radius: 3px;
     background-color: $white;
     box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
@@ -49,7 +49,7 @@
     &-text {
       font-weight: $font-bold;
       color: $caribbean-green;
-      font-size: 1.6rem;
+      font-size: 1rem;
       margin-left: 3px;
       padding-bottom: 1px;
     }

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -7,7 +7,7 @@
   &__login-options {
     margin-bottom: 5px;
     display: inline-block;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     font-family: $font-roboto;
     font-weight: $font-bold;
     color: $grayish-grey;
@@ -16,7 +16,7 @@
   &__required-inputs {
     color: $dove-gray;
     font-family: $font-roboto;
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-weight: $font-normal;
   }
 
@@ -63,7 +63,7 @@
     align-items: center;
     margin: 4px 0;
     font-family: $font-roboto;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 
   &__return-button:hover {
@@ -75,7 +75,7 @@
   &__error {
     text-align: center;
     color: $pure-orange;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     padding: 4px 10px;
 
     @include device-is('tablet') {

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -22,7 +22,7 @@
 
 .result-item__instruction {
   width: 82%;
-  font-size: 1.6rem;
+  font-size: 1rem;
   margin-left: 10px;
   overflow: hidden;
 
@@ -33,7 +33,7 @@
 }
 
 .result-item__correction {
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   margin-right: 26px;
   margin-left: 35px;
 
@@ -44,7 +44,7 @@
 
 .result-item__correction-button {
   font-weight: $font-normal;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   color: $pix-blue;
   border: none;
   outline: none;
@@ -61,7 +61,7 @@
 
 .result-item__icon {
   margin-left: 10px;
-  font-size: 2.2rem;
+  font-size: 1.375rem;
 
   @include device-is('tablet') {
     margin-left: 30px;

--- a/mon-pix/app/styles/components/_resume-campaign-banner.scss
+++ b/mon-pix/app/styles/components/_resume-campaign-banner.scss
@@ -16,10 +16,10 @@
 
     .resume-campaign-banner__title {
       font-family: $font-open-sans;
-      font-size: 1.2rem;
+      font-size: 0.75rem;
 
       @media (min-width: 768px) {
-        font-size: 1.85rem;
+        font-size: 1.156rem;
       }
     }
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -16,8 +16,8 @@
     font-family: $font-roboto;
     font-weight: $font-normal;
     color: $grey-90;
-    font-size: 1.6rem;
-    line-height: 2.6rem;
+    font-size: 1rem;
+    line-height: 1.625rem;
     margin: 0 0 10px;
   }
 }
@@ -26,10 +26,10 @@
   margin-bottom: 40px;
 
   &__title {
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: $font-normal;
     font-family: $font-open-sans;
-    line-height: 3.4rem;
+    line-height: 2.125rem;
     color: $grey-90;
     margin-bottom: 24px;
   }
@@ -105,8 +105,8 @@
 .scorecard-details-content-left {
   &__area {
     text-transform: uppercase;
-    font-size: 1.4rem;
-    letter-spacing: 0.2rem;
+    font-size: 0.875rem;
+    letter-spacing: 0.125rem;
 
     &--jaffa {
       color: $jaffa;
@@ -131,8 +131,8 @@
 
   &__description {
     font-family: $font-open-sans;
-    font-size: 1.6rem;
-    line-height: 2.6rem;
+    font-size: 1rem;
+    line-height: 1.625rem;
     color: $dove-gray;
   }
 }
@@ -149,7 +149,7 @@
     margin-top: 20px;
     color: $grayish-grey;
     text-transform: uppercase;
-    letter-spacing: 0.03rem;
+    letter-spacing: 0.019rem;
     white-space: nowrap;
   }
 
@@ -157,7 +157,7 @@
     padding-top: 50px;
     color: $dusty-grey;
     font-family: $font-roboto;
-    font-size: 1.3rem;
+    font-size: 0.813rem;
   }
 }
 
@@ -178,7 +178,7 @@
     color: $black;
     font-family: $font-roboto;
     font-weight: $font-medium;
-    font-size: 2.2rem;
+    font-size: 1.375rem;
 
     @include device-is('desktop') {
       padding: 50px 0 20px 0;
@@ -190,6 +190,6 @@
     color: $grayish-grey;
     font-family: $font-roboto;
     font-weight: $font-light;
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 }

--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -16,7 +16,7 @@
   }
 
   &__cgu {
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-weight: $font-medium;
   }
 
@@ -31,9 +31,9 @@
 
   &__cgu-label span {
     color: $charcoal-grey;
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     @include device-is('tablet') {
-      font-size: 1.4rem;
+      font-size: 0.875rem;
     }
   }
 
@@ -41,7 +41,7 @@
     display: block;
     max-width: 100%;
     padding: 10px;
-    font-size: 1.2rem;
+    font-size: 0.75rem;
 
     @include device-is('tablet') {
       padding: 10px 0;

--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -31,9 +31,9 @@
 
   &__cgu-label span {
     color: $charcoal-grey;
-    font-size: 13px;
+    font-size: 1.3rem;
     @include device-is('tablet') {
-      font-size: 14px;
+      font-size: 1.4rem;
     }
   }
 

--- a/mon-pix/app/styles/components/_timeout-jauge.scss
+++ b/mon-pix/app/styles/components/_timeout-jauge.scss
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: flex-end;
   flex-direction: row;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: $font-bold;
   font-style: normal;
 }

--- a/mon-pix/app/styles/components/_timeout-jauge.scss
+++ b/mon-pix/app/styles/components/_timeout-jauge.scss
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: flex-end;
   flex-direction: row;
-  font-size: 2rem;
+  font-size: 1.25rem;
   font-weight: $font-bold;
   font-style: normal;
 }

--- a/mon-pix/app/styles/components/_tutorial-item.scss
+++ b/mon-pix/app/styles/components/_tutorial-item.scss
@@ -22,8 +22,8 @@
 
 .tutorial-content {
   &__title {
-    font-size: 1.8rem;
-    line-height: 3rem;
+    font-size: 1.125rem;
+    line-height: 1.875rem;
     letter-spacing: 0;
     color: $grey-90;
     margin-bottom: 4px;
@@ -36,11 +36,11 @@
   }
 
   &__description {
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     font-family: $font-roboto;
     font-weight: $font-normal;
     color: $grey-45;
-    line-height: 2.4rem;
+    line-height: 1.5rem;
     margin: 0 0 14px;
 
     .tutorial-content__format {
@@ -49,9 +49,9 @@
   }
 
   &__competence-name {
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     font-weight: 400;
-    letter-spacing: 0.015rem;
+    letter-spacing: 0.009rem;
     margin: 0 0 8px;
     color: $pix-blue-hover;
     display: inline-block;
@@ -66,10 +66,10 @@
 
 .tutorial-content-actions {
   &__save {
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     font-weight: $font-medium;
     color: $grey-45;
-    letter-spacing: 0.045rem;
+    letter-spacing: 0.028rem;
     margin: 0 0 16px;
     background: transparent;
     border: none;
@@ -93,10 +93,10 @@
   }
 
   &__evaluate {
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     font-weight: $font-medium;
     color: $grey-45;
-    letter-spacing: 0.045rem;
+    letter-spacing: 0.028rem;
     margin: 0 0 16px;
     background: transparent;
     border: none;

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -30,14 +30,14 @@
 
 .tutorial-panel__tutorial-info {
   color: $raven-grey;
-  font-size: 1.3rem;
-  line-height: 2rem;
+  font-size: 0.813rem;
+  line-height: 1.25rem;
   margin: -5px 5px 0;
 }
 
 .tutorial-panel__hint-title {
   font-family: $font-open-sans;
-  font-size: 2.2rem;
+  font-size: 1.375rem;
   text-align: center;
   color: $charcoal-grey;
   font-weight: $font-semi-bold;
@@ -63,13 +63,13 @@
   }
 
   @include device-is('desktop') {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
     line-height: 26px;
   }
 }
 
 .tutorial-panel__hint-content {
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   font-family: $font-open-sans;
 
   & p {

--- a/mon-pix/app/styles/components/_user-certifications-detail-area.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-area.scss
@@ -21,14 +21,14 @@
   background-color: $mercury-grey;
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   font-weight: 600;
   letter-spacing: 1px;
-  line-height: 2.1rem;
+  line-height: 1.313rem;
   padding: 20px 40px;
 
   text-transform: uppercase;
   @include device-is('desktop') {
-    height: 5.9rem;
+    height: 3.688rem;
   }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -5,7 +5,7 @@
 
 .user-certifications-detail-competence__box-name {
   color: $charcoal-grey;
-  font-size: 16px;
+  font-size: 1.6rem;
   letter-spacing: 0.5px;
   line-height: 19px;
   display: flex;
@@ -20,7 +20,7 @@
   width: 25px;
   text-align: center;
   color: $charcoal-grey;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: bold;
   line-height: 24px;
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -5,7 +5,7 @@
 
 .user-certifications-detail-competence__box-name {
   color: $charcoal-grey;
-  font-size: 1.6rem;
+  font-size: 1rem;
   letter-spacing: 0.5px;
   line-height: 19px;
   display: flex;
@@ -20,7 +20,7 @@
   width: 25px;
   text-align: center;
   color: $charcoal-grey;
-  font-size: 2rem;
+  font-size: 1.25rem;
   font-weight: bold;
   line-height: 24px;
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -10,14 +10,14 @@
 }
 
 .user-certifications-detail-header__data-box {
-  padding-left: 3.2rem;
+  padding-left: 2rem;
   color: $charcoal-grey;
 
-  font-size: 1.8rem;
-  line-height: 2rem;
+  font-size: 1.125rem;
+  line-height: 1.25rem;
 
   p {
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.313rem;
     margin: 0;
     margin-block-start: 0;
     margin-block-end: 0;
@@ -25,16 +25,16 @@
 }
 
 .user-certifications-detail-header__data-box-title {
-  line-height: 2.4rem;
-  font-size: 2rem;
+  line-height: 1.5rem;
+  font-size: 1.25rem;
   font-weight: normal;
-  padding-bottom: 0.6rem;
+  padding-bottom: 0.375rem;
 }
 
 .user-certifications-detail-header__data-box-title-big {
   font-family: $font-open-sans;
 
-  line-height: 3.2rem;
-  font-size: 2.8rem;
+  line-height: 2rem;
+  font-size: 1.75rem;
   font-weight: 600;
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -8,8 +8,8 @@
   max-width:370px;
 
   color: $charcoal-grey;
-  font-size: 1.8rem;
-  line-height: 2.6rem;
+  font-size: 1.125rem;
+  line-height: 1.625rem;
   margin-bottom: 40px;
 
   @include device-is('desktop') {
@@ -17,14 +17,14 @@
   }
 
   &__pix-score{
-    margin-bottom: 1.25rem;
-    width: 27rem;
+    margin-bottom: 0.781rem;
+    width: 16.875rem;
   }
 
   &__badge-pix-score{
-    width: 13rem;
-    height: 13rem;
-    padding-top: 4.7rem;
+    width: 8.125rem;
+    height: 8.125rem;
+    padding-top: 2.938rem;
     float: left;
 
     background: url('/images/pix-pastille-certif.svg') no-repeat;
@@ -34,12 +34,12 @@
     display: table;
 
     span {
-      height: 1.75rem;
-      width: 2.81rem;
+      height: 1.094rem;
+      width: 1.756rem;
       color: $tundora-grey;
-      font-size: 3rem;
+      font-size: 1.875rem;
       font-weight: bold;
-      line-height: 2.06rem;
+      line-height: 1.288rem;
       text-align: center;
 
     }
@@ -47,24 +47,24 @@
 
   &__pix-certified {
     color: $tundora-grey;
-    font-size: 2.5rem;
+    font-size: 1.563rem;
     font-weight: bold;
-    line-height: 1.75rem;
-    margin-top: 4.8rem;
+    line-height: 1.094rem;
+    margin-top: 3rem;
     text-align: right;
   }
 
   &__separation{
     clear: both;
     position: absolute;
-    height: 14rem;
-    margin-top: 0.8rem;
-    width : 0.25rem;
+    height: 8.75rem;
+    margin-top: 0.5rem;
+    width : 0.156rem;
     background: black;
   }
 
   &__text-pix-certified {
-    padding-left: 1.25rem;
+    padding-left: 0.781rem;
 
     border-left-style: solid;
     border-left-color: $charcoal-grey;
@@ -79,9 +79,9 @@
   &__title-comment-jury {
     color: $raven-grey;
     font-family: $font-open-sans;
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-weight: $font-medium;
-    line-height: 2.6rem;
+    line-height: 1.625rem;
   }
 
   hr {

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -28,8 +28,8 @@
 .logged-user-name {
   word-break: break-all;
   font-family: $font-roboto;
-  font-size: 1.6rem;
-  letter-spacing: 0.05rem;
+  font-size: 1rem;
+  letter-spacing: 0.031rem;
   text-align: right;
   color: $dove-gray;
   text-transform: capitalize;
@@ -74,7 +74,7 @@
 }
 
 .logged-user-menu-details__fullname {
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-bold;
   white-space: nowrap;
   overflow: hidden;
@@ -82,14 +82,14 @@
 }
 
 .logged-user-menu-details__identifier {
-  font-size: 1.3rem;
+  font-size: 0.813rem;
   color: $dove-gray;
 }
 
 .logged-user-menu__link {
   display: flex;
   align-items: center;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   padding: 12px 16px;
   color: $charcoal-grey;
   transition: background-color 0.1s linear;

--- a/mon-pix/app/styles/components/_warning-timing-page.scss
+++ b/mon-pix/app/styles/components/_warning-timing-page.scss
@@ -11,7 +11,7 @@
 }
 
 .challenge-item-warning__instruction-primary {
-  font-size: 2.4rem;
+  font-size: 1.5rem;
   font-weight: $font-bold;
   font-style: normal;
   font-stretch: normal;
@@ -21,7 +21,7 @@
 }
 
 .challenge-item-warning__intruction-secondary {
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   margin-top: 9px;
   margin-bottom: 50px;
   font-style: normal;
@@ -71,6 +71,6 @@
   background-color: $jade;
   color: $white;
   text-transform: uppercase;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   cursor: pointer;
 }

--- a/mon-pix/app/styles/components/_warning-timing-page.scss
+++ b/mon-pix/app/styles/components/_warning-timing-page.scss
@@ -11,7 +11,7 @@
 }
 
 .challenge-item-warning__instruction-primary {
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: $font-bold;
   font-style: normal;
   font-stretch: normal;
@@ -21,7 +21,7 @@
 }
 
 .challenge-item-warning__intruction-secondary {
-  font-size: 18px;
+  font-size: 1.8rem;
   margin-top: 9px;
   margin-bottom: 50px;
   font-style: normal;

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -5,7 +5,7 @@
   margin-bottom: 11px;
   color: $white;
   text-shadow: none;
-  font-size: 1.4rem;
+  font-size: 0.875rem;
 }
 
 .challenge-response + .alert {
@@ -26,5 +26,5 @@ abbr[title="obligatoire"] {
   cursor: help;
   color: $monza;
   display: contents;
-  margin: 2rem;
+  margin: 1.25rem;
 }

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   outline: none;
-  border-radius: 0.3125em;
+  border-radius: 0.195em;
   padding: 9px;
   margin-bottom: 11px;
   color: $white;

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -1,9 +1,9 @@
 .button {
   font-family: $font-roboto;
   padding: 14px 20px;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: 500;
-  letter-spacing: 0.019rem;
+  letter-spacing: 0.012rem;
   text-align: center;
   border-radius: 5px;
   background-color: $pix-blue;
@@ -45,7 +45,7 @@
   &--extra-thin {
     padding-top: 8px;
     padding-bottom: 8px;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
   }
 
   &--regular {
@@ -91,7 +91,7 @@
     background: $pix-yellow;
     color: $nero;
     font-weight: $font-bold;
-    font-size: 1.45rem;
+    font-size: 0.906rem;
     box-shadow: 0 2px 6px 0 rgba(12, 22, 58, 0.11), 0 1px 3px 0 rgba(0, 0, 0, 0.08);
 
     &:hover, &:active, &:focus {
@@ -104,7 +104,7 @@
     background-color: $dove-gray;
     color: $white;
     font-weight: $font-bold;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     &:hover, &:active, &:focus {
       background-color: $charcoal-grey;
     }
@@ -143,7 +143,7 @@
   color: $dove-gray;
   padding: 4px 8px;
   border: none;
-  font-size: 1.6rem;
+  font-size: 1rem;
   background-color: transparent;
   cursor: pointer;
   outline: none;
@@ -190,9 +190,9 @@
 
   &__return-to {
     color: $black;
-    font-size: 1.3rem;
+    font-size: 0.813rem;
     font-weight: $font-semi-bold;
-    letter-spacing: 0.03rem;
+    letter-spacing: 0.019rem;
     display: inline-flex;
     align-items: center;
 

--- a/mon-pix/app/styles/globals/_loading.scss
+++ b/mon-pix/app/styles/globals/_loading.scss
@@ -12,7 +12,7 @@
 }
 
 .app-loader__text {
-  font-size: 2.6rem;
+  font-size: 1.625rem;
   padding: 20px;
   text-align: center;
 }

--- a/mon-pix/app/styles/globals/_loading.scss
+++ b/mon-pix/app/styles/globals/_loading.scss
@@ -12,7 +12,7 @@
 }
 
 .app-loader__text {
-  font-size: 26px;
+  font-size: 2.6rem;
   padding: 20px;
   text-align: center;
 }

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -188,7 +188,7 @@ body.centered-modal-showing {
 
 .centered-scrolling-container {
   position: relative;
-  min-height: 20em;
+  min-height: 12.5em;
   margin-top: 30px;
   margin-bottom: 30px;
   box-sizing: border-box;

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -33,7 +33,7 @@ $pix-modal-border-radius: 5px;
 
       &> span {
         color: inherit;
-        font-size: 1.4rem;
+        font-size: 0.875rem;
         margin-right: 5px;
 
         &:hover,
@@ -44,7 +44,7 @@ $pix-modal-border-radius: 5px;
       }
 
       &> svg {
-        font-size: 1.4rem;
+        font-size: 0.875rem;
       }
     }
 
@@ -52,7 +52,7 @@ $pix-modal-border-radius: 5px;
       border-radius: $pix-modal-border-radius;
       background-color: $porcelain-grey;
       box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.2);
-      font-size: 1.6rem;
+      font-size: 1rem;
       position: relative;
       margin: auto;
 
@@ -76,7 +76,7 @@ $pix-modal-border-radius: 5px;
           text-align: center;
           padding: 15px;
           font-family: $font-roboto;
-          font-size: 2.8rem;
+          font-size: 1.75rem;
 
           &--thin {
             font-weight: $font-light;
@@ -89,7 +89,7 @@ $pix-modal-border-radius: 5px;
           color: $nero;
           font-family: $font-roboto;
           font-weight: $font-normal;
-          font-size: 1.6rem;
+          font-size: 1rem;
         }
       }
 
@@ -136,7 +136,7 @@ $pix-modal-border-radius: 5px;
   background-color: $white;
   border: 2px solid $alto-grey;
   color: $slate-grey;
-  letter-spacing: 0.2rem;
+  letter-spacing: 0.125rem;
   box-sizing: border-box;
   margin-bottom: 5px;
   outline: none;

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -88,7 +88,7 @@ input[type=checkbox]:checked:after {
   position: relative;
   top: -21px;
 
-  font-size: 1.4rem;
+  font-size: 0.875rem;
   color: $white;
 
   font-weight: $font-bold;

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -88,7 +88,7 @@ input[type=checkbox]:checked:after {
   position: relative;
   top: -21px;
 
-  font-size: 14px;
+  font-size: 1.4rem;
   color: $white;
 
   font-weight: $font-bold;

--- a/mon-pix/app/styles/globals/_tables.scss
+++ b/mon-pix/app/styles/globals/_tables.scss
@@ -4,7 +4,7 @@
   border-spacing: 0;
   table-layout: fixed;
   box-sizing: border-box;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
 
   thead {
     display: none;

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -1,13 +1,13 @@
 .score-label {
-  font-size: 1rem;
-  letter-spacing: 0.25rem;
+  font-size: 0.625rem;
+  letter-spacing: 0.156rem;
   text-transform: uppercase;
   color: $nero;
 }
 
 .score-value {
-  font-size: 4.6rem;
-  line-height: 4.6rem;
+  font-size: 2.875rem;
+  line-height: 2.875rem;
   font-family: $font-open-sans;
   color: $black;
 }

--- a/mon-pix/app/styles/globals/_titles.scss
+++ b/mon-pix/app/styles/globals/_titles.scss
@@ -9,30 +9,30 @@ h6 {
 }
 
 h3 {
-  font-size: 2.6rem;
+  font-size: 1.625rem;
   color: $grey-90;
   font-family: $font-open-sans;
   font-weight: $font-light;
-  letter-spacing: 0.015rem;
-  line-height: 4.4rem;
+  letter-spacing: 0.009rem;
+  line-height: 2.75rem;
 
   @include device-is('tablet') {
-    font-size: 3.2rem;
-    line-height: 5.4rem;
+    font-size: 2rem;
+    line-height: 3.375rem;
   }
 }
 
 h4 {
-  font-size: 2.4rem;
+  font-size: 1.5rem;
   color: $grey-90;
   font-family: $font-open-sans;
   font-weight: $font-normal;
   letter-spacing: 0;
-  line-height: 3.6rem;
+  line-height: 2.25rem;
   margin-block-start: 0;
   margin-block-end: 0;
 
   @include device-is('tablet') {
-    line-height: 4.0rem;
+    line-height: 2.5rem;
   }
 }

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -82,7 +82,7 @@
 
 .assessment-results__link-back {
   text-transform: uppercase;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: $font-semi-bold;
   text-align: center;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -82,7 +82,7 @@
 
 .assessment-results__link-back {
   text-transform: uppercase;
-  font-size: 1.6rem;
+  font-size: 1rem;
   font-weight: $font-semi-bold;
   text-align: center;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -49,20 +49,20 @@
   }
 
   &__title {
-    font-size: 3rem;
+    font-size: 1.875rem;
     font-weight: $font-light;
 
     @include device-is('tablet') {
-      font-size: 4.8rem;
+      font-size: 3rem;
     }
   }
 
   &__announcement {
-    font-size: 1.8rem;
+    font-size: 1.125rem;
   }
 
   &__legal {
-    font-size: 1.2rem;
+    font-size: 0.75rem;
     color: $dove-gray;
   }
 }
@@ -72,7 +72,7 @@
   margin: auto;
   padding: 5px;
   font-family: $font-open-sans;
-  font-size: 1.6rem;
+  font-size: 1rem;
   text-align: left;
 
   strong {
@@ -80,15 +80,15 @@
   }
 
   h1 {
-    font-size: 3rem;
+    font-size: 1.875rem;
   }
 
   h2 {
-    font-size: 2.5rem;
+    font-size: 1.563rem;
   }
 
   h3 {
-    font-size: 2rem;
+    font-size: 1.25rem;
   }
 }
 
@@ -114,28 +114,28 @@
   font-family: $font-open-sans;
 
   .title {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
     font-weight: $font-light;
     text-align: center;
   }
 
   .article-title {
     color: $nero;
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     font-weight: $font-semi-bold;
     line-height: 30px;
   }
 
   .article-list {
     color: $nero;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     line-height: 22px;
   }
 
   .article-text {
     margin: auto;
     color: $nero;
-    font-size: 1.6rem;
+    font-size: 1rem;
     line-height: 24px;
   }
 
@@ -181,7 +181,7 @@
   padding-bottom: 50px;
 
   .title {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
     font-weight: $font-light;
     text-align: center;
   }

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -135,7 +135,7 @@
   .article-text {
     margin: auto;
     color: $nero;
-    font-size: 16px;
+    font-size: 1.6rem;
     line-height: 24px;
   }
 

--- a/mon-pix/app/styles/pages/_campaign-tutorial.scss
+++ b/mon-pix/app/styles/pages/_campaign-tutorial.scss
@@ -21,13 +21,13 @@
   &__title {
     color: $pix-blue;
     font-family: $font-open-sans;
-    font-size: 2em;
+    font-size: 1.25rem;
     font-weight: 600;
     line-height: 40px;
     text-align: center;
 
     @include device-is('tablet') {
-      font-size: 3em;
+      font-size: 1.875rem;
     }
   }
 

--- a/mon-pix/app/styles/pages/_campaign-tutorial.scss
+++ b/mon-pix/app/styles/pages/_campaign-tutorial.scss
@@ -40,12 +40,12 @@
   &__explanation-text {
     color: $nero;
     font-family: $font-open-sans;
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     text-align: center;
     white-space: pre-line;
 
     @include device-is('tablet') {
-      font-size: 2rem;
+      font-size: 1.25rem;
     }
   }
 

--- a/mon-pix/app/styles/pages/_certification-start.scss
+++ b/mon-pix/app/styles/pages/_certification-start.scss
@@ -8,7 +8,7 @@
 .certification-start-page__title {
   color: $nero;
   font-family: $font-open-sans;
-  font-size: 4.2rem;
+  font-size: 2.625rem;
   font-weight: $font-light;
   text-align: center;
   margin-bottom: 20px;

--- a/mon-pix/app/styles/pages/_competence-results.scss
+++ b/mon-pix/app/styles/pages/_competence-results.scss
@@ -70,7 +70,7 @@
   &__subtitle {
     color: $white;
     font-family: $font-open-sans;
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     margin-top: 14px;
     text-align: center;
 
@@ -134,13 +134,13 @@
   &__label {
     color: $white;
     font-family: $font-open-sans;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 
   &__value {
     color: $white;
     font-family: $font-open-sans;
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     padding: 0 10px;
   }
 }

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -39,6 +39,8 @@
 
   p {
     text-align: left;
+    font-size: 0.625rem;
+
     @include device-is('desktop') {
       text-align: center;
     }
@@ -46,6 +48,7 @@
 }
 
 .error-page-main-content__title {
+  font-size: 1.25rem;
   padding-bottom: 20px;
 }
 

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -12,7 +12,7 @@
   }
 
   &__error-title {
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     font-weight: 600;
   }
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -16,7 +16,7 @@
   &__instruction {
     color: $nero;
     font-family: $font-open-sans;
-    font-size: 1.95rem;
+    font-size: 1.219rem;
     text-align: center;
     font-weight: $font-light;
     margin-bottom: 16px;
@@ -42,7 +42,7 @@
         transparent 1.5ch) 0 96%/98% 2px no-repeat;
       background-origin: content-box;
       color: $tundora-grey;
-      font-size: 3rem;
+      font-size: 1.875rem;
       font-family: $font-roboto-mono;
       letter-spacing: .5ch;
 
@@ -83,7 +83,7 @@
 
   &__error {
     color: $pure-orange;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     padding: 16px 10px;
     text-align: center;
   }

--- a/mon-pix/app/styles/pages/_fill-in-id-pix.scss
+++ b/mon-pix/app/styles/pages/_fill-in-id-pix.scss
@@ -18,16 +18,16 @@
   font-family: $font-open-sans;
 
   &__title {
-    font-size: 3rem;
+    font-size: 1.875rem;
     font-weight: $font-bold;
 
     @include device-is('tablet') {
-      font-size: 3.2rem;
+      font-size: 2rem;
     }
   }
 
   &__announcement {
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     margin-bottom: 40px;
   }
 }
@@ -51,7 +51,7 @@
 .fill-in-id-pix__form label {
   display: block;
   font-weight: $font-bold;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   margin-bottom: 5px;
 }
 
@@ -77,6 +77,6 @@
 
 .fill-in-id-pix__form__error-message {
   margin-top: 5px;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   color: red;
 }

--- a/mon-pix/app/styles/pages/_fill-in-id-pix.scss
+++ b/mon-pix/app/styles/pages/_fill-in-id-pix.scss
@@ -77,6 +77,6 @@
 
 .fill-in-id-pix__form__error-message {
   margin-top: 5px;
-  font-size: 12px;
+  font-size: 1.2rem;
   color: red;
 }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -37,7 +37,7 @@
   &__title {
     color: $nero;
     font-family: $font-open-sans;
-    font-size: 4.2rem;
+    font-size: 2.625rem;
     font-weight: $font-light;
     text-align: center;
     margin-bottom: 12px;
@@ -46,7 +46,7 @@
   &__subtitle {
     color: $nero;
     font-family: $font-open-sans;
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     font-weight: $font-light;
     text-align: center;
     margin-bottom: 30px;
@@ -54,19 +54,19 @@
 
   &__label {
     font-family: $font-roboto;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     font-weight: $font-medium;
   }
 
   &__field-error {
     color: $pure-orange;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 
   &__error {
     text-align: center;
     color: $pure-orange;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     padding: 4px 10px;
 
     @include device-is('tablet') {

--- a/mon-pix/app/styles/pages/_not-connected.scss
+++ b/mon-pix/app/styles/pages/_not-connected.scss
@@ -22,7 +22,7 @@
     padding-top: 30px;
     text-align: center;
     line-height: 46px;
-    font-size: 3rem;
+    font-size: 1.875rem;
     font-weight: $font-light;
     color: $grayish-grey;
   }

--- a/mon-pix/app/styles/pages/_profile.scss
+++ b/mon-pix/app/styles/pages/_profile.scss
@@ -15,6 +15,6 @@
   font-weight: $font-light;
   font-family: $font-roboto;
   color: $black;
-  font-size: 1.8rem;
-  line-height: 2.1rem;
+  font-size: 1.125rem;
+  line-height: 1.313rem;
 }

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -10,16 +10,16 @@
   &__title {
     color: $grey-90;
     font-family: $font-open-sans;
-    font-size: 3.2rem;
+    font-size: 2rem;
     text-align: center;
     font-weight: $font-light;
   }
 
   &__instruction {
     color: $grey-90;
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-family: $font-open-sans;
-    line-height: 4rem;
+    line-height: 2.5rem;
     text-align: center;
     margin: 30px;
     font-weight: $font-light;
@@ -54,13 +54,13 @@
   &__recipient {
     color: $grey-90;
     font-family: $font-open-sans;
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: $font-medium;
   }
 
   &__warning {
     color: $grey-90;
-    font-size: 1.2rem;
+    font-size: 0.75rem;
     letter-spacing: 0.36px;
     padding-top: 10px;
   }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -62,7 +62,7 @@
     text-align: center;
     border-radius: 3px;
     color: $white;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     padding: 9px;
     margin: 10px 0;
 
@@ -89,7 +89,7 @@
     flex-direction: column;
     text-align: center;
     font-family: $font-open-sans;
-    font-size: 1.6rem;
+    font-size: 1rem;
 
     @include device-is('tablet') {
       flex-direction: row;
@@ -118,7 +118,7 @@
 
   &__instruction {
     margin: 10px 0;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 
   &__input {
@@ -168,29 +168,29 @@
   font-family: $font-open-sans;
   color: $charcoal-grey;
   margin: 0;
-  font-size: 2.5rem;
+  font-size: 1.563rem;
   font-weight: $font-light;
 
   @include device-is('desktop') {
-    font-size: 3.6rem;
+    font-size: 2.25rem;
   }
 }
 
 .sign-form-subtitle {
   font-family: $font-open-sans;
   color: $charcoal-grey;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-weight: $font-light;
   line-height: 28px;
   text-align: center;
 
   @include device-is('tablet') {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
   }
 }
 
 .sign-form-instruction {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-weight: $font-light;
   color: $charcoal-grey;
 }
@@ -198,13 +198,13 @@
 .sign-form-text {
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 1.0rem;
+  font-size: 0.625rem;
 
   @include device-is('tablet') {
-    font-size: 1.5rem;
+    font-size: 0.938rem;
   }
 }
 
 .sign-form-link {
-  font-size: 1.5rem;
+  font-size: 0.938rem;
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -53,7 +53,7 @@
   &__info-icon {
     float: left;
     color: $dove-gray;
-    font-size: 1.5em;
+    font-size: 0.938em;
   }
 
   &__text {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -211,7 +211,7 @@
 }
 
 .skill-review__campaign-archived-text {
-  font-size: 22px;
+  font-size: 2.2rem;
   line-height: 30px;
   max-width: 640px;
   margin: 30px auto 60px;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -38,7 +38,7 @@
   }
 
   &__explain-text {
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     color: $dove-gray;
     line-height: 33px;
     font-weight: $font-light;
@@ -61,13 +61,13 @@
     margin-top: 14px;
     color: $dove-gray;
     font-family: $font-open-sans;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 }
 
 .skill-review-competence {
   &__bullet {
-    font-size: 1.8rem;
+    font-size: 1.125rem;
     margin-right: 12px;
 
     &--jaffa {
@@ -96,7 +96,7 @@
   &__circle-chart-value {
     color: $nero;
     font-family: $font-roboto;
-    font-size: 3.1rem;
+    font-size: 1.938rem;
   }
 }
 
@@ -115,8 +115,8 @@
     &-information {
       font-family: $font-roboto;
       font-weight: $font-light;
-      font-size: 2rem;
-      line-height: 3.2rem;
+      font-size: 1.25rem;
+      line-height: 2rem;
       margin: 32px 0;
     }
   }
@@ -171,14 +171,14 @@
 .skill-review-share {
   &__button {
     text-transform: uppercase;
-    letter-spacing: 0.05rem;
+    letter-spacing: 0.031rem;
   }
 
   &__legal {
     text-align: center;
-    font-size: 2rem;
+    font-size: 1.25rem;
     color: $dove-gray;
-    line-height: 3.2rem;
+    line-height: 2rem;
     font-weight: $font-light;
     margin: 0 20px 16px 20px;
   }
@@ -186,18 +186,18 @@
   &__thanks {
     font-family: $font-open-sans;
     font-weight: $font-light;
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     padding-top: 20px;
   }
 
   &__error {
     color: $pure-orange;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     padding-bottom: 10px;
   }
 
   &__back-to-home {
-    font-size: 1.6rem;
+    font-size: 1rem;
     font-weight: $font-bold;
     font-family: $font-open-sans;
     text-align: center;
@@ -211,7 +211,7 @@
 }
 
 .skill-review__campaign-archived-text {
-  font-size: 2.2rem;
+  font-size: 1.375rem;
   line-height: 30px;
   max-width: 640px;
   margin: 30px auto 60px;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -29,20 +29,20 @@
     text-align: center;
     color: $grey-80;
     font-family: $font-roboto;
-    font-size: 1.5rem;
+    font-size: 0.938rem;
     font-weight: normal;
 
   }
 
   &__title {
     font-weight: 300;
-    font-size: 2.5rem;
+    font-size: 1.56rem;
   }
 
   &__conditions {
     font-weight: normal;
-    font-size: 1.4rem;
-    letter-spacing: 0.015rem;
+    font-size: 0.875rem;
+    letter-spacing: 0.009rem;
     text-align: center;
 
   }

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -61,7 +61,7 @@
     text-align: center;
     border-radius: 3px;
     color: $white;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
     padding: 9px;
     margin: 10px 0;
 
@@ -88,7 +88,7 @@
     flex-direction: column;
     text-align: center;
     font-family: $font-open-sans;
-    font-size: 1.6rem;
+    font-size: 1rem;
 
     @include device-is('tablet') {
       flex-direction: row;
@@ -113,7 +113,7 @@
 
   &__instruction {
     margin: 10px 0;
-    font-size: 1.4rem;
+    font-size: 0.875rem;
   }
 
   &__input {
@@ -164,33 +164,33 @@
   font-family: $font-open-sans;
   color: $charcoal-grey;
   margin: 0;
-  font-size: 2.5rem;
+  font-size: 1.563rem;
   font-weight: $font-light;
 
   @include device-is('desktop') {
-    font-size: 3.6rem;
+    font-size: 2.25rem;
   }
 }
 
 .update-expired-password-form-subtitle {
   font-family: $font-roboto;
   color: $charcoal-grey;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
   font-weight: $font-light;
   line-height: 28px;
   text-align: center;
 
   @include device-is('tablet') {
-    font-size: 2.2rem;
+    font-size: 1.375rem;
   }
 }
 
 .update-expired-password-form-text {
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 1.0rem;
+  font-size: 0.625rem;
 
   @include device-is('tablet') {
-    font-size: 1.5rem;
+    font-size: 0.938rem;
   }
 }

--- a/mon-pix/app/styles/pages/_user-certifications.scss
+++ b/mon-pix/app/styles/pages/_user-certifications.scss
@@ -16,7 +16,7 @@
 
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 28px;
+  font-size: 2.8rem;
   font-weight: $font-medium;
   line-height: 33px;
 

--- a/mon-pix/app/styles/pages/_user-certifications.scss
+++ b/mon-pix/app/styles/pages/_user-certifications.scss
@@ -16,7 +16,7 @@
 
   color: $charcoal-grey;
   font-family: $font-open-sans;
-  font-size: 2.8rem;
+  font-size: 1.75rem;
   font-weight: $font-medium;
   line-height: 33px;
 

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -38,9 +38,9 @@
   }
 
   &__description {
-    font-size: 1.6rem;
+    font-size: 1rem;
     margin: auto;
-    line-height: 2.7rem;
+    line-height: 1.688rem;
     letter-spacing: 0.15px;
     max-width: 440px;
 
@@ -114,17 +114,17 @@
     font-family: $font-open-sans;
     font-weight: $font-normal;
     letter-spacing: 0;
-    line-height: 4rem;
+    line-height: 2.5rem;
 
     @include device-is('tablet') {
-      line-height: 5.4rem;
+      line-height: 3.375rem;
     }
   }
 
   &-instructions__description {
     margin: 0;
-    font-size: 1.6rem;
-    line-height: 2.7rem;
-    letter-spacing: 0.015rem;
+    font-size: 1rem;
+    line-height: 1.688rem;
+    letter-spacing: 0.009rem;
   }
 }

--- a/mon-pix/app/styles/vendor/ember-routable-modal/dialog.scss
+++ b/mon-pix/app/styles/vendor/ember-routable-modal/dialog.scss
@@ -15,15 +15,15 @@
 .routable-modal--title {
   margin-top: 0;
   margin-bottom: 0;
-  font-size: 1.5rem;
+  font-size: 0.938rem;
 }
 
 button.routable-modal--close {
   background: transparent;
   padding: 0;
   margin: 0;
-  font-size: 2rem;
-  line-height: 1.5rem;
+  font-size: 1.25rem;
+  line-height: 0.938rem;
   border: 0;
   color: $boulder-grey;
   cursor: pointer;

--- a/scripts/clean-up/convert-fontsize-px-to-rem.js
+++ b/scripts/clean-up/convert-fontsize-px-to-rem.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const fs = require('fs');
+
+const DIRECTORY_PATH = process.argv[2];
+
+const readDirRecursive = function(workingDirectoryPath) {
+  fs.readdir(workingDirectoryPath, function(err, files) {
+    if (err) {
+      return console.log('Unable to scan directory: ' + err);
+    }
+
+    files.forEach(function(file) {
+      const fileExt = path.extname(file);
+      if (fileExt && fileExt.includes('scss')) {
+        _editFile(`${workingDirectoryPath}/${file}`);
+      } else {
+        readDirRecursive(`${workingDirectoryPath}/${file}`);
+      }
+    });
+  });
+};
+
+function _editFile(scssFile) {
+  const content = fs.readFileSync(scssFile).toString();
+  const fontSizeInRem = _convertFontSizePxtoRem(content);
+  const fontSizeInRem16pxBase = _convertRemTo16PxBase(fontSizeInRem);
+
+  fs.writeFileSync(scssFile, fontSizeInRem16pxBase);
+}
+
+function _convertFontSizePxtoRem(string) {
+  function convert(chn, valueInPx) {
+    return `font-size: ${(valueInPx / 10)}rem;`;
+  }
+
+  const fontsizePx = /font-size: (\d+)px;/g;
+  return string.replace(fontsizePx, convert);
+}
+
+function _convertRemTo16PxBase(string) {
+  function convert(chn, oldRem) {
+    const valueInNewRem = Math.round(oldRem * 0.625 * 1000) / 1000;
+    return `${valueInNewRem}rem;`;
+  }
+
+  const remValues = /([.\d]+)rem;/g;
+  return string.replace(remValues, convert);
+}
+
+readDirRecursive(DIRECTORY_PATH);


### PR DESCRIPTION
## :unicorn: Problème
Il restait de nombreuses `font-size` exprimées en px sur Pix App. 
Par ailleurs, le rem sur Pix App valait 10px vs 16px sur les autres front (vestige de l'époque où bootstrap était sur le projet).

## :robot: Solution
Convertir tous les px en rem.
Convertir tous les rem dans la nouvelle échelle `1 rem = 16px` pour rester cohérent avec le reste du projet. 

## :rainbow: Remarques
Contrairement à la PR qui visait à supprimer Bootstrap, les règles CSS visées ici sont plus restreintes (font-size, line-height pour la plupart), il ne devrait pas y avoir (trop) de régressions visuelles. 🙈
