### PR TITLE
[FEATURE][FIX] Utiliser l'élément UL pour la liste à puces dans la double mire de connexion SCO (PIX-647).

### DIFF
--- a/mon-pix/app/templates/components/routes/login-form.hbs
+++ b/mon-pix/app/templates/components/routes/login-form.hbs
@@ -33,8 +33,13 @@
 
   <div class="login-form__forgotten-password help-text">
     <span>Mot de passe oublié ? Vous avez un compte Pix avec :</span>
-    <br>• Une Adresse e-mail :
-    <LinkTo @id="link_password-reset-demand" @route="password-reset-demand" target="_blank" rel="noopener noreferrer" class="link">Cliquez ici pour le réinitialiser</LinkTo>
-    <br>• Un identifiant : Contactez votre enseignant pour le réinitialiser
+    <ul>
+      <li>Une Adresse e-mail :
+        <LinkTo @id="link_password-reset-demand" @route="password-reset-demand" target="_blank" rel="noopener noreferrer" class="link">Cliquez ici pour le réinitialiser</LinkTo>
+      </li>
+      <li>
+        Un identifiant : Contactez votre enseignant pour le réinitialiser
+      </li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Dans Mon Pix, sur la double mire de connexion SCO, un caractère unicode est utilisé dans la liste à puces.

## :robot: Solution
Remplacer ce caractère par les éléments `<ul>` et `<li>`

## :100: Pour tester
* Aller sur la page /campagnes/RESTRICTD
* Cliquer sur Je me connecte