### PR TITLE
[FEATURE] Empêcher le candidat de faire un signalement pendant le test de certification (PIX-578)

### DIFF
--- a/mon-pix/app/templates/components/feedback-certification-section.hbs
+++ b/mon-pix/app/templates/components/feedback-certification-section.hbs
@@ -1,0 +1,14 @@
+<div class="feedback-certification-section__div">
+  Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :
+  <ul>
+    <li>
+      votre n° de certification (en haut à droite de l'écran)
+    </li>
+    <li>
+      le numéro de la question (en haut à droite de l'écran)
+    </li>
+    <li>
+      le problème rencontré
+    </li>
+  </ul>
+</div>

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -11,61 +11,64 @@
   {{else}}
     <div class="feedback-panel__view feedback-panel__view--form">
       <div class="feedback-panel__form-description">
-        <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*</p>
       </div>
-
-      <div class="feedback-panel__form-wrapper">
-        <form class="feedback-panel__form">
-          <div class="feedback-panel__group">
-            <div class="feedback-panel__category-selection">
-              <select class="feedback-panel__dropdown" {{action "displayCategoryOptions" on="change"}}>
-                <option value="" disabled selected>J’ai un problème avec</option>
-                {{#each categories as |category|}}
-                  <option value={{category.value}}>{{category.name}}</option>
-                {{/each}}
-              </select>
-              {{#if displayQuestionDropdown}}
-                <select class="feedback-panel__dropdown" {{action "showFeedback" on="change"}}>
-                  <option value="default" selected>Précisez</option>
-                  {{#each nextCategory as |question index|}}
-                    <option value={{index}}>{{question.name}}</option>
+      {{#if @assessment.isCertification}}
+        <FeedbackCertificationSection/>
+      {{else}}
+        <p>Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*</p>
+        <div class="feedback-panel__form-wrapper">
+          <form class="feedback-panel__form">
+            <div class="feedback-panel__group">
+              <div class="feedback-panel__category-selection">
+                <select class="feedback-panel__dropdown" {{action "displayCategoryOptions" on="change"}}>
+                  <option value="" disabled selected>J’ai un problème avec</option>
+                  {{#each categories as |category|}}
+                    <option value={{category.value}}>{{category.name}}</option>
                   {{/each}}
                 </select>
-              {{/if}}
-              {{#if quickHelpInstructions}}
-                <div class="feedback-panel__quick-help">
-                  {{fa-icon 'exclamation-circle' class="tuto-icon__warning"}}
-                  <p>{{{quickHelpInstructions}}}</p>
+                {{#if displayQuestionDropdown}}
+                  <select class="feedback-panel__dropdown" {{action "showFeedback" on="change"}}>
+                    <option value="default" selected>Précisez</option>
+                    {{#each nextCategory as |question index|}}
+                      <option value={{index}}>{{question.name}}</option>
+                    {{/each}}
+                  </select>
+                {{/if}}
+                {{#if quickHelpInstructions}}
+                  <div class="feedback-panel__quick-help">
+                    {{fa-icon 'exclamation-circle' class="tuto-icon__warning"}}
+                    <p>{{{quickHelpInstructions}}}</p>
+                  </div>
+                {{/if}}
+              </div>
+            </div>
+            {{#if displayTextBox}}
+              <div class="feedback-panel__group">
+                <p>Votre message est limité à 10 000 caractères.</p>
+                <Textarea class="feedback-panel__field feedback-panel__field--content" @value={{_content}} placeholder="Précisez" @maxlength="10000" @rows={{5}} />
+              </div>
+              {{#if _error}}
+                <div class="alert alert-danger" role="alert">
+                  {{_error}}
                 </div>
               {{/if}}
-            </div>
-          </div>
-          {{#if displayTextBox}}
-            <div class="feedback-panel__group">
-              <p>Votre message est limité à 10 000 caractères.</p>
-              <Textarea class="feedback-panel__field feedback-panel__field--content" @value={{_content}} placeholder="Précisez" @maxlength="10000" @rows={{5}} />
-            </div>
-            {{#if _error}}
-              <div class="alert alert-danger" role="alert">
-                {{_error}}
-              </div>
+              <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
             {{/if}}
-            <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
-          {{/if}}
-        </form>
-      </div>
-
-      <div class="feedback-panel__form-legal-notice">
-        <div class="feedback-panel__form-description">
-          <p>* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
-          <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
+          </form>
         </div>
 
-        <div class="feedback-panel__form-description">
-          <p>Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de <a href="mailto:dpo@pix.fr" class="link">dpo@pix.fr</a>.</p>
-          <p><a href="https://pix.fr/dp-formulaire-signalement-epreuve" target="_blank" class="link">Pour en savoir plus sur la protection de vos données et sur vos droits.</a></p>
+        <div class="feedback-panel__form-legal-notice">
+          <div class="feedback-panel__form-description">
+            <p>* Soyez attentifs à ce que vous écrivez dans cette zone : restez objectif et factuel pour votre intérêt et celui des autres.</p>
+            <p>Notamment, ne saisissez aucune information, vous concernant ou concernant des tiers, sur la santé, la religion, les opinions politiques, syndicales et philosophiques, les origines ethniques, ainsi que sur les sanctions et condamnations.</p>
+          </div>
+
+          <div class="feedback-panel__form-description">
+            <p>Pix traite les données de cette zone pour gérer et analyser la difficulté rencontrée et bénéficier de votre retour d'expérience. Vous disposez de droits sur vos données qui peuvent être exercés auprès de <a href="mailto:dpo@pix.fr" class="link">dpo@pix.fr</a>.</p>
+            <p><a href="https://pix.fr/dp-formulaire-signalement-epreuve" target="_blank" class="link">Pour en savoir plus sur la protection de vos données et sur vos droits.</a></p>
+          </div>
         </div>
-      </div>
+      {{/if}}
 
     </div>
   {{/if}}

--- a/mon-pix/tests/integration/components/feedback-certification-section-test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section-test.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | feedback-certification-section', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+
+    await render(hbs`{{feedback-certification-section}}`);
+
+    expect(find('.feedback-certification-section__div').textContent.trim()).to.contain('Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :');
+  });
+});

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -48,27 +48,48 @@ describe('Integration | Component | feedback-panel', function() {
   setupRenderingTest();
 
   describe('Default rendering', function() {
-
-    beforeEach(async function() {
-      await render(hbs`{{feedback-panel isFormOpened=false}}`);
+    context('when assessment is not of type certification', function() {
+      beforeEach(async function() {
+        await render(hbs`{{feedback-panel isFormOpened=false}}`);
+      });
+  
+      it('should display the feedback panel', function() {
+        expect(find('.feedback-panel__view--link')).to.exist;
+      });
+  
+      it('should toggle the form view when clicking on the toggle link', async function() {
+        // when
+        await click(TOGGLE_LINK);
+  
+        // then
+        expectFormViewToBeVisible();
+  
+        // then when
+        await click(TOGGLE_LINK);
+  
+        // then
+        expectFormViewToNotBeVisible();
+      });
     });
 
-    it('should display the feedback panel', function() {
-      expect(find('.feedback-panel__view--link')).to.exist;
-    });
+    context('when assessment is of type certification', function() {
+      beforeEach(async function() {
+        const assessment = EmberObject.create({
+          isCertification: true
+        });
+        this.set('assessment', assessment);
+        this.set('isFormOpened', true);
 
-    it('should toggle the form view when clicking on the toggle link', async function() {
-      // when
-      await click(TOGGLE_LINK);
+        await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @isFormOpened={{this.isFormOpened}} />`);
+      });
 
-      // then
-      expectFormViewToBeVisible();
+      it('should display the feedback certification section', async function() {
+        expect(find('.feedback-certification-section__div')).to.exist;
 
-      // then when
-      await click(TOGGLE_LINK);
+        await click(TOGGLE_LINK);
 
-      // then
-      expectFormViewToNotBeVisible();
+        expect(find('.feedback-certification-section__div')).not.to.exist;
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, il y a 2 sources possibles de signalements dans le cadre d'une session de certification :

- la page de finalisation de session : le surveillant peut pendant la session noter tout incident concernant un candidat en particulier sur son PV de session, puis le reporter (lui ou toute personne en charge de l'espace Pix certif) sur la page de finalisation de session dans Pix certif

- le bouton "Signaler un problème" accessible depuis toutes les épreuves du test de certification

Seuls les signalements des surveillants sont pris en compte par le pôle certification qui pourra en fonction déclencher un jury si besoin. Il a donc été indiqué dans la dernière version du cahier des charges des centres de certification de ne plus demander aux candidats de "signaler un problème" via leur test, mais de demander au surveillant de reporter tout incident sur le PV de session (puis sur la page de finalisation). Il reste néanmoins possible pour le moment pour un candidat de "signaler un problème" pendant son test de certification.

## :robot: Solution
Remplacer le formulaire de signalement existant par une section expliquant au candidat comment signaler un pb pendant sa session de certification. 

![Capture d’écran de 2020-05-29 17-39-52](https://user-images.githubusercontent.com/37305474/83278414-de6bce80-a1d3-11ea-9cf9-1590f3cfbff6.png)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec le profil certif1@example.net (pix123), rejoindre une session de certification: 

-  id de session: 4
- prénom: Anne
- nom de famille: Missing
- date de naissance: 01/01/2000
- code session: ANNE04

cliquer sur "Signaler un problème", et constater l'affichage tel que sur le screen
