### PR TITLE
[FEATURE] Tracer les modifications des appartenances aux organisations (PF-494).

### DIFF
--- a/api/db/migrations/20200515163806_add-column-createdat-updatedat-to-memberships.js
+++ b/api/db/migrations/20200515163806_add-column-createdat-updatedat-to-memberships.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'memberships';
+const CREATED_AT_COLUMN = 'createdAt';
+const UPDATED_AT_COLUMN = 'updatedAt';
+
+exports.up = async function(knex) {
+
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(CREATED_AT_COLUMN);
+    table.dateTime(UPDATED_AT_COLUMN);
+  });
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dateTime(CREATED_AT_COLUMN).defaultTo(knex.fn.now()).alter();
+    table.dateTime(UPDATED_AT_COLUMN).defaultTo(knex.fn.now()).alter();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(UPDATED_AT_COLUMN);
+    table.dropColumn(CREATED_AT_COLUMN);
+
+  });
+};
+

--- a/api/lib/infrastructure/data/membership.js
+++ b/api/lib/infrastructure/data/membership.js
@@ -6,6 +6,7 @@ require('./user');
 module.exports = Bookshelf.model('Membership', {
 
   tableName: 'memberships',
+  hasTimestamps: ['createdAt', 'updatedAt'],
 
   user() {
     return this.belongsTo('User', 'userId');


### PR DESCRIPTION
## :unicorn: Problème
Le support Pix souhaite savoir quand un utilisateur:
* a été rattaché à une organisation (création d'une appartenance)
* a vu son rôle sur l'organisation modifié (modification d'une appartenance)

Il doit pouvoir distinguer les cas où les données existaient avant la mise de cette fonctionnalité.
Le support modifie parfois ces données via une invite SQL.
## :robot: Solution
Ajout de deux propriétés d'audit:
* createdAt: création
* upadtedAt: modification

Alimentation de ces champs:
* via l'application, par un modèle Bookshelf paramétré avec ces propriétés
* pour les données existantes, avec la date [Unix epoch (01/01/1970)](https://en.wikipedia.org/wiki/Unix_time)
* pour les données manipulées via une invite SQL, avec une valeur par défaut, l'horodatage du jour

## :rainbow: Remarques
En cas de mise à jour de données via une invite SQL, la champ updatedAt ne sera pas mis à jour. 
Il est de la responsabilité du support de l'alimenter manuellement.
Cela pourrait être fait par un trigger, mais cette solution pose plus de problème qu'elle n'en résoud.

De plus, il aurait été possible de mettre à jour les données existantes avec un update, dans une migration séparée de l'ajout de de colonne. La solution choisie effectue les deux actions en même temps.
## :100: Pour tester
Se connecter à [PixOrga](https://orga-pr1437.review.pix.fr/) - avec le compte sco@example.net  / pix123 et 
- rattacher un utilisateur, vérifier que les deux champs sont en horodatage courant
- changer le rôle d'un utilisateur, vérifier que seul le champ updatedAt est à l'horodatage courant

Se connecter via une invite SQL:
-  insérer un enregistrement, vérifier que les deux champs sont en horodatage courant