### PR TITLE
[TECH] Utiliser .integer() sur les validations d'ID (PIX-591).

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -27,7 +27,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -43,6 +43,11 @@ exports.register = async (server) => {
       path: '/api/sessions/{id}/attendance-sheet',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         handler: sessionController.getAttendanceSheet,
         tags: ['api', 'sessions'],
         notes: [
@@ -69,7 +74,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -90,7 +95,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         payload: {
@@ -115,7 +120,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -137,7 +142,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -158,7 +163,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -179,8 +184,8 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required(),
-            certificationCandidateId: Joi.number().required(),
+            id: Joi.number().integer().required(),
+            certificationCandidateId: Joi.number().integer().required(),
           }),
         },
         pre: [{
@@ -199,6 +204,11 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/{id}/certifications',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         pre: [{
           method: securityController.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster'
@@ -217,7 +227,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -237,6 +247,11 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/sessions/{id}/candidate-participation',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         handler: sessionController.createCandidateParticipation,
         tags: ['api', 'sessions', 'certification-candidates'],
         notes: [
@@ -252,7 +267,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required(),
+            id: Joi.number().integer().required()
           }),
         },
         pre: [{
@@ -275,6 +290,11 @@ exports.register = async (server) => {
       method: 'PATCH',
       path: '/api/sessions/{id}/publication',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         pre: [{
           method: securityController.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
@@ -291,10 +311,16 @@ exports.register = async (server) => {
       method: 'PUT',
       path: '/api/sessions/{id}/results-sent-to-prescriber',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         pre: [{
           method: securityController.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+
         handler: sessionController.flagResultsAsSentToPrescriber,
         tags: ['api', 'sessions'],
         notes: [
@@ -308,6 +334,11 @@ exports.register = async (server) => {
       method: 'PATCH',
       path: '/api/sessions/{id}/certification-officer-assignment',
       config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         pre: [{
           method: securityController.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -17,12 +17,12 @@ exports.register = async function(server) {
               relationships: {
                 organization: {
                   data: {
-                    id: Joi.number().required(),
+                    id: Joi.number().integer().required(),
                   }
                 },
                 user: {
                   data: {
-                    id: Joi.number().required()
+                    id: Joi.number().integer().required()
                   }
                 }
               }
@@ -53,7 +53,7 @@ exports.register = async function(server) {
               relationships: {
                 organization: {
                   data: {
-                    id: Joi.number().required(),
+                    id: Joi.number().integer().required(),
                   }
                 }
               }
@@ -83,7 +83,7 @@ exports.register = async function(server) {
               relationships: {
                 organization: {
                   data: {
-                    id: Joi.number().required(),
+                    id: Joi.number().integer().required(),
                   }
                 }
               }

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -52,7 +52,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required(),
+            id: Joi.number().integer().required(),
           }),
           failAction: (request, h) => {
             const errorHttpStatusCode = 400;

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -4,7 +4,7 @@ const Joi = require('@hapi/joi')
 const { InvalidCertificationCandidate } = require('../errors');
 
 const certificationCandidateValidationJoiSchema_v1_1 = Joi.object({
-  id: Joi.number().optional(),
+  id: Joi.number().integer().optional(),
   firstName: Joi.string().required(),
   lastName: Joi.string().required(),
   birthCity: Joi.string().required(),
@@ -21,7 +21,7 @@ const certificationCandidateValidationJoiSchema_v1_1 = Joi.object({
 
 // Same as v1_1 but with email
 const certificationCandidateValidationJoiSchema_v1_2 = Joi.object({
-  id: Joi.number().optional(),
+  id: Joi.number().integer().optional(),
   firstName: Joi.string().required(),
   lastName: Joi.string().required(),
   birthCity: Joi.string().required(),

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -2,7 +2,7 @@ const Joi = require('@hapi/joi');
 const { ObjectValidationError } = require('../errors');
 
 const schemaValidateCompetenceMark = Joi.object({
-  id: Joi.number().optional(),
+  id: Joi.number().integer().optional(),
   level: Joi.number().integer().min(-1).max(8).required(),
   score: Joi.number().integer().min(0).max(64).required(),
   area_code: Joi.required(),

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -46,6 +46,28 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
 
     });
 
+    context('when session id is not an integer', () => {
+
+      beforeEach(() => {
+        options = {
+          method: 'POST',
+          url: '/api/sessions/2.1/candidate-participation',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+      });
+
+      it('should respond with a 400 - Bad Request', async () => {
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        expect(response.result.error).to.equal('Bad Request');
+      });
+
+    });
+
     context('when user is authenticated', () => {
       let sessionId;
 

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -21,7 +21,7 @@ describe('PATCH /api/sessions/:id/certification-officer-assignment', () => {
 
     it('should return a 403 error code', async () => {
       // given
-      options.url = '/api/sessions/any/certification-officer-assignment';
+      options.url = '/api/sessions/12/certification-officer-assignment';
       options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
 
       // when
@@ -44,15 +44,15 @@ describe('PATCH /api/sessions/:id/certification-officer-assignment', () => {
 
     context('when the session id has an invalid format', () => {
 
-      it('should return a 422 error code', async () => {
+      it('should return a 400 error code', async () => {
         // given
-        options.url = '/api/sessions/any/certification-officer-assignment';
+        options.url = '/api/sessions/test/certification-officer-assignment';
 
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(422);
+        expect(response.statusCode).to.equal(400);
       });
     });
 

--- a/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
@@ -21,7 +21,7 @@ describe('PUT /api/sessions/:id/results-sent-to-prescriber', () => {
 
     it('should return a 403 error code', async () => {
       // given
-      options.url = '/api/sessions/any/results-sent-to-prescriber';
+      options.url = '/api/sessions/12/results-sent-to-prescriber';
       options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
 
       // when
@@ -44,7 +44,7 @@ describe('PUT /api/sessions/:id/results-sent-to-prescriber', () => {
 
     context('when the session id has an invalid format', () => {
 
-      it('should return a 404 error code', async () => {
+      it('should return a 400 error code', async () => {
         // given
         options.url = '/api/sessions/any/results-sent-to-prescriber';
 
@@ -52,7 +52,7 @@ describe('PUT /api/sessions/:id/results-sent-to-prescriber', () => {
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(404);
+        expect(response.statusCode).to.equal(400);
       });
     });
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -79,7 +79,7 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/attendance-sheet' });
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/1/attendance-sheet' });
 
       expect(res.statusCode).to.equal(200);
     });
@@ -294,7 +294,7 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/sessions/{id}/certifications' });
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/1/certifications' });
       expect(res.statusCode).to.equal(200);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Sentry remontait régulièrement une erreur (https://sentry.io/organizations/pix/issues/1447539303/?project=1398749&query=is%3Aunresolved) indiquant : 
`select "certification-candidates".* from "certification-candidates" where "sessionId" = $1 and LOWER($2)=LOWER("firstName") and LOWER($3)=LOWER("lastName") and "birthdate" = $4 - invalid input syntax for integer: "2.1"`
Ce problème remonte car l'ID de session reçu par l'API peut être autre chose qu'un Integer

## :robot: Solution
- Utiliser la validation Joi sur la route qui pose problème
- Vérifier que l'id est bien un nombre et un entier. 

## :rainbow: Remarques
- Les vérifications existantes utilisaient souvent `Joi.number()` seulement. Malheureusement, cela laisse passer les id comme "2.1". L'ajout de `.integer()` permet de préciser que l'on souhaite un entier