### PR TITLE
[BUGFIX] Empêcher l'utilisateur de demander plusieurs fois la réinitialisation de son mot de passe (PIX-489).

### DIFF
--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -9,6 +9,7 @@ export default class PasswordResetDemandForm extends Component {
 
   @tracked hasFailed = false;
   @tracked hasSucceeded = false;
+  @tracked isButtonEnabled = true;
 
   email = '';
 
@@ -21,15 +22,19 @@ export default class PasswordResetDemandForm extends Component {
     event && event.preventDefault();
     this.hasFailed = false;
     this.hasSucceeded = false;
+    this.isButtonEnabled = false;
 
-    const trimmedEmail = this.email ? this.email.trim() : '';
+    if (!this.email) {
+      return;
+    }
 
     try {
-      const passwordResetDemand = await this.store.createRecord('password-reset-demand', { email: trimmedEmail });
+      const passwordResetDemand = await this.store.createRecord('password-reset-demand', { email: this.email.trim() });
       await passwordResetDemand.save();
       this.hasSucceeded = true;
     } catch (error) {
       this.hasFailed = true;
+      this.isButtonEnabled = true;
     }
   }
 }

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -36,13 +36,19 @@
 
       <div class="sign-form-body__input">
         <FormTextfield @label="Adresse e-mail" @textfieldName="email" @validationStatus="default"
-                       @inputBindingValue={{this.email}} />
+                       @inputBindingValue={{this.email}} @require="true" />
       </div>
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <button type="submit" class="button button--uppercase button--thin button--round">
-          Réinitialiser mon mot de passe
-        </button>
+        {{#if this.isButtonEnabled}}
+          <button type="submit" class="button button--uppercase button--thin button--round">
+            Réinitialiser mon mot de passe
+          </button>
+        {{else}}
+          <button type="button" disabled class="button button--uppercase button--thin button--round button--big">
+            <span class="loader-in-button">&nbsp;</span>
+          </button>
+        {{/if}}
         <LinkTo @route="login" class="link link--grey sign-form-link password-reset-demand-form__cancel-link">
           Retour à la page de connexion
         </LinkTo>

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
-import { find, render, click } from '@ember/test-helpers';
+import { fillIn, find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
@@ -28,7 +28,7 @@ describe('Integration | Component | password reset demand form', function() {
     expect(find('.button')).to.exist;
   });
 
-  it('should display error message when there is an error on password reset demand', async function() {
+  it('should display error message and re enable the button when there is an error on password reset demand', async function() {
     // given
     const storeStub = Service.extend({
       createRecord() {
@@ -44,10 +44,12 @@ describe('Integration | Component | password reset demand form', function() {
     await render(hbs`<PasswordResetDemandForm />`);
 
     // when
+    await fillIn('#email', 'test@example.net');
     await click('.sign-form-body__bottom-button .button');
 
     // then
     expect(find('.sign-form__notification-message--error')).to.exist;
+    expect(find('.button').textContent.trim()).to.equal('Réinitialiser mon mot de passe');
   });
 
   it('should display success message when there is no error on password reset demand', async function() {
@@ -66,6 +68,7 @@ describe('Integration | Component | password reset demand form', function() {
     await render(hbs`<PasswordResetDemandForm />`);
 
     // when
+    await fillIn('#email', 'test@example.net');
     await click('.sign-form-body__bottom-button .button');
 
     // then

--- a/mon-pix/tests/unit/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/unit/components/password-reset-demand-form-test.js
@@ -29,6 +29,15 @@ describe('Unit | Component | password-reset-demand-form', () => {
       component.email = sentEmail;
     });
 
+    it('should not call api if the user did not enter any email', async () => {
+      // when
+      component.email = undefined;
+      await component.savePasswordResetDemand();
+
+      // then
+      sinon.assert.notCalled(createRecordStub);
+    });
+
     it('should create a passwordResetDemand Record', async () => {
       // when
       await component.savePasswordResetDemand();


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur est sur la page de réinitialisation de mot de passe par email, et lorsque la connection est lente, il peut cliquer plusieurs fois sur le bouton "Réinitialiser", avant que la page de confirmation ne soit affichée.  Cela envoie autant de demandes à l'API, qui ne sont pas utiles.

## :robot: Solution
Désactiver le bouton "Réinitialiser" lorsqu'un appel a été effectué à l'API (afficher lo loader habituel avec des points). Si l'appel échoue, réactiver le bouton.

## :rainbow: Remarques
Attendre le merge de #1436

Lorsque l'utilisateur ne saisit pas de mot de passse, une vérification a été rajoutée, qui empêche l'appel à l'API. Elle n'affiche pas de mssage d'erreur, et ne désactive pas le bouton.

## :100: Pour tester
Se rendre sur la page [de réinitialisation](https://app-pr1428.review.pix.fr/mot-de-passe-oublie). Afficher les appels réseau et selectionner une connexion slow 3g pour voir le loader. Entrer un email valide, cliquer plusieurs fois sur "Réinitialiser". Vérifier qu'un seul appel API a été envoyé. Vérifier la même chose, en mode Offline (= simule erreur lors de l'appel API), pour vérifier que le bouton est réactivé.