### PR TITLE
[FEATURE] Retirer la pagination à 100 sur les participations aux campagnes (PIX-594).

### DIFF
--- a/orga/app/templates/components/pagination-control.hbs
+++ b/orga/app/templates/components/pagination-control.hbs
@@ -6,7 +6,6 @@
         <option value="10" selected="{{if (eq this.pagination.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq this.pagination.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq this.pagination.pageSize 50) true}}">50</option>
-        <option value="100" selected="{{if (eq this.pagination.pageSize 100) true}}">100</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, des appels trop long pour afficher la page de résultats des campagnes font planter des containers. Une solution est à l'étude pour éviter que ces appels soient trop long/trop lourd. 

## :robot: Solution
En attendant la solution finale, je propose d'éviter la pagination à 100 utilisateurs, qui est souvent celle choisit sur les requêtes qui ne finissent pas coté API.

## :rainbow: Remarques
Ceci n'est pas une correction pour le moment, c'est juste pour éviter la casse.
