### PR TITLE
[CLEANUP] Change la manière de récupérer les réponses d'un QCM (PIX-768).

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,16 +1,16 @@
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
-import classic from 'ember-classic-decorator';
+import _ from 'lodash';
 
-@classic
-class ChallengeItemQcm extends ChallengeItemGeneric {
+export default class ChallengeItemQcm extends ChallengeItemGeneric {
+  answersValue= [];
+
   _hasError() {
     return this._getAnswerValue().length < 1;
   }
 
-  // FIXME refactor that
   _getAnswerValue() {
-    return this.$('input[type=checkbox][id^=checkbox_]:checked').map(function() {return this.name; }).get().join(',');
+    return this.answersValue.join(',');
   }
 
   _getErrorMessage() {
@@ -18,9 +18,8 @@ class ChallengeItemQcm extends ChallengeItemGeneric {
   }
 
   @action
-  answerChanged() {
+  answerChanged(checkboxName) {
+    _.indexOf(this.answersValue, checkboxName) === -1 ? this.answersValue.push(checkboxName) : _.remove(this.answersValue, (value) => value === checkboxName);
     this.set('errorMessage', null);
   }
 }
-
-export default ChallengeItemQcm;

--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,16 +1,15 @@
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
-import _ from 'lodash';
 
 export default class ChallengeItemQcm extends ChallengeItemGeneric {
-  answersValue= [];
+  checkedValues = new Set();
 
   _hasError() {
-    return this._getAnswerValue().length < 1;
+    return this.checkedValues.size < 1;
   }
 
   _getAnswerValue() {
-    return this.answersValue.join(',');
+    return Array.from(this.checkedValues).join(',');
   }
 
   _getErrorMessage() {
@@ -19,7 +18,11 @@ export default class ChallengeItemQcm extends ChallengeItemGeneric {
 
   @action
   answerChanged(checkboxName) {
-    _.indexOf(this.answersValue, checkboxName) === -1 ? this.answersValue.push(checkboxName) : _.remove(this.answersValue, (value) => value === checkboxName);
+    if (this.checkedValues.has(checkboxName)) {
+      this.checkedValues.delete(checkboxName);
+    } else {
+      this.checkedValues.add(checkboxName);
+    }
     this.set('errorMessage', null);
   }
 }

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -22,7 +22,7 @@ export default class QcmProposals extends Component {
   }
 
   @action
-  checkboxClicked() {
-    this.answerChanged();
+  checkboxClicked(checkboxName) {
+    this.answerChanged(checkboxName);
   }
 }

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -2,12 +2,12 @@
 <p class="proposal-paragraph">
 
   {{!-- Checkbox button : hidden  - SVG displayed instead - but needed. --}}
-  <input type="checkbox"
+  <Input @type="checkbox"
          id="checkbox_{{inc index}}"
-         checked={{labeledCheckbox.[1]}}
+         @checked={{labeledCheckbox.[1]}}
          name="{{inc index}}"
          onclick={{action "checkboxClicked" (inc index)}}
-         disabled={{if answer true}}>
+         disabled={{if answer true}} />
 
   {{!-- Surrounding label --}}
   <label for="checkbox_{{inc index}}"

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -6,7 +6,7 @@
          id="checkbox_{{inc index}}"
          checked={{labeledCheckbox.[1]}}
          name="{{inc index}}"
-         onclick={{action "checkboxClicked"}}
+         onclick={{action "checkboxClicked" (inc index)}}
          disabled={{if answer true}}>
 
   {{!-- Surrounding label --}}


### PR DESCRIPTION
## :unicorn: Problème
La façon dont on récupérait les réponses aux QCM utilisait le jQuery d'Ember, et était noté depuis longtemps en "FIX ME"

## :robot: Solution
- Utiliser l'action answerChanged appelé à chaque modification pour récupérer la valeur et la mettre dans un tableau. Il faut aussi gérer le décochage.
 
## :rainbow: Remarques
- Ceci n'est qu'une proposition d'amélioration, la méthode actuelle ayant fait ses preuves au fil des années.
- Si cette façon convient, elle pourra être utilisé pour les QCU et d'autres types d'épreuves.

## :100: Pour tester
https://app-pr1457.review.pix.fr/courses/recvS3WQht3DV2nYM