### PR TITLE
[FEATURE] Afficher le bon lien vers les CGU sur .org et .fr (PIX-683).

### DIFF
--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -32,6 +32,10 @@ export default Component.extend({
     return this.url.homeUrl;
   },
 
+  get cguUrl() {
+    return this.url.cguUrl;
+  },
+
   _getErrorMessage(status, key) {
     return (status === 'error') ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
   },

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -16,4 +16,8 @@ export default class Url extends Service {
     const homeUrl = `https://pix.${this.currentDomain.getExtension()}`;
     return this.definedHomeUrl || homeUrl;
   }
+
+  get cguUrl() {
+    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+  }
 }

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -69,7 +69,7 @@
       <label for="pix-cgu" class="signup-form__cgu-label">
         <div class="signup-form__cgu">
           <Input @type="checkbox" @id="pix-cgu" @checked={{user.cgu}} />
-           {{t 'signup-form.fields.cgu.label' htmlSafe=true}}
+           {{t 'signup-form.fields.cgu.label' cguUrl=cguUrl htmlSafe=true}}
         </div>
 
         {{#if user.errors.cgu}}

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -74,4 +74,21 @@ describe('Unit | Service | locale', function() {
 
   });
 
+  describe('#cguUrl', function() {
+
+    it('should get "pix.fr" url when current domain contains pix.fr', function() {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      expect(cguUrl).to.equal(expectedCguUrl);
+    });
+
+  });
+
 });

--- a/mon-pix/translations/en-us.json
+++ b/mon-pix/translations/en-us.json
@@ -49,7 +49,7 @@
     "fields": {
       "cgu": {
         "error": "Please accept terms of service before you sign up",
-        "label": "I accept <a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">Pix's CGU</a>"
+        "label": "<abbr title=\"mandatory\">*</abbr> I accept <a href=\"{cguUrl}\" class=\"link\" target=\"_blank\">Pix's CGU</a>"
       },
       "email": {
         "error": "Your email is invalid",

--- a/mon-pix/translations/fr-fr.json
+++ b/mon-pix/translations/fr-fr.json
@@ -49,7 +49,7 @@
     "fields": {
       "cgu": {
         "error": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
-        "label": "<abbr title=\"obligatoire\">*</abbr> J'accepte les <a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">conditions d'utilisation de Pix</a>"
+        "label": "<abbr title=\"obligatoire\">*</abbr> J'accepte les <a href=\"{cguUrl}\" class=\"link\" target=\"_blank\">conditions d'utilisation de Pix</a>"
       },
       "email": {
         "error": "Votre adresse e-mail n’est pas valide.",


### PR DESCRIPTION
## :unicorn: Problème
Le lien vers les CGU était en dur vers pix.fr

## :robot: Solution
Utiliser le service url pour récupérer le bon host et injecter le bon lien dans le template.

## :rainbow: Remarques
On utilise le templating des traductions :
https://ember-intl.github.io/ember-intl/versions/master/docs/helpers/t

## :100: Pour tester
Sur .fr on veut un lien vers pix.fr/conditions-generales-d-utilisation, sur .org, pix.org/conditions-generales-d-utilisation