### PR TITLE
[FEATURE] Modification du calcul des Pix Globaux (PIX-649)

### DIFF
--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -28,7 +28,10 @@ function getBlockedPixScore(pixScore) {
 }
 
 function totalUserPixScore(pixEarnedByCompetence) {
-  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => getBlockedPixScore(pixEarnedForOneCompetence));
+  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => {
+    const flooredPixEarnedForOneCompetence = _.floor(pixEarnedForOneCompetence);
+    return getBlockedPixScore(flooredPixEarnedForOneCompetence);
+  });
   return _.sum(pixByCompetenceLimited);
 }
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -99,7 +99,7 @@ module.exports = {
       .where({ rank: 1 })
       .groupBy('competenceId')
       .then((pixEarnedByCompetence) => {
-        const pixScoreByCompetence = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) =>  pixEarnedForOneCompetence.earnedPix);
+        const pixScoreByCompetence = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => pixEarnedForOneCompetence.earnedPix);
         return scoringService.totalUserPixScore(pixScoreByCompetence);
       });
   },

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -198,14 +198,13 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const userId_tmp = databaseBuilder.factory.buildUser().id;
 
       _.each([
-        { skillId: 'rec1', userId, earnedPix: 5, competenceId: 1 },
-        { skillId: 'rec3', userId, earnedPix: 40, status: 'validated', competenceId: 1 },
-        { skillId: 'rec2', userId, earnedPix: 10, status: 'validated', createdAt: today, competenceId: 1 },
-        { skillId: 'rec4', userId, earnedPix: 10, status: 'validated', competenceId: 2 },
+        { skillId: 'rec1', userId, earnedPix: 5.0, competenceId: 1 },
+        { skillId: 'rec3', userId, earnedPix: 20.4, status: 'validated', competenceId: 1 },
+        { skillId: 'rec2', userId, earnedPix: 10.7, status: 'validated', createdAt: today, competenceId: 1 },
+        { skillId: 'rec4', userId, earnedPix: 50, status: 'validated', competenceId: 2 },
         { skillId: 'rec5', userId, earnedPix: 10, status: 'validated', competenceId: 3 },
-        { skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
-        { skillId: 'rec2', userId, earnedPix: 1000, status: 'validated', createdAt: yesterday },
-        { skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated' },
+        { skillId: 'rec2', userId, earnedPix: 1.1, status: 'validated', createdAt: yesterday, competenceId: 3 },
+        { skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated', competenceId: 1 },
       ], (ke) => databaseBuilder.factory.buildKnowledgeElement(ke));
 
       return databaseBuilder.commit();
@@ -216,7 +215,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       const earnedPix = await KnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
 
       // then
-      expect(earnedPix).to.equal(60);
+      expect(earnedPix).to.equal(86);
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Le nombre total de Pix est calculé de plusieurs façon en fonction:
- sur la page /profile mon-pix: on récupère le nombre pix de chaque compétence de l'utilisateur, puis on fait la somme et on affiche la valeur arrondi
- pour génération des résultats côté orga, les Pix de chaque compétence sont d'abord arrondi, puis on fait la somme
La valeur du nombre total de Pix peut alors différer.

## :robot: Solution
Il a été opté de garder la méthode de calcul d'arrondir d'abord les pix de chaque compétence avant de faire la somme.

## :100: Pour tester
Normalement, le nombre total de Pix affiché sur la page `/profil` devrait correspondre au résultat de la requête:

```js
select SUM("pixEarnedByCompetence"."earnedPix")
FROM (
         with earnedPixWithRankPerSkill as (
             select "earnedPix",
                    "competenceId",
                    ROW_NUMBER() OVER (PARTITION BY "skillId" order by "createdAt" DESC) AS rank
             from "knowledge-elements"
             where "userId" = <insérer ici le userId>
         )
         select "competenceId", floor(sum("earnedPix")) AS "earnedPix"
         from earnedPixWithRankPerSkill
         where "rank" = 1
         group by "competenceId"
) AS "pixEarnedByCompetence";
```