### PR TITLE
[FEATURE] Ajuster la formulation de la page d'identifiant externe (PIX-564).

### DIFF
--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -4,7 +4,7 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
     <h1 class="fill-in-id-pix-text fill-in-id-pix-text__title">Avant de commencer</h1>
     <p class="fill-in-id-pix-text fill-in-id-pix-text__announcement">
-      L'organisateur de votre parcours a besoin de l'information ci-dessous pour pouvoir vous accompagner :
+      L'organisateur a besoin de l'information ci-dessous pour pouvoir vous accompagner :
     </p>
 
     <form {{action "submit" on="submit"}} class="fill-in-id-pix__form">


### PR DESCRIPTION
## :unicorn: Problème
La formulation de la page d'identifiant externe n'est plus adaptée aux campagnes de collecte de profils.

## :robot: Solution
Revoir la formulation.

## :rainbow: Remarques
NA

## :100: Pour tester
- Rejoindre une campagne à laquelle il est nécéssaire de remplir l'identifiant externe (AZERTY123) ;
- Passer la page de présentation ;
- Voir la page de d'identifiant externe.