### PR TITLE
[FEATURE] Ajoute le système d'archivage sur les campagnes de type collecte de profils (PIX-584).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -20,6 +20,9 @@ function _mapToHttpError(error) {
     return error;
   }
 
+  if (error instanceof DomainErrors.CampaignAlreadyArchivedError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {
     return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
   }

--- a/mon-pix/app/controllers/campaigns/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/send-profile.js
@@ -15,14 +15,23 @@ export default class SendProfileController extends Controller {
 
     const campaignParticipation = this.model.campaignParticipation;
     campaignParticipation.isShared = true;
-    return campaignParticipation.save()
-      .then(() => {
-        this.isLoading = false;
-      })
-      .catch(() => {
-        campaignParticipation.rollbackAttributes();
-        this.isLoading = false;
-        this.errorMessage = true;
+
+    try {
+      await campaignParticipation.save();
+    } catch (errorResponse) {
+      campaignParticipation.rollbackAttributes();
+      this._handleCampaignParticipationSaveErrors(errorResponse.errors);
+    }
+    this.isLoading = false;
+  }
+
+  _handleCampaignParticipationSaveErrors(errors) {
+    if (errors && errors.length > 0) {
+      errors.forEach((error) => {
+        if (error.status === '412') {
+          this.errorMessage = 'L’envoi de votre profil n’est plus possible car l’organisateur a archivé la collecte de profils.';
+        }
       });
+    }
   }
 }

--- a/mon-pix/app/templates/components/profile-sharing-form.hbs
+++ b/mon-pix/app/templates/components/profile-sharing-form.hbs
@@ -3,7 +3,10 @@
 
   {{#if @campaignParticipation.isShared}}
     <p class="skill-review-share__thanks">Merci, votre profil a bien été envoyé !</p>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>  
+  {{else if @errorMessage}}
+    <p class="skill-review-share__thanks">{{@errorMessage}}</p>
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>  
   {{else}}
     {{#if @isLoading}}
       <button type="button" disabled class="button button--big">
@@ -11,9 +14,6 @@
       </button>
     {{else}}
       <button type="submit" class="button button--big">J'envoie mon profil</button>
-    {{/if}}
-    {{#if @errorMessage}}
-      <div class="fill-in-id-pix__form__error-message">{{@errorMessage}}</div>
     {{/if}}
 
     <p class="send-profile-header__warning">

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -88,11 +88,6 @@ export default class Campaign extends Model {
     return Boolean(this.archivedAt);
   }
 
-  @computed('isTypeAssessment', 'isArchived')
-  get canBeArchived() {
-    return this.isTypeAssessment && ! this.isArchived;
-  }
-
   async archive() {
     await this.store.adapterFor('campaign').archive(this);
     return this.store.findRecord('campaign', this.id, { include: 'targetProfile' });

--- a/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details-item.hbs
@@ -36,8 +36,11 @@
       <FaIcon @icon='archive'></FaIcon>
     </div>
     <div class="campaign-archived-banner__text">Campagne archivée</div>
-    <button type="button" class="button button--link campaign-archived-banner__unarchive-button" {{on 'click'
-                                                                                                      (fn this.unarchiveCampaign @campaign.id)}}>
+    <button
+      type="button"
+      class="button button--link campaign-archived-banner__unarchive-button"
+      {{on 'click' (fn this.unarchiveCampaign @campaign.id)}}
+    >
       Désarchiver la campagne
     </button>
   </div>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -76,3 +76,4 @@
       </div>
     {{/unless}}
   </div>
+</div>

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -19,7 +19,12 @@
         {{#if (is-clipboard-supported)}}
           <div class="tooltip content-text content-text--small">
             <span class="tooltip-text campaign-details-content__tooltip-text">{{this.tooltipText}}</span>
-            <CopyButton @clipboardText={{@campaign.url}} @success={{this.clipboardSuccess}} {{on 'mouseLeave' this.clipboardOut}} @classNames="icon-button campaign-details-content__clipboard-button">
+            <CopyButton
+              @clipboardText={{@campaign.url}}
+              @success={{this.clipboardSuccess}}
+              {{on 'mouseLeave' this.clipboardOut}}
+              @classNames="icon-button campaign-details-content__clipboard-button"
+            >
               <FaIcon @icon='copy' @prefix='far'></FaIcon>
             </CopyButton>
           </div>
@@ -28,14 +33,14 @@
     </div>
   </div>
 
-{{#if @campaign.isTypeAssessment}}
-  <div class="campaign-details-row">
-    <div class="campaign-details-content campaign-details-content--single">
-      <h4 class="label-text campaign-details-content__label">Titre du parcours</h4>
-      <p class="content-text campaign-details-content__text">{{@campaign.title}}</p>
+  {{#if @campaign.isTypeAssessment}}
+    <div class="campaign-details-row">
+      <div class="campaign-details-content campaign-details-content--single">
+        <h4 class="label-text campaign-details-content__label">Titre du parcours</h4>
+        <p class="content-text campaign-details-content__text">{{@campaign.title}}</p>
+      </div>
     </div>
-  </div>
-{{/if}}
+  {{/if}}
 
   <div class="campaign-details-row">
     <div class="campaign-details-content campaign-details-content--single">
@@ -45,23 +50,29 @@
       </p>
     </div>
   </div>
+  <div class="campaign-details-row">
+    {{#unless @campaign.isArchived}}
       <div class="campaign-details-row">
-      {{#unless @campaign.isArchived}}
         <div class="campaign-details-content campaign-details-content--button campaign-details--button">
-          <LinkTo @route="authenticated.campaigns.update" @model={{@campaign.id}} class="button button--grey button--regular button--link campaign-details-content__update-button" aria-label="Modifier">
+          <LinkTo
+            @route="authenticated.campaigns.update"
+            @model={{@campaign.id}}
+            class="button button--grey button--regular button--link campaign-details-content__update-button"
+            aria-label="Modifier"
+          >
             Modifier
           </LinkTo>
         </div>
-      {{/unless}}
-
-    {{#if @campaign.canBeArchived}}
-      <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
-        <button type="button" {{on 'click' (fn this.archiveCampaign @campaign.id)}}
-                   class="button button--grey button--regular button--link" aria-label="Archiver">
-          Archiver
-        </button>
+        <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
+          <button
+            type="button"
+            {{on 'click' (fn this.archiveCampaign @campaign.id)}}
+            class="button button--grey button--regular button--link"
+            aria-label="Archiver"
+          >
+            Archiver
+          </button>
+        </div>
       </div>
-    {{/if}}
-    </div>
-</div>
-
+    {{/unless}}
+  </div>

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
@@ -145,39 +145,19 @@ module('Integration | Component | routes/authenticated/campaign/details | parame
   });
 
   module('on Archived action display', function() {
-    module('when type campaign can be archived', function() {
-      test('it should display the button archived', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          type: 'ASSESSMENT',
-          archivedAt: null,
-        });
-
-        this.set('campaign', campaign);
-
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
-
-        // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('Archiver');
+    test('it should display the button archived', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        archivedAt: null,
       });
-    });
 
-    module('when type campaign cannot be archived', function() {
-      test('it should not display the button archived', async function(assert) {
-        // given
-        const campaign = store.createRecord('campaign', {
-          type: 'PROFILES_COLLECTION',
-        });
+      this.set('campaign', campaign);
 
-        this.set('campaign', campaign);
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
 
-        // when
-        await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
-
-        // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Archiver');
-      });
+      // then
+      assert.dom('[aria-label="Détails de la campagne"]').includesText('Archiver');
     });
   });
 

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -86,43 +86,29 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('canBeArchived', function() {
+  module('isArchived', function() {
     let store;
 
     hooks.beforeEach(function() {
       store = this.owner.lookup('service:store');
     });
 
-    module('when type is ASSESSMENT', function() {
-      module('when campaign is not archived', function() {
-        test('it should return true', function(assert) {
-          const campaign = store.createRecord('campaign', {
-            type: 'ASSESSMENT',
-            archivedAt: null,
-          });
-
-          assert.equal(campaign.canBeArchived, true);
-        });
-        module('when campaign is archived', function() {
-          test('it should return false', function(assert) {
-            const campaign = store.createRecord('campaign', {
-              type: 'ASSESSMENT',
-              archivedAt: new Date('2020-01-01'),
-            });
-
-            assert.equal(campaign.canBeArchived, false);
-          });
-        });
-      });
-    });
-    module('when type is PROFILES_COLLECTION', function() {
-      test('it should be false', function(assert) {
+    module('when campaign is not archived', function() {
+      test('it should return false', function(assert) {
         const campaign = store.createRecord('campaign', {
-          type: 'PROFILES_COLLECTION',
           archivedAt: null,
         });
 
-        assert.equal(campaign.canBeArchived, false);
+        assert.equal(campaign.isArchived, false);
+      });
+    });
+    module('when campaign is archived', function() {
+      test('it should return true', function(assert) {
+        const campaign = store.createRecord('campaign', {
+          archivedAt: new Date('2020-01-01'),
+        });
+
+        assert.equal(campaign.isArchived, true);
       });
     });
   });

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -93,7 +93,7 @@ module('Unit | Model | campaign', function(hooks) {
       store = this.owner.lookup('service:store');
     });
 
-    module('when campaign is not archived', function() {
+    module('when campaign does not have an archived date', function() {
       test('it should return false', function(assert) {
         const campaign = store.createRecord('campaign', {
           archivedAt: null,
@@ -102,7 +102,7 @@ module('Unit | Model | campaign', function(hooks) {
         assert.equal(campaign.isArchived, false);
       });
     });
-    module('when campaign is archived', function() {
+    module('when campaign has an archived date', function() {
       test('it should return true', function(assert) {
         const campaign = store.createRecord('campaign', {
           archivedAt: new Date('2020-01-01'),


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas archiver une campagne de type collecte de profils.

## :robot: Solution
Suppression du feature toggle spécifique au campaign de type évaluation.

## :rainbow: Remarques
Voici les impacts de l'archivage d'une campagne : 
- Affichage du bandeau archivage dans la campagne
- Ne plus pouvoir modifier une campagne (enlever le bouton)
- Ne plus pouvoir envoyer de profil pix dans Pix APP (lorsque le code de la campagne est saisie, reprendre le message d’erreur afficher dans le cas d’une campagne d’évaluation).

## :100: Pour tester
Rendez vous sur PixOrga et cliquer sur le bouton "Archiver" dans le détails d'une campagne de collecte de profils. Vous pouvez ensuite constater qu'elle apparaît dans la liste des campagne archivées et que vous ne pouvez plus la modifier. Si vous essayer d'utiliser son code dans PixApp vous aurez un message qui vous informe que la campagne a été archivée.
