### PR TITLE
[BUGFIX] Rétablissement du loader quand on lance une évaluation (PIX-653).

### DIFF
--- a/mon-pix/app/templates/assessments/loading.hbs
+++ b/mon-pix/app/templates/assessments/loading.hbs
@@ -1,0 +1,1 @@
+<Loader @loaderText="En cours de chargement…" />

--- a/mon-pix/app/templates/assessments/results-loading.hbs
+++ b/mon-pix/app/templates/assessments/results-loading.hbs
@@ -1,4 +1,1 @@
-<div class="app-loader">
-  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
-  <p class="app-loader__text">Préparation de vos résultats...</p>
-</div>
+<Loader @loaderText="Préparation de vos résultats…" />

--- a/mon-pix/app/templates/assessments/resume-loading.hbs
+++ b/mon-pix/app/templates/assessments/resume-loading.hbs
@@ -1,4 +1,1 @@
-<div class="app-loader">
-  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
-  <p class="app-loader__text">Votre test est en cours de chargement…</p>
-</div>
+<Loader @loaderText="Votre test est en cours de chargement…" />

--- a/mon-pix/app/templates/campaigns/loading.hbs
+++ b/mon-pix/app/templates/campaigns/loading.hbs
@@ -1,6 +1,1 @@
-<div class="app-loader">
-  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
-  <p class="app-loader__text">
-    En cours de chargement…
-  </p>
-</div>
+<Loader @loaderText="En cours de chargement…" />

--- a/mon-pix/app/templates/components/loader.hbs
+++ b/mon-pix/app/templates/components/loader.hbs
@@ -1,0 +1,4 @@
+<div class="app-loader">
+  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+  <p class="app-loader__text">{{@loaderText}}</p>
+</div>


### PR DESCRIPTION
## :unicorn: Problème
Si ma connexion est lente et qu'on lance une évaluation par compétence, on a un écran blanc sans l'affichage du chargement.

## :robot: Solution
Le souci est causé par l'utilisation des hooks `redirect` en lieu et place de `beforeModel`.
En ajoutant un fichier `loading.js` à la racine du répertoire `assessment`, le loader est affiché.

## :rainbow: Remarques
On profite de toucher au chargement pour créer un composant `Loader`.

## :100: Pour tester
Avec les devtools, limiter la vitesse de connexion.
Lancer une évaluation par compétence.
Vérifier que le loader est affiché.