### PR TITLE
[INFRA] Possibilité d'ajouter des en-têtes HTTP grâce à des variables d'environnement.

### DIFF
--- a/admin/nginx.conf.erb
+++ b/admin/nginx.conf.erb
@@ -49,3 +49,13 @@ location /api/ {
 add_header X-Content-Type-Options "nosniff";
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection 1;
+
+<% ENV.each do |key,value| %>
+  <% if key.start_with? 'ADD_HTTP_HEADER' %>
+    add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+  <% end %>
+<% end %>

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -49,3 +49,13 @@ location /api/ {
 add_header X-Content-Type-Options "nosniff";
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection 1;
+
+<% ENV.each do |key,value| %>
+  <% if key.start_with? 'ADD_HTTP_HEADER' %>
+    add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+  <% end %>
+<% end %>

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -49,3 +49,13 @@ location /api/ {
 add_header X-Content-Type-Options "nosniff";
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection 1;
+
+<% ENV.each do |key,value| %>
+  <% if key.start_with? 'ADD_HTTP_HEADER' %>
+    add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+  <% end %>
+<% end %>

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -9,3 +9,13 @@ location ~ ^/(?<app>[^/]+)/.*$ {
 add_header X-Content-Type-Options "nosniff";
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection 1;
+
+<% ENV.each do |key,value| %>
+  <% if key.start_with? 'ADD_HTTP_HEADER' %>
+    add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+  <% end %>
+<% end %>

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -49,3 +49,13 @@ location /api/ {
 add_header X-Content-Type-Options "nosniff";
 add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection 1;
+
+<% ENV.each do |key,value| %>
+  <% if key.start_with? 'ADD_HTTP_HEADER' %>
+    add_header <%=
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+  <% end %>
+<% end %>


### PR DESCRIPTION
## :unicorn: Problème
On aimerait pouvoir rajouter à chaud des en-têtes HTTP aux réponses des applications, notamment pour pouvoir tester la mise en place d'une _Content Security Policy_.

## :robot: Solution
Vérifier dans les fichiers nginx.conf.erb,  que des variables d'environnement commencent par `ADD_HTTP_HEADER` auquel cas on ajoute l'en-tête correspondant.

Par exemple, `ADD_HTTP_HEADER_X_EXAMPLE=test` ajoutera `X-Example: test` à toutes les réponses HTTP.

## :100: Pour tester
Ajouter une variable d'environnement qui commence par `ADD_HTTP_HEADER` sur le front de la review app et voir qu'après le restart celui-ci est ajouté. 