### PR TITLE
[BUGFIX] Stabilisation des perfs pour l'export CSV des campagnes de collecte de profils et d'évaluation (PIX-607).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -113,6 +113,10 @@ module.exports = (function() {
       dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2,7),
     },
 
+    infra: {
+      concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),
+    },
+
     pixOrgaUrl: process.env.PIXORGA_URL,
 
     sentry: {

--- a/api/lib/infrastructure/constants.js
+++ b/api/lib/infrastructure/constants.js
@@ -1,0 +1,5 @@
+const settings = require('../config');
+
+module.exports = {
+  CONCURRENCY_HEAVY_OPERATIONS: settings.infra.concurrencyForHeavyOperations,
+};


### PR DESCRIPTION
## :unicorn: Problème
L'export CSV pour les campagnes de type "collecte de profils" a été mis en production et exploitable, dans un premier temps,
par un groupe restreint d'organisations bêta testeuses. Malheureusement, les premiers retours indiquent un temps de téléchargement trop long. En effet, il semblerait qu'il faille plusieurs minutes pour télécharger un export csv de collecte de profils.
Ce n'est pas surprenant: les expérimentations passées nous ont apprises qu'à calculer le profil de plusieurs utilisateurs d'un coup, on risquait l'explosion mémoire. De fait, pour pallier à cela, divers travaux ont été effectués pour mettre en place, en dernière instance, un mécanisme de streaming pour la génération des CSV (export de résultats et de collecte de profils). Ce mécanisme de streaming s'associe à un calcul séquentiel des profils des participants d'une campagne.
On évite donc l'explosion mémoire, mais en contre-partie cela prend du temps.

## :female_detective: Etude
Entre temps, deux PRs sont passées et permettent une réduction de la charge mémoire nécessaire aux calculs nécessaires à la génération du CSV :
- https://github.com/1024pix/pix/pull/1382 --> Réduction de l'occupation mémoire nécessaire pour récupérer les KEs pour constituer un profil
- https://github.com/1024pix/pix/pull/1399 --> Amélioration du CertificationProfile en déplaçant la récupération la liste des challenges répondues correctement par l'utilisateur (pas utile pour la constitution du profil en soit mais utile seulement pour la génération du test de certification)

Ces deux améliorations nous autorisent à essayer de paralllélélélliser (pardon je craque, ce mot est difficile à épeler) la génération de lignes de CSV.
Cependant, il ne faut pas oublier qu'en prod, les serveurs API (et par extension LE serveur BDD) traitent plusieurs autres requêtes. Il s'agit donc ici de ne pas accaparer l'ensemble des ressources.
On a donc procédé à des tests afin d'essayer de déterminer quelle valeur de concurrence est une bonne valeur (à savoir on constate un gain sans pomper toutes les ressources).
On a réalisé des tests **AVANT** que les deux PRs mentionnés ci-dessus soient incluses dans la PR ici présente, et **APRES**.
Pour réaliser ces tests, nous avons créé une campagne de collecte de profils comprenant 3300 participants (worst case scenario actuellement existant en prod).

**AVANT :**
| Concurrence  | Temps de téléchargement (secondes) |
| ------------- | ------------- |
| 50  | 280  |
| 25  | 280  |
| 15  | 285  |
| 10  | 285  |
| 8  | 285  |
| 4  | 330  |
| 2  | 720  |
| 1*  | N/A*  |

* Malheureusement, le script a tellement pris de temps que sonna le gong de 5h du matin -> déclenchement de la réplication -> interruption du script :(
Métriques BDD :
![screenshot_2020-05-15_17:23:06](https://user-images.githubusercontent.com/48727874/82220805-683bb200-991f-11ea-9064-1c68fc252040.png)
Il faut ignorer la partie après 5h du mat, c'est la réplication qui fait son oeuvre. Autrement, on constate une charge CPU assez élevée pour le traitement des requêtes, mais une charge CPU significativement en baisse lorsque nous passons à une valeur de concurrence de 2 (la petite chute sur le graphe avant 5h du mat')
+ On passait environ 30% du temps en BDD à réclamer depuis la table `answers` la liste des challenges (inutile)

**APRES:**
Vu qu'on a constaté la non-variation du temps de téléchargement lorsque la valeur de concurrence est élevée, on ne prend pas la peine de re-tester avec certaines valeurs.
| Concurrence  | Temps de téléchargement (secondes) |
| ------------- | ------------- |
| 15  | 150  |
| 10  | 150  |
| 8  | 150  |
| 4  | 150  |
| 2  | 300  |
| 1  | 550  |

Le premier constat chouette ici est que les temps de téléchargement ont bien baissé :+1: 
![Capture d’écran de 2020-05-15 23-07-23](https://user-images.githubusercontent.com/48727874/82222013-0419ed80-9921-11ea-9f99-bd24caf1506f.png)
On constate à nouveau une charge CPU plus faible à mesure que la valeur de concurrence est réduite. Le plus bas atteint est obtenu à partir d'une concurrence mise à 2.

## :robot: Solution
Mise en place d'une valeur de concurrence fixée à 2 (voir étude ci-dessus).
La valeur est mise en variable d'environnement, une mesure prise "au cas-où".
+ On a décidé, vu la faible modification au niveau du code, d'appliquer également ce correctif sur le téléchargement CSV des résultats de campagne.

## :rainbow: Remarques
Rien à signaler côté "mémoire", du "spam-click" a même été effectué pendant plusieurs secondes sur le bouton de téléchargement du CSV.

## :100: Pour tester
Non-régression de la génération CSV de collecte de profils.
