### PR TITLE
[FEATURE] Afficher la dernière date d'envoi d'une invitation dans Pix Orga (PIX-730).

### DIFF
--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -27,6 +27,8 @@ const createOrganizationInvitation = async ({
     tags
   });
 
+  await organizationInvitationRepository.updateModificationDate(organizationInvitation.id);
+
   return organizationInvitation;
 };
 

--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -75,4 +75,10 @@ module.exports = {
       .then(_toDomain);
   },
 
+  updateModificationDate(id) {
+    return new BookshelfOrganizationInvitation({ id })
+      .save({}, { method: 'update', patch: true, require: true })
+      .catch((err) => _checkNotFoundError(err, id));
+  },
+
 };

--- a/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(invitations) {
     return new Serializer('organization-invitations', {
-      attributes: ['organizationId', 'organizationName', 'email', 'status', 'createdAt'],
+      attributes: ['organizationId', 'organizationName', 'email', 'status', 'createdAt', 'updatedAt'],
     }).serialize(invitations);
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-invitation-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
 
   serialize(invitations) {
     return new Serializer('organization-invitations', {
-      attributes: ['organizationId', 'organizationName', 'email', 'status', 'createdAt', 'updatedAt'],
+      attributes: ['organizationId', 'organizationName', 'email', 'status', 'updatedAt'],
     }).serialize(invitations);
   },
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -929,9 +929,9 @@ describe('Acceptance | Application | organization-controller', () => {
         // then
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.length).equal(2);
-        expect(_.omit(response.result.data[0], 'id', 'attributes.created-at', 'attributes.updated-at', 'attributes.organization-name'))
+        expect(_.omit(response.result.data[0], 'id', 'attributes.updated-at', 'attributes.organization-name'))
           .to.deep.equal(expectedResults[0]);
-        expect(_.omit(response.result.data[1], 'id', 'attributes.created-at', 'attributes.updated-at', 'attributes.organization-name'))
+        expect(_.omit(response.result.data[1], 'id', 'attributes.updated-at', 'attributes.organization-name'))
           .to.deep.equal(expectedResults[1]);
       });
     });
