### PR TITLE
[CLEANUP] Retrait d'une clause SELECT inutile dans le KE repository

### DIFF
--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -41,9 +41,7 @@ async function _findByCampaignIdForSharedCampaignParticipationWhere(campaignPart
 }
 
 function _getByUserIdAndLimitDateQuery({ userId, limitDate }) {
-  return Bookshelf.knex
-    .select('*', Bookshelf.knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS rank', ['skillId', 'createdAt']))
-    .from('knowledge-elements')
+  return Bookshelf.knex('knowledge-elements')
     .where((qb) => {
       qb.where({ userId });
       if (limitDate) {


### PR DESCRIPTION
## :unicorn: Problème
Un oubli (non impactant, mais oubli quand même) laissé par la PR https://github.com/1024pix/pix/pull/1382.
Vu que la charge de filtrer les KE (le + récent par acquis + exclusion des remises à zéro) a été remis au code JS (et pas à la BDD comme le suggérait la première proposition de la PR mentionnée ci-dessus), on n'a plus besoin de classer les KE par date.
Du coup j'ai oublié de retirer la fonction fenêtrée.

## :robot: Solution
Retrait de la fonction fenêtrée. Aucun impact fonctionnel, car de toute façon le KE créé ne tenait pas compte du retour la fonction fenêtrée.

## :rainbow: Remarques


## :100: Pour tester

