### PR TITLE
[TECH] Eviter les erreurs de contraintes d'unicité. 

### DIFF
--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -66,6 +66,35 @@ exports.register = async function(server) {
         ],
         tags: ['api', 'user-orga-settings']
       }
+    },
+    {
+      method: 'PUT',
+      path: '/api/user-orga-settings/{id}',
+      config: {
+        handler: userOrgaSettingsController.createOrUpdate,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              relationships: {
+                organization: {
+                  data: {
+                    id: Joi.number().required(),
+                  }
+                }
+              }
+            }
+          })
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Création ou Mise à jour des paramètres utilisateurs liés à Pix Orga\n' +
+          '- L’id en paramètre doit correspondre à celui de l’utilisateur authentifié',
+        ],
+        tags: ['api', 'user-orga-settings']
+      }
     }
   ]);
 };

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -30,6 +30,7 @@ exports.register = async function(server) {
           })
         },
         notes: [
+          '- **Cette route est dépréciée**\n' +
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Création des paramètres utilisateurs liés à Pix Orga\n' +
           '- L’id dans le payload doit correspondre à celui de l’utilisateur authentifié',
@@ -60,6 +61,7 @@ exports.register = async function(server) {
           })
         },
         notes: [
+          '- **Cette route est dépréciée**\n' +
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Mise à jour des paramètres utilisateurs liés à Pix Orga\n' +
           '- L’id dans le payload doit correspondre à celui de l’utilisateur authentifié',

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -25,5 +25,19 @@ module.exports = {
     const result = await usecases.updateUserOrgaSettings({ userId: authenticatedUserId, organizationId });
 
     return userOrgaSettingsSerializer.serialize(result);
+  },
+
+  async createOrUpdate(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+    const userId = parseInt(request.params.id);
+    const organizationId = request.payload.data.relationships.organization.data.id;
+
+    if (userId !== authenticatedUserId) {
+      throw new UserNotAuthorizedToCreateResourceError();
+    }
+
+    const result = await usecases.createOrUpdateUserOrgaSettings({ userId, organizationId });
+
+    return userOrgaSettingsSerializer.serialize(result);
   }
 };

