### PR TITLE
[CLEANUP] Correction du changelog après une mauvaise manip qui a provoqué la duplication d'une entrée (PIX-774)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 - [#1454](https://github.com/1024pix/pix/pull/1454) [FEATURE] Montrer de manière claire que l'utilisateur a déjà envoyé son profil Pix (PIX-610).
 - [#1453](https://github.com/1024pix/pix/pull/1453) [FEATURE] Ne pas montrer la page de présentation si l'utilisateur a déjà commencé sa participation (PIX-616).
 - [#1461](https://github.com/1024pix/pix/pull/1461) [BUGFIX] Vérifier le seuil des 75% CléA sur le score certifié par compétence (et non positionné) (PIX-680).
-- [#1446](https://github.com/1024pix/pix/pull/1446) [BUGFIX] Vérifier le seuil des 75% CléA sur le score certifié par compétence (et non positionné) (PIX-680)
 - [#1397](https://github.com/1024pix/pix/pull/1397) [TECH] Améliorer l'accès à la liste des participants sur Pix Orga (PIX-608).
 - [#1448](https://github.com/1024pix/pix/pull/1448) [CLEANUP] Utilisation d'un read-model dans le service Current-user de Pix Orga (PIX-553).
 - [#1418](https://github.com/1024pix/pix/pull/1418) [CLEANUP] Suppression du package "api/lib/interfaces" et de ses modules devenus inutiles.


### PR DESCRIPTION
## :unicorn: Problème
Le merge de la PR https://github.com/1024pix/pix/pull/1446 n'a pas été sans quelques problèmes. En effet, cette PR a embarqué par erreur des commits qui ne lui appartenait pas. Suite à diverses manips de drop, ré-ouverture de PR et re-merge, on s'est retrouvé avec un changelog qui présente deux fois la même entrée (une par PR ouverte).

## :robot: Solution
On nettoie le changelog en conservant l'entrée pour la PR "corrective" (qui contient de toute façon un lien vers la PR d'origine)

## :rainbow: Remarques

## :100: Pour tester
Aucune régression attendue, c'est juste un diff de changelog
