### PR TITLE
[BUGFIX] Suppression de warnings ember-data sur les memberships.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -5,6 +5,9 @@ module.exports = {
   serialize(membership) {
     return new Serializer('memberships', {
       transform(record) {
+        if (!record.user) {
+          delete record.user;
+        }
         // we add a 'campaigns' attr to the organization so that the serializer
         // can see there is a 'campaigns' attribute and add the relationship link.
         if (record.organization) {

--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -8,6 +8,7 @@ module.exports = {
         if (!record.user) {
           delete record.user;
         }
+
         // we add a 'campaigns' attr to the organization so that the serializer
         // can see there is a 'campaigns' attribute and add the relationship link.
         if (record.organization) {
@@ -16,6 +17,8 @@ module.exports = {
           record.organization.memberships = [];
           record.organization.students = [];
           record.organization.organizationInvitations = [];
+        } else {
+          delete record.organization;
         }
         return record;
       },

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -661,7 +661,7 @@ describe('Acceptance | Application | organization-controller', () => {
         await databaseBuilder.commit();
       });
 
-      it('should return the matching organization as JSON API', async () => {
+      it('should return the matching membership as JSON API', async () => {
         // given
         const expectedResult = {
           'data': [
@@ -671,9 +671,6 @@ describe('Acceptance | Application | organization-controller', () => {
               },
               'id': membershipId.toString(),
               'relationships': {
-                'organization': {
-                  'data': null
-                },
                 'user': {
                   'data': {
                     'id': user.id.toString(),

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -74,8 +74,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
                 'organization-role': organizationRole,
               },
               relationships: {
-                'organization': { data: { type: 'organizations', id: organization.id.toString() }, },
-                'user': { data: null, },
+                'organization': { data: { type: 'organizations', id: organization.id.toString() }, }
               },
             },
           ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -18,6 +18,12 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
           externalId: 'EXTID'
         },
         organizationRole: Membership.roles.ADMIN,
+        user: {
+          id: 123,
+          firstName: 'firstName',
+          lastName: 'lastName',
+          email: 'email',
+        }
       });
 
       const expectedSerializedMembership = {
@@ -35,7 +41,10 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
                 },
             },
             user: {
-              'data': null
+              'data': {
+                id: '123',
+                type: 'users'
+              }
             }
           }
         },
@@ -75,6 +84,15 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
               },
             },
           }
+        },
+        {
+          type: 'users',
+          id: '123',
+          attributes: {
+            'first-name': 'firstName',
+            'last-name': 'lastName',
+            email: 'email',
+          },
         }]
       };
 
@@ -133,6 +151,20 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
 
       // then
       expect(json.data.relationships.organization.data).to.be.null;
+    });
+
+    it('should not force the add of user relation link if the user is undefined', () => {
+      // given
+      const membership = domainBuilder.buildMembership();
+      membership.user = undefined;
+
+      // when
+      const json = serializer.serialize(membership);
+
+      // then
+      expect(json.data.relationships.user).to.be.undefined;
+      expect(json.included.length).to.equal(1);
+      expect(json.included[0].type).to.not.equal('users');
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/membership-serializer_test.js
@@ -150,7 +150,10 @@ describe('Unit | Serializer | JSONAPI | membership-serializer', () => {
       const json = serializer.serialize(membership);
 
       // then
-      expect(json.data.relationships.organization.data).to.be.null;
+      expect(json.data.relationships.organization).to.be.undefined;
+      expect(json.included.length).to.equal(1);
+      expect(json.included[0].type).to.not.equal('organization');
+
     });
 
     it('should not force the add of user relation link if the user is undefined', () => {


### PR DESCRIPTION
## :unicorn: Problème

> DEPRECATION: Encountered mismatched relationship: Ember Data expected data[0].relationships.user.data in the payload from user:4.hasMany("memberships") to include '{"id":"4","type":"user"}' but got 'null' instead.
> 
> The <membership:100048> record loaded at data[0] in the payload specified null as its '"user"', but should have specified user:4 (the record the relationship is being loaded from) as its '"user"' instead.
> This could mean that the response for user:4.hasMany("memberships") may have accidentally returned '"membership"' records that aren't related to user:4 and could be related to a different user record instead.
> Ember Data has corrected the <membership:100048> record's '"user"' relationship to user:4 so that user:4.hasMany("memberships") will include <membership:100048>.
> Please update the response from the server or change your serializer to either ensure that the response for only includes '"membership"' records that specify user:4 as their '"user"', or omit the '"user"' relationship from the response.

> DEPRECATION: Encountered mismatched relationship: Ember Data expected data[1].relationships.organization.data in the payload from organization:3.hasMany("memberships") to include '{"id":"3","type":"organization"}' but got 'null' instead.
> 
> The <membership:100049> record loaded at data[1] in the payload specified null as its '"organization"', but should have specified organization:3 (the record the relationship is being loaded from) as its '"organization"' instead.
> This could mean that the response for organization:3.hasMany("memberships") may have accidentally returned '"membership"' records that aren't related to organization:3 and could be related to a different organization record instead.
> Ember Data has corrected the <membership:100049> record's '"organization"' relationship to organization:3 so that organization:3.hasMany("memberships") will include <membership:100049>.
> Please update the response from the server or change your serializer to either ensure that the response for only includes '"membership"' records that specify organization:3 as their '"organization"', or omit the '"organization"' relationship from the response.
>  [deprecation id: mismatched-inverse-relationship-data-from-payload]

## :robot: Solution
Ne pas rajouter la relationship user quand le user est undefined.
Ne pas rajouter la relationship organization quand l'organisation est undefined.