### PR TITLE
[FEATURE] Renommer et déplacer l'entrée vers la page de saisie de code depuis le menu de PIX App (PF-1226).

### DIFF
--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -13,6 +13,12 @@
   }
 }
 
+.navbar-burger-menu-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .navbar-burger-menu-user-info {
   &__item {
     margin: 5px 0;
@@ -60,6 +66,8 @@
 }
 
 .navbar-burger-menu-navigation {
+  margin-bottom: auto;
+
   &__item {
     margin: 5px 0;
     padding: 10px 32px;
@@ -82,5 +90,12 @@
       color: $dodger-blue;
       text-decoration: none;
     }
+  }
+
+  &__bottom-item {
+    margin-top: auto;
+    margin-bottom: 21px;
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -27,10 +27,6 @@
       Profil
     </LinkTo>
 
-    <LinkTo @route="campaigns" class="navbar-burger-menu-navigation__item">
-      Parcours
-    </LinkTo>
-
     <LinkTo @route="certifications" class="navbar-burger-menu-navigation__item">
       Certification
     </LinkTo>
@@ -38,5 +34,11 @@
     <a href="https://pix.fr/aide" target="_blank" class="navbar-burger-menu-navigation__item">
       Aide
     </a>
+
+  </div>
+  <div class="navbar-burger-menu-navigation__item  navbar-burger-menu-navigation__bottom-item">
+   <LinkTo @route="campaigns" class="button button--thin">
+     J'ai un code
+    </LinkTo>
   </div>
 {{/unless}}

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -15,9 +15,6 @@
         <LinkTo @route="profile" class="navbar-desktop-header-menu__item">
           Profil
         </LinkTo>
-        <LinkTo @route="campaigns" class="navbar-desktop-header-menu__item">
-          Parcours
-        </LinkTo>
         <LinkTo @route="certifications" class="navbar-desktop-header-menu__item">
           Certification
         </LinkTo>
@@ -27,6 +24,10 @@
       </div>
     {{/if}}
   {{/unless}}
+
+  <LinkTo @route="campaigns" class="button button--extra-thin button--link">
+    J'ai un code
+  </LinkTo>
 
   <!-- Links (right) -->
   <div class="navbar-desktop-header-right">

--- a/mon-pix/app/templates/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/templates/components/navbar-mobile-header.hbs
@@ -10,7 +10,7 @@
       </span>
 
       {{#burger.menu as |menu|}}
-        <NavbarBurgerMenu />
+        <NavbarBurgerMenu class="navbar-burger-menu-content"/>
       {{/burger.menu}}
     {{/if}}
   {{/if}}

--- a/mon-pix/tests/acceptance/navigation-test.js
+++ b/mon-pix/tests/acceptance/navigation-test.js
@@ -23,16 +23,12 @@ describe('Acceptance | Navbar', function() {
 
     [
       {
-        initialRoute: '/certifications', initialNavigationItem: '.navbar-desktop-header-menu__item:nth-child(3)',
+        initialRoute: '/certifications', initialNavigationItem: '.navbar-desktop-header-menu__item:nth-child(2)',
         expectedRoute: '/profil', targetedNavigationItem: '.navbar-desktop-header-menu__item:nth-child(1)',
       },
       {
         initialRoute: '/profil', initialNavigationItem: '.navbar-desktop-header-menu__item:nth-child(1)',
-        expectedRoute: '/campagnes', targetedNavigationItem: '.navbar-desktop-header-menu__item:nth-child(2)'
-      },
-      {
-        initialRoute: '/campagnes', initialNavigationItem: '.navbar-desktop-header-menu__item:nth-child(2)',
-        expectedRoute: '/certifications', targetedNavigationItem: '.navbar-desktop-header-menu__item:nth-child(3)'
+        expectedRoute: '/certifications', targetedNavigationItem: '.navbar-desktop-header-menu__item:nth-child(2)'
       },
     ].forEach((usecase) => {
       it(`should redirect from "${usecase.initialRoute}" to "${usecase.expectedRoute}"`, async function() {
@@ -66,7 +62,7 @@ describe('Acceptance | Navbar', function() {
       await visit('/profil');
 
       // then
-      expect(find('.navbar-desktop-header-menu__item:nth-child(4)').getAttribute('href')).to.equal('https://pix.fr/aide');
+      expect(find('.navbar-desktop-header-menu__item:nth-child(3)').getAttribute('href')).to.equal('https://pix.fr/aide');
     });
   });
 });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -47,7 +47,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await visit('/campagnes');
 
           // then
-          expect(find('.button').textContent).to.contains('Commencer');
+          expect(find('.fill-in-campaign-code__start-button').textContent).to.contains('Commencer');
         });
       });
 
@@ -64,7 +64,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await click('.button');
+              await click('.fill-in-campaign-code__start-button');
 
               // then
               expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
@@ -85,7 +85,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
                 // when
                 await fillIn('#campaign-code', campaign.code);
-                await click('.button');
+                await click('.fill-in-campaign-code__start-button');
                 await click('#login-button');
                 await fillIn('#login', prescritUser.email);
                 await fillIn('#password', prescritUser.password);
@@ -240,7 +240,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
             // when
             await fillIn('#campaign-code', campaignCode);
-            await click('.button');
+            await click('.fill-in-campaign-code__start-button');
 
             // then
             expect(currentURL()).to.equal('/campagnes');
@@ -256,7 +256,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await visit('/campagnes');
 
             // when
-            await click('.button');
+            await click('.fill-in-campaign-code__start-button');
 
             // then
             expect(currentURL()).to.equal('/campagnes');
@@ -471,7 +471,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
             //when
             await fillIn('#campaign-code', campaign.code);
-            await click('.button');
+            await click('.fill-in-campaign-code__start-button');
 
             //then
             expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/rejoindre`.toLowerCase());

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-collect-profiles-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-collect-profiles-test.js
@@ -52,7 +52,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Collect Profiles',
 
               // when
               await fillIn('#campaign-code', campaign.code);
-              await click('.button');
+              await click('.fill-in-campaign-code__start-button');
 
               // then
               expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code.toLowerCase()}/presentation`);
@@ -73,7 +73,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Collect Profiles',
 
                 // when
                 await fillIn('#campaign-code', campaign.code);
-                await click('.button');
+                await click('.fill-in-campaign-code__start-button');
                 await click('#login-button');
                 await fillIn('#login', campaignParticipant.email);
                 await fillIn('#password', campaignParticipant.password);
@@ -360,7 +360,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Collect Profiles',
 
             //when
             await fillIn('#campaign-code', campaign.code);
-            await click('.button');
+            await click('.fill-in-campaign-code__start-button');
 
             //then
             expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code.toLowerCase()}/rejoindre`);

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -40,8 +40,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
 
     expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(4);
     expect(findAll('.navbar-burger-menu-navigation__item')[0].textContent.trim()).to.equal('Profil');
-    expect(findAll('.navbar-burger-menu-navigation__item')[1].textContent.trim()).to.equal('Parcours');
-    expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Certification');
-    expect(findAll('.navbar-burger-menu-navigation__item')[3].textContent.trim()).to.equal('Aide');
+    expect(findAll('.navbar-burger-menu-navigation__item')[1].textContent.trim()).to.equal('Certification');
+    expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Aide');
   });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -89,11 +89,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
     it('should display the navigation menu with expected elements', function() {
       // then
       expect(find('.navbar-desktop-header-container__menu')).to.exist;
-      expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(4);
+      expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(3);
       expect(findAll('.navbar-desktop-header-menu__item')[0].textContent.trim()).to.equal('Profil');
-      expect(findAll('.navbar-desktop-header-menu__item')[1].textContent.trim()).to.equal('Parcours');
-      expect(findAll('.navbar-desktop-header-menu__item')[2].textContent.trim()).to.equal('Certification');
-      expect(findAll('.navbar-desktop-header-menu__item')[3].textContent.trim()).to.equal('Aide');
+      expect(findAll('.navbar-desktop-header-menu__item')[1].textContent.trim()).to.equal('Certification');
+      expect(findAll('.navbar-desktop-header-menu__item')[2].textContent.trim()).to.equal('Aide');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Il y a des codes qui permettent de faire des collectes de profils mais le wording propose de participer à un parcours.

## :robot: Solution
Changer le wording de l'item.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à PIX app et voir que le menu à changé ( mobile et web).
