### PR TITLE
[FEATURE] Changement du wording de la page de saisi de code (PF-1227).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -8,8 +8,8 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "NERA" dans le champ "Saisissez le code du parcours"
-    Lorsque je clique sur "Commencer mon parcours"
+    Et je saisis "NERA" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne evaluation" est correctement affichée
     Lorsque je clique sur "Je commence"
@@ -39,8 +39,8 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WINTER" dans le champ "Saisissez le code du parcours"
-    Et je clique sur "Commencer mon parcours"
+    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
+    Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis "Daenerys" dans le champ "Prénom"
     Et je saisis "Targaryen" dans le champ "Nom"
@@ -53,8 +53,8 @@ Fonctionnalité: Campagne d'évaluation
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je vais sur Pix via un organisme externe
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WINTER" dans le champ "Saisissez le code du parcours"
-    Et je clique sur "Commencer mon parcours"
+    Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
+    Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -8,8 +8,8 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "LION" dans le champ "Saisissez le code du parcours"
-    Lorsque je clique sur "Commencer mon parcours"
+    Et je saisis "LION" dans le champ "Ce code permet de démarrer un parcours"
+    Lorsque je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne collecte profils" est correctement affichée
     Lorsque je clique sur "C’est parti !"
@@ -32,8 +32,8 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WOLF" dans le champ "Saisissez le code du parcours"
-    Et je clique sur "Commencer mon parcours"
+    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
+    Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis "Daenerys" dans le champ "Prénom"
     Et je saisis "Targaryen" dans le champ "Nom"
@@ -48,8 +48,8 @@ Fonctionnalité: Campagne de collecte de profils
   Scénario: Je partage mon profil de manière restreinte en étant connecté via un organisme externe
     Étant donné que je vais sur Pix via un organisme externe
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WOLF" dans le champ "Saisissez le code du parcours"
-    Et je clique sur "Commencer mon parcours"
+    Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
+    Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -7,10 +7,10 @@
 
       <div class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
         <h3 class="fill-in-campaign-code__title rounded-panel-title">
-          Vous souhaitez participer<br>à un parcours de test
+          Saisissez votre code
         </h3>
 
-        <label for="campaign-code" class="fill-in-campaign-code__instruction">Saisissez le code du parcours</label>
+        <label for="campaign-code" class="fill-in-campaign-code__instruction">Ce code permet de démarrer un parcours<br>ou d’envoyer votre profil à une organisation</label>
         <form class="fill-in-campaign-code__form" autocomplete="off">
 
           <div class="fill-in-campaign-code__form-field">
@@ -26,7 +26,7 @@
           <div class="fill-in-campaign-code__actions">
             <button type="submit" class="button button--extra-big fill-in-campaign-code__start-button" {{action
               'startCampaign'}}>
-              Commencer mon parcours
+              Commencer
             </button>
           </div>
         </form>

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -47,7 +47,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await visit('/campagnes');
 
           // then
-          expect(find('.button').textContent).to.contains('Commencer mon parcours');
+          expect(find('.button').textContent).to.contains('Commencer');
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Les codes campagnes correspondent à la fois à des campagnes d'évaluation et de collecte de profiles, mais le wording de la page de saisi n'a pas été changé et n'est donc plus cohérent.

## :robot: Solution
Changer le wording de la page de saisi de code pour que le message puisse convenir autant pour une campagne de type parcours de test ou a des campagnes de collectes de profil.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur pix app.
Cliquer sur "Parcours"
Vérifier que le texte de la page a été changé et est valide pour les campagnes d'évaluation et de collecte de profiles.