### PR TITLE
[BUGFIX] Corrections relatives au changement d'organisation dans Pix Orga (PIX-538).

### DIFF
--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -54,6 +54,8 @@ export default class UserLoggedMenu extends Component {
 
     await this.currentUser.load();
 
+    this.closeMenu();
+
     const queryParams = {};
     Object.keys(this.router.currentRoute.queryParams).forEach((key) => queryParams[key] = undefined);
     this.router.replaceWith('authenticated', { queryParams });

--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -50,7 +50,7 @@ export default class UserLoggedMenu extends Component {
     const selectedOrganization = await this.store.peekRecord('organization', organization.get('id'));
 
     userOrgaSettings.set('organization', selectedOrganization);
-    userOrgaSettings.save({ adapterOptions: { userId: prescriber.id } });
+    await userOrgaSettings.save({ adapterOptions: { userId: prescriber.id } });
 
     await this.currentUser.load();
 

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -90,6 +90,7 @@ module('Acceptance | Switch Organization', function(hooks) {
         // when
         await click('.logged-user-summary__link');
         await click('.logged-user-menu-item');
+        await click('.logged-user-summary__link');
 
         // then
         assert.dom('.logged-user-menu-item__organization-name').exists();


### PR DESCRIPTION
## :unicorn: Problème
Une régression a été introduite récemment relative au changement de l'organisation courante dans Pix Orga. En effet, il arrive parfois que lors du clique sur une organisation afin de changer l'organisation courante, le rechargement du current-user (GET) soit effectué avant la requête de modification de l'organisation courante (PUT). Cette "inversion" de l'ordre des appels provoque un nom changement de l'affichage de l'organisation courante côté front bien que ce changement ait été pris en compte par l'API. Nous avons donc une désynchronisation entre la valeur de l'organisation courante côté back et côté front.
De plus, le menu ne se ferme pas suite au changement de l'organisation courante.

## :robot: Solution
- Réparer le changement d'organisation.
- Fermer le menu suite au changement d'organisation.

## :100: Pour tester
Se connecter avec le compte sco@example.net