@@ -1011,39 +1011,39 @@ describe('Acceptance | Application | organization-controller', () => {
 
   describe('GET /api/organizations/{id}/invitations', () => {
 
-    let organization;
+    let organizationId;
     let options;
     let firstOrganizationInvitation;
     let secondOrganizationInvitation;
 
     beforeEach(async () => {
       const adminUserId = databaseBuilder.factory.buildUser().id;
-      organization = databaseBuilder.factory.buildOrganization();
+      organizationId = databaseBuilder.factory.buildOrganization().id;
 
       databaseBuilder.factory.buildMembership({
         userId: adminUserId,
-        organizationId: organization.id,
+        organizationId,
         organizationRole: Membership.roles.ADMIN,
       });
 
       firstOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
-        organizationId: organization.id,
+        organizationId,
         status: OrganizationInvitation.StatusType.PENDING,
       });
 
       secondOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
-        organizationId: organization.id,
+        organizationId,
         status: OrganizationInvitation.StatusType.PENDING,
       });
 
       databaseBuilder.factory.buildOrganizationInvitation({
-        organizationId: organization.id,
+        organizationId,
         status: OrganizationInvitation.StatusType.ACCEPTED,
       });
 
       options = {
         method: 'GET',
-        url: `/api/organizations/${organization.id}/invitations`,
+        url: `/api/organizations/${organizationId}/invitations`,
         headers: { authorization: generateValidRequestAuthorizationHeader(adminUserId) },
       };
 
@@ -1064,20 +1064,18 @@ describe('Acceptance | Application | organization-controller', () => {
             {
               type: 'organization-invitations',
               attributes: {
-                'organization-id': organization.id,
+                'organization-id': organizationId,
                 email: firstOrganizationInvitation.email,
                 status: OrganizationInvitation.StatusType.PENDING,
-                'created-at': firstOrganizationInvitation.createdAt,
                 'updated-at': firstOrganizationInvitation.updatedAt,
               },
             },
             {
               type: 'organization-invitations',
               attributes: {
-                'organization-id': organization.id,
+                'organization-id': organizationId,
                 email: secondOrganizationInvitation.email,
                 status: OrganizationInvitation.StatusType.PENDING,
-                'created-at': secondOrganizationInvitation.createdAt,
                 'updated-at': secondOrganizationInvitation.updatedAt,
               },
             },

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -929,9 +929,9 @@ describe('Acceptance | Application | organization-controller', () => {
         // then
         expect(response.statusCode).to.equal(201);
         expect(response.result.data.length).equal(2);
-        expect(_.omit(response.result.data[0], 'id', 'attributes.created-at', 'attributes.organization-name'))
+        expect(_.omit(response.result.data[0], 'id', 'attributes.created-at', 'attributes.updated-at', 'attributes.organization-name'))
           .to.deep.equal(expectedResults[0]);
-        expect(_.omit(response.result.data[1], 'id', 'attributes.created-at', 'attributes.organization-name'))
+        expect(_.omit(response.result.data[1], 'id', 'attributes.created-at', 'attributes.updated-at', 'attributes.organization-name'))
           .to.deep.equal(expectedResults[1]);
       });
     });
@@ -1013,6 +1013,8 @@ describe('Acceptance | Application | organization-controller', () => {
 
     let organization;
     let options;
+    let firstOrganizationInvitation;
+    let secondOrganizationInvitation;
 
     beforeEach(async () => {
       const adminUserId = databaseBuilder.factory.buildUser().id;
@@ -1024,21 +1026,18 @@ describe('Acceptance | Application | organization-controller', () => {
         organizationRole: Membership.roles.ADMIN,
       });
 
-      databaseBuilder.factory.buildOrganizationInvitation({
+      firstOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization.id,
-        email: 'jojo@business.company',
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+
+      secondOrganizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization.id,
         status: OrganizationInvitation.StatusType.PENDING,
       });
 
       databaseBuilder.factory.buildOrganizationInvitation({
         organizationId: organization.id,
-        email: 'jojo@tech.company',
-        status: OrganizationInvitation.StatusType.PENDING,
-      });
-
-      databaseBuilder.factory.buildOrganizationInvitation({
-        organizationId: organization.id,
-        email: 'jojo@medical.company',
         status: OrganizationInvitation.StatusType.ACCEPTED,
       });
 
@@ -1066,16 +1065,20 @@ describe('Acceptance | Application | organization-controller', () => {
               type: 'organization-invitations',
               attributes: {
                 'organization-id': organization.id,
-                email: 'jojo@tech.company',
+                email: firstOrganizationInvitation.email,
                 status: OrganizationInvitation.StatusType.PENDING,
+                'created-at': firstOrganizationInvitation.createdAt,
+                'updated-at': firstOrganizationInvitation.updatedAt,
               },
             },
             {
               type: 'organization-invitations',
               attributes: {
                 'organization-id': organization.id,
-                email: 'jojo@business.company',
+                email: secondOrganizationInvitation.email,
                 status: OrganizationInvitation.StatusType.PENDING,
+                'created-at': secondOrganizationInvitation.createdAt,
+                'updated-at': secondOrganizationInvitation.updatedAt,
               },
             },
           ],
@@ -1086,8 +1089,8 @@ describe('Acceptance | Application | organization-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(200);
-        const omittedResult = _.omit(response.result, 'data[0].id', 'data[0].attributes.created-at', 'data[0].attributes.organization-name',
-          'data[1].id', 'data[1].attributes.created-at', 'data[1].attributes.organization-name');
+        const omittedResult = _.omit(response.result, 'data[0].id', 'data[0].attributes.organization-name',
+          'data[1].id', 'data[1].attributes.organization-name');
         expect(omittedResult.data).to.deep.have.members(expectedResult.data);
       });
     });

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -245,7 +245,6 @@ describe('Integration | Application | Organizations | organization-controller', 
             'organization-id': invitation.organizationId,
             email: invitation.email,
             status,
-            'created-at': invitation.createdAt,
             'updated-at': invitation.updatedAt
           }
         };

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -245,7 +245,8 @@ describe('Integration | Application | Organizations | organization-controller', 
             'organization-id': invitation.organizationId,
             email: invitation.email,
             status,
-            'created-at': invitation.createdAt
+            'created-at': invitation.createdAt,
+            'updated-at': invitation.updatedAt
           }
         };
         usecases.createOrganizationInvitations.resolves([invitation]);

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -234,4 +234,33 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
     });
   });
 