--- a/api/lib/domain/usecases/create-or-update-user-orga-settings.js
+++ b/api/lib/domain/usecases/create-or-update-user-orga-settings.js
@@ -1,0 +1,23 @@
+const { UserNotMemberOfOrganizationError } = require('../errors');
+const _ = require('lodash');
+
+module.exports = async function createOrUpdateUserOrgaSettings({
+  userId,
+  organizationId,
+  userOrgaSettingsRepository,
+  membershipRepository
+}) {
+  const memberships = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId });
+
+  if (_.isEmpty(memberships)) {
+    throw new UserNotMemberOfOrganizationError(`L'utilisateur ${userId} n'est pas membre de l'organisation ${organizationId}.`);
+  }
+
+  const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userId);
+
+  if (_.isEmpty(userOrgaSettings)) {
+    return userOrgaSettingsRepository.create(userId, organizationId);
+  }
+
+  return userOrgaSettingsRepository.update(userId, organizationId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -86,6 +86,7 @@ module.exports = injectDependencies({
   createMembership: require('./create-membership'),
   createOrganization: require('./create-organization'),
   createOrganizationInvitations: require('./create-organization-invitations'),
+  createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
   createSession: require('./create-session'),
   createUser: require('./create-user'),
   createUserOrgaSettings: require('./create-user-orga-settings'),

--- a/api/lib/infrastructure/repositories/user-orga-settings-repository.js
+++ b/api/lib/infrastructure/repositories/user-orga-settings-repository.js
@@ -5,6 +5,19 @@ const { UserOrgaSettingsCreationError } = require('../../domain/errors');
 
 module.exports = {
 
+  findOneByUserId(userId) {
+    return BookshelfUserOrgaSettings
+      .where({ userId })
+      .fetch({ require: true, withRelated: ['user', 'currentOrganization'] })
+      .then((userOrgaSettings) => bookshelfToDomainConverter.buildDomainObject(BookshelfUserOrgaSettings, userOrgaSettings))
+      .catch((err) => {
+        if (err instanceof BookshelfUserOrgaSettings.NotFoundError) {
+          return {};
+        }
+        throw err;
+      });
+  },
+
   create(userId, currentOrganizationId) {
     return new BookshelfUserOrgaSettings({ userId, currentOrganizationId })
       .save()

--- a/api/tests/acceptance/application/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings-controller_test.js
@@ -188,4 +188,77 @@ describe('Acceptance | Controller | user-orga-settings-controller', () => {
       });
     });
   });
+
+  describe('PUT /api/user-orga-settings/{id}', () => {
+
+    let expectedOrganizationId;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      const actualOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      expectedOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId: actualOrganizationId, organizationRole: 'MEMBER' });
+      databaseBuilder.factory.buildMembership({ userId, organizationId: expectedOrganizationId, organizationRole: 'MEMBER' });
+      databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: actualOrganizationId });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'PUT',
+        url: `/api/user-orga-settings/${userId}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: expectedOrganizationId,
+                  type: 'organizations'
+                }
+              }
+            }
+          }
+        }
+      };
+    });
+
+    describe('When user is not authenticated', () => {
+
+      it('should respond with a 401 - unauthorized access', async () => {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+    });
+
+    describe('When user is authenticated', () => {
+
+      it('should update and return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('When user is not member of organization', () => {
+
+      it('should respond with a 422 HTTP status code', async () => {
+        // given
+        options.payload.data.relationships.organization.data.id = 12345;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -92,4 +92,40 @@ describe('Integration | Repository | UserOrgaSettings', function() {
       expect(_.omit(updatedUserOrgaSettings.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(expectedOrganization, ORGANIZATION_OMITTED_PROPERTIES));
     });
   });
+
+  describe('#findOneByUserId', () => {
+
+    let userOrgaSettingsId;
+
+    beforeEach(async () => {
+      userOrgaSettingsId = databaseBuilder.factory.buildUserOrgaSettings({ userId: user.id, currentOrganizationId: organization.id }).id;
+      await databaseBuilder.commit();
+    });
+
+    it('should return an UserOrgaSettings domain object', async () => {
+      // when
+      const foundUserOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(user.id);
+
+      // then
+      expect(foundUserOrgaSettings).to.be.an.instanceof(UserOrgaSettings);
+    });
+
+    it('should return the userOrgaSettings belonging to user', async () => {
+      // when
+      const foundUserOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(user.id);
+
+      // then
+      expect(foundUserOrgaSettings.id).to.deep.equal(userOrgaSettingsId);
+      expect(_.omit(foundUserOrgaSettings.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.omit(foundUserOrgaSettings.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(organization, ORGANIZATION_OMITTED_PROPERTIES));
+    });
+
+    it('should return empty object when user-orga-settings doesn\'t exists', async () => {
+      // when
+      const foundUserOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(user.id + 1);
+
+      // then
+      expect(foundUserOrgaSettings).to.deep.equal({});
+    });
+  });
 });

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -10,6 +10,7 @@ describe('Unit | Router | user-orga-settings-router', () => {
   beforeEach(() => {
     sinon.stub(userOrgaSettingsController, 'create').returns('ok');
     sinon.stub(userOrgaSettingsController, 'update').returns('ok');
+    sinon.stub(userOrgaSettingsController, 'createOrUpdate').returns('ok');
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -114,6 +115,77 @@ describe('Unit | Router | user-orga-settings-router', () => {
     it('should exist', async () => {
       // when
       const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    describe('Payload schema validation', () => {
+
+      it('should be mandatory', async () => {
+        // given
+        payload = undefined;
+
+        // when
+        const result = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should contain relationships.organization.data.id', async () => {
+        // given
+        payload.data.relationships.organization.data.id = undefined;
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should contain relationships.organization.data.id as number', async () => {
+        // given
+        payload.data.relationships.organization.data = { id: 'test' };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+    });
+
+  });
+
+  describe('PUT /api/user-orga-settings/{id}', () => {
+    const userId = 2;
+    const auth = { credentials: { userId: userId }, strategy: {} };
+    let method;
+    let url;
+    let payload;
+
+    beforeEach(() => {
+      method = 'PUT';
+      url = `/api/user-orga-settings/${userId}`;
+      payload = {
+        data: {
+          relationships: {
+            organization: {
+              data: {
+                id: 1,
+                type: 'organizations'
+              }
+            }
+          }
+        }
+      };
+    });
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request(method, url, payload, auth);
 
       // then
       expect(response.statusCode).to.equal(200);

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -164,4 +164,79 @@ describe('Unit | Controller | user-orga-settings-controller', () => {
       expect(response).to.deep.equal(serializedUseOrgaSettings);
     });
   });
+
+  describe('#createOrUpdate', () => {
+
+    const userId = 7;
+    const organizationId = 2;
+    const request = {
+      auth: { credentials: { userId } },
+      params: {
+        id: userId
+      },
+      payload: {
+        data: {
+          relationships: {
+            organization: {
+              data: {
+                id: organizationId,
+                type: 'organizations'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const serializedUseOrgaSettings = {
+      data: {
+        type: 'user-orga-settings',
+        id: 1,
+        attributes: {},
+        relationships: {
+          organization: {
+            data: {
+              type: 'organizations',
+              id: organizationId,
+            },
+          },
+          user: {
+            data: {
+              type: 'users',
+              id: userId,
+            },
+          },
+        },
+      },
+    };
+
+    let expectedUserOrgaSettings;
+    let response;
+
+    beforeEach(async () => {
+      sinon.stub(usecases, 'createOrUpdateUserOrgaSettings');
+      sinon.stub(userOrgaSettingsSerializer, 'serialize');
+
+      expectedUserOrgaSettings = { id: 1, user: { id: userId }, organization: { id: organizationId } };
+      usecases.createOrUpdateUserOrgaSettings.resolves(expectedUserOrgaSettings);
+      userOrgaSettingsSerializer.serialize.resolves(serializedUseOrgaSettings);
+
+      response = await userOrgaSettingsController.createOrUpdate(request);
+    });
+
+    it('should call the usecase to update the userOrgaSetting', async () => {
+      // then
+      expect(usecases.createOrUpdateUserOrgaSettings).to.have.been.calledWith({ userId, organizationId });
+    });
+
+    it('should serialize the userOrgaSettings', () => {
+      // then
+      expect(userOrgaSettingsSerializer.serialize).to.have.been.calledWith(expectedUserOrgaSettings);
+    });
+
+    it('should return the serialized userOrgaSettings', () => {
+      // then
+      expect(response).to.deep.equal(serializedUseOrgaSettings);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-user-orga-settings_test.js
@@ -1,0 +1,54 @@
+const createOrUpdateUserOrgaSettings = require('../../../../lib/domain/usecases/create-or-update-user-orga-settings');
+const { expect, catchErr, sinon } = require('../../../test-helper');
+const { UserNotMemberOfOrganizationError } = require('../../../../lib/domain/errors');
+const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+
+describe('Unit | UseCase | create-or-update-user-orga-settings', () => {
+
+  const userId = 1;
+  const organizationId = 3;
+
+  beforeEach(() => {
+    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+    userOrgaSettingsRepository.findOneByUserId = sinon.stub();
+    sinon.stub(userOrgaSettingsRepository, 'update');
+    sinon.stub(userOrgaSettingsRepository, 'create');
+  });
+
+  it('should create the user orga settings if it doesn\'t exist', async () => {
+    // given
+    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
+
+    // when
+    userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves([]);
+    await createOrUpdateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+
+    // then
+    expect(userOrgaSettingsRepository.create).to.have.been.calledWithExactly(userId, organizationId);
+  });
+
+  it('should update the user orga settings if it already exists', async () => {
+    // given
+    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([{}]);
+
+    // when
+    userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves([{ id: 22, userId: userId, organizationId: organizationId }]);
+    await createOrUpdateUserOrgaSettings({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+
+    // then
+    expect(userOrgaSettingsRepository.update).to.have.been.calledWithExactly(userId, organizationId);
+  });
+
+  it('should throw a UserNotMemberOfOrganizationError if user is not member of the organization', async () => {
+    // given
+    membershipRepository.findByUserIdAndOrganizationId.withArgs({ userId, organizationId }).resolves([]);
+
+    // when
+    const error = await catchErr(createOrUpdateUserOrgaSettings)({ userId, organizationId, userOrgaSettingsRepository, membershipRepository });
+
+    // then
+    expect(error).to.be.an.instanceof(UserNotMemberOfOrganizationError);
+    expect(error.message).to.equal(`L'utilisateur ${userId} n'est pas membre de l'organisation ${organizationId}.`);
+  });
+});

