### PR TITLE
[BUGFIX] Corriger les rem de la communication banner (PIX-646).

### DIFF
--- a/mon-pix/app/styles/components/_communication-banner.scss
+++ b/mon-pix/app/styles/components/_communication-banner.scss
@@ -4,16 +4,16 @@
   height: 56px;
   font-family: $font-open-sans;
   font-weight: 400;
-  line-height: 1.5rem;
-  font-size: 1rem;
+  line-height: 0.938rem;
+  font-size: 0.625rem;
   padding: 10px 0;
   display: flex;
   align-items: center;
   justify-content: center;
 
   @include device-is('tablet') {
-    font-size: 1.6rem;
-    line-height: 2rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 
   &__icon {


### PR DESCRIPTION
## :unicorn: Problème
Ce fichier est passé entre les mailles du filet et les rem dans `_communication-banner.scss` sont exprimés en `1 rem = 10 px`.

## :robot: Solution
Convertir : new rem = old rem * 0.625.

## :🐓Pour tester 
Sur https://app.integration.pix.fr/ :
![image](https://user-images.githubusercontent.com/5982021/81281845-acdf6780-905a-11ea-8ac7-e4cae91ccefd.png)

On veut : 
![image](https://user-images.githubusercontent.com/5982021/81282313-46a71480-905b-11ea-8172-69cebba57efb.png)
