### PR TITLE
[BUGFIX] Réduction de la largeur de certaines colonnes dans le tableau des membres (PIX-459).

### DIFF
--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -6,34 +6,40 @@ export default class OrganizationMembersSection extends Component {
   columns = [
     {
       propertyName: 'id',
-      title: 'Numéro du membre',
+      title: 'ID Membre',
       disableFiltering: true,
       editable: false,
+      className: 'models-table-column--small',
     },
     {
       propertyName: 'user.firstName',
       title: 'Prénom',
       editable: false,
+      className: 'models-table-column',
     },
     {
       propertyName: 'user.lastName',
       title: 'Nom',
       editable: false,
+      className: 'models-table-column',
     },
     {
       propertyName: 'user.email',
       title: 'Courriel',
       editable: false,
+      className: 'models-table-column',
     },
     {
       propertyName: 'displayedOrganizationRole',
       title: 'Rôle',
       componentForEdit: 'role-edit',
+      className: 'models-table-column--small',
     },
     {
       title: 'Action',
       component: 'editRow',
       editable: false,
+      className: 'models-table-column--small',
     },
   ];
 

--- a/admin/app/styles/misc/tables.scss
+++ b/admin/app/styles/misc/tables.scss
@@ -61,3 +61,13 @@ td, th {
   text-align: center;
   border-top: 2px solid $grey-22;
 }
+
+.models-table-column {
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &--small {
+    width: 150px;
+  }
+}

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -59,7 +59,7 @@ module('Acceptance | organization memberships management', function(hooks) {
       // then
       assert.equal(this.element.querySelectorAll('div.member-list table > thead > tr > th ').length, 12);
 
-      assert.contains('Numéro du membre');
+      assert.contains('ID Membre');
       assert.contains('Prénom');
       assert.contains('Nom');
       assert.contains('Courriel');


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, toutes les colonnes du tableau listant les membres d'une organisation ont la même taille et il arrive parfois que l'adresse email ne soit pas entièrement visible car sa colonne est trop petite.  

## :robot: Solution
Réduire la taille des colonnes `Numéro du membre`, `Rôle` et `Action`

## :rainbow: Remarques
La colonne `Numéro du membre` a été renommée en `ID Membre`