### PR TITLE
[BUGFIX] Supprime le bouton "J'ai un code" pour les utilisateurs non connectés (PIX-601).

### DIFF
--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -52,6 +52,7 @@
   display: flex;
   padding: 0;
   margin: 0;
+  margin-left: auto;
 }
 
 /* Logo

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -28,9 +28,11 @@
       {{/if}}
     {{/unless}}
 
-    <LinkTo @route="campaigns" class="button button--extra-thin button--link">
-      J'ai un code
-    </LinkTo>
+    {{#if isUserLogged}}
+      <LinkTo @route="campaigns" class="button button--extra-thin button--link">
+        J'ai un code
+      </LinkTo>
+    {{/if}}
 
     <!-- Links (right) -->
     <div class="navbar-desktop-header-right">

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -42,6 +42,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
       // then
       expect(find('.navbar-menu-signin-link')).to.exist;
     });
+
+    it('should not display the link "J\'ai un code"', function() {
+      expect(find('.button')).not.to.exist;
+    });
   });
 
   context('When user is logged', function() {
@@ -63,6 +67,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
 
     it('should be rendered', function() {
       expect(find('.navbar-desktop-header')).to.exist;
+    });
+
+    it('should display the link "J\'ai un code"', function() {
+      expect(find('.button').textContent.trim()).to.equal('J\'ai un code');
     });
 
     it('should display the Pix logo', function() {


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "J'ai un code" apparaît sur la page `/campagnes` lorsque que l'utilisateur n'est pas connecté. 

## :robot: Solution
Supprimer le bouton de l'entête de la page quand l'utilisateur n'est pas connecté.

## :rainbow: Remarques
Nous en avons profité pour aligner à droite les boutons connexion et s'inscrire. Cela a aussi corriger un petit problème graphique qui faisait que l'élément de profil du menu n'était pas parfaitement aligné à droite.

## :100: Pour tester
Se rendre sur la page `/campagnes` en étant non connecté et constater la disparition du bouton "J'ai un code".
