### PR TITLE
[FEATURE] Supprime le terme parcours des messages d'erreurs des pages de réconciliation (PIX-582).

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -161,7 +161,7 @@ export default class RegisterForm extends Component {
         this.set('isLoading', false);
         errorResponse.errors.forEach((error) => {
           if (error.status === '404') {
-            return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+            return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
           }
           if (error.status === '409') {
             return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');

--- a/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/controllers/campaigns/join-restricted-campaign.js
@@ -140,10 +140,10 @@ export default class JoinRestrictedCampaignController extends Controller {
   _setErrorMessageForAttemptNextAction(errorResponse) {
     errorResponse.errors.forEach((error) => {
       if (error.status === '409') {
-        return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
+        return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur.');
       }
       if (error.status === '404') {
-        return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+        return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
       }
       return this.set('errorMessage', error.detail);
     });

--- a/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join-restricted-campaign-test.js
@@ -463,7 +463,7 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+      expect(controller.get('errorMessage')).to.equal('Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });
@@ -477,7 +477,7 @@ describe('Unit | Controller | campaigns/join-restricted-campaign', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Les informations saisies ont déjà été utilisées. Prévenez l’organisateur de votre parcours.');
+      expect(controller.get('errorMessage')).to.equal('Les informations saisies ont déjà été utilisées. Prévenez l’organisateur.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });


### PR DESCRIPTION
## :unicorn: Problème
Au vu de l'arrivée des campagnes de collecte de profils, nous ne pouvons plus utiliser le terme parcours dans les pages de réconciliation.

## :robot: Solution
Supprimer le terme parcours des messages d'erreurs présent sur les pages de réconciliation.
