### PR TITLE
[FEATURE] Permettre la modification du rôle d'un membership dans Pix Admin (PIX-455).

### DIFF
--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -53,8 +53,12 @@
   </header>
   <div class="member-list">
     <ModelsTable @data={{@organization.memberships}}
-                 @columns={{this.columns}}
-                 @showColumnsDropdown={{false}}
-                 @showGlobalFilter={{false}} />
+      @columns={{this.columns}}
+      @showColumnsDropdown={{false}}
+      @showGlobalFilter={{false}}
+      @columnComponents={{hash editRow=(component 'models-table/cell-edit-toggle'
+        editButtonLabel='Editer' cancelButtonLabel='Annuler' saveButtonLabel='Enregistrer'
+        saveRowAction=this.onSaveRow cancelRowAction=this.onCancelRow)}}
+    />
   </div>
 </section>

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class OrganizationMembersSection extends Component {
 
@@ -7,22 +8,43 @@ export default class OrganizationMembersSection extends Component {
       propertyName: 'id',
       title: 'Numéro du membre',
       disableFiltering: true,
+      editable: false,
     },
     {
       propertyName: 'user.firstName',
       title: 'Prénom',
+      editable: false,
     },
     {
       propertyName: 'user.lastName',
       title: 'Nom',
+      editable: false,
     },
     {
       propertyName: 'user.email',
       title: 'Courriel',
+      editable: false,
     },
     {
       propertyName: 'displayedOrganizationRole',
       title: 'Rôle',
+      componentForEdit: 'role-edit',
+    },
+    {
+      title: 'Action',
+      component: 'editRow',
+      editable: false,
     },
   ];
+
+  @action
+  onSaveRow({ record }) {
+    return record.save();
+  }
+
+  @action
+  onCancelRow({ record }) {
+    record.rollbackAttributes();
+    return true;
+  }
 }

--- a/admin/app/components/role-edit.hbs
+++ b/admin/app/components/role-edit.hbs
@@ -1,0 +1,7 @@
+<PowerSelect
+  @options={{this.options}}
+  @selected={{this.selectedRole}}
+  @onchange={{this.changeRole}} as |role|
+>
+  {{role.label}}
+</PowerSelect>

--- a/admin/app/components/role-edit.js
+++ b/admin/app/components/role-edit.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class RoleEdit extends Component {
+
+  options = [
+    { value: 'ADMIN', label: 'Administrateur' },
+    { value: 'MEMBER', label: 'Membre' }
+  ];
+
+  @tracked selectedRole;
+
+  constructor() {
+    super(...arguments);
+    this._updateSelectedRole();
+  }
+
+  @action
+  changeRole(role) {
+    this.args.record.organizationRole = role.value;
+    this._updateSelectedRole();
+  }
+
+  _updateSelectedRole() {
+    this.selectedRole = this.options.find((opt) => opt.value === this.args.record.organizationRole);
+  }
+}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -47,4 +47,13 @@ export default function() {
 
     return schema.organizationInvitations.where({ email });
   });
