### PR TITLE
[BUGFIX] Remettre l'ancien gradient sur la page de connexion sur Pix Orga (PIX-655).

### DIFF
--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: $pix-orga-gradient;
+  background: $pix-orga-old-gradient;
   align-items: center;
   justify-content: center;
   min-height: 800px;


### PR DESCRIPTION
## :unicorn: Problème
Le nouveau gradient n'a pas été validé pour toutes les pages. En attendant, nous remettons l'ancien. 

## :robot: Solution
Remettre l'ancien gradient. `$pix-orga-gradient` 


## :100: Pour tester
Voir la page de connexion qui a l'ancien gradient. 
