### PR TITLE
[BUGFIX] Limiter les Pix et Levels max sur l'export de collecte de profils (PIX-615).

### DIFF
--- a/api/lib/domain/models/CertificationProfile.js
+++ b/api/lib/domain/models/CertificationProfile.js
@@ -10,13 +10,11 @@ class CertificationProfile {
       profileDate,
       userId,
       userCompetences,
-      challengeIdsCorrectlyAnswered,
     } = {}) {
     // attributes
     this.profileDate = profileDate;
     this.userId = userId;
     this.userCompetences = userCompetences;
-    this.challengeIdsCorrectlyAnswered = challengeIdsCorrectlyAnswered;
   }
 
   isCertifiable() {

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -175,8 +175,8 @@ function _getChallengeInformation(listAnswers, certificationChallenges, competen
   });
 }
 
-async function _getTestedCompetences({ userId, limitDate, isV2Certification }) {
-  const certificationProfile = await userService.getCertificationProfile({ userId, limitDate, isV2Certification });
+async function _getTestedCompetences({ userId, limitDate, isV2Certification, competences }) {
+  const certificationProfile = await userService.getCertificationProfile({ userId, limitDate, isV2Certification, competences });
   return _(certificationProfile.userCompetences)
     .filter((uc) => uc.estimatedLevel > 0)
     .map((uc) => _.pick(uc, ['id', 'area', 'index', 'name', 'estimatedLevel', 'pixScore']))
@@ -216,6 +216,7 @@ module.exports = {
       userId: assessment.userId,
       limitDate: assessment.createdAt,
       isV2Certification: certificationCourse.isV2Certification,
+      competences: allCompetences
     });
 
     const matchingCertificationChallenges = _selectChallengesMatchingCompetences(certificationChallenges, testedCompetences);

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -8,30 +8,38 @@ const CertificationProfile = require('../models/CertificationProfile');
 const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const challengeRepository = require('../../../lib/infrastructure/repositories/challenge-repository');
 const answerRepository = require('../../../lib/infrastructure/repositories/answer-repository');
-const competenceRepository = require('../../../lib/infrastructure/repositories/competence-repository');
 const knowledgeElementRepository = require('../../../lib/infrastructure/repositories/knowledge-element-repository');
 
-async function getCertificationProfile({ userId, limitDate, isV2Certification = true }) {
+async function getCertificationProfile({ userId, limitDate, competences, isV2Certification = true, limitPixAndLevels = false }) {
   const certificationProfile = new CertificationProfile({
     userId,
     profileDate: limitDate,
   });
   if (isV2Certification) {
-    return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2(certificationProfile);
+    return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, limitPixAndLevels });
   }
-  return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1(certificationProfile);
+  return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1({ certificationProfile, competences });
 }
 
 async function fillCertificationProfileWithChallenges(certificationProfile) {
+  const certificationProfileClone = _.clone(certificationProfile);
+  const knowledgeElementsByCompetence = await knowledgeElementRepository
+    .findUniqByUserIdGroupedByCompetenceId({ userId: certificationProfile.userId, limitDate: certificationProfile.profileDate });
+
+  const knowledgeElements = KnowledgeElement.findDirectlyValidatedFromGroups(knowledgeElementsByCompetence);
+  const answerIds = _.map(knowledgeElements, 'answerId');
+
+  const challengeIdsCorrectlyAnswered = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
+
   const allChallenges = await challengeRepository.list();
-  const challengesAlreadyAnswered = certificationProfile.challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
+  const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
 
   challengesAlreadyAnswered.forEach((challenge) => {
     if (!challenge) {
       return;
     }
 
-    const userCompetence = _getUserCompetenceByChallengeCompetenceId(certificationProfile.userCompetences, challenge);
+    const userCompetence = _getUserCompetenceByChallengeCompetenceId(certificationProfileClone.userCompetences, challenge);
 
     if (!userCompetence || !userCompetence.isCertifiable()) {
       return;
@@ -42,9 +50,9 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
       .forEach((publishedSkill) => userCompetence.addSkill(publishedSkill));
   });
 
-  certificationProfile.userCompetences = UserCompetence.orderSkillsOfCompetenceByDifficulty(certificationProfile.userCompetences);
+  certificationProfileClone.userCompetences = UserCompetence.orderSkillsOfCompetenceByDifficulty(certificationProfileClone.userCompetences);
 
-  certificationProfile.userCompetences.forEach((userCompetence) => {
+  certificationProfileClone.userCompetences.forEach((userCompetence) => {
     const testedSkills = [];
     userCompetence.skills.forEach((skill) => {
       if (!userCompetence.hasEnoughChallenges()) {
@@ -63,16 +71,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
     userCompetence.skills = testedSkills;
   });
 
-  return certificationProfile;
-}
-
-async function _findCorrectAnswersByAssessments(assessments) {
-  const answersByAssessmentsPromises = assessments.map((assessment) =>
-    answerRepository.findCorrectAnswersByAssessmentId(assessment.id));
-
-  const answersByAssessments = await Promise.all(answersByAssessmentsPromises);
-
-  return _.flatten(answersByAssessments);
+  return certificationProfileClone;
 }
 
 function _getUserCompetenceByChallengeCompetenceId(userCompetences, challenge) {
@@ -94,19 +93,16 @@ function _createUserCompetencesV1({ allCompetences, userLastAssessments }) {
   });
 }
 
-async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1(certificationProfile) {
+async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1({ certificationProfile, competences }) {
   const certificationProfileToFill = _.clone(certificationProfile);
-  const allCompetences = await competenceRepository.listPixCompetencesOnly();
   const userLastAssessments = await assessmentRepository
     .findLastCompletedAssessmentsForEachCompetenceByUser(certificationProfile.userId, certificationProfile.profileDate);
-  certificationProfileToFill.userCompetences = _createUserCompetencesV1({ allCompetences, userLastAssessments });
-  const correctAnswers = await _findCorrectAnswersByAssessments(userLastAssessments);
-  certificationProfileToFill.challengeIdsCorrectlyAnswered = _.map(correctAnswers, 'challengeId');
+  certificationProfileToFill.userCompetences = _createUserCompetencesV1({ allCompetences: competences, userLastAssessments });
 
   return certificationProfileToFill;
 }
 
-function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCompetences }) {
+function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCompetences, limitPixAndLevels = false }) {
   return allCompetences.map((competence) => {
     const userCompetence = new UserCompetence(competence);
 
@@ -114,8 +110,8 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
       userId,
       knowledgeElements: knowledgeElementsByCompetence[competence.id],
       competence,
-      allowExcessPix: true,
-      allowExcessLevel: true
+      allowExcessPix: !limitPixAndLevels,
+      allowExcessLevel: !limitPixAndLevels,
     });
 
     userCompetence.estimatedLevel = scorecard.level;
@@ -125,18 +121,18 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
   });
 }
 
-async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2(certificationProfile) {
+async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, limitPixAndLevels }) {
   const certificationProfileToFill = _.clone(certificationProfile);
-  const allCompetences = await competenceRepository.listPixCompetencesOnly();
 
   const knowledgeElementsByCompetence = await knowledgeElementRepository
     .findUniqByUserIdGroupedByCompetenceId({ userId: certificationProfile.userId, limitDate: certificationProfile.profileDate });
-  certificationProfileToFill.userCompetences = _createUserCompetencesV2({ userId: certificationProfile.userId, knowledgeElementsByCompetence, allCompetences });
 
-  const knowledgeElements = KnowledgeElement.findDirectlyValidatedFromGroups(knowledgeElementsByCompetence);
-  const answerIds = _.map(knowledgeElements, 'answerId');
-
-  certificationProfileToFill.challengeIdsCorrectlyAnswered = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
+  certificationProfileToFill.userCompetences = _createUserCompetencesV2({
+    userId: certificationProfile.userId,
+    knowledgeElementsByCompetence,
+    allCompetences: competences,
+    limitPixAndLevels,
+  });
 
   return certificationProfileToFill;
 }

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -10,13 +10,13 @@ const challengeRepository = require('../../../lib/infrastructure/repositories/ch
 const answerRepository = require('../../../lib/infrastructure/repositories/answer-repository');
 const knowledgeElementRepository = require('../../../lib/infrastructure/repositories/knowledge-element-repository');
 
-async function getCertificationProfile({ userId, limitDate, competences, isV2Certification = true, limitPixAndLevels = false }) {
+async function getCertificationProfile({ userId, limitDate, competences, isV2Certification = true, allowExcessPixAndLevels = true }) {
   const certificationProfile = new CertificationProfile({
     userId,
     profileDate: limitDate,
   });
   if (isV2Certification) {
-    return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, limitPixAndLevels });
+    return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, allowExcessPixAndLevels });
   }
   return _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV1({ certificationProfile, competences });
 }
