### PR TITLE
[FEATURE] Ajout du filtre sur la colonne "Qui ?" dans la liste des sessions dans Pix Admin (PA-211)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -18,6 +18,8 @@ export default class SessionListController extends Controller {
   @tracked certificationCenterName = null;
   @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
+  @tracked assignedToSelfOnly = false;
+
   pendingFilters = {};
 
   sessionStatusAndLabels = [
@@ -31,7 +33,7 @@ export default class SessionListController extends Controller {
     { value: 'false', label: 'Résultats non diffusés' },
   ];
 
-  @(task(function * (fieldName, param) {
+  @(task(function* (fieldName, param) {
     let value;
     let debounceDuration = this.DEBOUNCE_MS;
     switch (fieldName) {
@@ -41,6 +43,7 @@ export default class SessionListController extends Controller {
         break;
       case 'status':
       case 'resultsSentToPrescriberAt':
+      case 'assignedToSelfOnly':
         debounceDuration = 0;
         value = param;
         break;
@@ -52,5 +55,6 @@ export default class SessionListController extends Controller {
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
+
   }).restartable()) triggerFiltering;
 }

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { FINALIZED } from 'pix-admin/models/session';
+import { trim } from 'lodash';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   queryParams: {
@@ -10,6 +11,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     certificationCenterName: { refreshModel: true },
     status: { refreshModel: true },
     resultsSentToPrescriberAt: { refreshModel: true },
+    assignedToSelfOnly: { refreshModel: true },
   },
 
   async model(params) {
@@ -17,10 +19,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
     try {
       sessions = await this.store.query('session', {
         filter: {
-          id: params.id && params.id.trim(),
-          certificationCenterName: params.certificationCenterName && params.certificationCenterName.trim(),
-          status: params.status && params.status.trim(),
-          resultsSentToPrescriberAt: params.resultsSentToPrescriberAt && params.resultsSentToPrescriberAt.trim(),
+          id: trim(params.id) || undefined,
+          certificationCenterName: trim(params.certificationCenterName) || undefined,
+          status: params.status || undefined,
+          resultsSentToPrescriberAt: params.resultsSentToPrescriberAt || undefined,
+          assignedToSelfOnly: params.assignedToSelfOnly,
         },
         page: {
           number: params.pageNumber,
@@ -42,6 +45,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.certificationCenterName = null;
       controller.status = FINALIZED;
       controller.resultsSentToPrescriberAt = null;
+      controller.assignedToSelfOnly = false;
     }
   }
 });

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -1,3 +1,13 @@
+.session-list__self-toogle {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 10px;
+
+  p {
+    margin: 0;
+  }
+}
+
 .session-list {
   &__item {
     &--align-center {

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -4,6 +4,15 @@
 
 <main class="page-body">
   <section class="page-section">
+      <span class="session-list__self-toogle">
+          <p>Afficher uniquement mes sessions</p>
+          <XToggle
+            @size='small'
+            @theme='light'
+            @value={{this.assignedToSelfOnly}}
+            @onToggle={{perform this.triggerFiltering 'assignedToSelfOnly'}}
+          />
+      </span>
       <Sessions::ListItems
         @sessions={{@model}}
         @id={{this.id}}

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -9693,6 +9693,12 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "animation-frame": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/animation-frame/-/animation-frame-0.2.5.tgz",
+      "integrity": "sha1-zfWpGmmtLIXdrCuC2vcpAwDwWWA=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -15032,6 +15038,16 @@
         }
       }
     },
+    "ember-class-based-modifier": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/ember-class-based-modifier/-/ember-class-based-modifier-0.10.0.tgz",
+      "integrity": "sha512-GPPOCYmRibGBUfiuq7oHQAGXgM6X8LK2I2crvQadqwbft5PjXDbR6x1xnOQ8TDWeOE0EluahXXOgWgdUVcmaMQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.2.0"
+      }
+    },
     "ember-cli": {
       "version": "3.15.2",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.15.2.tgz",
@@ -18596,6 +18612,38 @@
         "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
       }
     },
+    "ember-copy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-copy/-/ember-copy-1.0.0.tgz",
+      "integrity": "sha512-aiZNAvOmdemHdvZNn0b5b/0d9g3JFpcOsrDgfhYEbfd7SzE0b69YiaVK2y3wjqfjuuiA54vOllGN4pjSzECNSw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "dependencies": {
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        }
+      }
+    },
     "ember-data": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.17.0.tgz",
@@ -20799,6 +20847,95 @@
         "focus-trap": "^5.0.1"
       }
     },
+    "ember-gestures": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ember-gestures/-/ember-gestures-1.1.5.tgz",
+      "integrity": "sha512-bzLTe1HzpFCUEZHX89ysTXMf6qYp+7U1ZyHP3gJr31Ik/pCBwfsvDxOr+JIImsnhkDKkuZSrQSvlQSrQgXM6cA==",
+      "dev": true,
+      "requires": {
+        "animation-frame": "~0.2.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "ember-class-based-modifier": "^0.10.0",
+        "ember-cli-babel": "^7.7.0",
+        "ember-cli-htmlbars": "^2.0.1",
+        "ember-cli-version-checker": "^2.1.0",
+        "ember-copy": "^1.0.0",
+        "fastboot-transform": "^0.1.3",
+        "hammerjs": "^2.0.8",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
+          "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
+          "dev": true,
+          "requires": {
+            "broccoli-persistent-filter": "^1.4.3",
+            "hash-for-dep": "^1.2.3",
+            "json-stable-stringify": "^1.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
+          "requires": {
+            "fs-updater": "^1.0.4",
+            "heimdalljs": "^0.2.5"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "ember-get-config": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
@@ -21951,6 +22088,39 @@
         }
       }
     },
