### PR TITLE
[FEATURE] Afficher uniquement la date sans la partie "temps" pour les valeurs de date de finalisation, publication et diffusion au prescripteur (PIX-765)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -10,8 +10,8 @@ function _getNumberOf(juryCertificationSummaries, booleanFct) {
   );
 }
 
-function _formatHumanReadableLocaleDateTime(date, options) {
-  return date ? (new Date(date)).toLocaleString('fr-FR', options) : date;
+function _formatHumanReadableLocaleDateTime(date) {
+  return date ? (new Date(date)).toLocaleString('fr-FR', { day: 'numeric', month: 'numeric', year: 'numeric' }) : date;
 }
 
 export const CREATED = 'created';
@@ -96,7 +96,7 @@ export default class Session extends Model {
 
   @computed('date')
   get displayDate() {
-    return _formatHumanReadableLocaleDateTime(this.date, { day: 'numeric', month: 'numeric', year: 'numeric' });
+    return _formatHumanReadableLocaleDateTime(this.date);
   }
 
   @computed('finalizedAt')

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -14,7 +14,7 @@
           />
       </span>
       <Sessions::ListItems
-        @sessions={{@model}}
+        @sessions={{this.model}}
         @id={{this.id}}
         @certificationCenterName={{this.certificationCenterName}}
         @status={{this.status}}

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -56,7 +56,7 @@ module('Acceptance | Session page', function(hooks) {
       await visit(`/sessions/${session.id}`);
       assert.dom('div.session-info__details').exists();
       assert.dom(`.row:nth-child(${STATUS_SECTION}) .col:nth-child(${VALUE_ROW_INDEX})`).containsText(statusToDisplayName[FINALIZED]);
-      assert.dom(`.row:nth-child(${FINALISATION_DATE_SECTION}) .col:nth-child(${VALUE_ROW_INDEX})`).containsText(finalizedDate.toLocaleString('fr-FR'));
+      assert.dom(`.row:nth-child(${FINALISATION_DATE_SECTION}) .col:nth-child(${VALUE_ROW_INDEX})`).containsText('10/03/2019');
       assert.dom(`.row:nth-child(${SENT_TO_PRESCRIPTEUR_DATE_SECTION}) .col:nth-child(${VALUE_ROW_INDEX})`).doesNotExist();
     });
 

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -98,7 +98,7 @@ module('Acceptance | Session pages', function(hooks) {
         test('it shows session informations', function(assert) {
           // then
           assert.dom('.session-info__details .row div:last-child').hasText(session.certificationCenterName);
-          assert.dom('[data-test-id="session-info__finalized-at"]').hasText(session.finalizedAt.toLocaleString('fr-FR'));
+          assert.dom('[data-test-id="session-info__finalized-at"]').hasText('01/01/2020');
           assert.dom('[data-test-id="session-info__examiner-global-comment"]').hasText(session.examinerGlobalComment);
         });
       });

--- a/admin/tests/unit/models/session-test.js
+++ b/admin/tests/unit/models/session-test.js
@@ -282,7 +282,7 @@ module('Unit | Model | session', function(hooks) {
       const displayFinalizationDate = session.displayFinalizationDate;
 
       // then
-      assert.equal(displayFinalizationDate, finalizedAt.toLocaleString('fr-FR'));
+      assert.equal(displayFinalizationDate, '01/12/2018');
     });
   });
 
@@ -297,7 +297,7 @@ module('Unit | Model | session', function(hooks) {
       const displayResultsSentToPrescriberDate = session.displayResultsSentToPrescriberDate;
 
       // then
-      assert.equal(displayResultsSentToPrescriberDate, resultsSentToPrescriberAt.toLocaleString('fr-FR'));
+      assert.equal(displayResultsSentToPrescriberDate, '01/12/2018');
     });
   });
 
@@ -312,7 +312,7 @@ module('Unit | Model | session', function(hooks) {
       const displayPublishedAtDate = session.displayPublishedAtDate;
 
       // then
-      assert.equal(displayPublishedAtDate, publishedAt.toLocaleString('fr-FR'));
+      assert.equal(displayPublishedAtDate, '01/12/2018');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, la date et l’heure sont affichées pour les champs suivants, alors que l’heure n’est pas utilisée (seule la date suffit). Cela “pollue” la lecture des autres informations importantes sur les pages concernées : 

- Date de finalisation
- Date de diffusion
- Date de publication

## :robot: Solution
Dans Pix Admin, n’afficher QUE la date (donc masquer l’heure) pour les champs listés ci-dessus, qui apparaissent sur les pages suivantes : 

- Liste des sessions
- Page de détails d’une session

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur Pix Admin et constater que l'heure n'est plus présente pour les date de finalisation, diffusion et publication