+
+  this.patch('/memberships/:id', (schema, request) => {
+    const membershipId = request.params.id;
+    const params = JSON.parse(request.requestBody);
+    const organizationRole = params.data.attributes.organizationRole;
+
+    const membership = schema.memberships.findBy({ id: membershipId });
+    return membership.update({ organizationRole });
+  });
 }

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -42,9 +42,9 @@ module('Acceptance | organization memberships management', function(hooks) {
 
       // then
       assert.equal(this.element.querySelectorAll('div.member-list table > tbody > tr').length, 3);
-      assert.dom('div.member-list').includesText('Alice');
-      assert.dom('div.member-list').includesText('Bob');
-      assert.dom('div.member-list').includesText('Charlie');
+      assert.contains('Alice');
+      assert.contains('Bob');
+      assert.contains('Charlie');
     });
 
     test('should display the correct user data', async function(assert) {
@@ -57,19 +57,21 @@ module('Acceptance | organization memberships management', function(hooks) {
       await visit(`/organizations/${organization.id}`);
 
       // then
-      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 10);
+      assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 12);
 
-      assert.dom('div.member-list table > thead').includesText('Numéro du membre');
-      assert.dom('div.member-list table > thead').includesText('Prénom');
-      assert.dom('div.member-list table > thead').includesText('Nom');
-      assert.dom('div.member-list table > thead').includesText('Courriel');
-      assert.dom('div.member-list table > thead').includesText('Rôle');
+      assert.contains('Numéro du membre');
+      assert.contains('Prénom');
+      assert.contains('Nom');
+      assert.contains('Courriel');
+      assert.contains('Rôle');
+      assert.contains('Action');
 
-      assert.dom('div.member-list table > tbody').includesText(user.id);
-      assert.dom('div.member-list table > tbody').includesText('Denise');
-      assert.dom('div.member-list table > tbody').includesText('Ter Hegg');
-      assert.dom('div.member-list table > tbody').includesText('denise@example.com');
-      assert.dom('div.member-list table > tbody').includesText('Administrateur');
+      assert.contains(user.id);
+      assert.contains('Denise');
+      assert.contains('Ter Hegg');
+      assert.contains('denise@example.com');
+      assert.contains('Administrateur');
+      assert.contains('Editer');
     });
 
     test('should display the correct user data when the user is a MEMBER', async function(assert) {
@@ -82,7 +84,31 @@ module('Acceptance | organization memberships management', function(hooks) {
       await visit(`/organizations/${organization.id}`);
 
       // then
-      assert.dom('div.member-list table > tbody').includesText('Membre');
+      assert.contains('Membre');
+    });
+
+    module('modifying member\'s role', async function() {
+
+      test('should modify member\'s role', async function(assert) {
+        // given
+        const organization = this.server.create('organization');
+        const user = this.server.create('user', { firstName: 'Denise', lastName: 'Ter Hegg', email: 'denise@example.com' });
+        this.server.create('membership', { user, organization, organizationRole: 'MEMBER' });
+
+        // when
+        await visit(`/organizations/${organization.id}`);
+
+        const organizationRoleCell = 'div.member-list table > tbody > tr > td:nth-child(5)';
+        const actionCell = 'div.member-list table > tbody > tr > td:nth-child(6)';
+
+        await click(`${actionCell} > div > button`);
+        await click(`${organizationRoleCell} > div.ember-power-select-trigger`);
+        await click('.ember-power-select-option:nth-child(1)');
+        await click(`${actionCell} > div > button:nth-child(2)`);
+
+        // then
+        assert.contains('Administrateur');
+      });
     });
   });
 
@@ -99,9 +125,9 @@ module('Acceptance | organization memberships management', function(hooks) {
       await click('[aria-label="Ajouter un membre"] button');
 
       // then
-      assert.dom('div.member-list').includesText('John');
-      assert.dom('div.member-list').includesText('Doe');
-      assert.dom('div.member-list').includesText('user@example.com');
+      assert.contains('John');
+      assert.contains('Doe');
+      assert.contains('user@example.com');
       assert.dom('#userEmailToAdd').hasNoValue();
     });
 
@@ -118,7 +144,7 @@ module('Acceptance | organization memberships management', function(hooks) {
 
       // then
       assert.equal(this.element.querySelectorAll('div.member-list table > tbody > tr').length, 1);
-      assert.dom('div.member-list').includesText('Denise');
+      assert.contains('Denise');
       assert.dom('#userEmailToAdd').hasValue('denise@example.com');
     });
 
@@ -135,7 +161,7 @@ module('Acceptance | organization memberships management', function(hooks) {
 
       // then
       assert.equal(this.element.querySelectorAll('div.member-list table > tbody > tr').length, 1);
-      assert.dom('div.member-list').includesText('Erica');
+      assert.contains('Erica');
       assert.dom('#userEmailToAdd').hasValue('unexisting@example.com');
     });
   });
@@ -154,7 +180,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       await click('[aria-label="Inviter un membre"] button');
 
       // then
-      assert.dom('.c-notification__content:last-child').includesText('Un email a bien a été envoyé à l\'adresse user@example.com.');
+      assert.contains('Un email a bien a été envoyé à l\'adresse user@example.com.');
       assert.dom('#userEmailToInvite').hasNoValue();
     });
 
@@ -171,7 +197,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       await click('[aria-label="Inviter un membre"] button');
 
       // then
-      assert.dom('.c-notification__content:last-child').includesText('Une erreur s’est produite, veuillez réessayer.');
+      assert.contains('Une erreur s’est produite, veuillez réessayer.');
     });
   });
 });

--- a/admin/tests/helpers/contains.js
+++ b/admin/tests/helpers/contains.js
@@ -1,0 +1,48 @@
+import { getRootElement } from '@ember/test-helpers';
+
+function getChildrenThatContainsText(element, text) {
+  if (element.textContent.trim() === text) {
+    return element;
+  }
+
+  if (element.children.length === 0) {
+    return null;
+  }
+
+  return [...element.children]
+    .map((child) => {
+      return getChildrenThatContainsText(child, text);
+    })
+    .filter(Boolean)
+    .flatMap((v) => v);
+}
+
+export function contains(text) {
+  const elements = getChildrenThatContainsText(getRootElement(), text);
+  const result = elements.length > 0;
+
+  let message = `There is no elements with "${ text }"`;
+  if (result) {
+    message = `Element with "${ text }" found`;
+  }
+
+  this.pushResult({
+    result,
+    message
+  });
+}
+
+export function notContains(text) {
+  const elements = getChildrenThatContainsText(getRootElement(), text);
+  const result = elements.length === 0;
+
+  let message = `Element with "${ text }" found`;
+  if (result) {
+    message = `There is no elements with "${ text }"`;
+  }
+
+  this.pushResult({
+    result,
+    message
+  });
+}

