### PR TITLE
[BUGFIX] Correction du calcul du score en pix (différence entre export du profil et affichage sur le profil) (PIX-739).

### DIFF
--- a/api/lib/domain/services/scoring/scoring-service.js
+++ b/api/lib/domain/services/scoring/scoring-service.js
@@ -10,7 +10,7 @@ function calculateScoringInformationForCompetence({ knowledgeElements, allowExce
 
   const realTotalPixScoreForCompetence = _(knowledgeElements).sumBy('earnedPix');
   const pixScoreForCompetence = _getPixScoreForOneCompetence(realTotalPixScoreForCompetence, allowExcessPix);
-  const currentLevel = getCompetenceLevel(realTotalPixScoreForCompetence, allowExcessLevel);
+  const currentLevel = _getCompetenceLevel(realTotalPixScoreForCompetence, allowExcessLevel);
   const pixAheadForNextLevel = _getPixScoreAheadOfNextLevel(pixScoreForCompetence);
   return {
     realTotalPixScoreForCompetence,
@@ -26,15 +26,6 @@ function getBlockedLevel(level) {
 function getBlockedPixScore(pixScore) {
   return Math.min(pixScore, MAX_REACHABLE_PIX_BY_COMPETENCE);
 }
-
-function totalUserPixScore(pixEarnedByCompetence) {
-  const pixByCompetenceLimited = _.map(pixEarnedByCompetence, (pixEarnedForOneCompetence) => {
-    const flooredPixEarnedForOneCompetence = _.floor(pixEarnedForOneCompetence);
-    return getBlockedPixScore(flooredPixEarnedForOneCompetence);
-  });
-  return _.sum(pixByCompetenceLimited);
-}
-
 function _getPixScoreForOneCompetence(exactlyEarnedPix, allowExcessPix = false) {
   const userEarnedPix = _.floor(exactlyEarnedPix);
   if (allowExcessPix) {
@@ -43,7 +34,7 @@ function _getPixScoreForOneCompetence(exactlyEarnedPix, allowExcessPix = false) 
   return getBlockedPixScore(userEarnedPix);
 }
 
-function getCompetenceLevel(pixScoreForCompetence, allowExcessLevel = false) {
+function _getCompetenceLevel(pixScoreForCompetence, allowExcessLevel = false) {
   const level = _.floor(pixScoreForCompetence / PIX_COUNT_BY_LEVEL);
   if (allowExcessLevel) {
     return level;
@@ -59,7 +50,4 @@ module.exports = {
   calculateScoringInformationForCompetence,
   getBlockedLevel,
   getBlockedPixScore,
-  getCompetenceLevel,
-  totalUserPixScore,
-
 };

--- a/api/lib/domain/usecases/get-user-pix-score.js
+++ b/api/lib/domain/usecases/get-user-pix-score.js
@@ -1,4 +1,7 @@
-module.exports = async function getUserPixScore({ userId, knowledgeElementRepository }) {
-  const userPixScore = await knowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
+const _ = require('lodash');
+
+module.exports = async function getUserPixScore({ userId, competenceRepository }) {
+  const competenceScores = await competenceRepository.getPixScoreByCompetence({ userId });
+  const userPixScore = _.sum(_.values(competenceScores));
   return { id: userId, value: userPixScore };
 };

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -186,40 +186,6 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
   });
 
-  describe('#getSumOfPixFromUserKnowledgeElements', () => {
-
-    let userId;
-    const today = new Date('2018-08-01T12:34:56Z');
-    const yesterday = moment(today).subtract(1, 'days').toDate();
-
-    beforeEach(() => {
-      // given
-      userId = databaseBuilder.factory.buildUser().id;
-      const userId_tmp = databaseBuilder.factory.buildUser().id;
-
-      _.each([
-        { skillId: 'rec1', userId, earnedPix: 5.0, competenceId: 1 },
-        { skillId: 'rec3', userId, earnedPix: 20.4, status: 'validated', competenceId: 1 },
-        { skillId: 'rec2', userId, earnedPix: 10.7, status: 'validated', createdAt: today, competenceId: 1 },
-        { skillId: 'rec4', userId, earnedPix: 50, status: 'validated', competenceId: 2 },
-        { skillId: 'rec5', userId, earnedPix: 10, status: 'validated', competenceId: 3 },
-        { skillId: 'rec2', userId, earnedPix: 1.1, status: 'validated', createdAt: yesterday, competenceId: 3 },
-        { skillId: 'rec1', userId: userId_tmp, earnedPix: 3, status: 'invalidated', competenceId: 1 },
-      ], (ke) => databaseBuilder.factory.buildKnowledgeElement(ke));
-
-      return databaseBuilder.commit();
-    });
-
-    it('should return the right sum of Pix from user knowledge elements', async () => {
-      // when
-      const earnedPix = await KnowledgeElementRepository.getSumOfPixFromUserKnowledgeElements(userId);
-
-      // then
-      expect(earnedPix).to.equal(86);
-    });
-
-  });
-
   describe('findUniqByUserIdAndCompetenceId', () => {
     let wantedKnowledgeElements;
     let userId;

--- a/api/tests/unit/domain/usecases/get-user-pix-score_test.js
+++ b/api/tests/unit/domain/usecases/get-user-pix-score_test.js
@@ -3,10 +3,10 @@ const getUserPixScore = require('../../../../lib/domain/usecases/get-user-pix-sc
 
 describe('Unit | UseCase | get-user-pix-score', () => {
 
-  let knowledgeElementRepository;
+  let competenceRepository;
 
   beforeEach(() => {
-    knowledgeElementRepository = { getSumOfPixFromUserKnowledgeElements: sinon.stub() };
+    competenceRepository = { getPixScoreByCompetence: sinon.stub() };
   });
 
   afterEach(() => {
@@ -16,33 +16,36 @@ describe('Unit | UseCase | get-user-pix-score', () => {
   it('should resolve when authenticated user is the same as asked', () => {
     // given
     const userId = 2;
-    knowledgeElementRepository.getSumOfPixFromUserKnowledgeElements.resolves([]);
+    competenceRepository.getPixScoreByCompetence.resolves({});
 
     // when
     const promise = getUserPixScore({
       userId,
-      knowledgeElementRepository,
+      competenceRepository,
     });
 
     // then
     return expect(promise).to.be.fulfilled;
   });
 
-  it('should return the user Pix score', async () => {
+  it('should sum the competence Pix scores', async () => {
     // given
     const userId = 2;
-    const sumOfPixKnowledgeElement = 6;
+    const sumOfPixCompetenceScores = 7;
     const pixScoreExpected = {
       id: userId,
-      value: sumOfPixKnowledgeElement
+      value: sumOfPixCompetenceScores
     };
 
-    knowledgeElementRepository.getSumOfPixFromUserKnowledgeElements.resolves(sumOfPixKnowledgeElement);
+    competenceRepository.getPixScoreByCompetence.resolves({
+      'recCompetence1': 2,
+      'recCompetence2': 5,
+    });
 
     // when
     const userPixScore = await getUserPixScore({
       userId,
-      knowledgeElementRepository,
+      competenceRepository,
     });
 
     //then


### PR DESCRIPTION
## :unicorn: Problème
Le score (en pix) d'un utilisateur est parfois différent entre celui affiché sur son profil et celui dans la collecte de profil.

## 🔎 Analyse
Le problème a été identifié sur la base de recette, sur l'utilisateur numéro `220970`.
Le score affiché est de 160 pix sur son profil.
Le score dans la collecte de profil est de 161.

Après investigation, il apparaît que la seule différence entre les deux calculs est que la somme des pix est faite en SQL pour le score affiché sur le profil et en JavaScript pour le score de la collecte de profil.

Le type en base de données de la colonne stockant les pix de chaque `knowledge-element` (`earnedPix`) est `real`.
En parcourant la [documentation de PostgreSQL](https://www.postgresql.org/docs/current/datatype-numeric.html), on voit que le type `real` est  un nombre à virgule flottante sur 4 octets.
Le type `Number` utilisé JavaScript est un nombre à virgule flottante sur 8 octets.

Avant d'aller plus loin dans les explications, il est nécessaire de comprendre que le nombre de pix gagnés par épreuves (et donc stocké dans `earnedPix`) est la fraction de 8 (le nombre de pix par acquis) sur le nombre d'épreuves dans l'acquis. Plus d'informations sur [cette page](https://1024pix.atlassian.net/wiki/spaces/PROD/pages/596213777/Valorisation+des+Acquis+en+Pix).
```
Nombre de pix d'une épreuve = 8 / (Nombre d'acquis du même niveau dans la compétence)
```

Lorsqu'on stocke le nombre de `earnedPix`, celui-ci est donc un quotient tronqué sur 4 octets.
Si ensuite on le lit et le manipule en JavaScript, c'est alors un nombre décimal initialement sur 4 octets, représenté dès lors sur 8 octets, **qui n'est plus le résultat du quotient initial**.

## :robot: Solution

On décide, pour garantir l'homogénéité des résultats et factoriser le calcul, d'utiliser la fonction `competenceRepository.getPixScoreByCompetence` en lieu et place de la somme en SQL.

### 💡 Propositions pour le futur

Avec la centralisation du calcul de pix, on peut imaginer faire un calcul fractionnel en retrouvant le dénominateur de chaque fraction ainsi :
```
nombre d'acquis dans le niveau de l'épreuve = arrondi(8 / earnedPix)
```

Par exemple, si le nombre d'acquis dans le niveau est 3, la valeur en Pix de l'épreuve est 8/3 et le nombre stocké approché sera environ 2.66667 ; en divisant 8 par ce nombre et en arrondissant à l'entier le plus proche on retrouve bien le 3 de départ.

Ainsi, le calcul serait la somme suivante : 
```
score = 8/(nombre d'acquis dans le niveau de l'épreuve du `knowledge-element` 1) +
              8/(nombre d'acquis dans le niveau de l'épreuve du `knowledge-element` 2 +
              ... +
              8/(nombre d'acquis dans le niveau de l'épreuve du `knowledge-element` N
```

Il est possible de faire cette somme de fractions de façon exacte (dénominateur commun, etc.).

Alternativement, pour aligner la précision entre les nombres stockés et manipulés, on pourrait utiliser le type `double precision` (8 octets) en SQL.
Cette migration ne devra pas être un simple `cast` de type mais devra valoriser la colonne avec le résultat du quotient initial, soit :

```
8 / arrondi(8 / earnedPix)
```

Cette instruction SQL effectuerait la migration en question :
```sql
ALTER TABLE "knowledge-elements"
  ALTER COLUMN "earnedPix"
    TYPE double precision
    USING (CASE
      WHEN "earnedPix" > 0 THEN 8/round(8/"earnedPix")::double precision
      ELSE 0
    END)
```

Pour aller plus loin, on pourrait également stocker directement le nombre d'acquis dans le niveau de l'épreuve au lieu du résultat du quotient.
Attention, cette solution crée une adhérence entre la logique du référentiel de contenu et son stockage : le nombre de Pix d'un acquis serait restreint à une fraction de la forme `8/n` où n est un entier. C'est le cas actuellement par construction pour tous les acquis du référentiel ; nous avons vérifié que c'était également le cas pour toutes les valeurs de `earnedPix` stockées dans la table `knowledge-elements` en production.

Dans tous les cas, une migration impactant la table `knowledge-elements` serait à envisager avec précaution compte tenu du nombre de lignes (150 millions actuellement) et de l'activité soutenue sur cette table. Pour mémoire, une migration changeant le type d'une colonne bloque l'intégralité des accès à une table durant son exécution.

## :rainbow: Remarques

La fonction de calcul de pix par compétence est située dans `competence-repository`, ce qui ne parait pas idéal. Jusque là `competence-repository` a pour rôle d'exposer les compétences du référentiel de contenu (à travers le datasource associé). De plus cette fonction de `competence-repository` fait appel à une méthode de `scoring-service` ce qui paraît anormal du point de vue du découpage en couches (infrastructure appelant le domaine).

Un refactoring futur pourrait être de déplacer cette fonction.

L'investigation de ce bug a entrainé un vidage partiel des données de la base de recette.
Plus d'info ici : https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1474068755/2020-05-22+Post+Mortem+vidage+partiel+de+la+base+de+donn+es+de+Recette

## :100: Pour tester
Vérifier que le nombre de pix est cohérent entre :
- La page d'accueil de l'utilisateur
- La somme des compétences qu'il peut trouver sur sa page d'accueil
- Le fichier de partage de profil
