### PR TITLE
[FEATURE] Changer la façon d'accéder à la page de détail d'un utilisateur dans Pix Admin (PIX-677). 

### DIFF
--- a/admin/app/components/users/list-items.hbs
+++ b/admin/app/components/users/list-items.hbs
@@ -36,8 +36,8 @@
       {{#if @users}}
       <tbody>
       {{#each @users as |user|}}
-        <tr {{on "click" (fn @goToUserDetailPage user.id)}} class="tr--clickable">
-          <td>{{user.id}}</td>
+        <tr>
+          <td><LinkTo @route="authenticated.users.get" @model={{user.id}}> {{user.id}} </LinkTo></td>
           <td>{{user.firstName}}</td>
           <td>{{user.lastName}}</td>
           <td>{{user.email}}</td>

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import config from 'pix-admin/config/environment';
@@ -26,9 +25,4 @@ export default class ListController extends Controller {
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
-
-  @action
-  goToUserDetailPage(userId) {
-    this.transitionToRoute('authenticated.users.get', userId);
-  }
 }

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -23,7 +23,7 @@ module('Acceptance | authenticated/users/get', function(hooks) {
 
   test('User detail page can be accessed from user list page', async function(assert) {
     await visit('/users');
-    await click(this.element.querySelector('.tr--clickable:first-child'));
+    await click('tbody > tr:nth-child(1) > td:nth-child(1) > a');
     assert.equal(currentURL(), `/users/${currentUser.id}`);
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, l'accès à la page de détail d'un utilisateur dans Pix Admin se fait en cliquant sur une des lignes du tableau des utilisateurs. Ce fonctionnement, pose néanmoins problème lorsque l'on cherche à copier une des informations du tableau. En effet, tout clique puis relâchement du bouton de la souris entraîne l'ouverture de la page de détail.

## :robot: Solution
Permettre l'accès à la page de détail d'un utilisateur en cliquant sur l'id de celui depuis le tableau. 