### PR TITLE
[BUGFIX] Suppression d'un warning ember-data sur les user-orga-settings.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
@@ -5,6 +5,10 @@ module.exports = {
   serialize(userOrgaSettings) {
     return new Serializer('user-orga-settings', {
       transform(record) {
+        if (!record.user) {
+          delete record.user;
+        }
+
         record.organization = record.currentOrganization;
 
         // we add a 'campaigns' attr to the organization so that the serializer

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-orga-settings-serializer_test.js
@@ -17,6 +17,12 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
           code: 'WASABI666',
           externalId: 'EXTID'
         },
+        user: {
+          id: 123,
+          firstName: 'firstName',
+          lastName: 'lastName',
+          email: 'email',
+        }
       });
 
       const expectedSerializedUserOrgaSettings = {
@@ -32,7 +38,10 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
                 },
             },
             user: {
-              'data': null
+              data: {
+                id: '123',
+                type: 'users'
+              }
             }
           }
         },
@@ -71,6 +80,15 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
                 related: '/api/organizations/10293/invitations',
               },
             },
+          }
+        },
+        {
+          id: '123',
+          type: 'users',
+          attributes: {
+            'first-name': 'firstName',
+            'last-name': 'lastName',
+            email: 'email',
           }
         }]
       };
@@ -130,6 +148,20 @@ describe('Unit | Serializer | JSONAPI | user-orga-settings-serializer', () => {
 
       // then
       expect(json.data.relationships.organization.data).to.be.null;
+    });
+
+    it('should not force the add of user relation link if user is undefined', () => {
+      // given
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings();
+      userOrgaSettings.user = undefined;
+
+      // when
+      const json = serializer.serialize(userOrgaSettings);
+
+      // then
+      expect(json.data.relationships.user).to.be.undefined;
+      expect(json.included.length).to.equal(1);
+      expect(json.included[0].type).to.not.equal('users');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

> DEPRECATION: Encountered mismatched relationship: Ember Data expected data.relationships.user.data in the payload from user:4.belongsTo("userOrgaSettings") to include '{"id":"4","type":"user"}' but got 'null' instead.
> 
> The <user-orga-setting:10000000> record loaded at data in the payload specified null as its '"user"', but should have specified user:4 (the record the relationship is being loaded from) as its '"user"' instead.
> This could mean that the response for user:4.belongsTo("userOrgaSettings") may have accidentally returned '"user-orga-setting"' records that aren't related to user:4 and could be related to a different user record instead.
> Ember Data has corrected the <user-orga-setting:10000000> record's '"user"' relationship to user:4 so that user:4.belongsTo("userOrgaSettings") will include <user-orga-setting:10000000>.
> Please update the response from the server or change your serializer to either ensure that the response for only includes '"user-orga-setting"' records that specify user:4 as their '"user"', or omit the '"user"' relationship from the response.
>  [deprecation id: mismatched-inverse-relationship-data-from-payload]

## :robot: Solution
Ne pas rajouter la relationship user quand le user est undefined.