### PR TITLE
[FEATURE] Ajout d'un filtre sur la colonne "Centre de certification" dans la liste des sessions paginée sur PixAdmin (PA-210)

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -19,7 +19,13 @@
                  oninput={{perform @triggerFiltering 'id'}}
                  class="table-admin-input" />
         </th>
-        <th></th>
+        <th>
+          <input id="certificationCenterName"
+                 type="text"
+                 value={{@certificationCenterName}}
+                 oninput={{perform @triggerFiltering 'certificationCenterName'}}
+                 class="table-admin-input" />
+        </th>
         <th></th>
         <th></th>
         <th>

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -9,12 +9,13 @@ const DEFAULT_PAGE_NUMBER = 1;
 
 export default class SessionListController extends Controller {
 
-  queryParams = ['pageNumber', 'pageSize', 'id', 'status', 'resultsSentToPrescriberAt'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'certificationCenterName', 'status', 'resultsSentToPrescriberAt'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
   @tracked id = null;
+  @tracked certificationCenterName = null;
   @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
 
@@ -34,12 +35,10 @@ export default class SessionListController extends Controller {
     let debounceDuration = this.DEBOUNCE_MS;
     switch (fieldName) {
       case 'id':
+      case 'certificationCenterName':
         value = param.target.value; // param is an InputEvent
         break;
       case 'status':
-        debounceDuration = 0;
-        value = param;
-        break;
       case 'resultsSentToPrescriberAt':
         debounceDuration = 0;
         value = param;

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -15,10 +15,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
   model(params) {
     return this.store.query('session', {
       filter: {
-        id: params.id ? params.id.trim() : undefined,
-        certificationCenterName: params.certificationCenterName ? params.certificationCenterName.trim() : undefined,
-        status: params.status ? params.status.trim() : undefined,
-        resultsSentToPrescriberAt: params.resultsSentToPrescriberAt ? params.resultsSentToPrescriberAt.trim() : undefined,
+        id: params.id && params.id.trim(),
+        certificationCenterName: params.certificationCenterName && params.certificationCenterName.trim(),
+        status: params.status && params.status.trim(),
+        resultsSentToPrescriberAt: params.resultsSentToPrescriberAt && params.resultsSentToPrescriberAt.trim(),
       },
       page: {
         number: params.pageNumber,

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -7,6 +7,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
+    certificationCenterName: { refreshModel: true },
     status: { refreshModel: true },
     resultsSentToPrescriberAt: { refreshModel: true },
   },
@@ -15,6 +16,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     return this.store.query('session', {
       filter: {
         id: params.id ? params.id.trim() : undefined,
+        certificationCenterName: params.certificationCenterName ? params.certificationCenterName.trim() : undefined,
         status: params.status ? params.status.trim() : undefined,
         resultsSentToPrescriberAt: params.resultsSentToPrescriberAt ? params.resultsSentToPrescriberAt.trim() : undefined,
       },
@@ -30,6 +32,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.pageNumber = 1;
       controller.pageSize = 10;
       controller.id = null;
+      controller.certificationCenterName = null;
       controller.status = FINALIZED;
       controller.resultsSentToPrescriberAt = null;
     }

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -7,6 +7,7 @@
       <Sessions::ListItems
         @sessions={{@model}}
         @id={{this.id}}
+        @certificationCenterName={{this.certificationCenterName}}
         @status={{this.status}}
         @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
         @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}

--- a/admin/app/templates/components/pagination-control.hbs
+++ b/admin/app/templates/components/pagination-control.hbs
@@ -2,7 +2,7 @@
   <div class="page-size">
     <div class="page-size__label">Voir</div>
     <div class="page-size__choice">
-      <select class="select content-text content-text--small" onchange={{action 'changePageSize' value='target.value'}}>
+      <select id="pageSize" class="select content-text content-text--small" onchange={{action 'changePageSize' value='target.value'}}>
         <option value="10" selected="{{if (eq @pagination.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq @pagination.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq @pagination.pageSize 50) true}}">50</option>
@@ -12,7 +12,8 @@
   </div>
   <div class="page-navigation">
     <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq @pagination.page 1) "page-navigation__arrow--disabled"}}">
-      <LinkTo @query={{hash pageNumber=previousPage}}
+      <LinkTo aria-label="Aller à la page précédente"
+              @query={{hash pageNumber=previousPage}}
               @disabledWhen={{eq @pagination.page 1}}
               @replace={{true}}
               class="icon-button icon-button--link">
@@ -25,7 +26,8 @@
       <div class="page-navigation__last-page">/&nbsp;{{@pagination.pageCount}}</div>
     </div>
     <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq @pagination.page @pagination.pageCount) "page-navigation__arrow--disabled"}}">
-      <LinkTo @query={{hash pageNumber=nextPage}}
+      <LinkTo aria-label="Aller à la page suivante"
+              @query={{hash pageNumber=nextPage}}
               @disabledWhen={{eq @pagination.page @pagination.pageCount}}
               @replace={{true}}
               class="icon-button icon-button--link">

--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -1,7 +1,7 @@
 import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'faker';
 import moment from 'moment';
-import { CREATED, FINALIZED, PROCESSED } from 'pix-admin/models/session';
+import { CREATED, FINALIZED, IN_PROCESS, PROCESSED } from 'pix-admin/models/session';
 
 export default Factory.extend({
 
@@ -59,12 +59,21 @@ export default Factory.extend({
     }
   }),
 
+  withResultsSentToPrescriber: trait({
+    resultsSentToPrescriberAt: faker.date.past(),
+  }),
+
   created: trait({
     status: CREATED,
   }),
 
   finalized: trait({
     status: FINALIZED,
+    finalizedAt: faker.date.past(),
+  }),
+
+  inProcess: trait({
+    status: IN_PROCESS,
     finalizedAt: faker.date.past(),
   }),
 

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -1,31 +1,57 @@
 import _ from 'lodash';
 
 export function findPaginatedAndFilteredSessions(schema, request) {
-  const pageSize = request.queryParams.page ? parseInt(request.queryParams.page.size) : 10;
-  const filters = request.queryParams.filter;
+  const queryParams = request.queryParams;
+  const pageSize = queryParams ? parseInt(queryParams['page[size]']) : 10;
+  const page = queryParams ? parseInt(queryParams['page[number]']) : 1;
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  const idFilter = queryParams ? queryParams['filter[id]'] : null;
+  const certificationCenterNameFilter = queryParams ? queryParams['filter[certificationCenterName]'] : null;
+  const statusFilter = queryParams ? queryParams['filter[status]'] : null;
+  const resultsSentToPrescriberAtFilter = queryParams ? queryParams['filter[resultsSentToPrescriberAt]'] : null;
   const sessions = schema.sessions.all().models;
-  const allSessionsCount = sessions.length;
+  const rowCount = sessions.length;
+
   // Apply filters
   let filteredSessions = sessions;
-  if (filters && filters.id) {
-    const filterId = filters.id;
-    filteredSessions = _.map(sessions, (session) => {
-      const currentSessionId = session.id;
-      const match = currentSessionId.search(filterId);
-      return match !== -1;
+  if (idFilter) {
+    filteredSessions = _.filter(filteredSessions, (session) => {
+      return session.id === idFilter;
     });
   }
-  // Apply sorting
-  const sortedSessions = _.sortBy(filteredSessions, ['id']);
+  if (certificationCenterNameFilter) {
+    const filterName = certificationCenterNameFilter.toLowerCase();
+    filteredSessions = _.filter(filteredSessions, (session) => {
+      const currentName = session.certificationCenterName.toLowerCase();
+      return currentName.search(filterName) !== -1;
+    });
+  }
+  if (statusFilter) {
+    filteredSessions = _.filter(filteredSessions, { status: statusFilter });
+  }
+  if (resultsSentToPrescriberAtFilter) {
+    if (resultsSentToPrescriberAtFilter === 'true') {
+      filteredSessions = _.filter(filteredSessions, (session) => {
+        return Boolean(session.resultsSentToPrescriberAt);
+      });
+    }
+    if (resultsSentToPrescriberAtFilter === 'false') {
+      filteredSessions = _.filter(filteredSessions, (session) => {
+        return !(session.resultsSentToPrescriberAt);
+      });
+    }
+  }
+
   // Apply page size
-  const sessionsToSend = _.slice(sortedSessions, 0, pageSize);
+  const sessionsToSend = _.slice(filteredSessions, start, end);
 
   const json = this.serialize({ modelName: 'session', models: sessionsToSend }, 'session');
   json.meta = {
-    page: 1,
+    page,
     pageSize,
-    rowCount: allSessionsCount,
-    pageCount: Math.ceil(allSessionsCount / pageSize),
+    rowCount,
+    pageCount: Math.ceil(rowCount / pageSize),
   };
   return json;
 }

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -34,26 +34,143 @@ module('Acceptance | Session List', function(hooks) {
       assert.equal(currentURL(), '/sessions/list');
     });
 
-    test('it should display the first page of the list of sessions', async function(assert) {
-      // given
-      server.createList('session', 60);
+    module('#Pagination', function(hooks) {
 
-      // when
-      await visit('/sessions/list');
+      hooks.beforeEach(function() {
+        server.createList('session', 15, 'finalized');
+        server.createList('session', 20);
+      });
 
-      // then
-      assert.dom('.table-admin tbody tr').exists({ count: 10 });
+      module('Default display', function() {
+
+        test('it should display the first page of finalized sessions', async function(assert) {
+          // when
+          await visit('/sessions/list');
+
+          // then
+          assert.dom('select#pageSize').hasValue('10');
+          assert.dom('.table-admin tbody tr').exists({ count: 10 });
+          assert.dom('div.page-navigation__current-page').hasText('1');
+        });
+      });
+
+      module('when selecting a different page', function() {
+
+        test('it should display the second page of finalized sessions', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await click('[aria-label="Aller à la page suivante"]');
+
+          // then
+          assert.dom('select#pageSize').hasValue('10');
+          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+          assert.dom('div.page-navigation__current-page').hasText('2');
+        });
+      });
+
+      module('when selecting a different pageSize', function() {
+
+        test('it should display all the finalized sessions', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('select#pageSize', '25');
+
+          // then
+          assert.dom('select#pageSize').hasValue('25');
+          assert.dom('.table-admin tbody tr').exists({ count: 15 });
+          assert.dom('div.page-navigation__current-page').hasText('1');
+        });
+      });
     });
 
-    test('it should display the current filter when sessions are filtered', async function(assert) {
-      // given
-      server.createList('session', 60);
+    module('#Filters', function() {
 
-      // when
-      await visit('/sessions/list?id=1');
+      module('#id', function(hooks) {
+        let expectedSession;
 
-      // then
-      assert.dom('#id').hasValue('1');
+        hooks.beforeEach(function() {
+          expectedSession = server.create('session', 'finalized');
+          server.createList('session', 10, 'finalized');
+        });
+
+        test('it should display the session with the ID specified in the input field', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('#id', expectedSession.id);
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 1 });
+        });
+      });
+
+      module('#certificationCenterName', function(hooks) {
+        let expectedSession;
+
+        hooks.beforeEach(function() {
+          expectedSession = server.create('session', 'finalized');
+          server.createList('session', 10, 'finalized');
+        });
+
+        test('it should display the session with a certification center name alike the one specified in the field', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('#certificationCenterName', expectedSession.certificationCenterName.toUpperCase());
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 1 });
+        });
+      });
+
+      module('#status', function(hooks) {
+
+        hooks.beforeEach(function() {
+          server.createList('session', 5, 'processed');
+          server.createList('session', 3, 'finalized');
+        });
+
+        test('it should display the session with status as specified in the dropdown', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('select#status', 'processed');
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+        });
+      });
+
+      module('#resultsSentToPrescriberAt', function(hooks) {
+
+        hooks.beforeEach(function() {
+          server.createList('session', 5, 'withResultsSentToPrescriber', 'finalized');
+          server.createList('session', 3, 'finalized');
+        });
+
+        test('it should display sessions regardless the results have been sent or not', async function(assert) {
+          // when
+          await visit('/sessions/list');
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 8 });
+        });
+
+        test('it should only display sessions which results have been sent', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('select#resultsSentToPrescriberAt', 'true');
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+        });
+
+        test('it should only display sessions which results have not been sent', async function(assert) {
+          // when
+          await visit('/sessions/list');
+          await fillIn('select#resultsSentToPrescriberAt', 'false');
+
+          // then
+          assert.dom('.table-admin tbody tr').exists({ count: 3 });
+        });
+      });
     });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -58,6 +58,28 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     assert.dom('table tbody tr:nth-child(3) td:nth-child(3)').hasText('-');
   });
 
