### PR TITLE
[FEATURE] Changer les messages d'erreur à la saisie de code campagne (PIX-573).

### DIFF
--- a/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
@@ -12,32 +12,31 @@ export default class FillInCampaignCodeController extends Controller {
 
   @action
   async startCampaign() {
-    this.set('errorMessage', null);
+    this.clearErrorMessage();
 
     if (!this.campaignCode) {
-      this.set('errorMessage', 'Merci de renseigner le code du parcours.');
-
-    } else {
-      const campaignCode = this.campaignCode.toUpperCase();
-
-      const campaignCodeExists = await this.store.query('campaign', { filter: { code: campaignCode } })
-        .then(() => true,
-          (error) => {
-            if (error.errors[0].status === '403') {
-              this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
-              return false;
-            }
-            if (error.errors[0].status === '404') {
-              this.set('errorMessage', 'Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
-              return false;
-            }
-            throw (error);
-          });
-
-      if (campaignCodeExists) {
-        return this.transitionToRoute('campaigns.start-or-resume', campaignCode);
-      }
+      this.set('errorMessage', 'Veuillez saisir un code.');
+      return;
     }
+  
+    const campaignCode = this.campaignCode.toUpperCase();
+    try {
+      await this.store.query('campaign', { filter: { code: campaignCode } });
+      return this.transitionToRoute('campaigns.start-or-resume', campaignCode);
+    } catch (error) {
+      this.onStartCampaignError(error);
+    }
+  }
+
+  onStartCampaignError(error) {
+    const { status } = error.errors[0];
+    if (status === '403') {
+      this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur.');
+    } else if (status === '404') {
+      this.set('errorMessage', 'Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
+    } else {
+      throw (error);
+    } 
   }
 
   @action

--- a/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-campaign-code.js
@@ -1,13 +1,14 @@
-import classic from 'ember-classic-decorator';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
-@classic
 export default class FillInCampaignCodeController extends Controller {
   @service store;
 
   campaignCode = null;
+
+  @tracked
   errorMessage = null;
 
   @action
@@ -15,7 +16,7 @@ export default class FillInCampaignCodeController extends Controller {
     this.clearErrorMessage();
 
     if (!this.campaignCode) {
-      this.set('errorMessage', 'Veuillez saisir un code.');
+      this.errorMessage = 'Veuillez saisir un code.';
       return;
     }
   
@@ -31,9 +32,9 @@ export default class FillInCampaignCodeController extends Controller {
   onStartCampaignError(error) {
     const { status } = error.errors[0];
     if (status === '403') {
-      this.set('errorMessage', 'Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur.');
+      this.errorMessage = 'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.';
     } else if (status === '404') {
-      this.set('errorMessage', 'Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
+      this.errorMessage = 'Votre code est erroné, veuillez vérifier ou contacter l’organisateur.';
     } else {
       throw (error);
     } 
@@ -41,6 +42,6 @@ export default class FillInCampaignCodeController extends Controller {
 
   @action
   clearErrorMessage() {
-    this.set('errorMessage', null);
+    this.errorMessage = null;
   }
 }

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -14,12 +14,12 @@
         <form class="fill-in-campaign-code__form" autocomplete="off">
 
           <div class="fill-in-campaign-code__form-field">
-            <Input required @type="text" @id="campaign-code" @value={{campaignCode}} @maxlength="9" @key-down={{action "clearErrorMessage"}} />
+            <Input required @type="text" @id="campaign-code" @value={{this.campaignCode}} @maxlength="9" @key-down={{this.clearErrorMessage}} />
           </div>
 
-          {{#if errorMessage}}
+          {{#if this.errorMessage}}
             <div class="fill-in-campaign-code__error" aria-live="polite">
-              {{ errorMessage }}
+              {{ this.errorMessage }}
             </div>
           {{/if}}
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -245,7 +245,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             // then
             expect(currentURL()).to.equal('/campagnes');
             expect(find('.fill-in-campaign-code__error').textContent)
-              .to.contains('Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+              .to.contains('Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
           });
         });
 
@@ -260,7 +260,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
             // then
             expect(currentURL()).to.equal('/campagnes');
-            expect(find('.fill-in-campaign-code__error').textContent).to.contains('Merci de renseigner le code du parcours.');
+            expect(find('.fill-in-campaign-code__error').textContent).to.contains('Veuillez saisir un code.');
           });
         });
       });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -245,7 +245,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             // then
             expect(currentURL()).to.equal('/campagnes');
             expect(find('.fill-in-campaign-code__error').textContent)
-              .to.contains('Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
+              .to.contains('Votre code est erroné, veuillez vérifier ou contacter l’organisateur.');
           });
         });
 

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
@@ -54,7 +54,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
+      expect(controller.get('errorMessage')).to.equal('Votre code est erroné, veuillez vérifier ou contacter l’organisateur.');
     });
 
     it('should set error when student is not authorized in campaign', async () => {
@@ -66,7 +66,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur.');
+      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
     });
   });
 

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-campaign-code-test.js
@@ -42,7 +42,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Merci de renseigner le code du parcours.');
+      expect(controller.get('errorMessage')).to.equal('Veuillez saisir un code.');
     });
 
     it('should set error when campaign code is wrong', async () => {
@@ -54,7 +54,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Votre code de parcours est erroné, veuillez vérifier ou contacter la personne organisant le parcours de test.');
+      expect(controller.get('errorMessage')).to.equal('Votre code est erroné, veuillez vérifier ou contacter l\'organisateur.');
     });
 
     it('should set error when student is not authorized in campaign', async () => {
@@ -66,7 +66,7 @@ describe('Unit | Controller | Campaigns | Fill in Campaign Code', function() {
       await controller.actions.startCampaign.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+      expect(controller.get('errorMessage')).to.equal('Oups ! nous ne parvenons pas à vous trouver. Verifiez vos informations afin de continuer ou prévenez l’organisateur.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les messages d'erreur à la saisie de code de campagne ne sont pas adaptés aux campagnes de collecte de profils

## :robot: Solution
Modifier les messages d'erreur à la saisie de code pour qu'il soit valable pour les 2 types de campagnes.

## :100: Pour tester
Dans Pix-app 
1. Ne pas saisir de code
> Le message "Veuillez saisir un code." apparait
2. Saisir un mauvais code
> Le message "Votre code est erroné, veuillez vérifier ou contacter l'organisateur." apparait
3. Saisir le code de campagne d'évaluation AZERTY123
> La campagne se lance
4. Saisir le code de campagne de collecte de profils SNAP123
> La campagne se lance