### PR TITLE
[FEATURE] Montrer de manière claire que l'utilisateur a déjà envoyé son profil Pix (PIX-610).

### DIFF
--- a/mon-pix/app/controllers/profiles-collection-campaigns/profile-already-shared.js
+++ b/mon-pix/app/controllers/profiles-collection-campaigns/profile-already-shared.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class ProfileAlreadySharedController extends Controller {
+  pageTitle = 'Profil déjà envoyé';
+}

--- a/mon-pix/app/models/campaign-participation.js
+++ b/mon-pix/app/models/campaign-participation.js
@@ -5,6 +5,7 @@ export default class CampaignParticipation extends Model {
   // attributes
   @attr('boolean') isShared;
   @attr('date') createdAt;
+  @attr('date') sharedAt;
 
   // references
   @attr('string') participantExternalId;

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -66,6 +66,7 @@ Router.map(function() {
   this.route('profiles-collection-campaigns', { path: '/campagnes/:campaign_code/collecte' }, function() {
     this.route('start-or-resume', { path: '/' });
     this.route('send-profile', { path: '/envoi-profil' });
+    this.route('profile-already-shared', { path: '/deja-envoye' });
   });
 
   this.route('competences', { path: '/competences/:competence_id' }, function() {

--- a/mon-pix/app/routes/profiles-collection-campaigns/profile-already-shared.js
+++ b/mon-pix/app/routes/profiles-collection-campaigns/profile-already-shared.js
@@ -1,0 +1,20 @@
+import RSVP from 'rsvp';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ProfileAlreadySharedRoute extends Route {
+  @service currentUser;
+  @service store;
+
+  async model() {
+    const user = this.currentUser.user;
+    const campaignCode = this.paramsFor('profiles-collection-campaigns').campaign_code;
+    const campaigns = await this.store.query('campaign', { filter: { code: campaignCode } });
+    const campaign = campaigns.get('firstObject');
+    return RSVP.hash({
+      campaign,
+      campaignParticipation: this.store.queryRecord('campaignParticipation', { campaignId: campaign.id, userId: user.id }),
+      user
+    });
+  }
+}

--- a/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/profiles-collection-campaigns/start-or-resume.js
@@ -27,6 +27,9 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
   async redirect(campaign) {
     const campaignParticipation = await this.store.queryRecord('campaignParticipation', { campaignId: campaign.id, userId: this.currentUser.user.id });
 
+    if (this._isParticipationShared(campaignParticipation)) {
+      return this.replaceWith('profiles-collection-campaigns.profile-already-shared', this.campaignCode);
+    }
     if (campaignParticipation) {
       return this.replaceWith('profiles-collection-campaigns.send-profile', this.campaignCode);
     }
@@ -37,5 +40,9 @@ export default class ProfilesCollectionCampaignsStartOrResumeRoute extends Route
       return this.replaceWith('campaigns.campaign-landing-page', this.campaignCode, { queryParams: { participantExternalId: this.participantExternalId } });
     }
     return this.replaceWith('restricted-campaigns.join-restricted-campaign', this.campaignCode, { queryParams: { participantExternalId: this.participantExternalId } });
+  }
+
+  _isParticipationShared(campaignParticipation) {
+    return campaignParticipation && campaignParticipation.isShared;
   }
 }

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -5,6 +5,11 @@
     display: flex;
     flex-flow: column;
     align-items: center;
+    margin-bottom: 10px;
+  }
+
+  &__image {
+    margin-top: -50px;
   }
 
   &__title {

--- a/mon-pix/app/templates/components/profile-sharing-form.hbs
+++ b/mon-pix/app/templates/components/profile-sharing-form.hbs
@@ -3,10 +3,10 @@
 
   {{#if @campaignParticipation.isShared}}
     <p class="skill-review-share__thanks">Merci, votre profil a bien été envoyé !</p>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>  
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
   {{else if @errorMessage}}
     <p class="skill-review-share__thanks">{{@errorMessage}}</p>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>  
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
   {{else}}
     {{#if @isLoading}}
       <button type="button" disabled class="button button--big">

--- a/mon-pix/app/templates/profiles-collection-campaigns/profile-already-shared.hbs
+++ b/mon-pix/app/templates/profiles-collection-campaigns/profile-already-shared.hbs
@@ -1,0 +1,16 @@
+{{title pageTitle}}
+<div class="background-banner-wrapper">
+  <div class="background-banner"></div>
+  <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
+    <img class="send-profile-header__image" src="{{rootURL}}/images/bees/fat-bee.svg" alt="Tout ne se passe pas comme prévu">
+    <div class="send-profile-header__announcement">
+      <p class="send-profile-header__instruction">
+        Vous avez déjà envoyé votre profil à l'organisation {{this.model.campaign.organizationName}}
+        <br>le {{moment-format this.model.campaignParticipation.sharedAt 'LL' locale='fr' allow-empty=true}}
+        à {{moment-format this.model.campaignParticipation.sharedAt 'HH:mm' locale='fr' allow-empty=true}}
+      </p>
+      <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+    </div>
+
+  </div>
+</div>

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
@@ -73,7 +73,8 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collecti
         // when
         await visit(`/campagnes/${campaign.code}`);
 
-        expect(contains('Merci, votre profil a bien été envoyé !')).to.exist;
+        // then
+        expect(currentURL()).to.contains('/deja-envoye');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les utilisateurs qui ont envoyé leur profil Pix au prescripteur ressaisissent le code campagne, ils voient la page d'envoi profil avec comme titre "ENVOI DE VOTRE PROFIL PIX" et en petit "votre profil a déjà été envoyé". Cette page n'est pas suffisamment claire pour comprendre qu'on ne peut pas ré-envoyer son profil.

## :robot: Solution
Faire un affichage dédié.
![image](https://user-images.githubusercontent.com/23451175/82917034-2344fa80-9f73-11ea-9c03-60ff8c9254cb.png)

## 🌈 Remarques
On va afficher par la suite le profil qui a été envoyé en dessous, sinon on n'a aucun moyen de le revoir.

## :100: Pour tester
- Saisir le code SNAP123
- Passer la page de présentation
- Envoyer son profil
- Sortir
- Ressaisir le code SNAP123
- Vérifier qu'on arrive bien sur la page dédiée
