### PR TITLE
[INFRA] Ajouter les dernières variables d'environnement dans le fichier sample.env

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -167,6 +167,20 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # default: none
 # SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID=
 
+# String for links in emails redirect to a specific domain when user comes from french domain
+#
+# presence: optional
+# type: String
+# default: 'pix.fr'
+# DOMAIN_NAME_FR=
+
+# String for links in emails redirect to a specific domain when user comes from international domain
+#
+# presence: optional
+# type: String
+# default: 'pix.org'
+# DOMAIN_NAME_ORG=
+
 # ================
 # LEARNING CONTENT
 # ================
@@ -223,4 +237,3 @@ LOG_ENABLED=true
 # type: String
 # default: none
 AUTH_SECRET=Change me!
-


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR #1471, 2 variables d'environnement ont été ajouté. 
```
DOMAIN_NAME_FR
DOMAIN_NAME_ORG 
```
Seulement, celles-ci n'ont pas été ajouté au fichier sample.env.

## :robot: Solution
Ajouter ces variables dans le fichier sample.env et expliquer à quoi elles servent. 
