### PR TITLE
[FEATURE] Centrer les messages d'erreur sur la page de connexion de Pix Orga (PIX-652).

### DIFF
--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -14,6 +14,7 @@
   &__error-message {
     margin-bottom: 10px;
     font-size: 0.875rem;
+    text-align: center;
   }
 
   &__forgotten-password {


### PR DESCRIPTION
## :unicorn: Problème
Le design de la page de connexion de Pix Orga a changé.
Les textes sont dorénavant centrés.
Or les messages d'erreur ne le sont pas encore.

## :robot: Solution
Modifier le css pour centrer ces messages.

## :100: Pour tester
* Se connecter en utilisant un password erroné
* Se connecter avec `userpix1@example.net`, qui n'est pas membre d'une organisation