### PR TITLE
[BUGFIX] Deux épreuves avec des fichiers à télécharger ont les mêmes fichiers (PIX-642).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -46,13 +46,13 @@ export default class ChallengeStatement extends Component {
 
   }
 
-  @computed('challenge')
+  @computed('challenge.attachments')
   get attachmentsData() {
     return this.challenge.attachments;
   }
 
   @action
-  selectAttachementUrl(attachementUrl) {
+  chooseAttachmentUrl(attachementUrl) {
     this.set('selectedAttachmentUrl', attachementUrl);
   }
 

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -13,10 +13,10 @@ export default class ChallengeStatement extends Component {
 
   challenge = null;
   assessment = null;
-  selectedAttachmentUrl = null;
 
-  didReceiveAttrs() {
-    this.selectedAttachmentUrl =  _.get(this.challenge, 'attachments.firstObject');
+  @computed('challenge.attachments')
+  get selectedAttachmentUrl() {
+    return  _.get(this.challenge, 'attachments.firstObject');
   }
 
   @computed('challenge.instruction')
@@ -46,7 +46,7 @@ export default class ChallengeStatement extends Component {
 
   }
 
-  @computed('challenge.attachments')
+  @computed('challenge')
   get attachmentsData() {
     return this.challenge.attachments;
   }

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -18,7 +18,7 @@
 
       {{#if @answer}}
         <div class="challenge-response__locked-overlay">
-          <FaIcon @icon='lock' class='challenge-response-locked__icon'></FaIcon>
+          <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
       

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,47 +1,57 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QcuProposals @answer={{answer}} @answerValue={{answer.value}} @proposals={{challenge.proposals}} @answerChanged={{action "answerChanged"}} />
+        <QcuProposals @answer={{@answer}}
+                      @answerValue={{@answer.value}}
+                      @proposals={{@challenge.proposals}}
+                      @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if @answer}}
         <div class="challenge-response__locked-overlay">
-          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+          <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
       
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if @challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{@challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if @assessment}}
+      <ChallengeActions @challenge={{@challenge}}
+                        @answer={{@answer}}
+                        @resumeAssessment={{action "resumeAssessment"}}
+                        @validateAnswer={{action "validateAnswer"}}
+                        @skipChallenge={{action "skipChallenge"}}
+                        @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                        @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+                        @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,47 +1,58 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QrocProposal @answer={{answer}} @format={{challenge.format}} @proposals={{challenge.proposals}} @answerValue={{answer.value}} @answerChanged={{action "answerChanged"}} />
+        <QrocProposal @answer={{@answer}}
+                      @format={{@challenge.format}}
+                      @proposals={{@challenge.proposals}}
+                      @answerValue={{@answer.value}}
+                      @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if @answer}}
         <div class="challenge-response__locked-overlay">
