### PR TITLE
[BUGFIX] Ne plus avoir les erreurs de transition dans la console (PIX-632).

### DIFF
--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -17,7 +17,7 @@ export default class ResumeRoute extends Route {
     this.set('competenceLeveled', transition.to.queryParams.competenceLeveled || null);
   }
 
-  async afterModel(assessment) {
+  async redirect(assessment) {
     if (assessment.isCompleted) {
       return this._routeToResults(assessment);
     }

--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -1,10 +1,8 @@
-import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 import _ from 'lodash';
 
-@classic
 export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
   @service session;
   @service currentUser;
@@ -17,12 +15,11 @@ export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
   }
 
   async beforeModel(transition) {
-    this.set('givenParticipantExternalId', transition.to.queryParams && transition.to.queryParams.givenParticipantExternalId);
+    this.givenParticipantExternalId = transition.to.queryParams && transition.to.queryParams.givenParticipantExternalId;
   }
 
   async model(params) {
     const campaigns = await this.store.query('campaign', { filter: { code: params.campaign_code } });
-
     return campaigns.get('firstObject');
   }
 
@@ -48,17 +45,16 @@ export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
     controller.set('start', (campaign, participantExternalId) => this.start(campaign, participantExternalId));
   }
 
-  start(campaign, participantExternalId = null) {
-    return this.store.createRecord('campaign-participation', { campaign, participantExternalId })
-      .save()
-      .then(() => {
-        this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
-      }, (err) => {
-        if (_.get(err, 'errors[0].status') === 403) {
-          this.session.invalidate();
-          return this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
-        }
-        return this.send('error', err, this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } }));
-      });
+  async start(campaign, participantExternalId = null) {
+    try {
+      await this.store.createRecord('campaign-participation', { campaign, participantExternalId }).save();
+      this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+    } catch (err) {
+      if (_.get(err, 'errors[0].status') === 403) {
+        this.session.invalidate();
+        return this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+      }
+      return this.send('error', err, this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } }));
+    }
   }
 }

