### PR TITLE
[FEATURE] Ajustements des marges suite à l'introduction du bouton 'J'ai un code' (PIX-xxx).

### DIFF
--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -13,15 +13,15 @@
 .navbar-desktop-header-container {
   &__menu {
     display: flex;
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: 68px;
+    margin-right: 20px;
   }
 }
 
 .navbar-desktop-header-menu {
   &__item {
-    margin-left: 23.3px;
-    margin-right: 23.3px;
+    margin-left: 20px;
+    margin-right: 20px;
     padding-top: 5px;
     padding-bottom: 5px;
     font-size: 1.6rem;
@@ -73,6 +73,6 @@
   }
 
   &__marianne {
-    margin-left: 16px;
+    margin-left: 24px;
   }
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -10,7 +10,7 @@
 
   &__title {
     text-align: center;
-    margin-bottom: 42px;
+    margin-bottom: 32px;
   }
 
   &__instruction {
@@ -19,7 +19,7 @@
     font-size: 1.95rem;
     text-align: center;
     font-weight: $font-light;
-    margin-bottom: 8px;
+    margin-bottom: 16px;
   }
 
   &__form-field {
@@ -71,7 +71,7 @@
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
-    height: 130px;
+    height: 118px;
     margin-bottom: 30px;
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Suite au changement de la navigation de pix app (ajout du bouton `J'ai un code`), certaines marges ne respectent pas la maquette.

## :robot: Solution
Modifier les marges comme demandé par @QuentinChapelain-ui .

## :rainbow: Remarques
Notre accès JIRA étant en vrac, nous n'avons pas encore le numéro de ticket.
On changera le nom de la PR dès son retour.

**Capture d'écran avant**

<img width="1131" alt="Screenshot 2020-04-29 at 13 31 17" src="https://user-images.githubusercontent.com/2989532/80591523-23a6b000-8a1e-11ea-96a5-66a2cf0e8a5d.png">


**Capture d'écran après**

<img width="1104" alt="Screenshot 2020-04-29 at 13 33 09" src="https://user-images.githubusercontent.com/2989532/80591532-2903fa80-8a1e-11ea-98d5-c035dac822f3.png">


## :100: Pour tester
Se rendre sur pix app et vérifier les margins, tels que mentionnées dans le ticket.

> margin entre logo Pix et marianne de 24px et non 16
> margin entre le logo Marianne et label “profil” 88 px
> margin entre les labels de la nav de 40 px margin de 40 px entre « Aide » et j’ai un code margin entre saisissez un code et sous-titre ” Ce code...” de 32 px
> margin entre le code de saisie et le bouton de 16px