--- a/orga/app/adapters/user-orga-setting.js
+++ b/orga/app/adapters/user-orga-setting.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from './application';
+
+export default class UserOrgaSetting extends ApplicationAdapter {
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    const { userId } = adapterOptions;
+    return `${this.host}/${this.namespace}/user-orga-settings/${userId}`;
+  }
+
+  updateRecord(store, type, snapshot) {
+    const data = this.serialize(snapshot);
+    const url = this.buildURL(type.modelName, snapshot.adapterOptions.userId, snapshot, 'updateRecord');
+    return this.ajax(url, 'PUT', { data });
+  }
+}

--- a/orga/app/adapters/user-orga-setting.js
+++ b/orga/app/adapters/user-orga-setting.js
@@ -1,9 +1,20 @@
 import ApplicationAdapter from './application';
 
 export default class UserOrgaSetting extends ApplicationAdapter {
+  urlForCreateRecord(modelName, { adapterOptions }) {
+    const { userId } = adapterOptions;
+    return `${this.host}/${this.namespace}/user-orga-settings/${userId}`;
+  }
+
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const { userId } = adapterOptions;
     return `${this.host}/${this.namespace}/user-orga-settings/${userId}`;
+  }
+
+  createRecord(store, type, snapshot) {
+    const data = this.serialize(snapshot);
+    const url = this.buildURL(type.modelName, snapshot.adapterOptions.userId, snapshot, 'createRecord');
+    return this.ajax(url, 'PUT', { data });
   }
 
   updateRecord(store, type, snapshot) {

--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -50,7 +50,7 @@ export default class UserLoggedMenu extends Component {
     const selectedOrganization = await this.store.peekRecord('organization', organization.get('id'));
 
     userOrgaSettings.set('organization', selectedOrganization);
-    userOrgaSettings.save();
+    userOrgaSettings.save({ adapterOptions: { userId: user.id } });
 
     await this.currentUser.load();
 

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -56,7 +56,7 @@ export default class CurrentUserService extends Service {
 
   async _createUserOrgaSettings(user, membership) {
     const organization = await membership.organization;
-    await this.store.createRecord('user-orga-setting', { user, organization }).save();
+    await this.store.createRecord('user-orga-setting', { user, organization }).save({ adapterOptions: { userId: user.id } });
   }
 
   async _setOrganizationProperties(membership) {

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -21,7 +21,7 @@ export default class CurrentUserService extends Service {
           membership = await this._getMembershipByUserOrgaSettings(userMemberships.toArray(), userOrgaSettings);
           if (!membership) {
             membership = await userMemberships.firstObject;
-            await this._updateUserOrgaSettings(userOrgaSettings, membership);
+            await this._updateUserOrgaSettings(userOrgaSettings, membership, user.id);
           }
         } else {
           membership = await userMemberships.firstObject;
@@ -49,9 +49,9 @@ export default class CurrentUserService extends Service {
     return null;
   }
 
-  async _updateUserOrgaSettings(userOrgaSettings, membership) {
+  async _updateUserOrgaSettings(userOrgaSettings, membership, userId) {
     userOrgaSettings.organization = await membership.organization;
-    userOrgaSettings.save();
+    userOrgaSettings.save({ adapterOptions: { userId: userId } });
   }
 
   async _createUserOrgaSettings(user, membership) {

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -253,7 +253,7 @@ export default function() {
     return schema.userOrgaSettings.create({ user, organization });
   });
 
-  this.patch('/user-orga-settings/:id', (schema, request) => {
+  this.put('/user-orga-settings/:id', (schema, request) => {
     const requestBody = JSON.parse(request.requestBody);
     const userOrgaSettingsId = request.params.id;
     const organizationId = requestBody.data.relationships.organization.data.id;

--- a/orga/tests/unit/adapters/user-orga-setting-test.js
+++ b/orga/tests/unit/adapters/user-orga-setting-test.js
@@ -58,4 +58,46 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
     });
   });
 
+  module('#urlForCreateRecord', function() {
+
+    test('it should build create url from user id', async function(assert) {
+      // when
+      const snapshot = { adapterOptions: { userId: 1 } };
+      const url = await adapter.urlForCreateRecord('user-orga-setting', snapshot);
+
+      // then
+      assert.equal(url.endsWith('/user-orga-settings/1'), true);
+    });
+  });
+
+  module('#createRecord', function() {
+    module('when userId adapterOption passed', function(hooks) {
+
+      hooks.beforeEach(function() {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function() {
+        adapter.ajax.restore();
+      });
+
+      test('should send a put request to /user-orga-settings to create', async function(assert) {
+        // given
+        adapter.ajax.resolves();
+        const snapshot = {
+          id: 1,
+          adapterOptions: { userId },
+          serialize: function() {},
+
+        };
+
+        // when
+        await adapter.createRecord(null, { modelName: 'user-orga-setting' }, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, `http://localhost:3000/api/user-orga-settings/${userId}`, 'PUT');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
 });

--- a/orga/tests/unit/adapters/user-orga-setting-test.js
+++ b/orga/tests/unit/adapters/user-orga-setting-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { resolve } from 'rsvp';
+import sinon from 'sinon';
+
+module('Unit | Adapters | user-orga-setting', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+  const userId = 1;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:user-orga-setting');
+    const ajaxStub = () => resolve();
+    adapter.set('ajax', ajaxStub);
+  });
+
+  module('#urlForUpdateRecord', function() {
+
+    test('it should build update url from user id', async function(assert) {
+      // when
+      const snapshot = { adapterOptions: { userId } };
+      const url = await adapter.urlForUpdateRecord(123, 'user-orga-setting', snapshot);
+
+      // then
+      assert.equal(url.endsWith(`/user-orga-settings/${userId}`), true);
+    });
+  });
+
+  module('#updateRecord', function() {
+    module('when userId adapterOption passed', function(hooks) {
+
+      hooks.beforeEach(function() {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function() {
+        adapter.ajax.restore();
+      });
+
+      test('should send a put request to user-orga-settings endpoint', async function(assert) {
+        // given
+        adapter.ajax.resolves();
+        const snapshot = {
+          id: 1,
+          adapterOptions: { userId },
+          serialize: function() {},
+
+        };
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'user-orga-setting' }, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, `http://localhost:3000/api/user-orga-settings/${userId}`, 'PUT');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un un utilisateur rejoint Pix Orga pour la première fois, on lui créé des paramètres utilisateurs : `user-orga-settings`, qu'on créé grâce à la route `POST /user-orga-settings`.

Un `user-orga-settings` est construit avec un `userId` et un `organisationId`. Il y a une contrainte d'unicité sur l'`userId`, car l'utilisateur n'a qu'un seul tuple de paramètre qu'on met à jour si besoin avec `PATCH /user-orga-settings`.

Seulement, on peut voir que presque tous les jours, nous avons des erreurs qui remontent de violation de contraintes d'unicité dont la plupart à cause de cette table `user-orga-settings`. 
<img width="1336" alt="Screenshot 2020-04-23 at 18 49 48" src="https://user-images.githubusercontent.com/26384707/80126316-37bc5e80-8593-11ea-859f-df83ea6bccc4.png">
<img width="1337" alt="Screenshot 2020-04-23 at 18 49 08" src="https://user-images.githubusercontent.com/26384707/80126377-4c98f200-8593-11ea-9609-e7c9fd3b8188.png">

Cette erreur est reproductible en ouvrant deux onglets de Pix Orga avec un nouveau compte, lorsqu'on arrive sur la page CGU, on voit dans le network de chaque onglet qu'une requête `POST /user-orga-settings` est envoyée, l'une tombe en `201`, la seconde en `400`.

## :robot: Solution
Au lieu d'utiliser les routes `POST` et `PATCH`, créer une route `PUT` qui correspond mieux à notre besoin d'idempotence. 

## :100: Pour tester
Utiliser un compte qui n'a pas encore d'`user-orga-settings` et qui n'a pas validé les CGU. 
Voir que les requêtes de création sont des `PUT` et voir ensuite en changeant d'organisation que les requêtes de mise à jour sont aussi des `PUT`. 
On peut reproduire les deux onglets ouverts et voir que les deux `PUT` partent mais que les deux sont en `200`. 