### PR TITLE
[FEATURE] Ajout d'un composant dropdown dans Pix Orga (PIX-716).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/student-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/student-management.feature
@@ -10,7 +10,7 @@ Fonctionnalité: Génération du mot de passe à usage unique
     Alors je suis redirigé vers le compte Orga de "John Snow"
     Lorsque je clique sur "Élèves"
     Alors je suis redirigé vers la page "/eleves"
-    Lorsque je clique sur l'engrenage
+    Lorsque je veux gérer le compte d'un élève
     Alors je vois la modal de gestion du compte de l'élève
     Lorsque je clique sur "Réinitialiser le mot de passe"
     Alors je vois le mot de passe généré

--- a/high-level-tests/e2e/cypress/support/step_definitions/student.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/student.js
@@ -1,5 +1,6 @@
-when(`je clique sur l'engrenage`, () => {
-  cy.get('table > tbody > tr:nth-child(1) > td.list-students-page__password-reset-cell > div > button').click();
+when(`je veux gérer le compte d'un élève`, () => {
+  cy.get('[aria-label="Afficher les actions"]').click();
+  cy.contains('Gérer le compte').click();
 });
 
 then(`je vois la modal de gestion du compte de l'élève`, () => {

--- a/orga/app/components/dropdown/content.hbs
+++ b/orga/app/components/dropdown/content.hbs
@@ -1,6 +1,6 @@
 {{#if @display}}
   <ClickOutside @onClickOutside={{@close}}>
-    <ul class="dropdown__content">
+    <ul class="dropdown__content" ...attributes>
       {{yield}}
     </ul>
   </ClickOutside>

--- a/orga/app/components/dropdown/content.hbs
+++ b/orga/app/components/dropdown/content.hbs
@@ -1,0 +1,7 @@
+{{#if @display}}
+  <ClickOutside @onClickOutside={{@close}}>
+    <ul class="dropdown__content">
+      {{yield}}
+    </ul>
+  </ClickOutside>
+{{/if}}

--- a/orga/app/components/dropdown/icon-trigger.hbs
+++ b/orga/app/components/dropdown/icon-trigger.hbs
@@ -1,14 +1,15 @@
-<div id="icon-trigger" class="dropdown">
-  <button type="button"
-          class={{concat "button button--round-with-icon " @dropdownButtonClass}}
-          aria-haspopup="listbox"
-          aria-expanded="{{this.display}}"
-          aria-label="Afficher les actions"
-          {{on 'click' this.toggle}}
+<div id="icon-trigger" class="dropdown" ...attributes>
+  <button 
+    type="button"
+    class="button button--round-with-icon {{@dropdownButtonClass}}"
+    aria-haspopup="listbox"
+    aria-expanded="{{this.display}}"
+    aria-label="Afficher les actions"
+    {{on 'click' this.toggle}}
   >
     <FaIcon @icon={{@icon}} />
   </button>
-  <Dropdown::Content @display={{this.display}} @close={{this.close}} aria-label="Actions">
+  <Dropdown::Content @display={{this.display}} @close={{this.close}} class="{{@dropdownContentClass}}" aria-label="Actions">
     {{yield}}
   </Dropdown::Content>
 </div>

--- a/orga/app/components/dropdown/icon-trigger.hbs
+++ b/orga/app/components/dropdown/icon-trigger.hbs
@@ -1,0 +1,14 @@
+<div id="icon-trigger" class="dropdown">
+  <button type="button"
+          class={{concat "button button--round-with-icon " @dropdownButtonClass}}
+          aria-haspopup="listbox"
+          aria-expanded="{{this.display}}"
+          aria-label="Afficher les actions"
+          {{on 'click' this.toggle}}
+  >
+    <FaIcon @icon={{@icon}} />
+  </button>
+  <Dropdown::Content @display={{this.display}} @close={{this.close}} aria-label="Actions">
+    {{yield}}
+  </Dropdown::Content>
+</div>

--- a/orga/app/components/dropdown/icon-trigger.js
+++ b/orga/app/components/dropdown/icon-trigger.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class IconTrigger extends Component {
+  @tracked display = false;
+
+  @action
+  toggle() {
+    this.display = !this.display;
+  }
+
+  @action
+  close() {
+    this.display = false;
+  }
+}

--- a/orga/app/components/dropdown/item-link.hbs
+++ b/orga/app/components/dropdown/item-link.hbs
@@ -1,0 +1,5 @@
+<li class="dropdown__item dropdown__item--link">
+  <LinkTo @route={{@linkTo}} class="link" ...attributes>
+    {{yield}}
+  </LinkTo>
+</li>

--- a/orga/app/components/dropdown/item.hbs
+++ b/orga/app/components/dropdown/item.hbs
@@ -1,0 +1,3 @@
+<li class="dropdown__item" role="button" {{on 'click' @onClick}}>
+  {{yield}}
+</li>

--- a/orga/app/components/dropdown/item.hbs
+++ b/orga/app/components/dropdown/item.hbs
@@ -1,3 +1,3 @@
-<li class="dropdown__item" role="button" {{on 'click' @onClick}}>
+<li class="dropdown__item" role="button" {{on 'click' @onClick}} ...attributes>
   {{yield}}
 </li>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -22,6 +22,7 @@
 @import "components/campaign-list";
 @import "components/circle-chart";
 @import "components/current-organization";
+@import "components/dropdown";
 @import "components/pagination-control";
 @import "components/progression-gauge";
 @import "components/recommendation-indicator";

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -1,5 +1,4 @@
 .dropdown {
-  float: right;
   position: relative;
   display: inline-block;
 
@@ -9,10 +8,9 @@
     box-shadow: 1px 1px 3px 1px rgba($black, 0.13), 0 1px 1px 0 rgba($black, 0.08);
     overflow: hidden;
     position: absolute;
-    width: 200px;
-    right: 32px; //TODO find a way to put this in common
     padding: 0;
     margin: 0;
+    z-index: 1;
   }
 
   &__item {
@@ -22,16 +20,23 @@
     cursor: pointer;
     display: flex;
     font-size: 0.875rem;
-    padding: 12px 16px;
-    text-decoration: none;
     transition: background-color 0.1s linear;
+    padding: 12px 16px;
+
+    &--link {
+      padding: 0;
+      > a {
+        padding: 12px 16px;
+        width: 100%;
+        height: 100%;
+      }
+    }
 
     &:hover,
     &:active,
     &:focus {
       background-color: $grey-10;
       color: $grey-60;
-      text-decoration: none;
     }
   }
 }

--- a/orga/app/styles/components/dropdown.scss
+++ b/orga/app/styles/components/dropdown.scss
@@ -1,0 +1,37 @@
+.dropdown {
+  float: right;
+  position: relative;
+  display: inline-block;
+
+  &__content {
+    background-color: $white;
+    border-radius: 4px;
+    box-shadow: 1px 1px 3px 1px rgba($black, 0.13), 0 1px 1px 0 rgba($black, 0.08);
+    overflow: hidden;
+    position: absolute;
+    width: 200px;
+    right: 32px; //TODO find a way to put this in common
+    padding: 0;
+    margin: 0;
+  }
+
+  &__item {
+    align-items: center;
+    border-radius: 4px;
+    color: $grey-60;
+    cursor: pointer;
+    display: flex;
+    font-size: 0.875rem;
+    padding: 12px 16px;
+    text-decoration: none;
+    transition: background-color 0.1s linear;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: $grey-10;
+      color: $grey-60;
+      text-decoration: none;
+    }
+  }
+}

--- a/orga/app/styles/components/user-logged-menu.scss
+++ b/orga/app/styles/components/user-logged-menu.scss
@@ -41,30 +41,17 @@
 }
 
 .logged-user-menu {
-  background-color: $white;
-  border-radius: 4px;
-  box-shadow: 1px 1px 3px 1px rgba($black, 0.13), 0 1px 1px 0 rgba($black, 0.08);
-  overflow: hidden;
-  position: absolute;
   right: 0;
   top: 49px;
   width: 400px;
 
   &-item {
-    align-items: center;
-    border-radius: 4px;
     color: $grey-60;
-    cursor: pointer;
-    display: flex;
-    font-size: 0.875rem;
-    padding: 12px 16px;
     text-decoration: none;
-    transition: background-color 0.1s linear;
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $grey-10;
       color: $grey-60;
       text-decoration: none;
     }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -1,3 +1,5 @@
+$margin-right: 32px;
+
 .list-students-page {
   display: flex;
   flex-direction: column;
@@ -24,11 +26,11 @@
 
   &__dropdown-button {
     font-size: 1.1rem;
-    margin-right: 32px; //TODO find a way to put this in common
+    margin-right: $margin-right;
   }
 
   &__dropdown-content {
     width: 200px;
-    right: 32px; //TODO find a way to put this in common
+    right: $margin-right;
   }
 }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -26,4 +26,9 @@
     font-size: 1.1rem;
     margin-right: 32px; //TODO find a way to put this in common
   }
+
+  &__dropdown-content {
+    width: 200px;
+    right: 32px; //TODO find a way to put this in common
+  }
 }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -18,18 +18,12 @@
     white-space: pre;
   }
 
-  &__password-reset-cell {
+  &__actions {
     text-align: right;
   }
 
-  &__manage-button {
-    margin-right: 32px;
-  }
-
-  &__tooltip {
-    bottom: 42px;
-    border-radius: 4px;
-    left: 55px;
-    width: 64px;
+  &__dropdown-button {
+    font-size: 1.1rem;
+    margin-right: 32px; //TODO find a way to put this in common
   }
 }

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -30,14 +30,11 @@
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
             <td class="list-students-page__authentication-methods">{{student.authenticationMethods}}</td>
-            <td class="list-students-page__password-reset-cell">
-              {{#if (or student.hasUsername  student.hasEmail) }}
-                <div class="tooltip">
-                  <span class="tooltip-text list-students-page__tooltip">Gérer</span>
-                  <button class="button button--round-with-icon list-students-page__manage-button" type="button" {{on 'click' (fn this.openPasswordReset student)}}>
-                    {{fa-icon "cog" }}
-                  </button>
-                </div>
+            <td class="list-students-page__actions">
+              {{#if (or student.hasUsername student.hasEmail) }}
+                <Dropdown::IconTrigger @icon="ellipsis-v" @dropdownButtonClass="list-students-page__dropdown-button">
+                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>Gérer le compte</Dropdown::Item>
+                </Dropdown::IconTrigger>
               {{/if}}
             </td>
           </tr>

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -32,8 +32,14 @@
             <td class="list-students-page__authentication-methods">{{student.authenticationMethods}}</td>
             <td class="list-students-page__actions">
               {{#if (or student.hasUsername student.hasEmail) }}
-                <Dropdown::IconTrigger @icon="ellipsis-v" @dropdownButtonClass="list-students-page__dropdown-button">
-                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>Gérer le compte</Dropdown::Item>
+                <Dropdown::IconTrigger
+                  @icon="ellipsis-v"
+                  @dropdownButtonClass="list-students-page__dropdown-button"
+                  @dropdownContentClass="list-students-page__dropdown-content"
+                >
+                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                    Gérer le compte
+                  </Dropdown::Item>
                 </Dropdown::IconTrigger>
               {{/if}}
             </td>

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -25,7 +25,7 @@
       {{#if @students}}
         <tbody>
         {{#each @students as |student|}}
-          <tr>
+          <tr aria-label="Élève">
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>

--- a/orga/app/templates/components/user-logged-menu.hbs
+++ b/orga/app/templates/components/user-logged-menu.hbs
@@ -1,5 +1,5 @@
-<div class="logged-user-summary content-text content-text--small" aria-haspopup="true" aria-expanded="{{this.isMenuOpen}}">
-  <a href="#" class="link logged-user-summary__link" {{on 'click' this.toggleUserMenu}}>
+<div class="dropdown logged-user-summary content-text content-text--small" aria-label="Résumé utilisateur">
+  <a href="#" class="link logged-user-summary__link" {{on 'click' this.toggleUserMenu}} aria-haspopup="listbox" aria-expanded="{{this.isMenuOpen}}">
     <div>
       <div class="logged-user-summary__name">{{this.currentUser.prescriber.firstName}} {{this.currentUser.prescriber.lastName}}</div>
       <div class="logged-user-summary__organization">{{this.organizationNameAndExternalId}}</div>
@@ -12,21 +12,17 @@
   </a>
 </div>
 
-{{#if this.isMenuOpen}}
-  <ClickOutside @onClickOutside={{this.closeMenu}}>
-    <div class="logged-user-menu">
-      {{#each this.eligibleOrganizations as |organization|}}
-        <div class="logged-user-menu-item" title="{{organization.name}}" role="button" {{on 'click' (fn this.onOrganizationChange organization)}}>
-          <span class="logged-user-menu-item__organization-name">{{organization.name}}</span>
-          {{#if organization.externalId}}
-            <span class="logged-user-menu-item__organization-externalId">({{organization.externalId}})</span>
-          {{/if}}
-        </div>
-      {{/each}}
-      <LinkTo @route="logout" class="link logged-user-menu-item logged-user-menu-item__last">
-        <FaIcon @icon="power-off" @class="logged-user-menu-item__icon"></FaIcon>
-        Se déconnecter
-      </LinkTo>
-    </div>
-  </ClickOutside>
-{{/if}}
+<Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} class="logged-user-menu" aria-label="Menu utilisateur">
+  {{#each this.eligibleOrganizations as |organization|}}
+    <Dropdown::Item @onClick={{fn this.onOrganizationChange organization}} title="{{organization.name}}" class="logged-user-menu-item">
+      <span class="logged-user-menu-item__organization-name">{{organization.name}}</span>
+      {{#if organization.externalId}}
+        <span class="logged-user-menu-item__organization-externalId">({{organization.externalId}})</span>
+      {{/if}}
+    </Dropdown::Item>
+  {{/each}}
+  <Dropdown::ItemLink @linkTo="logout" class="logged-user-menu-item logged-user-menu-item__last">
+      <FaIcon @icon="power-off" @class="logged-user-menu-item__icon"></FaIcon>
+      Se déconnecter
+  </Dropdown::ItemLink>
+</Dropdown::Content>

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -99,44 +99,7 @@ module('Acceptance | Student List', function(hooks) {
         assert.equal(currentURL(), '/eleves');
       });
 
-      test('it should show title of team page', async function(assert) {
-        // when
-        await visit('/eleves');
-
-        // then
-        assert.dom('.page-title').hasText('Élèves');
-      });
-
-      test('it should list the students', async function(assert) {
-        // when
-        await visit('/eleves');
-
-        // then
-        assert.dom('.table thead th').exists({ count: 5 });
-        assert.dom('.table tbody tr').exists({ count: 6 });
-      });
-
-      test('it should display headers labels', async function(assert) {
-        // when
-        await visit('/eleves');
-
-        // then
-        assert.dom('.table thead th:nth-child(1)').hasText('Nom');
-        assert.dom('.table thead th:nth-child(2)').hasText('Prénom');
-        assert.dom('.table thead th:nth-child(3)').hasText('Date de naissance');
-        assert.dom('.table thead th:nth-child(4)').hasText('Connecté avec');
-        assert.dom('.table thead th:nth-child(5)').hasText('');
-      });
-
       module('when student authenticated by username and email', async function() {
-
-        test('it should have a button to display actions on the student', async function(assert) {
-          // when
-          await visit('/eleves');
-
-          // then
-          assert.dom('[aria-label="Afficher les actions pour cet élève"]').exists();
-        });
 
         test('it should open modal and display password reset button', async function(assert) {
           // given
@@ -226,14 +189,6 @@ module('Acceptance | Student List', function(hooks) {
         });
       });
 
-      test('it should display import button', async function(assert) {
-        // when
-        await visit('/eleves');
-
-        // then
-        assert.contains('Importer (.xml)');
-      });
-
       test('it should display success message and reload students', async function(assert) {
         // given
         await visit('/eleves');
@@ -247,9 +202,9 @@ module('Acceptance | Student List', function(hooks) {
         // then
         assert.dom('[data-test-notification-message="success"]').exists();
         assert.dom('[data-test-notification-message="success"]').hasText('La liste a été importée avec succès.');
-        assert.dom('.table tbody tr').exists({ count: 1 });
-        assert.dom('.table tbody tr td:first-child').hasText('Cover');
-        assert.dom('.table tbody tr td:nth-child(2)').hasText('Harry');
+        assert.dom('[aria-label="Élève"]').exists({ count: 1 });
+        assert.contains('Cover');
+        assert.contains('Harry');
       });
 
       test('it should display an error message when uploading an invalid file', async function(assert) {
@@ -310,29 +265,6 @@ module('Acceptance | Student List', function(hooks) {
         // then
         assert.dom('[data-test-notification-message="error"]').exists();
         assert.dom('[data-test-notification-message="error"]').hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
-      });
-    });
-
-    module('When prescriber is not admin in organization', function(hooks) {
-
-      hooks.beforeEach(async () => {
-        user = createUserManagingStudents('MEMBER');
-        createPrescriberByUser(user);
-
-        await authenticateSession({
-          user_id: user.id,
-          access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
-          expires_in: 3600,
-          token_type: 'Bearer token type',
-        });
-      });
-
-      test('it should not display import button', async function(assert) {
-        // when
-        await visit('/eleves');
-
-        // then
-        assert.notContains('Importer (.xml)');
       });
     });
   });

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -130,12 +130,12 @@ module('Acceptance | Student List', function(hooks) {
 
       module('when student authenticated by username and email', async function() {
 
-        test('it should display password reset modal button for student', async function(assert) {
+        test('it should have a button to display actions on the student', async function(assert) {
           // when
           await visit('/eleves');
 
           // then
-          assert.dom('.table tbody tr:nth-child(6) td:last-child button .fa-cog').exists();
+          assert.dom('[aria-label="Afficher les actions pour cet élève"]').exists();
         });
 
         test('it should open modal and display password reset button', async function(assert) {
@@ -143,18 +143,18 @@ module('Acceptance | Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('.table tbody tr:nth-child(6) td:last-child button');
+          await click('[aria-label="Afficher les actions"]');
+          await click('li');
 
           // then
-          assert.dom('.pix-modal-overlay').exists();
-          assert.dom('.pix-modal-footer button').exists();
-          assert.dom('.pix-modal-footer button').hasText('Réinitialiser le mot de passe');
+          assert.contains('Réinitialiser le mot de passe');
         });
 
         test('it should display unique password input when reset button is clicked', async function(assert) {
           // given
           await visit('/eleves');
-          await click('.table tbody tr:nth-child(6) td:last-child button');
+          await click('[aria-label="Afficher les actions"]');
+          await click('li');
 
           // when
           await click('#generate-password');
@@ -170,26 +170,26 @@ module('Acceptance | Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('.table tbody tr:nth-child(6) td:last-child button');
+          await click('[aria-label="Afficher les actions"]');
+          await click('li');
 
           // then
-          assert.dom('.pix-modal-overlay').exists();
           assert.dom('#username').hasValue(username);
           assert.dom('#email').hasValue(email);
         });
       });
 
-      module('when student authenticated by username )', async function() {
+      module('when student authenticated by username', async function() {
 
         test('it should open password modal window with username value', async function(assert) {
           // given
           await visit('/eleves');
 
           // when
-          await click('.table tbody tr:nth-child(6) td:last-child button');
+          await click('[aria-label="Afficher les actions"]');
+          await click('li');
 
           // then
-          assert.dom('.pix-modal-overlay').exists();
           assert.dom('#username').hasValue(username);
         });
 
@@ -203,10 +203,10 @@ module('Acceptance | Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('.table tbody tr:nth-child(6) td:last-child button');
+          await click('[aria-label="Afficher les actions"]');
+          await click('li');
 
           // then
-          assert.dom('.pix-modal-overlay').exists();
           assert.dom('#email').hasValue(email);
         });
       });
@@ -231,7 +231,7 @@ module('Acceptance | Student List', function(hooks) {
         await visit('/eleves');
 
         // then
-        assert.dom('.button').hasText('Importer (.xml)');
+        assert.contains('Importer (.xml)');
       });
 
       test('it should display success message and reload students', async function(assert) {
@@ -332,7 +332,7 @@ module('Acceptance | Student List', function(hooks) {
         await visit('/eleves');
 
         // then
-        assert.dom('.button').doesNotExist();
+        assert.notContains('Importer (.xml)');
       });
     });
   });

--- a/orga/tests/integration/components/dropdown/icon-trigger-test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
+
+  setupRenderingTest(hooks);
+
+  test('should display actions menu', async function(assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger/>`);
+
+    // then
+    assert.dom('[aria-label="Afficher les actions"]').exists();
+  });
+
+  test('should display actions on click', async function(assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger/>`);
+    await click('[aria-label="Afficher les actions"]');
+
+    // then
+    assert.dom('[aria-label="Actions"]').exists();
+  });
+
+  test('should hide actions on click again', async function(assert) {
+    // when
+    await render(hbs`<Dropdown::IconTrigger/>`);
+    await click('[aria-label="Afficher les actions"]');
+    await click('[aria-label="Afficher les actions"]');
+
+    // then
+    assert.dom('[aria-label="Actions"]').doesNotExist();
+  });
+});

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -8,20 +8,27 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | routes/authenticated/students | list-items', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display the header names', async function(assert) {
+  test('it should show title of team page', async function(assert) {
+    // when
+    await render(hbs`<Routes::Authenticated::Students::ListItems/>`);
+
+    // then
+    assert.contains('Élèves');
+  });
+
+  test('it should display the header labels', async function(assert) {
     // given
     this.set('students', []);
 
     // when
-    await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
     // then
-    assert.dom('.table thead tr th').exists({ count: 5 });
-    assert.dom('.table thead tr th:first-child').hasText('Nom');
-    assert.dom('.table thead tr th:nth-child(2)').hasText('Prénom');
-    assert.dom('.table thead tr th:nth-child(3)').hasText('Date de naissance');
-    assert.dom('.table thead tr th:nth-child(4)').hasText('Connecté avec');
-    assert.dom('.table thead tr th:last-child').hasText('');
+    assert.dom('th').exists({ count: 5 });
+    assert.contains('Nom');
+    assert.contains('Prénom');
+    assert.contains('Date de naissance');
+    assert.contains('Connecté avec');
   });
 
   test('it should display a list of students', async function(assert) {
@@ -34,180 +41,138 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     this.set('students', students);
 
     // when
-    await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
     // then
-    assert.dom('.table tbody tr').exists();
-    assert.dom('.table tbody tr').exists({ count: 2 });
+    assert.dom('[aria-label="Élève"]').exists({ count: 2 });
   });
 
   test('it should display the firstName, lastName and birthdate of student', async function(assert) {
     // given
-    const students = [
-      { lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },
-      { lastName: 'L\'asticot', firstName: 'Gogo', birthdate: new Date('2010-05-10') },
-    ];
+    const students = [{ lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },];
 
     this.set('students', students);
 
     // when
-    await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
     // then
-    assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
-    assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
-    assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/02/2010');
+    assert.contains('La Terreur');
+    assert.contains('Gigi');
+    assert.contains('01/02/2010');
   });
 
-  test('it should not display password update button when student have not username', async function(assert) {
-    const store = this.owner.lookup('service:store');
-
+  module('when user is not reconciled', function({ beforeEach }) {
     const storedStudents = [];
-    [
-      {
-        id: 1,
-        firstName: 'Paul',
-        lastName: 'Durant',
-        birthdate: new Date('2008-10-01'),
-      },
-      {
-        id: 2,
-        firstName: 'Jackie',
-        lastName: 'Coogan',
-        birthdate: new Date('2004-10-26'),
-        username: 'jackie.coogan2610',
-        isAuthenticatedFromGar: false,
-      },
-    ].forEach((student) => {
-      storedStudents.push(run(() => store.createRecord('student', student)));
+
+    beforeEach(function() {
+      const store = this.owner.lookup('service:store');
+      [{
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        birthdate: '2010-01-01',
+      }].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
     });
 
-    this.set('students', storedStudents);
-
-    // when
-    await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
-
-    // then
-    assert.dom('.table tbody tr:first-child td:last-child button .fa-cog').doesNotExist();
-    assert.dom('.table tbody tr:nth-child(2) td:last-child button .fa-cog').exists();
-  });
-
-  module('it should display the authentication method', ()=> {
-
-    test('it should display dash when not reconcilied', async function(assert) {
+    test('it should display dash for authentication method', async function(assert) {
       // given
-      const store = this.owner.lookup('service:store');
       const dash = '\u2013';
-
-      const storedStudents = [];
-      [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-          birthdate: '2010-01-01',
-        },
-      ].forEach((student) => {
-        storedStudents.push(run(() => store.createRecord('student', student)));
-      });
-
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
       // then
-      assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
-      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
-      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/01/2010');
-      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText(dash);
+      assert.dom('[aria-label="Élève"]').containsText(dash);
     });
-    test('it should display Identifiant when identified by username', async function(assert) {
-      // given
-      const store = this.owner.lookup('service:store');
 
-      const storedStudents = [];
-      [
-        {
-          lastName: 'La Terreur',
-          firstName: 'Gigi',
-          birthdate: '2010-01-01',
-          username: 'blueivy.carter0701',
-          isAuthenticatedFromGar: false,
-        },
-      ].forEach((student) => {
-        storedStudents.push(run(() => store.createRecord('student', student)));
-      });
-
+    test('it should not display actions menu for username', async function(assert) {
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
       // then
-      assert.dom('.table tbody tr:first-child td:first-child').hasText('La Terreur');
-      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('Gigi');
-      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/01/2010');
-      assert.dom('.table tbody tr:first-child td:nth-child(4)').hasText('Identifiant');
+      assert.dom('[aria-label="Afficher les actions"]').doesNotExist();
     });
-
   });
 
-  module('when student have a username', () => {
+  module('when user is reconciled with username', function({ beforeEach }) {
+    const storedStudents = [];
 
-    test('it should display the student\'s firstName, lastName and birthdate, and password update button', async function(assert) {
-      // given
+    beforeEach(function() {
       const store = this.owner.lookup('service:store');
-      const student =
-        run(() => store.createRecord('student', {
-          id: 1,
-          lastName: 'lastName',
-          firstName: 'firstName',
-          birthdate: new Date('2008-10-01'),
-          username: 'firstname.lastname0110',
-          isAuthenticatedFromGar: false,
-        }));
-
-      this.set('students', [student]);
-
-      // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
-
-      // then
-      assert.dom('.table tbody tr:first-child td:first-child').hasText('lastName');
-      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('firstName');
-      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/10/2008');
-      assert.dom('.table tbody tr:first-child td:last-child button .fa-cog').exists();
+      [{
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        birthdate: '2010-01-01',
+        username: 'blueivy.carter0701',
+        isAuthenticatedFromGar: false,
+      }].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
     });
 
+    test('it should display "Identifiant" as authentication method', async function(assert) {
+      // given
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+
+      // then
+      assert.dom('[aria-label="Élève"]').containsText('Identifiant');
+    });
+
+    test('it should display actions menu', async function(assert) {
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+
+      // then
+      assert.dom('[aria-label="Afficher les actions"]').exists();
+    });
   });
 
-  module('when student have an email', () => {
+  module('when user is reconciled with email', function({ beforeEach }) {
+    const storedStudents = [];
 
-    test('it should display the student\'s firstName, lastName and birthdate, and password manage button', async function(assert) {
-      // given
+    beforeEach(function() {
       const store = this.owner.lookup('service:store');
-      const student =
-        run(() => store.createRecord('student', {
-          id: 1,
-          lastName: 'lastName',
-          firstName: 'firstName',
-          birthdate: new Date('2008-10-01'),
-          email: 'firstname.lastname@example.net',
-          isAuthenticatedFromGar: false,
-        }));
-
-      this.set('students', [student]);
-
-      // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
-
-      // then
-      assert.dom('.table tbody tr:first-child td:first-child').hasText('lastName');
-      assert.dom('.table tbody tr:first-child td:nth-child(2)').hasText('firstName');
-      assert.dom('.table tbody tr:first-child td:nth-child(3)').hasText('01/10/2008');
-      assert.dom('.table tbody tr:first-child td:last-child button .fa-cog').exists();
+      [{
+        lastName: 'La Terreur',
+        firstName: 'Gigi',
+        birthdate: '2010-01-01',
+        email: 'firstname.lastname@example.net',
+        isAuthenticatedFromGar: false,
+      }].forEach((student) => {
+        storedStudents.push(run(() => store.createRecord('student', student)));
+      });
     });
 
+    test('it should display "Adresse email" as authentication method', async function(assert) {
+      // given
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+
+      // then
+      assert.dom('[aria-label="Élève"]').containsText('Adresse e-mail');
+    });
+
+    test('it should display actions menu for email', async function(assert) {
+      this.set('students', storedStudents);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+
+      // then
+      assert.dom('[aria-label="Afficher les actions"]').exists();
+    });
   });
 
   module('when user is admin in organization', (hooks) => {
@@ -220,10 +185,10 @@ module('Integration | Component | routes/authenticated/students | list-items', f
 
     test('it should display import button', async function(assert) {
       // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students importStudents=(action importStudentsSpy)}}`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
       // then
-      assert.dom('.button').hasText('Importer (.xml)');
+      assert.contains('Importer (.xml)');
     });
   });
 
@@ -236,10 +201,10 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', []);
 
       // when
-      await render(hbs`{{routes/authenticated/students/list-items students=students}}`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
 
       // then
-      assert.dom('.button').doesNotExist();
+      assert.notContains('Importer (.xml)');
     });
   });
 

--- a/orga/tests/integration/components/user-logged-menu-test.js
+++ b/orga/tests/integration/components/user-logged-menu-test.js
@@ -20,33 +20,25 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     this.owner.register('service:current-user', Service.extend({ prescriber, organization }));
   });
 
-  test('it renders', async function(assert) {
-    // when
-    await render(hbs`{{user-logged-menu}}`);
-
-    // then
-    assert.dom('.logged-user-summary').exists();
-  });
-
   test('should display user\'s firstName and lastName', async function(assert) {
     // when
-    await render(hbs`{{user-logged-menu}}`);
+    await render(hbs`<UserLoggedMenu/>`);
 
     // then
-    assert.dom('.logged-user-summary__name').hasText(`${prescriber.firstName} ${prescriber.lastName}`);
+    assert.contains(`${prescriber.firstName} ${prescriber.lastName}`);
   });
 
   test('should display the user current organization name and externalId', async function(assert) {
     // when
-    await render(hbs`{{user-logged-menu}}`);
+    await render(hbs`<UserLoggedMenu/>`);
 
     // then
-    assert.dom('.logged-user-summary__organization').hasText(`${organization.name} (${organization.externalId})`);
+    assert.contains(`${organization.name} (${organization.externalId})`);
   });
 
   test('should display the chevron-down icon when menu is close', async function(assert) {
     // when
-    await render(hbs`{{user-logged-menu}}`);
+    await render(hbs`<UserLoggedMenu/>`);
 
     // then
     assert.dom('.fa-chevron-down').exists();
@@ -55,7 +47,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
 
   test('should display the chevron-up icon when menu is open', async function(assert) {
     // when
-    await render(hbs`{{user-logged-menu}}`);
+    await render(hbs`<UserLoggedMenu/>`);
     await click('.logged-user-summary__link');
 
     // then
@@ -65,12 +57,11 @@ module('Integration | Component | user-logged-menu', function(hooks) {
 
   test('should display the disconnect link when menu is open', async function(assert) {
     // when
-    await render(hbs`{{user-logged-menu}}`);
+    await render(hbs`<UserLoggedMenu/>`);
     await click('.logged-user-summary__link');
 
     // then
-    assert.dom('.logged-user-menu').exists();
-    assert.dom('.logged-user-menu-item__last').hasText('Se déconnecter');
+    assert.contains('Se déconnecter');
   });
 
   test('should display the organizations name and externalId when menu is open', async function(assert) {
@@ -78,14 +69,13 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     const organization1 = { id: 2, name: 'Organization 2', externalId: 'EXT2' };
     const organization2 = { id: 3, name: 'Organization 3', externalId: 'EXT3' };
     this.set('organizations', [organization1, organization2]);
-    await render(hbs`{{user-logged-menu eligibleOrganizations=organizations}}`);
+    await render(hbs`<UserLoggedMenu @eligibleOrganizations={{organizations}} />`);
     await click('.logged-user-summary__link');
 
     // then
-    assert.dom('.logged-user-menu').exists();
-    assert.dom('.logged-user-menu > div:nth-child(1) > span.logged-user-menu-item__organization-name').hasText(organization1.name);
-    assert.dom('.logged-user-menu > div:nth-child(1) > span.logged-user-menu-item__organization-externalId').hasText(`(${organization1.externalId})`);
-    assert.dom('.logged-user-menu > div:nth-child(2) > span.logged-user-menu-item__organization-name').hasText(organization2.name);
-    assert.dom('.logged-user-menu > div:nth-child(2) > span.logged-user-menu-item__organization-externalId').hasText(`(${organization2.externalId})`);
+    assert.contains(organization1.name);
+    assert.contains(`(${organization1.externalId})`);
+    assert.contains(organization2.name);
+    assert.contains(`(${organization2.externalId})`);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs de Pix Orga ne peuvent réaliser qu'une seule action ("gérer") sur un élève. Nous allons rajouter une action "dissocier" afin de dissocier un élève à son compte Pix si l'élève a fait une erreur.

## :robot: Solution
Remplacer la roue crantée par un menu dropdown, afin de rajoutée une entrée à ce menu.

## :rainbow: Remarques
Création d'un composant et réutilisation de celui-ci au sein du composant `user-logged-menu`

## :100: Pour tester
- Se connecter en tant que sco@example.net
- Aller dans l'onglet élève
- Vérifier le bon fonctionnement du dropdown pour les élèves réconciliés
- Vérifier le bon fonctionnement de la pop-up au click sur "Gérer le compte"
- Vérifier le bon fonctionnement du menu pour changer de compte Orga