--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -52,7 +52,7 @@ export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
     return this.store.createRecord('campaign-participation', { campaign, participantExternalId })
       .save()
       .then(() => {
-        return this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+        this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
       }, (err) => {
         if (_.get(err, 'errors[0].status') === 403) {
           this.session.invalidate();

--- a/mon-pix/app/routes/campaigns/join-restricted-campaign.js
+++ b/mon-pix/app/routes/campaigns/join-restricted-campaign.js
@@ -18,7 +18,7 @@ export default class JoinRestrictedCampaignRoute extends Route.extend(SecuredRou
     const student = await this.store.queryRecord('student-user-association', { userId: this.currentUser.user.id, campaignCode });
 
     if (!isEmpty(student)) {
-      return this.replaceWith('campaigns.start-or-resume', campaignCode, {
+      this.replaceWith('campaigns.start-or-resume', campaignCode, {
         queryParams: { associationDone: true }
       });
     }

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -49,7 +49,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     return campaigns.get('firstObject');
   }
 
-  async afterModel(campaign) {
+  async redirect(campaign) {
 
     if (campaign.isArchived) {
       this.set('isLoading', false);

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -27,7 +27,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     this.set('campaignCode', transition.to.params.campaign_code);
     this.set('associationDone', transition.to.queryParams.associationDone);
     this.set('campaignIsRestricted', transition.to.queryParams.campaignIsRestricted);
-    this.set('givenParticipantExternalId', transition.to.queryParams.participantExternalId);
+    this.set('givenParticipantExternalId', this.givenParticipantExternalId || transition.to.queryParams.participantExternalId);
     this.set('userHasSeenLanding', transition.to.queryParams.hasSeenLanding);
     this.set('userHasJustConsultedTutorial', transition.to.queryParams.hasJustConsultedTutorial);
     this.set('campaignParticipationIsStarted', transition.to.queryParams.campaignParticipationIsStarted);

--- a/mon-pix/tests/unit/routes/assessments/resume-test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume-test.js
@@ -26,7 +26,7 @@ describe('Unit | Route | Assessments | Resume', function() {
     route.replaceWith = sinon.stub();
   });
 
-  describe('#afterModel', function() {
+  describe('#redirect', function() {
 
     let assessment;
 
@@ -38,7 +38,7 @@ describe('Unit | Route | Assessments | Resume', function() {
     it('should not query next challenge if assessment is completed', function() {
       assessment.isCompleted = true;
 
-      route.afterModel(assessment);
+      route.redirect(assessment);
 
       sinon.assert.notCalled(queryRecordStub);
     });
@@ -48,7 +48,7 @@ describe('Unit | Route | Assessments | Resume', function() {
       queryRecordStub.resolves();
 
       // when
-      const promise = route.afterModel(assessment);
+      const promise = route.redirect(assessment);
 
       // then
       return promise.then(() => {
@@ -88,7 +88,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
             it('should redirect to the challenge view', function() {
               // when
-              const promise = route.afterModel(assessment);
+              const promise = route.redirect(assessment);
 
               // then
               return promise.then(() => {
@@ -106,7 +106,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
             it('should redirect to assessment checkpoint page', function() {
               // when
-              const promise = route.afterModel(assessment);
+              const promise = route.redirect(assessment);
 
               // then
               return promise.then(() => {
@@ -121,7 +121,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
           it('should redirect to the challenge view', function() {
             // when
-            const promise = route.afterModel(assessment);
+            const promise = route.redirect(assessment);
 
             // then
             return promise.then(() => {
@@ -138,7 +138,7 @@ describe('Unit | Route | Assessments | Resume', function() {
         });
         it('should redirect to the challenge view', function() {
           // when
-          const promise = route.afterModel(assessment);
+          const promise = route.redirect(assessment);
 
           // then
           return promise.then(() => {
@@ -179,7 +179,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
             it('should redirect to campaigns.skill-review page', function() {
               // when
-              const promise = route.afterModel(assessment);
+              const promise = route.redirect(assessment);
 
               // then
               return promise.then(() => {
@@ -196,7 +196,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
             it('should redirect to assessment last checkpoint page', function() {
               // when
-              const promise = route.afterModel(assessment);
+              const promise = route.redirect(assessment);
 
               // then
               return promise.then(() => {
@@ -216,7 +216,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
           it('should redirect to campaigns.skill-review page', function() {
             // when
-            route.afterModel(assessment);
+            route.redirect(assessment);
 
             // then
             sinon.assert.calledWith(route.replaceWith, 'campaigns.skill-review', 'konami', 123);
@@ -232,7 +232,7 @@ describe('Unit | Route | Assessments | Resume', function() {
 
         it('should redirect to certifications.results page', function() {
           // when
-          const promise = route.afterModel(assessment);
+          const promise = route.redirect(assessment);
 
           // then
           return promise.then(() => {
@@ -249,7 +249,7 @@ describe('Unit | Route | Assessments | Resume', function() {
         it('should redirect to competences.results page', function() {
           // when
           const competenceId = 'recCompetenceId';
-          const promise = route.afterModel(assessment);
+          const promise = route.redirect(assessment);
 
           // then
           return promise.then(() => {
@@ -261,7 +261,7 @@ describe('Unit | Route | Assessments | Resume', function() {
       context('when assessment is a DEMO', function() {
         it('should redirect to assessments.results page', function() {
           // when
-          const promise = route.afterModel(assessment);
+          const promise = route.redirect(assessment);
 
           // then
           return promise.then(() => {


### PR DESCRIPTION
## :unicorn: Problème
On a des erreurs dans la console durant les évaluations, des `TransitionAborted`.

## :robot: Solution
- Utiliser `redirect` à la place de `afterModel` dans les routes resume.js et start-or-resume.js.
En effet, ces pages ne servent qu'à faire des redirections. Si on utilise redirect à la place d'afterModel, la transition de start-or-resume ne pose plus problème.
- Attention avec les `return this.transitionTo` : il n'y a normalement pas de return devant les transitionTo. Ca lance bien la transition, mais la route dans laquelle on est attend le résultat pour le return et peut aussi provoquer les `transitionAborted`
- Modification sur : `this.set('givenParticipantExternalId', this.givenParticipantExternalId || transition.to.queryParams.participantExternalId);` qui posait problème car parfois on le récupère à la main alors qu'il est déjà présent. 

## :rainbow: Remarques
> redirect and afterModel behave very similarly and are called almost at the same time, but they have an important distinction in the case that, from one of these hooks, a redirect into a child route of this route occurs: redirects from afterModel essentially invalidate the current attempt to enter this route, and will result in this route's beforeModel, model, and afterModel hooks being fired again within the new, redirecting transition. Redirects that occur within the redirect hook, on the other hand, will not cause these hooks to be fired again the second time around; in other words, by the time the redirect hook has been called, both the resolved model and attempted entry into this route are considered to be fully validated.

