### PR TITLE
[FEATURE] Voir les campagnes archivées quand plus de campagnes actives (PIX-663)

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -61,8 +61,8 @@ module.exports = {
       options.filter.ongoing = false;
       delete options.filter.status;
     }
-    const { models: campaigns, pagination } = await usecases.findPaginatedFilteredOrganizationCampaigns({ organizationId, filter: options.filter, page: options.page });
-    return campaignSerializer.serialize(campaigns, pagination, { ignoreCampaignReportRelationshipData : false });
+    const { models: campaigns, meta } = await usecases.findPaginatedFilteredOrganizationCampaigns({ organizationId, filter: options.filter, page: options.page });
+    return campaignSerializer.serialize(campaigns, meta, { ignoreCampaignReportRelationshipData : false });
   },
 
   getMemberships(request) {

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -422,7 +422,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should return archived campaigns', async () => {
         // given
         options.url = `/api/organizations/${organizationId}/campaigns?page[number]=1&page[size]=2&filter[status]=archived`;
-        const expectedMetaData = { page: 1, pageSize: 2, rowCount: 2, pageCount: 1 };
+        const expectedMetaData = { page: 1, pageSize: 2, rowCount: 2, pageCount: 1, hasCampaigns: true };
 
         // when
         const response = await server.inject(options);
@@ -452,7 +452,7 @@ describe('Acceptance | Application | organization-controller', () => {
 
       it('should return default pagination meta data', async () => {
         // given
-        const expectedMetaData = { page: 1, pageSize: 10, rowCount: 2, pageCount: 1 };
+        const expectedMetaData = { page: 1, pageSize: 10, rowCount: 2, pageCount: 1, hasCampaigns: true };
 
         // when
         const response = await server.inject(options);
@@ -464,7 +464,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should return a 200 status code with paginated data', async () => {
         // given
         options.url = `/api/organizations/${organizationId}/campaigns?&page[number]=2&page[size]=1`;
-        const expectedMetaData = { page: 2, pageSize: 1, rowCount: 2, pageCount: 2 };
+        const expectedMetaData = { page: 2, pageSize: 1, rowCount: 2, pageCount: 2, hasCampaigns: true };
 
         // when
         const response = await server.inject(options);
@@ -479,7 +479,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should return a 200 status code with paginated and filtered data', async () => {
         // given
         options.url = `/api/organizations/${organizationId}/campaigns?filter[name]=Two&page[number]=1&page[size]=1`;
-        const expectedMetaData = { page: 1, pageSize: 1, rowCount: 1, pageCount: 1 };
+        const expectedMetaData = { page: 1, pageSize: 1, rowCount: 1, pageCount: 1, hasCampaigns: true };
 
         // when
         const response = await server.inject(options);
@@ -494,7 +494,7 @@ describe('Acceptance | Application | organization-controller', () => {
       it('should return a 200 status code with empty result', async () => {
         // given
         options.url = `/api/organizations/${organizationId}/campaigns?&page[number]=3&page[size]=1`;
-        const expectedMetaData = { page: 3, pageSize: 1, rowCount: 2, pageCount: 2 };
+        const expectedMetaData = { page: 3, pageSize: 1, rowCount: 2, pageCount: 2, hasCampaigns: true };
 
         // when
         const response = await server.inject(options);

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -325,14 +325,14 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       expect(response).to.deep.equal(expectedResponse);
     });
 
-    it('should return a JSON API response with pagination information', async () => {
+    it('should return a JSON API response with meta information', async () => {
       // given
       request.query = {};
       const expectedResults = [campaign];
-      const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
+      const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4, hasCampaigns: true };
       const expectedConfig = { ignoreCampaignReportRelationshipData: false };
       queryParamsUtils.extractParameters.withArgs({}).returns({ filter: {} });
-      usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: expectedResults, pagination: expectedPagination });
+      usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: expectedResults, meta: expectedPagination });
 
       // when
       await organizationController.findPaginatedFilteredCampaigns(request, hFake);

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -1,6 +1,5 @@
 import { action, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
-import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
@@ -23,8 +22,7 @@ export default class ListController extends Controller {
 
   @computed('model')
   get displayNoCampaignPanel() {
-    const { hasCampaigns } = this.model.meta;
-    return !hasCampaigns && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
+    return !this.model.meta.hasCampaigns;
   }
 
   @equal('status', 'archived') isArchived;

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -1,5 +1,5 @@
 import { action, computed } from '@ember/object';
-import { empty, equal } from '@ember/object/computed';
+import { equal } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import { debounce } from '@ember/runloop';
@@ -21,11 +21,10 @@ export default class ListController extends Controller {
 
   @service currentUser;
 
-  @empty('model') hasNoCampaign;
-
   @computed('model')
   get displayNoCampaignPanel() {
-    return this.hasNoCampaign && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
+    const { hasCampaigns } = this.model.meta;
+    return !hasCampaigns && isEmpty(this.name) && isEmpty(this.status) && isEmpty(this.creatorId);
   }
 
   @equal('status', 'archived') isArchived;

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -38,6 +38,9 @@
         {{/each}}
         </tbody>
       </table>
+      {{#if (eq @campaigns.length 0)}}
+        <div class="table__empty content-text">Aucune campagne</div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -59,8 +59,12 @@ export default function() {
     return schema.memberships.find(id);
   });
 
-  this.get('/organizations/:id/campaigns', (schema) => {
-    return schema.campaigns.all();
+  this.get('/organizations/:id/campaigns', (schema, request) => {
+    const results = schema.campaigns.all();
+    const json = this.serializerOrRegistry.serialize(results, request);
+    json.meta = { hasCampaigns: results.length > 0 };
+
+    return json;
   });
 
   this.get('/organizations/:id/memberships', (schema, request) => {

--- a/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
@@ -11,217 +11,237 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
     this.set('goToCampaignPageSpy', () => {});
     this.set('triggerFilteringSpy', () => {});
   });
+  
+  module('When there are no campaigns to display', function() {
+    test('it should display an empty list message', async function(assert) {
+      // given
+      const campaigns = [];
+      campaigns.meta = { rowCount: 0 };
+      this.set('campaigns', campaigns);
 
-  test('it should display a list of campaigns', async function(assert) {
-    // given
-    const campaigns = [
-      { name: 'campagne 1', code: 'AAAAAA111' },
-      { name: 'campagne 2', code: 'BBBBBB222' },
-    ];
-    campaigns.meta = {
-      rowCount: 2
-    };
-    this.set('campaigns', campaigns);
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list').exists();
-    assert.dom('.campaign-list .table tbody tr').exists({ count: 2 });
+      // then
+      assert.contains('Aucune campagne');
+    });
   });
 
-  test('it should display the name of the campaigns', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const campaign1 = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'campagne 1',
-      code: 'AAAAAA111',
-    }));
-    const campaign2 = run(() => store.createRecord('campaign', {
-      id: 2,
-      name: 'campagne 1',
-      code: 'BBBBBB222'
-    }));
-    const campaigns = [campaign1, campaign2];
-    campaigns.meta = {
-      rowCount: 2
-    };
-    this.set('campaigns', campaigns);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:first-child').hasText('campagne 1');
-  });
-
-  test('it should display the creator of the campaigns', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const user1 = run(() => store.createRecord('user', {
-      id: 1,
-      firstName: 'Jean-Michel',
-      lastName: 'Jarre',
-    }));
-    const user2 = run(() => store.createRecord('user', {
-      id: 2,
-      firstName: 'Mathilde',
-      lastName: 'Bonnin de La Bonninière de Beaumont',
-    }));
-    const campaign1 = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'campagne 1',
-      creator: user1,
-      code: 'AAAAAA111',
-    }));
-    const campaign2 = run(() => store.createRecord('campaign', {
-      id: 2,
-      name: 'campagne 1',
-      creator: user2,
-      code: 'BBBBBB222'
-    }));
-    const campaigns = [campaign1, campaign2];
-    campaigns.meta = {
-      rowCount: 2
-    };
-    this.set('campaigns', campaigns);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(2)').hasText('Jean-Michel Jarre');
-    assert.dom('.campaign-list .table tbody tr:last-child td:nth-child(2)').hasText('Mathilde Bonnin de La Bonninière de Beaumont');
-  });
-
-  test('it should display the list of memberships from the organization', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const user1 = store.createRecord('user', { firstName: 'Harry', lastName: 'Covert' });
-    const user2 = store.createRecord('user', { firstName: 'Jean-Michel', lastName: 'Jarre' });
-
-    const campaigns = [];
-    campaigns.meta = {
-      rowCount: 0
-    };
-
-    const organizationMembers = [{ user: user1 }, { user:  user2 }];
-
-    this.set('campaigns', campaigns);
-    this.set('organizationMembers', organizationMembers);
-
-    // when
-    await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns organizationMembers=organizationMembers triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
-
-    // then
-    assert.dom('select option:nth-child(1)').hasText('Tous');
-    assert.dom('select option:nth-child(2)').hasText('Harry Covert');
-    assert.dom('select option:nth-child(3)').hasText('Jean-Michel Jarre');
-  });
-
-  test('it must display the creation date of the campaigns', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const campaign1 = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'campagne 1',
-      code: 'AAAAAA111',
-      createdAt: '03/02/2020',
-    }));
-    const campaign2 = run(() => store.createRecord('campaign', {
-      id: 2,
-      name: 'campagne 2',
-      code: 'BBBBBB222',
-      createdAt: '02/02/2020',
-    }));
-    const campaigns = [campaign2, campaign1];
-    campaigns.meta = {
-      rowCount: 2
-    };
-    this.set('campaigns', campaigns);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(3)').hasText('02/02/2020');
-  });
-
-  test('it should display the participations count', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const campaignReport = run(() => store.createRecord('campaignReport', {
-      id: 1,
-      participationsCount: 10,
-      sharedParticipationsCount: 4,
-    }));
-
-    const campaign1 = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'campagne 1',
-      code: 'AAAAAA111',
-      campaignReport
-    }));
-
-    const campaigns = [campaign1];
-    campaigns.meta = {
-      rowCount: 1
-    };
-    this.set('campaigns', campaigns);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(4)').hasText('10');
-  });
-
-  test('it should display the shared participations count', async function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const campaignReport = run(() => store.createRecord('campaignReport', {
-      id: 1,
-      participationsCount: 10,
-      sharedParticipationsCount: 4,
-    }));
-
-    const campaign1 = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'campagne 1',
-      code: 'AAAAAA111',
-      campaignReport
-    }));
-
-    const campaigns = [campaign1];
-    campaigns.meta = {
-      rowCount: 1
-    };
-    this.set('campaigns', campaigns);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Campaigns::ListItems
-                @campaigns={{campaigns}}
-                @triggerFiltering={{this.triggerFilteringSpy}}
-                @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
-
-    // then
-    assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(5)').hasText('4');
+  module('When there are campaigns to display', function() {
+    test('it should display a list of campaigns', async function(assert) {
+      // given
+      const campaigns = [
+        { name: 'campagne 1', code: 'AAAAAA111' },
+        { name: 'campagne 2', code: 'BBBBBB222' },
+      ];
+      campaigns.meta = {
+        rowCount: 2
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list').exists();
+      assert.dom('.campaign-list .table tbody tr').exists({ count: 2 });
+    });
+  
+    test('it should display the name of the campaigns', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaign1 = run(() => store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+      }));
+      const campaign2 = run(() => store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 1',
+        code: 'BBBBBB222'
+      }));
+      const campaigns = [campaign1, campaign2];
+      campaigns.meta = {
+        rowCount: 2
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list .table tbody tr:first-child td:first-child').hasText('campagne 1');
+    });
+  
+    test('it should display the creator of the campaigns', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const user1 = run(() => store.createRecord('user', {
+        id: 1,
+        firstName: 'Jean-Michel',
+        lastName: 'Jarre',
+      }));
+      const user2 = run(() => store.createRecord('user', {
+        id: 2,
+        firstName: 'Mathilde',
+        lastName: 'Bonnin de La Bonninière de Beaumont',
+      }));
+      const campaign1 = run(() => store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        creator: user1,
+        code: 'AAAAAA111',
+      }));
+      const campaign2 = run(() => store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 1',
+        creator: user2,
+        code: 'BBBBBB222'
+      }));
+      const campaigns = [campaign1, campaign2];
+      campaigns.meta = {
+        rowCount: 2
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(2)').hasText('Jean-Michel Jarre');
+      assert.dom('.campaign-list .table tbody tr:last-child td:nth-child(2)').hasText('Mathilde Bonnin de La Bonninière de Beaumont');
+    });
+  
+    test('it should display the list of memberships from the organization', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const user1 = store.createRecord('user', { firstName: 'Harry', lastName: 'Covert' });
+      const user2 = store.createRecord('user', { firstName: 'Jean-Michel', lastName: 'Jarre' });
+  
+      const campaigns = [];
+      campaigns.meta = {
+        rowCount: 0
+      };
+  
+      const organizationMembers = [{ user: user1 }, { user:  user2 }];
+  
+      this.set('campaigns', campaigns);
+      this.set('organizationMembers', organizationMembers);
+  
+      // when
+      await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns organizationMembers=organizationMembers triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
+  
+      // then
+      assert.dom('select option:nth-child(1)').hasText('Tous');
+      assert.dom('select option:nth-child(2)').hasText('Harry Covert');
+      assert.dom('select option:nth-child(3)').hasText('Jean-Michel Jarre');
+    });
+  
+    test('it must display the creation date of the campaigns', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaign1 = run(() => store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        createdAt: '03/02/2020',
+      }));
+      const campaign2 = run(() => store.createRecord('campaign', {
+        id: 2,
+        name: 'campagne 2',
+        code: 'BBBBBB222',
+        createdAt: '02/02/2020',
+      }));
+      const campaigns = [campaign2, campaign1];
+      campaigns.meta = {
+        rowCount: 2
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(3)').hasText('02/02/2020');
+    });
+  
+    test('it should display the participations count', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaignReport = run(() => store.createRecord('campaignReport', {
+        id: 1,
+        participationsCount: 10,
+        sharedParticipationsCount: 4,
+      }));
+  
+      const campaign1 = run(() => store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        campaignReport
+      }));
+  
+      const campaigns = [campaign1];
+      campaigns.meta = {
+        rowCount: 1
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(4)').hasText('10');
+    });
+  
+    test('it should display the shared participations count', async function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const campaignReport = run(() => store.createRecord('campaignReport', {
+        id: 1,
+        participationsCount: 10,
+        sharedParticipationsCount: 4,
+      }));
+  
+      const campaign1 = run(() => store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        code: 'AAAAAA111',
+        campaignReport
+      }));
+  
+      const campaigns = [campaign1];
+      campaigns.meta = {
+        rowCount: 1
+      };
+      this.set('campaigns', campaigns);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+  
+      // then
+      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(5)').hasText('4');
+    });
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign | list-items', function(hooks) {
@@ -49,23 +48,23 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list').exists();
-      assert.dom('.campaign-list .table tbody tr').exists({ count: 2 });
+      assert.notContains('Aucune campagne');
+      assert.dom('[aria-label="Campagne"]').exists({ count: 2 });
     });
   
     test('it should display the name of the campaigns', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaign1 = run(() => store.createRecord('campaign', {
+      const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
-      }));
-      const campaign2 = run(() => store.createRecord('campaign', {
+      });
+      const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 1',
         code: 'BBBBBB222'
-      }));
+      });
       const campaigns = [campaign1, campaign2];
       campaigns.meta = {
         rowCount: 2
@@ -79,34 +78,34 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list .table tbody tr:first-child td:first-child').hasText('campagne 1');
+      assert.contains('campagne 1');
     });
   
     test('it should display the creator of the campaigns', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const user1 = run(() => store.createRecord('user', {
+      const user1 = store.createRecord('user', {
         id: 1,
         firstName: 'Jean-Michel',
         lastName: 'Jarre',
-      }));
-      const user2 = run(() => store.createRecord('user', {
+      });
+      const user2 = store.createRecord('user', {
         id: 2,
         firstName: 'Mathilde',
         lastName: 'Bonnin de La Bonninière de Beaumont',
-      }));
-      const campaign1 = run(() => store.createRecord('campaign', {
+      });
+      const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         creator: user1,
         code: 'AAAAAA111',
-      }));
-      const campaign2 = run(() => store.createRecord('campaign', {
+      });
+      const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 1',
         creator: user2,
         code: 'BBBBBB222'
-      }));
+      });
       const campaigns = [campaign1, campaign2];
       campaigns.meta = {
         rowCount: 2
@@ -120,8 +119,8 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(2)').hasText('Jean-Michel Jarre');
-      assert.dom('.campaign-list .table tbody tr:last-child td:nth-child(2)').hasText('Mathilde Bonnin de La Bonninière de Beaumont');
+      assert.dom('[aria-label="Campagne"]:first-child').containsText('Jean-Michel Jarre');
+      assert.dom('[aria-label="Campagne"]:last-child').containsText('Mathilde Bonnin de La Bonninière de Beaumont');
     });
   
     test('it should display the list of memberships from the organization', async function(assert) {
@@ -141,29 +140,33 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
       this.set('organizationMembers', organizationMembers);
   
       // when
-      await render(hbs`{{routes/authenticated/campaigns/list-items campaigns=campaigns organizationMembers=organizationMembers triggerFiltering=triggerFilteringSpy goToCampaignPage=goToCampaignPageSpy}}`);
+      await render(hbs`<Routes::Authenticated::Campaigns::ListItems
+                  @campaigns={{campaigns}}
+                  @organizationMembers={{organizationMembers}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('select option:nth-child(1)').hasText('Tous');
-      assert.dom('select option:nth-child(2)').hasText('Harry Covert');
-      assert.dom('select option:nth-child(3)').hasText('Jean-Michel Jarre');
+      assert.contains('Tous');
+      assert.contains('Harry Covert');
+      assert.contains('Jean-Michel Jarre');
     });
   
     test('it must display the creation date of the campaigns', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaign1 = run(() => store.createRecord('campaign', {
+      const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
         createdAt: '03/02/2020',
-      }));
-      const campaign2 = run(() => store.createRecord('campaign', {
+      });
+      const campaign2 = store.createRecord('campaign', {
         id: 2,
         name: 'campagne 2',
         code: 'BBBBBB222',
         createdAt: '02/02/2020',
-      }));
+      });
       const campaigns = [campaign2, campaign1];
       campaigns.meta = {
         rowCount: 2
@@ -177,24 +180,24 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(3)').hasText('02/02/2020');
+      assert.contains('02/02/2020');
     });
   
     test('it should display the participations count', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaignReport = run(() => store.createRecord('campaignReport', {
+      const campaignReport = store.createRecord('campaignReport', {
         id: 1,
         participationsCount: 10,
         sharedParticipationsCount: 4,
-      }));
+      });
   
-      const campaign1 = run(() => store.createRecord('campaign', {
+      const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
         campaignReport
-      }));
+      });
   
       const campaigns = [campaign1];
       campaigns.meta = {
@@ -209,24 +212,24 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(4)').hasText('10');
+      assert.dom('[aria-label="Campagne"]').containsText('10');
     });
   
     test('it should display the shared participations count', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaignReport = run(() => store.createRecord('campaignReport', {
+      const campaignReport = store.createRecord('campaignReport', {
         id: 1,
         participationsCount: 10,
         sharedParticipationsCount: 4,
-      }));
+      });
   
-      const campaign1 = run(() => store.createRecord('campaign', {
+      const campaign1 = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
         code: 'AAAAAA111',
         campaignReport
-      }));
+      });
   
       const campaigns = [campaign1];
       campaigns.meta = {
@@ -241,7 +244,7 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
   
       // then
-      assert.dom('.campaign-list .table tbody tr:first-child td:nth-child(5)').hasText('4');
+      assert.dom('[aria-label="Campagne"]').containsText('4');
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -13,12 +13,13 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
 
   module('#get displayNoCampaignPanel', function() {
 
-    test('it should know when there is no campaigns', function(assert) {
+    test('it should know when it should display "No campaign panel"', function(assert) {
       // given
       const campaigns = ArrayProxy.create({
         content: []
       });
       controller.model = campaigns;
+      controller.model.meta = { hasCampaigns: false };
 
       // when
       const displayNoCampaignPanel = controller.displayNoCampaignPanel;
@@ -27,13 +28,13 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       assert.equal(displayNoCampaignPanel, true);
     });
 
-    test('it should know when there are campaigns', function(assert) {
+    test('it should know when it should not display "No campaign panel"', function(assert) {
       // given
-      const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
       const campaigns = ArrayProxy.create({
-        content: [campaign1]
+        content: []
       });
       controller.model = campaigns;
+      controller.model.meta = { hasCampaigns: true };
 
       // when
       const displayNoCampaignPanel = controller.displayNoCampaignPanel;
@@ -52,6 +53,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
 
       test('it should display an empty table', function(assert) {
         controller.model = campaigns;
+        controller.model.meta = { hasCampaigns: true };
         controller.name = filterName;
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Quand une organisation n'a que des campagnes archivées, la page de "Création de première campagne" s'affiche et il est possible de voir les campagnes archivées sans en créer de nouvelles.

## :robot: Solution
Quand aucune campagne n'a été crée dans l'organisation, alors afficher la page "Création de première campagne". À partir du moment où au moins une campagne existe dans l'organisation (archivée ou non), il faut afficher la page de la liste des campagnes vide ou non (en fonction des campagnes actives et archivée)
Utilisation d'une meta JSON API `hasCampaigns` sur l'API `/api/organizations/{id}/campaigns` pour savoir si l'organisation possède déjà au moins une campagne (archivé ou non).
On affiche la page "Création de première campagne" uniquement si `hasCampaigns=false`

## :100: Pour tester
- Aller sur une organisation sans aucune campagne 
- Cliquer sur le menu "Campagnes"
> la page "Création de première campagne" s'affiche 

- Aller sur une organisation avec des campagnes
- Cliquer sur le menu "Campagnes"
- Archiver toutes ces campagnes (sélectionner une campagne et cliquer sur le bouton archiver)
> L'onglet "Active" des campagnes est vide avec le message "Aucune campagne
> L'onglet "Archivée" est disponible et il est possible de voir toutes les campagnes archivées