### PR TITLE
[BUGFIX] Empêcher le chevauchement des boutons sur la page CGU en version mobile (PIX-662)

### DIFF
--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -1,7 +1,7 @@
 .background-banner {
   width: 100%;
   min-height: 270px;
-  background: $pix-gradient;
+  background: $default-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   color: $white;
 }

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -5,7 +5,7 @@
       align-items: flex-start;
       width: 100%;
       height: 270px;
-      background: $pix-green-gradient;
+      background: $green-gradient;
       box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
       color: $white;
   }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -1,5 +1,5 @@
 .congratulations-banner {
-  background: $pix-green-gradient;
+  background: $green-gradient;
   position: relative;
   color: $grey-10;
   border-radius: 6px;

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -21,15 +21,15 @@ $light-blue: #388AFF;
 $pure-orange: #f45c00;
 
 // gradients
-$pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
-$pix-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
-$pix-green-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
+$blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
+$default-gradient: linear-gradient(135deg, #388AFF 0%, #985FFF 100%);
+$green-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
 $pix-orange-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
 $pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
 $pix-orga-old-gradient: linear-gradient(0deg, #0D7DC4 0%, #213371 100%);
 $pix-pink-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
 $pix-purple-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
-$pix-yellow-to-orange-gradient: linear-gradient(180deg, #fedc41 0%, #f45c00 100%);
+$yellow-gradient: linear-gradient(180deg, #fedc41 0%, #f45c00 100%);
 
 // light
 $grey-5: #FAFBFC;

--- a/mon-pix/app/styles/pages/_campaign-tutorial.scss
+++ b/mon-pix/app/styles/pages/_campaign-tutorial.scss
@@ -1,5 +1,5 @@
 .campaign-tutorial {
-  background: $pix-yellow-to-orange-gradient;
+  background: $yellow-gradient;
   width: 100%;
   height: 100vh;
   display: flex;

--- a/mon-pix/app/styles/pages/_login-or-register-to-access-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_login-or-register-to-access-restricted-campaign.scss
@@ -1,5 +1,5 @@
 .login-or-register-to-access-restricted-campaign {
-  background: $pix-blue-gradient;
+  background: $default-gradient;
   display: flex;
   justify-content: center;
   min-height: 100vh;

--- a/mon-pix/app/styles/pages/_not-connected.scss
+++ b/mon-pix/app/styles/pages/_not-connected.scss
@@ -1,5 +1,5 @@
 .not-connected {
-  background: $pix-blue-gradient;
+  background: $default-gradient;
   height: 100vh;
   padding-top: 5%;
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -1,7 +1,7 @@
 .sign-form-page {
   display: flex;
   justify-content: center;
-  background: $pix-blue-gradient;
+  background: $default-gradient;
   background-size: cover;
   width: 100%;
   height: 100%;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -3,7 +3,7 @@
   align-items: center;
   height: 100vh;
   width: 100vw;
-  background: $pix-purple-gradient;
+  background: $pix-gradient;
 
 }
 
@@ -83,7 +83,6 @@
   &__cancel {
     background-color: $grey-50;
     border-radius: 4px;
-    padding: 14px 36px;
     font-weight: 400;
 
     &:hover {

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -9,7 +9,7 @@
 
 .terms-of-service-form {
   margin: auto;
-  padding: 40px 88px 48px 88px;
+  padding: 40px 32px;
   background: white;
   border-radius: 8px;
   width: 581px;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -1,10 +1,10 @@
 .terms-of-service-page {
   display: flex;
-  align-items: center;
-  height: 100vh;
-  width: 100vw;
+  width: 100%;
+  height: 100px;
+  min-height: 100vh;
   background: $default-gradient;
-
+  align-items: center;
 }
 
 .terms-of-service-form {
@@ -12,7 +12,8 @@
   padding: 40px 32px;
   background: white;
   border-radius: 8px;
-  width: 581px;
+  max-width: 581px;
+  width: 100%;
 
   &__logo {
     margin-bottom: 24px;
@@ -73,7 +74,7 @@
 .terms-of-service-form-actions {
 
   &__submit {
-    margin-left: 16px;
+    margin-left: 8px;
     border-radius: 4px;
     padding: 14px 21px;
     font-weight: 400;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -3,7 +3,7 @@
   align-items: center;
   height: 100vh;
   width: 100vw;
-  background: $pix-gradient;
+  background: $default-gradient;
 
 }
 

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -1,7 +1,7 @@
 .update-expired-password-form-page {
   display: flex;
   justify-content: center;
-  background: $pix-blue-gradient;
+  background: $default-gradient;
   background-size: cover;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## :unicorn: Problème
Les deux bouttons de la page cgus s'affichent en superposé en version mobile

## :robot: Solution
Restructurer le style pour gérer le responsive et avoir un affichage correct sous IE et Firefox.
Enlever le padding du boutton cancel qui déborde en responsive.

## :robot: Remarque
-Cette PR corrige une régression sur la couleur de Pix gradient utilisé. 
-En plus d'un refactoring des noms de couleurs pour être plus explicite.

## :100: Pour tester
-Se connecter avec un utilisateur qui doit valider les nouvelles cgus.
-Le champ mustValidateTermsOfService
Utilisateur: lasttermsofservice@notvalidated.net / Password123

-Pour vérifier la bonne couleur du gradient, il faut checker l'ensemble du site ( login form, reset mot de pass, page d'inscription ...)