+  describe('#updateModificationDate', () => {
+
+    let organizationInvitation;
+
+    beforeEach(async () => {
+      const organizationId = 2323;
+      databaseBuilder.factory.buildOrganization({
+        id: organizationId,
+      });
+      organizationInvitation = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should update the modification date', async () => {
+      // given
+      const oldModificationDate = organizationInvitation.updatedAt;
+
+      // when
+      await organizationInvitationRepository.updateModificationDate(organizationInvitation.id);
+
+      // then
+      const updatedOrganizationInvitation = await organizationInvitationRepository.get(organizationInvitation.id);
+
+      expect(updatedOrganizationInvitation.updatedAt).to.be.above(oldModificationDate);
+    });
+  });
 });

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -19,6 +19,7 @@ describe('Unit | Service | Organization-Invitation Service', () => {
     organizationInvitationRepository = {
       create: sinon.stub(),
       findOnePendingByOrganizationIdAndEmail: sinon.stub().resolves(null),
+      updateModificationDate: sinon.stub().resolves()
     };
     organizationRepository = {
       get: sinon.stub().resolves({ name: organizationName })
@@ -73,26 +74,33 @@ describe('Unit | Service | Organization-Invitation Service', () => {
 
     context('when an organization-invitation with pending status already exists', () => {
 
-      it('should re-send an email with same code', async () => {
-        // given
-        const tags = undefined;
-        const isPending = true;
+      const isPending = true;
+      const tags = undefined;
 
+      beforeEach(async () => {
+        // given
         organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail.resolves({
           id: organizationInvitationId, isPending, code
         });
-
-        const expectedParameters = {
-          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
-        };
 
         // when
         await createOrganizationInvitation({
           organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress
         });
+      });
 
+      it('should re-send an email with same code', async () => {
         // then
+        const expectedParameters = {
+          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+        };
+
         expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);
+      });
+
+      it('should update organization-invitation modification date', () => {
+        // then
+        expect(organizationInvitationRepository.updateModificationDate).to.have.been.calledWith(organizationInvitationId);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
@@ -16,7 +16,6 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', () 
           'organization-name': invitationObject.organizationName,
           email: invitationObject.email,
           status: invitationObject.status,
-          'created-at': invitationObject.createdAt,
           'updated-at': invitationObject.updatedAt,
         },
       }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-invitation-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | organization-invitation-serializer', () 
           email: invitationObject.email,
           status: invitationObject.status,
           'created-at': invitationObject.createdAt,
+          'updated-at': invitationObject.updatedAt,
         },
       }
     };

--- a/orga/app/models/organization-invitation.js
+++ b/orga/app/models/organization-invitation.js
@@ -5,6 +5,7 @@ export default DS.Model.extend({
   email: DS.attr('string'),
   status: DS.attr('string'),
   createdAt: DS.attr('date'),
+  updatedAt: DS.attr('date'),
   organizationName: DS.attr('string'),
 
   organization: DS.belongsTo('organization'),

--- a/orga/app/models/organization-invitation.js
+++ b/orga/app/models/organization-invitation.js
@@ -4,7 +4,6 @@ import { equal } from '@ember/object/computed';
 export default DS.Model.extend({
   email: DS.attr('string'),
   status: DS.attr('string'),
-  createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
   organizationName: DS.attr('string'),
 

--- a/orga/app/templates/components/routes/authenticated/team/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/team/list-items.hbs
@@ -15,7 +15,7 @@
           {{#each @organizationInvitations as |organizationInvitation|}}
             <tr aria-label="Invitation en attente">
               <td>{{organizationInvitation.email}}</td>
-              <td colspan="3">Invité le {{moment-format organizationInvitation.createdAt 'DD/MM/YYYY'}}</td>
+              <td colspan="3">Dernière invitation envoyée le {{moment-format organizationInvitation.updatedAt 'DD/MM/YYYY [à] HH:mm' locale='fr'}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/list-items-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 
 module('Integration | Component | routes/authenticated/team | list-items', function(hooks) {
   setupRenderingTest(hooks);
@@ -45,8 +46,8 @@ module('Integration | Component | routes/authenticated/team | list-items', funct
   test('it should display a list of invitations, their email and creation date', async function(assert) {
     // given
     this.set('organizationInvitations', [
-      { email: 'gigi@pix.fr', createdAt: new Date('2019-10-08') },
-      { email: 'gogo@pix.fr', createdAt: new Date('2019-10-08') },
+      { email: 'gigi@example.net', updatedAt: moment('2019-10-08T10:50:00Z').utcOffset(2) },
+      { email: 'gogo@example.net', updatedAt: moment('2019-10-08T10:50:00Z').utcOffset(2) },
     ]);
 
     // when
@@ -54,7 +55,7 @@ module('Integration | Component | routes/authenticated/team | list-items', funct
 
     // then
     assert.dom('#table-invitations tbody tr').exists({ count: 2 });
-    assert.dom('#table-invitations tbody tr:last-child td:first-child').hasText('gogo@pix.fr');
-    assert.dom('#table-invitations tbody tr:last-child td:nth-child(2)').hasText('Invité le 08/10/2019');
+    assert.dom('#table-invitations tbody tr:last-child td:first-child').hasText('gogo@example.net');
+    assert.dom('#table-invitations tbody tr:last-child td:nth-child(2)').hasText('Dernière invitation envoyée le 08/10/2019 à 12:50');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible d'inviter plusieurs fois le même utilisateur à rejoindre une organisation dans Pix Orga. Cette ré-invitation ne recrée pas une entrée dans la table `organization-invitations` mais renvoie un email à l'utilisateur. Cependant, dans l'écran listant les invitations envoyées ne figure que la date de création de l'invitation ce qui ne permet pas à l'administrateur de l'organisation de s'assurer qu'un email a bien été envoyé.     

## :robot: Solution
- Mettre à jour la date de modification d'une invitation à chaque ré-envoi d'un email.
- Afficher la dernière date de modification de l'invitation plutôt que sa date de création.  

## :rainbow: Remarques
Etant donné qu'il est possible de renvoyer plusieurs fois une invitation dans la même journée, on affiche dorénavant en plus de la date, l'heure à laquelle l'invitation à été mise à jour. 
