### PR TITLE
[TECH] Faciliter le lancement de cypress en local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 .DS_Store
 
 **/.env
+**/.env.cypress
 
 # CircleCI
 *.circle-cache-key

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,4 +1,8 @@
-require('dotenv').config({ path: `${__dirname}/../.env` });
+if (process.env.NODE_ENV === 'cypress') {
+  require('dotenv').config({ path: `${__dirname}/../.env.cypress` });
+} else {
+  require('dotenv').config({ path: `${__dirname}/../.env` });
+}
 
 function localPostgresEnv(databaseUrl) {
   return {
@@ -23,6 +27,8 @@ module.exports = {
   development: localPostgresEnv(process.env.DATABASE_URL),
 
   test: localPostgresEnv(process.env.TEST_DATABASE_URL),
+
+  cypress: localPostgresEnv(process.env.DATABASE_URL),
 
   staging: {
     client: 'postgresql',

--- a/api/db/migrations/20190205153549_update_pix-score_column_in_knowledge_element_table.js
+++ b/api/db/migrations/20190205153549_update_pix-score_column_in_knowledge_element_table.js
@@ -14,7 +14,6 @@ exports.down = async function(knex) {
 
 /* Generating the skill value table:
 
-require('dotenv').config();
 const airtable = require('./lib/infrastructure/airtable.js');
 const _ = require('lodash');
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -30,8 +30,8 @@ module.exports = (function() {
     },
 
     airtable: {
-      apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
-      base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
+      apiKey: process.env.AIRTABLE_API_KEY,
+      base: process.env.AIRTABLE_BASE,
     },
 
     app: {

--- a/api/loadEnv.js
+++ b/api/loadEnv.js
@@ -1,0 +1,17 @@
+// As early as possible in your application, require and configure dotenv.
+// https://www.npmjs.com/package/dotenv#usage
+const fs = require('fs');
+const path = require('path');
+
+// load default configuration
+const dotenv = require('dotenv');
+dotenv.config();
+
+// override configuration for cypress env
+const cypressEnvPath = path.join(process.cwd(), '.env.cypress');
+if (process.env.NODE_ENV === 'cypress' && fs.existsSync(cypressEnvPath)) {
+  const envConfig = dotenv.parse(fs.readFileSync(cypressEnvPath));
+  for (const k in envConfig) {
+    process.env[k] = envConfig[k];
+  } 
+}

--- a/api/scripts/add-target-profile-shares-to-organizations.js
+++ b/api/scripts/add-target-profile-shares-to-organizations.js
@@ -3,7 +3,7 @@
 // To use on file with columns |externalId, targetProfileId-targetProfileId-targetProfileId|
 
 'use strict';
-require('dotenv').config();
+require('../loadEnv');
 const targetProfileShareRepository = require('../lib/infrastructure/repositories/target-profile-share-repository');
 const { findOrganizationsByExternalIds, organizeOrganizationsByExternalId } = require('./helpers/organizations-by-external-id-helper');
 const { parseCsv } = require('./helpers/csvHelpers');

--- a/api/scripts/create-or-update-sco-organizations.js
+++ b/api/scripts/create-or-update-sco-organizations.js
@@ -3,7 +3,7 @@
 // To use on file with columns |externalId, name|
 
 'use strict';
-require('dotenv').config();
+require('../loadEnv');
 const request = require('request-promise-native');
 
 const logoUrl = require('./default-sco-organization-logo-base64');

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('../../loadEnv');
 const PgClient = require('../PgClient');
 const { PGSQL_DUPLICATE_DATABASE_ERROR } = require('../../db/pgsql-errors');
 

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('../../loadEnv');
 const PgClient = require('../PgClient');
 const { PGSQL_NON_EXISTENT_DATABASE_ERROR } = require('../../db/pgsql-errors');
 

--- a/api/scripts/reload-cache-everyday.js
+++ b/api/scripts/reload-cache-everyday.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('../loadEnv');
 const cron = require('node-cron');
 const request = require('request-promise-native');
 

--- a/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
+++ b/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
@@ -3,7 +3,7 @@
 // To use on file with columns |externalId|
 
 'use strict';
-require('dotenv').config();
+require('../loadEnv');
 const request = require('request-promise-native');
 const { findOrganizationsByExternalIds, organizeOrganizationsByExternalId } = require('./helpers/organizations-by-external-id-helper');
 const { parseCsv } = require('./helpers/csvHelpers');

--- a/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
+++ b/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
@@ -1,5 +1,5 @@
 'use strict';
-require('dotenv').config();
+require('../loadEnv');
 const path = require('path');
 const fs = require('fs');
 const request = require('request-promise-native');

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,5 @@
-// As early as possible in your application, require and configure dotenv.
-// https://www.npmjs.com/package/dotenv#usage
-require('dotenv').config();
+require('./loadEnv');
+
 const Hapi = require('@hapi/hapi');
 
 const preResponseUtils = require('./lib/application/pre-response-utils');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,8 @@ services:
     image: redis:5.0.7-alpine
     ports:
       - "6379:6379"
+
+  redis-minimal:
+    image: redis:5.0.7-alpine
+    ports:
+      - "6380:6379"

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -14,21 +14,17 @@
     "url": "https://github.com/1024pix/pix"
   },
   "scripts": {
-    "cy:open": "npm run db:initialize && cypress open",
-    "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open",
-    "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
-    "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:run",
-    "cy:run:base": "cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base",
-    "cy:test": "run-p start:api start:mon-pix start:orga start:certif cy:run",
-    "cy:test:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga start:certif cy:run",
-    "cy:test:open": "run-p start:api start:mon-pix start:orga start:certif cy:open",
-    "cy:test:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga start:certif cy:open",
+    "cy:open": "NODE_ENV=cypress npm run db:initialize && NODE_ENV=cypress cypress open",
+    "cy:run": "NODE_ENV=cypress npm run db:initialize && NODE_ENV=cypress cypress run --browser=chrome && exit",
+    "cy:run:base": "NODE_ENV=cypress cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base",
+    "cy:test": "NODE_ENV=cypress run-p start:api start:mon-pix start:orga start:certif cy:run",
+    "cy:test:open": "NODE_ENV=cypress run-p start:api start:mon-pix start:orga start:certif cy:open",
     "db:empty": "cd ../../api && npm run db:empty",
-    "db:initialize": "cd ../../api && npm run db:prepare",
-    "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
-    "start:mon-pix": "cd ../../mon-pix && npx ember serve --proxy",
-    "start:orga": "cd ../../orga && npx ember serve --proxy",
-    "start:certif": "cd ../../certif && npx ember serve --proxy"
+    "db:initialize": "cd ../../api && NODE_ENV=cypress npm run db:delete && NODE_ENV=cypress npm run db:create && NODE_ENV=cypress npm run db:migrate",
+    "start:api": "NODE_ENV=cypress cd ../../api && npm run start:watch",
+    "start:mon-pix": "NODE_ENV=cypress cd ../../mon-pix && npx ember serve --proxy",
+    "start:orga": "NODE_ENV=cypress cd ../../orga && npx ember serve --proxy",
+    "start:certif": "NODE_ENV=cypress cd ../../certif && npx ember serve --proxy"
   },
   "devDependencies": {
     "cypress": "4.3.0",


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui il est difficile d'ajouter des tests cypress en local. Avant d'écrire ou éxecuter les tests, il est nécessaire changer la variables suivantes:
- CYPRESS_AIRTABLE_API_KEY (car les tests cypress sont basés sur le referentiel minimal)
- CYPRESS_AIRTABLE_BASE
- DATABASE_URL (car les tests cypress sont basés sur la BD de test)
Et également redémarrer son serveur et partir d'un cache redis vide.

## :robot: Solution
1. Ajouter une base redis dédiée au airtable minimal dans le docker-compose pour facilement switcher d'un env cypress à son en local
2. Ajouter les variables d'environnement à surcharger pour cypress dans un fichier `.env.cypress` (`AIRTABLE_API_KEY`, `AIRTABLE_BASE`, `DATABASE_URL`, `REDIS_URL`)
3. Surcharger les variables de `.env` par celles de `.env.cypress` au lancement des tests cypress 
