### PR TITLE
[BUGFIX] Vérifier le seuil des 75% CléA sur le score certifié par compétence (et non positionné) (PIX-680)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -51,7 +51,8 @@ export default class CertificationDetailsController extends Controller {
       marks: this.get('details.competences').reduce((marks, competence) => {
         marks[competence.index] = {
           level: (competence.juryLevel === false) ? competence.obtainedLevel : competence.juryLevel,
-          score: (competence.juryScore === false) ? competence.obtainedScore : competence.juryScore
+          score: (competence.juryScore === false) ? competence.obtainedScore : competence.juryScore,
+          competenceId: competence.id,
         };
         return marks;
       }, {})

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -168,7 +168,8 @@ export default class CertificationInformationsController extends Controller {
           'competence-code': code,
           'level': mark.level,
           'score': mark.score,
-          'area-code': code.substr(0, 1)
+          'area-code': code.substr(0, 1),
+          'competence-id': mark.competenceId,
         });
         return competences;
       }, A());

--- a/api/db/migrations/20200522090553_add-competenceId-column-competence-marks-table.js
+++ b/api/db/migrations/20200522090553_add-competenceId-column-competence-marks-table.js
@@ -1,0 +1,55 @@
+const TABLE_NAME = 'competence-marks';
+const COLUMN_NAME = 'competenceId';
+
+exports.up = async function(knex) {
+  await knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+  return knex.raw(`
+  UPDATE ?? SET ?? = CASE ??
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  WHEN ? THEN ?
+  ELSE NULL END
+  `,
+  [
+    TABLE_NAME,
+    COLUMN_NAME,
+    'competence_code',
+    '1.1', 'recsvLz0W2ShyfD63',
+    '1.2', 'recIkYm646lrGvLNT',
+    '1.3', 'recNv8qhaY887jQb2',
+    '2.1', 'recDH19F7kKrfL3Ii',
+    '2.2', 'recgxqQfz3BqEbtzh',
+    '2.3', 'recMiZPNl7V1hyE1d',
+    '2.4', 'recFpYXCKcyhLI3Nu',
+    '3.1', 'recOdC9UDVJbAXHAm',
+    '3.2', 'recbDTF8KwupqkeZ6',
+    '3.3', 'recHmIWG6D0huq6Kx',
+    '3.4', 'rece6jYwH4WEw549z',
+    '4.1', 'rec6rHqas39zvLZep',
+    '4.2', 'recofJCxg0NqTqTdP',
+    '4.3', 'recfr0ax8XrfvJ3ER',
+    '5.1', 'recIhdrmCuEmCDAzj',
+    '5.2', 'recudHE5Omrr10qrx',
+  ]);
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/certification/certification-data.js
+++ b/api/db/seeds/data/certification/certification-data.js
@@ -802,41 +802,41 @@ const CERTIFICATION_FAILURE_ANSWERS_DATA = [
 ];
 
 const CERTIFICATION_SUCCESS_COMPETENCE_MARKS_DATA = [
-  { level: 4, score: 39, area_code: '5', competence_code: '5.2' },
-  { level: 5, score: 40, area_code: '5', competence_code: '5.1' },
-  { level: 5, score: 40, area_code: '4', competence_code: '4.3' },
-  { level: -1, score: 0, area_code: '4', competence_code: '4.2' },
-  { level: 5, score: 40, area_code: '4', competence_code: '4.1' },
-  { level: 2, score: 17, area_code: '3', competence_code: '3.4' },
-  { level: 5, score: 40, area_code: '3', competence_code: '3.3' },
-  { level: -1, score: 0, area_code: '3', competence_code: '3.2' },
-  { level: 5, score: 40, area_code: '3', competence_code: '3.1' },
-  { level: 5, score: 40, area_code: '2', competence_code: '2.1' },
-  { level: 4, score: 36, area_code: '2', competence_code: '2.4' },
-  { level: 5, score: 40, area_code: '2', competence_code: '2.3' },
-  { level: 3, score: 26, area_code: '2', competence_code: '2.2' },
-  { level: 5, score: 40, area_code: '1', competence_code: '1.3' },
-  { level: 5, score: 40, area_code: '1', competence_code: '1.2' },
-  { level: 5, score: 40, area_code: '1', competence_code: '1.1' }
+  { level: 4, score: 39, area_code: '5', competence_code: '5.2', competenceId: 'recudHE5Omrr10qrx' },
+  { level: 5, score: 40, area_code: '5', competence_code: '5.1', competenceId: 'recIhdrmCuEmCDAzj' },
+  { level: 5, score: 40, area_code: '4', competence_code: '4.3', competenceId: 'recfr0ax8XrfvJ3ER' },
+  { level: -1, score: 0, area_code: '4', competence_code: '4.2', competenceId: 'recofJCxg0NqTqTdP' },
+  { level: 5, score: 40, area_code: '4', competence_code: '4.1', competenceId: 'rec6rHqas39zvLZep' },
+  { level: 2, score: 17, area_code: '3', competence_code: '3.4', competenceId: 'rece6jYwH4WEw549z' },
+  { level: 5, score: 40, area_code: '3', competence_code: '3.3', competenceId: 'recHmIWG6D0huq6Kx' },
+  { level: -1, score: 0, area_code: '3', competence_code: '3.2', competenceId: 'recbDTF8KwupqkeZ6' },
+  { level: 5, score: 40, area_code: '3', competence_code: '3.1', competenceId: 'recOdC9UDVJbAXHAm' },
+  { level: 5, score: 40, area_code: '2', competence_code: '2.1', competenceId: 'recDH19F7kKrfL3Ii' },
+  { level: 4, score: 36, area_code: '2', competence_code: '2.4', competenceId: 'recFpYXCKcyhLI3Nu' },
+  { level: 5, score: 40, area_code: '2', competence_code: '2.3', competenceId: 'recMiZPNl7V1hyE1d' },
+  { level: 3, score: 26, area_code: '2', competence_code: '2.2', competenceId: 'recgxqQfz3BqEbtzh' },
+  { level: 5, score: 40, area_code: '1', competence_code: '1.3', competenceId: 'recNv8qhaY887jQb2' },
+  { level: 5, score: 40, area_code: '1', competence_code: '1.2', competenceId: 'recIkYm646lrGvLNT' },
+  { level: 5, score: 40, area_code: '1', competence_code: '1.1', competenceId: 'recsvLz0W2ShyfD63' }
 ];
 
 const CERTIFICATION_FAILURE_COMPETENCE_MARKS_DATA = [
-  { level: -1, score: 0, area_code: '5', competence_code: '5.2' },
-  { level: -1, score: 0, area_code: '5', competence_code: '5.1' },
-  { level: -1, score: 0, area_code: '4', competence_code: '4.3' },
-  { level: -1, score: 0, area_code: '4', competence_code: '4.2' },
-  { level: -1, score: 0, area_code: '4', competence_code: '4.1' },
-  { level: -1, score: 0, area_code: '3', competence_code: '3.4' },
-  { level: -1, score: 0, area_code: '3', competence_code: '3.3' },
-  { level: -1, score: 0, area_code: '3', competence_code: '3.2' },
-  { level: -1, score: 0, area_code: '3', competence_code: '3.1' },
-  { level: -1, score: 0, area_code: '2', competence_code: '2.4' },
-  { level: -1, score: 0, area_code: '2', competence_code: '2.3' },
-  { level: -1, score: 0, area_code: '2', competence_code: '2.2' },
-  { level: -1, score: 0, area_code: '2', competence_code: '2.1' },
-  { level: -1, score: 0, area_code: '1', competence_code: '1.2' },
-  { level: -1, score: 0, area_code: '1', competence_code: '1.3' },
-  { level: -1, score: 0, area_code: '1', competence_code: '1.1' }
+  { level: -1, score: 0, area_code: '5', competence_code: '5.2', competenceId: 'recudHE5Omrr10qrx' },
+  { level: -1, score: 0, area_code: '5', competence_code: '5.1', competenceId: 'recIhdrmCuEmCDAzj' },
+  { level: -1, score: 0, area_code: '4', competence_code: '4.3', competenceId: 'recfr0ax8XrfvJ3ER' },
+  { level: -1, score: 0, area_code: '4', competence_code: '4.2', competenceId: 'recofJCxg0NqTqTdP' },
+  { level: -1, score: 0, area_code: '4', competence_code: '4.1', competenceId: 'rec6rHqas39zvLZep' },
+  { level: -1, score: 0, area_code: '3', competence_code: '3.4', competenceId: 'rece6jYwH4WEw549z' },
+  { level: -1, score: 0, area_code: '3', competence_code: '3.3', competenceId: 'recHmIWG6D0huq6Kx' },
+  { level: -1, score: 0, area_code: '3', competence_code: '3.2', competenceId: 'recbDTF8KwupqkeZ6' },
+  { level: -1, score: 0, area_code: '3', competence_code: '3.1', competenceId: 'recOdC9UDVJbAXHAm' },
+  { level: -1, score: 0, area_code: '2', competence_code: '2.4', competenceId: 'recFpYXCKcyhLI3Nu' },
+  { level: -1, score: 0, area_code: '2', competence_code: '2.3', competenceId: 'recMiZPNl7V1hyE1d' },
+  { level: -1, score: 0, area_code: '2', competence_code: '2.2', competenceId: 'recgxqQfz3BqEbtzh' },
+  { level: -1, score: 0, area_code: '2', competence_code: '2.1', competenceId: 'recDH19F7kKrfL3Ii' },
+  { level: -1, score: 0, area_code: '1', competence_code: '1.2', competenceId: 'recNv8qhaY887jQb2' },
+  { level: -1, score: 0, area_code: '1', competence_code: '1.3', competenceId: 'recIkYm646lrGvLNT' },
+  { level: -1, score: 0, area_code: '1', competence_code: '1.1', competenceId: 'recsvLz0W2ShyfD63' }
 ];
 
 module.exports = {

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -21,6 +21,7 @@ function _deserializeResultsAdd(json) {
       score: competenceMark.score,
       area_code: competenceMark['area-code'],
       competence_code: competenceMark['competence-code'],
+      competenceId: competenceMark['competence-id'],
     });
   });
   return { assessmentResult, competenceMarks };

