### PR TITLE
[INFRA] Corrige le status code HTTP "precondition failed" (421 -> 412)

### DIFF
--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -18,7 +18,7 @@ class PreconditionFailedError extends BaseHttpError {
   constructor(message) {
     super(message);
     this.title = 'Precondition Failed';
-    this.status = 421;
+    this.status = 412;
   }
 }
 

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -642,7 +642,7 @@ describe('Acceptance | API | Campaign Participations', () => {
       expect(response.statusCode).to.equal(404);
     });
 
-    it('should return 421 error if the user has already participated to the campaign', async () => {
+    it('should return 412 error if the user has already participated to the campaign', async () => {
       // given
       options.payload.data.relationships.campaign.data.id = campaignId;
       databaseBuilder.factory.buildCampaignParticipation({ userId: user.id, campaignId });
@@ -652,7 +652,7 @@ describe('Acceptance | API | Campaign Participations', () => {
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(421);
+      expect(response.statusCode).to.equal(412);
     });
   });
 
@@ -741,12 +741,12 @@ describe('Acceptance | API | Campaign Participations', () => {
         };
       });
 
-      it('should return 421 HTTP status code', async () => {
+      it('should return 412 HTTP status code', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
     });
   });

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -104,7 +104,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should respond with a 421 if organization-invitation is already accepted', async () => {
+      it('should respond with a 412 if organization-invitation is already accepted', async () => {
         // given
         const { id: organizationInvitationId, code } = databaseBuilder.factory.buildOrganizationInvitation({
           organizationId,
@@ -120,7 +120,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
 
       it('should respond with a 404 if given email is not linked to an existing user', async () => {
@@ -143,7 +143,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should respond with a 421 if membership already exist with userId and OrganizationId', async () => {
+      it('should respond with a 412 if membership already exist with userId and OrganizationId', async () => {
         // given
         const { id: userId, email } = databaseBuilder.factory.buildUser();
 
@@ -164,7 +164,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
     });
   });
@@ -247,7 +247,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should respond with a 421 if organization-invitation is already accepted', async () => {
+      it('should respond with a 412 if organization-invitation is already accepted', async () => {
         // given
         const code = 'ABCDEFGH01';
         organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -264,7 +264,7 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
     });
   });

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -100,12 +100,12 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
         await databaseBuilder.commit();
       });
 
