### PR TITLE
[BUGFIX] Validation de la longueur d'un id de session. 

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,6 +2,7 @@ const Joi = require('@hapi/joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
+const settings = require('../../config');
 
 exports.register = async (server) => {
   server.route([
@@ -27,7 +28,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -44,7 +45,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -62,7 +63,7 @@ exports.register = async (server) => {
         auth: false,
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         handler: sessionController.getAttendanceSheet,
@@ -91,7 +92,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -112,7 +113,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         payload: {
@@ -137,7 +138,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -159,7 +160,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -180,7 +181,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -201,8 +202,8 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
-            certificationCandidateId: Joi.number().integer().required(),
+            id: settings.idValidator,
+            certificationCandidateId: settings.idValidator,
           }),
         },
         pre: [{
@@ -223,7 +224,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -244,7 +245,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -266,7 +267,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         handler: sessionController.createCandidateParticipation,
@@ -284,7 +285,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -305,7 +306,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{
@@ -328,7 +329,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required()
+            id: settings.idValidator
           }),
         },
         pre: [{

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const Joi = require('@hapi/joi');
 
 function parseJSONEnv(varName) {
   if (process.env[varName]) {
@@ -121,6 +122,8 @@ module.exports = (function() {
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
       debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
     },
+
+    idValidator: Joi.number().integer().max(2147483647).required(),
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -13,44 +13,38 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   beforeEach(() => {
     server = this.server = Hapi.server();
+    sinon.stub(sessionAuthorization, 'verify').returns(null);
+    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+
+    sinon.stub(sessionController, 'get').returns('ok');
+    sinon.stub(sessionController, 'getJurySession').returns('ok');
+    sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
+    sinon.stub(sessionController, 'save').returns('ok');
+    sinon.stub(sessionController, 'getAttendanceSheet').returns('ok');
+    sinon.stub(sessionController, 'update').returns('ok');
+    sinon.stub(sessionController, 'importCertificationCandidatesFromAttendanceSheet').returns('ok');
+    sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
+    sinon.stub(sessionController, 'addCertificationCandidate').returns('ok');
+    sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
+    sinon.stub(sessionController, 'getCertifications').returns('ok');
+    sinon.stub(sessionController, 'createCandidateParticipation').returns('ok');
+    sinon.stub(sessionController, 'finalize').returns('ok');
+    sinon.stub(sessionController, 'updatePublication').returns('ok');
+    sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
+    sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
+
+    return server.register(route);
   });
 
   describe('GET /api/sessions/{id}', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'get').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      // given
-      sessionId = 3;
-
-      const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}` });
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/3' });
       expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 'salut';
-
-        const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}` });
-        expect(res.statusCode).to.equal(400);
-      });
     });
   });
 
   describe('GET /api/jury/sessions/{id}', () => {
-
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'getJurySession').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
       const res = await server.inject({ method: 'GET', url: '/api/jury/sessions/123' });
@@ -60,12 +54,6 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('GET /api/jury/sessions', () => {
 
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
-      return server.register(route);
-    });
-
     it('should exist', async () => {
       const res = await server.inject({ method: 'GET', url: '/api/jury/sessions' });
       expect(res.statusCode).to.equal(200);
@@ -73,11 +61,6 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('POST /api/session', () => {
-
-    beforeEach(() => {
-      sinon.stub(sessionController, 'save').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
       const res = await server.inject({ method: 'POST', url: '/api/sessions' });
@@ -87,43 +70,17 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('GET /api/sessions/{id}/attendance-sheet', () => {
 
-    beforeEach(() => {
-      sinon.stub(sessionController, 'getAttendanceSheet').returns('ok');
-      return server.register(route);
-    });
-
     it('should exist', async () => {
       const res = await server.inject({ method: 'GET', url: '/api/sessions/1/attendance-sheet' });
-
       expect(res.statusCode).to.equal(200);
     });
   });
 
   describe('PATCH /api/sessions/{id}', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sessionId = 1;
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'update').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'PATCH', url: `/api/sessions/${sessionId}` });
-
+      const res = await server.inject({ method: 'PATCH', url: '/api/sessions/1' });
       expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 'salut';
-
-        const res = await server.inject({ method: 'PATCH', url: `/api/sessions/${sessionId}` });
-        expect(res.statusCode).to.equal(400);
-      });
     });
   });
 
