### PR TITLE
[DOC] Ajouter les cas nominaux/exception au standard de test

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -86,14 +86,19 @@ Exemple:
 * use-case [ici](https://github.com/1024pix/pix/blob/prod/api/tests/unit/domain/usecases/update-expired-password_test.js)
 * composant avec un service, non stubbé [ici](https://github.com/1024pix/pix/blob/prod/api/tests/unit/domain/models/CampaignTubeRecommendation_test.js)
 
+Le but est de tester le plus de cas possible.  
+
 ### Intégration
 L'utilisation de Bookshelf, Knex, Nock pour faire des assertions est autorisé.
 Exemple:
 * entre HAPI et configuration de la route [ici](https://github.com/1024pix/pix/blob/prod/api/tests/integration/application/passwords/index_test.js)
 
+Le but est de tester un cas nominal.
 ### Acceptation
 Exemple:
 * sur l'application : [ici](https://github.com/1024pix/pix/blob/prod/api/tests/acceptance/application/password-controller_test.js)
+
+Le but est de tester un cas nominal.
 
 ## Front
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -125,3 +125,21 @@ Elles sont testées unitairement, peu importe leur nature (component, controller
 
 ## Bout-en-bout 
 Raison: éviter les tests manuels, longs et répétitifs, de non-régression
+
+
+Exemple de use case : 
+Pas besoin de test unitaire
+api/lib/domain/usecases/find-completed-user-certifications.js
+api/lib/domain/usecases/find-latest-ongoing-user-campaign-participations.js
+
+On peut faire des tests unitaires parce qu'ils ont des responsabilités
+mais on peux faire plusieurs tests d'intégrations à voir.
+
+C'est use case très simple  ou les tests  avec les mocks / stubs ne sont pas trop complexe
+api/lib/domain/usecases/archive-campaign.js
+api/lib/domain/usecases/create-organization.js
+api/lib/domain/usecases/find-answer-by-challenge-and-assessment.js
+
+Trop complexe pour les tests unitairies et pour les test d'intégrations
+api/lib/domain/usecases/find-campaign-participations-with-results.js
+api/lib/domain/usecases/correct-answer-then-update-assessment.js


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas clair quel type de scénario (nominal/exceptionnel) est ciblé par chaque type de test (unitaire, intégration). Cela ralenti les revues de code.

## :robot: Solution
Discussion et mise à jour du standard de test

## :rainbow: Remarques
Soumis à discussion dans l'atelier test
Inclure des exemples 