### PR TITLE
[INFRA] Désactivation de la compression des réponses HTTP

### DIFF
--- a/admin/nginx.conf.erb
+++ b/admin/nginx.conf.erb
@@ -1,3 +1,6 @@
+# Disable compression that is performed by the Scalingo router anyway
+gzip off;
+
 root /app/dist/;
 
 # in case of 503, serve this URI

--- a/api/server.js
+++ b/api/server.js
@@ -13,6 +13,7 @@ const security = require('./lib/infrastructure/security');
 const createServer = async () => {
 
   const server = new Hapi.server({
+    compression: false,
     routes: {
       cors: {
         origin: ['*'],

--- a/certif/nginx.conf.erb
+++ b/certif/nginx.conf.erb
@@ -1,3 +1,6 @@
+# Disable compression that is performed by the Scalingo router anyway
+gzip off;
+
 root /app/dist/;
 
 # in case of 503, serve this URI

--- a/mon-pix/nginx.conf.erb
+++ b/mon-pix/nginx.conf.erb
@@ -1,3 +1,6 @@
+# Disable compression that is performed by the Scalingo router anyway
+gzip off;
+
 root /app/dist/;
 
 # in case of 503, serve this URI

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,3 +1,6 @@
+# Disable compression that is performed by the Scalingo router anyway
+gzip off;
+
 location ~ ^/(?<app>[^/]+)/.*$ {
   root /app/dist/;
 

--- a/orga/nginx.conf.erb
+++ b/orga/nginx.conf.erb
@@ -1,3 +1,6 @@
+# Disable compression that is performed by the Scalingo router anyway
+gzip off;
+
 root /app/dist/;
 
 # in case of 503, serve this URI


### PR DESCRIPTION
## :unicorn: Problème

La compression `gzip` des requêtes HTTP est faite au niveau applicatif alors que [le routeur Scalingo est capable de l'effectuer automatiquement](https://doc.scalingo.com/platform/internals/routing). Ceci consomme du CPU et de la mémoire inutilement sur les conteneurs applicatifs.

## :robot: Solution

On désactive la compression :
 * au niveau de HapiJS pour l'API ;
 * au niveau `nginx` pour les applications _front_.

## :100: Pour tester

Sur une application Scalingo : vérifier que les réponses qui ont lieu de l'être (d'une taille supérieure à 1 kilo-octet environ) sont toujours compressées.

En local pour l'API : constater que les réponses API même conséquentes (ex. `/api/users/{id}/scorecards`) ne sont plus compressées.
