### PR TITLE
[BUGFIX] Correction de la mise à jour de l'affichage de la liste des participants (PIX-747).

### DIFF
--- a/orga/app/adapters/campaign-profiles-collection-participation-summary.js
+++ b/orga/app/adapters/campaign-profiles-collection-participation-summary.js
@@ -2,9 +2,14 @@ import ApplicationAdapter from './application';
 
 export default class CampaignProfilesCollectionParticipationSummary extends ApplicationAdapter {
 
-  urlForFindAll(modelName, { adapterOptions }) {
-    const { campaignId } = adapterOptions;
-    return `${this.host}/${this.namespace}/campaigns/${campaignId}/profiles-collection/participations`;
+  urlForQuery(query) {
+    if (query.filter.campaignId) {
+      const { campaignId } = query.filter;
+      delete query.filter.campaignId;
+
+      return `${this.host}/${this.namespace}/campaigns/${campaignId}/profiles-collection/participations`;
+    }
+    return super.urlForQuery(...arguments);
   }
 
 }

--- a/orga/app/routes/authenticated/campaigns/details/profiles.js
+++ b/orga/app/routes/authenticated/campaigns/details/profiles.js
@@ -6,8 +6,10 @@ export default class ProfilesRoute extends Route {
     const campaign = this.modelFor('authenticated.campaigns.details');
     return RSVP.hash({
       campaign,
-      profiles: this.store.findAll('CampaignProfilesCollectionParticipationSummary', {
-        adapterOptions: { campaignId: campaign.id },
+      profiles: this.store.query('CampaignProfilesCollectionParticipationSummary', {
+        filter: {
+          campaignId: campaign.id,
+        },
       }),
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on consulte l'onglet "participants" de 2 campagnes de collecte de profils à la suite, les participants se cumulent dans le tableau.

## :robot: Solution
Utiliser `query` à la place de `findAll`.

## :100: Pour tester
- Afficher la liste des participants à une campagne A de type "collecte profils" ;
- Retourner sur la liste des campagnes ;
- Afficher la liste des participants à une campagne B de type "collecte profils" ;
- Vérifier que ce sont bien uniquement les participants de la campagne B qui sont affichés dans l'onglet "participants" de la campagne B.
