### PR TITLE
[TECH] Merge automatique grâce aux Github Actions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,25 @@
+name: check
+on:
+  pull_request:
+    types:
+      - labeled
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status:
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.8.3"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "Merge-auto test"
+          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          UPDATE_LABELS: "Merge-auto test"
+          UPDATE_METHOD: "rebase"
+          MERGE_FORKS: "false"


### PR DESCRIPTION
## :unicorn: Problème
Le processus de merge des PRs est assez fastidieux actuellement.
Quand on souhaite merger une PR, on doit :
- Prévenir les autres dev que l'on souhaite merger une PR
- Rebase la PR avec la branche `dev`
- Attendre que le workflow de CI soit ok
- Prier pour que personne n'ai mergé entre temps
- Faire le merge de la PR et changer le titre de merge par défaut avec celui de la PR

## :robot: Solution
Automatiser ce processus grâce aux Github Actions.
Nous utilisons un github action qui répond exactement à nos besoins : 
https://github.com/pascalgn/automerge-action

Elle permet de déclencher un processus de merge automatique sur le PR ayant été labellisées ":rocket: Ready to merge". Quand la PR a ce label, l'action va:
- Checkout la branche
- Vérifier que les checks **obligatoires** sont passés et ok
- Vérifier que la PR respecte les conditions d'approbation
- Rebaser la PR avec la branche cible (dev)
    - Si KO => un check d'erreur apparait dans la PR (car conflit au rebase)
    - Si OK => merge la branche dans la branche cible (dev) et change le titre du commit de merge avec le nom de la PR, et enfin ferme la PR 

## :rainbow: Remarques
Conditions à respecter pour que la PR soit merge :
> - the required number of review approvals has been given (if enabled in the branch protection rules) and
> - the required checks have passed (if enabled in the branch protection rules) and
> - the pull request is up to date (if enabled in the branch protection rules)

## :100: Pour tester
Vous pouvez tester sur ce [repo de test](https://github.com/1024pix/automatic-merge-actions)
1. Créer une PR
2. Mettre le label ":rocket: Ready to merge"
3. Faire approuver la PR

