### PR TITLE
[FEATURE] Permettre à l'utilisateur d'obtenir un e-mail de création de compte en fonction de sa région (PIX-745).

### DIFF
--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -14,8 +15,9 @@ module.exports = {
       password: payload.password,
       withUsername: payload['with-username']
     };
+    const locale = extractLocaleFromRequest(request);
 
-    const createdUser = await usecases.createAndAssociateUserToSchoolingRegistration({ userAttributes, campaignCode: payload['campaign-code'] });
+    const createdUser = await usecases.createAndAssociateUserToSchoolingRegistration({ userAttributes, campaignCode: payload['campaign-code'], locale });
 
     return h.response(userSerializer.serialize(createdUser)).created();
   },

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -8,6 +8,7 @@ const scorecardSerializer = require('../../infrastructure/serializers/jsonapi/sc
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const userDetailForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-detail-for-admin-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 const usecases = require('../../domain/usecases');
 
@@ -17,10 +18,11 @@ module.exports = {
 
     const reCaptchaToken = request.payload.data.attributes['recaptcha-token'];
     const user = userSerializer.deserialize(request.payload);
-
+    const locale = extractLocaleFromRequest(request);
     return usecases.createUser({
       user,
       reCaptchaToken,
+      locale,
     })
       .then((savedUser) => {
         return h.response(userSerializer.serialize(savedUser)).created();

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -36,8 +36,8 @@ module.exports = (function() {
     },
 
     app: {
-      domainFr: 'pix.fr',
-      domainOrg: 'pix.org'
+      domainFr: process.env.DOMAIN_NAME_FR || 'pix.fr',
+      domainOrg: process.env.DOMAIN_NAME_ORG || 'pix.org',
     },
 
     logging: {
@@ -134,7 +134,8 @@ module.exports = (function() {
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 
-    config.app.domain = 'localhost';
+    config.app.domainFr = 'pix.fr';
+    config.app.domainOrg = 'pix.org';
 
     config.airtable.apiKey = 'test-api-key';
     config.airtable.base = 'test-base';

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -5,13 +5,29 @@ const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_NAME = 'PIX - Ne pas répondre';
 const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
 
-function sendAccountCreationEmail(email) {
+function sendAccountCreationEmail(email, locale) {
+  let variables = {
+    homeName: `${settings.app.domainFr}`,
+    homeUrl: `https://${settings.app.domainFr}`,
+    loginUrl: `https://app.${settings.app.domainFr}/connexion`,
+    locale
+  };
+  if (locale === 'fr') {
+    variables = {
+      homeName: `${settings.app.domainOrg}`,
+      homeUrl: `https://${settings.app.domainOrg}`,
+      loginUrl: `https://app.${settings.app.domainOrg}/connexion`,
+      locale
+    };
+  }
+
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
     fromName: PIX_NAME,
     to: email,
     subject: 'Création de votre compte PIX',
     template: mailer.accountCreationTemplateId,
+    variables
   });
 }
 

--- a/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
@@ -77,6 +77,7 @@ async function _validateData(isUsernameMode, userAttributes, userRepository, use
 module.exports = async function createAndAssociateUserToSchoolingRegistration({
   userAttributes,
   campaignCode,
+  locale,
   campaignRepository,
   schoolingRegistrationRepository,
   userRepository,
@@ -101,6 +102,6 @@ module.exports = async function createAndAssociateUserToSchoolingRegistration({
   const userId = await userRepository.createAndAssociateUserToSchoolingRegistration({ domainUser, schoolingRegistrationId });
 
   const createdUser = await userRepository.get(userId);
-  if (!isUsernameMode) await mailService.sendAccountCreationEmail(createdUser.email);
+  if (!isUsernameMode) await mailService.sendAccountCreationEmail(createdUser.email, locale);
   return createdUser;
 };

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -96,6 +96,12 @@ describe('Acceptance | Controller | users-controller', () => {
           subject: 'Création de votre compte PIX',
           template: 'test-account-creation-template-id',
           to: 'john.dodoe@example.net',
+          variables: {
+            homeName: 'pix.fr',
+            homeUrl: 'https://pix.fr',
+            locale: 'fr-fr',
+            loginUrl: 'https://app.pix.fr/connexion',
+          }
         };
 
         // when

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -29,6 +29,7 @@ describe('Unit | Controller | user-controller', () => {
     const email = 'to-be-free@ozone.airplane';
     const deserializedUser = new User({ password: 'password_1234' });
     const savedUser = new User({ email });
+    const locale = 'fr-fr';
 
     beforeEach(() => {
       sinon.stub(userSerializer, 'deserialize').returns(deserializedUser);
@@ -81,6 +82,7 @@ describe('Unit | Controller | user-controller', () => {
         const useCaseParameters = {
           user: deserializedUser,
           reCaptchaToken,
+          locale,
         };
 
         // when

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -14,18 +14,26 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendAccountCreationEmail', () => {
 
-    it('should use mailer to send an email', async () => {
+    it('should use mailer to send an email with locale', async () => {
       // given
+      const locale = 'fr-fr';
+      const domainFr = 'pix.fr';
       const expectedOptions = {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',
         to: userEmailAddress,
         subject: 'Création de votre compte PIX',
         template: 'test-account-creation-template-id',
+        variables: {
+          homeName: `${domainFr}`,
+          homeUrl: `https://${domainFr}`,
+          loginUrl: `https://app.${domainFr}/connexion`,
+          locale
+        }
       };
 
       // when
-      await mailService.sendAccountCreationEmail(userEmailAddress);
+      await mailService.sendAccountCreationEmail(userEmailAddress, locale);
 
       // then
       expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -228,9 +228,9 @@ describe('Unit | UseCase | create-user', () => {
         expect(encryptionService.hashPassword).to.have.been.calledWith(password);
       });
 
-      it('should check if the password has been correctly encrypted, because we have a bug on this', async () => {
+      it('should throw Error when hash password function fails', async () => {
         // given
-        encryptionService.hashPassword.resolves(password);
+        encryptionService.hashPassword.rejects(new Error());
 
         // when
         const error = await catchErr(createUser)({
@@ -239,7 +239,6 @@ describe('Unit | UseCase | create-user', () => {
 
         // then
         expect(error).to.be.instanceOf(Error);
-        expect(error.message).to.equal('Erreur lors de l‘encryption du mot passe de l‘utilisateur');
       });
 
       it('should save the user with a properly encrypted password', async () => {
@@ -260,10 +259,14 @@ describe('Unit | UseCase | create-user', () => {
       const user = new User({ email: userEmail });
 
       it('should send the account creation email', async () => {
+        // given
+        const locale = 'fr-fr';
+
         // when
         await createUser({
           user,
           reCaptchaToken,
+          locale,
           userRepository,
           reCaptchaValidator,
           encryptionService,
@@ -271,7 +274,7 @@ describe('Unit | UseCase | create-user', () => {
         });
 
         // then
-        expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(userEmail);
+        expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(userEmail, locale);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Pix utilise différent nom de domaine : pix.fr, pix.org. 
Nous souhaitons que lorsqu’un utilisateur se crée un compte depuis un domaine, que les liens dans le mail envoyer redirige vers ce même domaine. Et nous voulons que pour les autres domaines que pix.fr, il n'y ai pas la Marianne dans le footer.

## :robot: Solution
Ces deux domaines sont associés à des locales différentes
- Nous récupérons la locale de l'utilisateur dans le `user-controller` pour la fournir à l'usecase qui la fournira au `mail-service`.
https://github.com/1024pix/pix/blob/b59a8421385fe5712fe196609b681573f207fe8a/api/lib/application/users/user-controller.js#L21-L29

- Nous faisons le même principe pour la création et reconciliation dans `schooling-registration-dependant-users` :
https://github.com/1024pix/pix/blob/f87e2953f665906c0959538bc5fbd20fd816da51/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js#L18-L20

- Nous avons ajouté des variables construites à partir de la locale, qui seront envoyés à notre mailer (SendInBlue).
https://github.com/1024pix/pix/blob/dcb2c3c06f7884376c499b99ef4359067c383a77/api/lib/domain/services/mail-service.js#L9-L22
- Nous envoyons aussi la variable : `locale` afin de la vérifier dans le template pour afficher ou non la Marianne. 

- Nous avons utilisé un nouveau template (id: 27) dans SendInBlue pour effectuer des modifications sur celui-ci. 
![account-creation-email](https://user-images.githubusercontent.com/26384707/83261987-81b0e980-a1bc-11ea-9e25-b7acde5a4138.gif)

## :rainbow: Remarques
- Il faudra modifier la variable `SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID` après la mise en production pour prendre en compte le nouveau template. 
- Les mails ont été activé pour tester dans la RA, et la variable d'environnement `SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID` a été modifié pour utiliser le nouveau template (id : 27).
- Le fichier config a été améliorer. Il utilise des variables d'environnement afin de choisir le domain sur les différents environnement. Cela facilitera les tests en intégration et recette.
https://github.com/1024pix/pix/blob/4e4c72ebf03265d84ded33daf5a3677a6a8456cc/api/lib/config.js#L39-L40
- Un refacto de l'usecases `create-user` a aussi été fait afin d'utiliser les `async / await` 


## :100: Pour tester

- Aller sur les pages de création de compte sur : 
     - https://app-pr1471.review.pix.fr/inscription
     - https://app-pr1471.review.pix.org/inscription
 - Lorsque vous faites la demande à partir de `.fr`, les liens dans l'e-mail doivent finir en `.fr` et la Marianne doit-être présente.
- Et lorsque vous faites la demande depuis `.org`, les liens doivent finir par `.org` et il ne doit pas y avoir la Marianne.

-  Faire de même pour la création de compte depuis la double-mire
