### PR TITLE
[FEATURE] Création d'une page pour afficher la nouvelle version des cgus Pix. (PF-998)

### DIFF
--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -63,6 +63,8 @@ Router.map(function() {
     this.route('resume', { path: '/evaluer' });
   });
 
+  this.route('terms-of-service', { path: '/cgu' });
+
   // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE
   this.route('not-found', { path: '/*path' });
 });

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRouteMixin) {
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -102,6 +102,7 @@
 @import 'pages/send-profile';
 @import 'pages/sign-form';
 @import 'pages/skill-review';
+@import 'pages/terms-of-service';
 @import 'pages/update-expired-password-form';
 @import 'pages/user-certifications';
 @import 'pages/user-certifications-get';

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -1,0 +1,64 @@
+.terms-of-service-page {
+  display: flex;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  background: $pix-blue-to-purple-gradient;
+
+}
+
+.terms-of-service-form {
+  margin: auto;
+  padding: 40px 32px;
+  background: white;
+  border-radius: 8px;
+  max-width: 580px;
+
+  &__logo {
+    margin-bottom: 24px;
+
+    & img {
+      display: flex;
+      margin: auto;
+    }
+
+  }
+
+  &__title, &__description, &__conditions {
+    margin-bottom: 30px;
+    text-align: center;
+    color: $grey-80;
+    font-family: $font-roboto;
+    font-size: 1.5rem;
+    font-weight: normal;
+
+  }
+
+  &__title {
+    font-weight: 300;
+    font-size: 2.5rem;
+  }
+
+  &__conditions {
+    font-weight: normal;
+    font-size: 1.4rem;
+    letter-spacing: 0.015rem;
+    text-align: center;
+
+  }
+
+  &__actions {
+    margin-bottom: 30px;
+    text-align: center;
+  }
+}
+
+.terms-of-service-form-conditions {
+
+  &__check {
+    margin-right: 8px;
+  }
+}
+
+
+

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -1,0 +1,26 @@
+<div class="terms-of-service-page">
+  <div class="terms-of-service-form">
+
+    <div class="terms-of-service-form__logo">
+      <a href={{urlHome}} title="Page d'accueil">
+        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+      </a>
+    </div>
+
+    <h2 class="terms-of-service-form__title">Conditions d'utilisation</h2>
+
+    <div class="terms-of-service-form__description">
+      Nous avons mis à jour nos conditions d'utilisation.
+    </div>
+
+    <div class="terms-of-service-form__conditions">
+      <label for="pix-cgu">
+        <Input @type="checkbox" @id="pix-cgu" class="terms-of-service-form-conditions__check"/>
+        J'accepte les <a href="https://pix.fr/conditions-generales-d-utilisation" class="link" target="_blank">conditions
+        d'utilisation de Pix</a>
+      </label>
+    </div>
+
+  </div>
+
+</div>

--- a/mon-pix/tests/acceptance/terms-of-service-test.js
+++ b/mon-pix/tests/acceptance/terms-of-service-test.js
@@ -1,0 +1,21 @@
+import {  describe, it } from 'mocha';
+import { currentURL } from '@ember/test-helpers';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import visit from '../helpers/visit';
+
+describe('Acceptance | terms-of-service', function() {
+  setupApplicationTest();
+  setupMirage();
+
+  it('should be redirect to login page when user is not authenticated', async function() {
+
+    // when
+    await visit('/cgu');
+
+    // then
+    expect(currentURL()).to.equal('/connexion');
+
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les conditions d'utilisations de Pix App ont évolués. Il faut donc les faire accepter par les utilisateurs.

## :robot: Solution
Une nouvelle page qui va informer l'utilisateur de valider les nouvelles conditions d'utilisations.
Les conditions sont affichées sous forme de redirection vers un lien vers Prismic.

## :rainbow: Remarques
Cette PR ne concerne que la partie graphique. Un autre PR va suivre pour enrichir la partie navigation.

## :100: Pour tester
Aller vers la nouvelle route {Pix App url}/cgu