-      it('should respond with a 421 - precondition failed - if last knowledge element date is not old enough', async () => {
+      it('should respond with a 412 - precondition failed - if last knowledge element date is not old enough', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
     });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -53,7 +53,7 @@ describe('Integration | Utils | Error Manager', function() {
       expect(result.statusCode).to.equal(422);
     });
 
-    it('should return 421 on domain AlreadyRatedAssessmentError', function() {
+    it('should return 412 on domain AlreadyRatedAssessmentError', function() {
       // given
       const error = new DomainErrors.AlreadyRatedAssessmentError();
 
@@ -61,7 +61,7 @@ describe('Integration | Utils | Error Manager', function() {
       const result = handle(hFake, error);
 
       // then
-      expect(result.statusCode).to.equal(421);
+      expect(result.statusCode).to.equal(412);
     });
 
     it('should return 409 on domain ChallengeAlreadyAnsweredError', function() {
@@ -328,7 +328,7 @@ describe('Integration | Utils | Error Manager', function() {
       expect(result.statusCode).to.equal(400);
     });
 
-    it('should return 400 on domain AlreadyExistingMembershipError', function() {
+    it('should return 412 on domain AlreadyExistingMembershipError', function() {
       // given
       const error = new DomainErrors.AlreadyExistingMembershipError();
 
@@ -336,7 +336,7 @@ describe('Integration | Utils | Error Manager', function() {
       const result = handle(hFake, error);
 
       // then
-      expect(result.statusCode).to.equal(421);
+      expect(result.statusCode).to.equal(412);
     });
 
     it('should return 400 on domain MembershipCreationError', function() {

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -55,7 +55,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
     context('Error cases', () => {
 
-      it('should respond an HTTP response with status code 421 when AlreadyExistingOrganizationInvitationError', async () => {
+      it('should respond an HTTP response with status code 412 when AlreadyExistingOrganizationInvitationError', async () => {
         // given
         usecases.answerToOrganizationInvitation.rejects(new AlreadyExistingOrganizationInvitationError());
 
@@ -63,7 +63,7 @@ describe('Integration | Application | Organization-invitations | organization-in
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
 
         // then
-        expect(response.statusCode).to.equal(421);
+        expect(response.statusCode).to.equal(412);
       });
 
       it('should respond an HTTP response with status code 404 when NotFoundError', async () => {

--- a/api/tests/integration/application/pre-response-utils_test.js
+++ b/api/tests/integration/application/pre-response-utils_test.js
@@ -26,7 +26,7 @@ describe('Integration | Application | PreResponse-utils', () => {
       { should: 'should return HTTP code 403 when ForbiddenError', response: new ForbiddenError('Error message'), expectedStatusCode: 403 },
       { should: 'should return HTTP code 404 when NotFoundError', response: new NotFoundError('Error message'), expectedStatusCode: 404 },
       { should: 'should return HTTP code 409 when ConflictError', response: new ConflictError('Error message'), expectedStatusCode: 409 },
-      { should: 'should return HTTP code 421 when PreconditionFailedError', response: new PreconditionFailedError('Error message'), expectedStatusCode: 421 },
+      { should: 'should return HTTP code 412 when PreconditionFailedError', response: new PreconditionFailedError('Error message'), expectedStatusCode: 412 },
       { should: 'should return HTTP code 422 when EntityValidationError', response: new EntityValidationError({ invalidAttributes }), expectedStatusCode: 422 },
       { should: 'should return HTTP code 422 when UnprocessableEntityError', response: new UnprocessableEntityError('Error message'), expectedStatusCode: 422 },
       { should: 'should return HTTP code 500 when BaseHttpError', response: new BaseHttpError('Error message'), expectedStatusCode: 500 },

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -33,7 +33,7 @@ export default class LoginForm extends Component {
         await this._acceptOrganizationInvitation(this.organizationInvitationId, this.organizationInvitationCode, email);
       } catch (errorResponse) {
         errorResponse.errors.forEach((error) => {
-          if (error.status === '421') {
+          if (error.status === '412') {
             return this._authenticate(password, email);
           }
         });

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -22,7 +22,7 @@ export default class NewController extends Controller {
       .catch((errorResponse) => {
         if (errorResponse.errors && errorResponse.errors.length > 0) {
           errorResponse.errors.forEach((error) => {
-            if (error.status === '421') {
+            if (error.status === '412') {
               return this.get('notifications').sendError('Ce membre a déjà été ajouté.');
             }
             if (error.status === '404') {

--- a/orga/app/routes/join.js
+++ b/orga/app/routes/join.js
@@ -11,7 +11,7 @@ export default class JoinRoute extends Route.extend(UnauthenticatedRouteMixin) {
       code: params.code
     }).catch((errorResponse) => {
       errorResponse.errors.forEach((error) => {
-        if (error.status === '421') {
+        if (error.status === '412') {
           this.replaceWith('login', { queryParams: { hasInvitationError: true } });
         }
       });

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -99,7 +99,7 @@ export default function() {
       return new Response(404, {}, { errors: [ { status: '404', detail: '' } ] });
     }
     if (organizationInvitation.status === 'accepted') {
-      return new Response(421, {}, { errors: [ { status: '421', detail: '' } ] });
+      return new Response(412, {}, { errors: [ { status: '412', detail: '' } ] });
     }
 
     return organizationInvitation;

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -223,10 +223,10 @@ module('Acceptance | join', function(hooks) {
         server.post(`/organization-invitations/${organizationInvitationId}/response`, {
           errors: [{
             detail: '',
-            status: '421',
+            status: '412',
             title: '',
           }]
-        }, 421);
+        }, 412);
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
         await fillIn('#login-email', user.email);

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -146,7 +146,7 @@ module('Acceptance | Team Creation', function(hooks) {
         assert.dom('[data-test-notification-message="error"]').hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
       });
 
-      test('it should display error on global form when error 421 is returned from backend', async function(assert) {
+      test('it should display error on global form when error 412 is returned from backend', async function(assert) {
         // given
         await visit('/equipe/creation');
         server.post(`/organizations/${organizationId}/invitations`,
@@ -154,11 +154,11 @@ module('Acceptance | Team Creation', function(hooks) {
             errors: [
               {
                 detail: '',
-                status: '421',
+                status: '412',
                 title: 'Precondition Failed',
               }
             ]
-          }, 421);
+          }, 412);
         await fillIn('#email', 'fake@email');
 
         // when


### PR DESCRIPTION
## :unicorn: Problème

Dans le code pix, un status HTTP "Precondition Failed" renvoie le code `421`. Dans la spécification HTTP et dans le reste du monde, le code est en réalité `412`.

- https://tools.ietf.org/html/rfc7232#section-4.2
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412

## :robot: Solution

Changer les occurrences de `421` correspondantes en `412`.

## :100: Pour tester

C'est compliqué, je tente une liste.

Vérifier qu'il y a bien une erreur et que c'est le bon message pour :
- POST /api/campaign-participations pour un utilisateur qui a déjà une participation pour cette campagne (est-ce possible en passant par le front ?)
- partager des résultats de campagne qui ont déjà été partagés
- accepter une invitation orga qui a déjà été acceptée (redirige vers terms of service)
- accepter une invitation orga alors qu'on est déjà membre de cette orga (redirige vers terms of service)
- ajouter un membre à une orga alors qu'il est déjà membre de cette orga
- créer une invitation à une orga d'un membre qui a déjà accepté une invitation (qui est déjà membre)
- reset de scorecard si le dernier KE n'est pas assez ancien