### PR TITLE
[BUGFIX] Problème d'affichage de la bannière de reprise de parcours (PIX-770)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -27,7 +27,7 @@ module.exports = {
         attributes: ['isShared', 'sharedAt', 'createdAt', 'participantExternalId',  'campaign', 'user', 'campaignParticipationResult', 'assessment', 'campaignAnalysis'],
         campaign: {
           ref: 'id',
-          attributes: ['code', 'title']
+          attributes: ['code', 'title', 'type']
         },
         user: {
           ref: 'id',

--- a/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
+++ b/api/tests/acceptance/application/users/users-get-campaign-participations_test.js
@@ -6,8 +6,10 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
   let userId;
   let campaign1;
   let campaign2;
+  let campaign3;
   let campaignParticipation1;
   let campaignParticipation2;
+  let campaignParticipation3;
   let assessment1;
   let assessment2;
   let options;
@@ -37,6 +39,14 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
         userId,
         campaignId: campaign2.id,
         createdAt: recentDate,
+      });
+
+      campaign3 = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION' });
+      const middleDate = new Date('2018-04-06T01:02:03Z');
+      campaignParticipation3 = databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        campaignId: campaign3.id,
+        createdAt: middleDate,
       });
 
       assessment1 = databaseBuilder.factory.buildAssessment({ campaignParticipationId: campaignParticipation1.id });
@@ -120,6 +130,32 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
             },
             {
               type: 'campaign-participations',
+              id: campaignParticipation3.id.toString(),
+              attributes: {
+                'is-shared': campaignParticipation3.isShared,
+                'participant-external-id': campaignParticipation3.participantExternalId,
+                'shared-at': campaignParticipation3.sharedAt,
+                'created-at': campaignParticipation3.createdAt
+              },
+              relationships: {
+                campaign: {
+                  data:
+                    { type: 'campaigns', id: `${campaign3.id}` },
+                },
+                'campaign-participation-result': {
+                  links: {
+                    'related': `/api/campaign-participations/${campaignParticipation3.id}/campaign-participation-result`
+                  }
+                },
+                'campaign-analysis': {
+                  links: {
+                    related: `/api/campaign-participations/${campaignParticipation3.id}/analyses`
+                  }
+                }
+              },
+            },
+            {
+              type: 'campaign-participations',
               id: campaignParticipation1.id.toString(),
               attributes: {
                 'is-shared': campaignParticipation1.isShared,
@@ -157,6 +193,16 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
               attributes: {
                 code: campaign2.code,
                 title: campaign2.title,
+                type: 'ASSESSMENT',
+              }
+            },
+            {
+              type: 'campaigns',
+              id: campaign3.id.toString(),
+              attributes: {
+                code: campaign3.code,
+                title: campaign3.title,
+                type: 'PROFILES_COLLECTION',
               }
             },
             {
@@ -165,6 +211,7 @@ describe('Acceptance | Route | GET /user/id/campaign-participations', () => {
               attributes: {
                 code: campaign1.code,
                 title: campaign1.title,
+                type: 'ASSESSMENT',
               }
             },
           ],


### PR DESCRIPTION
## :unicorn: Problème
Dans le bandeau "N'oubliez pas de finaliser votre envoi" nous devons voir le titre du parcours si le prescripteur en a renseigné un dans pix orga.

De plus, le message du bandeau affiché ne correspond pas à l'état actuel du parcous. Par exemple : Le bandeau d’envoi de résultat s’affiche alors que le parcours n’est pas terminé.

Les 2 problèmes observés sont liés au fait que la réponse de l'api `/users/{id}/campaign-participations` ne contient pas le type des campagnes liées aux participations. Par conséquent, le bandeau n'affichait que le texte par défaut qui était "N'oubliez pas de finaliser votre envoi".

## :robot: Solution
Ajouter le type de la campagne dans la réponse de l'api `/users/{id}/campaign-participations`

## :100: Pour tester
1. Commencer une campagne d'évaluation: AZERTY123
2. Quitter le parcours
3. Faire un refresh de la page
> Observer que le bandeau propose de reprendre le parcours avec le nom de campagne.
