### PR TITLE
[BUGFIX] Rediriger vers la page de campagne après revalidation des CGU (PIX-644).

### DIFF
--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 export default class TermsOfServiceController extends Controller {
 
   pageTitle = 'Conditions d\'utilisation';
+  @service session;
   @service currentUser;
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
@@ -17,7 +18,12 @@ export default class TermsOfServiceController extends Controller {
     if (this.isTermsOfServiceValidated) {
       this.showErrorTermsOfServiceNotSelected = false;
       await this.currentUser.user.save({ adapterOptions: { acceptPixTermsOfService: true } });
-      this.transitionToRoute('profile');
+
+      if (this.session.attemptedTransition) {
+        this.session.attemptedTransition.retry();
+      } else {
+        this.transitionToRoute('profile');
+      }
     } else {
       this.showErrorTermsOfServiceNotSelected = true;
     }

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -10,7 +10,7 @@
     <h2 class="terms-of-service-form__title">Conditions d'utilisation</h2>
 
     <div class="terms-of-service-form__description">
-      Nous avons mis à jour nos conditions d'utilisation.
+      Nous avons mis à jour nos conditions d'utilisation. Veuillez les accepter afin de pouvoir continuer votre expérience sur Pix.
     </div>
 
     <div class="terms-of-service-form__conditions">

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -29,13 +29,20 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
       userId: null,
       organizationId: null
     });
+
+    this.server.schema.users.create({
+      mustValidateTermsOfService: true
+    });
   });
 
   describe('Start a campaign', function() {
     let prescritUser;
 
     beforeEach(function() {
-      prescritUser = server.create('user', 'withEmail');
+      prescritUser = server.create('user', 'withEmail', {
+        mustValidateTermsOfService: false,
+        lastTermsOfServiceValidatedAt: null
+      });
     });
 
     context('When user is not logged in', function() {
@@ -93,6 +100,29 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
 
                 // then
                 expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/rejoindre`.toLowerCase());
+              });
+            });
+
+            context('When user must accept Pix last terms of service', async function() {
+
+              it('should redirect to campaign landing page after accept terms of service', async function() {
+                // given
+                await visit('/campagnes');
+                prescritUser.mustValidateTermsOfService = true;
+                await fillIn('#campaign-code', campaign.code);
+                await click('.fill-in-campaign-code__start-button');
+                await click('#login-button');
+                await fillIn('#login', prescritUser.email);
+                await fillIn('#password', prescritUser.password);
+                await click('#submit-connexion');
+
+                // when
+                await click('#pix-cgu');
+                await click('.terms-of-service-form-actions__submit');
+
+                // then
+                expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/rejoindre`.toLowerCase());
+
               });
             });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur essaye de rejoindre une campagne restreinte et qu'il valide les nouvelles CGU, celui-ci est redirigé vers son profil au lieu de la campagne.  

## :robot: Solution
Vérifier s'il existe une transition qui a été annulée. Si oui, alors le rediriger vers sa transition initiale. 

## :rainbow: Remarques
En plus, le wording de la description a été modifié. 

## :100: Pour tester
- Taper un code parcours de campagnes restreinte. 
- Utiliser un utilisateur avec email devant valider les dernières CGU
- Valider les CGU.
- Et constater qu'on est bien redirigé vers la page de reconciliation de la campagne.
