### PR TITLE
[FEATURE] Ajout d'un lien vers la documentation pour les utilisateurs d'organisations pro (PIX-565).

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -1,6 +1,20 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default class SidebarMenu extends Component {
   @service currentUser;
+
+  @computed('currentUser.organization')
+  get documentationUrl() {
+    if (this.currentUser.isSCOManagingStudents) {
+      return 'https://bit.ly/ressourcespixorga';
+    }
+
+    if (this.currentUser.organization.isPro) {
+      return 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4';
+    }
+
+    return null;
+  }
 }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -17,4 +17,5 @@ export default class Organization extends Model {
   @hasMany('student') students;
 
   @equal('type', 'SCO') isSco;
+  @equal('type', 'PRO') isPro;
 }

--- a/orga/app/templates/components/sidebar-menu.hbs
+++ b/orga/app/templates/components/sidebar-menu.hbs
@@ -12,9 +12,9 @@
       Élèves
     </LinkTo>
   {{/if}}
-  {{#if this.currentUser.isSCOManagingStudents}}
+  {{#if this.documentationUrl}}
     <div class="sidebar-menu__documentation-item">
-      <a class="sidebar-menu-documentation-item__button" href="https://bit.ly/ressourcespixorga"
+      <a class="sidebar-menu-documentation-item__button" href={{this.documentationUrl}}
          target="_blank" rel="noopener noreferrer">
         <div class="sidebar-menu-documentation-item__bar"></div>
         <FaIcon @icon='book' @class="sidebar--padding-right sidebar--item-icon "></FaIcon>

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+module('Integration | Component | sidebar-menu', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let user;
+  hooks.beforeEach(function() {
+    user = Object.create({
+      firstName: 'givenFirstName',
+      lastName: 'givenLastName',
+    });
+  });
+
+  test('it should display documentation a pro organization', async function(assert) {
+    const organization = Object.create({ id: 1, isPro: true });
+    this.owner.register('service:current-user', Service.extend({ user, organization }));
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('a[href="https://cloud.pix.fr/s/cwZN2GAbqSPGnw4"]').exists();
+  });
+
+  test('it should display documentation a sco organization', async function(assert) {
+    const organization = Object.create({ id: 1, type: 'SCO' });
+    this.owner.register('service:current-user', Service.extend({ user, organization, isSCOManagingStudents: true }));
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('a[href="https://bit.ly/ressourcespixorga"]').exists();
+  });
+
+  test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
+    const organization = Object.create({ id: 1, type: 'SCO' });
+    this.owner.register('service:current-user', Service.extend({ user, organization, isSCOManagingStudents: false }));
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('.sidebar-menu__documentation-item').doesNotExist();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs d'organisations pro disposent d'une documentation cependant elle n'est pas accessible depuis PixOrga.

## :robot: Solution
Ajout d'un lien vers la documentation dans la sidebar pour les utilisateurs d'organisations pro.

## :100: Pour tester
Se connecter avec l'utilisateur `pro@example.net` et constater la présence d'un lien vers la documentation en bas de la sidebar.
