### PR TITLE
[BUGFIX] Corriger l'affichage de la progression sur le didacticiel (PIX-560).

### DIFF
--- a/mon-pix/app/templates/campaigns/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/tutorial.hbs
@@ -16,7 +16,7 @@
 
     <div class="campaign-tutorial__paging">
       {{#each model.paging as |page-class|}}
-        <div class="dot <PageClass />"> </div>
+        <div class="dot {{page-class}}"> </div>
       {{/each}}
 
     </div>


### PR DESCRIPTION
## :unicorn: Problème
On n'a plus d'indication visuelle sur la progression du didacticiel.

## :robot: Solution
Corriger la déclaration modifiée par erreur par le codemod.

## :100: Pour tester
Lancer une campagne et admirer les jolis ronds bleus :
![image](https://user-images.githubusercontent.com/5982021/81947361-be97b080-9600-11ea-9fe0-dc1491de5dfb.png)

