### PR TITLE
[FEATURE] Mettre à jour le texte de la page de login de PixOrga et son design (PIX-530).

### DIFF
--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -1,9 +1,14 @@
 .login-form {
-  max-width: 400px;
+  max-width: 450px;
 
   &__information {
-    max-width: 360px;
-    margin-bottom: 20px;
+    text-align: center;
+    margin-bottom: 32px;
+    color: $grey-90;
+    font-family: $roboto;
+    font-size: 0.875rem;
+    letter-spacing: 0.009375rem;
+    line-height: 1.5rem;
   }
 
   &__error-message {
@@ -13,11 +18,12 @@
 
   &__forgotten-password {
     font-size: 0.875rem;
-    text-align: center;
+    text-align: left;
   }
 
   &__button {
     font-weight: 600;
+    margin-top: 8px;
   }
 
   &__invitation-error {
@@ -27,6 +33,19 @@
     margin: 10px 0 16px 0;
     padding: 9px;
     text-align: center;
+  }
+
+  .input-container {
+    margin-bottom: 16px;
+  }
+
+  form {
+    width: 352px;
+    margin: auto;
+
+    .input {
+      padding-left: 16px;
+    }
   }
 }
 

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -3,8 +3,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: $pix-orga-old-gradient;
-  box-shadow: 0 2px 8px 0 rgba($black, 0.1);
+  background: $pix-orga-gradient;
   align-items: center;
   justify-content: center;
   min-height: 800px;
@@ -13,7 +12,15 @@
     display: flex;
     flex-direction: column;
     border-radius: 10px;
-    padding: 60px 100px;
+    padding: 40px 60px;
+  }
+
+  .form-title {
+    text-align: center;
+    font-family: $open-sans;
+    font-size: 2rem;
+    color: $grey-80;
+    margin-bottom: 8px;
   }
 }
 

--- a/orga/app/templates/components/routes/login-form.hbs
+++ b/orga/app/templates/components/routes/login-form.hbs
@@ -1,6 +1,6 @@
 <div class="login-form">
-  <div class="login-form__information paragraph">Vous avez déjà un compte sur Pix.fr ? Vous pouvez utiliser ce compte
-    pour rejoindre l'espace organisation.
+  <div class="login-form__information">
+    L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.
   </div>
 
   {{#if @hasInvitationError}}
@@ -59,9 +59,10 @@
       {{/if}}
     </div>
 
+    <div class="login-form__forgotten-password help-text">
+      <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">Mot de passe oublié ?</a>
+    </div>
   </form>
 
-  <div class="login-form__forgotten-password help-text">
-    <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">J'ai oublié mon mot de passe</a>
-  </div>
+
 </div>

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -3,7 +3,7 @@
     <div class="panel__image">
       <img src="/pix-orga.svg" alt="Pix Orga">
     </div>
-    <h1 class="form-title">Déjà utilisateur Pix ?</h1>
+    <h3 class="form-title">Connectez-vous</h3>
     <Routes::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le message sur la page de connexion porte à confusion.
On a l’impression qu’on peut se connecter dès lors qu’on a un compte sur app.pix.fr, ce qui n’est pas vrai.

De plus le design de la page n'est pas à jour.

## :robot: Solution
- Mettre à jour le texte en conséquence
- Mettre à jour le style css

## :100: Pour tester
 - Aller sur la page de connexion