### PR TITLE
[BUGFIX] L'ordre de tri sur la liste paginée des sessions sur PixAdmin n'est pas déterministe (PIX-728)

### DIFF
--- a/api/lib/infrastructure/repositories/jury-session-repository.js
+++ b/api/lib/infrastructure/repositories/jury-session-repository.js
@@ -34,6 +34,7 @@ module.exports = {
     _setupFilters(query, filters);
     query.orderByRaw('?? ASC NULLS FIRST', 'publishedAt')
       .orderByRaw('?? ASC', 'finalizedAt')
+      .orderBy('id')
       .select('sessions.*', 'certification-centers.type', 'users.firstName', 'users.lastName')
       .select(Bookshelf.knex.raw('COUNT(*) OVER() AS ??', ['rowCount']))
       .leftJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')


### PR DESCRIPTION
## :unicorn: Contexte
La récupération paginée des sessions de certification dans un contexte de traitement des certifications présente un tri obligatoire (vu que le tri à la mano n'est pas disponible).
Le tri en vigueur actuellement est le suivant :
```
query.orderByRaw('?? ASC NULLS FIRST', 'publishedAt')
      .orderByRaw('?? ASC', 'finalizedAt')
```
A savoir d'abord les sessions non publiées, puis de la plus anciennement publiée à la plus récemment publiée. Puis, en cas "d'égalité" au niveau de la publication (particulièrement dans le cas où `publishedAt` est NULL), on tri selon la date de finalisation, de la plus anciennement finalisée à la plus récemment finalisée. Ce stratagème permet de faire d'abord remonter les sessions finalisées mais non publiées. En effet, le statut d'une session se déduit à travers l'interprétation de ses colonnes (divers timestamps + assignedCertificationOfficerId).
Lors de l'introduction de la colonne `finalizedAt`, il a été décidé, pour ajouter de la cohérence dans les statuts des anciennes sessions, on a décidé de mettre une "fausse" date de finalisation pour les sessions pour lesquelles nous sommes sûrs qu'elles sont finalisées, mais qui n'ont pas eu la chance de passer par le tunnel de finalisation existant aujourd'hui, qui lui va venir justement timestamper la finalisation de la session.
La date inscrite dans cette colonne est la date d'exécution du script qui a permis la mise à jour de ces sessions.

## :pizza: Problème
Puisqu'il existe potentiellement des centaines de sessions avec la même date de finalisation (à la seconde près!), le tri n'est plus déterministe. Et même, dans la cas de pure coïncidence où deux personnes finalisent leur session à la même seconde (hautement improbable, mais bon à chaque fois qu'on dit ça se produit !), alors les exécutions successives de la requête pour obtenir la liste des sessions ne retournent pas les mêmes résultats.
Il manque une clause de tri qui permet, en dernière instance, de garantir l'ordre de résultat obtenu.

## :robot: Solution
On ajoute une clause de tri, la plus déterministe possible :
```
query.orderByRaw('?? ASC NULLS FIRST', 'publishedAt')
      .orderByRaw('?? ASC', 'finalizedAt')
      .orderBy('id')
```

## :rainbow: Remarques

## :100: Pour tester
Dur à tester avec les données actuellement présentes dans les seeds. Ce bug a été identifié en navigant sur une instance PixAdmin branchée sur la base de réplication.
On peut toujours tester la non-régression de la liste des sessions dans PixAdmin, mais je prends en charge le fait de tester avec des données qui ont révélées ce bug.
