### PR TITLE
[BUGFIX] Ne prendre en compte que les compétences évaluées en certification lors du scoring de certification CléA (PIX-679)

### DIFF
--- a/api/lib/domain/models/CertificationPartnerAcquisition.js
+++ b/api/lib/domain/models/CertificationPartnerAcquisition.js
@@ -8,9 +8,11 @@ function _isOverPercentage(value = 0, total, percentage = MIN_PERCENTAGE) {
 }
 
 function _hasRequiredPixValue({ totalPixCleaByCompetence, competenceMarks }) {
-  const competenceIds = _.keys(totalPixCleaByCompetence);
-  return !_.isEmpty(competenceIds)
-    && _.every(competenceIds, (competenceId) => _isOverPercentage(
+  const certifiableCompetenceIds = _.map(competenceMarks, 'competenceId');
+  const partnerCompetenceIds = _.keys(totalPixCleaByCompetence);
+  const consideredCompetenceIds = _.intersection(certifiableCompetenceIds, partnerCompetenceIds);
+  return !_.isEmpty(consideredCompetenceIds)
+    && _.every(consideredCompetenceIds, (competenceId) => _isOverPercentage(
       _.find(competenceMarks, { competenceId }).score,
       totalPixCleaByCompetence[competenceId]
     ));

--- a/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
+++ b/api/tests/unit/domain/models/CertificationPartnerAcquisition_test.js
@@ -54,11 +54,12 @@ describe('Unit | Domain | Models | CertificationPartnerAcquisition', () => {
         const reproducibilityRate = GREY_ZONE_REPRO[0];
         const competenceId1 = 'competenceId1', competenceId2 = 'competenceId2';
 
-        it('for 70 reproducibility rate, it should obtain certification with all pixValue above 75% of Clea skills pixValue for each competence', async () => {
+        it('for 70 reproducibility rate, it should obtain certification when the pixScore for each certifiable competences is above 75% of Clea corresponding competence\'s pixScore', async () => {
           // given
           const totalPixCleaByCompetence = {
             [competenceId1]: 20,
             [competenceId2]: 10,
+            ['competenceId4']: 30,
           };
 
           const competenceMarks = [
@@ -94,11 +95,12 @@ describe('Unit | Domain | Models | CertificationPartnerAcquisition', () => {
           expect(hasAcquiredCertif).to.be.true;
         });
 
-        it('for 70 reproducibility rate, it should not obtain certification without all pixValue above 75% of Clea skills pixValue for each competence', async () => {
+        it('for 70 reproducibility rate, it should not obtain certification when the pixScore for each certifiable competences is above 75% of Clea corresponding competence\'s pixScore', async () => {
           // given
           const totalPixCleaByCompetence = {
             [competenceId1]: 20,
             [competenceId2]: 10,
+            ['competenceId4']: 30,
           };
           const competenceMarks = [
             new CompetenceMark(


### PR DESCRIPTION
## :unicorn: Problème
Le critère des 75% réussi par compétence a été mis en place sur les compétences Pix et non les compétences CléA (qui elles couvrent plusieurs compétences Pix). Ce qui signifie par exemple qu’un candidat n'étant pas certifiable sur une compétence Pix couverte par le CléA, ne pourra jamais avoir sa certif CléA alors qu’il aurait pu éventuellement se rattraper avec d’autres compétences Pix couvertes par la même compétence CléA

## :robot: Solution
Il faut procéder au calcul d'évaluation de la certification CléA en se basant sur les compétences effectivement évaluées en certification (donc représentée dans les `competence-marks`). Plus précisément, il va s'agit d'une intersection entre les compétences certifiables (`competence-marks`) et les compétences PIX couvertes par CléA

## :rainbow: Remarques


## :100: Pour tester

