### PR TITLE
[BUGFIX] Utiliser le bon dégradé de couleur pour le fond de la bannière de la page évaluation.

### DIFF
--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -1,7 +1,7 @@
 .background-banner {
   width: 100%;
   min-height: 270px;
-  background: $pix-blue-gradient;
+  background: $pix-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   color: $white;
 }


### PR DESCRIPTION
## :unicorn: Problème
En rationalisant les couleurs utilisées dans l'application Pix App avec les couleurs du design system, une coquille s'est glissée dans le nom de la couleur utilisée pour le fond de la bannière de la page évaluation (`$pix-blue-gradient` au lieu de `$pix-gradient`).

![image](https://user-images.githubusercontent.com/2989532/81645656-4081b100-942a-11ea-8330-62bb32513532.png)

## :robot: Solution
Utiliser `$pix-gradient` comme couleur de fond de la bannière de la page évaluation.

<img width="1146" alt="Screenshot 2020-05-12 at 08 29 24" src="https://user-images.githubusercontent.com/2989532/81645970-c4d43400-942a-11ea-9aa3-8a014254ea36.png">

## :rainbow: Remarques
RAS

## :100: Pour tester
Démarrer une évaluation en cliquant sur une compétence.
Vérifier que le rendu de la bannière correspond à la capture présente dans `Solution`.