@@ -102,7 +102,7 @@ async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredC
   return certificationProfileToFill;
 }
 
-function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCompetences, limitPixAndLevels = false }) {
+function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCompetences, allowExcessPixAndLevels = true }) {
   return allCompetences.map((competence) => {
     const userCompetence = new UserCompetence(competence);
 
@@ -110,8 +110,8 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
       userId,
       knowledgeElements: knowledgeElementsByCompetence[competence.id],
       competence,
-      allowExcessPix: !limitPixAndLevels,
-      allowExcessLevel: !limitPixAndLevels,
+      allowExcessPix: allowExcessPixAndLevels,
+      allowExcessLevel: allowExcessPixAndLevels,
     });
 
     userCompetence.estimatedLevel = scorecard.level;
@@ -121,7 +121,7 @@ function _createUserCompetencesV2({ userId, knowledgeElementsByCompetence, allCo
   });
 }
 
-async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, limitPixAndLevels }) {
+async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredChallengeIdsV2({ certificationProfile, competences, allowExcessPixAndLevels }) {
   const certificationProfileToFill = _.clone(certificationProfile);
 
   const knowledgeElementsByCompetence = await knowledgeElementRepository
@@ -131,7 +131,7 @@ async function _fillCertificationProfileWithUserCompetencesAndCorrectlyAnsweredC
     userId: certificationProfile.userId,
     knowledgeElementsByCompetence,
     allCompetences: competences,
-    limitPixAndLevels,
+    allowExcessPixAndLevels,
   });
 
   return certificationProfileToFill;

