### PR TITLE
[FEATURE] Permettre à l'utilisateur d'obtenir un e-mail de réinitialisation de mot de passe en fonction de sa région (PIX-746).

### DIFF
--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -1,5 +1,3 @@
-const settings = require('../../config');
-
 const usecases = require('../../domain/usecases');
 
 const mailService = require('../../domain/services/mail-service');
@@ -10,6 +8,7 @@ const passwordResetSerializer = require('../../infrastructure/serializers/jsonap
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const resetPasswordDemandRepository = require('../../infrastructure/repositories/reset-password-demands-repository');
 const userRepository = require('../../infrastructure/repositories/user-repository');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -18,7 +17,8 @@ module.exports = {
     await userRepository.isUserExistingByEmail(user.email);
     const temporaryKey = resetPasswordService.generateTemporaryKey();
     const passwordResetDemand = await resetPasswordDemandRepository.create({ email: user.email, temporaryKey });
-    await mailService.sendResetPasswordDemandEmail(user.email, `https://${settings.app.domain}`, temporaryKey);
+    const locale = extractLocaleFromRequest(request);
+    await mailService.sendResetPasswordDemandEmail(user.email, locale, temporaryKey);
     const serializedPayload = passwordResetSerializer.serialize(passwordResetDemand.attributes);
 
     return h.response(serializedPayload).created();

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -36,7 +36,8 @@ module.exports = (function() {
     },
 
     app: {
-      domain: 'app.pix.fr'
+      domainFr: 'pix.fr',
+      domainOrg: 'pix.org'
     },
 
     logging: {

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -15,14 +15,30 @@ function sendAccountCreationEmail(email) {
   });
 }
 
-function sendResetPasswordDemandEmail(email, baseUrl, temporaryKey) {
+function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
+  let variables = {
+    homeName: `${settings.app.domainFr}`,
+    homeUrl: `https://${settings.app.domainFr}`,
+    resetUrl: `https://app.${settings.app.domainFr}/changer-mot-de-passe/${temporaryKey}`,
+    locale
+  };
+
+  if (locale === 'fr') {
+    variables = {
+      homeName: `${settings.app.domainOrg}`,
+      homeUrl: `https://${settings.app.domainOrg}`,
+      resetUrl: `https://app.${settings.app.domainOrg}/changer-mot-de-passe/${temporaryKey}`,
+      locale
+    };
+  }
+
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
     fromName: PIX_NAME,
     to: email,
     subject: 'Demande de réinitialisation de mot de passe PIX',
     template: mailer.passwordResetTemplateId,
-    variables: { resetUrl: `${baseUrl}/changer-mot-de-passe/${temporaryKey}` }
+    variables
   });
 }
 

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -46,7 +46,7 @@ describe('Unit | Controller | PasswordController', () => {
       // given
       const generatedToken = 'token';
       const demand = { email: 'shi@fu.me', temporaryKey: generatedToken };
-      const hostBaseUrl = 'https://localhost';
+      const locale = 'fr-fr';
       const resolvedPasswordReset = {
         attributes: {
           email: 'Giles75@hotmail.com',
@@ -54,6 +54,7 @@ describe('Unit | Controller | PasswordController', () => {
           id: 15
         }
       };
+      request.locale = locale;
 
       userRepository.isUserExistingByEmail.resolves();
       resetPasswordService.generateTemporaryKey.returns(generatedToken);
@@ -68,7 +69,7 @@ describe('Unit | Controller | PasswordController', () => {
       sinon.assert.calledWith(userRepository.isUserExistingByEmail, userEmail);
       sinon.assert.calledOnce(resetPasswordService.generateTemporaryKey);
       sinon.assert.calledWith(resetPasswordRepository.create, demand);
-      sinon.assert.calledWith(mailService.sendResetPasswordDemandEmail, request.payload.data.attributes.email, hostBaseUrl, generatedToken);
+      sinon.assert.calledWith(mailService.sendResetPasswordDemandEmail, request.payload.data.attributes.email, locale, generatedToken);
       sinon.assert.calledWith(passwordResetSerializer.serialize, resolvedPasswordReset.attributes);
     });
   });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -36,10 +36,11 @@ describe('Unit | Service | MailService', () => {
 
     context('when provided passwordResetDemandBaseUrl is not production', () => {
 
-      it('should call Mailjet with a sub-domain prefix', async () => {
+      it('should call mailer', async () => {
         // given
         const fakeTemporaryKey = 'token';
-        const passwordResetDemandBaseUrl = 'http://dev.pix.fr';
+        const locale = 'fr-fr';
+        const domainFr = 'pix.fr';
 
         const expectedOptions = {
           from: senderEmailAddress,
@@ -48,12 +49,42 @@ describe('Unit | Service | MailService', () => {
           subject: 'Demande de réinitialisation de mot de passe PIX',
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `${passwordResetDemandBaseUrl}/changer-mot-de-passe/${fakeTemporaryKey}`
+            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            homeName: `${domainFr}`,
+            homeUrl: `https://${domainFr}`,
+            locale
           }
         };
 
         // when
-        await mailService.sendResetPasswordDemandEmail(userEmailAddress, passwordResetDemandBaseUrl, fakeTemporaryKey);
+        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+
+      it('should call mailer with locale fr', async () => {
+        // given
+        const fakeTemporaryKey = 'token';
+        const locale = 'fr';
+        const domainOrg = 'pix.org';
+
+        const expectedOptions = {
+          from: senderEmailAddress,
+          fromName: 'PIX - Ne pas répondre',
+          to: userEmailAddress,
+          subject: 'Demande de réinitialisation de mot de passe PIX',
+          template: 'test-password-reset-template-id',
+          variables: {
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            homeName: `${domainOrg}`,
+            homeUrl: `https://${domainOrg}`,
+            locale
+          }
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
 
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);


### PR DESCRIPTION
## :unicorn: Problème
Pix utilise différent nom de domaine : pix.fr, pix.org. 
Nous souhaitons que lorsqu’un utilisateur fait une demande de réinitialisation de mot de passe depuis un domaine, que les liens dans le mail envoyer redirige vers ce même domaine. Et nous voulons que pour les autres domaines que pix.fr, il n'y ai pas la Marianne dans le footer.

## :robot: Solution
Ces deux domaines sont associés à des locales différentes
- Nous récupérons la locale de l'utilisateur dans le `password-controller` pour la fournir au `mail-service`.
https://github.com/1024pix/pix/blob/89574bf44e30301994e89a23d6e3713eac4393f2/api/lib/application/passwords/password-controller.js#L20-L21

- Nous avons ajouté des variables construites à partir de la locale, qui seront envoyés à notre mailer (SendInBlue).
https://github.com/1024pix/pix/blob/4cd9a529e7fc5a6fd37928a4ab7df295217def37/api/lib/domain/services/mail-service.js#L19-L33
- Nous envoyons aussi la variable : `locale` afin de la vérifier dans le template pour afficher ou non la Marianne. 

- Nous avons utilisé un nouveau template (id: 26) dans SendInBlue pour effectuer des modifications sur celui-ci. 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/26384707/83048243-928d1e00-a049-11ea-8a4a-03906e6a19b2.gif)



## :rainbow: Remarques
Il faudra choisir au moment de la mise en production s'ils ont souhaite garder ce template ou copier le contenu de celui-ci dans l'ancien. 
Les mails ont été activé pour tester dans la RA, et la variable d'environnement `SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID` a été modifié pour utiliser le nouveau template (id : 26).

## :100: Pour tester

- Aller sur les pages de réinitialisation de mot de passe sur : 
     - https://app-pr1460.review.pix.fr/mot-de-passe-oublie
     - https://app-pr1460.review.pix.org/mot-de-passe-oublie
 - Lorsque vous faites la demande à partir de `.fr`, les liens dans l'e-mail doivent finir en `.fr` et la Marianne doit-être présente.
- Et lorsque vous faites la demande depuis `.org`, les liens doivent finir par `.org` et il ne doit pas y avoir la Marianne.