--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -1,5 +1,3 @@
-const settings = require('../../config');
-
 const usecases = require('../../domain/usecases');
 
 const mailService = require('../../domain/services/mail-service');
@@ -10,6 +8,7 @@ const passwordResetSerializer = require('../../infrastructure/serializers/jsonap
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const resetPasswordDemandRepository = require('../../infrastructure/repositories/reset-password-demands-repository');
 const userRepository = require('../../infrastructure/repositories/user-repository');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -18,7 +17,8 @@ module.exports = {
     await userRepository.isUserExistingByEmail(user.email);
     const temporaryKey = resetPasswordService.generateTemporaryKey();
     const passwordResetDemand = await resetPasswordDemandRepository.create({ email: user.email, temporaryKey });
-    await mailService.sendResetPasswordDemandEmail(user.email, `https://${settings.app.domain}`, temporaryKey);
+    const locale = extractLocaleFromRequest(request);
+    await mailService.sendResetPasswordDemandEmail(user.email, locale, temporaryKey);
     const serializedPayload = passwordResetSerializer.serialize(passwordResetDemand.attributes);
 
     return h.response(serializedPayload).created();

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -36,7 +36,8 @@ module.exports = (function() {
     },
 
     app: {
-      domain: 'app.pix.fr'
+      domainFr: 'pix.fr',
+      domainOrg: 'pix.org'
     },
 
     logging: {

--- a/api/lib/domain/events/CertificationScoringCompleted.js
+++ b/api/lib/domain/events/CertificationScoringCompleted.js
@@ -1,7 +1,6 @@
 class CertificationScoringCompleted {
-  constructor({ certificationCourseId, limitDate, userId, reproducibilityRate, }) {
+  constructor({ certificationCourseId, userId, reproducibilityRate, }) {
     this.certificationCourseId = certificationCourseId;
-    this.limitDate = limitDate;
     this.userId = userId;
     this.reproducibilityRate = reproducibilityRate;
   }

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -6,27 +6,24 @@ async function handleCertificationAcquisitionForPartner({
   domainTransaction,
   badgeAcquisitionRepository,
   competenceRepository,
+  competenceMarkRepository,
   certificationPartnerAcquisitionRepository,
 }) {
-  const hasAcquiredBadgeClea = await _getHasAcquiredBadgeClea(badgeAcquisitionRepository, certificationScoringEvent.userId);
-
+  const certificationCourseId = certificationScoringEvent.certificationCourseId;
   const cleaPartnerAcquisition = new CertificationPartnerAcquisition({
-    certificationCourseId: certificationScoringEvent.certificationCourseId,
+    certificationCourseId,
     partnerKey: Badge.keys.PIX_EMPLOI_CLEA,
   });
 
-  const pixScoreByCompetence = await competenceRepository.getPixScoreByCompetence({
-    userId: certificationScoringEvent.userId,
-    limitDate: certificationScoringEvent.limitDate,
-  });
-
+  const hasAcquiredBadgeClea = await _getHasAcquiredBadgeClea(badgeAcquisitionRepository, certificationScoringEvent.userId);
+  const competenceMarks = await competenceMarkRepository.getLatestByCertificationCourseId({ certificationCourseId, domainTransaction });
   const totalPixCleaByCompetence = await competenceRepository.getTotalPixCleaByCompetence();
 
   if (cleaPartnerAcquisition.hasAcquiredCertification({
     hasAcquiredBadge: hasAcquiredBadgeClea,
     reproducibilityRate: certificationScoringEvent.reproducibilityRate,
     totalPixCleaByCompetence,
-    pixScoreByCompetence
+    competenceMarks
   })) {
     await certificationPartnerAcquisitionRepository.save(cleaPartnerAcquisition, domainTransaction);
   }

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -47,7 +47,6 @@ async function _calculateCertificationScore({
       userId: certificationAssessment.userId,
       certificationCourseId: certificationAssessment.certificationCourseId,
       reproducibilityRate: certificationAssessmentScore.percentageCorrectAnswers,
-      limitDate: certificationAssessment.createdAt,
     });
   }
   catch (error) {

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -14,7 +14,6 @@ const dependencies = {
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
-
 };
 
 module.exports = injectDependencies({

--- a/api/lib/domain/models/CertificationPartnerAcquisition.js
+++ b/api/lib/domain/models/CertificationPartnerAcquisition.js
@@ -7,10 +7,13 @@ function _isOverPercentage(value = 0, total, percentage = MIN_PERCENTAGE) {
   return value >= (total * percentage / 100);
 }
 
-function _hasRequiredPixValue({ totalPixCleaByCompetence, pixScoreByCompetence }) {
+function _hasRequiredPixValue({ totalPixCleaByCompetence, competenceMarks }) {
   const competenceIds = _.keys(totalPixCleaByCompetence);
   return !_.isEmpty(competenceIds)
-    && _.every(competenceIds, (id) => _isOverPercentage(pixScoreByCompetence[id], totalPixCleaByCompetence[id]));
+    && _.every(competenceIds, (competenceId) => _isOverPercentage(
+      _.find(competenceMarks, { competenceId }).score,
+      totalPixCleaByCompetence[competenceId]
+    ));
 }
 
 function _hasSufficientReproducibilityRateToBeCertified(reproducibilityRate) {
@@ -35,14 +38,15 @@ class CertificationPartnerAcquisition {
   hasAcquiredCertification({
     hasAcquiredBadge = false,
     reproducibilityRate = 0,
-    pixScoreByCompetence, totalPixCleaByCompetence,
+    competenceMarks,
+    totalPixCleaByCompetence,
   }) {
     if (!hasAcquiredBadge) return false;
     if (_hasNotMinimumReproducibilityRateToBeTrusted(reproducibilityRate)) return false;
 
     if (_hasSufficientReproducibilityRateToBeCertified(reproducibilityRate)) return true;
 
-    return _hasRequiredPixValue({ pixScoreByCompetence, totalPixCleaByCompetence });
+    return _hasRequiredPixValue({ competenceMarks, totalPixCleaByCompetence });
   }
 
 }

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -7,6 +7,7 @@ const schemaValidateCompetenceMark = Joi.object({
   score: Joi.number().integer().min(0).max(64).required(),
   area_code: Joi.required(),
   competence_code: Joi.required(),
+  competenceId: Joi.string().optional(),
   assessmentResultId: Joi.number().optional(),
 });
 
@@ -16,6 +17,7 @@ class CompetenceMark {
     // attributes
     area_code,
     competence_code,
+    competenceId,
     level,
     score,
     // includes
@@ -26,6 +28,7 @@ class CompetenceMark {
     // attributes
     this.area_code = area_code;
     this.competence_code = competence_code;
+    this.competenceId = competenceId;
     this.level = level;
     this.score = score;
     // includes

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -15,14 +15,30 @@ function sendAccountCreationEmail(email) {
   });
 }
 
-function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
+function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
+  let variables = {
+    homeName: `${settings.app.domainFr}`,
+    homeUrl: `https://${settings.app.domainFr}`,
+    resetUrl: `https://app.${settings.app.domainFr}/changer-mot-de-passe/${temporaryKey}`,
+    locale
+  };
+
+  if (locale === 'fr') {
+    variables = {
+      homeName: `${settings.app.domainOrg}`,
+      homeUrl: `https://${settings.app.domainOrg}`,
+      resetUrl: `https://app.${settings.app.domainOrg}/changer-mot-de-passe/${temporaryKey}`,
+      locale
+    };
+  }
+
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
     fromName: PIX_NAME,
     to: email,
     subject: 'Demande de réinitialisation de mot de passe PIX',
     template: mailer.passwordResetTemplateId,
-    variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }
+    variables
   });
 }
 

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -13,6 +13,7 @@ async function calculateCertificationAssessmentScore(certificationAssessment) {
       score: scoringService.getBlockedPixScore(certifiedCompetence.obtainedScore),
       area_code: certifiedCompetence.area_code,
       competence_code: certifiedCompetence.index,
+      competenceId: certifiedCompetence.id,
     });
   });
 

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -1,5 +1,8 @@
+const DomainTransaction = require('../DomainTransaction');
 const BookshelfCompetenceMark = require('../data/competence-mark');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
+const BookshelfAssessmentResult = require('../data/assessment-result');
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 
 function _toDomain(bookshelfCompetenceMark) {
   return new CompetenceMark(bookshelfCompetenceMark.attributes);
@@ -18,5 +21,21 @@ module.exports = {
       .fetchAll()
       .then((competenceMarks) => competenceMarks.models.map(_toDomain));
   },
+
+  async getLatestByCertificationCourseId({ certificationCourseId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const mostRecentAssessmentResultId = await BookshelfAssessmentResult
+      .where({ 'assessments.certificationCourseId': certificationCourseId })
+      .query((qb) => {
+        qb.innerJoin('assessments', 'assessments.id', 'assessment-results.assessmentId');
+      })
+      .orderBy('assessment-results.createdAt', 'desc')
+      .fetch({ require: true, columns: ['assessment-results.id'], transacting: domainTransaction.knexTransaction });
+
+    const mostRecentCompetenceMarksBookshelf = await BookshelfCompetenceMark
+      .where({ assessmentResultId: mostRecentAssessmentResultId.id })
+      .fetchAll({ transacting: domainTransaction.knexTransaction });
+
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceMark, mostRecentCompetenceMarksBookshelf);
+  }
 
 };

--- a/api/tests/integration/domain/services/scoring/scoring-certification_test.js
+++ b/api/tests/integration/domain/services/scoring/scoring-certification_test.js
@@ -9,8 +9,8 @@ describe('Integration | Domain | services | scoring | scoring-certification-serv
     const courseId = 123;
     const assessmentId = 836;
 
-    const competenceWithMark_1_1 = { index: '1.1', obtainedLevel: 0, obtainedScore: 4, area_code: '1', };
-    const competenceWithMark_1_2 = { index: '1.2', obtainedLevel: 1, obtainedScore: 8, area_code: '2', };
+    const competenceWithMark_1_1 = { index: '1.1', obtainedLevel: 0, obtainedScore: 4, area_code: '1', id: 'recComp1.1' };
+    const competenceWithMark_1_2 = { index: '1.2', obtainedLevel: 1, obtainedScore: 8, area_code: '2', id: 'recComp1.2' };
     const competencesWithMark = [competenceWithMark_1_1, competenceWithMark_1_2];
 
     const assessment = domainBuilder.buildAssessment({ id: assessmentId, courseId });
@@ -22,6 +22,7 @@ describe('Integration | Domain | services | scoring | scoring-certification-serv
         percentageCorrectAnswers: 0,
         competenceMarks: [{
           id: undefined,
+          competenceId: 'recComp1.1',
           assessmentResultId: undefined,
           'area_code': '1',
           'competence_code': '1.1',
@@ -29,6 +30,7 @@ describe('Integration | Domain | services | scoring | scoring-certification-serv
           score: 4
         }, {
           id: undefined,
+          competenceId: 'recComp1.2',
           assessmentResultId: undefined,
           'area_code': '2',
           'competence_code': '1.2',

--- a/api/tests/tooling/database-builder/factory/build-competence-mark.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-mark.js
@@ -9,6 +9,7 @@ module.exports = function buildCompetenceMark({
   score = faker.random.number(),
   area_code = faker.random.number().toString(),
   competence_code = `${faker.random.number()}_${faker.random.number()}`,
+  competenceId = `rec${faker.random.uuid()}`,
   assessmentResultId,
   createdAt = faker.date.past(),
 } = {}) {
@@ -21,6 +22,7 @@ module.exports = function buildCompetenceMark({
     score,
     area_code,
     competence_code,
+    competenceId,
     assessmentResultId,
     createdAt,
   };

--- a/api/tests/tooling/domain-builder/factory/build-competence-mark.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-mark.js
@@ -6,6 +6,7 @@ module.exports = function buildCompetenceMark({
   score = 13,
   area_code = '1',
   competence_code = '1.1',
+  competenceId = 'recSomeCompetence',
   assessmentResultId,
 } = {}) {
 
@@ -15,6 +16,7 @@ module.exports = function buildCompetenceMark({
     score,
     area_code,
     competence_code,
+    competenceId,
     assessmentResultId,
   });
 };

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -46,7 +46,7 @@ describe('Unit | Controller | PasswordController', () => {
       // given
       const generatedToken = 'token';
       const demand = { email: 'shi@fu.me', temporaryKey: generatedToken };
-      const hostBaseUrl = 'https://localhost';
+      const locale = 'fr-fr';
       const resolvedPasswordReset = {
         attributes: {
           email: 'Giles75@hotmail.com',
@@ -54,6 +54,7 @@ describe('Unit | Controller | PasswordController', () => {
           id: 15
         }
       };
+      request.locale = locale;
 
       userRepository.isUserExistingByEmail.resolves();
       resetPasswordService.generateTemporaryKey.returns(generatedToken);
@@ -68,7 +69,7 @@ describe('Unit | Controller | PasswordController', () => {
       sinon.assert.calledWith(userRepository.isUserExistingByEmail, userEmail);
       sinon.assert.calledOnce(resetPasswordService.generateTemporaryKey);
       sinon.assert.calledWith(resetPasswordRepository.create, demand);
-      sinon.assert.calledWith(mailService.sendResetPasswordDemandEmail, request.payload.data.attributes.email, hostBaseUrl, generatedToken);
+      sinon.assert.calledWith(mailService.sendResetPasswordDemandEmail, request.payload.data.attributes.email, locale, generatedToken);
       sinon.assert.calledWith(passwordResetSerializer.serialize, resolvedPasswordReset.attributes);
     });
   });

--- a/api/tests/unit/domain/events/handle-certification-partner_test.js
+++ b/api/tests/unit/domain/events/handle-certification-partner_test.js
@@ -1,7 +1,5 @@
 const _ = require('lodash');
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
-const Assessment = require('../../../../lib/domain/models/Assessment');
-const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const { expect, sinon } = require('../../../test-helper');
 const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
 const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
 const CertificationPartnerAcquisition = require('../../../../lib/domain/models/CertificationPartnerAcquisition');
@@ -9,27 +7,18 @@ const CertificationScoringCompleted = require('../../../../lib/domain/events/Cer
 const events = require('../../../../lib/domain/events');
 
 describe('Unit | Domain | Events | handle-certification-partner', () => {
-  const scoringCertificationService = { calculateCertificationAssessmentScore: _.noop };
-  const assessmentRepository = { get: _.noop };
-  const assessmentResultRepository = { save: _.noop };
   const certificationPartnerAcquisitionRepository = { save: _.noop };
   const domainTransaction = {};
 
   let certificationScoringEvent;
 
   const dependencies = {
-    scoringCertificationService,
-    assessmentRepository,
     certificationPartnerAcquisitionRepository,
   };
 
   context('when assessment is of type CERTIFICATION', () => {
-    let certificationAssessment;
 
     beforeEach(() => {
-      certificationAssessment = _buildCertificationAssessment();
-      sinon.stub(assessmentRepository, 'get').withArgs(certificationAssessment.id).resolves(certificationAssessment);
-
       certificationScoringEvent = new CertificationScoringCompleted({
         certificationCourseId: Symbol('certificationCourseId'),
         userId: Symbol('userId'),
@@ -41,22 +30,10 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
     });
 
     context('when scoring is successful', () => {
-      const assessmentResult = Symbol('AssessmentResult');
-      const assessmentResultId = 'assessmentResultId';
-      const savedAssessmentResult = { id: assessmentResultId };
-      const assessmentScore = {
-        nbPix: null,
-        level: null,
-        competenceMarks: null,
-      };
-
       const pixScoreByCompetence = Symbol('pixScoreByCompetence');
       const totalPixCleaByCompetence = Symbol('totalPixCleaByCompetence');
 
       beforeEach(() => {
-        sinon.stub(AssessmentResult, 'BuildStandardAssessmentResult').returns(assessmentResult);
-        sinon.stub(assessmentResultRepository, 'save').resolves(savedAssessmentResult);
-        sinon.stub(scoringCertificationService, 'calculateCertificationAssessmentScore').resolves(assessmentScore);
         sinon.stub(certificationPartnerAcquisitionRepository, 'save').resolves();
         sinon.stub(competenceRepository, 'getPixScoreByCompetence')
           .withArgs({
@@ -140,12 +117,3 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
     });
   });
 });
-
-function _buildCertificationAssessment() {
-  return domainBuilder.buildAssessment({
-    id: Symbol('assessmentId'),
-    certificationCourseId: Symbol('certificationCourseId'),
-    state: 'started',
-    type: Assessment.types.CERTIFICATION,
-  });
-}

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -168,7 +168,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should return a CertificationScoringCompleted', async () => {
         // when
-        const  certificationScoringCompleted = await events.handleCertificationScoring({
+        const certificationScoringCompleted = await events.handleCertificationScoring({
           assessmentCompletedEvent, ...dependencies, domainTransaction
         });
 
@@ -178,7 +178,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           userId: assessmentCompletedEvent.userId,
           certificationCourseId: certificationAssessment.certificationCourseId,
           reproducibilityRate: certificationAssessmentScore.percentageCorrectAnswers,
-          limitDate: certificationAssessment.createdAt,
         });
       });
 

--- a/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
+++ b/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
@@ -1,5 +1,6 @@
 const { expect } = require('../../../test-helper');
 const CertificationPartnerAcquisition = require('../../../../lib/domain/models/CertificationPartnerAcquisition');
+const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
 
 const GREEN_ZONE_REPRO = [80, 90, 100];
 const RED_ZONE_REPRO = [1, 50];
@@ -56,21 +57,37 @@ describe('Unit | Domain | Models | CertificationPartnerAcquisition', () => {
         it('for 70 reproducibility rate, it should obtain certification with all pixValue above 75% of Clea skills pixValue for each competence', async () => {
           // given
           const totalPixCleaByCompetence = {
-              [competenceId1]: 20,
-              [competenceId2]: 10,
-            },
-            pixScoreByCompetence = {
-              [competenceId1]: 15,
-              [competenceId2]: 7.5,
-              'competence3': 0,
-            };
+            [competenceId1]: 20,
+            [competenceId2]: 10,
+          };
+
+          const competenceMarks = [
+            new CompetenceMark(
+              {
+                competenceId: competenceId1,
+                score: 15
+              }
+            ),
+            new CompetenceMark(
+              {
+                competenceId: competenceId2,
+                score: 7.5
+              }
+            ),
+            new CompetenceMark(
+              {
+                competenceId: 'competence3',
+                score: 0
+              }
+            ),
+          ];
 
           // when
           const hasAcquiredCertif = certificationPartnerAcquisition.hasAcquiredCertification({
             hasAcquiredBadge: true,
             reproducibilityRate,
             totalPixCleaByCompetence,
-            pixScoreByCompetence,
+            competenceMarks,
           });
 
           // then
@@ -80,21 +97,36 @@ describe('Unit | Domain | Models | CertificationPartnerAcquisition', () => {
         it('for 70 reproducibility rate, it should not obtain certification without all pixValue above 75% of Clea skills pixValue for each competence', async () => {
           // given
           const totalPixCleaByCompetence = {
-              [competenceId1]: 20,
-              [competenceId2]: 10,
-            },
-            pixScoreByCompetence = {
-              [competenceId1]: 15,
-              [competenceId2]: 7.4,
-              'competence3': 0,
-            };
+            [competenceId1]: 20,
+            [competenceId2]: 10,
+          };
+          const competenceMarks = [
+            new CompetenceMark(
+              {
+                competenceId: competenceId1,
+                score: 15
+              }
+            ),
+            new CompetenceMark(
+              {
+                competenceId: competenceId2,
+                score: 7.4
+              }
+            ),
+            new CompetenceMark(
+              {
+                competenceId: 'competence3',
+                score: 0
+              }
+            ),
+          ];
 
           // when
           const hasAcquiredCertif = certificationPartnerAcquisition.hasAcquiredCertification({
             hasAcquiredBadge: true,
             reproducibilityRate,
             totalPixCleaByCompetence,
-            pixScoreByCompetence,
+            competenceMarks,
           });
 
           // then

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -12,8 +12,8 @@ const certificationAssessmentRepository = require('../../../../../lib/infrastruc
 const certificationCourseRepository = require('../../../../../lib/infrastructure/repositories/certification-course-repository');
 const certificationResultService = require('../../../../../lib/domain/services/certification-result-service');
 
-function _buildCompetenceMarks(level, score, area_code, competence_code) {
-  return new CompetenceMarks({ level, score, area_code, competence_code });
+function _buildCompetenceMarks(level, score, area_code, competence_code, competenceId) {
+  return new CompetenceMarks({ level, score, area_code, competence_code, competenceId });
 }
 
 function _buildAssessmentResult(pixScore, level) {
@@ -82,7 +82,7 @@ describe('Unit | Service | Certification Service', function() {
           examinerComment: '',
           hasSeenEndTestScreen: true,
         }));
-        assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1')];
+        assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1', 'rec2.1')];
         sinon.stub(assessmentResultRepository, 'get').resolves(
           assessmentResult,
         );
@@ -100,6 +100,7 @@ describe('Unit | Service | Certification Service', function() {
           area_code: '2',
           assessmentResultId: undefined,
           competence_code: '2.1',
+          competenceId: 'rec2.1',
           id: undefined,
           level: 3,
           score: 27,

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -36,10 +36,11 @@ describe('Unit | Service | MailService', () => {
 
     context('when provided passwordResetDemandBaseUrl is not production', () => {
 
-      it('should call Mailjet with a sub-domain prefix', async () => {
+      it('should call mailer', async () => {
         // given
         const fakeTemporaryKey = 'token';
-        const passwordResetDemandBaseUrl = 'http://dev.pix.fr';
+        const locale = 'fr-fr';
+        const domainFr = 'pix.fr';
 
         const expectedOptions = {
           from: senderEmailAddress,
@@ -48,12 +49,42 @@ describe('Unit | Service | MailService', () => {
           subject: 'Demande de réinitialisation de mot de passe PIX',
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `${passwordResetDemandBaseUrl}/changer-mot-de-passe/${fakeTemporaryKey}`
+            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            homeName: `${domainFr}`,
+            homeUrl: `https://${domainFr}`,
+            locale
           }
         };
 
         // when
-        await mailService.sendResetPasswordDemandEmail(userEmailAddress, passwordResetDemandBaseUrl, fakeTemporaryKey);
+        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+
+      it('should call mailer with locale fr', async () => {
+        // given
+        const fakeTemporaryKey = 'token';
+        const locale = 'fr';
+        const domainOrg = 'pix.org';
+
+        const expectedOptions = {
+          from: senderEmailAddress,
+          fromName: 'PIX - Ne pas répondre',
+          to: userEmailAddress,
+          subject: 'Demande de réinitialisation de mot de passe PIX',
+          template: 'test-password-reset-template-id',
+          variables: {
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            homeName: `${domainOrg}`,
+            homeUrl: `https://${domainOrg}`,
+            locale
+          }
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
 
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);


### PR DESCRIPTION
## :unicorn: Problème
La vérification du seuil des 75% CléA a été mis en place sur le score positionné par compétence. Ce n'est pas correct, ce devrait être sur le score certifié (sinon ça sert à quoi de passer une certif...)

## :robot: Solution
On récupère le score certifié par compétence à l'aide des `CompetenceMarks`.
On en profite aussi pour ajouter la colonne `competenceId` dans la table `competence-marks`, plus utile qu'un `competence_code` sujet à moult transformations pour en tirer quelque chose...

## :rainbow: Remarques


## :100: Pour tester
A l'aide Anne-So pour tester cette CHOSE
