### PR TITLE
[FEATURE]  Ajout de la page /cgu au workflow de connexion (PF-1249). 

### DIFF
--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -65,5 +65,14 @@
     "username": "user.shouldChangePassword1234",
     "password": "$2b$05$Ryd6vVDoubvN9MQmSGmfY.tscxdmWhu1g8NOrHI4dveemziMof6Qm",
     "shouldChangePassword": true
+  },
+  {
+    "id": 9,
+    "firstName": "Joffrey",
+    "lastName": "Baratheon",
+    "email": "user-who-must-validate-the-last-terms-of-service@example.net",
+    "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
+    "cgu": true,
+    "mustValidateTermsOfService": true
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-app/terms-of-service.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/terms-of-service.feature
@@ -1,0 +1,16 @@
+#language: fr
+Fonctionnalité: Validation des CGU
+
+  Contexte:
+    Étant donné que tous les comptes sont créés
+
+  Scénario: Je dois valider les nouvelles conditions d'utilisation
+    Étant donné que je vais sur Pix
+    Lorsque je me connecte avec le compte "user-who-must-validate-the-last-terms-of-service@example.net"
+    Alors je suis redirigé vers la page "/cgu"
+    Lorsque j'accepte les CGU de Pix
+    Et je clique sur "Je continue"
+    Alors je suis redirigé vers la page "/profil"
+    Lorsque je me déconnecte
+    Et je me connecte avec le compte "user-who-must-validate-the-last-terms-of-service@example.net"
+    Alors je suis redirigé vers la page "/profil"

--- a/mon-pix/app/mixins/secured-route-mixin.js
+++ b/mon-pix/app/mixins/secured-route-mixin.js
@@ -1,74 +1,22 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
-import { getOwner } from '@ember/application';
-
-function isFastBoot(owner) {
-  const fastboot = owner.lookup('service:fastboot');
-  return fastboot ? fastboot.get('isFastBoot') : false;
-}
-
-function runIfUnauthenticated(owner, transition, callback) {
-  const isFb = isFastBoot(owner);
-  const sessionSvc = owner.lookup('service:session');
-  if (!sessionSvc.get('isAuthenticated')) {
-    if (isFb) {
-      const fastboot = owner.lookup('service:fastboot');
-      const cookies = owner.lookup('service:cookies');
-      cookies.write('ember_simple_auth-redirectTarget', transition.intent.url, {
-        path: '/',
-        secure: fastboot.get('request.protocol') === 'https'
-      });
-    } else {
-      sessionSvc.set('attemptedTransition', transition);
-    }
-    callback();
-    return false;
-  }
-  return true;
-}
-
-function runIfTermsOfServiceNotAccepted(owner, transition, callback) {
-  const sessionSvc = owner.lookup('service:session');
-  const currentUser = owner.lookup('service:currentUser');
-  if (currentUser.user.mustValidateTermsOfService) {
-    sessionSvc.set('attemptedTransition', transition);
-    callback();
-    return false;
-  }
-  return true;
-}
 
 export default Mixin.create({
 
+  router: service(),
   session: service('session'),
   currentUser: service(),
   authenticationRoute: 'login',
 
   beforeModel(transition) {
-    const isAuthenticated = runIfUnauthenticated(getOwner(this), transition, () => {
-      this.triggerAuthentication();
-    });
-    if (isAuthenticated) {
-      const hasAcceptedTermsOfService = runIfTermsOfServiceNotAccepted(getOwner(this), transition, () => {
-        this.triggerTermsOfServiceSignature();
-      });
-      console.log(hasAcceptedTermsOfService);
-      if (hasAcceptedTermsOfService) {
-        return this._super(...arguments);
-      }
+    if (!this.session.get('isAuthenticated')) {
+      this.session.set('attemptedTransition', transition);
+      this.router.transitionTo(this.authenticationRoute);
+    } else if (this.currentUser.user.mustValidateTermsOfService) {
+      this.session.set('attemptedTransition', transition);
+      this.router.transitionTo('terms-of-service');
+    } else {
+      return this._super(...arguments);
     }
-  },
-
-  triggerAuthentication() {
-    const authenticationRoute = this.get('authenticationRoute');
-    const owner = getOwner(this);
-    const authRouter = owner.lookup('service:router') || owner.lookup('router:main');
-    authRouter.transitionTo(authenticationRoute);
-  },
-
-  triggerTermsOfServiceSignature() {
-    const owner = getOwner(this);
-    const authRouter = owner.lookup('service:router') || owner.lookup('router:main');
-    authRouter.transitionTo('terms-of-service');
   },
 });

--- a/mon-pix/app/mixins/secured-route-mixin.js
+++ b/mon-pix/app/mixins/secured-route-mixin.js
@@ -1,0 +1,74 @@
+import { inject as service } from '@ember/service';
+import Mixin from '@ember/object/mixin';
+import { getOwner } from '@ember/application';
+
+function isFastBoot(owner) {
+  const fastboot = owner.lookup('service:fastboot');
+  return fastboot ? fastboot.get('isFastBoot') : false;
+}
+
+function runIfUnauthenticated(owner, transition, callback) {
+  const isFb = isFastBoot(owner);
+  const sessionSvc = owner.lookup('service:session');
+  if (!sessionSvc.get('isAuthenticated')) {
+    if (isFb) {
+      const fastboot = owner.lookup('service:fastboot');
+      const cookies = owner.lookup('service:cookies');
+      cookies.write('ember_simple_auth-redirectTarget', transition.intent.url, {
+        path: '/',
+        secure: fastboot.get('request.protocol') === 'https'
+      });
+    } else {
+      sessionSvc.set('attemptedTransition', transition);
+    }
+    callback();
+    return false;
+  }
+  return true;
+}
+
+function runIfTermsOfServiceNotAccepted(owner, transition, callback) {
+  const sessionSvc = owner.lookup('service:session');
+  const currentUser = owner.lookup('service:currentUser');
+  if (currentUser.user.mustValidateTermsOfService) {
+    sessionSvc.set('attemptedTransition', transition);
+    callback();
+    return false;
+  }
+  return true;
+}
+
+export default Mixin.create({
+
+  session: service('session'),
+  currentUser: service(),
+  authenticationRoute: 'login',
+
+  beforeModel(transition) {
+    const isAuthenticated = runIfUnauthenticated(getOwner(this), transition, () => {
+      this.triggerAuthentication();
+    });
+    if (isAuthenticated) {
+      const hasAcceptedTermsOfService = runIfTermsOfServiceNotAccepted(getOwner(this), transition, () => {
+        this.triggerTermsOfServiceSignature();
+      });
+      console.log(hasAcceptedTermsOfService);
+      if (hasAcceptedTermsOfService) {
+        return this._super(...arguments);
+      }
+    }
+  },
+
+  triggerAuthentication() {
+    const authenticationRoute = this.get('authenticationRoute');
+    const owner = getOwner(this);
+    const authRouter = owner.lookup('service:router') || owner.lookup('router:main');
+    authRouter.transitionTo(authenticationRoute);
+  },
+
+  triggerTermsOfServiceSignature() {
+    const owner = getOwner(this);
+    const authRouter = owner.lookup('service:router') || owner.lookup('router:main');
+    authRouter.transitionTo('terms-of-service');
+  },
+});

--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -1,11 +1,11 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 import _ from 'lodash';
 
 @classic
-export default class FillInIdPixRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
   @service session;
   @service currentUser;
 

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -2,11 +2,11 @@ import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import { isEmpty } from '@ember/utils';
 
 @classic
-export default class JoinRestrictedCampaignRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class JoinRestrictedCampaignRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
 

--- a/mon-pix/app/routes/campaigns/skill-review.js
+++ b/mon-pix/app/routes/campaigns/skill-review.js
@@ -1,10 +1,10 @@
 import classic from 'ember-classic-decorator';
 import RSVP from 'rsvp';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class SkillReviewRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class SkillReviewRoute extends Route.extend(SecuredRouteMixin) {
   model(params) {
     const store = this.store;
     const assessmentId = params.assessment_id;

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -2,12 +2,12 @@ import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 import { isEmpty } from '@ember/utils';
 
 @classic
-export default class StartOrResumeRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
 

--- a/mon-pix/app/routes/campaigns/tutorial.js
+++ b/mon-pix/app/routes/campaigns/tutorial.js
@@ -1,9 +1,9 @@
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import campaignTutorial from 'mon-pix/static-data/campaign-tutorial';
 import { inject as service } from '@ember/service';
 
-export default Route.extend(AuthenticatedRouteMixin, {
+export default Route.extend(SecuredRouteMixin, {
 
   currentUser: service(),
 

--- a/mon-pix/app/routes/certifications/results.js
+++ b/mon-pix/app/routes/certifications/results.js
@@ -1,9 +1,9 @@
 import classic from 'ember-classic-decorator';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class ResultsRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
   model(params) {
     // FIXME certification number is a domain attribute and should not be queried as a technical id
     return params.certification_number;

--- a/mon-pix/app/routes/certifications/start.js
+++ b/mon-pix/app/routes/certifications/start.js
@@ -1,10 +1,10 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 @classic
-export default class StartRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class StartRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
 
   model() {

--- a/mon-pix/app/routes/competences.js
+++ b/mon-pix/app/routes/competences.js
@@ -1,11 +1,10 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 @classic
-export default class CompetencesRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class CompetencesRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
 
   model(params) {

--- a/mon-pix/app/routes/competences/details.js
+++ b/mon-pix/app/routes/competences/details.js
@@ -1,10 +1,10 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class DetailsRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class DetailsRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
 

--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -1,10 +1,10 @@
 import classic from 'ember-classic-decorator';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 import Route from '@ember/routing/route';
 
 @classic
-export default class ResultsRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
   async model(params) {
     const competenceEvaluations = await this.store.query('competenceEvaluation', {
       filter: {

--- a/mon-pix/app/routes/competences/resume.js
+++ b/mon-pix/app/routes/competences/resume.js
@@ -1,11 +1,10 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class ResumeRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ResumeRoute extends Route.extend(SecuredRouteMixin) {
   @service session;
   @service router;
 
@@ -13,8 +12,7 @@ export default class ResumeRoute extends Route.extend(AuthenticatedRouteMixin) {
 
   model(params, transition) {
     const competenceId = transition.to.parent.params.competence_id;
-    const competenceEvaluation = this.store.queryRecord('competenceEvaluation', { competenceId, startOrResume: true });
-    return competenceEvaluation;
+    return this.store.queryRecord('competenceEvaluation', { competenceId, startOrResume: true });
   }
 
   afterModel(competenceEvaluation) {

--- a/mon-pix/app/routes/index.js
+++ b/mon-pix/app/routes/index.js
@@ -1,9 +1,9 @@
 import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 @classic
-export default class IndexRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
   redirect() {
     this.replaceWith('profile');
   }

--- a/mon-pix/app/routes/profile.js
+++ b/mon-pix/app/routes/profile.js
@@ -1,10 +1,10 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class ProfileRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class ProfileRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
 
   model() {

--- a/mon-pix/app/routes/user-certifications/get.js
+++ b/mon-pix/app/routes/user-certifications/get.js
@@ -1,9 +1,9 @@
 import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 @classic
-export default class GetRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class GetRoute extends Route.extend(SecuredRouteMixin) {
   model(params) {
     return this.store.findRecord('certification', params.id, { reload: true })
       .then((certification) => {

--- a/mon-pix/app/routes/user-certifications/index.js
+++ b/mon-pix/app/routes/user-certifications/index.js
@@ -1,9 +1,9 @@
 import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
 @classic
-export default class IndexRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
   model() {
     return this.store.findAll('certification');
   }

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -9,10 +9,10 @@
 
 .terms-of-service-form {
   margin: auto;
-  padding: 40px 32px;
+  padding: 40px 88px 48px 88px;
   background: white;
   border-radius: 8px;
-  max-width: 580px;
+  width: 581px;
 
   &__logo {
     margin-bottom: 24px;
@@ -20,35 +20,39 @@
     & img {
       display: flex;
       margin: auto;
+      height: 75px;
     }
 
   }
 
   &__title, &__description, &__conditions {
-    margin-bottom: 30px;
+    margin-bottom: 32px;
     text-align: center;
     color: $grey-80;
     font-family: $font-roboto;
-    font-size: 0.938rem;
+    font-size: 1rem;
     font-weight: normal;
 
   }
 
   &__title {
     font-weight: 300;
-    font-size: 1.56rem;
+    font-size: 2.125rem;
+    margin-bottom: 8px;
+  }
+
+  &__description {
+    margin-bottom: 40px;
   }
 
   &__conditions {
     font-weight: normal;
-    font-size: 0.875rem;
+    font-size: 1rem;
     letter-spacing: 0.009rem;
     text-align: center;
-
   }
 
   &__actions {
-    margin-bottom: 30px;
     text-align: center;
   }
 }
@@ -62,7 +66,6 @@
   &__validation-error {
     color: $red-error;
     font-weight: normal;
-    margin-left: 16px;
     margin-top: 16px;
   }
 }
@@ -72,14 +75,16 @@
   &__submit {
     margin-left: 16px;
     border-radius: 4px;
-    padding: 10px 16px;
+    padding: 14px 21px;
+    font-weight: 400;
 
   }
 
   &__cancel {
     background-color: $grey-50;
     border-radius: 4px;
-    padding: 10px 16px;
+    padding: 14px 36px;
+    font-weight: 400;
 
     &:hover {
       background-color: $gray;

--- a/mon-pix/tests/acceptance/terms-of-service-test.js
+++ b/mon-pix/tests/acceptance/terms-of-service-test.js
@@ -4,7 +4,6 @@ import { authenticateByEmail } from '../helpers/authentification';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import visit from '../helpers/visit';
 
 describe('Acceptance | terms-of-service', function() {
   setupApplicationTest();
@@ -20,14 +19,24 @@ describe('Acceptance | terms-of-service', function() {
     });
   });
 
-  describe('Navigation buttons when user is authenticated', async function() {
+  describe('When user log in and must validate Pix latest terms of service', async function() {
 
-    it('should be redirect to profile page when user validate terms of service ', async function() {
+    it('should be redirected to terms-of-services page', async function() {
+      // when
+      await authenticateByEmail(user);
+
+      // then
+      expect(currentURL()).to.equal('/cgu');
+    });
+  });
+
+  describe('when the user has validated terms of service', async function() {
+
+    it('should be redirected to profile page when user validate terms of service ', async function() {
       // given
       await authenticateByEmail(user);
 
       // when
-      await visit('/cgu');
       await click('#pix-cgu');
       await click('.terms-of-service-form-actions__submit');
 

--- a/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
+++ b/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import sinonjs from 'sinon';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
-describe.only('Unit | Mixin | secured-route-mixin', function() {
+describe('Unit | Mixin | secured-route-mixin', function() {
   setupTest();
 
   let sinon;
@@ -138,29 +138,6 @@ describe.only('Unit | Mixin | secured-route-mixin', function() {
         sinon.assert.calledWith(router.transitionTo, authenticationRoute);
       });
 
-      it('sets the redirectTarget cookie in fastboot', function() {
-        this.owner.register('service:fastboot', Service.extend({
-          isFastBoot: true,
-          init() {
-            this._super(...arguments);
-            this.request = {
-              protocol: 'https'
-            };
-          },
-        }));
-        const writeCookieStub = sinon.stub();
-        this.owner.register('service:cookies', Service.extend({
-          write: writeCookieStub
-        }));
-
-        const cookieName = 'ember_simple_auth-redirectTarget';
-
-        route.beforeModel(transition);
-        sinon.assert.calledWith(writeCookieStub, cookieName, transition.intent.url, {
-          path: '/',
-          secure: true
-        });
-      });
     });
   });
 });

--- a/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
+++ b/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
@@ -1,0 +1,166 @@
+import Mixin from '@ember/object/mixin';
+import { setOwner } from '@ember/application';
+import RSVP from 'rsvp';
+import Route from '@ember/routing/route';
+import Service from '@ember/service';
+import { describe, beforeEach, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import { expect } from 'chai';
+import sinonjs from 'sinon';
+import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+
+describe.only('Unit | Mixin | secured-route-mixin', function() {
+  setupTest();
+
+  let sinon;
+  let route;
+  let router;
+  let transition;
+
+  beforeEach(function() {
+    sinon = sinonjs.createSandbox();
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  describe('#beforeModel', function() {
+    beforeEach(function() {
+      const MixinImplementingBeforeModel = Mixin.create({
+        beforeModel() {
+          return RSVP.resolve('upstreamReturnValue');
+        }
+      });
+
+      transition = {
+        intent: {
+          url: '/transition/target/url'
+        },
+        send() {}
+      };
+      this.owner.register('service:router', Service.extend({
+        transitionTo() {}
+      }));
+      router = this.owner.lookup('service:router');
+
+      this.owner.register('service:session', Service.extend());
+      this.owner.register('service:currentUser', Service.extend({
+        user: {}
+      }));
+
+      route = Route.extend(MixinImplementingBeforeModel, SecuredRouteMixin).create();
+      setOwner(route, this.owner);
+
+      sinon.spy(transition, 'send');
+      sinon.spy(router, 'transitionTo');
+    });
+
+    describe('when the session is authenticated', function() {
+
+      beforeEach(function() {
+        const session = this.owner.lookup('service:session');
+        session.set('isAuthenticated', true);
+      });
+
+      describe('when the user has accepted the terms of service', function() {
+
+        beforeEach(function() {
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.user.mustValidateTermsOfService = false;
+        });
+
+        it('returns the upstream promise', async function() {
+          const result = await route.beforeModel(transition);
+
+          expect(result).to.equal('upstreamReturnValue');
+        });
+
+        it('does not transition to the authentication route', function() {
+          route.beforeModel(transition);
+
+          sinon.assert.neverCalledWith(router.transitionTo, 'login');
+        });
+
+        it('does not transition to the terms-of-service route', function() {
+          route.beforeModel(transition);
+
+          sinon.assert.neverCalledWith(router.transitionTo, 'terms-of-service');
+        });
+      });
+
+      describe('when the user has not accepted the terms of service', function() {
+
+        beforeEach(function() {
+          const currentUser = this.owner.lookup('service:currentUser');
+          currentUser.user.mustValidateTermsOfService = true;
+        });
+
+        it('does not returns the upstream promise', async function() {
+          expect(route.beforeModel(transition)).to.be.undefined;
+        });
+
+        it('does not transition to the authentication route', function() {
+          route.beforeModel(transition);
+
+          sinon.assert.neverCalledWith(router.transitionTo, 'login');
+        });
+
+        it('transitions to terms-of-service route', function() {
+          route.beforeModel(transition);
+
+          sinon.assert.calledWith(router.transitionTo, 'terms-of-service');
+        });
+      });
+    });
+
+    describe('when the session is not authenticated', function() {
+
+      it('does not return the upstream promise', function() {
+        expect(route.beforeModel(transition)).to.be.undefined;
+      });
+
+      it('transitions to "login" as the default authentication route', function() {
+        route.beforeModel(transition);
+        sinon.assert.calledWith(router.transitionTo, 'login');
+      });
+
+      it('does not transition to the terms-of-service route', function() {
+        route.beforeModel(transition);
+        sinon.assert.neverCalledWith(router.transitionTo, 'terms-of-service');
+      });
+
+      it('transitions to the authentication route', function() {
+        const authenticationRoute = 'path/to/route';
+        route.set('authenticationRoute', authenticationRoute);
+
+        route.beforeModel(transition);
+        sinon.assert.calledWith(router.transitionTo, authenticationRoute);
+      });
+
+      it('sets the redirectTarget cookie in fastboot', function() {
+        this.owner.register('service:fastboot', Service.extend({
+          isFastBoot: true,
+          init() {
+            this._super(...arguments);
+            this.request = {
+              protocol: 'https'
+            };
+          },
+        }));
+        const writeCookieStub = sinon.stub();
+        this.owner.register('service:cookies', Service.extend({
+          write: writeCookieStub
+        }));
+
+        const cookieName = 'ember_simple_auth-redirectTarget';
+
+        route.beforeModel(transition);
+        sinon.assert.calledWith(writeCookieStub, cookieName, transition.intent.url, {
+          path: '/',
+          secure: true
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La page permettant d'accepter les nouvelles conditions d'utilisations dans Pix App a été créée (tickets https://1024pix.atlassian.net/browse/PF-998 et https://1024pix.atlassian.net/browse/PF-1235). Nous devons nous assurer qu'un utilisateur ne peut pas accéder au reste de l'application s'il n'a pas au préalable validé les nouvelles CGU (or routes accessibles sans être authentifié). Néanmoins, rien n'empêche aujourd'hui un utilisateur de modifier l'url d'accéder afin d'outrepasser la validation des CGU. 

## :robot: Solution
Il a été décidé de créer un nouveau mixin en remplacement du mixin `AuthenticatedRouteMixin` d'ember-simple-auth. Celui-ci devra reprendre le fonctionnement du mixin d'ember-simple-auth à savoir empêcher l'utilisateur d'accéder à une route s'il n'est pas authentifié. De plus, il devra aussi empêcher les utilisateurs d'accéder à une route s'il n'a pas encore validé les nouvelles CGU.  

## :rainbow: Remarques
Pour le développement de ce mixin, nous avons repris dans un premier commit le code du mixin  `AuthenticatedRouteMixin` d'ember-simple-auth en y ajoutant la validation des CGU (le test unitaire est aussi issu d'ember-simple-auth). Nous avons ensuite, dans un deuxième commit refactoré le mixin afin de grandement simplifier son code. Il est donc conseillé de **ne pas effectuer une review commit par commit**. Le premier commit a été laissé uniquement pour informations (il pourra être retiré si vous jugez qu'il n'est pas nécessaire). 

## :100: Pour tester
Cas 1: Utilisateur n'ayant pas accepté les CGU
- Se connecter à Pix App avec l'utilisateur lasttermsofservice@notvalidated.net 
- vérifier que l'on arrive bien sur la page de validation des nouvelles CGU
- Tenter de modifier l'url pour accéder, par exemple, au profil (/profil) et s'assurer que ce n'est pas possible
- Valider les nouvelles CGU et vérifier que l'on est bien redirigé vers le profil
- Se déconnecter, puis se reconnecter
- La page des CGU ne doit plus apparaître et l'on doit accéder directement au profil

Cas 2:Utilisateur ayant accepté les CGU
- Se connecter à Pix App avec l'utilisateur lasttermsofservice@validated.net
- vérifier que l'on arrive bien sur la page de profil