### PR TITLE
[BUGFIX] Export CSV d'une campagne, ne pas mettre l'id externe quand la campagne n'en a pas (PIX-592).

### DIFF
--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -89,7 +89,7 @@ class CampaignAssessmentCsvLine {
       this.targetProfile.name,
       participantLastName,
       participantFirstName,
-      this.campaign.idPixLabel ? this.campaignParticipationResultData.participantExternalId : EMPTY_CONTENT,
+      ...(this.campaign.idPixLabel ? [this.campaignParticipationResultData.participantExternalId] : []),
       this.campaignParticipationService.progress(this.campaignParticipationResultData.isCompleted, this.knowledgeElements.length, this.targetProfile.skills.length),
       moment.utc(this.campaignParticipationResultData.createdAt).format('YYYY-MM-DD'),
       this.isShared ? 'Oui' : 'Non',

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -454,6 +454,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     });
 
     context('when campaign do not have a idPixLabel', () => {
+      let campaignWithoutIdPixLabel;
 
       beforeEach(() => {
         const campaignParticipationResultData = {
@@ -463,11 +464,12 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           userId: 123,
           participantFirstName: user.firstName,
           participantLastName: user.lastName,
+          isCompleted: true,
         };
 
         findAssessmentResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
 
-        const campaignWithoutIdPixLabel = domainBuilder.buildCampaign.ofTypeAssessment({
+        campaignWithoutIdPixLabel = domainBuilder.buildCampaign.ofTypeAssessment({
           name: 'CampaignName',
           code: 'AZERTY123',
           organizationId: organization.id,
@@ -476,9 +478,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
         campaignRepository.get.resolves(campaignWithoutIdPixLabel);
       });
 
-      it('should return the header in CSV styles with all competence, domain and skills', async () => {
+      it('should return the header and the data in CSV styles with all competence, domain and skills', async () => {
         // given
-        const csvExpected = '\uFEFF"Nom de l\'organisation";' +
+        const csvHeadersExpected =
+          '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
           '"Nom de la campagne";' +
           '"Nom du Profil Cible";' +
@@ -501,6 +504,30 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
           '"\'@web4";' +
           '"\'@web5"';
 
+        const csvDataExpected =
+          `"${organization.name}";` +
+          `${campaignWithoutIdPixLabel.id};` +
+          `"${campaignWithoutIdPixLabel.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${user.lastName}";` +
+          `"'${user.firstName}";` +
+          '1;' +
+          '2019-02-25;' +
+          '"Non";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA"';
+
         // when
         startWritingCampaignAssessmentResultsToStream({
           userId: user.id,
@@ -520,7 +547,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
         const csvLines = csv.split('\n');
 
         // then
-        expect(csvLines[0]).to.equal(csvExpected);
+        expect(csvLines[0]).to.equal(csvHeadersExpected);
+        expect(csvLines[1]).to.equal(csvDataExpected);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Certaines campagnes n'ont pas d'id externe.
L'export CSV de campagnes d'évaluation actuel ne met pas l'entête `id externe` mais exporte une donnée `NA`.
Cela entraîne un décalage entre les entêtes et les données.
## :robot: Solution
Ne pas ajouter la donnée `NA` pour les campagnes d'évaluation sans id externe.

## :rainbow: Remarques
RAS

## :100: Pour tester
Exporter une campagne d'évaluation sans id externe.
Vérifier qu'il n'y a pas de décalage entre les entêtes et les données.