### PR TITLE
[CLEANUP] Suppression d'un appel inutile dans la page challenge (PIX-609).

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -23,14 +23,6 @@ export default class ChallengeRoute extends Route {
     });
   }
 
-  async afterModel(modelResult) {
-    if (modelResult.assessment.get('isSmartPlacement')) {
-      const campaignCode = modelResult.assessment.codeCampaign;
-      const campaigns = await this._findCampaigns({ campaignCode });
-      modelResult.campaign = campaigns.get('firstObject');
-    }
-  }
-
   serialize(model) {
     return {
       assessment_id: model.assessment.id,


### PR DESCRIPTION
## :unicorn: Problème
Depuis que le titre est dans l'objet Assessment, sur la page Challenge l'objet campaign n'est plus utilisé

## :robot: Solution
Supprimer l'afterModel concerné.

## :rainbow: Remarques
Cela permet d'éliminer un appel qui était fait à chaque épreuve dans les campagnes.
