### PR TITLE
[BUGFIX] Nom du fichier avant jury sans underscore (PIX-661)

### DIFF
--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -18,27 +18,23 @@ export default class SessionInfoServiceService extends Service {
   @service csvService;
 
   downloadSessionExportFile(session) {
+    const fileTitle = 'resultats_session';
     const data = this.buildSessionExportFileData(session);
     const fileHeaders = _buildSessionExportFileHeaders();
     const csv = json2csv.parse(data, { fields: fileHeaders, delimiter: ';', withBOM: true });
-    const sessionDateTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
-    const { day, month, year, hour, minute } = {
-      day: sessionDateTime.format('DD'),
-      month: sessionDateTime.format('MM'),
-      year: sessionDateTime.format('YYYY'),
-      hour: sessionDateTime.format('HH'),
-      minute: sessionDateTime.format('mm'),
-    };
-    const fileName = `${year}${month}${day}_${hour}${minute}_resultats_session_${session.id}.csv`;
+    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const fileName = _createFileNameWithDate(dateWithTime, fileTitle, session.id);
     this.fileSaver.saveAs(csv + '\n', fileName);
   }
 
   downloadJuryFile(sessionId, certifications) {
+    const fileTitle = 'jury_session';
     const certificationsForJury = _filterCertificationsEligibleForJury(certifications);
     const data = this.buildJuryFileData(certificationsForJury);
     const fileHeaders = _buildJuryFileHeaders();
     const csv = json2csv.parse(data, { fields: fileHeaders, delimiter: ';', withBOM: true, });
-    const fileName = 'jury_session_' + sessionId + ' ' + (new Date()).toLocaleString('fr-FR') + '.csv';
+    const dateWithTime = moment();
+    const fileName = _createFileNameWithDate(dateWithTime, fileTitle, sessionId);
     this.fileSaver.saveAs(`${csv}\n`, fileName);
   }
 
@@ -141,4 +137,8 @@ function _buildJuryFileHeaders() {
     ],
     competenceIndexes
   );
+}
+
+function _createFileNameWithDate(dateWithTime, fileTitle, sessionId) {
+  return `${dateWithTime.format('YYYYMMDD_HHmm')}_${fileTitle}_${sessionId}.csv`;
 }


### PR DESCRIPTION
## :unicorn: Problème
Le nom du fichier avant jury dans Pix Admin n'est pas au format attendu (c'est à dire avec des "_" dans le nom du fichier).
![image](https://user-images.githubusercontent.com/38167520/82043180-67024f00-96ab-11ea-96ef-8b9dc14a0a77.png)
Cela peut poser des problèmes de tris ou d'organisations pour la gestion de ce genre de fichier chez le pôle certif.

## :robot: Solution
Uniformiser le nom du fichier avant jury et du fichier d'export des résultats au format `AAAAmmjj_hhmm_jury_session_IDsession` . 

Il a été vu avec le pôle certif que la date à afficher, pour le fichier avant jury, est bien la date de téléchargement du fichier (car elle correspond au jour où est fait le jury). Et non la date de la session comme pour le fichier de résultats. 

## :rainbow: Remarques
Je ne sais pas s'il est vraiment intéressant de chercher à tester le nom du fichier ? 
Ca semble assez difficile à réaliser... sauf si on teste juste la méthode `_createFileNameWithSessionDate`. 


## :100: Pour tester
Aller sur Pix Admin > liste des sessions > cliquer sur une session pour afficher sa page d'informations > cliquer sur les boutons "Récupérer le fichier avant jury" et "Exporter les résultats" > observer que leur nom est bien au format "AAAAmmjj_hhmm_jury_session_IDsession" 