--- a/admin/tests/helpers/test-init.js
+++ b/admin/tests/helpers/test-init.js
@@ -1,4 +1,9 @@
+import QUnit from 'qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { contains, notContains } from './contains';
+
+QUnit.assert.contains = contains;
+QUnit.assert.notContains = notContains;
 
 export async function createAuthenticateSession({ userId }) {
   return authenticateSession({

--- a/admin/tests/integration/components/routes/role-edit-test.js
+++ b/admin/tests/integration/components/routes/role-edit-test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | role-edit', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should set selected value', async function(assert) {
+    // given
+    const record = { organizationRole: 'ADMIN' };
+    this.set('record', record);
+
+    // when
+    await render(hbs`<RoleEdit @record={{this.record}} />`);
+
+    // then
+    assert.dom('.ember-power-select-selected-item').hasText('Administrateur');
+  });
+
+  test('it should display the options when select is open', async function(assert) {
+    // given
+    const record = { organizationRole: 'ADMIN' };
+    this.set('record', record);
+
+    // when
+    await render(hbs`<RoleEdit @record={{this.record}} />`);
+    await click('.ember-power-select-trigger');
+
+    // then
+    assert.dom('.ember-power-select-option:nth-child(1)').hasText('Administrateur');
+    assert.dom('.ember-power-select-option:nth-child(2)').hasText('Membre');
+  });
+
+  test('it should update selected value when another option is selected', async function(assert) {
+    // given
+    const record = { organizationRole: 'ADMIN' };
+    this.set('record', record);
+
+    // when
+    await render(hbs`<RoleEdit @record={{this.record}} />`);
+    await click('.ember-power-select-trigger');
+    await click('.ember-power-select-option:nth-child(2)');
+
+    // then
+    assert.dom('.ember-power-select-selected-item').hasText('Membre');
+  });
+});

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -30,13 +30,13 @@ exports.register = async function(server) {
       path: '/api/memberships/{id}',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserIsAdminInOrganization,
-          assign: 'isAdminInOrganization'
+          method: securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster,
+          assign: 'isAdminInOrganizationOrHasRolePixMaster'
         }],
         handler: membershipController.update,
         description: 'Update organization role by admin for a organization members',
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation**\n' +
+          '- **Cette route est restreinte aux utilisateurs authentifiés en tant qu\'administrateur de l\'organisation ou ayant le rôle Pix Master**\n' +
           '- Elle permet de modifier le rôle d\'un membre de l\'organisation'
         ],
         plugins: {

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -129,7 +129,8 @@ async function checkUserIsAdminInOrganizationOrHasRolePixMaster(request, h) {
   }
 
   const userId = request.auth.credentials.userId;
-  const organizationId = parseInt(request.params.id);
+  //organizationId can be retrieved from path param in case organizations/id/invitations api or from memberships payload in case memberships/id
+  const organizationId = (request.path && request.path.includes('memberships')) ?  request.payload.data.relationships.organization.data.id : parseInt(request.params.id) ;
 
   const isAdminInOrganization = await checkUserIsAdminInOrganizationUseCase.execute(userId, organizationId);
   if (isAdminInOrganization) {

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -12,7 +12,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
     sinon.stub(usecases, 'createMembership');
     sinon.stub(usecases, 'updateMembershipRole');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
@@ -97,7 +97,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
           organizationRole: Membership.roles.MEMBER
         });
         usecases.updateMembershipRole.resolves(membership);
-        securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => h.response(true));
+        securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
       });
 
       it('should return a 200 HTTP response', async () => {
@@ -114,7 +114,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
       context('when user is not allowed to access resource', () => {
 
         beforeEach(() => {
-          securityPreHandlers.checkUserIsAdminInOrganization.callsFake((request, h) => {
+          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
         });


### PR DESCRIPTION
## :unicorn: Problème
Bien qu'il soit possible pour nos utilisateurs qui sont administrateur d'une organisation de modifier les rôles des membres de cette organisation dans Pix Orga, il arrive parfois que cet administrateur ne fasse plus partie de l'organisation. 

## :robot: Solution
Permettre de modifier le rôle des membres d'une organisation dans PixAdmin.

## :rainbow: Remarques
Nous utilisons le composant ember-models-table pour afficher le tableau des memberships. Il a donc été nécessaire d'ajouter un composant afin de permettre d'afficher un select plutôt qu'un input dans la cellule du tableau.
