### PR TITLE
[FEATURE] Ajout d'une bannière spécifique à l'envoi de profil (PIX-568).

### DIFF
--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -19,13 +19,14 @@ export default class ResumeCampaignBanner extends Component {
   }
 
   @computed(
-    'lastUnsharedCampaignParticipation.campaign.{title,code},lastUnsharedCampaignParticipation.assessment.isCompleted'
+    'lastUnsharedCampaignParticipation.campaign.{title,code,isTypeAssessment},lastUnsharedCampaignParticipation.assessment.isCompleted'
   )
-  get campaignToResumeOrShare() {
+  get campaignParticipationState() {
     if (this.lastUnsharedCampaignParticipation) {
       return {
         title: this.lastUnsharedCampaignParticipation.campaign.get('title'),
         code: this.lastUnsharedCampaignParticipation.campaign.get('code'),
+        isTypeAssessment: this.lastUnsharedCampaignParticipation.campaign.get('isTypeAssessment'),
         assessment: this.lastUnsharedCampaignParticipation.assessment
       };
     }

--- a/mon-pix/app/templates/components/resume-campaign-banner-assessment.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner-assessment.hbs
@@ -1,0 +1,15 @@
+{{#if @isCompleted}}
+  {{#if @title}}
+    <span class="resume-campaign-banner__title">Parcours "{{@title}}" terminé. N'oubliez pas de finaliser votre envoi !</span>
+  {{else}}
+    <span class="resume-campaign-banner__title">N'oubliez pas de finaliser votre envoi !</span>
+  {{/if}}
+  <LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>
+{{else}}
+  {{#if @title}}
+    <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{@title}}"</span>
+  {{else}}
+    <span class="resume-campaign-banner__title">Vous n'avez pas terminé votre parcours</span>
+  {{/if}}
+  <LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">Reprendre</LinkTo>
+{{/if}}

--- a/mon-pix/app/templates/components/resume-campaign-banner-collect-profile.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner-collect-profile.hbs
@@ -1,0 +1,2 @@
+<span class="resume-campaign-banner__title">N'oubliez pas de finaliser votre envoi !</span>
+<LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>

--- a/mon-pix/app/templates/components/resume-campaign-banner.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner.hbs
@@ -1,19 +1,13 @@
-{{#if campaignToResumeOrShare}}
+{{#if campaignParticipationState}}
   <div class="resume-campaign-banner__container">
-    {{#if campaignToResumeOrShare.assessment.isCompleted}}
-      {{#if campaignToResumeOrShare.title}}
-        <span class="resume-campaign-banner__title">Parcours "{{campaignToResumeOrShare.title}}" terminé ! Envoyez vos résultats.</span>
-      {{else}}
-        <span class="resume-campaign-banner__title">Parcours terminé ! Envoyez vos résultats.</span>
-      {{/if}}
-      <LinkTo @route="campaigns.start-or-resume" @model={{campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>
+    {{#if campaignParticipationState.isTypeAssessment}}
+      <ResumeCampaignBannerAssessment
+        @isCompleted={{campaignParticipationState.assessment.isCompleted}}
+        @title={{campaignParticipationState.title}}
+        @code={{campaignParticipationState.code}}
+      />
     {{else}}
-      {{#if campaignToResumeOrShare.title}}
-        <span class="resume-campaign-banner__title">Vous n'avez pas terminé le parcours "{{campaignToResumeOrShare.title}}"</span>
-      {{else}}
-        <span class="resume-campaign-banner__title">Vous n'avez pas terminé votre parcours</span>
-      {{/if}}
-      <LinkTo @route="campaigns.start-or-resume" @model={{campaignToResumeOrShare.code}} class="resume-campaign-banner__button button button--big button--link">Reprendre</LinkTo>
+      <ResumeCampaignBannerCollectProfile @code={{campaignParticipationState.code}} />
     {{/if}}
   </div>
 {{/if}}

--- a/mon-pix/tests/acceptance/profile-test.js
+++ b/mon-pix/tests/acceptance/profile-test.js
@@ -67,71 +67,88 @@ describe('Acceptance | Profile', function() {
       expect(currentURL()).to.equal(`/competences/${scorecard.competenceId}/details`);
     });
 
-    context('when user has not completed the campaign', () => {
+    context('when user is doing a campaign of type assessment', function() {
+      context('when user has not completed the campaign', () => {
 
-      it('should display a resume campaign banner for a campaign with no title', async function() {
-        // given
-        const campaign = server.create('campaign', { isArchived: false });
-        server.create('campaign-participation',
-          { campaign, user, isShared: false , createdAt: Date.now() });
+        it('should display a resume campaign banner for a campaign with no title', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, type: 'ASSESSMENT' });
+          server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
 
-        // when
-        await visit('/');
+          // when
+          await visit('/');
 
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
-        expect(find('.resume-campaign-banner__container').textContent).to.contain('Vous n\'avez pas terminé votre parcours');
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+          // then
+          expect(find('.resume-campaign-banner__container').textContent).to.contain('Vous n\'avez pas terminé votre parcours');
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+        });
+
+        it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle', type: 'ASSESSMENT' });
+          server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+
+          // when
+          await visit('/');
+
+          // then
+          expect(find('.resume-campaign-banner__container').textContent).to.contain(`Vous n'avez pas terminé le parcours "${campaign.title}"`);
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+        });
       });
 
-      it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
-        // given
-        const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle' });
-        server.create('campaign-participation',
-          { campaign, user, isShared: false , createdAt: Date.now() });
+      context('when user has completed the campaign but not shared', () => {
 
-        // when
-        await visit('/');
+        it('should display a resume campaign banner for a campaign with no title', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, type: 'ASSESSMENT' });
+          const campaignParticipation = server.create('campaign-participation', 
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+          campaignParticipation.assessment.update({ state: 'completed' });
 
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
-        expect(find('.resume-campaign-banner__container').textContent).to.contain(`Vous n'avez pas terminé le parcours "${campaign.title}"`);
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+          // when
+          await visit('/');
+
+          // then
+          expect(find('.resume-campaign-banner__container').textContent).to.contain('N\'oubliez pas de finaliser votre envoi !');
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+        });
+
+        it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle', type: 'ASSESSMENT' });
+          const campaignParticipation = server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+          campaignParticipation.assessment.update({ state: 'completed' });
+
+          // when
+          await visit('/');
+
+          // then
+          expect(find('.resume-campaign-banner__container').textContent).to.contain(`Parcours "${campaign.title}" terminé. N'oubliez pas de finaliser votre envoi !`);
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+        });
       });
     });
 
-    context('when user has completed the campaign but not shared', () => {
+    context('when user is doing a campaign of type collect profile', function() {
+      context('when user has not shared the collect profile campaign', () => {
+        it('should display a resume campaign banner for the campaign', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle', type: 'PROFILES_COLLECTION' });
+          const campaignParticipation = server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+          campaignParticipation.assessment.update({ state: 'completed' });
 
-      it('should display a resume campaign banner for a campaign with no title', async function() {
-        // given
-        const campaign = server.create('campaign', { isArchived: false });
-        const campaignParticipation = server.create('campaign-participation', 
-          { campaign, user, isShared: false , createdAt: Date.now() });
-        campaignParticipation.assessment.update({ state: 'completed' });
+          // when
+          await visit('/');
 
-        // when
-        await visit('/');
-
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
-        expect(find('.resume-campaign-banner__container').textContent).to.contain('Parcours terminé ! Envoyez vos résultats.');
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
-      });
-
-      it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
-        // given
-        const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle' });
-        const campaignParticipation = server.create('campaign-participation',
-          { campaign, user, isShared: false , createdAt: Date.now() });
-        campaignParticipation.assessment.update({ state: 'completed' });
-
-        // when
-        await visit('/');
-
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
-        expect(find('.resume-campaign-banner__container').textContent).to.contain(`Parcours "${campaign.title}" terminé ! Envoyez vos résultats.`);
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          // then
+          expect(find('.resume-campaign-banner__container').textContent).to.contain('N\'oubliez pas de finaliser votre envoi !');
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -15,7 +15,8 @@ describe('Integration | Component | resume-campaign-banner', function() {
       createdAt: '2019-09-30T12:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
-        title: 'Parcours Pix'
+        title: 'Parcours Pix',
+        isTypeAssessment: true,
       })
     });
     const oldCampaignNotFinished = EmberObject.create({
@@ -23,6 +24,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
       createdAt: '2019-09-30T10:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
+        isTypeAssessment: true,
       })
     });
     const campaignFinished = EmberObject.create({
@@ -30,146 +32,172 @@ describe('Integration | Component | resume-campaign-banner', function() {
       createdAt: '2019-09-30T14:30:00Z',
       campaign: EmberObject.create({
         code: 'AZERTY',
+        isTypeAssessment: true,
       }),
       assessment: EmberObject.create({
         isCompleted: true,
       }),
     });
 
-    context('when campaign is not finished and not shared', function() {
+    context('when campaign has type assessment', function() {
 
-      it('should display the resume campaign banner', async function() {
-        // given
-        this.set('campaignParticipations', [campaignToResume, oldCampaignNotFinished, campaignFinished]);
+      context('when campaign is not finished and not shared', function() {
 
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
+        it('should display the resume campaign banner', async function() {
+          // given
+          this.set('campaignParticipations', [campaignToResume, oldCampaignNotFinished, campaignFinished]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__container')).to.exist;
+        });
+  
+        it('should display a link to resume the campaign', async function() {
+          // given
+          this.set('campaignParticipations', [campaignToResume]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+        });
+  
+        it('should display a sentence to ask user to resume with the title of campaign', async function() {
+          // given
+          this.set('campaignParticipations', [campaignToResume]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
+        });
+  
+        it('should display a simple sentence to ask user to resume when campaign has no title', async function() {
+          // given
+          campaignToResume.campaign.set('title', null);
+          this.set('campaignParticipations', [campaignToResume]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__title').textContent).to.equal('Vous n\'avez pas terminé votre parcours');
+        });
+  
+      });
+  
+      context('when campaign is finished but not shared', function() {
+  
+        const campaignFinishedButNotShared = EmberObject.create({
+          isShared: false,
+          createdAt: '2019-09-30T10:30:00Z',
+          campaign: EmberObject.create({
+            code: 'AZERTY',
+            title: 'Parcours Pix',
+            isTypeAssessment: true,
+          }),
+          assessment: EmberObject.create({
+            isCompleted: true,
+          }),
+        });
+  
+        it('should display the resume campaign banner', async function() {
+          // given
+          this.set('campaignParticipations', [oldCampaignNotFinished, campaignFinished, campaignFinishedButNotShared]);
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+          // then
+          expect(find('.resume-campaign-banner__container')).to.exist;
+        });
+  
+        it('should display a link to shared the results', async function() {
+          // given
+          this.set('campaignParticipations', [campaignFinishedButNotShared]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+        });
+  
+        it('should display a sentence to ask user to share his results with the title of campaign', async function() {
+          // given
+          this.set('campaignParticipations', [campaignFinishedButNotShared]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(`Parcours "${campaignFinishedButNotShared.campaign.title}" terminé. N'oubliez pas de finaliser votre envoi !`);
+        });
+  
+        it('should display a simple sentence to ask user to share his results when campaign has no title', async function() {
+          // given
+          campaignFinishedButNotShared.campaign.set('title', null);
+          this.set('campaignParticipations', [campaignFinishedButNotShared]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
+        });
+      });
+  
+      context('when campaign is finished and shared', function() {
+  
+        it('should not display the resume campaign banner when the list of campaigns contains only finished campaign', async function() {
+          // given
+          this.set('campaignParticipations', [campaignFinished]);
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+          // then
+          expect(find('.resume-campaign-banner__container')).to.not.exist;
+        });
       });
 
-      it('should display a link to resume the campaign', async function() {
-        // given
-        this.set('campaignParticipations', [campaignToResume]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__button')).to.exist;
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
-      });
-
-      it('should display a sentence to ask user to resume with the title of campaign', async function() {
-        // given
-        this.set('campaignParticipations', [campaignToResume]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__title')).to.exist;
-        expect(find('.resume-campaign-banner__title').textContent).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
-      });
-
-      it('should display a simple sentence to ask user to resume when campaign has no title', async function() {
-        // given
-        campaignToResume.campaign.set('title', null);
-        this.set('campaignParticipations', [campaignToResume]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__title')).to.exist;
-        expect(find('.resume-campaign-banner__title').textContent).to.equal('Vous n\'avez pas terminé votre parcours');
-      });
-
-    });
-
-    context('when campaign is finished but not shared', function() {
-
-      const campaignFinishedButNotShared = EmberObject.create({
-        isShared: false,
-        createdAt: '2019-09-30T10:30:00Z',
-        campaign: EmberObject.create({
-          code: 'AZERTY',
-          title: 'Parcours Pix'
-        }),
-        assessment: EmberObject.create({
-          isCompleted: true,
-        }),
-      });
-
-      it('should display the resume campaign banner', async function() {
-        // given
-        this.set('campaignParticipations', [oldCampaignNotFinished, campaignFinished, campaignFinishedButNotShared]);
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-        // then
-        expect(find('.resume-campaign-banner__container')).to.exist;
-      });
-
-      it('should display a link to shared the results', async function() {
-        // given
-        this.set('campaignParticipations', [campaignFinishedButNotShared]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__button')).to.exist;
-        expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
-      });
-
-      it('should display a sentence to ask user to share his results with the title of campaign', async function() {
-        // given
-        this.set('campaignParticipations', [campaignFinishedButNotShared]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__title')).to.exist;
-        expect(find('.resume-campaign-banner__title').textContent).to.equal(`Parcours "${campaignFinishedButNotShared.campaign.title}" terminé ! Envoyez vos résultats.`);
-      });
-
-      it('should display a simple sentence to ask user to share his results when campaign has no title', async function() {
-        // given
-        campaignFinishedButNotShared.campaign.set('title', null);
-        this.set('campaignParticipations', [campaignFinishedButNotShared]);
-
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-
-        // then
-        expect(find('.resume-campaign-banner__title')).to.exist;
-        expect(find('.resume-campaign-banner__title').textContent).to.equal('Parcours terminé ! Envoyez vos résultats.');
-      });
-    });
-
-    context('when campaign is finished and shared', function() {
-
-      it('should not display the resume campaign banner when the list of campaigns contains only finished campaign', async function() {
-        // given
-        this.set('campaignParticipations', [campaignFinished]);
-        // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
-        // then
-        expect(find('.resume-campaign-banner__container')).to.not.exist;
-      });
     });
 
     context('when campaign is not started yet', function() {
-
+  
       it('should not display the resume campaign banner when the list of campaigns is empty', async function() {
         // given
         this.set('campaignParticipations', []);
         // when
-        await render(hbs`{{resume-campaign-banner campaignParticipations=campaignParticipations}}`);
+        await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
         // then
         expect(find('.resume-campaign-banner__container')).to.not.exist;
+      });
+    });
+
+    context('when campaign has type collect profiles', function() {
+      context('when campaign is not shared', function() {
+  
+        const campaignCollectNotShared = EmberObject.create({
+          isShared: false,
+          createdAt: '2019-09-30T14:30:00Z',
+          campaign: EmberObject.create({
+            code: 'AZERTY',
+            isTypeAssessment: false,
+          }),
+        });
+  
+        it('should display the resume campaign banner', async function() {
+          // given
+          this.set('campaignParticipations', [campaignCollectNotShared]);
+  
+          // when
+          await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+  
+          // then
+          expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
+        });
+  
       });
     });
 

--- a/mon-pix/tests/unit/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/unit/components/resume-campaign-banner-test.js
@@ -15,6 +15,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     createdAt: '2018-01-01',
     campaign: EmberObject.create({
       code: 'AZERTY0',
+      isTypeAssessment: true,
     })
   });
   const oldCampaignNotFinished = EmberObject.create({
@@ -22,6 +23,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     createdAt: '2017-01-01',
     campaign: EmberObject.create({
       code: 'AZERTY1',
+      isTypeAssessment: true,
     })
   });
   const campaignFinished = EmberObject.create({
@@ -29,6 +31,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     createdAt: '2018-12-12',
     campaign: EmberObject.create({
       code: 'AZERTY2',
+      isTypeAssessment: true,
     }),
     assessment: EmberObject.create({
       isCompleted: true,
@@ -39,6 +42,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     createdAt: '2017-12-12',
     campaign: EmberObject.create({
       code: 'AZERTY3',
+      isTypeAssessment: true,
     }),
     assessment: EmberObject.create({
       isCompleted: true,
@@ -49,7 +53,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     component = this.owner.lookup('component:resume-campaign-banner');
   });
 
-  describe('#campaignToResumeOrShare', function() {
+  describe('#campaignParticipationState', function() {
     it('should return the most recent campaign among campaigns not finished and not shared', function() {
       // given
       const listCampaignParticipations = [oldCampaignNotFinished, campaignNotFinished];
@@ -58,14 +62,15 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       const expectedResult = {
         title: campaignNotFinished.campaign.title,
         code: campaignNotFinished.campaign.code,
+        isTypeAssessment: true,
         assessment: campaignNotFinished.assessment
       };
 
       // when
-      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+      const campaignParticipationState = component.get('campaignParticipationState');
 
       // then
-      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+      expect(campaignParticipationState).to.deep.equal(expectedResult);
     });
 
     it('should return the most recent campaign among campaigns not finished and not shared dynamically', function() {
@@ -74,12 +79,13 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       component.set('campaignParticipations', participations);
 
       // then
-      expect(component.get('campaignToResumeOrShare')).to.equal(null);
+      expect(component.get('campaignParticipationState')).to.equal(null);
 
       // when
       const updatableCampaignNotFinished = EmberObject.create({
         isShared: false,
         createdAt: '2018-01-01',
+        isTypeAssessment: true,
         campaign: EmberObject.create({
           code: 'AZERTY0',
         })
@@ -88,11 +94,11 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       participations.addObject(updatableCampaignNotFinished);
 
       // then
-      expect(component.get('campaignToResumeOrShare').code).to.equal('AZERTY0');
+      expect(component.get('campaignParticipationState').code).to.equal('AZERTY0');
 
       updatableCampaignNotFinished.set('createdAt', '2000-05-13');
 
-      expect(component.get('campaignToResumeOrShare').code).to.equal(oldCampaignNotFinished.campaign.code);
+      expect(component.get('campaignParticipationState').code).to.equal(oldCampaignNotFinished.campaign.code);
     });
 
     it('should return the most recent campaign among campaigns not shared', function() {
@@ -102,14 +108,15 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       const expectedResult = {
         title: campaignFinishedButNotShared.campaign.title,
         code: campaignFinishedButNotShared.campaign.code,
+        isTypeAssessment: true,
         assessment: campaignFinishedButNotShared.assessment
       };
 
       // when
-      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+      const campaignParticipationState = component.get('campaignParticipationState');
 
       // then
-      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+      expect(campaignParticipationState).to.deep.equal(expectedResult);
     });
 
     it('should return the only campaign not finished or not shared', function() {
@@ -119,14 +126,15 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       const expectedResult = {
         title: campaignFinishedButNotShared.campaign.title,
         code: campaignFinishedButNotShared.campaign.code,
+        isTypeAssessment: true,
         assessment: campaignFinishedButNotShared.assessment
       };
 
       // when
-      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+      const campaignParticipationState = component.get('campaignParticipationState');
 
       // then
-      expect(campaignToResumeOrShare).to.deep.equal(expectedResult);
+      expect(campaignParticipationState).to.deep.equal(expectedResult);
     });
 
     it('should return null when all campaign are finished', function() {
@@ -135,10 +143,10 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       component.set('campaignParticipations', listCampaignParticipations);
 
       // when
-      const campaignToResumeOrShare = component.get('campaignToResumeOrShare');
+      const campaignParticipationState = component.get('campaignParticipationState');
 
       // then
-      expect(campaignToResumeOrShare).to.equal(null);
+      expect(campaignParticipationState).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Quand un utilisateur n'a pas envoyé son profil pour une collecte de profil, il voit une bannière spécifique au campagne d'évaluation.

## :robot: Solution
Faire un bannière dédié à la campagne de collecte de profil avec la phrase suivante:
> N'oubliez pas de finaliser votre envoi !

## :rainbow: Remarques
On en profite pour rendre les phrases des campagnes d'évaluation semblable à la phrase des collectes de profils: 
- Pour une campagne d'évaluation sans titre:
> N'oubliez pas de finaliser votre envoi !

- Pour une campagne d'évaluation avec titre:
> Parcours TITRE DU PARCOURS terminé. N'oubliez pas de finaliser votre envoi !

## :100: Pour tester
1. Se connecter sur mon pix
2. Démarrer une campagne de collecte (code: SNAP123)
3. Cliquer sur "c'est parti"
4. Revenir sur la page principal de mon pix
5. La bannière apparait avec "N'oubliez pas de finaliser votre envoi !"