### PR TITLE
[BUGFIX] Le temps d'attente d'envoi de requêtes mis en place lors de la recherche de campagnes par nom dans PixOrga ne marche plus (PO-440)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -32,8 +32,9 @@ export default class ListController extends Controller {
   }
 
   @action
-  triggerFiltering(fieldName, value) {
-    this.set('searchFilter', { fieldName, value });
+  triggerFiltering(fieldName, event) {
+    const value = event.target.value;
+    this.searchFilter = { fieldName, value };
     debounce(this, this.setFieldName, 500);
   }
 

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -4,9 +4,11 @@ import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import config from 'pix-orga/config/environment';
 
 export default class ListController extends Controller {
   queryParams = ['pageNumber', 'pageSize', 'name', 'status', 'creatorId'];
+  DEBOUNCE_MS = config.pagination.debounce;
   pageNumber = 1;
   pageSize = 25;
   name = null;
@@ -35,7 +37,7 @@ export default class ListController extends Controller {
   triggerFiltering(fieldName, event) {
     const value = event.target.value;
     this.searchFilter = { fieldName, value };
-    debounce(this, this.setFieldName, 500);
+    debounce(this, this.setFieldName, this.DEBOUNCE_MS);
   }
 
   @action

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -12,7 +12,7 @@
           </tr>
           <tr>
             <th>
-              <SearchInput @inputName="campaignName" @class="input table__input search-input" @value={{@campaignName}} @placeholder="Rechercher une campagne" @keyUp={{fn @triggerFiltering "name" @campaignName}}/>
+              <SearchInput @inputName="campaignName" @class="input table__input search-input" @value={{@campaignName}} @placeholder="Rechercher une campagne" @filterFunction={{fn @triggerFiltering "name"}}/>
             </th>
             <th>
               <Routes::Authenticated::Campaigns::SelectCreator

--- a/orga/app/templates/components/search-input.hbs
+++ b/orga/app/templates/components/search-input.hbs
@@ -1,2 +1,7 @@
 <FaIcon @icon='search'></FaIcon>
-<Input id={{@inputName}} name={{@inputName}} placeholder={{@placeholder}} @value={{@value}} @keyUp={{@keyUp}} class="search-input__invisible-field" />
+<input id={{@inputName}}
+       name={{@inputName}}
+       placeholder={{@placeholder}}
+       value={{@value}}
+       oninput={{@filterFunction}}
+       class="search-input__invisible-field" />

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -65,6 +65,10 @@ module.exports = function(environment) {
       clearDuration: 5000,
       includeFontAwesome: true,
     },
+
+    pagination: {
+      debounce: 500,
+    },
   };
 
   if (environment === 'development') {
@@ -96,6 +100,8 @@ module.exports = function(environment) {
       autoClear: null,
       clearDuration: null,
     };
+    
+    ENV.pagination.debounce = 0;
   }
 
   if (environment === 'production') {

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -1,89 +1,153 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
+import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
   setupTest(hooks);
+  let controller;
 
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-    assert.ok(controller);
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/campaigns/list');
   });
 
-  test('it should know when there is no campaigns', function(assert) {
-    // given
-    const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-    const campaigns = ArrayProxy.create({
-      content: []
-    });
-    controller.set('model', campaigns);
+  module('#get displayNoCampaignPanel', function() {
 
-    // when
-    const displayNoCampaignPanel = controller.get('displayNoCampaignPanel');
-
-    // then
-    assert.equal(displayNoCampaignPanel, true);
-  });
-
-  test('it should know when there are campaigns', function(assert) {
-    // given
-    const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-    const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
-    const campaigns = ArrayProxy.create({
-      content: [campaign1]
-    });
-    controller.set('model', campaigns);
-
-    // when
-    const displayNoCampaignPanel = controller.get('displayNoCampaignPanel');
-
-    // then
-    assert.equal(displayNoCampaignPanel, false);
-  });
-
-  module('when there is a filter on campaigns name that does not match any campaign', function() {
-    // given
-    const filterName = 'Dog';
-    const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
-    const campaigns = ArrayProxy.create({
-      content: [campaign1]
-    });
-
-    test('it should display an empty table', function(assert) {
-      const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-      controller.set('model', campaigns);
-      controller.set('name', filterName);
+    test('it should know when there is no campaigns', function(assert) {
+      // given
+      const campaigns = ArrayProxy.create({
+        content: []
+      });
+      controller.model = campaigns;
 
       // when
-      const displayNoCampaignPanel = controller.get('displayNoCampaignPanel');
+      const displayNoCampaignPanel = controller.displayNoCampaignPanel;
+
+      // then
+      assert.equal(displayNoCampaignPanel, true);
+    });
+
+    test('it should know when there are campaigns', function(assert) {
+      // given
+      const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
+      const campaigns = ArrayProxy.create({
+        content: [campaign1]
+      });
+      controller.model = campaigns;
+
+      // when
+      const displayNoCampaignPanel = controller.displayNoCampaignPanel;
 
       // then
       assert.equal(displayNoCampaignPanel, false);
     });
+
+    module('when there is a filter on campaigns name that does not match any campaign', function() {
+      // given
+      const filterName = 'Dog';
+      const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
+      const campaigns = ArrayProxy.create({
+        content: [campaign1]
+      });
+
+      test('it should display an empty table', function(assert) {
+        controller.model = campaigns;
+        controller.name = filterName;
+
+        // when
+        const displayNoCampaignPanel = controller.displayNoCampaignPanel;
+
+        // then
+        assert.equal(displayNoCampaignPanel, false);
+      });
+    });
   });
 
-  module('isArchived', function() {
+  module('#get isArchived', function() {
+
     module('when status is archived', function() {
+
       test('it should returns true', function(assert) {
-        const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-        controller.set('status', 'archived');
+        // given
+        controller.status = 'archived';
 
-        const isArchived = controller.get('isArchived');
+        // when
+        const isArchived = controller.isArchived;
 
+        // then
         assert.equal(isArchived, true);
       });
     });
 
     module('when status is not archived', function() {
+
       test('it should returns false', function(assert) {
-        const controller = this.owner.lookup('controller:authenticated/campaigns/list');
-        controller.set('status', null);
+        // given
+        controller.status = null;
 
-        const isArchived = controller.get('isArchived');
+        // when
+        const isArchived = controller.isArchived;
 
+        // then
         assert.equal(isArchived, false);
       });
     });
   });
 
+  module('#setFieldName', function() {
+
+    test('it should put value from searchFilter into appropriate controller property', function(assert) {
+      // given
+      controller.name = 'someName';
+      controller.searchFilter = { fieldName: 'name', value: 'someOtherName' };
+
+      // when
+      controller.setFieldName();
+
+      // then
+      assert.equal(controller.name, 'someOtherName');
+    });
+  });
+
+  module('#action updateCampaignStatus', function() {
+
+    test('it should update controller status field', function(assert) {
+      // given
+      controller.status = 'someStatus';
+
+      // when
+      controller.send('updateCampaignStatus', 'someOtherStatus');
+
+      // then
+      assert.equal(controller.status, 'someOtherStatus');
+    });
+  });
+
+  module('#action updateCampaignCreator', function() {
+
+    test('it should update controller creatorId field', function(assert) {
+      // given
+      controller.creatorId = 'someCreatorId';
+
+      // when
+      controller.send('updateCampaignCreator', 'someOtherCreatorId');
+
+      // then
+      assert.equal(controller.creatorId, 'someOtherCreatorId');
+    });
+  });
+
+  module('#action goToCampaignPage', function() {
+
+    test('it should call transitionToRoute with appropriate arguments', function(assert) {
+      // given
+      controller.transitionToRoute = sinon.stub();
+
+      // when
+      controller.send('goToCampaignPage', 123);
+
+      // then
+      assert.equal(controller.transitionToRoute.calledWith('authenticated.campaigns.details', 123), true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
![azertyfail](https://user-images.githubusercontent.com/48727874/80337693-cf9f9e00-885a-11ea-9cca-ee93389161b7.png)
Il s'agit du même problème que sur PixAdmin, à savoir que depuis la montée de version vers EmberOctane, le debounce mis en place pour éviter le spam de requêtes ne marche plus.
L'explication + complète est ici : https://github.com/1024pix/pix/pull/1320 dans la description de la PR.
Mais grossièrement, deux facteurs :
1) Le `controller` lié à la page de liste des campagnes n'hérite plus d'EmberObject mais est une classe native JS. Du coup, plus besoin de passer par la méthode `set()` pour déclencher tous les `listeners` qui observent la variable mise à jour
2) L'input utilisé pour mettre en place le filtre sur le nom est un built-in component Ember <Input>, qui est two-way bindé. Ce qui veut dire que lorsque qu'on modifie la valeur du champ input ça modifie également la valeur bindée au component (dans notre cas `controller.name`). Du coup, dès lors qu'on frappe une touche dans le champ, on met à jour immédiatement l'attribut `name` du `controller`, ce qui déclenche immédiatement la nouvelle requête XHR.

## :robot: Solution
Solution un poil différente que dans PixAdmin. Dans PixAdmin, la dépendance ember-concurrency était déjà installée, et permettait de faire élégamment le mécanisme d'attente + mise à jour de la variable en une seule méthode.
Dans PixOrga, la dépendance n'est pas installée, et tant qu'on en aura pas + besoin que cela, ça me semble overkill de l'installer juste pour réparer le mécanisme de debounce.
Du coup, la solution pour PixOrga a été de modifier légèrement l'existant afin que la méthode `triggerFiltering` du controller puisse traiter un event émis depuis un component html <input>, et non plus le component built-in <Input> d'Ember. En effet, le <input> classique ne permet pas un tway-way binding sur une variable.
+ Pour accélérer légèrement l'exécution des tests d'acceptance portant sur la liste des campagnes, on déplace la configuration du temps de debounce dans la config, afin de la fixer à 0 pour les tests (et pas 500ms)

## :rainbow: Remarques
Après :
![azerty1](https://user-images.githubusercontent.com/48727874/80338163-ff9b7100-885b-11ea-9a3c-dd711a7e0715.png)

## :100: Pour tester
RDV sur PixOrga, ouvrez la console du développeur sur l'onglet des requêtes.
Frapper du texte dans le champ de recherche par nom sur la liste paginée des campagnes, constater qu'on n'envoie plus une requête par frappe.
