### PR TITLE
[FEATURE] Ne pas montrer la page de présentation si l'utilisateur a déjà commencé sa participation (PIX-616).

### DIFF
--- a/mon-pix/app/routes/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/routes/campaigns/fill-in-id-pix.js
@@ -29,7 +29,7 @@ export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
     const campaignParticipation = await this.store.queryRecord('campaignParticipation', { campaignId: campaign.id, userId });
 
     if (campaignParticipation) {
-      return this.replaceWith('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+      return this.replaceWith('campaigns.start-or-resume', campaign.code);
     }
 
     if (!campaign.idPixLabel) {
@@ -49,13 +49,13 @@ export default class FillInIdPixRoute extends Route.extend(SecuredRouteMixin) {
   async start(campaign, participantExternalId = null) {
     try {
       await this.store.createRecord('campaign-participation', { campaign, participantExternalId }).save();
-      this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+      this.transitionTo('campaigns.start-or-resume', campaign.code);
     } catch (err) {
       if (_.get(err, 'errors[0].status') === 403) {
         this.session.invalidate();
-        return this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } });
+        return this.transitionTo('campaigns.start-or-resume', campaign.code);
       }
-      return this.send('error', err, this.transitionTo('campaigns.start-or-resume', campaign.code, { queryParams: { campaignParticipationIsStarted: true } }));
+      return this.send('error', err, this.transitionTo('campaigns.start-or-resume', campaign.code));
     }
   }
 }