--- a/api/lib/domain/usecases/get-user-current-certification-profile.js
+++ b/api/lib/domain/usecases/get-user-current-certification-profile.js
@@ -1,8 +1,11 @@
-module.exports = function getUserCurrentCertificationProfile(
+module.exports = async function getUserCurrentCertificationProfile(
   {
     userId,
     userService,
+    competenceRepository
   }) {
   const now = new Date();
-  return userService.getCertificationProfile({ userId, limitDate: now });
+  const competences = await competenceRepository.listPixCompetencesOnly();
+
+  return userService.getCertificationProfile({ userId, limitDate: now, competences });
 };

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -8,6 +8,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   sessionId,
   userId,
   assessmentRepository,
+  competenceRepository,
   certificationCandidateRepository,
   certificationChallengeRepository,
   certificationCourseRepository,
@@ -33,6 +34,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     sessionId,
     userId,
     assessmentRepository,
+    competenceRepository,
     certificationCandidateRepository,
     certificationChallengeRepository,
     certificationCourseRepository,
@@ -46,19 +48,21 @@ async function _startNewCertification({
   sessionId,
   userId,
   assessmentRepository,
+  competenceRepository,
   certificationCandidateRepository,
   certificationChallengeRepository,
   certificationCourseRepository,
   certificationChallengesService,
   userService,
 }) {
-  const certificationProfile = await userService.getCertificationProfile({ userId, limitDate: new Date() });
+  const competences = await competenceRepository.listPixCompetencesOnly();
+  let certificationProfile = await userService.getCertificationProfile({ userId, limitDate: new Date(), competences });
 
   if (!certificationProfile.isCertifiable()) {
     throw new UserNotAuthorizedToCertifyError();
   }
 
-  await userService.fillCertificationProfileWithChallenges(certificationProfile);
+  certificationProfile = await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
   const existingCertificationCourse = await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({ userId, sessionId, domainTransaction });
   if (existingCertificationCourse) {

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -164,7 +164,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
       userId: campaignParticipationResultData.userId,
       limitDate: campaignParticipationResultData.sharedAt,
       competences: allCompetences,
-      limitPixAndLevels: true
+      allowExcessPixAndLevels: false
     });
 
     const csvLine = _createOneLineOfCSV({

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -162,7 +162,9 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
 
     const certificationProfile = await userService.getCertificationProfile({
       userId: campaignParticipationResultData.userId,
-      limitDate: campaignParticipationResultData.sharedAt
+      limitDate: campaignParticipationResultData.sharedAt,
+      competences: allCompetences,
+      limitPixAndLevels: true
     });
 
     const csvLine = _createOneLineOfCSV({

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -294,7 +294,7 @@ describe('Integration | Service | User Service', function() {
               userId,
               limitDate: 'salut',
               competences,
-              limitPixAndLevels: false
+              allowExcessPixAndLevels: true
             });
 
             // then
@@ -323,7 +323,7 @@ describe('Integration | Service | User Service', function() {
               userId,
               limitDate: 'salut',
               competences,
-              limitPixAndLevels: true
+              allowExcessPixAndLevels: false
             });
 
             // then

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -31,7 +31,8 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
       const skillWeb2 = airtableBuilder.factory.buildSkill({ id: 'recSkillWeb2', nom: '@web2', ['compétenceViaTube']: ['recCompetence1'] });
       const skillWeb3 = airtableBuilder.factory.buildSkill({ id: 'recSkillWeb3', nom: '@web3', ['compétenceViaTube']: ['recCompetence1'] });
       const skillUrl1 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl1', nom: '@url1', ['compétenceViaTube']: ['recCompetence2'] });
-      const skills = [skillWeb1, skillWeb2, skillWeb3, skillUrl1];
+      const skillUrl8 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl8', nom: '@url8', ['compétenceViaTube']: ['recCompetence2'] });
+      const skills = [skillWeb1, skillWeb2, skillWeb3, skillUrl1, skillUrl8];
 
       participant = databaseBuilder.factory.buildUser({ firstName: '@Jean', lastName: '=Bono' });
       const createdAt = new Date('2019-02-25T10:00:00Z');
@@ -79,6 +80,14 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         userId: participant.id,
         createdAt,
       });
+      databaseBuilder.factory.buildKnowledgeElement({
+        status: 'validated',
+        skillId: skillUrl8.id,
+        earnedPix: 64,
+        competenceId: 'recCompetence2',
+        userId: participant.id,
+        createdAt,
+      });
 
       campaign = databaseBuilder.factory.buildCampaign({
         name: '@Campagne de Test N°2',
@@ -114,7 +123,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         titre: 'Competence2',
         sousDomaine: '3.2',
         domaineIds: ['recArea3'],
-        acquisViaTubes: [skillUrl1.id],
+        acquisViaTubes: [skillUrl1.id, skillUrl8.id],
       });
 
       const area1 = airtableBuilder.factory.buildArea({ id: 'recArea1', code: '1', titre: 'Domain 1' });
@@ -144,13 +153,13 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         `"'${campaignParticipation.participantExternalId}";` +
         '"Oui";' +
         '2019-03-01;' +
-        '14;' +
+        '52;' +
         '"Non";' +
-        '1;' +
+        '2;' +
         '1;' +
         '12;' +
-        '0;' +
-        '2';
+        '5;' +
+        '40';
 
       // when
       startWritingCampaignProfilesCollectionResultsToStream({

--- a/api/tests/unit/domain/models/CertificationProfile_test.js
+++ b/api/tests/unit/domain/models/CertificationProfile_test.js
@@ -19,7 +19,6 @@ describe('Unit | Domain | Models | CertificationProfile', () => {
           pixScore: 10,
           estimatedLevel: 5,
         })],
-        challengeIdsCorrectlyAnswered: ['challengeId'],
       };
 
       // when

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -164,6 +164,7 @@ describe('Unit | Service | Certification Result Service', function() {
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
           isV2Certification: certificationCourseV2.isV2Certification,
+          competences: competencesFromAirtable
         }).resolves({ userCompetences: [] });
       });
 
@@ -204,6 +205,7 @@ describe('Unit | Service | Certification Result Service', function() {
           userId: 'user_id',
           limitDate: dateCreationCertif,
           isV2Certification: certificationCourseV1.isV2Certification,
+          competences: competencesFromAirtable
         }).resolves({ userCompetences });
         sinon.stub(certificationCourseRepository, 'get').resolves(certificationCourseV1);
       });
