### PR TITLE
[TECH] Ajouter les sourcemaps en développement

### DIFF
--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    babel: {
+      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+    },
     'ember-bootstrap': {
       'importBootstrapFont': false,
       'importBootstrapCSS': true,

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -6,7 +6,9 @@ const pluginsToBlacklist = environment === 'production' ? ['ember-freestyle'] : 
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
-    // Add options here
+    babel: {
+      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+    },
     'ember-cli-babel': {
       includePolyfill: true
     },

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
-    // Add options here
+    babel: {
+      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+    },
     'ember-cli-babel': {
       includePolyfill: true
     }

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -6,6 +6,9 @@ const pluginsToBlacklist = environment === 'production' ? ['ember-freestyle'] : 
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    babel: {
+      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+    },
     addons: {
       blacklist: pluginsToBlacklist
     },


### PR DESCRIPTION
## :unicorn: Problème
Les sourcemaps ne sont jamais générés ce qui rend le debugging ember compliqué

## :robot: Solution
Generer les sourcemaps en inline quand l'environnement est en mode "development"

## :rainbow: Remarques
- Les _sourcemaps_ sont en inline mais cela pourrait etre dans des fichiers séparés.
- La generation des _sourcemaps_ selon [la doc d'ember](https://cli.emberjs.com/release/advanced-use/asset-compilation/) ne fonctionne pas 


## :100: Pour tester
Lancer l'appli en dev, debugger/voir les sources depuis le browser
