### PR TITLE
[FEATURE] Résultats collectifs prenant en compte les nouvelles compétences de Pix + (PIX-673)

### DIFF
--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -184,7 +184,8 @@ describe('Acceptance | API | Campaign Controller', () => {
       const competence1 = airtableBuilder.factory.buildCompetence({
         id: 'recCompetence1',
         titre: 'Fabriquer un meuble',
-        domaineIds: [area.id]
+        domaineIds: [area.id],
+        acquisViaTubes: ['recSkillId1','recSkillId2']
       });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([
         airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: ['recCompetence1'] }),


### PR DESCRIPTION
## :unicorn: Problème
Des acquis vont changer de compétences et vont passer d'une compétence PIX à une compétence PIX + (international).

Ce qui va provoquer des erreurs côté calcul des résultats collectifs :
> Un prescrit envoi ses résultats avec l'acquis dans une compétence PIX.
> Un nouveau prescrit envoi ses résultats mais cette fois-ci l'acquis à changer de compétence pour être lié à une compétence Pix+. Même si il a eu 100% juste, le pourcentage de la nouvelle compétence ne sera pas 100% car elle n'aura pas été testée par les autres. 

Le problème vient du fait que les résultats collectifs sont calculés à partir du `competenceId` porté par les knowledge element. Ce compétence id peut ne plus correspondre à l'acqui associé avec les nouvelles compétences. 

## :robot: Solution
Il faut utiliser la liste des compétences actuelle (récupérée à partir de AirTable) pour en déduire la compétence d'un knowledge element (par rapport à son acqui).

## :100: Pour tester
**AVANT cette PR:**
Pour voir le comportement avant cette PR, vous pouvez vous connecter sur la RA de la PR https://orga-pr1349.review.pix.fr/campagnes/10000000/resultats-collectifs
- Avec le compte `pro@example.net`
- On constate que dans les résultats collectifs l'acquis "Droit" est à 33% au lieu de 100% (alors que tous les résultats individuels sont à 100%.

**APRÈS cette PR:**
Connectez sur la RA de la PR https://orga-pr1441.review.pix.fr/campagnes/10000000/resultats-collectifs
- Avec le compte `pro@example.net`
- On constate que dans les résultats collectifs l'acquis "Droit" sont bien à 100% maintenant.
