### PR TITLE
[FEATURE] Redirige vers le partage de profil à la reprise d'une campagne de collecte (PIX-616)

### DIFF
--- a/mon-pix/app/templates/components/resume-campaign-banner-collect-profile.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner-collect-profile.hbs
@@ -1,2 +1,9 @@
 <span class="resume-campaign-banner__title">N'oubliez pas de finaliser votre envoi !</span>
-<LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">Continuer</LinkTo>
+<LinkTo
+  @route="campaigns.start-or-resume"
+  @model={{@code}}
+  @query={{hash campaignParticipationIsStarted="true"}}
+  class="resume-campaign-banner__button button button--big button--link"
+>
+  Continuer
+</LinkTo>

--- a/mon-pix/tests/acceptance/profile-test.js
+++ b/mon-pix/tests/acceptance/profile-test.js
@@ -147,7 +147,7 @@ describe('Acceptance | Profile', function() {
 
           // then
           expect(find('.resume-campaign-banner__container').textContent).to.contain('N\'oubliez pas de finaliser votre envoi !');
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          expect(find('.resume-campaign-banner__button').textContent.trim()).to.equal('Continuer');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Quand l'utilisateur reprend une campagne de collecte, il arrive sur la page de présentation au lieu de la page de partage de profil.

## :robot: Solution
Rediriger directement sur la page de partage de profil à la reprise d'une campagne de collecte en utilisant le query param `campaignParticipationIsStarted` de la route `campaigns.start-or-resume`.

## :100: Pour tester
1. se connecter à mon pix
2. saisir la campagne SNAP123
3. cliquer sur c'est parti
4. revenir sur la page de profil
5. cliquer sur "Continuer" dans le bandeau jaune
> Vous arrivez directement sur la page de partage de profil
