### PR TITLE
[TECH] Ajout d'un helper de test contains pour vérifier qu'un texte est présent dans le rendu (PIX-675) .

### DIFF
--- a/mon-pix/tests/helpers/contains.js
+++ b/mon-pix/tests/helpers/contains.js
@@ -1,0 +1,30 @@
+import { getRootElement } from '@ember/test-helpers';
+
+function getChildrenThatContainsText(element, text) {
+  if (element.children.length === 0) {
+    if (element.textContent.trim() === text) {
+      return element;
+    }
+    return null;
+  }
+
+  return [...element.children]
+    .map((child) => {
+      return getChildrenThatContainsText(child, text);
+    })
+    .filter(Boolean)
+    .flatMap((v) => v);
+}
+
+export function contains(text) {
+  const result = getChildrenThatContainsText(getRootElement(), text);
+  if (result.length > 0) {
+    return result[0];
+  }
+  return null;
+}
+
+export function containsAll(text) {
+  return getChildrenThatContainsText(getRootElement(), text);
+}
+

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -6,6 +6,8 @@ import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
+import { contains } from '../../helpers/contains';
+
 describe('Integration | Component | navbar-desktop-header', function() {
 
   setupRenderingTest();
@@ -44,7 +46,7 @@ describe('Integration | Component | navbar-desktop-header', function() {
     });
 
     it('should not display the link "J\'ai un code"', function() {
-      expect(find('.button')).not.to.exist;
+      expect(contains('J\'ai un code')).not.to.exist;
     });
   });
 
@@ -70,7 +72,7 @@ describe('Integration | Component | navbar-desktop-header', function() {
     });
 
     it('should display the link "J\'ai un code"', function() {
-      expect(find('.button').textContent.trim()).to.equal('J\'ai un code');
+      expect(contains('J\'ai un code')).to.exist;
     });
 
     it('should display the Pix logo', function() {
@@ -98,9 +100,9 @@ describe('Integration | Component | navbar-desktop-header', function() {
       // then
       expect(find('.navbar-desktop-header-container__menu')).to.exist;
       expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(3);
-      expect(findAll('.navbar-desktop-header-menu__item')[0].textContent.trim()).to.equal('Profil');
-      expect(findAll('.navbar-desktop-header-menu__item')[1].textContent.trim()).to.equal('Certification');
-      expect(findAll('.navbar-desktop-header-menu__item')[2].textContent.trim()).to.equal('Aide');
+      expect(contains('Profil')).to.exist;
+      expect(contains('Certification')).to.exist;
+      expect(contains('Aide')).to.exist;
     });
   });
 

--- a/mon-pix/tests/unit/helpers/contains-test.js
+++ b/mon-pix/tests/unit/helpers/contains-test.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+import { contains, containsAll } from '../../helpers/contains';
+
+describe('Unit | Helpers | contains', function() {
+  setupRenderingTest();
+
+  describe('contains', function() {
+    it('should contains Hello', async function() {
+      await render(hbs`<div>Hello</div>`);
+      expect(contains('Hello')).to.exist;
+    });
+
+    it('should not find any element', async function() {
+      await render(hbs`<div>Goodbye</div>`);
+      expect(contains('Hello')).not.to.exist;
+    });
+
+    it('should find only one element', async function() {
+      await render(hbs`<div><span id="first">Hello</span><span>Hello</span></div>`);
+      expect(contains('Hello').getAttribute('id')).to.equal('first');
+    });
+
+    it('should not find any element deeply', async function() {
+      await render(hbs`<div><span>Goodbye</span></div>`);
+      expect(contains('Hello')).not.to.exist;
+    });
+
+    it('should return element that contains exactly the text', async function() {
+      await render(hbs`<div>Hellow</div>`);
+      expect(contains('Hello')).not.to.exist;
+    });
+  });
+
+  describe('containsAll', function() {
+    it('should contains Hello twice', async function() {
+      await render(hbs`<ul><li>Hello</li><li>Hello</li></ul>`);
+      expect(containsAll('Hello')).to.have.lengthOf(2);
+    });
+
+    it('should not find any elements', async function() {
+      await render(hbs`<ul><li>Goodbye</li><li>Hellow</li></ul>`);
+      expect(containsAll('Hello')).to.have.lengthOf(0);
+    });
+  });
+});
+


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de verifier la présence d'un élément textuel sans écrire un sélecteur lié à l'implémentation. Cela rend les tests moins robuste. Ils sont sensible aux changements de nom de classes ou au changement dans la structure du HTML.

## :robot: Solution
Côté tests e2e avec Cypress on a l'habitude d'utiliser `contains` pour éviter ces problématiques. J'ai donc implémenté un helper du même nom qui vérifie sur le rendu du test courant contient un élément textuel. J'ai aussi réalisé le helper `containsAll` si on peut vérifier la présence de plusieurs éléments contenant le texte fourni en paramètre.

## :rainbow: Remarques
J'ai refactoré les tests de `navbar-desktop-header` qui donnent un exemple assez facile à réaliser.