### PR TITLE
[FEATURE] Permettre la modification d'une campagne de type collecte de profils (PIX-579).

### DIFF
--- a/api/lib/domain/usecases/update-campaign.js
+++ b/api/lib/domain/usecases/update-campaign.js
@@ -1,4 +1,5 @@
 const { UserNotAuthorizedToUpdateResourceError } = require('../errors');
+const campaignValidator = require('../validators/campaign-validator');
 
 module.exports = async function updateCampaign(
   {
@@ -25,6 +26,8 @@ module.exports = async function updateCampaign(
   if (name !== undefined) campaign.name = name;
   if (title !== undefined) campaign.title = title;
   if (customLandingPageText !== undefined) campaign.customLandingPageText = customLandingPageText;
+
+  campaignValidator.validate(campaign);
 
   await campaignRepository.update(campaign);
 

--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -44,7 +44,7 @@ const campaignValidationJoiSchema = Joi.object({
     .when('$type', {
       switch: [{
         is: Joi.string().required().valid(Campaign.types.PROFILES_COLLECTION),
-        then: Joi.forbidden(),
+        then: Joi.valid(null).optional(),
       }, {
         is: Joi.string().required().valid(Campaign.types.ASSESSMENT),
         then: Joi.required(),
@@ -54,7 +54,7 @@ const campaignValidationJoiSchema = Joi.object({
     .messages({
       'any.required': 'Veuillez sélectionner un profil cible pour votre campagne.',
       'number.base': 'Veuillez sélectionner un profil cible pour votre campagne.',
-      'any.unknown': 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
+      'any.only': 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
     }),
 
   idPixLabel: Joi.string()

--- a/api/tests/unit/domain/validations/campaign-validator_test.js
+++ b/api/tests/unit/domain/validations/campaign-validator_test.js
@@ -309,69 +309,96 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
     });
 
     context('on targetProfileId attribute', () => {
-      it('should reject with error when targetProfileId is provided and campaign type is PROFILES_COLLECTION', () => {
-        // given
-        const expectedError = {
-          attribute: 'targetProfileId',
-          message: 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
-        };
 
-        try {
-          // when
-          campaignValidator.validate({
-            ...campaignOfTypeProfilesCollection,
-            targetProfileId: '1',
-          });
-          expect.fail('should have thrown an error');
+      context('when type is PROFILES_COLLECTION', () => {
+        it('should reject with error when targetProfileId is provide', () => {
+          // given
+          const expectedError = {
+            attribute: 'targetProfileId',
+            message: 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.'
+          };
 
-        } catch (entityValidationErrors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-        }
+          try {
+            // when
+            campaignValidator.validate({
+              ...campaignOfTypeProfilesCollection,
+              targetProfileId: '1',
+            });
+            expect.fail('should have thrown an error');
+
+          } catch (entityValidationErrors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          }
+        });
+
+        it('should be valid with null as targetProfileId', () => {
+          try {
+            campaignValidator.validate({
+              ...campaignOfTypeProfilesCollection,
+              targetProfileId: MISSING_VALUE,
+            });
+          } catch (entityValidationErrors) {
+            expect.fail('should be valid when targetProfileId is null');
+          }
+        });
+
+        it('should be valid when targetProfileId is not provided', () => {
+          try {
+            campaignValidator.validate({
+              ...campaignOfTypeProfilesCollection,
+              targetProfileId: UNDEFINED_VALUE,
+            });
+
+          } catch (entityValidationErrors) {
+            expect.fail('should be valid when targetProfileId is undefined');
+          }
+        });
       });
 
-      it('should reject with error when targetProfileId is missing and campaign type is ASSESSMENT', () => {
+      context('when type is ASSESSMENT', () => {
+        it('should reject with error when targetProfileId is missing', () => {
         // given
-        const expectedError = {
-          attribute: 'targetProfileId',
-          message: 'Veuillez sélectionner un profil cible pour votre campagne.'
-        };
+          const expectedError = {
+            attribute: 'targetProfileId',
+            message: 'Veuillez sélectionner un profil cible pour votre campagne.'
+          };
 
-        try {
-          // when
-          campaignValidator.validate({
-            ...campaignOfTypeAssessment,
-            targetProfileId: MISSING_VALUE,
-          });
-          expect.fail('should have thrown an error');
+          try {
+            // when
+            campaignValidator.validate({
+              ...campaignOfTypeAssessment,
+              targetProfileId: MISSING_VALUE,
+            });
+            expect.fail('should have thrown an error');
 
-        } catch (entityValidationErrors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-        }
-      });
+          } catch (entityValidationErrors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          }
+        });
 
-      it('should reject with error when targetProfileId is undefined and campaign type is ASSESSMENT', () => {
+        it('should reject with error when targetProfileId is undefined', () => {
         // given
-        const expectedError = {
-          attribute: 'targetProfileId',
-          message: 'Veuillez sélectionner un profil cible pour votre campagne.'
-        };
+          const expectedError = {
+            attribute: 'targetProfileId',
+            message: 'Veuillez sélectionner un profil cible pour votre campagne.'
+          };
 
-        try {
-          // when
-          campaignValidator.validate({
-            ...campaignOfTypeAssessment,
-            targetProfileId: UNDEFINED_VALUE,
-          });
-          expect.fail('should have thrown an error');
+          try {
+            // when
+            campaignValidator.validate({
+              ...campaignOfTypeAssessment,
+              targetProfileId: UNDEFINED_VALUE,
+            });
+            expect.fail('should have thrown an error');
 
-        } catch (entityValidationErrors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-        }
+          } catch (entityValidationErrors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+          }
+        });
       });
-
     });
 
     context('when a title is provided', () => {

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -45,21 +45,23 @@
       </p>
     </div>
   </div>
+      <div class="campaign-details-row">
+      {{#unless @campaign.isArchived}}
+        <div class="campaign-details-content campaign-details-content--button campaign-details--button">
+          <LinkTo @route="authenticated.campaigns.update" @model={{@campaign.id}} class="button button--grey button--regular button--link campaign-details-content__update-button" aria-label="Modifier">
+            Modifier
+          </LinkTo>
+        </div>
+      {{/unless}}
 
-  {{#if @campaign.canBeArchived}}
-    <div class="campaign-details-row">
-      <div class="campaign-details-content campaign-details-content--button campaign-details--button">
-        <LinkTo @route="authenticated.campaigns.update" @model={{@campaign.id}} class="button button--grey button--regular button--link campaign-details-content__update-button" aria-label="Modifier">
-          Modifier
-        </LinkTo>
-      </div>
+    {{#if @campaign.canBeArchived}}
       <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
         <button type="button" {{on 'click' (fn this.archiveCampaign @campaign.id)}}
                    class="button button--grey button--regular button--link" aria-label="Archiver">
           Archiver
         </button>
       </div>
+    {{/if}}
     </div>
-  {{/if}}
 </div>
 

--- a/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/update-item.hbs
@@ -15,17 +15,19 @@
       />
     </div>
 
-    <div class="form__field">
-      <label for="campaign-title" class="label">Titre du parcours</label>
-      <Input
-        @id="campaign-title"
-        @name="campaign-title"
-        @type="text"
-        @class="input"
-        @maxlength="50"
-        @value={{@campaign.title}}
-      />
-    </div>
+    {{#if @campaign.isTypeAssessment}}
+      <div class="form__field">
+        <label for="campaign-title" class="label">Titre du parcours</label>
+        <Input
+          @id="campaign-title"
+          @name="campaign-title"
+          @type="text"
+          @class="input"
+          @maxlength="50"
+          @value={{@campaign.title}}
+        />
+      </div>
+    {{/if}}
 
     <div class="form__field">
       <label for="campaign-custom-landing-page-text" class="label">Texte de la page d'accueil</label>

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -20,18 +20,18 @@ module('Acceptance | Campaign Update', function(hooks) {
       token_type: 'Bearer token type',
     });
     const campaign = server.create('campaign', { id: 1 });
-    const newTitle = 'New title';
+    const newName = 'New NAme';
     const newText = 'New text';
 
     await visit(`/campagnes/${campaign.id}/modification`);
-    await fillIn('#campaign-title', newTitle);
+    await fillIn('#campaign-name', newName);
     await fillIn('#campaign-custom-landing-page-text', newText);
 
     // when
     await click('button[type="submit"]');
 
     // then
-    assert.equal(server.db.campaigns.find(1).title, newTitle);
+    assert.equal(server.db.campaigns.find(1).name, newName);
     assert.equal(server.db.campaigns.find(1).customLandingPageText, newText);
     assert.equal(currentURL(), '/campagnes/1');
   });

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -20,7 +20,7 @@ module('Acceptance | Campaign Update', function(hooks) {
       token_type: 'Bearer token type',
     });
     const campaign = server.create('campaign', { id: 1 });
-    const newName = 'New NAme';
+    const newName = 'New Name';
     const newText = 'New text';
 
     await visit(`/campagnes/${campaign.id}/modification`);

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
@@ -182,39 +182,17 @@ module('Integration | Component | routes/authenticated/campaign/details | parame
   });
 
   module('on Modify action display', function() {
-    module('when type campaign can be archived', function() {
-      test('it should display the button modify', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          type: 'ASSESSMENT',
-          archivedAt: null,
-        });
+    test('it should display the button modify', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {});
 
-        this.set('campaign', campaign);
+      this.set('campaign', campaign);
 
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
 
-        // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('Modifier');
-      });
-    });
-
-    module('when type campaign cannot archived', function() {
-      test('it should hide the button modify', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          type: 'PROFILES_COLLECTION',
-        });
-
-        this.set('campaign', campaign);
-
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
-
-        // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Modifier');
-      });
+      // then
+      assert.dom('[aria-label="Détails de la campagne"]').includesText('Modifier');
     });
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
@@ -182,17 +182,34 @@ module('Integration | Component | routes/authenticated/campaign/details | parame
   });
 
   module('on Modify action display', function() {
-    test('it should display the button modify', async function(assert) {
-      // given
-      const campaign = store.createRecord('campaign', {});
+    module('when the campaign is not archived', function() {
+      test('it should display the button modify', async function(assert) {
+        // given
+        const campaign = store.createRecord('campaign', { isArchived: false });
 
-      this.set('campaign', campaign);
+        this.set('campaign', campaign);
 
-      // when
-      await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
+        // when
+        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
 
-      // then
-      assert.dom('[aria-label="Détails de la campagne"]').includesText('Modifier');
+        // then
+        assert.dom('[aria-label="Détails de la campagne"]').includesText('Modifier');
+      });
+    });
+
+    module('when the campaign is archived', function() {
+      test('it should not display the button modify', async function(assert) {
+        // given
+        const campaign = store.createRecord('campaign', { isArchived: true });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
+
+        // then
+        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Modifier');
+      });
     });
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaigns/update-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/update-item-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | routes/authenticated/campaign | update-item', 
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    this.campaign = EmberObject.create({});
+    this.campaign = EmberObject.create({ isTypeAssessment: true });
     this.set('updateCampaignSpy', (event) => event.preventDefault());
     this.set('cancelSpy', () => {});
   });
@@ -19,10 +19,8 @@ module('Integration | Component | routes/authenticated/campaign | update-item', 
     await render(hbs`<Routes::Authenticated::Campaigns::UpdateItem @campaign={{this.campaign}} @update={{this.updateCampaignSpy}} @cancel={{this.cancelSpy}} />`);
 
     // then
-    assert.dom('#campaign-title').exists();
     assert.dom('#campaign-custom-landing-page-text').exists();
     assert.dom('button[type="submit"]').exists();
-    assert.dom('#campaign-title').hasAttribute('maxLength', '50');
     assert.dom('#campaign-custom-landing-page-text').hasAttribute('maxLength', '350');
   });
 
@@ -35,5 +33,26 @@ module('Integration | Component | routes/authenticated/campaign | update-item', 
     await click('button[type="submit"]');
 
     assert.deepEqual(this.campaign.title, 'New title');
+  });
+
+  module('When campaign type is ASSESSMENT', function() {
+    test('it should display campaign title input', async function(assert) {
+      this.campaign = EmberObject.create({ isTypeAssessment: true });
+
+      await render(hbs`<Routes::Authenticated::Campaigns::UpdateItem @campaign={{this.campaign}} @update={{this.updateCampaignSpy}} @cancel={{this.cancelSpy}} />`);
+
+      assert.dom('input#campaign-title').exists();
+      assert.dom('#campaign-title').hasAttribute('maxLength', '50');
+    });
+  });
+
+  module('When campaign type is not ASSESSMENT', function() {
+    test('it should not display campaign title input', async function(assert) {
+      this.campaign = EmberObject.create({ isTypeAssessment: false });
+
+      await render(hbs`<Routes::Authenticated::Campaigns::UpdateItem @campaign={{this.campaign}} @update={{this.updateCampaignSpy}} @cancel={{this.cancelSpy}} />`);
+
+      assert.dom('input#campaign-title').doesNotExist();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas modifier un campagne de type collecte de profils.

## :robot: Solution
Afficher le bouton modifier dans la page de détails d'une campagne. 
Cacher le champ titre du parcours dans le formulaire de mise à jour car les campagnes de collecte de profils n'ont pas de parcours.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à PIX Orga et modifier une campagne.
Le champ titre du parcours ne doit pas être présent pour une campagne de type collection de profils, mais il est présent pour les campagnes de type évaluation
