### PR TITLE
[INFRA] Amélioration des performances mémoire (et donc vitesse) lors de l'utilisation du knowledge-element-repository (PIX-635).

### DIFF
--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -73,15 +73,12 @@ module.exports = {
     return _applyFilters(knowledgeElements);
   },
 
-  findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {
-    return BookshelfKnowledgeElement
-      .query((qb) => {
-        qb.where({ userId, assessmentId });
-      })
-      .fetchAll()
-      .then(_toDomain)
-      .then(_getUniqMostRecents)
-      .then(_dropResetKnowledgeElements);
+  async findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {
+    const query = _getByUserIdAndLimitDateQuery({ userId });
+    const keRows = await query.where({ assessmentId });
+
+    const knowledgeElements = _.map(keRows, (keRow) => new KnowledgeElement(keRow));
+    return _applyFilters(knowledgeElements);
   },
 
   findUniqByUserIdAndCompetenceId({ userId, competenceId }) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -55,37 +55,37 @@ function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {
 module.exports = {
 
   async save(knowledgeElement) {
-    const keToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
-    const savedKe = await new BookshelfKnowledgeElement(keToSave).save();
+    const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
+    const savedKnowledgeElement = await new BookshelfKnowledgeElement(knowledgeElementToSave).save();
 
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKe);
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
   },
 
   async findUniqByUserId({ userId, limitDate }) {
-    const keRows = await _getByUserIdAndLimitDateQuery({ userId, limitDate });
+    const knowledgeElementRows = await _getByUserIdAndLimitDateQuery({ userId, limitDate });
 
-    const knowledgeElements = _.map(keRows, (keRow) => new KnowledgeElement(keRow));
+    const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
     return _applyFilters(knowledgeElements);
   },
 
   async findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {
     const query = _getByUserIdAndLimitDateQuery({ userId });
-    const keRows = await query.where({ assessmentId });
+    const knowledgeElementRows = await query.where({ assessmentId });
 
-    const knowledgeElements = _.map(keRows, (keRow) => new KnowledgeElement(keRow));
+    const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
     return _applyFilters(knowledgeElements);
   },
 
   async findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
     const query = _getByUserIdAndLimitDateQuery({ userId });
-    const keRows = await query.where({ competenceId });
+    const knowledgeElementRows = await query.where({ competenceId });
 
-    const knowledgeElements = _.map(keRows, (keRow) => new KnowledgeElement(keRow));
+    const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
     return _applyFilters(knowledgeElements);
   },
 
   async findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {
-    const knowledgeElements = await this.findUniqByUserId({ userId, limitDate })
+    const knowledgeElements = await this.findUniqByUserId({ userId, limitDate });
     return _.groupBy(knowledgeElements, 'competenceId');
   },
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -27,8 +27,8 @@ function _applyFilters(knowledgeElements) {
   return _dropResetKnowledgeElements(uniqsMostRecentPerSkill);
 }
 
-function _findByCampaignIdForSharedCampaignParticipationWhere(campaignParticipationsWhereClause) {
-  return BookshelfKnowledgeElement
+async function _findByCampaignIdForSharedCampaignParticipationWhere(campaignParticipationsWhereClause) {
+  const keResults = await BookshelfKnowledgeElement
     .query((qb) => {
       qb.select('knowledge-elements.*');
       qb.leftJoin('campaign-participations', 'campaign-participations.userId', 'knowledge-elements.userId');
@@ -41,8 +41,9 @@ function _findByCampaignIdForSharedCampaignParticipationWhere(campaignParticipat
     .where({ 'campaign-participations.isShared': true })
     .where(campaignParticipationsWhereClause)
     .where({ status: 'validated' })
-    .fetchAll()
-    .then(_toDomain);
+    .fetchAll();
+
+  return _toDomain(keResults);
 }
 
 function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -89,10 +89,9 @@ module.exports = {
     return _applyFilters(knowledgeElements);
   },
 
-  findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {
-    return this.findUniqByUserId({ userId, limitDate })
-      .then(_dropResetKnowledgeElements)
-      .then((knowledgeElements) => _.groupBy(knowledgeElements, 'competenceId'));
+  async findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {
+    const knowledgeElements = await this.findUniqByUserId({ userId, limitDate })
+    return _.groupBy(knowledgeElements, 'competenceId');
   },
 
   getSumOfPixFromUserKnowledgeElements(userId) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -59,12 +59,11 @@ function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {
 
 module.exports = {
 
-  save(knowledgeElement) {
+  async save(knowledgeElement) {
+    const keToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
+    const savedKe = await new BookshelfKnowledgeElement(keToSave).save();
 
-    return Promise.resolve(_.omit(knowledgeElement, ['id', 'createdAt']))
-      .then((knowledgeElement) => new BookshelfKnowledgeElement(knowledgeElement))
-      .then((knowledgeElementBookshelf) => knowledgeElementBookshelf.save())
-      .then(_toDomain);
+    return _toDomain(savedKe);
   },
 
   async findUniqByUserId({ userId, limitDate }) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -81,13 +81,12 @@ module.exports = {
     return _applyFilters(knowledgeElements);
   },
 
-  findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
-    return BookshelfKnowledgeElement
-      .where({ userId, competenceId })
-      .fetchAll()
-      .then(_toDomain)
-      .then(_getUniqMostRecents)
-      .then(_dropResetKnowledgeElements);
+  async findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
+    const query = _getByUserIdAndLimitDateQuery({ userId });
+    const keRows = await query.where({ competenceId });
+
+    const knowledgeElements = _.map(keRows, (keRow) => new KnowledgeElement(keRow));
+    return _applyFilters(knowledgeElements);
   },
 
   findUniqByUserIdGroupedByCompetenceId({ userId, limitDate }) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -1,15 +1,9 @@
-const KnowledgeElement = require('../../domain/models/KnowledgeElement');
-const BookshelfKnowledgeElement = require('../data/knowledge-element');
 const _ = require('lodash');
 const Bookshelf = require('../bookshelf');
+const KnowledgeElement = require('../../domain/models/KnowledgeElement');
+const BookshelfKnowledgeElement = require('../data/knowledge-element');
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const scoringService = require('../../domain/services/scoring/scoring-service');
-
-function _toDomain(knowledgeElementBookshelf) {
-  const knowledgeElements = knowledgeElementBookshelf.toJSON();
-  return _.isArray(knowledgeElements)
-    ? knowledgeElements.map((ke) => new KnowledgeElement(ke))
-    : new KnowledgeElement(knowledgeElements);
-}
 
 function _getUniqMostRecents(knowledgeElements) {
   return _(knowledgeElements)
@@ -43,7 +37,7 @@ async function _findByCampaignIdForSharedCampaignParticipationWhere(campaignPart
     .where({ status: 'validated' })
     .fetchAll();
 
-  return _toDomain(keResults);
+  return bookshelfToDomainConverter.buildDomainObjects(BookshelfKnowledgeElement, keResults);
 }
 
 function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {
@@ -64,7 +58,7 @@ module.exports = {
     const keToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
     const savedKe = await new BookshelfKnowledgeElement(keToSave).save();
 
-    return _toDomain(savedKe);
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKe);
   },
 
   async findUniqByUserId({ userId, limitDate }) {


### PR DESCRIPTION
## :unicorn: Problème
Les méthodes du `knowledgeElementRepository` de type `findUniqByUserId*` n'étaient pas très efficaces d'un point de vue de l'usage de la mémoire et d'allocation d'objets.
En effet, la plupart de nos méthodes de répo se déroulent de la manière suivante :
-> Construction de la requête (via bookshelf)
-> Récupération des résultats via des objets Bookshelf
-> Transformation des objets Bookshelf en objets du domaine.

Ce qui signifie que les objets Bookshelf instanciés ont très peu (pas ?) d'utilité. De plus, des mesures nous ont montré que ces objets prenaient une place en mémoire non négligeable.

## :robot: Solution
Nous proposons donc ici de remplacer l'usage de Bookshelf par celui du query-builder Knex, et d'instancier les résultats retournés directement en objets du domaine.
La requête de base est donc la suivante :
```js
function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {
  return Bookshelf.knex
    .select('*', Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', ['skillId', 'createdAt']))
    .from('knowledge-elements')
    .where((qb) => {
      qb.where({ userId });
      if (limitDate) {
        qb.where('createdAt', '<', limitDate);
      }
    });
}
```

Voici un comparatif du avant/après du point de vue perf/mémoire/ etc.... Tests effectués sur dev et sur cette branche. Procédé :
On lance l'API avec les arguments nécessaires afin d'éviter les nettoyages mémoire par le GC (voir https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1401094177/2020-04-28+Comprendre+et+analyser+la+consommation+en+m+moire+de+notre+API#Guide-pour-chiffrer-l’allocation-mémoire-d’une-route)
A côté (on récupère un token utilisateur au préalable), on lance un client via la commande siege, qui permet de lancer plein de requêtes HTTP d'un coup (https://linux.die.net/man/1/siege)

En gros, l'API :
`node --expose-gc --max-old-space-size=1024 --initial-old-space-size=512 --min-semi-space-size=4096 --max-semi-space-size=4096 --no-idle-time-scavenge  --no-incremental-marking --no-page-promotion --nologfile-per-isolate -e 'require("./bin/www")' --experimental-repl-await -i --trace-gc`

Le client :
`siege -r10 -c5 --header="Authorization:Bearer <someToken>" http://localhost:3000/api/users/:id/certification-profile -b`

Route testée : `GET /api/users/:id/certification-profile` avec un utilisateur ayant un pixScore de 160.

Résultats sur dev (sans amélioration) :
![bench1_ke_without_opt](https://user-images.githubusercontent.com/48727874/81177599-37668f00-8fa7-11ea-845f-9640c6cdc74f.png)

Résultats branche (avec amélioration):
![bench1_ke_with_opt](https://user-images.githubusercontent.com/48727874/81177651-506f4000-8fa7-11ea-8199-bedcc5ce38dc.png)

Résumé :     Avant / Après
Durée totale :                                  2.27 s / 1.60 s           (30% + rapide)
Consommation mémoire totale :     ~970 Mb / 96 Mb      (10x moins)

## :rainbow: Remarques
1) Aspect rassurant de la modification : non-régression des tests auto, je n'y ai pas touché du tout !
2) A été envisagé de déplacer les filtres (le plus récent par acquis + retrait des remises à zéro) vers la requête BDD. Ce n'est finalement pas une si bonne idée, car il s'agit tout compte fait de déplacer du travail côté BDD, alors qu'on le sait notre base est déjà beaucoup sollicitée. Pour les containers serveur, ça ne fait pas beaucoup de travail en plus d'effectuer ces filtres.

## :100: Pour tester
Non régression sur les features qui sollicitent le retrait de KE
