### PR TITLE
[FEATURE] Changer le texte du loader de campagne dans pix-app  (PIX-572)

### DIFF
--- a/mon-pix/app/templates/campaigns/loading.hbs
+++ b/mon-pix/app/templates/campaigns/loading.hbs
@@ -1,6 +1,6 @@
 <div class="app-loader">
   <p class="app-loader__image"><img src="/images/interwind.gif"></p>
   <p class="app-loader__text">
-    Votre test est en cours de chargement...
+    En cours de chargement…
   </p>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Quand on démarre une campagne de collecte de profil on a le texte suivant dans le loader:
"Test en cours de chargement..." ce qui n'est pas correct pour une campagne de collecte de profil.

## :robot: Solution
Mettre le même texte pour les campagnes de collecte de profil et d'évaluation dans la loader:
"En cours de chargement..."

## :100: Pour tester
Dans Pix-app saisir le code de campagne d'évaluation AZERTY123
> Le loader apparaît avec le texte "En cours de chargement..."

Dans Pix-app saisir le code de campagne d'évaluation SNAP123
> Le loader apparaît avec le texte "En cours de chargement..."