+    "ember-runtime-enumerable-includes-polyfill": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.1.0.tgz",
+      "integrity": "sha512-au18iI8VbEDYn3jLFZzETnKN5ciPgCUxMRucEP3jkq7qZ6sE0FVKpWMPY/h9tTND3VOBJt6fgPpEBJoJVCUudg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.9.0",
+        "ember-cli-version-checker": "^2.1.0"
+      },
+      "dependencies": {
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        }
+      }
+    },
     "ember-simple-auth": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-3.0.0.tgz",
@@ -22955,6 +23125,138 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.1.0"
+      }
+    },
+    "ember-toggle": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ember-toggle/-/ember-toggle-6.0.2.tgz",
+      "integrity": "sha512-rsuB58s0v1SMPsHi6bgHVzrETpUGVGuOHSpXcjDyaYZ8Jdjvj3rtALX9VbZk4czZnxi6RWi9aT9JBtURv8RD+g==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-cli-htmlbars": "^3.0.1",
+        "ember-gestures": "^1.1.1",
+        "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
+      },
+      "dependencies": {
+        "broccoli-persistent-filter": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+          "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^1.2.1",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^2.6.1",
+            "rsvp": "^4.7.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^1.3.3",
+            "walk-sync": "^1.0.0"
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz",
+          "integrity": "sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==",
+          "dev": true,
+          "requires": {
+            "broccoli-persistent-filter": "^2.3.1",
+            "hash-for-dep": "^1.5.1",
+            "json-stable-stringify": "^1.0.1",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "ensure-posix-path": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+          "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
+          "dev": true
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "hash-for-dep": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.5.1.tgz",
+          "integrity": "sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==",
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "heimdalljs": "^0.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "path-root": "^0.1.1",
+            "resolve": "^1.10.0",
+            "resolve-package-path": "^1.0.11"
+          }
+        },
+        "matcher-collection": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+          "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+          "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.10.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
+        }
       }
     },
     "ember-truth-helpers": {
@@ -26221,6 +26523,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
       "dev": true
     },
     "handlebars": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -79,6 +79,7 @@
     "ember-simple-auth": "^3.0.0",
     "ember-sinon": "^4.1.1",
     "ember-source": "^3.15.0",
+    "ember-toggle": "^6.0.2",
     "ember-truth-helpers": "^2.1.0",
     "emberx-select": "^4.0.0-beta.2",
     "eslint": "^6.8.0",

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -35,6 +35,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
           certificationCenterName: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: undefined,
         };
 
         // then
@@ -53,6 +54,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
           certificationCenterName: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: undefined,
         };
 
         // when
@@ -74,6 +76,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
           certificationCenterName: 'someName',
           status: undefined,
           resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: undefined,
         };
 
         // when