@@ -134,8 +91,6 @@ describe('Unit | Application | Sessions | Routes', () => {
     let options;
     beforeEach(async () => {
       // given
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'importCertificationCandidatesFromAttendanceSheet').returns('ok');
       fs.writeFileSync(testFilePath, Buffer.alloc(0));
       const form = new FormData();
       form.append('file', fs.createReadStream(testFilePath), { knownLength: fs.statSync(testFilePath).size });
@@ -145,8 +100,6 @@ describe('Unit | Application | Sessions | Routes', () => {
         headers: form.getHeaders(),
         payload,
       };
-
-      await server.register(route);
     });
 
     afterEach(() => {
@@ -180,132 +133,47 @@ describe('Unit | Application | Sessions | Routes', () => {
       });
     });
 
-  });
-
-  describe('GET /api/sessions/{id}/certification-candidates', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'getCertificationCandidates').returns('ok');
-      return server.register(route);
-    });
-
-    it('should exist', async () => {
-      //given
-      sessionId = 3;
-
-      const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}/certification-candidates` });
-      expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
+    context('when session ID params is out of range for database integer (> 2147483647)', () => {
 
       it('should return 400', async () => {
         // given
-        sessionId = 'salut';
+        sessionId = 9999999999;
+        options.url = `/api/sessions/${sessionId}/certification-candidates/import`;
 
-        const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}/certification-candidates` });
+        // when
+        const res = await server.inject(options);
+
+        // then
         expect(res.statusCode).to.equal(400);
       });
+    });
+  });
+
+  describe('GET /api/sessions/{id}/certification-candidates', () => {
+
+    it('should exist', async () => {
+      const res = await server.inject({ method: 'GET', url: '/api/sessions/3/certification-candidates' });
+      expect(res.statusCode).to.equal(200);
     });
   });
 
   describe('POST /api/sessions/{id}/certification-candidates', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'addCertificationCandidate').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      // given
-      sessionId = 3;
-
-      // when
-      const res = await server.inject({ method: 'POST', url: `/api/sessions/${sessionId}/certification-candidates` });
-
-      // then
+      const res = await server.inject({ method: 'POST', url: '/api/sessions/3/certification-candidates' });
       expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 'salut';
