### PR TITLE
[FEATURE] Enregister l'acceptation des CGU par l'utilisateur (PF-1235)

### DIFF
--- a/api/db/migrations/20200503193240_add_lastTermsOfServiceValidatedAt_to_user.js
+++ b/api/db/migrations/20200503193240_add_lastTermsOfServiceValidatedAt_to_user.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'lastTermsOfServiceValidatedAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -66,4 +66,24 @@ module.exports = function usersBuilder({ databaseBuilder }) {
   };
   databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithSamlId);
 
+  const userWithLastTermsOfServiceValidated = {
+    firstName: 'lasttermsofservice',
+    lastName: 'validated',
+    email: null,
+    rawPassword: 'Password123',
+    cgu: false,
+    lastTermsOfServiceValidatedAt: '2020-07-22',
+  };
+  databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceValidated);
+
+  const userWithLastTermsOfServiceNotValidated = {
+    firstName: 'lasttermsofservice',
+    lastName: 'notValidated',
+    email: null,
+    rawPassword: 'Password123',
+    cgu: false,
+    lastTermsOfServiceValidatedAt: '2020-07-22',
+  };
+  databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceNotValidated);
+
 };

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -69,9 +69,10 @@ module.exports = function usersBuilder({ databaseBuilder }) {
   const userWithLastTermsOfServiceValidated = {
     firstName: 'lasttermsofservice',
     lastName: 'validated',
-    email: null,
+    email: 'lasttermsofservice@validated.net',
     rawPassword: 'Password123',
-    cgu: false,
+    cgu: true,
+    mustValidateTermsOfService: false,
     lastTermsOfServiceValidatedAt: '2020-07-22',
   };
   databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceValidated);
