### PR TITLE
[TECH] Utiliser un EventDispatcher pour passer les Domain Events aux Event Handlers

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -9,9 +9,6 @@ const challengeSerializer = require('../../infrastructure/serializers/jsonapi/ch
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
-const EventDispatcher = require('../../infrastructure/events/EventDispatcher');
-const AssessmentCompleted = require('../../domain/events/AssessmentCompleted');
-const CertificationScoringCompleted = require('../../domain/events/CertificationScoringCompleted');
 
 module.exports = {
 
@@ -94,16 +91,9 @@ module.exports = {
   async completeAssessment(request) {
     const assessmentId = parseInt(request.params.id);
 
-    // TODO move Dispatcher instanciation and subscriptions elsewhere ?
-    // In DI ? In a factory ?
-    const eventDispatcher = new EventDispatcher();
-    eventDispatcher.subscribe(AssessmentCompleted, events.handleBadgeAcquisition);
-    eventDispatcher.subscribe(AssessmentCompleted, events.handleCertificationScoring);
-    eventDispatcher.subscribe(CertificationScoringCompleted, events.handleCertificationAcquisitionForPartner);
-
     await DomainTransaction.execute(async (domainTransaction) => {
       const event = await usecases.completeAssessment({ domainTransaction, assessmentId });
-      await eventDispatcher.dispatch(domainTransaction, event);
+      await events.eventDispatcher.dispatch(domainTransaction, event);
     });
 
     return null;

--- a/api/lib/domain/events/check-event-type.js
+++ b/api/lib/domain/events/check-event-type.js
@@ -1,0 +1,7 @@
+module.exports = {
+  checkEventType(event, eventType) {
+    if (!(event instanceof eventType)) {
+      throw new Error(`event must be of type ${eventType.name}`);
+    }
+  }
+};

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -1,3 +1,6 @@
+const AssessmentCompleted = require('../events/AssessmentCompleted');
+const { checkEventType } = require('./check-event-type');
+
 const handleBadgeAcquisition = async function({
   domainTransaction,
   event,
@@ -6,6 +9,8 @@ const handleBadgeAcquisition = async function({
   badgeRepository,
   campaignParticipationResultRepository,
 }) {
+  checkEventType(event, AssessmentCompleted);
+
   if (completedAssessmentBelongsToACampaign(event)) {
     const badge = await fetchPossibleCampaignAssociatedBadge(event, badgeRepository);
     if (isABadgeAssociatedToCampaign(badge)) {

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -1,39 +1,39 @@
 const handleBadgeAcquisition = async function({
   domainTransaction,
-  assessmentCompletedEvent,
+  event,
   badgeCriteriaService,
   badgeAcquisitionRepository,
   badgeRepository,
   campaignParticipationResultRepository,
 }) {
-  if (completedAssessmentBelongsToACampaign(assessmentCompletedEvent)) {
-    const badge = await fetchPossibleCampaignAssociatedBadge(assessmentCompletedEvent, badgeRepository);
+  if (completedAssessmentBelongsToACampaign(event)) {
+    const badge = await fetchPossibleCampaignAssociatedBadge(event, badgeRepository);
     if (isABadgeAssociatedToCampaign(badge)) {
-      const campaignParticipationResult = await fetchCampaignParticipationResults(assessmentCompletedEvent, badge, campaignParticipationResultRepository);
+      const campaignParticipationResult = await fetchCampaignParticipationResults(event, badge, campaignParticipationResultRepository);
       if (isBadgeAcquired(campaignParticipationResult, badge.badgeCriteria, badgeCriteriaService)) {
         await badgeAcquisitionRepository.create({
           badgeId: badge.id,
-          userId: assessmentCompletedEvent.userId
+          userId: event.userId
         }, domainTransaction);
       }
     }
   }
 };
 
-function completedAssessmentBelongsToACampaign(assessmentCompletedEvent) {
-  return !!assessmentCompletedEvent.targetProfileId;
+function completedAssessmentBelongsToACampaign(event) {
+  return !!event.targetProfileId;
 }
 
-async function fetchPossibleCampaignAssociatedBadge(assessmentCompletedEvent, badgeRepository) {
-  return await badgeRepository.findOneByTargetProfileId(assessmentCompletedEvent.targetProfileId);
+async function fetchPossibleCampaignAssociatedBadge(event, badgeRepository) {
+  return await badgeRepository.findOneByTargetProfileId(event.targetProfileId);
 }
 
 function isABadgeAssociatedToCampaign(badge) {
   return !!badge;
 }
 
-async function fetchCampaignParticipationResults(assessmentCompletedEvent, badge, campaignParticipationResultRepository) {
-  return await campaignParticipationResultRepository.getByParticipationId(assessmentCompletedEvent.campaignParticipationId, badge);
+async function fetchCampaignParticipationResults(event, badge, campaignParticipationResultRepository) {
+  return await campaignParticipationResultRepository.getByParticipationId(event.campaignParticipationId, badge);
 }
 
 function isBadgeAcquired(campaignParticipationResult, badgeCriteria, badgeCriteriaService) {

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -1,6 +1,7 @@
 const AssessmentCompleted = require('../events/AssessmentCompleted');
 const { checkEventType } = require('./check-event-type');
 
+const eventType = AssessmentCompleted;
 const handleBadgeAcquisition = async function({
   domainTransaction,
   event,
@@ -9,7 +10,7 @@ const handleBadgeAcquisition = async function({
   badgeRepository,
   campaignParticipationResultRepository,
 }) {
-  checkEventType(event, AssessmentCompleted);
+  checkEventType(event, eventType);
 
   if (completedAssessmentBelongsToACampaign(event)) {
     const badge = await fetchPossibleCampaignAssociatedBadge(event, badgeRepository);
@@ -45,4 +46,5 @@ function isBadgeAcquired(campaignParticipationResult, badgeCriteria, badgeCriter
   return badgeCriteriaService.areBadgeCriteriaFulfilled({ campaignParticipationResult, badgeCriteria });
 }
 
+handleBadgeAcquisition.eventType = eventType;
 module.exports = handleBadgeAcquisition;

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -2,26 +2,26 @@ const Badge = require('../models/Badge');
 const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
 
 async function handleCertificationAcquisitionForPartner({
-  certificationScoringEvent,
   domainTransaction,
+  event,
   badgeAcquisitionRepository,
   competenceRepository,
   competenceMarkRepository,
   certificationPartnerAcquisitionRepository,
 }) {
-  const certificationCourseId = certificationScoringEvent.certificationCourseId;
+  const certificationCourseId = event.certificationCourseId;
   const cleaPartnerAcquisition = new CertificationPartnerAcquisition({
     certificationCourseId,
     partnerKey: Badge.keys.PIX_EMPLOI_CLEA,
   });
 
-  const hasAcquiredBadgeClea = await _getHasAcquiredBadgeClea(badgeAcquisitionRepository, certificationScoringEvent.userId);
+  const hasAcquiredBadgeClea = await _getHasAcquiredBadgeClea(badgeAcquisitionRepository, event.userId);
   const competenceMarks = await competenceMarkRepository.getLatestByCertificationCourseId({ certificationCourseId, domainTransaction });
   const totalPixCleaByCompetence = await competenceRepository.getTotalPixCleaByCompetence();
 
   if (cleaPartnerAcquisition.hasAcquiredCertification({
     hasAcquiredBadge: hasAcquiredBadgeClea,
-    reproducibilityRate: certificationScoringEvent.reproducibilityRate,
+    reproducibilityRate: event.reproducibilityRate,
     totalPixCleaByCompetence,
     competenceMarks
   })) {

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -3,6 +3,8 @@ const CertificationPartnerAcquisition = require('../models/CertificationPartnerA
 const CertificationScoringCompleted = require('./CertificationScoringCompleted');
 const { checkEventType } = require('./check-event-type');
 
+const eventType = CertificationScoringCompleted;
+
 async function handleCertificationAcquisitionForPartner({
   domainTransaction,
   event,
@@ -11,7 +13,7 @@ async function handleCertificationAcquisitionForPartner({
   competenceMarkRepository,
   certificationPartnerAcquisitionRepository,
 }) {
-  checkEventType(event, CertificationScoringCompleted);
+  checkEventType(event, eventType);
 
   const certificationCourseId = event.certificationCourseId;
   const cleaPartnerAcquisition = new CertificationPartnerAcquisition({
@@ -40,4 +42,5 @@ async function _getHasAcquiredBadgeClea(badgeAcquisitionRepository, userId) {
   });
 }
 
+handleCertificationAcquisitionForPartner.eventType = eventType;
 module.exports = handleCertificationAcquisitionForPartner;

--- a/api/lib/domain/events/handle-certification-partner.js
+++ b/api/lib/domain/events/handle-certification-partner.js
@@ -1,5 +1,7 @@
 const Badge = require('../models/Badge');
 const CertificationPartnerAcquisition = require('../models/CertificationPartnerAcquisition');
+const CertificationScoringCompleted = require('./CertificationScoringCompleted');
+const { checkEventType } = require('./check-event-type');
 
 async function handleCertificationAcquisitionForPartner({
   domainTransaction,
@@ -9,6 +11,8 @@ async function handleCertificationAcquisitionForPartner({
   competenceMarkRepository,
   certificationPartnerAcquisitionRepository,
 }) {
+  checkEventType(event, CertificationScoringCompleted);
+
   const certificationCourseId = event.certificationCourseId;
   const cleaPartnerAcquisition = new CertificationPartnerAcquisition({
     certificationCourseId,

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -5,6 +5,8 @@ const bluebird = require('bluebird');
 const {
   CertificationComputeError,
 } = require('../errors');
+const AssessmentCompleted = require('./AssessmentCompleted');
+const { checkEventType } = require('./check-event-type');
 
 async function handleCertificationScoring({
   domainTransaction,
@@ -17,6 +19,8 @@ async function handleCertificationScoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
+  checkEventType(event, AssessmentCompleted);
+
   if (event.isCertification) {
     const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
     return _calculateCertificationScore({ certificationAssessment, domainTransaction, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService, badgeAcquisitionRepository, certificationPartnerAcquisitionRepository });

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -7,8 +7,8 @@ const {
 } = require('../errors');
 
 async function handleCertificationScoring({
-  assessmentCompletedEvent,
   domainTransaction,
+  event,
   assessmentResultRepository,
   badgeAcquisitionRepository,
   certificationAssessmentRepository,
@@ -17,8 +17,8 @@ async function handleCertificationScoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  if (assessmentCompletedEvent.isCertification) {
-    const certificationAssessment = await certificationAssessmentRepository.get(assessmentCompletedEvent.assessmentId);
+  if (event.isCertification) {
+    const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
     return _calculateCertificationScore({ certificationAssessment, domainTransaction, assessmentResultRepository, certificationCourseRepository, competenceMarkRepository, scoringCertificationService, badgeAcquisitionRepository, certificationPartnerAcquisitionRepository });
   }
 

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -8,6 +8,8 @@ const {
 const AssessmentCompleted = require('./AssessmentCompleted');
 const { checkEventType } = require('./check-event-type');
 
+const eventType = AssessmentCompleted;
+
 async function handleCertificationScoring({
   domainTransaction,
   event,
@@ -19,7 +21,7 @@ async function handleCertificationScoring({
   competenceMarkRepository,
   scoringCertificationService,
 }) {
-  checkEventType(event, AssessmentCompleted);
+  checkEventType(event, eventType);
 
   if (event.isCertification) {
     const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
@@ -106,5 +108,5 @@ async function _saveResultAfterCertificationComputeError({
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(certificationAssessment.certificationCourseId, new Date(), domainTransaction);
 }
-
+handleCertificationScoring.eventType = eventType;
 module.exports = handleCertificationScoring;

--- a/api/lib/infrastructure/events/EventDispatcher.js
+++ b/api/lib/infrastructure/events/EventDispatcher.js
@@ -3,17 +3,18 @@ class EventDispatcher {
     this._subscriptions = [];
   }
 
-  subscribe(event, subscriber) {
-    this._subscriptions.push([event, subscriber]);
+  subscribe(event, eventHandler) {
+    this._subscriptions.push([event, eventHandler]);
   }
 
-  dispatch(dispatchedEvent) {
+  dispatch(domainTransaction, dispatchedEvent) {
     const subscriptions = this._subscriptions.filter(([event, _]) => {
       return event == dispatchedEvent;
     });
 
-    subscriptions.forEach(([_, subscriber]) => {
-      subscriber.handle(dispatchedEvent);
+    subscriptions.forEach(([_, eventHandler]) => {
+      const returnedEvent = eventHandler.handle(domainTransaction, dispatchedEvent);
+      this.dispatch(domainTransaction, returnedEvent);
     });
   }
 }

--- a/api/lib/infrastructure/events/EventDispatcher.js
+++ b/api/lib/infrastructure/events/EventDispatcher.js
@@ -1,0 +1,16 @@
+class EventDispatcher {
+  constructor() {
+    this._subscribers = [];
+  }
+  subscribe(event, subscriber) {
+    this._subscribers.push(subscriber);
+  }
+
+  dispatch(event) {
+    this._subscribers.forEach((subscriber) => {
+      subscriber.handle(event);
+    });
+  }
+}
+
+module.exports = EventDispatcher;

--- a/api/lib/infrastructure/events/EventDispatcher.js
+++ b/api/lib/infrastructure/events/EventDispatcher.js
@@ -1,14 +1,19 @@
 class EventDispatcher {
   constructor() {
-    this._subscribers = [];
-  }
-  subscribe(event, subscriber) {
-    this._subscribers.push(subscriber);
+    this._subscriptions = [];
   }
 
-  dispatch(event) {
-    this._subscribers.forEach((subscriber) => {
-      subscriber.handle(event);
+  subscribe(event, subscriber) {
+    this._subscriptions.push([event, subscriber]);
+  }
+
+  dispatch(dispatchedEvent) {
+    const subscriptions = this._subscriptions.filter(([event, _]) => {
+      return event == dispatchedEvent;
+    });
+
+    subscriptions.forEach(([_, subscriber]) => {
+      subscriber.handle(dispatchedEvent);
     });
   }
 }

--- a/api/lib/infrastructure/utils/dependency-injection.js
+++ b/api/lib/infrastructure/utils/dependency-injection.js
@@ -8,4 +8,4 @@ function injectDependencies(toBeInjected, dependencies) {
   return _.mapValues(toBeInjected, _.partial(injectDefaults, dependencies));
 }
 
-module.exports = { injectDependencies };
+module.exports = { injectDependencies, injectDefaults };

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -2,80 +2,90 @@ const { expect, sinon } = require('../../test-helper');
 const EventDispatcher = require('../../../lib/infrastructure/events/EventDispatcher');
 
 function getEventHandlerMock() {
-  return {
-    handle: sinon.stub()
-  };
+  return sinon.stub();
 }
+
+class TestEvent {}
+
+class AnotherTestEvent {}
 
 describe('Integration | Infrastructure | EventHandler', () => {
   let eventDispatcher;
-  const event = Symbol('an event');
+  const event = new TestEvent();
   const domainTransaction = Symbol('domain transaction');
 
   beforeEach(() => {
     eventDispatcher = new EventDispatcher();
   });
 
-  it('dispatches event to subscriber', () => {
+  it('dispatches event to subscriber', async () => {
     // given
     const eventHandler = getEventHandlerMock();
-    eventDispatcher.subscribe(event, eventHandler);
+    eventDispatcher.subscribe(TestEvent, eventHandler);
 
     // when
-    eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(domainTransaction, event);
 
     // then
-    expect(eventHandler.handle).to.have.been.calledWith(domainTransaction, event);
+    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
   });
 
-  it('dispatches event to several eventHandlers', () => {
+  it('thows when duplicate subscription', async () => {
+    // given
+    const eventHandler = getEventHandlerMock();
+
+    // when / then
+    expect(() => {
+      eventDispatcher.subscribe(TestEvent, eventHandler);
+      eventDispatcher.subscribe(AnotherTestEvent, eventHandler);
+      eventDispatcher.subscribe(TestEvent, eventHandler);
+    }).to.throw();
+  });
+
+  it('dispatches event to several eventHandlers', async () => {
     // given
     const eventHandler_1 = getEventHandlerMock();
     const eventHandler_2 = getEventHandlerMock();
 
-    eventDispatcher.subscribe(event, eventHandler_1);
-    eventDispatcher.subscribe(event, eventHandler_2);
+    eventDispatcher.subscribe(TestEvent, eventHandler_1);
+    eventDispatcher.subscribe(TestEvent, eventHandler_2);
 
     // when
-    eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(domainTransaction, event);
 
     // then
-    expect(eventHandler_1.handle).to.have.been.calledWith(domainTransaction, event);
-    expect(eventHandler_2.handle).to.have.been.calledWith(domainTransaction, event);
+    expect(eventHandler_1).to.have.been.calledWith({ domainTransaction, event });
+    expect(eventHandler_2).to.have.been.calledWith({ domainTransaction, event });
   });
 
-  it('calls handler only for subscribed events', () => {
+  it('calls handler only for subscribed events', async () => {
     // given
     const eventHandler = getEventHandlerMock();
-    const otherEvent = Symbol('another event');
+    const otherEvent = new AnotherTestEvent();
 
-    eventDispatcher.subscribe(event, eventHandler);
+    eventDispatcher.subscribe(TestEvent, eventHandler);
 
     // when
-    eventDispatcher.dispatch(domainTransaction, event);
-    eventDispatcher.dispatch(domainTransaction, otherEvent);
+    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(domainTransaction, otherEvent);
 
     // then
-    expect(eventHandler.handle).to.have.been.calledWith(domainTransaction, event);
-    expect(eventHandler.handle).not.to.have.been.calledWith(domainTransaction, otherEvent);
+    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
+    expect(eventHandler).not.to.have.been.calledWith({ domainTransaction, otherEvent });
   });
 
-  it('dispatches events returned by eventHandlers', () => {
+  it('dispatches events returned by eventHandlers', async () => {
     // given
-    const returnedEvent = Symbol('returned event');
-    const originEventEmitter = {
-      handle() {
-        return returnedEvent;
-      }
-    };
+    const returnedEvent = new AnotherTestEvent();
+    const originEventEmitter = () => returnedEvent;
     const eventHandler = getEventHandlerMock();
-    eventDispatcher.subscribe(event, originEventEmitter);
-    eventDispatcher.subscribe(returnedEvent, eventHandler);
+    eventDispatcher.subscribe(TestEvent, originEventEmitter);
+    eventDispatcher.subscribe(AnotherTestEvent, eventHandler);
 
     // when
-    eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(domainTransaction, event);
 
     // then
-    expect(eventHandler.handle).to.have.been.calledWith(domainTransaction, returnedEvent);
+    expect(eventHandler).to.have.been.calledWith({ domainTransaction, event:returnedEvent });
   });
 });

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -49,4 +49,20 @@ describe('Integration | Infrastructure | EventHandler', () => {
     expect(subscriber_1.handle).to.have.been.calledWith(event);
     expect(subscriber_2.handle).to.have.been.calledWith(event);
   });
+
+  it('calls handler only for subscribed events', () => {
+    // given
+    const subscriber = getSubscriberMock();
+    const otherEvent = Symbol('another event');
+
+    eventDispatcher.subscribe(event, subscriber);
+
+    // when
+    eventDispatcher.dispatch(event);
+    eventDispatcher.dispatch(otherEvent);
+
+    // then
+    expect(subscriber.handle).to.have.been.calledWith(event);
+    expect(subscriber.handle).not.to.have.been.calledWith(otherEvent);
+  });
 });

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -1,0 +1,52 @@
+const { expect, sinon } = require('../../test-helper');
+const EventDispatcher = require('../../../lib/infrastructure/events/EventDispatcher');
+
+/*
+ * un event, un subscribers, on pop des events, on vérifie que le subscriber a été appelé
+ * deux subscribers, on pop des events, on vérifie que les subscribers ont été appelés
+ * Notion de domain transaction ???
+ * injection
+ */
+
+function getSubscriberMock() {
+  return {
+    handle: sinon.stub()
+  };
+}
+
+describe('Integration | Infrastructure | EventHandler', () => {
+  let eventDispatcher;
+  const event = Symbol('an event');
+
+  beforeEach(() => {
+    eventDispatcher = new EventDispatcher();
+  });
+
+  it('dispatches event to subscriber', () => {
+    // given
+    const subscriber = getSubscriberMock();
+    eventDispatcher.subscribe(event, subscriber);
+
+    // when
+    eventDispatcher.dispatch(event);
+
+    // then
+    expect(subscriber.handle).to.have.been.calledWith(event);
+  });
+
+  it('dispatches event to several subscribers', () => {
+    // given
+    const subscriber_1 = getSubscriberMock();
+    const subscriber_2 = getSubscriberMock();
+
+    eventDispatcher.subscribe(event, subscriber_1);
+    eventDispatcher.subscribe(event, subscriber_2);
+
+    // when
+    eventDispatcher.dispatch(event);
+
+    // then
+    expect(subscriber_1.handle).to.have.been.calledWith(event);
+    expect(subscriber_2.handle).to.have.been.calledWith(event);
+  });
+});

--- a/api/tests/tooling/events/event-dispatcher-builder.js
+++ b/api/tests/tooling/events/event-dispatcher-builder.js
@@ -1,0 +1,16 @@
+const { sinon } = require('../../test-helper');
+const { _forTestOnly } = require('../../../lib/domain/events');
+
+function buildEventDispatcherAndHandlersForTest() {
+  const handlerStubs = {};
+  Object.keys(_forTestOnly.handlers).forEach((h) => {
+    handlerStubs[h] = sinon.stub();
+  });
+
+  return {
+    handlerStubs,
+    eventDispatcher: _forTestOnly.buildEventDispatcher(handlerStubs)
+  };
+}
+
+module.exports = buildEventDispatcherAndHandlersForTest;

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -4,6 +4,8 @@ const usecases = require('../../../../lib/domain/usecases');
 const events = require('../../../../lib/domain/events');
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+const CertificationScoringCompleted = require('../../../../lib/domain/events/CertificationScoringCompleted');
 
 describe('Unit | Controller | assessment-controller', function() {
 
@@ -104,8 +106,8 @@ describe('Unit | Controller | assessment-controller', function() {
 
   describe('#completeAssessment', () => {
     const assessmentId = 2;
-    const assessmentCompletedEvent = Symbol('un événement de fin de test');
-    const certificationScoringEvent = Symbol('un événement de fin de scoring');
+    const assessmentCompletedEvent = new AssessmentCompleted();
+    const certificationScoringEvent = new CertificationScoringCompleted({});
     const domainTransaction = Symbol('domain transaction');
     let transactionToBeExecuted;
 
@@ -142,7 +144,7 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleBadgeAcquisition).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent });
+      expect(events.handleBadgeAcquisition).to.have.been.calledWithExactly({ domainTransaction, event:assessmentCompletedEvent });
     });
 
     it('should pass the assessment completed event to the CertificationScoringHandler', async () => {
@@ -155,10 +157,10 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, assessmentCompletedEvent,  });
+      expect(events.handleCertificationScoring).to.have.been.calledWithExactly({ domainTransaction, event:assessmentCompletedEvent });
     });
 
-    it('should pass the assessment completed event to the CertificationPartnerHandler', async () => {
+    it('should pass the scoring completed event to the CertificationPartnerHandler', async () => {
       /// given
       events.handleBadgeAcquisition.resolves({});
       events.handleCertificationScoring.resolves(certificationScoringEvent);
@@ -168,7 +170,7 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.handleCertificationAcquisitionForPartner).to.have.been.calledWithExactly({ domainTransaction, certificationScoringEvent });
+      expect(events.handleCertificationAcquisitionForPartner).to.have.been.calledWithExactly({ domainTransaction, event:certificationScoringEvent });
     });
 
     it('should call usecase and handler within the transaction', async () => {

--- a/api/tests/unit/domain/events/check-event-type_test.js
+++ b/api/tests/unit/domain/events/check-event-type_test.js
@@ -14,5 +14,4 @@ describe('Unit | Domain | Events | check-event-type', () => {
   });
 });
 
-class TestEvent {
-}
+class TestEvent {}

--- a/api/tests/unit/domain/events/check-event-type_test.js
+++ b/api/tests/unit/domain/events/check-event-type_test.js
@@ -1,0 +1,18 @@
+const { expect, catchErr } = require('../../../test-helper');
+const { checkEventType } = require('../../../../lib/domain/events/check-event-type');
+
+describe('Unit | Domain | Events | check-event-type', () => {
+  it('throw with right message when event of wront type ', async () => {
+    // given
+    const wrongTypeEvent = 'Event of wrong type';
+
+    // when
+    const error = await catchErr(checkEventType)(wrongTypeEvent, TestEvent);
+
+    // then
+    expect(error.message).to.equal('event must be of type TestEvent');
+  });
+});
+
+class TestEvent {
+}

--- a/api/tests/unit/domain/events/event-choregraphy-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-badge-acquisition_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+
+describe('Event Choregraphy | Badge Acquisition', function() {
+  it('Should trigger Badge Acquisition handler on Assessment Completed event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new AssessmentCompleted();
+    const domainTransaction = Symbol('a transaction');
+
+    // when
+    await eventDispatcher.dispatch(domainTransaction, event);
+
+    // then
+    expect(handlerStubs.handleBadgeAcquisition).to.have.been.calledWith({ domainTransaction, event });
+  });
+});

--- a/api/tests/unit/domain/events/event-choregraphy-score-certification_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-score-certification_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+
+describe('Event Choregraphy | Score Certification', function() {
+  it('Should trigger Certification Scoring handler on Assessment Completed event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new AssessmentCompleted();
+    const domainTransaction = Symbol('a transaction');
+
+    // when
+    await eventDispatcher.dispatch(domainTransaction, event);
+
+    // then
+    expect(handlerStubs.handleCertificationScoring).to.have.been.calledWith({ domainTransaction, event });
+  });
+});

--- a/api/tests/unit/domain/events/event-choregraphy-score-partner-certification_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-score-partner-certification_test.js
@@ -1,0 +1,26 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
+const CertificationScoringCompleted = require('../../../../lib/domain/events/CertificationScoringCompleted');
+
+describe('Event Choregraphy | Score Partner Certification', function() {
+  it('chains Certification Scoring and Partner Certification Scoring on Assessment Completed', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+
+    const domainTransaction = Symbol('a transaction');
+
+    const assessmentCompleted = new AssessmentCompleted();
+    const certificationScoringCompleted = new CertificationScoringCompleted({});
+
+    handlerStubs.handleCertificationScoring.withArgs({ domainTransaction, event:assessmentCompleted }).resolves(
+      certificationScoringCompleted
+    );
+
+    // when
+    await eventDispatcher.dispatch(domainTransaction, assessmentCompleted);
+
+    // then
+    expect(handlerStubs.handleCertificationAcquisitionForPartner).to.have.been.calledWith({ domainTransaction, event:certificationScoringCompleted });
+  });
+});

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const events = require('../../../../lib/domain/events');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
@@ -29,6 +29,17 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
       badgeCriteriaService,
     };
 
+    it('fails when event is not of correct type', async () => {
+      // given
+      const event = 'not an event of the correct type';
+      // when / then
+      const error = await catchErr(events.handleBadgeAcquisition)(
+        { event, ...dependencies, domainTransaction }
+      );
+
+      // then
+      expect(error).not.to.be.null;
+    });
     context('when the assessment belongs to a campaign', () => {
 
       context('when the campaign is associated to a badge', () => {
@@ -72,7 +83,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({ badgeId, userId: event.userId }, domainTransaction);
+          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({
+            badgeId,
+            userId: event.userId
+          }, domainTransaction);
         });
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
-
 const { expect, sinon, catchErr } = require('../../../test-helper');
-const events = require('../../../../lib/domain/events');
+const { handleBadgeAcquisition } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
 describe('Unit | Domain | Events | handle-badge-acquisition', () => {
@@ -33,7 +32,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
       // given
       const event = 'not an event of the correct type';
       // when / then
-      const error = await catchErr(events.handleBadgeAcquisition)(
+      const error = await catchErr(handleBadgeAcquisition)(
         { event, ...dependencies, domainTransaction }
       );
 
@@ -80,7 +79,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({
@@ -95,7 +94,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .withArgs({ campaignParticipationResult, badgeCriteria: badge.badgeCriteria })
             .returns(false);
           // when
-          await events.handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -115,7 +114,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           const event = new AssessmentCompleted(userId, targetProfileId);
 
           // when
-          await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -133,7 +132,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         const event = new AssessmentCompleted(userId, targetProfileId);
 
         // when
-        await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+        await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
         // then
         expect(badgeAcquisitionRepository.create).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -33,7 +33,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
       context('when the campaign is associated to a badge', () => {
 
-        const assessmentCompletedEvent = new AssessmentCompleted(
+        const event = new AssessmentCompleted(
           Symbol('userId'),
           Symbol('targetProfileId'),
           Symbol('campaignParticipationId')
@@ -50,12 +50,12 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             id: badgeId,
             badgeCriteria: Symbol('badgeCriteria')
           };
-          badgeRepository.findOneByTargetProfileId.withArgs(assessmentCompletedEvent.targetProfileId).resolves(badge);
+          badgeRepository.findOneByTargetProfileId.withArgs(event.targetProfileId).resolves(badge);
 
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           sinon.stub(campaignParticipationResultRepository, 'getByParticipationId');
-          campaignParticipationResultRepository.getByParticipationId.withArgs(assessmentCompletedEvent.campaignParticipationId, badge).resolves(
+          campaignParticipationResultRepository.getByParticipationId.withArgs(event.campaignParticipationId, badge).resolves(
             campaignParticipationResult
           );
 
@@ -69,10 +69,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
+          await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
-          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({ badgeId, userId: assessmentCompletedEvent.userId }, domainTransaction);
+          expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly({ badgeId, userId: event.userId }, domainTransaction);
         });
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
@@ -81,7 +81,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .withArgs({ campaignParticipationResult, badgeCriteria: badge.badgeCriteria })
             .returns(false);
           // when
-          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies });
+          await events.handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -98,10 +98,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           const userId = 42;
-          const assessmentCompletedEvent = new AssessmentCompleted(userId, targetProfileId);
+          const event = new AssessmentCompleted(userId, targetProfileId);
 
           // when
-          await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
+          await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -116,10 +116,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
         const targetProfileId = null;
         const userId = 42;
-        const assessmentCompletedEvent = new AssessmentCompleted(userId, targetProfileId);
+        const event = new AssessmentCompleted(userId, targetProfileId);
 
         // when
-        await events.handleBadgeAcquisition({ assessmentCompletedEvent, ...dependencies, domainTransaction });
+        await events.handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
         // then
         expect(badgeAcquisitionRepository.create).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-certification-partner_test.js
+++ b/api/tests/unit/domain/events/handle-certification-partner_test.js
@@ -1,15 +1,15 @@
 const _ = require('lodash');
 const { expect, sinon, catchErr } = require('../../../test-helper');
-const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
-const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
 const CertificationPartnerAcquisition = require('../../../../lib/domain/models/CertificationPartnerAcquisition');
 const CertificationScoringCompleted = require('../../../../lib/domain/events/CertificationScoringCompleted');
-const events = require('../../../../lib/domain/events');
+const { handleCertificationAcquisitionForPartner } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Unit | Domain | Events | handle-certification-partner', () => {
   const competenceMarkRepository = { getLatestByCertificationCourseId: _.noop };
   const certificationPartnerAcquisitionRepository = { save: _.noop };
+  const competenceRepository = { getTotalPixCleaByCompetence: _.noop };
+  const badgeAcquisitionRepository = { hasAcquiredBadgeWithKey: _.noop };
   const domainTransaction = {};
 
   let event;
@@ -17,13 +17,15 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
   const dependencies = {
     certificationPartnerAcquisitionRepository,
     competenceMarkRepository,
+    competenceRepository,
+    badgeAcquisitionRepository
   };
 
   it('fails when event is not of correct type', async () => {
     // given
     const event = 'not an event of the correct type';
     // when / then
-    const error = await catchErr(events.handleCertificationAcquisitionForPartner)(
+    const error = await catchErr(handleCertificationAcquisitionForPartner)(
       { event, ...dependencies, domainTransaction }
     );
 
@@ -82,7 +84,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
           .returns(true);
 
         // when
-        await events.handleCertificationAcquisitionForPartner({
+        await handleCertificationAcquisitionForPartner({
           event, ...dependencies, domainTransaction
         });
 
@@ -105,7 +107,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
           .returns(false);
 
         // when
-        await events.handleCertificationAcquisitionForPartner({
+        await handleCertificationAcquisitionForPartner({
           event, ...dependencies, domainTransaction
         });
 

--- a/api/tests/unit/domain/events/handle-certification-partner_test.js
+++ b/api/tests/unit/domain/events/handle-certification-partner_test.js
@@ -12,7 +12,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
   const certificationPartnerAcquisitionRepository = { save: _.noop };
   const domainTransaction = {};
 
-  let certificationScoringEvent;
+  let event;
 
   const dependencies = {
     certificationPartnerAcquisitionRepository,
@@ -24,7 +24,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
     const userId = Symbol('userId');
 
     beforeEach(() => {
-      certificationScoringEvent = new CertificationScoringCompleted({
+      event = new CertificationScoringCompleted({
         certificationCourseId,
         userId,
         isCertification: true,
@@ -63,7 +63,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
         sinon.stub(CertificationPartnerAcquisition.prototype, 'hasAcquiredCertification')
           .withArgs({
             hasAcquiredBadge,
-            reproducibilityRate: certificationScoringEvent.reproducibilityRate,
+            reproducibilityRate: event.reproducibilityRate,
             competenceMarks,
             totalPixCleaByCompetence,
           })
@@ -71,7 +71,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
 
         // when
         await events.handleCertificationAcquisitionForPartner({
-          certificationScoringEvent, ...dependencies, domainTransaction
+          event, ...dependencies, domainTransaction
         });
 
         // then
@@ -86,7 +86,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
         sinon.stub(CertificationPartnerAcquisition.prototype, 'hasAcquiredCertification')
           .withArgs({
             hasAcquiredBadge,
-            reproducibilityRate: certificationScoringEvent.reproducibilityRate,
+            reproducibilityRate: event.reproducibilityRate,
             competenceMarks,
             totalPixCleaByCompetence,
           })
@@ -94,7 +94,7 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
 
         // when
         await events.handleCertificationAcquisitionForPartner({
-          certificationScoringEvent, ...dependencies, domainTransaction
+          event, ...dependencies, domainTransaction
         });
 
         // then

--- a/api/tests/unit/domain/events/handle-certification-partner_test.js
+++ b/api/tests/unit/domain/events/handle-certification-partner_test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
 const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
 const CertificationPartnerAcquisition = require('../../../../lib/domain/models/CertificationPartnerAcquisition');
@@ -18,6 +18,18 @@ describe('Unit | Domain | Events | handle-certification-partner', () => {
     certificationPartnerAcquisitionRepository,
     competenceMarkRepository,
   };
+
+  it('fails when event is not of correct type', async () => {
+    // given
+    const event = 'not an event of the correct type';
+    // when / then
+    const error = await catchErr(events.handleCertificationAcquisitionForPartner)(
+      { event, ...dependencies, domainTransaction }
+    );
+
+    // then
+    expect(error).not.to.be.null;
+  });
 
   context('when assessment is of type CERTIFICATION', () => {
     const certificationCourseId = Symbol('certificationCourseId');

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -55,6 +55,18 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       sinon.stub(certificationAssessmentRepository, 'get').withArgs(assessmentId).resolves(certificationAssessment);
     });
 
+    it('fails when event is not of correct type', async () => {
+      // given
+      const event = 'not an event of the correct type';
+      // when / then
+      const error = await catchErr(events.handleCertificationScoring)(
+        { event, ...dependencies, domainTransaction }
+      );
+
+      // then
+      expect(error).not.to.be.null;
+    });
+
     context('when an error different from a compute error happens', () => {
       const otherError = new Error();
       beforeEach(() => {

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { expect, sinon, catchErr } = require('../../../test-helper');
-const events = require('../../../../lib/domain/events');
+const { handleCertificationScoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
@@ -59,7 +59,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       // given
       const event = 'not an event of the correct type';
       // when / then
-      const error = await catchErr(events.handleCertificationScoring)(
+      const error = await catchErr(handleCertificationScoring)(
         { event, ...dependencies, domainTransaction }
       );
 
@@ -78,7 +78,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should not save any results', async () => {
         // when
-        await catchErr(events.handleCertificationScoring)({
+        await catchErr(handleCertificationScoring)({
           event, ...dependencies
         });
 
@@ -101,7 +101,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should call the scoring service with the right arguments', async () => {
         // when
-        await events.handleCertificationScoring({
+        await handleCertificationScoring({
           event,
           ...dependencies,
           domainTransaction,
@@ -115,7 +115,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should save the error result appropriately', async () => {
         // when
-        await events.handleCertificationScoring({
+        await handleCertificationScoring({
           event,
           ...dependencies,
           domainTransaction,
@@ -161,7 +161,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should build and save an assessment result with the expected arguments', async () => {
         // when
-        await events.handleCertificationScoring({
+        await handleCertificationScoring({
           event, ...dependencies, domainTransaction
         });
 
@@ -180,7 +180,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should return a CertificationScoringCompleted', async () => {
         // when
-        const certificationScoringCompleted = await events.handleCertificationScoring({
+        const certificationScoringCompleted = await handleCertificationScoring({
           event, ...dependencies, domainTransaction
         });
 
@@ -195,7 +195,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       it('should build and save as many competence marks as present in the certificationAssessmentScore', async () => {
         // when
-        await events.handleCertificationScoring({
+        await handleCertificationScoring({
           event, ...dependencies, domainTransaction
         });
 
@@ -216,7 +216,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       );
 
       // when
-      const certificationScoringCompleted = await events.handleCertificationScoring({
+      const certificationScoringCompleted = await handleCertificationScoring({
         event, ...dependencies, domainTransaction
       });
 

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -15,7 +15,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
   const domainTransaction = {};
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
-  let assessmentCompletedEvent;
+  let event;
 
   const dependencies = {
     assessmentResultRepository,
@@ -39,7 +39,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
     let certificationAssessment;
 
     beforeEach(() => {
-      assessmentCompletedEvent = new AssessmentCompleted(
+      event = new AssessmentCompleted(
         assessmentId,
         userId,
         Symbol('targetProfileId'),
@@ -67,7 +67,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should not save any results', async () => {
         // when
         await catchErr(events.handleCertificationScoring)({
-          assessmentCompletedEvent, ...dependencies
+          event, ...dependencies
         });
 
         // then
@@ -90,7 +90,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should call the scoring service with the right arguments', async () => {
         // when
         await events.handleCertificationScoring({
-          assessmentCompletedEvent,
+          event,
           ...dependencies,
           domainTransaction,
         });
@@ -104,7 +104,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should save the error result appropriately', async () => {
         // when
         await events.handleCertificationScoring({
-          assessmentCompletedEvent,
+          event,
           ...dependencies,
           domainTransaction,
         });
@@ -150,7 +150,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should build and save an assessment result with the expected arguments', async () => {
         // when
         await events.handleCertificationScoring({
-          assessmentCompletedEvent, ...dependencies, domainTransaction
+          event, ...dependencies, domainTransaction
         });
 
         // then
@@ -169,13 +169,13 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should return a CertificationScoringCompleted', async () => {
         // when
         const certificationScoringCompleted = await events.handleCertificationScoring({
-          assessmentCompletedEvent, ...dependencies, domainTransaction
+          event, ...dependencies, domainTransaction
         });
 
         // then
         expect(certificationScoringCompleted).to.be.instanceof(CertificationScoringCompleted);
         expect(certificationScoringCompleted).to.deep.equal({
-          userId: assessmentCompletedEvent.userId,
+          userId: event.userId,
           certificationCourseId: certificationAssessment.certificationCourseId,
           reproducibilityRate: certificationAssessmentScore.percentageCorrectAnswers,
         });
@@ -184,7 +184,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should build and save as many competence marks as present in the certificationAssessmentScore', async () => {
         // when
         await events.handleCertificationScoring({
-          assessmentCompletedEvent, ...dependencies, domainTransaction
+          event, ...dependencies, domainTransaction
         });
 
         // then
@@ -195,7 +195,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
   context('when completed assessment is not of type CERTIFICATION', () => {
     it('should not do anything', async () => {
       // given
-      const assessmentCompletedEvent = new AssessmentCompleted(
+      const event = new AssessmentCompleted(
         Symbol('an assessment Id'),
         Symbol('userId'),
         Symbol('targetProfileId'),
@@ -205,7 +205,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       // when
       const certificationScoringCompleted = await events.handleCertificationScoring({
-        assessmentCompletedEvent, ...dependencies, domainTransaction
+        event, ...dependencies, domainTransaction
       });
 
       expect(certificationScoringCompleted).to.be.null;

--- a/docs/adr/0008-découplage-fonctionnel-via-evenements.md
+++ b/docs/adr/0008-découplage-fonctionnel-via-evenements.md
@@ -4,7 +4,7 @@ Date : 2020-03-27
 
 ## État
 
-En cours d'expérimentation
+Cet ADR est étendu par l'ADR [#10](docs/adr/0010-propager-domain-events-via-event-dispatcher.md)
 
 ## Contexte
 Il y a une richesse métier spécifique importante qui gravite autour de la notion de "badge":

--- a/docs/adr/0010-propager-domain-events-via-event-dispatcher.md
+++ b/docs/adr/0010-propager-domain-events-via-event-dispatcher.md
@@ -1,0 +1,113 @@
+# 10. Propager les _Domain Events_ via un _Event Dispatcher_ 
+
+Date : 2020-06-04
+
+Cet ADR étend l'ADR [#8](./0008-découplage-fonctionnel-via-evenements.md)
+
+## État
+
+En cours d'expérimentation
+
+## Contexte
+
+Actuellement, les _Domain Events_ sont distribués au _Event Handlers_ à la main dans le controller (orchestration).
+Ceci était une solution temporaire, on souhaite que les _Domain Handlers_ puissent s'abonner à des _Domain Events_ (chorégraphie).   
+
+## Décision
+
+Les _Event Handlers_ définissent eux-même le type de _Domain Events_ auxquels ils réagissent.
+Un mécanisme de _publisher/subscribers_ appelé _EventDispatcher_ est instancié au moment de l'injection de dépendances.
+Tous les handlers sont abonnés aux _Domain Events_ qui les regardent au moment de leur injection.
+
+## Conséquences
+
+### Controller
+_Avant :_ 
+```javascript
+  async completeAssessment(request) {
+    const assessmentId = parseInt(request.params.id);
+
+    await DomainTransaction.execute(async (domainTransaction) => {
+      const assessmentCompletedEvent = await usecases.completeAssessment({ domainTransaction, assessmentId });
+      const certificationScoringEvent = await events.handleCertificationScoring({ domainTransaction, assessmentCompletedEvent });
+
+      await events.handleBadgeAcquisition({ domainTransaction, assessmentCompletedEvent });
+
+      await events.handleCertificationAcquisitionForPartner({ domainTransaction, certificationScoringEvent });
+    });
+
+    return null;
+  }
+```
+
+_Après :_
+```javascript
+  async completeAssessment(request) {
+    const assessmentId = parseInt(request.params.id);
+
+    await DomainTransaction.execute(async (domainTransaction) => {
+      const event = await usecases.completeAssessment({ domainTransaction, assessmentId });
+      await events.eventDispatcher.dispatch(domainTransaction, event);
+    });
+
+    return null;
+  }
+```
+
+### Injection de dépendances
+_Pseudo-code illustratif:_
+```javascript
+const handlersToBeInjected = {
+  handleBadgeAcquisition: require('./handle-badge-acquisition'),
+  handleCertificationScoring: require('./handle-certification-scoring'),
+  handleCertificationAcquisitionForPartner: require('./handle-certification-partner')
+};
+
+function buildEventDispatcher() {
+  const eventDispatcher = new EventDispatcher();
+  for (const handler of handlersToBeInjected) {
+    eventDispatcher.subscribe(handler.eventType, inject(handler));
+  }
+  return eventDispatcher;
+}
+
+module.exports = {
+  eventDispatcher: buildEventDispatcher()
+}
+```
+
+
+### Tests de chorégraphie
+Il devient alors possible (et précieux à titre de non-régression) de tester la bonne mise en place des _Event Handlers_ en testant les chaînages.
+
+```javascript
+describe('Event Choregraphy | Score Partner Certification', function() {
+  it('chains Certification Scoring and Partner Certification Scoring on Assessment Completed', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+
+    const domainTransaction = Symbol('a transaction');
+
+    const assessmentCompleted = new AssessmentCompleted();
+    const certificationScoringCompleted = new CertificationScoringCompleted({});
+
+    handlerStubs.handleCertificationScoring.withArgs({ domainTransaction, event:assessmentCompleted }).resolves(
+      certificationScoringCompleted
+    );
+
+    // when
+    await eventDispatcher.dispatch(domainTransaction, assessmentCompleted);
+
+    // then
+    expect(handlerStubs.handleCertificationAcquisitionForPartner).to.have.been.calledWith({ domainTransaction, event:certificationScoringCompleted });
+  });
+});
+```
+
+## Références : 
+- https://medium.com/ingeniouslysimple/choreography-vs-orchestration-a6f21cfaccae
+
+
+
+
+


### PR DESCRIPTION
## :unicorn: Problème
Les Domain Events sont passés à la mano entre les émetteurs et les handlers dans le controller.

## :robot: Solution
Passer par un EventDispatcher (pub/sub) pour faire ça automatiquement.

## :rainbow: Remarques
Il reste à déplacer l'instanciation de l'EventDispatcher et les subscriptions hors du controller.

## :100: Pour tester
Valider une certification donnant lieu à un badge pix et cléa.
