### PR TITLE
[BUGFIX] Correction des couleurs de la navigation.

### DIFF
--- a/mon-pix/app/styles/components/_navbar-desktop-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-menu.scss
@@ -25,7 +25,7 @@
   height: 40px;
   margin-left: 20px;
   border: none;
-  color: $white;
+  color: $grey-45;
   text-transform: uppercase;
 }
 
@@ -60,8 +60,8 @@
   border-radius: 20px;
   font-size: 0.813rem;
   text-align: center;
-  color: $white;
-  border: 2px solid $white;
+  color: $blue;
+  border: 2px solid $blue;
   width: 140px;
   padding: 10px;
   background-color: transparent;
@@ -69,9 +69,9 @@
   &:hover,
   &:focus,
   &:active {
-    color: $blue;
+    color: $white;
     text-decoration: none;
-    background-color: $white;
+    background-color: $blue;
   }
 }
 

--- a/mon-pix/app/styles/components/_navbar-header.scss
+++ b/mon-pix/app/styles/components/_navbar-header.scss
@@ -1,11 +1,6 @@
 .navbar-header {
-  background-color: transparent;
   float: none;
-  color: $white;
   width: 100%;
-}
-
-.navbar-header--white {
   background-color: $white;
   color: $grey-50;
 }

--- a/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-campaign-code.hbs
@@ -1,6 +1,6 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
 
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>

--- a/mon-pix/app/templates/certifications/start-loading.hbs
+++ b/mon-pix/app/templates/certifications/start-loading.hbs
@@ -1,7 +1,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
 

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -2,7 +2,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
 

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -1,7 +1,7 @@
 {{title pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
     <div class="background-banner-wrapper competence-details">
       <div class="background-banner"></div>
 

--- a/mon-pix/app/templates/competences/results.hbs
+++ b/mon-pix/app/templates/competences/results.hbs
@@ -2,7 +2,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
 
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -1,7 +1,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
 
     <div class="error-page">
       <div class="rounded-panel rounded-panel--strong error-page__body-section">

--- a/mon-pix/app/templates/profile.hbs
+++ b/mon-pix/app/templates/profile.hbs
@@ -4,7 +4,7 @@
     {{#if @model.campaignParticipations}}
       <ResumeCampaignBanner @campaignParticipations={{@model.campaignParticipations}} />
     {{/if}}
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
 
     <ProfileContent @model={{@model}} />
 

--- a/mon-pix/app/templates/user-certifications.hbs
+++ b/mon-pix/app/templates/user-certifications.hbs
@@ -1,7 +1,7 @@
 {{title pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
 
     <div class="user-certifications-page__container">
       {{outlet}}

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -1,7 +1,7 @@
 {{title pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    <NavbarHeader @class="navbar-header--white" @burger={{burger}} />
+    <NavbarHeader @burger={{burger}} />
     <header role="banner" class="background-banner">
       <div class="user-tutorials-banner">
         <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt=""/>


### PR DESCRIPTION
## :unicorn: Problème
Les boutons `Se connecter` et `S'inscrire` ne sont pas visibles (couleur trop claire).
Le fond de la barre de navigation est gris pâle au lieu d'être blanc.

<img width="987" alt="Screenshot 2020-05-12 at 12 06 45" src="https://user-images.githubusercontent.com/2989532/81671224-11c70300-9449-11ea-847a-88dc8c1bba19.png">


## :robot: Solution
Les deux problèmes ont des origines différentes.
Le problème des boutons est liés à l'uniformisation des couleurs du design system.
Il faut les remplacer par les couleurs correctes.

Le problème du fond de la barre de navigation est due à la glimmerisation du composant `NavbarHeader`. Chaque page affichant ce composant définit une classe pour ce composant comme suit.
```
<NavbarHeader @class="navbar-header--white">
```
Le composant en lui même override cette valeur en définissant la classe `navra-header`.

En regardant les usages, il apparaît que les 2 classes sont toujours utilisées ensemble. Aussi il est décidé de les fusionner dans `navbar-header`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur la page `/campagnes` quand tu n'es pas connecté.
Vérifier que les couleurs sont conformes.

<img width="1120" alt="Screenshot 2020-05-12 at 12 11 40" src="https://user-images.githubusercontent.com/2989532/81671995-d37e1380-9449-11ea-811b-9f9e241a9c5c.png">