@@ -87,14 +90,15 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
 
     module('when queryParams status is truthy', function() {
 
-      test('it should call store.query with a filter with trimmed status', async function(assert) {
+      test('it should call store.query with a filter with status', async function(assert) {
         // given
-        params.status = ' someStatus';
+        params.status = 'someStatus';
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
           status: 'someStatus',
           resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: undefined,
         };
 
         // when
@@ -106,16 +110,39 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
       });
     });
 
-    module('when queryParams resultsSentToPrescriberAt is truthy', function() {
+    module('when queryParams resultsSentToPrescriberAt is true', function() {
 
-      test('it should call store.query with a filter with trimmed resultsSentToPrescriberAt', async function(assert) {
+      test('it should call store.query with a filter with true resultsSentToPrescriberAt', async function(assert) {
         // given
-        params.resultsSentToPrescriberAt = ' someValue';
+        params.resultsSentToPrescriberAt = true;
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
           status: undefined,
-          resultsSentToPrescriberAt: 'someValue',
+          resultsSentToPrescriberAt: true,
+          assignedToSelfOnly: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams assignedToSelfOnly is truthy', function() {
+
+      test('it should call store.query with a filter with assignedToSelfOnly', async function(assert) {
+        // given
+        params.assignedToSelfOnly = true;
+        expectedQueryArgs.filter = {
+          id: undefined,
+          certificationCenterName: undefined,
+          status: undefined,
+          resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: true,
         };
 
         // when

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -18,8 +18,12 @@ module.exports = {
   async findPaginatedFilteredJurySessions(request) {
     const currentUserId = requestResponseUtils.extractUserIdFromRequest(request);
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
-    const normalizedFilters = sessionValidator.validateAndNormalizeFilters(filter);
-    const jurySessionsForPaginatedList = await jurySessionRepository.findPaginatedFiltered({ filters: normalizedFilters, page, currentUserId });
+    const normalizedFilters
+      = sessionValidator.validateAndNormalizeFilters(filter, currentUserId);
+    const jurySessionsForPaginatedList = await jurySessionRepository.findPaginatedFiltered({
+      filters: normalizedFilters,
+      page
+    });
 
     return jurySessionSerializer.serializeForPaginatedList(jurySessionsForPaginatedList);
   },
@@ -78,7 +82,10 @@ module.exports = {
   async addCertificationCandidate(request, h) {
     const sessionId = parseInt(request.params.id);
     const certificationCandidate = await certificationCandidateSerializer.deserialize(request.payload);
-    const addedCertificationCandidate = await usecases.addCertificationCandidateToSession({ sessionId, certificationCandidate });
+    const addedCertificationCandidate = await usecases.addCertificationCandidateToSession({
+      sessionId,
+      certificationCandidate
+    });
 
     return h.response(certificationCandidateSerializer.serialize(addedCertificationCandidate)).created();
   },
@@ -112,8 +119,7 @@ module.exports = {
 
     try {
       await usecases.importCertificationCandidatesFromAttendanceSheet({ sessionId, odsBuffer });
-    }
-    catch (err) {
+    } catch (err) {
       if (err instanceof CertificationCandidateAlreadyLinkedToUserError) {
         throw new BadRequestError(err.message);
       }

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { BadRequestError } = require('../http-errors');
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
@@ -12,14 +11,15 @@ const juryCertificationSummarySerializer = require('../../infrastructure/seriali
 const juryCertificationSummaryRepository = require('../../infrastructure/repositories/jury-certification-summary-repository');
 const jurySessionRepository = require('../../infrastructure/repositories/jury-session-repository');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
   async findPaginatedFilteredJurySessions(request) {
+    const currentUserId = requestResponseUtils.extractUserIdFromRequest(request);
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
-    const trimmedFilters = _trimValues(filter);
-    const normalizedFilters = sessionValidator.validateFilters(trimmedFilters);
-    const jurySessionsForPaginatedList = await jurySessionRepository.findPaginatedFiltered({ filters: normalizedFilters, page });
+    const normalizedFilters = sessionValidator.validateFilters(filter);
+    const jurySessionsForPaginatedList = await jurySessionRepository.findPaginatedFiltered({ filters: normalizedFilters, page, currentUserId });
 
     return jurySessionSerializer.serializeForPaginatedList(jurySessionsForPaginatedList);
   },
@@ -175,12 +175,3 @@ module.exports = {
   },
 
 };
-
-function _trimValues(values) {
-  return _.mapValues(values, (value) => {
-    if (typeof value === 'string') {
-      return value.trim() || undefined;
-    }
-    return value;
-  });
-}

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -18,7 +18,7 @@ module.exports = {
   async findPaginatedFilteredJurySessions(request) {
     const currentUserId = requestResponseUtils.extractUserIdFromRequest(request);
     const { filter, page } = queryParamsUtils.extractParameters(request.query);
-    const normalizedFilters = sessionValidator.validateFilters(filter);
+    const normalizedFilters = sessionValidator.validateAndNormalizeFilters(filter);
     const jurySessionsForPaginatedList = await jurySessionRepository.findPaginatedFiltered({ filters: normalizedFilters, page, currentUserId });
 
     return jurySessionSerializer.serializeForPaginatedList(jurySessionsForPaginatedList);

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -59,11 +59,19 @@ module.exports = {
     }
   },
 
-  validateAndNormalizeFilters(filters) {
+  validateAndNormalizeFilters(filters, assignedCertificationOfficerId) {
     const { value, error } = sessionFiltersValidationSchema.validate(filters, validationConfiguration);
+
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
     }
+
+    if (value.assignedToSelfOnly) {
+      value.assignedCertificationOfficerId = assignedCertificationOfficerId;
+    }
+
+    delete value.assignedToSelfOnly;
+
     return value;
   }
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -43,10 +43,11 @@ const sessionValidationJoiSchema = Joi.object({
 
 const sessionFiltersValidationSchema = Joi.object({
   id: Joi.number().integer().optional(),
-  status: Joi.string()
+  status: Joi.string().trim()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
-  resultsSentToPrescriberAt: Joi.string().valid('true', 'false').optional(),
-  certificationCenterName: Joi.string().optional(),
+  resultsSentToPrescriberAt: Joi.boolean().optional(),
+  assignedToSelfOnly: Joi.boolean().optional(),
+  certificationCenterName: Joi.string().trim().optional(),
 });
 
 module.exports = {

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -59,7 +59,7 @@ module.exports = {
     }
   },
 
-  validateFilters(filters) {
+  validateAndNormalizeFilters(filters) {
     const { value, error } = sessionFiltersValidationSchema.validate(filters, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);

--- a/api/lib/infrastructure/repositories/jury-session-repository.js
+++ b/api/lib/infrastructure/repositories/jury-session-repository.js
@@ -25,13 +25,13 @@ module.exports = {
     return _toDomain(results[0]);
   },
 
-  async findPaginatedFiltered({ filters, page, currentUserId }) {
+  async findPaginatedFiltered({ filters, page }) {
     const pageSize = page.size ? page.size : DEFAULT_PAGE_SIZE;
     const pageNumber = page.number ? page.number : DEFAULT_PAGE_NUMBER;
     const offset = (pageNumber - 1) * pageSize;
     const query = Bookshelf.knex.from('sessions');
 
-    _setupFilters(query, filters, currentUserId);
+    _setupFilters(query, filters);
     query.orderByRaw('?? ASC NULLS FIRST', 'publishedAt')
       .orderByRaw('?? ASC', 'finalizedAt')
       .orderBy('id')
@@ -94,8 +94,8 @@ function _toDomain(jurySessionFromDB) {
   return jurySession;
 }
 
-function _setupFilters(query, filters, currentUserId) {
-  const { id, certificationCenterName, status, resultsSentToPrescriberAt, assignedToSelfOnly } = filters;
+function _setupFilters(query, filters) {
+  const { id, certificationCenterName, status, resultsSentToPrescriberAt, assignedCertificationOfficerId } = filters;
 
   if (id) {
     query.where('sessions.id', id);
@@ -104,8 +104,8 @@ function _setupFilters(query, filters, currentUserId) {
     query.whereRaw('LOWER("certificationCenter") LIKE ?', `%${certificationCenterName.toLowerCase()}%`);
   }
 
-  if (assignedToSelfOnly === true && currentUserId) {
-    query.where('sessions.assignedCertificationOfficerId', currentUserId);
+  if (assignedCertificationOfficerId) {
+    query.where({ assignedCertificationOfficerId });
   }
 
   if (resultsSentToPrescriberAt === true) {

--- a/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -459,13 +459,12 @@ describe('Integration | Repository | JurySession', function() {
 
         it('should only return the session assigned to the given certification officer ', async () => {
           // given
-          const currentUserId = certificationOfficerToMatchId;
-          const filters = { assignedToSelfOnly: true };
+          const filters = { assignedCertificationOfficerId: certificationOfficerToMatchId };
           const page = { number: 1, size: 10 };
           const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
 
           // when
-          const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page, currentUserId });
+          const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
 
           // then
           expect(pagination).to.deep.equal(expectedPagination);

--- a/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -14,7 +14,10 @@ describe('Integration | Repository | JurySession', function() {
       let sessionId;
 
       beforeEach(() => {
-        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({ firstName: 'Pix', lastName: 'Doe' }).id;
+        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({
+          firstName: 'Pix',
+          lastName: 'Doe'
+        }).id;
         sessionId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId }).id;
 
         return databaseBuilder.commit();
@@ -50,7 +53,10 @@ describe('Integration | Repository | JurySession', function() {
       let sessionWithoutCertificationCenterId;
 
       beforeEach(() => {
-        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({ firstName: 'Pix', lastName: 'Doe' }).id;
+        const assignedCertificationOfficerId = databaseBuilder.factory.buildUser({
+          firstName: 'Pix',
+          lastName: 'Doe'
+        }).id;
         sessionWithCertificationOfficerId = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId }).id;
         sessionWithoutCertificationCenterId = databaseBuilder.factory.buildSession({ certificationCenterId: null }).id;
 
@@ -64,7 +70,10 @@ describe('Integration | Repository | JurySession', function() {
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 2 };
 
         // when
-        const { jurySessions: matchingJurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+        const { jurySessions: matchingJurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({
+          filters,
+          page
+        });
 
         // then
         expect(matchingJurySessions).to.exist;
@@ -79,7 +88,10 @@ describe('Integration | Repository | JurySession', function() {
         const page = { number: 1, size: 3 };
 
         // when
-        const { jurySessions: matchingJurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+        const { jurySessions: matchingJurySessions } = await jurySessionRepository.findPaginatedFiltered({
+          filters,
+          page
+        });
 
         // then
         const sessionWithOfficer = _.find(matchingJurySessions, { id: sessionWithCertificationOfficerId });
@@ -104,7 +116,10 @@ describe('Integration | Repository | JurySession', function() {
         const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 4, rowCount: 12 };
 
         // when
-        const { jurySessions: matchingJurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+        const { jurySessions: matchingJurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({
+          filters,
+          page
+        });
 
         // then
         expect(matchingJurySessions).to.have.lengthOf(3);
@@ -119,10 +134,22 @@ describe('Integration | Repository | JurySession', function() {
       let fourthSessionId;
 
       beforeEach(() => {
-        firstSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-01T00:00:00Z'), resultsSentToPrescriberAt: null }).id;
-        secondSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-02T00:00:00Z'), resultsSentToPrescriberAt: null }).id;
-        thirdSessionId = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2020-01-02T00:00:00Z'), resultsSentToPrescriberAt: new Date('2020-01-03T00:00:00Z') }).id;
-        fourthSessionId = databaseBuilder.factory.buildSession({ finalizedAt: null, resultsSentToPrescriberAt: null }).id;
+        firstSessionId = databaseBuilder.factory.buildSession({
+          finalizedAt: new Date('2020-01-01T00:00:00Z'),
+          resultsSentToPrescriberAt: null
+        }).id;
+        secondSessionId = databaseBuilder.factory.buildSession({
+          finalizedAt: new Date('2020-01-02T00:00:00Z'),
+          resultsSentToPrescriberAt: null
+        }).id;
+        thirdSessionId = databaseBuilder.factory.buildSession({
+          finalizedAt: new Date('2020-01-02T00:00:00Z'),
+          resultsSentToPrescriberAt: new Date('2020-01-03T00:00:00Z')
+        }).id;
+        fourthSessionId = databaseBuilder.factory.buildSession({
+          finalizedAt: null,
+          resultsSentToPrescriberAt: null
+        }).id;
 
         return databaseBuilder.commit();
       });
@@ -133,7 +160,10 @@ describe('Integration | Repository | JurySession', function() {
         const page = { number: 1, size: 10 };
 
         // when
-        const { jurySessions: matchingJurySessions } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+        const { jurySessions: matchingJurySessions } = await jurySessionRepository.findPaginatedFiltered({
+          filters,
+          page
+        });
 
         // then
         expect(matchingJurySessions[0].id).to.equal(firstSessionId);
@@ -199,7 +229,10 @@ describe('Integration | Repository | JurySession', function() {
 
         beforeEach(() => {
           const certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'Université des Laura en Folie !' });
-          expectedSession = databaseBuilder.factory.buildSession({ certificationCenter: certificationCenter.name, certificationCenterId: certificationCenter.id });
+          expectedSession = databaseBuilder.factory.buildSession({
+            certificationCenter: certificationCenter.name,
+            certificationCenterId: certificationCenter.id
+          });
           databaseBuilder.factory.buildSession();
 
           return databaseBuilder.commit();
@@ -252,8 +285,16 @@ describe('Integration | Repository | JurySession', function() {
 
           beforeEach(() => {
             const someDate = new Date('2020-01-01T00:00:00Z');
-            expectedSessionId = databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: null, assignedCertificationOfficerId: null }).id;
-            databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: someDate, assignedCertificationOfficerId: null });
+            expectedSessionId = databaseBuilder.factory.buildSession({
+              finalizedAt: someDate,
+              publishedAt: null,
+              assignedCertificationOfficerId: null
+            }).id;
+            databaseBuilder.factory.buildSession({
+              finalizedAt: someDate,
+              publishedAt: someDate,
+              assignedCertificationOfficerId: null
+            });
 
             return databaseBuilder.commit();
           });
@@ -278,7 +319,11 @@ describe('Integration | Repository | JurySession', function() {
           beforeEach(() => {
             const someDate = new Date('2020-01-01T00:00:00Z');
             const assignedCertificationOfficerId = databaseBuilder.factory.buildUser().id;
-            expectedSessionId = databaseBuilder.factory.buildSession({ finalizedAt: someDate, publishedAt: null, assignedCertificationOfficerId }).id;
+            expectedSessionId = databaseBuilder.factory.buildSession({
+              finalizedAt: someDate,
+              publishedAt: null,
+              assignedCertificationOfficerId
+            }).id;
             databaseBuilder.factory.buildSession({ publishedAt: someDate, assignedCertificationOfficerId });
 
             return databaseBuilder.commit();
@@ -338,7 +383,7 @@ describe('Integration | Repository | JurySession', function() {
 
           it('should apply the strict filter and return the appropriate results', async () => {
             // given
-            const filters = { resultsSentToPrescriberAt: 'true' };
+            const filters = { resultsSentToPrescriberAt: true };
             const page = { number: 1, size: 10 };
 
             // when
@@ -362,7 +407,7 @@ describe('Integration | Repository | JurySession', function() {
 
           it('should apply the strict filter and return the appropriate results', async () => {
             // given
-            const filters = { resultsSentToPrescriberAt: 'false' };
+            const filters = { resultsSentToPrescriberAt: false };
             const page = { number: 1, size: 10 };
 
             // when
@@ -396,6 +441,38 @@ describe('Integration | Repository | JurySession', function() {
           });
         });
       });
+
+      context('when there is a filter on the assigned certification officer', () => {
+        let certificationOfficerToMatchId;
+        let expectedSession;
+
+        beforeEach(() => {
+          certificationOfficerToMatchId = databaseBuilder.factory.buildUser().id;
+          const anotherCertificationOfficerId = databaseBuilder.factory.buildUser().id;
+
+          expectedSession = databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: certificationOfficerToMatchId });
+          databaseBuilder.factory.buildSession({ assignedCertificationOfficerId: anotherCertificationOfficerId });
+          databaseBuilder.factory.buildSession();
+
+          return databaseBuilder.commit();
+        });
+
+        it('should only return the session assigned to the given certification officer ', async () => {
+          // given
+          const currentUserId = certificationOfficerToMatchId;
+          const filters = { assignedToSelfOnly: true };
+          const page = { number: 1, size: 10 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+
+          // when
+          const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page, currentUserId });
+
+          // then
+          expect(pagination).to.deep.equal(expectedPagination);
+          expect(jurySessions[0].id).to.equal(expectedSession.id);
+          expect(jurySessions).to.have.length(1);
+        });
+      });
     });
   });
 
@@ -412,7 +489,10 @@ describe('Integration | Repository | JurySession', function() {
 
     it('should return an updated Session domain object', async () => {
       // when
-      const updatedSession = await jurySessionRepository.assignCertificationOfficer({ id: sessionId, assignedCertificationOfficerId });
+      const updatedSession = await jurySessionRepository.assignCertificationOfficer({
+        id: sessionId,
+        assignedCertificationOfficerId
+      });
 
       // then
       expect(updatedSession).to.be.an.instanceof(JurySession);
@@ -428,7 +508,10 @@ describe('Integration | Repository | JurySession', function() {
         const unknownUserId = assignedCertificationOfficerId + 1;
 
         // when
-        const error = await catchErr(jurySessionRepository.assignCertificationOfficer)({ id: sessionId, assignedCertificationOfficerId: unknownUserId });
+        const error = await catchErr(jurySessionRepository.assignCertificationOfficer)({
+          id: sessionId,
+          assignedCertificationOfficerId: unknownUserId
+        });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
@@ -442,7 +525,10 @@ describe('Integration | Repository | JurySession', function() {
         const unknownSessionId = sessionId + 1;
 
         // when
-        const error = await catchErr(jurySessionRepository.assignCertificationOfficer)({ id: unknownSessionId, assignedCertificationOfficerId });
+        const error = await catchErr(jurySessionRepository.assignCertificationOfficer)({
+          id: unknownSessionId,
+          assignedCertificationOfficerId
+        });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -11,6 +11,7 @@ const certificationCandidateSerializer = require('../../../../lib/infrastructure
 const certificationReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-report-serializer');
 const juryCertificationSummarySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
+const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
 const jurySessionRepository = require('../../../../lib/infrastructure/repositories/jury-session-repository');
@@ -631,29 +632,30 @@ describe('Unit | Controller | sessionController', () => {
       sinon.stub(sessionValidator, 'validateFilters');
       sinon.stub(jurySessionRepository, 'findPaginatedFiltered');
       sinon.stub(jurySessionSerializer, 'serializeForPaginatedList');
+      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
     });
 
     it('should return the serialized jurySessions', async () => {
       // given
+      const currentUserId = 5;
       const request = { query: {} };
-      const filter = { filter1: ' filter1ToTrim', filter2: 'filter2' };
+      const filters = { filter1: ' filter1ToTrim', filter2: 'filter2' };
       const normalizedFilters = 'normalizedFilters';
       const page = 'somePageConfiguration';
       const jurySessionsForPaginatedList = Symbol('jurySessionsForPaginatedList');
       const serializedJurySessionsForPaginatedList = Symbol('serializedJurySessionsForPaginatedList');
-      queryParamsUtils.extractParameters.withArgs(request.query).returns({ filter, page });
+      queryParamsUtils.extractParameters.withArgs(request.query).returns({ filters, page });
       sessionValidator.validateFilters.withArgs({ filter1: 'filter1ToTrim', filter2: 'filter2' })
         .returns(normalizedFilters);
-      jurySessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page })
+      jurySessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page, currentUserId })
         .resolves(jurySessionsForPaginatedList);
       jurySessionSerializer.serializeForPaginatedList.returns(serializedJurySessionsForPaginatedList);
+      requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(currentUserId);
 
       // when
       const result = await sessionController.findPaginatedFilteredJurySessions(request, hFake);
 
       // then
-      expect(jurySessionRepository.findPaginatedFiltered).to.have.been.calledWithExactly({ filters: normalizedFilters, page });
-      expect(jurySessionSerializer.serializeForPaginatedList).to.have.been.calledWithExactly(jurySessionsForPaginatedList);
       expect(result).to.equal(serializedJurySessionsForPaginatedList);
     });
   });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -639,17 +639,17 @@ describe('Unit | Controller | sessionController', () => {
       // given
       const currentUserId = 5;
       const request = { query: {} };
-      const filters = { filter1: ' filter1ToTrim', filter2: 'filter2' };
+      const filter = { filter1: ' filter1ToTrim', filter2: 'filter2' };
       const normalizedFilters = 'normalizedFilters';
       const page = 'somePageConfiguration';
       const jurySessionsForPaginatedList = Symbol('jurySessionsForPaginatedList');
       const serializedJurySessionsForPaginatedList = Symbol('serializedJurySessionsForPaginatedList');
-      queryParamsUtils.extractParameters.withArgs(request.query).returns({ filters, page });
-      sessionValidator.validateAndNormalizeFilters.withArgs({ filter1: 'filter1ToTrim', filter2: 'filter2' })
+      queryParamsUtils.extractParameters.withArgs(request.query).returns({ filter, page });
+      sessionValidator.validateAndNormalizeFilters.withArgs(filter, currentUserId)
         .returns(normalizedFilters);
-      jurySessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page, currentUserId })
+      jurySessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page })
         .resolves(jurySessionsForPaginatedList);
-      jurySessionSerializer.serializeForPaginatedList.returns(serializedJurySessionsForPaginatedList);
+      jurySessionSerializer.serializeForPaginatedList.withArgs(jurySessionsForPaginatedList).returns(serializedJurySessionsForPaginatedList);
       requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(currentUserId);
 
       // when

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -629,7 +629,7 @@ describe('Unit | Controller | sessionController', () => {
 
     beforeEach(() => {
       sinon.stub(queryParamsUtils, 'extractParameters');
-      sinon.stub(sessionValidator, 'validateFilters');
+      sinon.stub(sessionValidator, 'validateAndNormalizeFilters');
       sinon.stub(jurySessionRepository, 'findPaginatedFiltered');
       sinon.stub(jurySessionSerializer, 'serializeForPaginatedList');
       sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
@@ -645,7 +645,7 @@ describe('Unit | Controller | sessionController', () => {
       const jurySessionsForPaginatedList = Symbol('jurySessionsForPaginatedList');
       const serializedJurySessionsForPaginatedList = Symbol('serializedJurySessionsForPaginatedList');
       queryParamsUtils.extractParameters.withArgs(request.query).returns({ filters, page });
-      sessionValidator.validateFilters.withArgs({ filter1: 'filter1ToTrim', filter2: 'filter2' })
+      sessionValidator.validateAndNormalizeFilters.withArgs({ filter1: 'filter1ToTrim', filter2: 'filter2' })
         .returns(normalizedFilters);
       jurySessionRepository.findPaginatedFiltered.withArgs({ filters: normalizedFilters, page, currentUserId })
         .resolves(jurySessionsForPaginatedList);

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -352,9 +352,36 @@ describe('Unit | Domain | Validators | session-validator', () => {
             expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: true })).to.not.throw;
             expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: false })).to.not.throw;
           });
+
+          it('should set certificationOfficerId with currentUserId', async () => {
+            // given
+            const filters = {
+              assignedToSelfOnly: true
+            };
+            const currentUserId = 5;
+
+            // when
+            const normalizedFilters = sessionValidator.validateAndNormalizeFilters(filters, currentUserId);
+
+            // then
+            expect(normalizedFilters.assignedCertificationOfficerId).to.equal(currentUserId);
+          });
         });
       });
 
+    });
+
+    it('should unset assignToSelfOnly in filters', () => {
+      // given
+      const filters = {
+        assignedToSelfOnly: true
+      };
+
+      // when
+      const normalizedFilters = sessionValidator.validateAndNormalizeFilters(filters, null);
+
+      // then
+      expect(normalizedFilters.assignedToSelfOnly).to.be.undefined;
     });
   });
 });

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -174,7 +174,6 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
         expect(typeof value.id).to.equal('number');
         expect(value.status).to.equal('finalized');
-        expect(value.certificationCenterName).to.be.undefined;
       });
     });
 
@@ -233,7 +232,9 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when certificationCenterName is a string', () => {
 
           it('should not throw an error', async () => {
-            expect(sessionValidator.validateFilters({ certificationCenterName: 'Coucou le dév qui lit ce message !' })).to.not.throw;
+            const certificationCenterName = '   Coucou le dév qui lit ce message !   ';
+            expect(sessionValidator.validateFilters({ certificationCenterName })).to.not.throw;
+            expect(sessionValidator.validateFilters({ certificationCenterName }).certificationCenterName).to.equal(certificationCenterName.trim());
           });
         });
       });
@@ -291,7 +292,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
       context('when resultsSentToPrescriberAt is in submitted filters', () => {
 
-        context('when resultsSentToPrescriberAt is not an string', () => {
+        context('when resultsSentToPrescriberAt is not a boolean', () => {
 
           it('should throw an error', async () => {
             const error = await catchErr(sessionValidator.validateFilters)({ resultsSentToPrescriberAt: 123 });
@@ -307,11 +308,49 @@ describe('Unit | Domain | Validators | session-validator', () => {
           });
         });
 
-        context('when resultsSentToPrescriberAt is string true or false', () => {
+        context('when resultsSentToPrescriberAt is a boolean', () => {
 
           it('should not throw an error', async () => {
-            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: 'true' })).to.not.throw;
-            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: 'false' })).to.not.throw;
+            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: true })).to.not.throw;
+            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: false })).to.not.throw;
+          });
+        });
+      });
+
+    });
+
+    context('when validating assignedToSelfOnly', () => {
+
+      context('when assignedToSelfOnly not in submitted filters', () => {
+
+        it('should not throw any error', () => {
+          expect(sessionValidator.validateFilters({})).to.not.throw;
+        });
+      });
+
+      context('when assignedToSelfOnly is in submitted filters', () => {
+
+        context('when assignedToSelfOnly is not an boolean', () => {
+
+          it('should throw an error', async () => {
+            const error = await catchErr(sessionValidator.validateFilters)({ assignedToSelfOnly: 'coucou' });
+            expect(error).to.be.instanceOf(EntityValidationError);
+          });
+        });
+
+        context('when assignedToSelfOnly is a boolean string', () => {
+
+          it('should throw an error', async () => {
+            expect(sessionValidator.validateFilters({ assignedToSelfOnly: 'true' })).to.not.throw;
+            expect(sessionValidator.validateFilters({ assignedToSelfOnly: 'false' })).to.not.throw;
+          });
+        });
+
+        context('when assignedToSelfOnly is a boolean', () => {
+
+          it('should not throw an error', async () => {
+            expect(sessionValidator.validateFilters({ assignedToSelfOnly: true })).to.not.throw;
+            expect(sessionValidator.validateFilters({ assignedToSelfOnly: false })).to.not.throw;
           });
         });
       });

--- a/api/tests/unit/domain/validations/session-validator_test.js
+++ b/api/tests/unit/domain/validations/session-validator_test.js
@@ -167,7 +167,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
     context('return value', () => {
 
       it('should return the filters in a normalized form', () => {
-        const value = sessionValidator.validateFilters({
+        const value = sessionValidator.validateAndNormalizeFilters({
           id: '123',
           status: 'finalized',
         });
@@ -182,7 +182,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
       context('when id not in submitted filters', () => {
 
         it('should not throw any error', () => {
-          expect(sessionValidator.validateFilters({})).to.not.throw;
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
         });
       });
 
@@ -191,7 +191,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when id is not an integer', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ id: 'salut' });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ id: 'salut' });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -199,11 +199,11 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when id is an integer', () => {
 
           it('accept a string containing an int', () => {
-            expect(sessionValidator.validateFilters({ id: '123' })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ id: '123' })).to.not.throw;
           });
 
           it('should not throw any error', () => {
-            expect(sessionValidator.validateFilters({ id: 123 })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ id: 123 })).to.not.throw;
           });
         });
       });
@@ -215,7 +215,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
       context('when certificationCenterName not in submitted filters', () => {
 
         it('should not throw any error', () => {
-          expect(sessionValidator.validateFilters({})).to.not.throw;
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
         });
       });
 
@@ -224,7 +224,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when certificationCenterName is not an string', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ certificationCenterName: 123 });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ certificationCenterName: 123 });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -233,8 +233,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
 
           it('should not throw an error', async () => {
             const certificationCenterName = '   Coucou le dév qui lit ce message !   ';
-            expect(sessionValidator.validateFilters({ certificationCenterName })).to.not.throw;
-            expect(sessionValidator.validateFilters({ certificationCenterName }).certificationCenterName).to.equal(certificationCenterName.trim());
+            expect(sessionValidator.validateAndNormalizeFilters({ certificationCenterName })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ certificationCenterName }).certificationCenterName).to.equal(certificationCenterName.trim());
           });
         });
       });
@@ -246,7 +246,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
       context('when status not in submitted filters', () => {
 
         it('should not throw any error', () => {
-          expect(sessionValidator.validateFilters({})).to.not.throw;
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
         });
       });
 
@@ -255,7 +255,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when status is not an string', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ status: 123 });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ status: 123 });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -263,7 +263,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when status is not in the statuses list', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ status: 'SomeOtherStatus' });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ status: 'SomeOtherStatus' });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -271,10 +271,10 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when status is in the statuses list', () => {
 
           it('should not throw an error', async () => {
-            expect(sessionValidator.validateFilters({ status: statuses.CREATED })).to.not.throw;
-            expect(sessionValidator.validateFilters({ status: statuses.FINALIZED })).to.not.throw;
-            expect(sessionValidator.validateFilters({ status: statuses.IN_PROCESS })).to.not.throw;
-            expect(sessionValidator.validateFilters({ status: statuses.PROCESSED })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.CREATED })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.FINALIZED })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.IN_PROCESS })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ status: statuses.PROCESSED })).to.not.throw;
           });
         });
       });
@@ -286,7 +286,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
       context('when resultsSentToPrescriberAt not in submitted filters', () => {
 
         it('should not throw any error', () => {
-          expect(sessionValidator.validateFilters({})).to.not.throw;
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
         });
       });
 
@@ -295,7 +295,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when resultsSentToPrescriberAt is not a boolean', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ resultsSentToPrescriberAt: 123 });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ resultsSentToPrescriberAt: 123 });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -303,7 +303,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when resultsSentToPrescriberAt is not in the resultsSentToPrescriberAt list', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ resultsSentToPrescriberAt: 'SomeOtherValue' });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ resultsSentToPrescriberAt: 'SomeOtherValue' });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -311,8 +311,8 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when resultsSentToPrescriberAt is a boolean', () => {
 
           it('should not throw an error', async () => {
-            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: true })).to.not.throw;
-            expect(sessionValidator.validateFilters({ resultsSentToPrescriberAt: false })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: true })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ resultsSentToPrescriberAt: false })).to.not.throw;
           });
         });
       });