--- a/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
@@ -27,7 +27,9 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   }
 
   async redirect(campaign) {
-    if (this.campaignParticipationIsStarted) {
+    const campaignParticipation = await this.store.queryRecord('campaignParticipation', { campaignId: campaign.id, userId: this.currentUser.user.id });
+
+    if (this.campaignParticipationIsStarted || campaignParticipation) {
       return this.replaceWith('profiles-collection-campaigns.send-profile', this.campaignCode);
     }
     if (this.userHasSeenLanding) {

--- a/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
@@ -10,14 +10,12 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   participantExternalId = null;
   associationDone = false;
   userHasSeenLanding = false;
-  campaignParticipationIsStarted = false;
 
   beforeModel(transition) {
     this.campaignCode = transition.to.parent.params.campaign_code;
     this.associationDone = transition.to.queryParams.associationDone;
     this.participantExternalId = transition.to.queryParams.participantExternalId;
     this.userHasSeenLanding = transition.to.queryParams.hasSeenLanding;
-    this.campaignParticipationIsStarted = transition.to.queryParams.campaignParticipationIsStarted;
     super.beforeModel(...arguments);
   }
 
@@ -29,7 +27,7 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   async redirect(campaign) {
     const campaignParticipation = await this.store.queryRecord('campaignParticipation', { campaignId: campaign.id, userId: this.currentUser.user.id });
 
-    if (this.campaignParticipationIsStarted || campaignParticipation) {
+    if (campaignParticipation) {
       return this.replaceWith('profiles-collection-campaigns.send-profile', this.campaignCode);
     }
     if (this.userHasSeenLanding) {

--- a/mon-pix/tests/acceptance/navigation-test.js
+++ b/mon-pix/tests/acceptance/navigation-test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-mocha';
 import { authenticateByEmail } from '../helpers/authentication';
-import { resumeCampaignByCode } from '../helpers/campaign';
+import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import visit from '../helpers/visit';
 
 describe('Acceptance | Navbar', function() {
@@ -50,7 +50,7 @@ describe('Acceptance | Navbar', function() {
       const campaign = server.create('campaign', 'withOneChallenge');
 
       // when
-      await resumeCampaignByCode(campaign.code, false);
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, false);
 
       // then
       expect(find('.navbar-desktop-header')).to.not.exist;

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment-test.js
@@ -9,16 +9,18 @@ import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import {
-  completeCampaignAndSeeResultsByCode,
-  completeCampaignByCode,
-  resumeCampaignByCode
+  completeCampaignOfTypeAssessmentAndSeeResultsByCode,
+  completeCampaignOfTypeAssessmentByCode,
+  resumeCampaignOfTypeAssessmentByCode
 } from '../helpers/campaign';
 import visit from '../helpers/visit';
 import { invalidateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Campaigns | Resume Campaigns', function() {
+const ASSESSMENT = 'ASSESSMENT';
+
+describe('Acceptance | Campaigns | Resume Campaigns with type Assessment', function() {
   setupApplicationTest();
   setupMirage();
   let campaign;
@@ -29,8 +31,8 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
     beforeEach(async function() {
       studentInfo = server.create('user', 'withEmail');
       await authenticateByEmail(studentInfo);
-      campaign = server.create('campaign', { idPixLabel: 'email' }, 'withThreeChallenges');
-      await resumeCampaignByCode(campaign.code, true);
+      campaign = server.create('campaign', { idPixLabel: 'email', type: ASSESSMENT }, 'withThreeChallenges');
+      await resumeCampaignOfTypeAssessmentByCode(campaign.code, true);
     });
 
     context('When the user is not logged', function() {
@@ -90,7 +92,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
         it('should show the last checkpoint page', async function() {
           // given
-          await completeCampaignByCode(campaign.code);
+          await completeCampaignOfTypeAssessmentByCode(campaign.code);
 
           // when
           await visit(`/campagnes/${campaign.code}`);
@@ -101,7 +103,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
         it('should show the results page when user clicks on "voir mes résultats"', async function() {
           // given
-          await completeCampaignByCode(campaign.code);
+          await completeCampaignOfTypeAssessmentByCode(campaign.code);
           await visit(`/campagnes/${campaign.code}`);
 
           // when
@@ -114,14 +116,14 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
           it('should suggest to share his results', async function() {
             // when
-            await completeCampaignAndSeeResultsByCode(campaign.code);
+            await completeCampaignOfTypeAssessmentAndSeeResultsByCode(campaign.code);
 
             expect(find('.skill-review-share__button')).to.exist;
           });
 
           it('should thank the user when he clicks on the share button', async function() {
             // when
-            await completeCampaignAndSeeResultsByCode(campaign.code);
+            await completeCampaignOfTypeAssessmentAndSeeResultsByCode(campaign.code);
             await click('.skill-review-share__button');
 
             expect(find('.skill-review-share__thanks')).to.exist;
@@ -132,7 +134,7 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
 
           it('should still display thank message when reloading the page', async function() {
             // given
-            await completeCampaignAndSeeResultsByCode(campaign.code);
+            await completeCampaignOfTypeAssessmentAndSeeResultsByCode(campaign.code);
             const currentAssessment = server.schema.campaignParticipations.findBy({ campaignId: campaign.id }).assessment;
             await click('.skill-review-share__button');
 
@@ -157,8 +159,8 @@ describe('Acceptance | Campaigns | Resume Campaigns', function() {
     beforeEach(async function() {
       prescritUserInfo = server.create('user', 'withEmail');
       await authenticateByEmail(prescritUserInfo);
-      campaign1 = server.create('campaign', 'withThreeChallenges');
-      campaign2 = server.create('campaign', 'withThreeChallenges');
+      campaign1 = server.create('campaign', { type: ASSESSMENT }, 'withThreeChallenges');
+      campaign2 = server.create('campaign', { type: ASSESSMENT }, 'withThreeChallenges');
       campaignParticipation1 = server.create('campaignParticipation', { campaign: campaign1 }, 'completedWithResults');
       campaignParticipation2 = server.create('campaignParticipation', { campaign: campaign2 }, 'completedWithResults');
     });

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
@@ -1,0 +1,80 @@
+import { click, fillIn, currentURL } from '@ember/test-helpers';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import { authenticateByEmail } from '../helpers/authentication';
+import { resumeCampaignOfTypeProfilesCollectionByCode, completeCampaignOfTypeProfilesCollectionByCode } from '../helpers/campaign';
+import visit from '../helpers/visit';
+import { invalidateSession } from 'ember-simple-auth/test-support';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { contains } from '../helpers/contains';
+
+const PROFILES_COLLECTION = 'PROFILES_COLLECTION';
+
+describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection', function() {
+  setupApplicationTest();
+  setupMirage();
+  let campaign;
+  let studentInfo;
+
+  beforeEach(async function() {
+    studentInfo = server.create('user', 'withEmail');
+    await authenticateByEmail(studentInfo);
+    campaign = server.create('campaign', { idPixLabel: 'email', type: PROFILES_COLLECTION });
+    await resumeCampaignOfTypeProfilesCollectionByCode(campaign.code, true);
+  });
+
+  context('When the user is not logged', function() {
+
+    beforeEach(async function() {
+      await invalidateSession();
+      await visit(`/campagnes/${campaign.code}`);
+      await click(contains('C’est parti !'));
+    });
+
+    it('should propose to signup', function() {
+      expect(currentURL()).to.contains('/inscription');
+    });
+
+    it('should redirect to send profile page when user logs in', async function() {
+      // given
+      await click('.sign-form-header__subtitle [href="/connexion"]');
+      await fillIn('#login', studentInfo.email);
+      await fillIn('#password', studentInfo.password);
+
+      // when
+      await click('.sign-form-body__bottom-button button');
+
+      // then
+      expect(currentURL()).to.contains('/envoi-profil');
+    });
+
+  });
+
+  context('When user is logged', async function() {
+
+    context('When user has seen send profile page but has not send it', async function() {
+
+      it('should redirect directly to send profile page', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        // then
+        expect(currentURL()).to.contains('/envoi-profil');
+      });
+    });
+
+    context('When user has already send his profile', async function() {
+
+      it('should redirect directly to send profile page', async function() {
+        // given
+        await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
+
+        // when
+        await visit(`/campagnes/${campaign.code}`);
+
+        expect(contains('Merci, votre profil a bien été envoyé !')).to.exist;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
@@ -15,7 +15,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const PROFILES_COLLECTION = 'PROFILES_COLLECTION';
 
-describe('Acceptance | Campaigns | Start Campaigns with type Collect Profiles', function() {
+describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collection', function() {
   setupApplicationTest();
   setupMirage();
   let campaign;

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -1,5 +1,6 @@
 import { click, fillIn } from '@ember/test-helpers';
 import visit from './visit';
+import { contains } from './contains';
 
 export async function startCampaignByCode(campaignCode) {
   await visit(`/campagnes/${campaignCode}`);
@@ -11,7 +12,7 @@ export async function startCampaignByCodeAndExternalId(campaignCode) {
   await click('.campaign-landing-page__start-button');
 }
 
-export async function resumeCampaignByCode(campaignCode, hasExternalParticipantId) {
+export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExternalParticipantId) {
   await visit(`/campagnes/${campaignCode}`);
   await click('.campaign-landing-page__start-button');
   if (hasExternalParticipantId) {
@@ -22,13 +23,27 @@ export async function resumeCampaignByCode(campaignCode, hasExternalParticipantI
   await click('.challenge-actions__action-skip');
 }
 
-export async function completeCampaignByCode(campaignCode) {
+export async function resumeCampaignOfTypeProfilesCollectionByCode(campaignCode, hasExternalParticipantId) {
+  await visit(`/campagnes/${campaignCode}`);
+  await click(contains('C’est parti !'));
+  if (hasExternalParticipantId) {
+    await fillIn('#id-pix-label', 'monmail@truc.fr');
+    await click(contains('Continuer'));
+  }
+}
+
+export async function completeCampaignOfTypeProfilesCollectionByCode(campaignCode) {
+  await visit(`/campagnes/${campaignCode}`);
+  await click(contains('J\'envoie mon profil'));
+}
+
+export async function completeCampaignOfTypeAssessmentByCode(campaignCode) {
   await visit(`/campagnes/${campaignCode}`);
   await click('.challenge-actions__action-skip');
   await click('.challenge-actions__action-skip');
 }
 
-export async function completeCampaignAndSeeResultsByCode(campaignCode) {
+export async function completeCampaignOfTypeAssessmentAndSeeResultsByCode(campaignCode) {
   await visit(`/campagnes/${campaignCode}`);
   await click('.challenge-actions__action-skip');
   await click('.challenge-actions__action-skip');

--- a/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/fill-in-id-pix-test.js
@@ -112,7 +112,7 @@ describe('Unit | Route | campaigns/fill-in-id-pix', function() {
       await route.afterModel(campaign);
 
       // then
-      sinon.assert.calledWithExactly(route.replaceWith, 'campaigns.start-or-resume', campaignCode, { queryParams: { campaignParticipationIsStarted: true } });
+      sinon.assert.calledWithExactly(route.replaceWith, 'campaigns.start-or-resume', campaignCode);
     });
 
     it('should start the campaign when there is no idPixLabel', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Si un utilisateur qui a déjà envoyé son profil Pix à son prescripteur ressaisi le code campagne, il revoit la page de présentation. De ce fait il a l'impression qu'il peut ré-envoyer ses résultats. Ce n'est pas le cas.

De même si l'utilisateur a déjà vu la page d'envoi profil, qu'il décide de l'améliorer puis ressaisi le code plus tard, il revoit la page de présentation.

## :robot: Solution
Lorsque la participation à la campagne existe déjà, ne pas passer par cette page de présentation.

## :rainbow: Remarques
Une nouvelle page va également être réalisée pour spécifier de manière plus claire lorsque le profil a déjà été envoyé.

## :100: Pour tester
- Saisir le code SNAP123, et arriver jusqu'à la page d'envoi profil
- Sortir
- Cliquer sur le bandeau de reprise
- Vérifier qu'on arrive bien directement sur la page d'envoi profil
- Sortir
- Ressaisir le code avec "J'ai un code"
- Vérifier qu'on arrive bien directement sur la page d'envoi profil
- Sortir
- Saisir directement l'url /campagnes/SNAP123
- Vérifier qu'on arrive bien directement sur la page d'envoi profil
- Cliquer sur le bouton d'envoi
- Sortir
- Ressaisir le code
- Vérifier qu'on arrive bien directement sur la page d'envoi profil avec le message "profil déjà envoyé".
