### PR TITLE
[BUGFIX] Affichage défectueux lorsqu'on supprime rapidement un filtre sur nom dans la liste des campagnes (PIX-583)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -19,7 +19,7 @@ export default class ListController extends Controller {
 
   @empty('model') hasNoCampaign;
 
-  @computed('name', 'hasNoCampaign')
+  @computed('model')
   get displayNoCampaignPanel() {
     return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
   }


### PR DESCRIPTION
## :unicorn: Problème
Pour le reproduire :
- Aller sur la liste paginée des campagnes dans PixOrga (sur intégration ou une autre RA)
- Taper 'ezgjergbezfin' (_whatever_ en somme) dans la recherche par nom, pour n'obtenir aucun résultat lors de la recherche
- Effacer le contenu en appuyant en continu sur la touche **Backspace** sur clavier et être attentif à l'affichage
- On devrait constater l'apparition FURTIVE de la page qui s'affiche lorsqu'il n'existe aucune campagne et qu'on est invité à créer la toute première campagne de l'orga.
C'est dû au `computed` suivant dans le `controller` de la liste des campagnes :
```js
  @computed('name', 'hasNoCampaign')
  get displayNoCampaignPanel() {
    return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
  }
```
La mise en place de ce `computed` fait qu'on déclenche deux fois le re-calcul de celui-ci lorsqu'on on interagit avec le filtre sur le nom dans la liste des campagnes.
![png4](https://user-images.githubusercontent.com/48727874/80339636-65d5c300-885f-11ea-88fe-0961118281e3.png)

Du coup, mettons-nous dans la situation où on a tapé un contenu dans l'input du filtre qui ne retourne aucun résultat. Nous sommes dans l'état suivant :
- hasNoCampaign est vrai
- isEmpty(name) est faux

Donc le `computed` `displayNoCampaignPanel` est faux, tout va bien. Effaçons le contenu du filtre avec la touche Backspace. Lorsqu'on efface la dernière lettre, on se retrouve dans l'état suivant pendant très très peu de temps :
- hasNoCampaign est faux (le résultat n'a pas encore été rechargé, la requête vient à peine d'être lancée)
- isEmpty(name) est faux

Donc le `computed` `displayNoCampaignPanel` est vrai le temps que la requête de recherche sans filtre réponde. Du coup, pendant quelques fractions de seconde (à priori environ la durée du debounce, soit 500ms), on peut apercevoir le panel sur la page !!
Lorsqu'elle répond, on se retrouve dans l'état suivant :
- hasNoCampaign est vrai
- isEmpty(name) est faux

Le `computed` `displayNoCampaignPanel` redevient faux, tout va pour le mieux.

## :robot: Solution
Eviter le schéma de triangle de dépendances. L'attribut `name` déclenche de toute façon la mise à jour du contenu de l'attribut `model`, il est donc inutile de configurer le `computed` pour qu'il se recalcule en se basant sur les deux attributs, seul `model` suffit.
```js
  @computed('model')
  get displayNoCampaignPanel() {
    return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
  }
```
![png3](https://user-images.githubusercontent.com/48727874/80339586-463e9a80-885f-11ea-9105-3587dd000967.png)



## :rainbow: Remarques

## :100: Pour tester
Faire le même cheminement que pour tester l'affichage défectueux, constater que ce n'est PLUS défectueux <3