-
-        // when
-        const res = await server.inject({ method: 'GET', url: `/api/sessions/${sessionId}/certification-candidates` });
-
-        // then
-        expect(res.statusCode).to.equal(400);
-      });
     });
   });
 
   describe('DELETE /api/sessions/{id}/certification-candidates/{certificationCandidateId}', () => {
-    let sessionId;
-    let certificationCandidateId;
-
-    beforeEach(() => {
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'deleteCertificationCandidate').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      // given
-      sessionId = 3;
-      certificationCandidateId = 1;
-
-      // when
-      const res = await server.inject({ method: 'DELETE', url: `/api/sessions/${sessionId}/certification-candidates/${certificationCandidateId}` });
-
-      // then
+      const res = await server.inject({ method: 'DELETE', url: '/api/sessions/3/certification-candidates/1' });
       expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 'salut';
-        certificationCandidateId = 1;
-
-        // when
-        const res = await server.inject({ method: 'DELETE', url: `/api/sessions/${sessionId}/certification-candidates/${certificationCandidateId}` });
-
-        // then
-        expect(res.statusCode).to.equal(400);
-      });
-    });
-
-    context('when certification candidate ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 3;
-        certificationCandidateId = 'salut';
-
-        // when
-        const res = await server.inject({ method: 'DELETE', url: `/api/sessions/${sessionId}/certification-candidates/${certificationCandidateId}` });
-
-        // then
-        expect(res.statusCode).to.equal(400);
-      });
     });
   });
 
   describe('GET /api/jury/sessions/{id}/certifications', () => {
-
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'getCertifications').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
       const res = await server.inject({ method: 'GET', url: '/api/jury/sessions/1/certifications' });
@@ -315,11 +183,6 @@ describe('Unit | Application | Sessions | Routes', () => {
 
   describe('POST /api/sessions/{id}/candidate-participation', () => {
 
-    beforeEach(() => {
-      sinon.stub(sessionController, 'createCandidateParticipation').returns('ok');
-      return server.register(route);
-    });
-
     it('should exist', async () => {
       const res = await server.inject({ method: 'POST', url: '/api/sessions/3/candidate-participation' });
       expect(res.statusCode).to.equal(200);
@@ -327,96 +190,70 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('PUT /api/sessions/{id}/finalization', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sinon.stub(sessionAuthorization, 'verify').returns(null);
-      sinon.stub(sessionController, 'finalize').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      // given
-      sessionId = 3;
-
-      const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/finalization` });
+      const res = await server.inject({ method: 'PUT', url: '/api/sessions/3/finalization' });
       expect(res.statusCode).to.equal(200);
-    });
-
-    context('when session ID params is not a number', () => {
-
-      it('should return 400', async () => {
-        // given
-        sessionId = 'salut';
-
-        const res = await server.inject({ method: 'PUT', url: `/api/sessions/${sessionId}/finalization` });
-        expect(res.statusCode).to.equal(400);
-      });
     });
   });
 
   describe('PATCH /api/jury/sessions/{id}/publication', () => {
-    let options;
-
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'updatePublication').returns('ok');
-      const sessionId = 1;
-      options = {
-        method: 'PATCH',
-        url: `/api/jury/sessions/${sessionId}/publication`,
-        payload: {
-          data: {
-            attributes: {
-              toPublish: true
-            }
-          }
-        },
-      };
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      const res = await server.inject(options);
+      const res = await server.inject({ method: 'PATCH', url: '/api/jury/sessions/1/publication', payload: { data: { attributes: { toPublish: true } } } });
       expect(res.statusCode).to.equal(200);
     });
   });
 
   describe('PUT /api/jury/sessions/{id}/results-sent-to-prescriber', () => {
-    let sessionId;
-
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      // given
-      sessionId = 3;
-
-      const res = await server.inject({ method: 'PUT', url: `/api/jury/sessions/${sessionId}/results-sent-to-prescriber` });
+      const res = await server.inject({ method: 'PUT', url: '/api/jury/sessions/3/results-sent-to-prescriber' });
       expect(res.statusCode).to.equal(200);
     });
   });
 
   describe('PATCH /api/jury/sessions/{id}/certification-officer-assignment', () => {
-    let options;
-
-    beforeEach(() => {
-      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-      sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
-      const sessionId = 1;
-      options = {
-        method: 'PATCH',
-        url: `/api/jury/sessions/${sessionId}/certification-officer-assignment`,
-      };
-      return server.register(route);
-    });
 
     it('should exist', async () => {
-      const res = await server.inject(options);
+      const res = await server.inject({ method: 'PATCH', url: '/api/jury/sessions/1/certification-officer-assignment' });
       expect(res.statusCode).to.equal(200);
+    });
+  });
+
+  [
+    { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999' } },
+    { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/jury/sessions/salut' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/jury/sessions/9999999999' } },
+    { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut/attendance-sheet' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999/attendance-sheet' } },
+    { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/sessions/salut' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/sessions/9999999999' } },
+    { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut/certification-candidates' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999/certification-candidates' } },
+    { condition: 'session ID params is not a number', request: { method: 'POST', url: '/api/sessions/salut/certification-candidates' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'POST', url: '/api/sessions/9999999999/certification-candidates' } },
+    { condition: 'session ID params is not a number', request: { method: 'DELETE', url: '/api/sessions/salut/certification-candidates/1' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'DELETE', url: '/api/sessions/9999999999/certification-candidates/1' } },
+    { condition: 'certification candidate ID params is not a number', request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/salut' } },
+    { condition: 'certification candidate ID params is out of range for database integer (> 2147483647)', request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/9999999999' } },
+    { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/jury/sessions/salut/certifications' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/jury/sessions/9999999999/certifications' } },
+    { condition: 'session ID params is not a number', request: { method: 'POST', url: '/api/sessions/salut/candidate-participation' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'POST', url: '/api/sessions/9999999999/candidate-participation' } },
+    { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/sessions/salut/finalization' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PUT', url: '/api/sessions/9999999999/finalization' } },
+    { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/jury/sessions/salut/publication', payload: { data: { attributes: { toPublish: true } } } } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/jury/sessions/9999999999/publication', payload: { data: { attributes: { toPublish: true } } } } },
+    { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/jury/sessions/salut/results-sent-to-prescriber' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PUT', url: '/api/jury/sessions/9999999999/results-sent-to-prescriber' } },
+    { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/jury/sessions/salut/certification-officer-assignment' } },
+    { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/jury/sessions/9999999999/certification-officer-assignment' } },
+  ].forEach(({ condition, request }) => {
+    it(`should return 400 when ${condition}`, async () => {
+      const res = await server.inject(request);
+      expect(res.statusCode).to.equal(400);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible depuis Pix App de rejoindre une session de certification en spécifiant notamment un id de session. Néanmoins, il arrive parfois que des utilisateurs renseignent des id "fantaisistes"  tel que "99456787654321" ce qui cause l'erreur suivante en base: `value "99456787654321" is out of range for type integer`.

## :robot: Solution
Ajouter dans la validation Joi un contrôle sur la longueur maximale d'un id de session en base, soit 2147483647 (2^31 - 1).  

## :rainbow: Remarques
L'erreur remontée ne concernait que la route `POST /api/sessions/{id}/candidate-participation` mais la validation a aussi été appliquée aux autres routes du session-controller.

## :100: Pour tester
- Se connecter à Pix App et cliquer sur l'onglet "Certifications".
- Remplir le champs "Numéro de session" avec la valeur "99456787654321".
- Remplir les autres champs.
- Cliquer sur "Continuer".
Vérifier que la requête `POST /api/sessions/{id}/candidate-participation` renvoie bien une erreur 400 et non plus 500.