@@ -324,7 +324,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
       context('when assignedToSelfOnly not in submitted filters', () => {
 
         it('should not throw any error', () => {
-          expect(sessionValidator.validateFilters({})).to.not.throw;
+          expect(sessionValidator.validateAndNormalizeFilters({})).to.not.throw;
         });
       });
 
@@ -333,7 +333,7 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when assignedToSelfOnly is not an boolean', () => {
 
           it('should throw an error', async () => {
-            const error = await catchErr(sessionValidator.validateFilters)({ assignedToSelfOnly: 'coucou' });
+            const error = await catchErr(sessionValidator.validateAndNormalizeFilters)({ assignedToSelfOnly: 'coucou' });
             expect(error).to.be.instanceOf(EntityValidationError);
           });
         });
@@ -341,16 +341,16 @@ describe('Unit | Domain | Validators | session-validator', () => {
         context('when assignedToSelfOnly is a boolean string', () => {
 
           it('should throw an error', async () => {
-            expect(sessionValidator.validateFilters({ assignedToSelfOnly: 'true' })).to.not.throw;
-            expect(sessionValidator.validateFilters({ assignedToSelfOnly: 'false' })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: 'true' })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: 'false' })).to.not.throw;
           });
         });
 
         context('when assignedToSelfOnly is a boolean', () => {
 
           it('should not throw an error', async () => {
-            expect(sessionValidator.validateFilters({ assignedToSelfOnly: true })).to.not.throw;
-            expect(sessionValidator.validateFilters({ assignedToSelfOnly: false })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: true })).to.not.throw;
+            expect(sessionValidator.validateAndNormalizeFilters({ assignedToSelfOnly: false })).to.not.throw;
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Le pôle certification a besoin de pouvoir connaître rapidement quelles sessions leurs sont assignées car cela correspond à leur travail à faire. 
_Exemple: si une (ou plusieurs) session est assignée à Mr.Dupont, ce dernier devrait pouvoir la voir rapidement afin de terminer son traitement. Or la liste des sessions actuelle ne permet pas cela, elle affiche la liste de toutes les sessions indépendamment de qui s'en occupe._

## :robot: Solution
Ajouter un toogle / boutton interrupteur permettant de n'afficher que les sessions assignées à l'utilisateur courant. 
<img width="460" alt="image" src="https://user-images.githubusercontent.com/38167520/82315025-f15bf300-99ca-11ea-8515-fb5ff17712cf.png">


## :rainbow: Remarques
Nouvel addon ember installé pour les boutons toogle : https://github.com/knownasilya/ember-toggle

## :100: Pour tester
- Aller sur PixAdmin
- Liste des sessions
- S'assigner quelques sessions (cliquer sur l'id de la session puis le bouton "M'assigner la session")
- Liste des sessions : trier par status "En cours de traitement"
- Activer et désactiver l'interrupteur "Afficher uniquement mes sessions" en haut à droite 
- Constater que cela affiche uniquement mes sessions ou celles de tous le monde selon l'activation du bouton ou non.

TODO : 
- [x] : validation Joi côté back pour l'id ?
- [x] : finir les tests fronts
- [x] : mettre le toogle au bon endroit (dans le tableau, hors tableau, quel affichage ? )
- [x] : tester / peaufiner
