### PR TITLE
[INFRA] Corriger le démarrage des apps pour les tests Cypress en local (PIX-596).

### DIFF
--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -26,9 +26,9 @@
     "db:empty": "cd ../../api && npm run db:empty",
     "db:initialize": "cd ../../api && npm run db:prepare",
     "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
-    "start:mon-pix": "cd ../../mon-pix && npx ember serve --proxy",
-    "start:orga": "cd ../../orga && npx ember serve --proxy",
-    "start:certif": "cd ../../certif && npx ember serve --proxy"
+    "start:mon-pix": "cd ../../mon-pix && npm start",
+    "start:orga": "cd ../../orga && npm start",
+    "start:certif": "cd ../../certif && npm start"
   },
   "devDependencies": {
     "cypress": "4.3.0",


### PR DESCRIPTION
## :unicorn: Problème
La PR #1326 a affiné notre utilisation de `npm start` en développement mais les commandes de lancement automatique de cypress sont devenues obsolètes. 

## :robot: Solution
Ajouter le localhost aux composants des commandes de lancement automatique dans cypress.

## :100: Pour tester
Lancer les tests cypress en utilisant notamment la commande `npm run cy:test:open:local`