@@ -79,10 +80,11 @@ module.exports = function usersBuilder({ databaseBuilder }) {
   const userWithLastTermsOfServiceNotValidated = {
     firstName: 'lasttermsofservice',
     lastName: 'notValidated',
-    email: null,
+    email: 'lasttermsofservice@notvalidated.net',
     rawPassword: 'Password123',
-    cgu: false,
-    lastTermsOfServiceValidatedAt: '2020-07-22',
+    cgu: true,
+    mustValidateTermsOfService: true,
+    lastTermsOfServiceValidatedAt: null,
   };
   databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceNotValidated);
 

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -186,7 +186,7 @@ exports.register = async function(server) {
         handler: userController.acceptLastPixTermsOfService,
         notes : [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Sauvegarde le fait que l\'utilisateur a accepté les Conditions Générales d\'Utilisation de Pix App\n' +
+          '- Sauvegarde le fait que l\'utilisateur a accepté les dernières Conditions Générales d\'Utilisation de Pix App\n' +
           '- L’id demandé doit correspondre à celui de l’utilisateur authentifié\n' +
           '- Le contenu de la requête n\'est pas pris en compte.',
         ],

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -177,6 +177,24 @@ exports.register = async function(server) {
     },
     {
       method: 'PATCH',
+      path: '/api/users/{id}/pix-terms-of-service-acceptance',
+      config: {
+        pre: [{
+          method: securityController.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser'
+        }],
+        handler: userController.acceptLastPixTermsOfService,
+        notes : [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Sauvegarde le fait que l\'utilisateur a accepté les Conditions Générales d\'Utilisation de Pix App\n' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié\n' +
+          '- Le contenu de la requête n\'est pas pris en compte.',
+        ],
+        tags: ['api', 'user'],
+      }
+    },
+    {
+      method: 'PATCH',
       path: '/api/users/{id}/pix-orga-terms-of-service-acceptance',
       config: {
         pre: [{

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -183,7 +183,7 @@ exports.register = async function(server) {
           method: securityController.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser'
         }],
-        handler: userController.acceptLastPixTermsOfService,
+        handler: userController.accepPixLastTermsOfService,
         notes : [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Sauvegarde le fait que l\'utilisateur a accepté les dernières Conditions Générales d\'Utilisation de Pix App\n' +

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -53,6 +53,16 @@ module.exports = {
     return userSerializer.serialize(updatedUser);
   },
 
+  async acceptPixTermsOfService(request) {
+    const authenticatedUserId = request.auth.credentials.userId;
+
+    const updatedUser = await usecases.acceptPixTermsOfService({
+      userId: authenticatedUserId
+    });
+
+    return userSerializer.serialize(updatedUser);
+  },
+
   async acceptPixOrgaTermsOfService(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -53,10 +53,10 @@ module.exports = {
     return userSerializer.serialize(updatedUser);
   },
 
-  async acceptPixTermsOfService(request) {
+  async acceptLastPixTermsOfService(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 
-    const updatedUser = await usecases.acceptPixTermsOfService({
+    const updatedUser = await usecases.acceptLastPixTermsOfService({
       userId: authenticatedUserId
     });
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -53,10 +53,10 @@ module.exports = {
     return userSerializer.serialize(updatedUser);
   },
 
-  async acceptLastPixTermsOfService(request) {
+  async accepPixLastTermsOfService(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 
-    const updatedUser = await usecases.acceptLastPixTermsOfService({
+    const updatedUser = await usecases.acceptPixLastTermsOfService({
       userId: authenticatedUserId
     });
 

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -37,7 +37,7 @@ class User {
     this.email = email ? _.toLower(email) : undefined;
     this.password = password;
     this.cgu = cgu;
-    this.lastTermsOfServiceValidatedAt=lastTermsOfServiceValidatedAt;
+    this.lastTermsOfServiceValidatedAt = lastTermsOfServiceValidatedAt;
     this.mustValidateTermsOfService = mustValidateTermsOfService;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -13,6 +13,7 @@ class User {
     firstName,
     knowledgeElements,
     lastName,
+    lastTermsOfServiceValidatedAt,
     password,
     samlId,
     hasSeenAssessmentInstructions,
@@ -36,6 +37,7 @@ class User {
     this.email = email ? _.toLower(email) : undefined;
     this.password = password;
     this.cgu = cgu;
+    this.lastTermsOfServiceValidatedAt=lastTermsOfServiceValidatedAt;
     this.mustValidateTermsOfService = mustValidateTermsOfService;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;

--- a/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
+++ b/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
@@ -1,4 +1,4 @@
-module.exports = function acceptPixTermsOfService({
+module.exports = function acceptLastPixTermsOfService({
   userId,
   userRepository
 }) {

--- a/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
+++ b/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
@@ -1,0 +1,6 @@
+module.exports = function acceptPixTermsOfService({
+  userId,
+  userRepository
+}) {
+  return userRepository.updateLastPixTermsOfServiceAccepted(userId);
+};

--- a/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
+++ b/api/lib/domain/usecases/accept-last-pix-terms-of-service.js
@@ -1,6 +1,0 @@
-module.exports = function acceptLastPixTermsOfService({
-  userId,
-  userRepository
-}) {
-  return userRepository.updateLastPixTermsOfServiceAccepted(userId);
-};

--- a/api/lib/domain/usecases/accept-pix-last-terms-of-service.js
+++ b/api/lib/domain/usecases/accept-pix-last-terms-of-service.js
@@ -1,0 +1,6 @@
+module.exports = function acceptPixLastTermsOfService({
+  userId,
+  userRepository
+}) {
+  return userRepository.acceptPixLastTermsOfService(userId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -65,6 +65,7 @@ const dependencies = {
 };
 
 module.exports = injectDependencies({
+  acceptLastPixTermsOfService: require('./accept-last-pix-terms-of-service'),
   acceptPixCertifTermsOfService: require('./accept-pix-certif-terms-of-service'),
   acceptPixOrgaTermsOfService: require('./accept-pix-orga-terms-of-service'),
   addCertificationCandidateToSession: require('./add-certification-candidate-to-session'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -65,7 +65,7 @@ const dependencies = {
 };
 
 module.exports = injectDependencies({
-  acceptLastPixTermsOfService: require('./accept-last-pix-terms-of-service'),
+  acceptPixLastTermsOfService: require('./accept-pix-last-terms-of-service'),
   acceptPixCertifTermsOfService: require('./accept-pix-certif-terms-of-service'),
   acceptPixOrgaTermsOfService: require('./accept-pix-orga-terms-of-service'),
   addCertificationCandidateToSession: require('./add-certification-candidate-to-session'),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const Bookshelf = require('../bookshelf');
 const BookshelfUser = require('../data/user');
+const moment = require('moment');
 const { AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError, SchoolingRegistrationAlreadyLinkedToUserError, UserNotFoundError } = require('../../domain/errors');
 const User = require('../../domain/models/User');
 const UserDetailForAdmin = require('../../domain/read-models/UserDetailForAdmin');
@@ -323,6 +324,14 @@ module.exports = {
     let updatedUser = await BookshelfUser
       .where({ id })
       .save({ 'hasSeenAssessmentInstructions': true }, { patch: true, method: 'update' });
+    updatedUser = await updatedUser.refresh();
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, updatedUser);
+  },
+
+  async updateLastPixTermsOfServiceAccepted(id) {
+    let updatedUser = await BookshelfUser
+      .where({ id })
+      .save({ 'lastTermsOfServiceValidatedAt': moment().toDate() , 'mustValidateTermsOfService': false }, { patch: true, method: 'update' });
     updatedUser = await updatedUser.refresh();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, updatedUser);
   },

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -328,7 +328,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, updatedUser);
   },
 
-  async updateLastPixTermsOfServiceAccepted(id) {
+  async acceptPixLastTermsOfService(id) {
     let updatedUser = await BookshelfUser
       .where({ id })
       .save({ 'lastTermsOfServiceValidatedAt': moment().toDate() , 'mustValidateTermsOfService': false }, { patch: true, method: 'update' });

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -15,7 +15,7 @@ module.exports = {
       },
       attributes: [
         'firstName', 'lastName', 'email', 'username',
-        'cgu', 'mustValidateTermsOfService',
+        'cgu', 'lastTermsOfServiceValidatedAt', 'mustValidateTermsOfService',
         'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted',
         'memberships', 'certificationCenterMemberships',
         'pixScore', 'scorecards',
@@ -97,6 +97,7 @@ module.exports = {
       email: json.data.attributes.email,
       password: json.data.attributes.password,
       cgu: json.data.attributes.cgu,
+      lastTermsOfServiceValidatedAt: json.data.attributes['lastTermsOfServiceValidatedAt'],
       mustValidateTermsOfService: json.data.attributes['must-validate-terms-of-service'],
       pixOrgaTermsOfServiceAccepted: json.data.attributes['pix-orga-terms-of-service-accepted'],
       pixCertifTermsOfServiceAccepted: json.data.attributes['pix-certif-terms-of-service-accepted'],

--- a/api/tests/acceptance/application/users/accept-pix-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-terms-of-service_test.js
@@ -1,0 +1,63 @@
+const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-accept-pix-terms-of-service', () => {
+
+  let server;
+  let user;
+  let options;
+
+  beforeEach(async () => {
+    server = await createServer();
+
+    user = databaseBuilder.factory.buildUser({ mustValidateTermsOfService: true });
+
+    options = {
+      method: 'PATCH',
+      url: `/api/users/${user.id}/pix-terms-of-service-acceptance`,
+      headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+    };
+
+    return databaseBuilder.commit();
+  });
+
+  describe('Resource access management', () => {
+
+    it('should respond with a 401 - unauthorized access - if user is not authenticated', async () => {
+      // given
+      options.headers.authorization = 'invalid.access.token';
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('should respond with a 403 - forbidden access - if requested user is not the same as authenticated user', async () => {
+      // given
+      const otherUserId = 9999;
+      options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('Success case', () => {
+
+    it('should return the user with pixTermsOfServiceAccepted', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.attributes['must-validate-terms-of-service']).to.be.false;
+      expect(response.result.data.attributes['last-terms-of-service-validated-at']).to.exist;
+
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -36,6 +36,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             email: user.email.toLowerCase(),
             username: user.username,
             cgu: user.cgu,
+            'last-terms-of-service-validated-at': user.lastTermsOfServiceValidatedAt,
             'must-validate-terms-of-service': user.mustValidateTermsOfService,
             'pix-orga-terms-of-service-accepted': user.pixOrgaTermsOfServiceAccepted,
             'pix-certif-terms-of-service-accepted': user.pixCertifTermsOfServiceAccepted,

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -990,6 +990,26 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
   });
 
+  describe('#updateLastPixTermsOfServiceAccepted', () => {
+    let userId;
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser({ mustValidateTermsOfService: true , lastTermsOfServiceValidatedAt: null }).id;
+      return databaseBuilder.commit();
+    });
+
+    it('should validate the last terms of service and save the date of acceptance ', async () => {
+      // when
+      const actualUser = await userRepository.updateLastPixTermsOfServiceAccepted(userId);
+
+      // then
+      expect(actualUser.lastTermsOfServiceValidatedAt).to.be.exist;
+      expect(actualUser.mustValidateTermsOfService).to.be.false;
+
+    });
+
+  });
+
   describe('#updatePixOrgaTermsOfServiceAcceptedToTrue', () => {
     let userId;
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -990,7 +990,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
   });
 
-  describe('#updateLastPixTermsOfServiceAccepted', () => {
+  describe('#acceptPixLastTermsOfService', () => {
     let userId;
 
     beforeEach(() => {
@@ -1000,10 +1000,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     it('should validate the last terms of service and save the date of acceptance ', async () => {
       // when
-      const actualUser = await userRepository.updateLastPixTermsOfServiceAccepted(userId);
+      const actualUser = await userRepository.acceptPixLastTermsOfService(userId);
 
       // then
       expect(actualUser.lastTermsOfServiceValidatedAt).to.be.exist;
+      expect(actualUser.lastTermsOfServiceValidatedAt).to.be.a('Date');
       expect(actualUser.mustValidateTermsOfService).to.be.false;
 
     });

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -5,6 +5,7 @@ const encrypt = require('../../../../lib/domain/services/encryption-service');
 const buildUserPixRole = require('./build-user-pix-role');
 const buildOrganization = require('./build-organization');
 const buildMembership = require('./build-membership');
+const moment = require('moment');
 const _ = require('lodash');
 
 const PIX_MASTER_ROLE_ID = 1;
@@ -17,6 +18,7 @@ const buildUser = function buildUser({
   username = firstName + '.' + lastName + faker.random.number({ min: 1000, max: 9999 }),
   password,
   cgu = true,
+  lastTermsOfServiceValidatedAt,
   mustValidateTermsOfService = false,
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
@@ -27,9 +29,10 @@ const buildUser = function buildUser({
 
   password = _.isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
   email = _.isUndefined(email) ? faker.internet.exampleEmail(firstName, lastName).toLowerCase() : email || null;
+  lastTermsOfServiceValidatedAt = _.isUndefined(lastTermsOfServiceValidatedAt) ? moment().toDate() : null;
 
   const values = {
-    id, firstName, lastName, email, username, password, cgu, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
+    id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword,
   };
 
@@ -47,6 +50,7 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   username,
   rawPassword = faker.internet.password(),
   cgu = true,
+  lastTermsOfServiceValidatedAt,
   mustValidateTermsOfService = false,
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
@@ -58,7 +62,7 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   const password = encrypt.hashPasswordSync(rawPassword);
 
   const values = {
-    id, firstName, lastName, email, username, password, cgu, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
+    id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword,
   };
 
@@ -75,6 +79,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
   email = faker.internet.exampleEmail().toLowerCase(),
   password = encrypt.hashPasswordSync(faker.internet.password()),
   cgu = true,
+  lastTermsOfServiceValidatedAt,
   mustValidateTermsOfService = false,
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
@@ -82,7 +87,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
 } = {}) {
 
   const values = {
-    id, firstName, lastName, email, password, cgu, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
+    id, firstName, lastName, email, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions
   };
 
@@ -103,6 +108,7 @@ buildUser.withMembership = function buildUserWithMemberships({
   email = faker.internet.exampleEmail().toLowerCase(),
   password = 'encrypt.hashPasswordSync(faker.internet.password())',
   cgu = true,
+  lastTermsOfServiceValidatedAt,
   mustValidateTermsOfService,
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
@@ -112,7 +118,7 @@ buildUser.withMembership = function buildUserWithMemberships({
 } = {}) {
 
   const values = {
-    id, firstName, lastName, email, password, cgu, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
+    id, firstName, lastName, email, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions
   };
 

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -5,7 +5,6 @@ const encrypt = require('../../../../lib/domain/services/encryption-service');
 const buildUserPixRole = require('./build-user-pix-role');
 const buildOrganization = require('./build-organization');
 const buildMembership = require('./build-membership');
-const moment = require('moment');
 const _ = require('lodash');
 
 const PIX_MASTER_ROLE_ID = 1;
@@ -18,7 +17,7 @@ const buildUser = function buildUser({
   username = firstName + '.' + lastName + faker.random.number({ min: 1000, max: 9999 }),
   password,
   cgu = true,
-  lastTermsOfServiceValidatedAt,
+  lastTermsOfServiceValidatedAt = null,
   mustValidateTermsOfService = false,
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
@@ -29,7 +28,6 @@ const buildUser = function buildUser({
 
   password = _.isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
   email = _.isUndefined(email) ? faker.internet.exampleEmail(firstName, lastName).toLowerCase() : email || null;
-  lastTermsOfServiceValidatedAt = _.isUndefined(lastTermsOfServiceValidatedAt) ? moment().toDate() : null;
 
   const values = {
     id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -12,6 +12,7 @@ module.exports = function buildUser(
     username = 'jean.bono1234',
     password = 'liuehrfi128743KUUKNSUkuz12Ukun',
     cgu = true,
+    lastTermsOfServiceValidatedAt,
     mustValidateTermsOfService = false,
     pixOrgaTermsOfServiceAccepted = false,
     pixCertifTermsOfServiceAccepted = false,
@@ -24,7 +25,7 @@ module.exports = function buildUser(
 
   return new User({
     id, firstName, lastName, email, username, password,
-    cgu, mustValidateTermsOfService,
+    cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService,
     pixOrgaTermsOfServiceAccepted, pixCertifTermsOfServiceAccepted,
     hasSeenAssessmentInstructions, shouldChangePassword,
     pixRoles, memberships, certificationCenterMemberships,

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -12,7 +12,7 @@ module.exports = function buildUser(
     username = 'jean.bono1234',
     password = 'liuehrfi128743KUUKNSUkuz12Ukun',
     cgu = true,
-    lastTermsOfServiceValidatedAt,
+    lastTermsOfServiceValidatedAt = null,
     mustValidateTermsOfService = false,
     pixOrgaTermsOfServiceAccepted = false,
     pixCertifTermsOfServiceAccepted = false,

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -138,7 +138,7 @@ describe('Unit | Controller | user-controller', () => {
     });
   });
 
-  describe('#acceptPixTermsOfService', () => {
+  describe('#acceptPixLastTermsOfService', () => {
     let request;
     const userId = 1;
 
@@ -148,20 +148,21 @@ describe('Unit | Controller | user-controller', () => {
         params: { id: userId },
       };
 
-      sinon.stub(usecases, 'acceptLastPixTermsOfService');
+      sinon.stub(usecases, 'acceptPixLastTermsOfService');
       sinon.stub(userSerializer, 'serialize');
     });
 
     it('should accept pix terms of service', async () => {
       // given
-      usecases.acceptLastPixTermsOfService.withArgs({ userId }).resolves({});
-      userSerializer.serialize.withArgs({}).returns('ok');
+      usecases.acceptPixLastTermsOfService.withArgs({ userId }).resolves({});
+      const stubSerializedObject = 'ok';
+      userSerializer.serialize.withArgs({}).returns(stubSerializedObject);
 
       // when
-      const response = await userController.acceptLastPixTermsOfService(request);
+      const response = await userController.accepPixLastTermsOfService(request);
 
       // then
-      expect(response).to.be.equal('ok');
+      expect(response).to.be.equal(stubSerializedObject);
     });
   });
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -138,6 +138,33 @@ describe('Unit | Controller | user-controller', () => {
     });
   });
 
+  describe('#acceptPixTermsOfService', () => {
+    let request;
+    const userId = 1;
+
+    beforeEach(() => {
+      request = {
+        auth: { credentials: { userId } },
+        params: { id: userId },
+      };
+
+      sinon.stub(usecases, 'acceptPixTermsOfService');
+      sinon.stub(userSerializer, 'serialize');
+    });
+
+    it('should accept pix terms of service', async () => {
+      // given
+      usecases.acceptPixTermsOfService.withArgs({ userId }).resolves({});
+      userSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await userController.acceptPixTermsOfService(request);
+
+      // then
+      expect(response).to.be.equal('ok');
+    });
+  });
+
   describe('#acceptPixOrgaTermsOfService', () => {
     let request;
     const userId = 1;

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -148,17 +148,17 @@ describe('Unit | Controller | user-controller', () => {
         params: { id: userId },
       };
 
-      sinon.stub(usecases, 'acceptPixTermsOfService');
+      sinon.stub(usecases, 'acceptLastPixTermsOfService');
       sinon.stub(userSerializer, 'serialize');
     });
 
     it('should accept pix terms of service', async () => {
       // given
-      usecases.acceptPixTermsOfService.withArgs({ userId }).resolves({});
+      usecases.acceptLastPixTermsOfService.withArgs({ userId }).resolves({});
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.acceptPixTermsOfService(request);
+      const response = await userController.acceptLastPixTermsOfService(request);
 
       // then
       expect(response).to.be.equal('ok');

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -15,6 +15,7 @@ describe('Unit | Domain | Models | User', () => {
         email: 'email@example.net',
         password: 'pix123',
         cgu: true,
+        lastTermsOfServiceValidatedAt: '2020-05-04T13:40:00.000Z',
         mustValidateTermsOfService: true,
         samlId: 'some-saml-id',
         shouldChangePassword: false,
@@ -30,6 +31,7 @@ describe('Unit | Domain | Models | User', () => {
       expect(user.email).to.equal(rawData.email);
       expect(user.password).to.equal(rawData.password);
       expect(user.cgu).to.equal(rawData.cgu);
+      expect(user.lastTermsOfServiceValidatedAt).to.equal(rawData.lastTermsOfServiceValidatedAt);
       expect(user.mustValidateTermsOfService).to.equal(rawData.mustValidateTermsOfService);
       expect(user.samlId).to.equal(rawData.samlId);
       expect(user.shouldChangePassword).to.equal(rawData.shouldChangePassword);

--- a/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../../test-helper');
+const acceptPixTermsOfService = require('../../../../lib/domain/usecases/accept-pix-terms-of-service');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+describe('Unit | UseCase | accept-pix-terms-of-service', () => {
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'updateLastPixTermsOfServiceAccepted');
+  });
+
+  it('should accept terms of service of pix', async () => {
+    // given
+    const userId = Symbol('userId');
+    const updatedUser = Symbol('updateduser');
+    userRepository.updateLastPixTermsOfServiceAccepted.resolves(updatedUser);
+
+    // when
+    const actualUpdatedUser = await acceptPixTermsOfService({ userId, userRepository });
+
+    // then
+    expect(userRepository.updateLastPixTermsOfServiceAccepted).to.have.been.calledWith(userId);
+    expect(actualUpdatedUser).to.equal(updatedUser);
+  });
+
+});

--- a/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
@@ -1,8 +1,8 @@
 const { expect, sinon } = require('../../../test-helper');
-const acceptPixTermsOfService = require('../../../../lib/domain/usecases/accept-pix-terms-of-service');
+const acceptLastPixTermsOfService = require('../../../../lib/domain/usecases/accept-last-pix-terms-of-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
-describe('Unit | UseCase | accept-pix-terms-of-service', () => {
+describe('Unit | UseCase | accept-last-pix-terms-of-service', () => {
 
   beforeEach(() => {
     sinon.stub(userRepository, 'updateLastPixTermsOfServiceAccepted');
@@ -15,7 +15,7 @@ describe('Unit | UseCase | accept-pix-terms-of-service', () => {
     userRepository.updateLastPixTermsOfServiceAccepted.resolves(updatedUser);
 
     // when
-    const actualUpdatedUser = await acceptPixTermsOfService({ userId, userRepository });
+    const actualUpdatedUser = await acceptLastPixTermsOfService({ userId, userRepository });
 
     // then
     expect(userRepository.updateLastPixTermsOfServiceAccepted).to.have.been.calledWith(userId);

--- a/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
+++ b/api/tests/unit/domain/usecases/accept-pix-terms-of-service_test.js
@@ -1,24 +1,24 @@
 const { expect, sinon } = require('../../../test-helper');
-const acceptLastPixTermsOfService = require('../../../../lib/domain/usecases/accept-last-pix-terms-of-service');
+const acceptPixLastTermsOfService = require('../../../../lib/domain/usecases/accept-pix-last-terms-of-service');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
-describe('Unit | UseCase | accept-last-pix-terms-of-service', () => {
+describe('Unit | UseCase | accept-pix-last-terms-of-service', () => {
 
   beforeEach(() => {
-    sinon.stub(userRepository, 'updateLastPixTermsOfServiceAccepted');
+    sinon.stub(userRepository, 'acceptPixLastTermsOfService');
   });
 
   it('should accept terms of service of pix', async () => {
     // given
     const userId = Symbol('userId');
     const updatedUser = Symbol('updateduser');
-    userRepository.updateLastPixTermsOfServiceAccepted.resolves(updatedUser);
+    userRepository.acceptPixLastTermsOfService.resolves(updatedUser);
 
     // when
-    const actualUpdatedUser = await acceptLastPixTermsOfService({ userId, userRepository });
+    const actualUpdatedUser = await acceptPixLastTermsOfService({ userId, userRepository });
 
     // then
-    expect(userRepository.updateLastPixTermsOfServiceAccepted).to.have.been.calledWith(userId);
+    expect(userRepository.acceptPixLastTermsOfService).to.have.been.calledWith(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -1,5 +1,4 @@
 const { expect } = require('../../../../test-helper');
-
 const User = require('../../../../../lib/domain/models/User');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
 
@@ -17,6 +16,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
         email: 'lskywalker@deathstar.empire',
         username: 'luke.skywalker1234',
         cgu: true,
+        lastTermsOfServiceValidatedAt: '2020-05-04T13:18:26.323Z',
         mustValidateTermsOfService: true,
         pixOrgaTermsOfServiceAccepted: false,
         pixCertifTermsOfServiceAccepted: false,
@@ -39,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
               'email': userModelObject.email,
               'username': userModelObject.username,
               'cgu': userModelObject.cgu,
+              'last-terms-of-service-validated-at' : userModelObject.lastTermsOfServiceValidatedAt,
               'must-validate-terms-of-service': userModelObject.mustValidateTermsOfService,
               'pix-orga-terms-of-service-accepted': userModelObject.pixOrgaTermsOfServiceAccepted,
               'pix-certif-terms-of-service-accepted': userModelObject.pixCertifTermsOfServiceAccepted,
@@ -103,6 +104,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
               'email': userModelObject.email,
               'username': userModelObject.username,
               'cgu': userModelObject.cgu,
+              'last-terms-of-service-validated-at': userModelObject.lastTermsOfServiceValidatedAt,
               'must-validate-terms-of-service': userModelObject.mustValidateTermsOfService,
               'pix-orga-terms-of-service-accepted': userModelObject.pixOrgaTermsOfServiceAccepted,
               'pix-certif-terms-of-service-accepted': userModelObject.pixCertifTermsOfServiceAccepted,

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -66,6 +66,11 @@ export default class User extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);
 
+    if (adapterOptions && adapterOptions.acceptPixTermsOfService) {
+      delete adapterOptions.acceptPixTermsOfService;
+      return url + '/pix-terms-of-service-acceptance';
+    }
+
     if (adapterOptions && adapterOptions.rememberUserHasSeenAssessmentInstructions) {
       delete adapterOptions.rememberUserHasSeenAssessmentInstructions;
       return url + '/remember-user-has-seen-assessment-instructions';

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -1,0 +1,27 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import classic from 'ember-classic-decorator';
+import { tracked } from '@glimmer/tracking';
+
+@classic
+export default class TermsOfServiceController extends Controller {
+
+  pageTitle = 'Conditions d\'utilisation';
+  @service currentUser;
+  @tracked isTermsOfServiceValidated = false;
+  @tracked showErrorTermsOfServiceNotSelected = false;
+
+  @action
+  async submit() {
+    if (this.isTermsOfServiceValidated) {
+      this.showErrorTermsOfServiceNotSelected = false;
+      await this.currentUser.user.save({ adapterOptions: { acceptPixTermsOfService: true } });
+      this.transitionToRoute('profile');
+    } else {
+      this.showErrorTermsOfServiceNotSelected = true;
+    }
+  }
+
+}
+

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -10,6 +10,7 @@ export default class User extends Model {
   @attr('string') username;
   @attr('string') password;
   @attr('boolean') cgu;
+  @attr('boolean') mustValidateTermsOfService;
   @attr('boolean') hasSeenAssessmentInstructions;
   @attr('string') recaptchaToken;
 

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -1,5 +1,19 @@
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRouteMixin) {
+
+  @service store;
+
+  model() {
+    const users = this.store.peekAll('user');
+    const user = users.firstObject;
+
+    if (!user.mustValidateTermsOfService) {
+      return this.replaceWith('profile');
+    }
+
+    return user;
+  }
 }

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -58,6 +58,13 @@
   &__check {
     margin-right: 8px;
   }
+
+  &__validation-error {
+    color: $red-error;
+    font-weight: normal;
+    margin-left: 16px;
+    margin-top: 16px;
+  }
 }
 
 .terms-of-service-form-actions {

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -60,5 +60,24 @@
   }
 }
 
+.terms-of-service-form-actions {
+
+  &__submit {
+    margin-left: 16px;
+    border-radius: 4px;
+    padding: 10px 16px;
+
+  }
+
+  &__cancel {
+    background-color: $grey-50;
+    border-radius: 4px;
+    padding: 10px 16px;
+
+    &:hover {
+      background-color: $gray;
+    }
+  }
+}
 
 

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -21,6 +21,10 @@
       </label>
     </div>
 
-  </div>
+    <div class="terms-of-service-form__actions">
+      <LinkTo @route="login" class="button terms-of-service-form-actions__cancel">Retour</LinkTo>
+      <button type="submit" class="button terms-of-service-form-actions__submit">Je continue</button>
+    </div>
 
+  </div>
 </div>

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -21,7 +21,7 @@
       </label>
       {{#if this.showErrorTermsOfServiceNotSelected }}
         <div class="terms-of-service-form-conditions__validation-error">
-          {{'Veuillez accepter les conditions d\'utilisation.'}}
+          {{'Vous devez accepter les conditions d’utilisation de Pix.'}}
         </div>
       {{/if}}
     </div>

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -15,15 +15,20 @@
 
     <div class="terms-of-service-form__conditions">
       <label for="pix-cgu">
-        <Input @type="checkbox" @id="pix-cgu" class="terms-of-service-form-conditions__check"/>
+        <Input @type="checkbox" @id="pix-cgu" class="terms-of-service-form-conditions__check" @checked={{this.isTermsOfServiceValidated}}/>
         J'accepte les <a href="https://pix.fr/conditions-generales-d-utilisation" class="link" target="_blank">conditions
         d'utilisation de Pix</a>
       </label>
+      {{#if this.showErrorTermsOfServiceNotSelected }}
+        <div class="terms-of-service-form-conditions__validation-error">
+          {{'Veuillez accepter les conditions d\'utilisation.'}}
+        </div>
+      {{/if}}
     </div>
 
     <div class="terms-of-service-form__actions">
-      <LinkTo @route="login" class="button terms-of-service-form-actions__cancel">Retour</LinkTo>
-      <button type="submit" class="button terms-of-service-form-actions__submit">Je continue</button>
+      <LinkTo @route="logout" class="button terms-of-service-form-actions__cancel">Retour</LinkTo>
+      <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>Je continue</button>
     </div>
 
   </div>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -65,4 +65,12 @@ export default function() {
   this.post('/expired-password-updates', postExpiredPasswordUpdates);
 
   this.put('/users/tutorials/:tutorialId/evaluate', putTutorialEvaluation);
+
+  this.patch('/users/:id/pix-terms-of-service-acceptance', (schema, request) => {
+    const userId = request.params.id;
+    const user = schema.users.find(userId);
+    user.update({ mustValidateTermsOfService: false , lastTermsOfServiceValidatedAt: '2020-06-06' });
+
+    return user;
+  });
 }

--- a/mon-pix/tests/acceptance/terms-of-service-test.js
+++ b/mon-pix/tests/acceptance/terms-of-service-test.js
@@ -1,5 +1,6 @@
-import {  describe, it } from 'mocha';
-import { currentURL } from '@ember/test-helpers';
+import { describe, it } from 'mocha';
+import { click, currentURL } from '@ember/test-helpers';
+import { authenticateByEmail } from '../helpers/authentification';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,14 +9,33 @@ import visit from '../helpers/visit';
 describe('Acceptance | terms-of-service', function() {
   setupApplicationTest();
   setupMirage();
+  let user;
 
-  it('should be redirect to login page when user is not authenticated', async function() {
-
-    // when
-    await visit('/cgu');
-
-    // then
-    expect(currentURL()).to.equal('/connexion');
-
+  beforeEach(function() {
+    user = server.create('user', {
+      email: 'with-email',
+      password: 'pix123',
+      mustValidateTermsOfService: true,
+      lastTermsOfServiceValidatedAt: null
+    });
   });
+
+  describe('Navigation buttons when user is authenticated', async function() {
+
+    it('should be redirect to profile page when user validate terms of service ', async function() {
+      // given
+      await authenticateByEmail(user);
+
+      // when
+      await visit('/cgu');
+      await click('#pix-cgu');
+      await click('.terms-of-service-form-actions__submit');
+
+      // then
+      expect(currentURL()).to.equal('/profil');
+
+    });
+  });
+
 });
+

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -35,6 +35,15 @@ describe('Unit | Adapters | user', function() {
 
   describe('#urlForUpdateRecord', () => {
 
+    it('should redirect to /api/users/{id}/pix-terms-of-service-acceptance', async function() {
+      // when
+      const snapshot = { adapterOptions: { acceptPixTermsOfService: true } };
+      const url = await adapter.urlForUpdateRecord(123, 'user', snapshot);
+
+      // then
+      expect(url.endsWith('/users/123/pix-terms-of-service-acceptance')).to.be.true;
+    });
+
     it('should build update url from user id', async function() {
       // when
       const snapshot = { adapterOptions: { } };

--- a/mon-pix/tests/unit/controllers/terms-of-service-test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-test.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Controller | terms-of-service', function() {
+  setupTest();
+  let controller;
+
+  describe('#action submit', function() {
+
+    beforeEach(function() {
+      controller = this.owner.lookup('controller:terms-of-service');
+      controller.transitionToRoute = sinon.stub();
+      controller.currentUser = { user: { save: sinon.stub().resolves() } };
+    });
+
+    it('it should save the acceptance date of the last terms of service', async function() {
+      // when
+      controller.isTermsOfServiceValidated =  true ;
+      controller.showErrorTermsOfServiceNotSelected =  false ;
+
+      await controller.send('submit');
+
+      // then
+      sinon.assert.calledWith(controller.currentUser.user.save, { adapterOptions: { acceptPixTermsOfService: true } });
+      sinon.assert.calledWith(controller.transitionToRoute, 'profile');
+      expect(controller.showErrorTermsOfServiceNotSelected).to.be.false;
+
+    });
+
+    it('it should show an error to must validate terms of service ', async function() {
+      // when
+      controller.isTermsOfServiceValidated =  false ;
+      controller.showErrorTermsOfServiceNotSelected =  false ;
+      await controller.send('submit');
+
+      // then
+      expect(controller.showErrorTermsOfServiceNotSelected).to.be.true;
+
+    });
+
+  });
+});

--- a/mon-pix/tests/unit/controllers/terms-of-service-test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-test.js
@@ -29,7 +29,7 @@ describe('Unit | Controller | terms-of-service', function() {
 
     });
 
-    it('it should show an error to must validate terms of service ', async function() {
+    it('it should show an error to user to validate terms of service ', async function() {
       // when
       controller.isTermsOfServiceValidated =  false ;
       controller.showErrorTermsOfServiceNotSelected =  false ;


### PR DESCRIPTION
## :unicorn: Problème
Les conditions d'utilisation de Pix ont évoluées. Les utilisateurs ayant déjà validé l'ancienne version devront les approuver. Il faut garder une trace de la date d'approbation.

## :robot: Solution

- Création de la colonne "users”.”LastTermsOfServiceValidatedAt"
- Création de la nouvelle page app.pix.fr/cgu qui affiche un lien vers les nouvelles conditions d'utilisation.
- Bouton "retour" qui redirige vers la page de connexion app.pix.fr/connexion 
- Bouton "je me connecte”
- La checkbox ‘je valide les cgu’ doit être coché sinon un message erreur apparait.
- Si la checkbox est cochée, et si succès alors:
- - Mettre à jour la colonne "mustValidateTermsOfService" à FALSE
- - Mettre à jour la colonne "LastTermsOfServiceValidatedAt" avec la date du jour 
- Connecter l’utilisateur

## :100: Pour tester
- Tester avec un utilisateur ayant le flag mustValidateTermsOfService à true au niveau de la table
- S'authentifier avec l'utilisateur 
- Une redirection vers la nouvelle page des conditions d'utilisation
- Accepter les conditions 