-          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+          <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
 
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if @challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{@challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if @assessment}}
+      <ChallengeActions @challenge={{@challenge}}
+                        @answer={{@answer}}
+                        @resumeAssessment={{action "resumeAssessment"}}
+                        @validateAnswer={{action "validateAnswer"}}
+                        @skipChallenge={{action "skipChallenge"}}
+                        @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                        @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+                        @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,47 +1,58 @@
-{{#if hasChallengeTimer}}
-  {{#unless hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{challenge.timer}} />
+{{#if this.hasChallengeTimer}}
+  {{#unless this.hasUserConfirmWarning}}
+    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 
-{{#unless hasChallengeTimer}}
+{{#unless this.hasChallengeTimer}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
-    <ChallengeStatement @challenge={{challenge}} @assessment={{assessment}} @class="rounded-panel__row" />
+    <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} @class="rounded-panel__row" />
 
-    <div class="rounded-panel__row challenge-response {{if answer 'challenge-response--locked'}}">
+    <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
       <div class="challenge-proposals">
-        <QrocmProposal @answer={{answer}} @format={{challenge.format}} @proposals={{challenge.proposals}} @answersValue={{answer._valuesAsMap}} @answerChanged={{action "answerChanged"}} />
+        <QrocmProposal @answer={{@answer}}
+                       @format={{@challenge.format}}
+                       @proposals={{@challenge.proposals}}
+                       @answersValue={{@answer._valuesAsMap}}
+                       @answerChanged={{action "answerChanged"}} />
       </div>
 
-      {{#if answer}}
+      {{#if @answer}}
         <div class="challenge-response__locked-overlay">
-          {{fa-icon 'lock' class='challenge-response-locked__icon'}}
+          <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
 
-      {{#if challenge.timer}}
-        {{#if hasUserConfirmWarning}}
+      {{#if @challenge.timer}}
+        {{#if this.hasUserConfirmWarning}}
           <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{challenge.timer}} />
+            <TimeoutJauge @allotedTime={{@challenge.timer}} />
           </div>
         {{/if}}
       {{/if}}
     </div>
 
-    {{#if errorMessage}}
+    {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">
-        {{errorMessage}}
+        {{this.errorMessage}}
       </div>
     {{/if}}
 
-    {{#if assessment}}
-      <ChallengeActions @challenge={{challenge}} @answer={{answer}} @resumeAssessment={{action "resumeAssessment"}} @validateAnswer={{action "validateAnswer"}} @skipChallenge={{action "skipChallenge"}} @isValidateButtonEnabled={{isValidateButtonEnabled}} @isSkipButtonEnabled={{isSkipButtonEnabled}} @class="rounded-panel__row" />
+    {{#if @assessment}}
+      <ChallengeActions @challenge={{@challenge}}
+                        @answer={{@answer}}
+                        @resumeAssessment={{action "resumeAssessment"}}
+                        @validateAnswer={{action "validateAnswer"}}
+                        @skipChallenge={{action "skipChallenge"}}
+                        @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                        @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+                        @class="rounded-panel__row" />
     {{/if}}
   </form>
 {{/unless}}
 
-{{#if canDisplayFeedbackPanel}}
+{{#if this.canDisplayFeedbackPanel}}
   <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{assessment}} @challenge={{challenge}} @isFormOpened={{false}} />
+    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>
 {{/if}}

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -42,7 +42,7 @@
                    class="challenge-statement__file-option_input"
                    name="attachment_selector"
                    value="{{attachmentUrl}}"
-                   onclick={{action "selectAttachementUrl" attachmentUrl}}
+                   onclick={{action "chooseAttachmentUrl" attachmentUrl}}
                      checked="{{if (eq attachmentUrl selectedAttachmentUrl) "checked"}}">
 
             <label class="label-checkbox-downloadable" for="attachment{{index}}">

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -88,6 +88,22 @@ export default Factory.extend({
     timer: faker.random.number(),
   }),
 
+  QROCwithFile1: trait({
+    type: 'QROC',
+    instruction: 'Un QROC avec deux fichiers',
+    attachments: ['file1.docx', 'file1.odt'],
+    'illustration-url': 'http://fakeimg.pl/350x200/?text=QCU',
+    proposals: 'Entrez la premiere ligne ${ligne1}'
+  }),
+
+  QROCwithFile2: trait({
+    type: 'QROC',
+    instruction: 'Un QROC avec deux fichiers, deuxieme version',
+    attachments: ['file2.docx', 'file2.odt'],
+    'illustration-url': 'http://fakeimg.pl/350x200/?text=QCU',
+    proposals: 'Entrez la premiere ligne ${ligne2}'
+  }),
+
   withAttachment: trait({
     attachments: [faker.internet.url()],
   }),

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -1,4 +1,4 @@
-import { click, find, findAll, fillIn } from '@ember/test-helpers';
+import { click, find, findAll, fillIn, currentURL } from '@ember/test-helpers';
 import { describe, it, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import visit from '../helpers/visit';
@@ -56,6 +56,39 @@ describe('Acceptance | Displaying a QROC', function() {
 
       expect(find('.alert')).to.exist;
       expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
+    });
+
+  });
+
+  context('Two challenges with download file', () => {
+    let qrocWithFile1Challenge, qrocWithFile2Challenge;
+
+    beforeEach(async function() {
+      qrocWithFile1Challenge = server.create('challenge', 'forDemo', 'QROCwithFile1');
+      qrocWithFile2Challenge = server.create('challenge', 'forDemo', 'QROCwithFile2');
+      assessment = server.create('assessment', 'ofDemoType');
+
+      await visit(`/assessments/${assessment.id}/challenges/${qrocWithFile1Challenge.id}`);
+    });
+
+    it('should display the correct challenge for first one', async function() {
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocWithFile1Challenge.instruction);
+      expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile1Challenge.attachments[0]);
+
+      await click(find('#attachment1'));
+      expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile1Challenge.attachments[1]);
+    });
+
+    it('should display the error alert if the users tries to validate an empty answer', async function() {
+      await click(find('.challenge-actions__action-skip'));
+
+      expect(currentURL()).to.equal(`/assessments/${assessment.id}/challenges/${qrocWithFile2Challenge.id}`);
+      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocWithFile2Challenge.instruction);
+      expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile2Challenge.attachments[0]);
+
+      await click(find('#attachment1'));
+      expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile2Challenge.attachments[1]);
+
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on a à la suite deux épreuves qui proposent de télécharger deux types de fichiers, la deuxieme épreuve propose encore le fichier de l'épreuve précédente (sauf si on change le type du fichier).

## :robot: Solution
- Le selectedAttachmentsUrl, qui décrit l'URL du fichier à téléchargé, n'était pas mis à jour entre les deux épreuves. En repassant par une computed, elle l'est de nouveau.

## :rainbow: Remarques
- Ajout de test d'acceptance pour ce cas qui est une régression
- Passage des items des épreuves dans le même format octane (avec this. et @)

## :100: Pour tester
Création d'une démo avec deux épreuves :  https://app-pr1388.review.pix.fr/courses/recyLsVqy8Mm5rniR