### PR TITLE
[FEATURE] Valider les QROCM seulement si l'utilisateur a rempli tous les champs réponse (PIX-375).

### DIFF
--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import _ from 'mon-pix/utils/lodash-custom';
+import _ from 'lodash';
 import classic from 'ember-classic-decorator';
 
 import ChallengeItemGeneric from './challenge-item-generic';

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -33,7 +33,7 @@ class ChallengeItemQrocm extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Pour valider, saisir au moins une réponse. Sinon, passer.';
+    return 'Pour valider, veuillez remplir tous les champs réponse. Sinon, passer.';
   }
 
   @action

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -9,8 +9,11 @@ import jsyaml from 'js-yaml';
 class ChallengeItemQrocm extends ChallengeItemGeneric {
   _hasError() {
     const allAnswers = this._getRawAnswerValue(); // ex. {"logiciel1":"word", "logiciel2":"excel", "logiciel3":""}
-    const hasAtLeastOneAnswer = _(allAnswers).hasSomeTruthyProps();
-    return _.isFalsy(hasAtLeastOneAnswer);
+    return this._hasEmptyAnswerFields(allAnswers);
+  }
+
+  _hasEmptyAnswerFields(answers) {
+    return _.filter(answers, _.isEmpty).length;
   }
 
   _getAnswerValue() {
@@ -23,7 +26,7 @@ class ChallengeItemQrocm extends ChallengeItemGeneric {
   _getRawAnswerValue() {
     const result = {};
     // XXX : forEach on NodeList returned by document.querySelectorAll is not supported by IE
-    _.forEach(document.querySelectorAll('.challenge-proposals input'), (element)=> {
+    _.forEach(document.querySelectorAll('.challenge-proposals input'), (element) => {
       result[element.getAttribute('name')] = element.value;
     });
     return result;

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -83,14 +83,12 @@
   justify-content: center;
   @include button-background-transition();
   text-decoration: none;
-  &:hover{
-    background: $green-hover;
-    text-decoration: none;
-  }
 
+  &:hover,
   &:active,
   &:visited,
   &:focus {
+    background: $green-hover;
     text-decoration: none;
   }
 

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -51,15 +51,15 @@ describe('Acceptance | Displaying un QROCM', function() {
       expect(findAll('.challenge-response__proposal')).to.have.lengthOf(3);
     });
 
-    it('should display an error alert if the user tried to validate without checking anything first', async function() {
-      await fillIn(findAll('input')[0], '');
-      await fillIn(findAll('input')[1], '');
+    it('should display an error alert if the user tries to validate before filling all answer fields', async function() {
+      await fillIn(findAll('input')[0], 'ANSWER');
+      await fillIn(findAll('input')[1], 'ANSWER');
       await fillIn(findAll('input')[2], '');
 
       await click(find('.challenge-actions__action-validate'));
 
       expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir au moins une réponse. Sinon, passer.');
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir tous les champs réponse. Sinon, passer.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
On laisse la possibilité à l'utilisateur de valider sa réponse même si tous les champs ne sont pas remplis. On peut également valider avec la touche `Entrée` ce qui amène parfois à valider avant d'avoir fini de répondre.

## :robot: Solution
Modifier la vérification sur le formulaire au clic sur **Je valide**. 

## :100: Pour tester
Trouver un QROCM (par exemple : `recBzswglMDjdzrNp`) et valider sans répondre et en laissant un ou des champs vides. Un message d'erreur doit s'afficher.
