### PR TITLE
[BUGFIX] Le résultat de certificat de l'utilisateur ne s'affiche plus (PIX-631)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-profile.js
+++ b/mon-pix/app/components/user-certifications-detail-profile.js
@@ -10,6 +10,6 @@ export default class UserCertificationsDetailProfile extends Component {
 
   @computed('resultCompetenceTree.areas.[]')
   get sortedAreas() {
-    return this.resultCompetenceTree.areas.sortBy('code');
+    return this.resultCompetenceTree.get('areas').sortBy('code');
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Régression introduite par https://github.com/1024pix/pix/pull/1308/commits/3f4a85a93d173366a5026a0d3dae318fb1e7b8ed
Personnellement, ça reste encore un peu un mystère pour moi car :
Grâce à l'usage de classes natives JS en Octane, on n'est plus obligé de passer par la méthode `get()` pour lire des attributs en direct. Par contre, quand on cherche à lire le contenu d'une relation qui répond à un mécanisme de lazy-loading, il faut continuer à utiliser `.get()` car potentiellement la relation est toujours un _EmberProxy_, et donc pas encore chargée. 
Ce qui m'échappe, c'est que l'ensemble des relations, des grappes d'objets sérialisés retournés par l'appel `GET /api/certifications/:id` sont TOUTES incluses dans le résultat sérialisé (donc pas de lazy-loading à faire vu qu'on les a !)

Donc bon, piste à creuser, il semblerait que la déserialisation des included se passe moyennement bien ? à creuser.

## :robot: Solution
```js
// AVANT
return this.resultCompetenceTree.areas.sortBy('code');

// APRES
return this.resultCompetenceTree.get('areas').sortBy('code');
```

## :rainbow: Remarques

## :100: Pour tester
Se rendre sur la page de résultats d'une certif.
Utiliser le compte certif-success@example.net pix123 à cet effet.
