### PR TITLE
[BUGFIX] Suppression d'un warning ember-data sur les campaignParticipations.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -9,6 +9,9 @@ module.exports = {
     return new Serializer('campaign-participation',
       {
         transform: (campaignParticipation) => {
+          if (!campaignParticipation.user) {
+            delete campaignParticipation.user;
+          }
           const campaignParticipationForSerialization = Object.assign({}, campaignParticipation);
 
           if (campaignParticipation.lastAssessment) {

--- a/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-participation-to-campaign_test.js
@@ -49,9 +49,6 @@ describe('Acceptance | Route | GET /users/id/campaigns/id/campaign-participation
             campaign: {
               data: null
             },
-            user: {
-              data: null
-            },
             'campaign-participation-result': {
               links: {
                 'related': `/api/campaign-participations/${campaignParticipation.id}/campaign-participation-result`

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -101,9 +101,6 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                   data:
                     { type: 'campaigns', id: `${campaign2.id}` },
                 },
-                user: {
-                  data: null
-                },
                 assessment: {
                   links: {
                     related: `/api/assessments/${assessment2.id}`
@@ -134,9 +131,6 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
                 campaign: {
                   data:
                     { type: 'campaigns', id: `${campaign1.id}` },
-                },
-                user: {
-                  data: null
                 },
                 assessment: {
                   links: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-serializer_test.js
@@ -234,6 +234,19 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', func
       expect(result).to.deep.equal(expectedSerializedCampaignParticipation);
     });
 
+    it('should not serialize user if user is undefined', function() {
+      // given
+      campaignParticipation.user = undefined;
+      delete expectedSerializedCampaignParticipation.data.relationships.user;
+      expectedSerializedCampaignParticipation.included = expectedSerializedCampaignParticipation.included.filter((included) => included.type !== 'users');
+
+      // when
+      const result = serializer.serialize(campaignParticipation);
+
+      // then
+      expect(result).to.deep.equal(expectedSerializedCampaignParticipation);
+    });
+
   });
 
   describe('#deserialize', function() {


### PR DESCRIPTION
## :unicorn: Problème

> DEPRECATION: Encountered mismatched relationship: Ember Data expected data[0].relationships.user.data in the payload from user:10000000.hasMany("campaignParticipations") to include '{"id":"10000000","type":"user"}' but got 'null' instead.
> 
> The <campaign-participation:10000000> record loaded at data[0] in the payload specified null as its '"user"', but should have specified user:10000000 (the record the relationship is being loaded from) as its '"user"' instead.
> This could mean that the response for user:10000000.hasMany("campaignParticipations") may have accidentally returned '"campaign-participation"' records that aren't related to user:10000000 and could be related to a different user record instead.
> Ember Data has corrected the <campaign-participation:10000000> record's '"user"' relationship to user:10000000 so that user:10000000.hasMany("campaignParticipations") will include <campaign-participation:10000000>.
> Please update the response from the server or change your serializer to either ensure that the response for only includes '"campaign-participation"' records that specify user:10000000 as their '"user"', or omit the '"user"' relationship from the response.

## :robot: Solution
Ne pas rajouter la relationship user quand le user est undefined.

## :rainbow: Remarques
La meilleure solution serait d'utiliser des read models mais la mise en place de ceux-ci sont plus longs et les impacts plus nombreux/ La solution présentée ici représente un quick win permettant de faire disparaître le warning. 
