### PR TITLE
[BUGFIX] Ne pas permettre d'évaluer un tutoriel 2 fois (PIX-648).

### DIFF
--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -3,10 +3,10 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-const statusTypes = {
-  unsaved: 'unsaved',
-  saving: 'saving',
-  saved: 'saved',
+const buttonStatusTypes = {
+  unrecorded: 'unrecorded',
+  pending: 'pending',
+  recorded: 'recorded',
 };
 
 export default class TutorialItemComponent extends Component {
@@ -18,13 +18,13 @@ export default class TutorialItemComponent extends Component {
     'son': 'son',
     'page': 'page'
   };
-  @tracked status = statusTypes.unsaved;
-  @tracked evaluationStatus = statusTypes.unsaved;
+  @tracked savingStatus = buttonStatusTypes.unrecorded;
+  @tracked evaluationStatus = buttonStatusTypes.unrecorded;
 
   constructor(owner, args) {
     super(owner, args);
-    this.status = this.tutorial.isSaved ? statusTypes.saved : statusTypes.unsaved;
-    this.evaluationStatus = this.tutorial.isEvaluated ? statusTypes.saved : statusTypes.unsaved;
+    this.savingStatus = this.tutorial.isSaved ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
+    this.evaluationStatus = this.tutorial.isEvaluated ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
   }
 
   get tutorial() {
@@ -40,63 +40,63 @@ export default class TutorialItemComponent extends Component {
   }
 
   get isSaved() {
-    return this.status === 'saved';
+    return this.savingStatus === buttonStatusTypes.recorded;
   }
 
   get isEvaluated() {
-    return this.evaluationStatus === 'saved';
+    return this.evaluationStatus === buttonStatusTypes.recorded;
   }
 
   get buttonText() {
-    return this.status === statusTypes.saved ? 'Retirer' : 'Enregistrer';
+    return this.savingStatus === buttonStatusTypes.recorded ? 'Retirer' : 'Enregistrer';
   }
 
   get buttonTitle() {
-    return this.status === statusTypes.saved ? 'Retirer' : 'Enregistrer dans ma liste de tutos';
+    return this.savingStatus === buttonStatusTypes.recorded ? 'Retirer' : 'Enregistrer dans ma liste de tutos';
   }
 
-  get isButtonDisabled() {
-    return this.status === statusTypes.saving;
+  get isSaveButtonDisabled() {
+    return this.savingStatus === buttonStatusTypes.pending;
   }
 
   get isEvaluateButtonDisabled() {
-    return this.evaluationStatus !== statusTypes.unsaved;
+    return this.evaluationStatus !== buttonStatusTypes.unrecorded;
   }
 
   @action
   async saveTutorial() {
-    this.status = statusTypes.saving;
+    this.savingStatus = buttonStatusTypes.pending;
     const userTutorial = this.store.createRecord('userTutorial', { tutorial: this.tutorial });
     try {
       await userTutorial.save({ adapterOptions: { tutorialId: this.tutorial.id } });
       userTutorial.tutorial = this.tutorial;
-      this.status = statusTypes.saved;
+      this.savingStatus = buttonStatusTypes.recorded;
     } catch (e) {
-      this.status = statusTypes.unsaved;
+      this.savingStatus = buttonStatusTypes.unrecorded;
     }
   }
 
   @action
   async removeTutorial() {
-    this.status = statusTypes.saving;
+    this.savingStatus = buttonStatusTypes.pending;
     try {
       await this.tutorial.userTutorial.destroyRecord({ adapterOptions: { tutorialId: this.tutorial.id } });
-      this.status = statusTypes.unsaved;
+      this.savingStatus = buttonStatusTypes.unrecorded;
     } catch (e) {
-      this.status = statusTypes.saved;
+      this.savingStatus = buttonStatusTypes.recorded;
     }
   }
 
   @action
   async evaluateTutorial() {
-    this.evaluationStatus = statusTypes.saving;
+    this.evaluationStatus = buttonStatusTypes.pending;
     const tutorialEvaluation = this.store.createRecord('tutorialEvaluation', { tutorial: this.tutorial });
     try {
       await tutorialEvaluation.save({ adapterOptions: { tutorialId: this.tutorial.id } });
       tutorialEvaluation.tutorial = this.tutorial;
-      this.evaluationStatus = statusTypes.saved;
+      this.evaluationStatus = buttonStatusTypes.recorded;
     } catch (e) {
-      this.evaluationStatus = statusTypes.unsaved;
+      this.evaluationStatus = buttonStatusTypes.unrecorded;
     }
   }
 }

--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -59,6 +59,10 @@ export default class TutorialItemComponent extends Component {
     return this.status === statusTypes.saving;
   }
 
+  get isEvaluateButtonDisabled() {
+    return this.evaluationStatus !== statusTypes.unsaved;
+  }
+
   @action
   async saveTutorial() {
     this.status = statusTypes.saving;

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -16,7 +16,8 @@
           {{buttonText}}
         </button>
         <button class="tutorial-content-actions__evaluate" title="Donner mon avis sur ce tuto"
-          {{on 'click' this.evaluateTutorial}} disabled={{this.isEvaluated}}>
+          {{on 'click' this.evaluateTutorial}}
+                disabled={{this.isEvaluateButtonDisabled}}>
           <FaIcon @prefix={{if this.isEvaluated 'fas' 'far'}} @icon='thumbs-up'/>
           Tuto utile
         </button>

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -11,13 +11,13 @@
       <div class="tutorial-content__actions">
         <button class="tutorial-content-actions__save" title={{this.buttonTitle}}
           {{on 'click' (if this.isSaved this.removeTutorial this.saveTutorial)}}
-                disabled={{this.isButtonDisabled}}>
+          disabled={{this.isSaveButtonDisabled}}>
           <FaIcon @prefix={{if this.isSaved 'fas' 'far'}} @icon='bookmark'/>
           {{buttonText}}
         </button>
         <button class="tutorial-content-actions__evaluate" title="Donner mon avis sur ce tuto"
           {{on 'click' this.evaluateTutorial}}
-                disabled={{this.isEvaluateButtonDisabled}}>
+          disabled={{this.isEvaluateButtonDisabled}}>
           <FaIcon @prefix={{if this.isEvaluated 'fas' 'far'}} @icon='thumbs-up'/>
           Tuto utile
         </button>

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -301,4 +301,42 @@ describe('Unit | Component | tutorial item', function() {
       expect(tutorialEvaluation.tutorial).to.equal(tutorial);
     });
   });
+
+  describe('#isEvaluateButtonDisabled', function() {
+
+    it('should return false when the tutorial has not already been evaluated', function() {
+      // given
+      component.evaluationStatus = 'unsaved';
+
+      // when
+      const result = component.isEvaluateButtonDisabled;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return true when the tutorial has already been evaluated', function() {
+      // given
+      component.evaluationStatus = 'saved';
+
+      // when
+      const result = component.isEvaluateButtonDisabled;
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return true when the evaluate operation is in progress', function() {
+      // given
+      component.evaluationStatus = 'saving';
+
+      // when
+      const result = component.isEvaluateButtonDisabled;
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+  });
+
 });

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -69,7 +69,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return true when the tutorial has been saved', function() {
       // given
-      component.status = 'saved';
+      component.savingStatus = 'recorded';
 
       // when
       const result = component.isSaved;
@@ -92,7 +92,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return true when the tutorial has been evaluated', function() {
       // given
-      component.evaluationStatus = 'saved';
+      component.evaluationStatus = 'recorded';
 
       // when
       const result = component.isEvaluated;
@@ -115,7 +115,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return "Enregistrer" when the tutorial is succesfully saved', function() {
       // given
-      component.status = 'saved';
+      component.savingStatus = 'recorded';
 
       // when
       const result = component.buttonText;
@@ -138,7 +138,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return "Retirer" when the tutorial has been saved', function() {
       // given
-      component.status = 'saved';
+      component.savingStatus = 'recorded';
 
       // when
       const result = component.buttonTitle;
@@ -149,14 +149,14 @@ describe('Unit | Component | tutorial item', function() {
 
   });
 
-  describe('#isButtonDisabled', function() {
+  describe('#isSaveButtonDisabled', function() {
 
     it('should return false when the tutorial has not already been saved', function() {
       // given
-      component.status = 'unsaved';
+      component.savingStatus = 'unrecorded';
 
       // when
-      const result = component.isButtonDisabled;
+      const result = component.isSaveButtonDisabled;
 
       // then
       expect(result).to.equal(false);
@@ -164,10 +164,10 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return false when the tutorial has already been saved', function() {
       // given
-      component.status = 'saved';
+      component.savingStatus = 'recorded';
 
       // when
-      const result = component.isButtonDisabled;
+      const result = component.isSaveButtonDisabled;
 
       // then
       expect(result).to.equal(false);
@@ -175,10 +175,10 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return true when the save/unsave operation is in progress', function() {
       // given
-      component.status = 'saving';
+      component.savingStatus = 'pending';
 
       // when
-      const result = component.isButtonDisabled;
+      const result = component.isSaveButtonDisabled;
 
       // then
       expect(result).to.equal(true);
@@ -212,12 +212,12 @@ describe('Unit | Component | tutorial item', function() {
       sinon.assert.calledWith(userTutorial.save, { adapterOptions: { tutorialId: tutorial.id } });
     });
 
-    it('should set status to saved', async function() {
+    it('should set status to recorded', async function() {
       // when
       await component.saveTutorial();
 
       // then
-      expect(component.status).to.equal('saved');
+      expect(component.savingStatus).to.equal('recorded');
     });
 
     it('should link tutorial and userTutorial', async function() {
@@ -249,12 +249,12 @@ describe('Unit | Component | tutorial item', function() {
       sinon.assert.calledWith(userTutorial.destroyRecord, { adapterOptions: { tutorialId: tutorial.id } });
     });
 
-    it('should set status to unsaved', async function() {
+    it('should set status to unrecorded', async function() {
       // when
       await component.removeTutorial();
 
       // then
-      expect(component.status).to.equal('unsaved');
+      expect(component.savingStatus).to.equal('unrecorded');
     });
 
   });
@@ -285,12 +285,12 @@ describe('Unit | Component | tutorial item', function() {
       sinon.assert.calledWith(tutorialEvaluation.save, { adapterOptions: { tutorialId: tutorial.id } });
     });
 
-    it('should set status to saved', async function() {
+    it('should set status to recorded', async function() {
       // when
       await component.evaluateTutorial();
 
       // then
-      expect(component.evaluationStatus).to.equal('saved');
+      expect(component.evaluationStatus).to.equal('recorded');
     });
 
     it('should link tutorial and tutorialEvaluation', async function() {
@@ -306,7 +306,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return false when the tutorial has not already been evaluated', function() {
       // given
-      component.evaluationStatus = 'unsaved';
+      component.evaluationStatus = 'unrecorded';
 
       // when
       const result = component.isEvaluateButtonDisabled;
@@ -317,7 +317,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return true when the tutorial has already been evaluated', function() {
       // given
-      component.evaluationStatus = 'saved';
+      component.evaluationStatus = 'recorded';
 
       // when
       const result = component.isEvaluateButtonDisabled;
@@ -328,7 +328,7 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return true when the evaluate operation is in progress', function() {
       // given
-      component.evaluationStatus = 'saving';
+      component.evaluationStatus = 'pending';
 
       // when
       const result = component.isEvaluateButtonDisabled;


### PR DESCRIPTION
## :unicorn: Problème
Depuis la mise en production de la fonctionnalité d'évaluation d'un tutoriel, sentry remonte plusieurs fois par jour l'erreur de violation de contrainte d'unicité.
```
duplicate key value violates unique constraint "tutorial_evaluations_userid_tutorialid_unique"
```

## :robot: Solution
En analysant le code et les erreurs Sentry, ainsi que le contenu de la base de données, on se rend compte que l'erreur se produit quelques millisecondes après l'enregistrement en base de données.
En local, on arrive à déclencher 2 fois de suite le même appel réseau en faisant un double-clic sur le bouton, lorsque le réseau est lent (en le ralentissant avec les devtools).

La solution consiste alors, comme pour la sauvegarde d'un tutoriel, le bouton est désactivé durant l'appel API.

## :rainbow: Remarques
Cette PR est l'occasion de nettoyer le gommage de certaines variables dans le composant `tutorial-item.js`.

## :100: Pour tester
Limiter la vitesse de connexion via les devtools (`Good 2G` est une bonne valeur).
Double-cliquer sur le bouton d'évaluation d'un tutorial.
Vérifier dans l'onglet `Réseau` des devtools qu'un seul appel API a été effectué (route `/evaluate`).