+  module('Input field for id filtering', function() {
+
+    test('it should render a input field to filter on id', async function(assert) {
+      // when
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering}}`);
+
+      // then
+      assert.dom('table thead tr:nth-child(2) th:nth-child(1) input').exists();
+    });
+  });
+
+  module('Input field for certificationCenterName filtering', function() {
+
+    test('it should render a input field to filter on certificationCenterName', async function(assert) {
+      // when
+      await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering}}`);
+
+      // then
+      assert.dom('table thead tr:nth-child(2) th:nth-child(2) input').exists();
+    });
+  });
+
   module('Dropdown menu for status filtering', function(hooks) {
 
     hooks.beforeEach(function() {

--- a/admin/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -26,6 +26,21 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
       });
     });
 
+    module('when fieldName is certificationCenterName', function() {
+
+      test('it should update controller certificationCenterName field', async function(assert) {
+        // given
+        controller.certificationCenterName = 'someName';
+
+        // when
+        const expectedValue = 'someOtherName';
+        await controller.triggerFiltering.perform('certificationCenterName', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.certificationCenterName, expectedValue);
+      });
+    });
+
     module('when fieldName is status', function() {
 
       test('it should update controller status field', async function(assert) {

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -32,6 +32,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         await route.model(params);
         expectedQueryArgs.filter = {
           id: undefined,
+          certificationCenterName: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
         };
@@ -49,6 +50,28 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         params.id = ' someId';
         expectedQueryArgs.filter = {
           id: 'someId',
+          certificationCenterName: undefined,
+          status: undefined,
+          resultsSentToPrescriberAt: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams certificationCenterName is truthy', function() {
+
+      test('it should call store.query with a filter with trimmed certificationCenterName', async function(assert) {
+        // given
+        params.certificationCenterName = ' someName';
+        expectedQueryArgs.filter = {
+          id: undefined,
+          certificationCenterName: 'someName',
           status: undefined,
           resultsSentToPrescriberAt: undefined,
         };
@@ -69,6 +92,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         params.status = ' someStatus';
         expectedQueryArgs.filter = {
           id: undefined,
+          certificationCenterName: undefined,
           status: 'someStatus',
           resultsSentToPrescriberAt: undefined,
         };
@@ -89,6 +113,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         params.resultsSentToPrescriberAt = ' someValue';
         expectedQueryArgs.filter = {
           id: undefined,
+          certificationCenterName: undefined,
           status: undefined,
           resultsSentToPrescriberAt: 'someValue',
         };
@@ -112,6 +137,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
         id: 'someId',
+        certificationCenterName: 'someName',
         status: 'someStatus',
         resultsSentToPrescriberAt: 'someValue',
       };
@@ -127,6 +153,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         assert.equal(controller.pageNumber, 1);
         assert.equal(controller.pageSize, 10);
         assert.equal(controller.id, null);
+        assert.equal(controller.certificationCenterName, null);
         assert.equal(controller.status, 'finalized');
         assert.equal(controller.resultsSentToPrescriberAt, null);
       });
@@ -142,6 +169,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         assert.equal(controller.pageNumber, 'somePageNumber');
         assert.equal(controller.pageSize, 'somePageSize');
         assert.equal(controller.id, 'someId');
+        assert.equal(controller.certificationCenterName, 'someName');
         assert.equal(controller.status, 'someStatus');
         assert.equal(controller.resultsSentToPrescriberAt, 'someValue');
       });

--- a/api/lib/domain/usecases/find-paginated-filtered-sessions.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-sessions.js
@@ -1,18 +1,26 @@
+const _ = require('lodash');
 const sessionValidator = require('../validators/session-validator');
 
 module.exports = async function findPaginatedFilteredSessions({ filters, page, sessionRepository }) {
+  let normalizedFilters;
   try {
-    sessionValidator.validateFilters(filters);
+    const trimmedFilters = _.mapValues(filters, (value) => {
+      if (typeof value === 'string') {
+        return value.trim() || undefined;
+      }
+      return value;
+    });
+    normalizedFilters = sessionValidator.validateFilters(trimmedFilters);
   } catch (err) {
     return {
       sessions: [],
       pagination: {
         page: page.number,
         pageSize: page.size,
-        rowCount: 0, 
+        rowCount: 0,
         pageCount: 0,
       },
     };
   }
-  return sessionRepository.findPaginatedFiltered({ filters, page });
+  return sessionRepository.findPaginatedFiltered({ filters: normalizedFilters, page });
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -58,10 +58,11 @@ module.exports = {
     }
   },
 
-  validateFilters(sessionFilters) {
-    const { error } = sessionFiltersValidationSchema.validate(sessionFilters, validationConfiguration);
+  validateFilters(filters) {
+    const { value, error } = sessionFiltersValidationSchema.validate(filters, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }
+    return value;
   }
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -46,6 +46,7 @@ const sessionFiltersValidationSchema = Joi.object({
   status: Joi.string()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
   resultsSentToPrescriberAt: Joi.string().valid('true', 'false').optional(),
+  certificationCenterName: Joi.string().optional(),
 });
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -135,33 +135,7 @@ module.exports = {
   async findPaginatedFiltered({ filters = {}, page = {} }) {
     const { models, pagination } = await BookshelfSession
       .query((qb) => {
-        const { id, status, resultsSentToPrescriberAt } = filters;
-        if (id) {
-          qb.where({ id });
-        }
-        if (resultsSentToPrescriberAt === 'true') {
-          qb.whereNotNull('resultsSentToPrescriberAt');
-        }
-        if (resultsSentToPrescriberAt === 'false') {
-          qb.whereNull('resultsSentToPrescriberAt');
-        }
-        if (status === statuses.CREATED) {
-          qb.whereNull('finalizedAt');
-          qb.whereNull('publishedAt');
-        }
-        if (status === statuses.FINALIZED) {
-          qb.whereNotNull('finalizedAt');
-          qb.whereNull('assignedCertificationOfficerId');
-          qb.whereNull('publishedAt');
-        }
-        if (status === statuses.IN_PROCESS) {
-          qb.whereNotNull('finalizedAt');
-          qb.whereNotNull('assignedCertificationOfficerId');
-          qb.whereNull('publishedAt');
-        }
-        if (status === statuses.PROCESSED) {
-          qb.whereNotNull('publishedAt');
-        }
+        _setupFilters(qb, filters);
         qb.orderByRaw('?? ASC NULLS FIRST', 'publishedAt');
         qb.orderByRaw('?? ASC', 'finalizedAt');
       })
@@ -188,3 +162,36 @@ module.exports = {
   }
 
 };
+
+function _setupFilters(qb, filters) {
+  const { id, status, resultsSentToPrescriberAt, certificationCenterName } = filters;
+  if (id) {
+    qb.where({ id });
+  }
+  if (certificationCenterName) {
+    qb.whereRaw('LOWER("certificationCenter") LIKE ?', `%${certificationCenterName.toLowerCase()}%`);
+  }
+  if (resultsSentToPrescriberAt === 'true') {
+    qb.whereNotNull('resultsSentToPrescriberAt');
+  }
+  if (resultsSentToPrescriberAt === 'false') {
+    qb.whereNull('resultsSentToPrescriberAt');
+  }
+  if (status === statuses.CREATED) {
+    qb.whereNull('finalizedAt');
+    qb.whereNull('publishedAt');
+  }
+  if (status === statuses.FINALIZED) {
+    qb.whereNotNull('finalizedAt');
+    qb.whereNull('assignedCertificationOfficerId');
+    qb.whereNull('publishedAt');
+  }
+  if (status === statuses.IN_PROCESS) {
+    qb.whereNotNull('finalizedAt');
+    qb.whereNotNull('assignedCertificationOfficerId');
+    qb.whereNull('publishedAt');
+  }
+  if (status === statuses.PROCESSED) {
+    qb.whereNotNull('publishedAt');
+  }
+}

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -584,6 +584,33 @@ describe('Integration | Repository | Session', function() {
         });
       });
 
+      context('when there is a filter on the certificationCenterName', () => {
+        let expectedSession;
+
+        beforeEach(() => {
+          const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'Université des Laura en Folie !' });
+          expectedSession = databaseBuilder.factory.buildSession({ certificationCenter: certificationCenter.name, certificationCenterId: certificationCenter.id });
+          databaseBuilder.factory.buildSession();
+
+          return databaseBuilder.commit();
+        });
+
+        it('it should find sessions by part of their certification center name, in a case-insensitive way', async () => {
+          // given
+          const filters = { certificationCenterName: ' Des laURa' };
+          const page = { number: 1, size: 10 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+
+          // when
+          const { sessions, pagination } = await sessionRepository.findPaginatedFiltered({ filters, page });
+
+          // then
+          expect(pagination).to.deep.equal(expectedPagination);
+          expect(sessions[0].id).to.equal(expectedSession.id);
+          expect(sessions).to.have.length(1);
+        });
+      });
+
       context('when there is a filter regarding session status', () => {
         context('when there is a filter on created sessions', () => {
           let expectedSessionId;

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-sessions_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-sessions_test.js
@@ -22,12 +22,15 @@ describe('Unit | UseCase | find-paginated-filtered-sessions', () => {
 
     it('should result sessions with filtering and pagination', async () => {
       // given
-      const filters = 'someFilters';
+      const filters = { filter1: ' filter1ToTrim', filter2: 'filter2' };
+      const normalizedFilters = 'normalizedFilters';
       const page = 'somePageConfiguration';
       const resolvedPagination = 'pagination';
       const matchingSessions = 'listOfMatchingSessions';
-      sessionValidator.validateFilters.withArgs(filters).returns();
-      sessionRepository.findPaginatedFiltered.withArgs({ filters, page }).resolves({ sessions: matchingSessions, pagination: resolvedPagination });
+      sessionValidator.validateFilters.withArgs({ filter1: 'filter1ToTrim', filter2: 'filter2' })
+        .returns(normalizedFilters);
+      sessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page })
+        .resolves({ sessions: matchingSessions, pagination: resolvedPagination });
 
       // when
       const response = await usecases.findPaginatedFilteredSessions({ filters, page, sessionRepository });
@@ -42,7 +45,7 @@ describe('Unit | UseCase | find-paginated-filtered-sessions', () => {
 
     it('should result empty list of session with basic pagination', async () => {
       // given
-      const filters = 'someFilters';
+      const filters = { filter1: 'filter1', filter2: 'filter2' };
       const page = { number: 'aNumber', size: 'aSize' };
       const basicPagination = {
         page: 'aNumber',

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -197,6 +197,35 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
     });
 
+    context('when validating certificationCenterName', () => {
+
+      context('when certificationCenterName not in submitted filters', () => {
+
+        it('should not throw any error', () => {
+          expect(sessionValidator.validateFilters({})).to.not.throw;
+        });
+      });
+
+      context('when status is in submitted filters', () => {
+
+        context('when certificationCenterName is not an string', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ certificationCenterName: 123 });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when certificationCenterName is a string', () => {
+
+          it('should not throw an error', async () => {
+            expect(sessionValidator.validateFilters({ certificationCenterName: 'Coucou le dév qui lit ce message !' })).to.not.throw;
+          });
+        });
+      });
+
+    });
+
     context('when validating status', () => {
 
       context('when status not in submitted filters', () => {

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -164,6 +164,20 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
   describe('#validateFilters', () => {
 
+    context('return value', () => {
+
+      it('should return the filters in a normalized form', () => {
+        const value = sessionValidator.validateFilters({
+          id: '123',
+          status: 'finalized',
+        });
+
+        expect(typeof value.id).to.equal('number');
+        expect(value.status).to.equal('finalized');
+        expect(value.certificationCenterName).to.be.undefined;
+      });
+    });
+
     context('when validating id', () => {
 
       context('when id not in submitted filters', () => {
@@ -185,7 +199,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
         context('when id is an integer', () => {
 
-          it('should not throw any error in form of a string', () => {
+          it('accept a string containing an int', () => {
             expect(sessionValidator.validateFilters({ id: '123' })).to.not.throw;
           });
 
@@ -206,7 +220,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         });
       });
 
-      context('when status is in submitted filters', () => {
+      context('when certificationCenterName is in submitted filters', () => {
 
         context('when certificationCenterName is not an string', () => {
 


### PR DESCRIPTION
## :unicorn: Contexte
Toujours dans l'optique de faire de PixAdmin l'outil exclusif servant au traitement des sessions de certification pour le pôle certification.
Ils ont besoin de pouvoir filtrer par nom de centre de certification.

## :robot: Solution
On ajoute un champ de saisie sur la colonne "Centre de certification". La recherche est insensible à la casse et est de type `LIKE %<value>%`

## :rainbow: Remarques
On en profite pour bien renforcer les tests d'acceptance sur la liste paginée des sessions.

## :100: Pour tester
Rendez-vous sur PixAdmin, dans la liste des sessions de certifs. Essayez des combinaisons de différentes casses sur la recherche par centre de certification