@@ -700,6 +702,7 @@ describe('Unit | Service | Certification Result Service', function() {
                 userId: 'user_id',
                 limitDate: dateCreationCertif,
                 isV2Certification: false,
+                competences: competencesFromAirtable
               }).resolves({ userCompetences });
 
               // When
@@ -737,6 +740,7 @@ describe('Unit | Service | Certification Result Service', function() {
           userId: 'user_id',
           limitDate: dateCreationCertif,
           isV2Certification: false,
+          competences: competencesFromAirtable
         }).resolves({ userCompetences });
         sinon.stub(answersRepository, 'findByAssessment').resolves(wrongAnswersForAllChallenges());
         sinon.stub(certificationChallengesRepository, 'findByCertificationCourseId').resolves(challenges);
@@ -1094,6 +1098,7 @@ describe('Unit | Service | Certification Result Service', function() {
             userId: 'user_id',
             limitDate: dateCreationCertif,
             isV2Certification: false,
+            competences: competencesFromAirtable
           }).resolves({ userCompetences });
 
         });

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -58,6 +58,7 @@ describe('Unit | Service | Certification Service', function() {
         userId: 'user_id',
         limitDate: dateCreationCertif,
         isV2Certification: certificationCourseV1.isV2Certification,
+        competences: []
       }).resolves([]);
       sinon.stub(certificationCourseRepository, 'get').resolves(certificationCourseV1);
     });

