### PR TITLE
[BUGFIX] Le changement rapide du contenu de plusieurs filtres dans les listes paginées n'est pas bien géré (PIX-598)

### DIFF
--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -16,11 +16,14 @@ export default class ListController extends Controller {
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;
+  pendingFilters = {};
 
   @(task(function * (fieldName, event) {
     const value = event.target.value;
+    this.pendingFilters[fieldName] = value;
     yield timeout(this.DEBOUNCE_MS);
-    this[fieldName] = value;
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
 }

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -16,11 +16,14 @@ export default class ListController extends Controller {
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;
+  pendingFilters = {};
 
   @(task(function * (fieldName, event) {
     const value = event.target.value;
+    this.pendingFilters[fieldName] = value;
     yield timeout(this.DEBOUNCE_MS);
-    this[fieldName] = value;
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
 

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -18,6 +18,7 @@ export default class SessionListController extends Controller {
   @tracked certificationCenterName = null;
   @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
+  pendingFilters = {};
 
   sessionStatusAndLabels = [
     { status: null, label: 'Tous' },
@@ -46,8 +47,10 @@ export default class SessionListController extends Controller {
       default:
         return;
     }
+    this.pendingFilters[fieldName] = value;
     yield timeout(debounceDuration);
-    this[fieldName] = value;
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
 }

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -16,11 +16,14 @@ export default class ListController extends Controller {
   @tracked firstName = null;
   @tracked lastName = null;
   @tracked email = null;
+  pendingFilters = {};
 
   @(task(function * (fieldName, event) {
     const value = event.target.value;
+    this.pendingFilters[fieldName] = value;
     yield timeout(this.DEBOUNCE_MS);
-    this[fieldName] = value;
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
 

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -1,5 +1,5 @@
 import { action, computed } from '@ember/object';
-import { empty } from '@ember/object/computed';
+import { empty, equal } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
@@ -26,10 +26,7 @@ export default class ListController extends Controller {
     return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
   }
 
-  @computed('status')
-  get isArchived() {
-    return this.status === 'archived';
-  }
+  @equal('status', 'archived') isArchived;
 
   setFieldName() {
     this.set(this.searchFilter.fieldName, this.searchFilter.value);

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -7,10 +7,12 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'pix-orga/config/environment';
 
+const DEFAULT_PAGE_NUMBER = 1;
+
 export default class ListController extends Controller {
   queryParams = ['pageNumber', 'pageSize', 'name', 'status', 'creatorId'];
   DEBOUNCE_MS = config.pagination.debounce;
-  pageNumber = 1;
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   pageSize = 25;
   name = null;
   @tracked creatorId = null;
@@ -30,6 +32,7 @@ export default class ListController extends Controller {
 
   setFieldName() {
     this.set(this.searchFilter.fieldName, this.searchFilter.value);
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -4,6 +4,7 @@ import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import config from 'pix-orga/config/environment';
 
 export default class ListController extends Controller {
@@ -12,8 +13,10 @@ export default class ListController extends Controller {
   pageNumber = 1;
   pageSize = 25;
   name = null;
-  searchFilter = null;
   campaignName = null;
+  @tracked creatorId = null;
+  @tracked status = null;
+  searchFilter = null;
 
   @service currentUser;
 
@@ -42,12 +45,12 @@ export default class ListController extends Controller {
 
   @action
   updateCampaignStatus(newStatus) {
-    this.set('status', newStatus);
+    this.status = newStatus;
   }
 
   @action
   updateCampaignCreator(creatorId) {
-    this.set('creatorId', creatorId);
+    this.creatorId = creatorId;
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -17,7 +17,7 @@ export default class ListController extends Controller {
   name = null;
   @tracked creatorId = null;
   @tracked status = null;
-  searchFilter = null;
+  pendingFilters = {};
 
   @service currentUser;
 
@@ -30,16 +30,17 @@ export default class ListController extends Controller {
 
   @equal('status', 'archived') isArchived;
 
-  setFieldName() {
-    this.set(this.searchFilter.fieldName, this.searchFilter.value);
+  updateFilters() {
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }
 
   @action
   triggerFiltering(fieldName, event) {
     const value = event.target.value;
-    this.searchFilter = { fieldName, value };
-    debounce(this, this.setFieldName, this.DEBOUNCE_MS);
+    this.pendingFilters[fieldName] = value;
+    debounce(this, this.updateFilters, this.DEBOUNCE_MS);
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -13,7 +13,6 @@ export default class ListController extends Controller {
   pageNumber = 1;
   pageSize = 25;
   name = null;
-  campaignName = null;
   @tracked creatorId = null;
   @tracked status = null;
   searchFilter = null;

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -94,18 +94,22 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
     });
   });
 
-  module('#setFieldName', function() {
+  module('#updateFilters', function() {
 
-    test('it should put value from searchFilter into appropriate controller property', function(assert) {
+    test('it should put value from pendingFilters into appropriate controller properties', function(assert) {
       // given
-      controller.name = 'someName';
-      controller.searchFilter = { fieldName: 'name', value: 'someOtherName' };
+      controller.prop1 = 'someValue1';
+      controller.prop2 = 'someValue2';
+      controller.prop3 = 'someValue3';
+      controller.pendingFilters = { prop1: 'someOtherValue1', prop2: 'someOtherValue2' };
 
       // when
-      controller.setFieldName();
+      controller.updateFilters();
 
       // then
-      assert.equal(controller.name, 'someOtherName');
+      assert.equal(controller.prop1, 'someOtherValue1');
+      assert.equal(controller.prop2, 'someOtherValue2');
+      assert.equal(controller.prop3, 'someValue3');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Sur les listes paginées avec plusieurs filtres, le fait de modifier très rapidement plusieurs filtres est mal géré. En effet, il existe un temps d'attente entre le moment où on frappe sur le clavier et l'envoi de la requête de recherche. Durant ce temps d'attente, si on est très habiles, on peut modifier le contenu de plusieurs filtres. Malheureusement, dans le code, ce cas n'est pas bien géré.
Pour en avoir une illustration claire, rendez-vous sur PixAdmin en Intégration ou sur la RA de votre choix (mais pas celle-ci !) :
- Aller sur la liste des centres de certification
- Vous positionner sur le champ de recherche par ID
- Tapez rapidement du contenu, PUIS changer de champ (via la touche TAB par exemple) puis tapez encore du contenu une fois dans le champ de recherche par nom de centre.
Vous remarquerez que seul le dernier filtre (celui sur le nom) est pris en compte

## :robot: Solution
Fix du bug sur tous les composants de listes paginées via la méthode proposée en commentaire de la https://github.com/1024pix/pix/pull/1341, à savoir :
- Stocker dans une variable la liste des filtres en attente pas encore appliqués
- Après le temps d'attente, mettre à jour le controller et vider les filtres en attente.

Au passage, quelques BSRs dans le controller de liste de campagnes sur PixOrga :
- Retrait d'une variable non utilisée
- Retrait des appels `set()` (Ember Octane :rocket: )
- Oubli de revenir à la première page lorsque les filtres provoquent une nouvelle recherche
- Remplacement d'un computed par sa macro adaptée

## :rainbow: Remarques

## :100: Pour tester
Tester la même chose que dans la section Problème, mais cette fois-ci on constate que les deux filtres sont pris en compte
