### PR TITLE
[FEATURE] Retrait de la colonne "Nombre de certifications publiées" dans la liste des sessions de PixAdmin (PIX-566).

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -8,7 +8,6 @@
         <th>Date de session</th>
         <th>Statut</th>
         <th>Date de finalisation</th>
-        <th>Nombre de certifications publiées</th>
         <th>Date de publication</th>
         <th>Date de diffusion au prescripteur</th>
       </tr>
@@ -32,7 +31,6 @@
             <xs.option @value={{@sessionStatusAndLabels.[4].status}}>{{@sessionStatusAndLabels.[4].label}}</xs.option>
           </XSelect>
         </th>
-        <th></th>
         <th></th>
         <th></th>
         <th>
@@ -59,7 +57,6 @@
           <td>{{session.displayDate}} à {{session.time}}</td>
           <td>{{session.displayStatus}}</td>
           <td>{{session.displayFinalizationDate}}</td>
-          <td>{{session.countPublishedCertifications}}</td>
           <td>{{session.displayPublishedAtDate}}</td>
           <td>{{session.displayResultsSentToPrescriberDate}}</td>
         </tr>

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -80,11 +80,6 @@ export default class Session extends Model {
     return _getNumberOf(this.certifications, (certif) => certif.status !== 'validated');
   }
 
-  @computed('certifications.@each.isPublished')
-  get countPublishedCertifications() {
-    return _getNumberOf(this.certifications, (certif) => certif.isPublished);
-  }
-
   @computed('resultsSentToPrescriberAt')
   get displayResultsSentToPrescriberDate() {
     return _formatHumanReadableLocaleDateTime(this.resultsSentToPrescriberAt);

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -21,17 +21,17 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     const sessions = [
       { id: 1, certificationCenterName: 'Centre A', certificationCenter: { type: 'SUP' },
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 0, displayFinalizationDate: '', displayPublishedAtDate: '',
+        displayStatus, displayFinalizationDate: '', displayPublishedAtDate: '',
         displayResultsSentToPrescriberDate: '',
       },
       { id: 2, certificationCenterName: 'Centre B', certificationCenter: { type: null },
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
+        displayStatus, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
         displayResultsSentToPrescriberDate: 'SomeRDate',
       },
       { id: 3, certificationCenterName: 'Centre C',
         date: now, time: '14:00:00', displayDate,
-        displayStatus, countPublishedCertifications: 1, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
+        displayStatus, displayFinalizationDate: 'SomeFDate', displayPublishedAtDate: 'SomePDate',
         displayResultsSentToPrescriberDate: 'SomeRDate',
       },
     ];
@@ -50,9 +50,8 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(4)`).hasText(displayDate + ' à ' + sessions[i].time);
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(5)`).hasText(sessions[i].displayStatus);
       assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(6)`).hasText(sessions[i].displayFinalizationDate);
-      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(7)`).hasText(sessions[i].countPublishedCertifications.toString());
-      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(8)`).hasText(sessions[i].displayPublishedAtDate);
-      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(9)`).hasText(sessions[i].displayResultsSentToPrescriberDate);
+      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(7)`).hasText(sessions[i].displayPublishedAtDate);
+      assert.dom(`table tbody tr:nth-child(${i + 1}) td:nth-child(8)`).hasText(sessions[i].displayResultsSentToPrescriberDate);
     }
     assert.dom('table tbody tr:nth-child(1) td:nth-child(3)').hasText(sessions[0].certificationCenter.type);
     assert.dom('table tbody tr:nth-child(2) td:nth-child(3)').hasText('-');
@@ -108,7 +107,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       await render(hbs`{{sessions/list-items triggerFiltering=triggerFiltering sessionResultsSentToPrescriberAtAndLabels=sessionResultsSentToPrescriberAtAndLabels}}`);
 
       // then
-      const option1 = find('table thead tr:nth-child(2) th:nth-child(9) select option:nth-child(1)');
+      const option1 = find('table thead tr:nth-child(2) th:nth-child(8) select option:nth-child(1)');
       assert.dom(option1).hasText('label1');
     });
 

--- a/admin/tests/unit/models/session-test.js
+++ b/admin/tests/unit/models/session-test.js
@@ -257,35 +257,6 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countPublishedCertifications', function() {
-
-    let sessionWithOnePublishedCertif;
-    let sessionWithNoPublishedCertif;
-
-    hooks.beforeEach(async function() {
-      sessionWithOnePublishedCertif = run(() => {
-        const certif = store.createRecord('certification', { isPublished: true });
-        return store.createRecord('session', { certifications: [certif] });
-      });
-
-      sessionWithNoPublishedCertif = run(() => {
-        const certif = store.createRecord('certification', { isPublished: false });
-        return store.createRecord('session', { certifications: [certif] });
-      });
-    });
-
-    test('it should count 1 published', function(assert) {
-      const countPublished = sessionWithOnePublishedCertif.countPublishedCertifications;
-      assert.equal(countPublished, 1);
-    });
-
-    test('it should count 0 published', function(assert) {
-      const countNonValidated = sessionWithNoPublishedCertif.countPublishedCertifications;
-      assert.equal(countNonValidated, 0);
-    });
-
-  });
-
   module('#displayDate', function() {
 
     test('it should display date without time properly', function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
A l'origine, la présence de cette colonne dans la googleSheet du pôle certification leur permettait de faire des stats (vu que googleSheet c'est un tableur, c'était facile).
Du coup, l'apparition de cette colonne dans PixAdmin n'a pas grand intérêt, d'autant que le besoin de réaliser cette statistique a été rempli via l'élaboration d'une requête sur Metabase.

## :robot: Solution
On la supprime !

## :rainbow: Remarques

## :100: Pour tester
Constater la disparition de la colonne