--- a/api/tests/unit/domain/usecases/get-user-current-certification-profile_test.js
+++ b/api/tests/unit/domain/usecases/get-user-current-certification-profile_test.js
@@ -4,12 +4,19 @@ const getUserCurrentCertificationProfile = require('../../../../lib/domain/useca
 describe('Unit | UseCase | get-user-current-certification-profile', () => {
 
   let userService;
+  let competenceRepository;
+  let clock;
+  const now = new Date(2020, 1, 1);
+  const competences = [{ id: 'rec1' }, { id: 'rec2' }];
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
     userService = { getCertificationProfile: sinon.stub() };
+    competenceRepository = { listPixCompetencesOnly: sinon.stub().resolves(competences) };
   });
 
   afterEach(() => {
+    clock.restore();
     sinon.restore();
   });
 
@@ -17,12 +24,13 @@ describe('Unit | UseCase | get-user-current-certification-profile', () => {
     // given
     const userId = 2;
 
-    userService.getCertificationProfile.resolves('certificationProfile');
+    userService.getCertificationProfile.withArgs({ userId, limitDate: now, competences }).resolves('certificationProfile');
 
     // when
     const actualCertificationProfile = await getUserCurrentCertificationProfile({
       userId,
       userService,
+      competenceRepository
     });
 
     //then


### PR DESCRIPTION
## :unicorn: Problème
Dans l'export de collecte de profil en CSV, on calcul le profil pix en prennant en compte les questions qui dépassent le niveau 5. On a alors un nombre de pix qui n’est pas le même entre le profil récupéré dans pix orga et le profil affiché au prescrit.

## :robot: Solution
L'export de collecte de profil en CSV utilise le service `getCertificationProfile`. Il faut lui passer une option pour activer la limitation de pix et niveau sur la récupération des compétences de l'utilisateur.

## :100: Pour tester
1. Atteindre un niveau supérieur à 5 sur un compétence dans pix-app
2. Faire une campagne collecte de profil avec cet utilisateur
3. Extraire le CSV de la campagne de collecte
> Vérifier que la compétence est limitée au niveau 5 et avec un maximum de pix à 40
