### PR TITLE
[FEATURE] Clarifier la page de changement de mot de passe (PIX-554).

### DIFF
--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -97,15 +97,7 @@
 
   &__instruction {
     width: 100%;
-    margin: 10px 0 40px;
-
-    @include device-is('tablet') {
-      margin: 28px 0 40px;
-
-      &--short {
-        width: 400px
-      }
-    }
+    margin: 10px 0;
   }
 }
 
@@ -117,6 +109,7 @@
   }
 
   &__input {
+    font-size: 0.875rem;
     max-width: 449px;
     width: 100%;
     padding: 0 20px;
@@ -130,26 +123,30 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
     margin: 5px auto 20px;
 
     &--big {
       margin: 10px auto;
-      width: 300px;
+      padding: 0 10px;
+      width: 100%;
 
       @include device-is('desktop') {
         margin: 30px auto;
       }
 
-      @include device-is('mobile') {
-        width: 280px;
-      }
     }
 
     &--margin-top {
       margin-top: 25px;
     }
+    &--round{
+      border-radius: 5px;
+    }
+
   }
+
+
 
   &__forgotten-password-link {
     align-self: flex-end;
@@ -162,27 +159,23 @@
 
 .update-expired-password-form-title {
   font-family: $font-open-sans;
+  font-weight: $font-light;
+  font-size: 1.563rem;
   color: $grey-80;
   margin: 0;
-  font-size: 1.563rem;
-  font-weight: $font-light;
+  text-align: center;
 
   @include device-is('desktop') {
-    font-size: 2.25rem;
+    font-size: 2.125rem;
   }
 }
 
 .update-expired-password-form-subtitle {
   font-family: $font-roboto;
   color: $grey-80;
-  font-size: 0.938rem;
-  font-weight: $font-light;
+  font-size: 1rem;
   line-height: 28px;
   text-align: center;
-
-  @include device-is('tablet') {
-    font-size: 1.375rem;
-  }
 }
 
 .update-expired-password-form-text {

--- a/mon-pix/app/templates/components/update-expired-password-form.hbs
+++ b/mon-pix/app/templates/components/update-expired-password-form.hbs
@@ -5,11 +5,11 @@
     </a>
 
     <div class="update-expired-password-form__header">
-      <h1 class="update-expired-password-form-title">Nouveau mot de passe</h1>
+      <h1 class="update-expired-password-form-title">Réinitialiser le mot de passe</h1>
 
       {{#unless this.authenticationHasFailed}}
-        <div class="update-expired-password-form-hea  der__instruction update-expired-password-form-subtitle">
-          Pour continuer, vous devez choisir un nouveau mot de passe.
+        <div class="update-expired-password-form-header__instruction update-expired-password-form-subtitle">
+          Choisissez un nouveau mot de passe pour continuer
         </div>
       {{/unless}}
     </div>
@@ -18,7 +18,7 @@
       <form {{action "handleUpdatePasswordAndAuthenticate" on="submit"}} class="update-expired-password-form__body">
 
         <div class="update-expired-password-form-body__input">
-          <FormTextfield @label="Nouveau mot de passe"
+          <FormTextfield @label="Mot de passe"
                          @help="(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)"
                          @textfieldName="password"
                          @inputBindingValue={{this.newPassword}}
@@ -34,8 +34,8 @@
               <span class="loader-in-button">&nbsp;</span>
             </button>
           {{else}}
-            <button type="submit" class="button button--thin button--round">
-              Modifier mon mot de passe
+            <button type="submit" class="button button--thin button--round update-expired-password-form-body__bottom-button--round">
+              Réinitialiser
             </button>
           {{/if}}
         </div>


### PR DESCRIPTION
## :unicorn: Problème
La page de choix de nouveau mot de passe, suite à utilisation de mot de passe temporaire, utilise plusieurs termes: réinitialiser, nouveau, changer. Cela peut faire douter l'utilisateur

## :robot: Solution
Garder le terme réinitialisation et supprimer les autres.

## :100: Pour tester
Se connecter sur [PixApp RA](https://app-pr1408.review.pix.fr/)
Utiliser le compte username123/Password123
