### PR TITLE
[FEATURE] Ajout d'un outil sur PixAdmin pour copier "presque" complètement un utilisateur d'une base à l'autre (PIX-786)

### DIFF
--- a/admin/app/adapters/profile-copy.js
+++ b/admin/app/adapters/profile-copy.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class ProfileCopy extends ApplicationAdapter {
+
+  copyProfile(data) {
+    const url = `${this.host}/${this.namespace}/system/profile-copy`;
+    return this.ajax(url, 'POST', { data: data });
+  }
+}

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -5,6 +5,13 @@ import Controller from '@ember/controller';
 export default class ToolsController extends Controller {
 
   isLoading = false;
+  srcDatabaseUrl = null;
+  srcUserId = null;
+  destDatabaseUrl = null;
+  destUserId = null;
+  destOrganizationId = null;
+  destCreatorId = null;
+  destCertificationCenterId = null;
 
   @service notifications;
 
@@ -19,5 +26,50 @@ export default class ToolsController extends Controller {
     } finally {
       this.set('isLoading', false);
     }
+  }
+
+  @action
+  async copyProfile() {
+    this.set('isLoading', true);
+    try {
+      await this.store.adapterFor('profile-copy').copyProfile({
+        srcDatabaseUrl: this.srcDatabaseUrl,
+        srcUserId: this.srcUserId,
+        destDatabaseUrl: this.destDatabaseUrl,
+        destUserId: this.destUserId,
+        destOrganizationId: this.destOrganizationId,
+        destCreatorId: this.destCreatorId,
+        destCertificationCenterId: this.destCertificationCenterId,
+      });
+      this.notifications.success('Succès de copie');
+    } catch (err) {
+      this._handleError(err);
+    } finally {
+      this.set('isLoading', false);
+    }
+  }
+
+  _handleError(err) {
+    if (!err || !err.errors || !err.errors[0]) {
+      this.notifications.error(`Erreur lors de la copie du profil : erreur inconnue ${err}`);
+    }
+    const error = err.errors[0];
+    if (error.status === '422') {
+      let errorMessage;
+      if (error.detail.includes('srcUserId')) errorMessage = 'ID utilisateur d\'origine est obligatoire et doit être un nombre';
+      if (error.detail.includes('destUserId')) errorMessage = 'ID utilisateur de destination est obligatoire et doit être un nombre';
+      if (error.detail.includes('srcDatabaseUrl')) errorMessage = 'Adresse vers la base de données source doit être une chaîne de caractères';
+      if (error.detail.includes('destDatabaseUrl')) errorMessage = 'Adresse vers la base de données destination doit être une chaîne de caractères';
+      if (error.detail.includes('destOrganizationId')) errorMessage = 'ID organisation de destination est obligatoire et doit être un nombre';
+      if (error.detail.includes('destCreatorId')) errorMessage = 'ID membre de l\'organisation de destination est obligatoire et doit être un nombre';
+      if (error.detail.includes('destCertificationCenterId')) errorMessage = 'ID du centre de certification est obligatoire et doit être un nombre';
+      this.notifications.error(`Erreur lors de la copie du profil: ${errorMessage}`);
+      return;
+    }
+    if (error.status === '400') {
+      this.notifications.error(`Erreur lors de la copie du profil: ${error.detail}`);
+      return;
+    }
+    this.notifications.error(`Erreur lors de la copie du profil : erreur inconnue ${err}`);
   }
 }

--- a/admin/app/styles/authenticated/tools.scss
+++ b/admin/app/styles/authenticated/tools.scss
@@ -1,3 +1,10 @@
 .btn-refresh-cache {
   width: 180px;
 }
+
+.form-copy-user {
+  .form-group {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -26,6 +26,60 @@
         {{/if}}
       </div>
     </section>
+    <section class="page-section" aria-label="Section de copie de profil utilisateur">
+      <header class="page-section__header">
+        <h2 class="page-section__title">Copie d'un profil utilisateur</h2>
+      </header>
+      <div>
+        <p>Outil de copie de profil à utiliser avec intelligence.<br/>
+          Cet outil permet très exactement de : copier le profil de parcours et positionnement, ainsi que les éventuels tests de certification. Il faut de toute façon renseigner tous les champs avec des valeurs valides.</p>
+        <ul>
+          <li>Pour le parcours, la campagne de chaque participation sera aussi copiée dans l'organisation de destination indiquée dans le formulaire.</li>
+          <li>Pour la certification, la session de chaque participation sera aussi copiée dans le centre de certification de destination indiqué dans le formulaire.</li>
+        </ul>
+
+        <form class="form-copy-user" {{action "copyProfile" on='submit'}}>
+          <div class="form-field form-group">
+            <label class="form-field__label">URL de la base de données SOURCE : </label>
+            <Input placeholder="URL Base de données SOURCE" @type="text" @value={{this.srcDatabaseUrl}} aria-label="Champ URL base de données source"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">ID de l'utilisateur à copier (depuis la base de données SOURCE) : </label>
+            <Input placeholder="ID utilisateur à copier" @type="text" @value={{this.srcUserId}} aria-label="Champ ID utilisateur source"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">URL de la base de données DESTINATION : </label>
+            <Input placeholder="URL Base de données DESTINATION" @type="text" @value={{this.destDatabaseUrl}} aria-label="Champ URL base de données destination"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">ID de l'utilisateur recevant la copie (vers la base de données DESTINATION) : </label>
+            <Input placeholder="ID utilisateur recevant la copie" @type="text" @value={{this.destUserId}} aria-label="Champ ID utilisateur destination"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">ID de l'organisation recevant la copie des campagnes (vers la base de données DESTINATION) : </label>
+            <Input placeholder="ID organisation" @type="text" @value={{this.destOrganizationId}} aria-label="Champ ID organisation destination"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">ID d'un membre de l'organisation qui sera créateur de campagne (vers la base de données DESTINATION) : </label>
+            <Input placeholder="ID membre de l'organisation" @type="text" @value={{this.destCreatorId}} aria-label="Champ ID membre organisation destination"/>
+          </div>
+          <div class="form-field form-group">
+            <label class="form-field__label">ID du centre de certification recevant la copie des sessions (vers la base de données DESTINATION) : </label>
+            <Input placeholder="ID centre de certification" @type="text" @value={{this.destCertificationCenterId}} aria-label="Champ ID centre de certification destination"/>
+          </div>
+          <div class="callout alert"><strong>Attention !</strong> NE JAMAIS INDIQUER LA BASE DE PRODUCTION, RISQUE TRES ELEVEE.</div>
+          <div class="callout info">Durée de l’opération : <strong>Moins d'1 minute</strong>.</div>
+          {{#if isLoading}}
+            <button type="submit" class="btn btn-primary"><span class="loader-in-button">&nbsp;</span>
+            </button>
+          {{else}}
+            <button type="submit" class="btn btn-primary" aria-label="Copier le profil utilisateur">
+              <FaIcon @icon="copy"></FaIcon> Copier le profil
+            </button>
+          {{/if}}
+        </form>
+      </div>
+    </section>
   </main>
 
 </div>

--- a/admin/tests/acceptance/tools-page-test.js
+++ b/admin/tests/acceptance/tools-page-test.js
@@ -33,6 +33,17 @@ module('Acceptance | tools page', function(hooks) {
       assert.dom('section.learning-content').exists();
       assert.dom('button.btn-refresh-cache').exists();
     });
+
+    test('Should render "Profile copy" section', async function(assert) {
+      assert.dom('[aria-label="Section de copie de profil utilisateur"]').exists();
+      assert.dom('[aria-label="Champ URL base de données source"]').exists();
+      assert.dom('[aria-label="Champ ID utilisateur source"]').exists();
+      assert.dom('[aria-label="Champ URL base de données destination"]').exists();
+      assert.dom('[aria-label="Champ ID utilisateur destination"]').exists();
+      assert.dom('[aria-label="Champ ID organisation destination"]').exists();
+      assert.dom('[aria-label="Champ ID membre organisation destination"]').exists();
+      assert.dom('[aria-label="Champ ID centre de certification destination"]').exists();
+    });
   });
 
 });

--- a/admin/tests/unit/adapters/profile-copy-test.js
+++ b/admin/tests/unit/adapters/profile-copy-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | profile copy', function(hooks) {
+
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:profile-copy');
+    sinon.stub(adapter, 'ajax');
+  });
+
+  hooks.afterEach(function() {
+    adapter.ajax.restore();
+  });
+
+  test('it should make AJAX call "POST /api/system/profile-copy" in order to copy a user profile', async function(assert) {
+    // given
+    const data = 'someData';
+    adapter.ajax.resolves();
+
+    // when
+    await adapter.copyProfile(data);
+
+    // then
+    sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/system/profile-copy', 'POST', { data });
+    assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/tools-test.js
+++ b/admin/tests/unit/controllers/authenticated/tools-test.js
@@ -1,12 +1,54 @@
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
 module('Unit | Controller | authenticated/tools', function(hooks) {
   setupTest(hooks);
+  let controller;
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:authenticated/tools');
-    assert.ok(controller);
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/tools');
+  });
+
+  module('#copyProfile', function(hooks) {
+    let copyProfileStub;
+
+    hooks.beforeEach(function() {
+      copyProfileStub = sinon.stub().resolves();
+      const adapter = { copyProfile: copyProfileStub };
+      controller.store = { adapterFor: sinon.stub().withArgs('profile-copy').returns(adapter) };
+      controller.srcDatabaseUrl = 'srcDatabaseUrl';
+      controller.srcUserId = 'srcUserId';
+      controller.destDatabaseUrl = 'destDatabaseUrl';
+      controller.destUserId = 'destUserId';
+      controller.destOrganizationId = 'destOrganizationId';
+      controller.destCreatorId = 'destCreatorId';
+      controller.destCertificationCenterId = 'destCertificationCenterId';
+    });
+
+    test('it should reset isLoading marker to false when action is done', async function(assert) {
+      // when
+      await controller.send('copyProfile');
+
+      // then
+      assert.equal(controller.isLoading, false);
+    });
+
+    test('it should pass the appropriate arguments to store call', async function(assert) {
+      // when
+      await controller.send('copyProfile');
+
+      // then
+      sinon.assert.calledWith(copyProfileStub, {
+        srcDatabaseUrl: controller.srcDatabaseUrl,
+        srcUserId: controller.srcUserId,
+        destDatabaseUrl: controller.destDatabaseUrl,
+        destUserId: controller.destUserId,
+        destOrganizationId: controller.destOrganizationId,
+        destCreatorId: controller.destCreatorId,
+        destCertificationCenterId: controller.destCertificationCenterId,
+      });
+      assert.ok(controller);
+    });
   });
 });

--- a/api/lib/application/system/index.js
+++ b/api/lib/application/system/index.js
@@ -36,6 +36,22 @@ exports.register = async function(server) {
         tags: ['api', 'system']
       }
     },
+    {
+      method: 'POST',
+      path: '/api/system/profile-copy',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster'
+        }],
+        handler: systemController.copyProfile,
+        notes: [
+          '- **Route nécessitant une authentification en tant que Pix Master**\n' +
+          '- Copie un profil utilisateur d\'une base de données à une autre'
+        ],
+        tags: ['api', 'system']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/system/system-controller.js
+++ b/api/lib/application/system/system-controller.js
@@ -2,7 +2,98 @@ const os = require('os');
 const util = require('util');
 const heapdump = require('heapdump');
 const heapProfile = require('heap-profile');
+const Joi = require('joi');
+const _ = require('lodash');
+const { BadRequestError } = require('../http-errors');
+const { EntityValidationError } = require('../../domain/errors');
+const { QUERY, SPLIT_MARKER } = require('../../infrastructure/utils/sql/query-profile-copy');
 const { system } = require('../../config');
+
+const copyProfileParamsSchema = Joi.object({
+  srcUserId: Joi.number().integer().required(),
+  destUserId: Joi.number().integer().required(),
+  destOrganizationId: Joi.number().integer().required(),
+  destCreatorId: Joi.number().integer().required(),
+  destCertificationCenterId: Joi.number().integer().required(),
+  srcDatabaseUrl: Joi.string().required(),
+  destDatabaseUrl: Joi.string().required(),
+});
+
+const baseDbConfig = {
+  client: 'postgresql',
+  pool: {
+    min: 1,
+    max: 4,
+  },
+};
+
+async function getDBClient(databaseUrl) {
+  const config = _.clone(baseDbConfig);
+  config.connection = databaseUrl;
+  const dbClient = require('knex')(config);
+  // Ping
+  try {
+    await dbClient.raw('SELECT * FROM ??', ['pix_roles']);
+  } catch (err) {
+    throw new BadRequestError(`${databaseUrl} n'existe pas ou bien est impossible à contacter`);
+  }
+
+  return dbClient;
+}
+
+async function killDBClient(dbClient) {
+  return dbClient.destroy();
+}
+
+async function copyFromDB(databaseUrl, data) {
+  const completedQuery = util.format(QUERY, data.destUserId, data.srcUserId, data.destOrganizationId, data.destCreatorId, data.destCertificationCenterId);
+  let dbClient;
+  let results;
+  try {
+    dbClient = await getDBClient(databaseUrl);
+    results = await dbClient.transaction(async (trx) => {
+      return trx.raw(completedQuery);
+    });
+  } catch (err) {
+    if (err instanceof BadRequestError) {
+      throw new BadRequestError(`Erreur de la copie depuis la base source : ${err.message}.`);
+    }
+    throw err;
+  } finally {
+    if (dbClient) {
+      await killDBClient(dbClient);
+    }
+  }
+
+  const result = _.last(results);
+  if (result && result.rows && result.rows[0] && result.rows[0]['query_to_execute']) {
+    return _.last(results).rows[0]['query_to_execute'];
+  }
+
+  throw new BadRequestError(`Erreur de la copie depuis la base source : aucune donnée à copier depuis ${databaseUrl}.`);
+}
+
+async function pasteToDB(databaseUrl, query) {
+  let dbClient;
+  try {
+    dbClient = await getDBClient(databaseUrl);
+    const queryParts = _.split(query, SPLIT_MARKER);
+    await dbClient.transaction(async (trx) => {
+      for (const queryPart of queryParts) {
+        await trx.raw(queryPart);
+      }
+    });
+  } catch (err) {
+    if (err instanceof BadRequestError) {
+      throw new BadRequestError(`Erreur du collage vers la base destination : ${err.message}.`);
+    }
+    throw err;
+  } finally {
+    if (dbClient) {
+      await killDBClient(dbClient);
+    }
+  }
+}
 
 module.exports = {
 
@@ -28,4 +119,22 @@ module.exports = {
     const filename = await heapProfile.write();
     return h.file(filename, { mode: 'attachment' });
   },
+
+  async copyProfile(request) {
+    const {
+      srcDatabaseUrl,
+      destDatabaseUrl,
+    } = request.payload;
+    const data = _.pick(request.payload, ['srcUserId', 'destUserId', 'destOrganizationId', 'destCreatorId', 'destCertificationCenterId', 'srcDatabaseUrl', 'destDatabaseUrl']);
+
+    const { error } = copyProfileParamsSchema.validate(data);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+
+    const queryToExecute = await copyFromDB(srcDatabaseUrl, data);
+    await pasteToDB(destDatabaseUrl, queryToExecute);
+
+    return null;
+  }
 };

--- a/api/lib/infrastructure/utils/sql/query-profile-copy.js
+++ b/api/lib/infrastructure/utils/sql/query-profile-copy.js
@@ -1,0 +1,557 @@
+const SPLIT_MARKER = 'SPLIT_MARKER';
+const QUERY = `
+SET LOCAL copy_profile.dest_userid = %d;
+SET LOCAL copy_profile.src_userid = %d;
+SET LOCAL copy_profile.dest_organizationid = %d;
+SET LOCAL copy_profile.dest_creatorid = %d;
+SET LOCAL copy_profile.dest_certificationcenterid = %d;
+SELECT setval(pg_get_serial_sequence('knowledge-elements', 'id'), max("id")) FROM "knowledge-elements";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('answers', 'id'), max("id")) FROM "answers";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('assessments', 'id'), max("id")) FROM "assessments";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('campaign-participations', 'id'), max("id")) FROM "campaign-participations";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('campaigns', 'id'), max("id")) FROM "campaigns";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('target-profiles', 'id'), max("id")) FROM "target-profiles";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('target-profiles_skills', 'id'), max("id")) FROM "target-profiles_skills";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('sessions', 'id'), max("id")) FROM "sessions";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('certification-courses', 'id'), max("id")) FROM "certification-courses";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('assessment-results', 'id'), max("id")) FROM "assessment-results";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('competence-marks', 'id'), max("id")) FROM "competence-marks";${SPLIT_MARKER}
+SELECT setval(pg_get_serial_sequence('certification-challenges', 'id'), max("id")) FROM "certification-challenges";${SPLIT_MARKER}
+
+
+WITH TEMP_TABLE_TARGET_PROFILE AS (
+  SELECT 'CREATE TEMP TABLE target_profiles_by_campaign (
+          dest_target_profile_id INTEGER,
+          src_campaign_id INTEGER
+        ) ON COMMIT DROP;' AS query
+),
+TEMP_TABLE_CERTIFICATION_ASSESSMENT AS (
+  SELECT 'CREATE TEMP TABLE certification_assessment_link (
+          src_assessment_id INTEGER,
+          dest_assessment_id INTEGER
+        ) ON COMMIT DROP;' AS query
+),
+TEMP_TABLE_CERTIFICATION_COURSE AS (
+  SELECT 'CREATE TEMP TABLE certification_course_link (
+          src_certification_course_id INTEGER,
+          dest_certification_course_id INTEGER
+        ) ON COMMIT DROP;' AS query
+),
+
+
+POSITIONNEMENT AS (
+
+
+  WITH POSITIONNEMENT_ALL_DATA AS (
+    SELECT
+
+      'assessment_' || ass."id" || ' AS (
+         INSERT INTO "assessments" ("courseId", "createdAt", "updatedAt", "userId", "type", "state", "competenceId", "campaignParticipationId", "isImproving", "certificationCourseId")
+         VALUES (' ||
+                   CASE WHEN ass."courseId" IS NULL THEN 'NULL' ELSE '''' || ass."courseId" || '''' END || ', ' ||
+                   CASE WHEN ass."createdAt" IS NULL THEN 'NULL' ELSE '''' || ass."createdAt" || '''' END || ', ' ||
+                   CASE WHEN ass."updatedAt" IS NULL THEN 'NULL' ELSE '''' || ass."updatedAt" || '''' END || ', ' ||
+                   current_setting('copy_profile.dest_userid') || ', ' ||
+                   CASE WHEN ass."type" IS NULL THEN 'NULL' ELSE '''' || ass."type" || '''' END || ', ' ||
+                   CASE WHEN ass."state"  IS NULL THEN 'NULL' ELSE '''' || ass."state" || '''' END || ', ' ||
+                   CASE WHEN ass."competenceId"  IS NULL THEN 'NULL' ELSE '''' || ass."competenceId" || '''' END || ', ' ||
+                   CASE WHEN ass."campaignParticipationId" IS NULL THEN 'NULL' ELSE '''' || ass."campaignParticipationId" || '''' END || ', ' ||
+                   CASE WHEN ass."isImproving" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+                   CASE WHEN ass."certificationCourseId" IS NULL THEN 'NULL' ELSE '''' || ass."certificationCourseId" || '''' END ||
+          ')
+          RETURNING "id"
+      )' AS assessment_cte,
+
+      'answer_' || ans."id" || ' AS (
+         INSERT INTO "answers" ("value", "result", "assessmentId", "challengeId", "createdAt", "updatedAt", "timeout", "elapsedTime", "resultDetails")
+         SELECT ' ||
+                   CASE WHEN ans."value" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."value", '''', '''''', 'g' ) || '''' END || ', ' ||
+                   CASE WHEN ans."result" IS NULL THEN 'NULL' ELSE '''' || ans."result" || '''' END || ', ' ||
+                   'assessment_' || ass."id" || '.id, ' ||
+                   CASE WHEN ans."challengeId" IS NULL THEN 'NULL' ELSE '''' || ans."challengeId" || '''' END || ', ' ||
+                   CASE WHEN ans."createdAt"  IS NULL THEN 'NULL' ELSE '''' || ans."createdAt" || '''' END || ', ' ||
+                   CASE WHEN ans."updatedAt"  IS NULL THEN 'NULL' ELSE '''' || ans."updatedAt" || '''' END || ', ' ||
+                   CASE WHEN ans."timeout" IS NULL THEN 'NULL' ELSE '''' || ans."timeout" || '''' END || ', ' ||
+                   CASE WHEN ans."elapsedTime" IS NULL THEN 'NULL' ELSE '''' || ans."elapsedTime" || '''' END || ', ' ||
+                   CASE WHEN ans."resultDetails" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."resultDetails", '''', '''''', 'g' ) || '''' END ||
+          ' FROM assessment_' || ass."id" || ' RETURNING "id"
+      )' AS answer_cte,
+
+      'knowledgeelement_' || ke."id" || ' AS (
+         INSERT INTO "knowledge-elements" ("source", "status", "assessmentId", "answerId", "skillId", "createdAt", "earnedPix", "userId", "competenceId")
+         SELECT ' ||
+                   CASE WHEN ke."source" IS NULL THEN 'NULL' ELSE '''' || ke."source" || '''' END || ', ' ||
+                   CASE WHEN ke."status" IS NULL THEN 'NULL' ELSE '''' || ke."status" || '''' END || ', ' ||
+                   'assessment_' || ass."id" || '.id, ' ||
+                   'answer_' || ans."id" || '.id, ' ||
+                   CASE WHEN ke."skillId" IS NULL THEN 'NULL' ELSE '''' || ke."skillId" || '''' END || ', ' ||
+                   CASE WHEN ke."createdAt"  IS NULL THEN 'NULL' ELSE '''' || ke."createdAt" || '''' END || ', ' ||
+                   CASE WHEN ke."earnedPix"  IS NULL THEN 'NULL' ELSE '''' || ke."earnedPix" || '''' END || ', ' ||
+                   current_setting('copy_profile.dest_userid') || ', ' ||
+                   CASE WHEN ke."competenceId" IS NULL THEN 'NULL' ELSE '''' || ke."competenceId" || '''' END ||
+          ' FROM answer_' || ans."id" || ', assessment_' || ass."id" || ' RETURNING "id"
+      )' AS knowledgeelement_cte
+    FROM "knowledge-elements" AS ke
+    LEFT JOIN "answers" AS ans ON ans."id" = ke."answerId"
+    LEFT JOIN "assessments" AS ass ON ass."id" = ans."assessmentId"
+    WHERE ke."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+      AND ass."type" = 'COMPETENCE_EVALUATION'
+  ), GROUPED_KNOWLEDGE_ELEMENTS AS (
+    SELECT
+      distinct "answer_cte",
+      "assessment_cte",
+      STRING_AGG("knowledgeelement_cte", ' , ') OVER (PARTITION BY "answer_cte") AS "ke_ctes"
+    FROM POSITIONNEMENT_ALL_DATA
+  ), CONCATENED_KNOWLEDGE_ELEMENTS AS (
+    SELECT
+      "answer_cte" || ', ' || "ke_ctes" AS "answer_with_ke_ctes",
+      "assessment_cte"
+    FROM GROUPED_KNOWLEDGE_ELEMENTS
+  ), GROUPED_ANSWERS AS (
+    SELECT
+      distinct "assessment_cte",
+      STRING_AGG("answer_with_ke_ctes", ' , ') OVER (PARTITION BY "assessment_cte") AS "answers_with_ke_ctes"
+    FROM CONCATENED_KNOWLEDGE_ELEMENTS
+  ), CONCATENED_ANSWERS AS (
+    SELECT
+      'WITH ' || "assessment_cte" || ', ' || "answers_with_ke_ctes"|| ' SELECT ''DATA OK'';' AS "full_assessment_cte"
+    FROM GROUPED_ANSWERS
+  )
+  SELECT
+    STRING_AGG(full_assessment_cte, '${SPLIT_MARKER}') AS data
+  FROM CONCATENED_ANSWERS
+),
+
+
+PARCOURS AS (
+
+
+  WITH TARGET_PROFILES_ALL_DATA AS (
+    SELECT
+
+      'targetprofile_' || cmp."id" || ' AS (
+        INSERT INTO "target-profiles" ("name", "isPublic", "organizationId", "createdAt", "outdated")
+        VALUES(' ||
+               CASE WHEN tpr."name" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(tpr."name", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN tpr."isPublic" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+               'NULL, ' ||
+               CASE WHEN tpr."createdAt" IS NULL THEN 'NULL' ELSE '''' || tpr."createdAt" || '''' END || ', ' ||
+               CASE WHEN tpr."outdated" IS TRUE THEN 'true' ELSE 'false' END ||
+        ')
+        RETURNING "id"
+      ),
+      targetprofile_' || cmp."id" || '_record AS ( INSERT INTO "target_profiles_by_campaign" ("dest_target_profile_id", "src_campaign_id") SELECT targetprofile_' || cmp."id" || '.id, ' || cmp."id" || ' FROM targetprofile_' || cmp."id" ||
+      ')' AS targetprofile_cte,
+
+      'targetprofileskill_' || tps."id" || ' AS (
+        INSERT INTO "target-profiles_skills" ("targetProfileId", "skillId")
+        SELECT ' ||
+               'targetprofile_' || cmp."id" || '.id, ' ||
+               CASE WHEN tps."skillId" IS NULL THEN 'NULL' ELSE '''' || tps."skillId" || '''' END ||
+        ' FROM targetprofile_' || cmp."id" || ' RETURNING "id"
+      )' AS targetprofileskill_cte
+    FROM "campaigns" AS cmp
+    JOIN "target-profiles" AS tpr ON tpr."id" = cmp."targetProfileId"
+    JOIN "target-profiles_skills" AS tps ON tps."targetProfileId" = tpr."id"
+    WHERE cmp."id" = ANY(
+      SELECT DISTINCT cmp."id"
+      FROM "campaigns" AS cmp
+      JOIN "campaign-participations" AS cpp ON cpp."campaignId" = cmp."id"
+      WHERE cpp."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+    )
+  )
+
+
+  , PARCOURS_ALL_DATA AS (
+    SELECT
+
+      'campaign_' || cmp."id" || ' AS (
+        INSERT INTO "campaigns" ("name", "code", "organizationId", "creatorId", "createdAt", "targetProfileId", "idPixLabel", "title", "customLandingPageText", "archivedAt", "type")
+        SELECT ' ||
+               CASE WHEN cmp."name" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(cmp."name", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN cmp."code" IS NULL THEN 'NULL' ELSE '''' || cmp."code" || '''' END || ', ' ||
+               current_setting('copy_profile.dest_organizationid') || ', ' ||
+               current_setting('copy_profile.dest_creatorid') || ', ' ||
+               CASE WHEN cmp."createdAt" IS NULL THEN 'NULL' ELSE '''' || cmp."createdAt" || '''' END || ', ' ||
+               'target_profiles_by_campaign.dest_target_profile_id, ' ||
+               CASE WHEN cmp."idPixLabel" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(cmp."idPixLabel", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN cmp."title" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(cmp."title", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN cmp."customLandingPageText" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(cmp."customLandingPageText", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN cmp."archivedAt" IS NULL THEN 'NULL' ELSE '''' || cmp."archivedAt" || '''' END || ', ' ||
+               CASE WHEN cmp."type" IS NULL THEN 'NULL' ELSE '''' || cmp."type" || '''' END ||
+        ' FROM target_profiles_by_campaign WHERE target_profiles_by_campaign.src_campaign_id = ' || cmp."id" || ' RETURNING "id"
+      )' AS campaign_cte,
+
+      'campaignparticipation_' || cpp."id" || ' AS (
+        INSERT INTO "campaign-participations" ("campaignId", "createdAt", "isShared", "sharedAt", "participantExternalId", "userId")
+        SELECT ' ||
+               'campaign_' || cmp."id" || '.id, ' ||
+               CASE WHEN cpp."createdAt" IS NULL THEN 'NULL' ELSE '''' || cpp."createdAt" || '''' END || ', ' ||
+               CASE WHEN cpp."isShared" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+               CASE WHEN cpp."sharedAt" IS NULL THEN 'NULL' ELSE '''' || cpp."sharedAt" || '''' END || ', ' ||
+               CASE WHEN cpp."participantExternalId" IS NULL THEN 'NULL' ELSE '''' || cpp."participantExternalId" || '''' END || ', ' ||
+               current_setting('copy_profile.dest_userid') ||
+        ' FROM campaign_' || cmp."id" || ' RETURNING "id"
+      )' AS campaignparticipation_cte,
+
+      'assessment_' || ass."id" || ' AS (
+        INSERT INTO "assessments" ("courseId", "createdAt", "updatedAt", "userId", "type", "state", "competenceId", "campaignParticipationId", "isImproving", "certificationCourseId")
+        SELECT ' ||
+               CASE WHEN ass."courseId" IS NULL THEN 'NULL' ELSE '''' || ass."courseId" || '''' END || ', ' ||
+               CASE WHEN ass."createdAt" IS NULL THEN 'NULL' ELSE '''' || ass."createdAt" || '''' END || ', ' ||
+               CASE WHEN ass."updatedAt" IS NULL THEN 'NULL' ELSE '''' || ass."updatedAt" || '''' END || ', ' ||
+               current_setting('copy_profile.dest_userid') || ', ' ||
+               CASE WHEN ass."type" IS NULL THEN 'NULL' ELSE '''' || ass."type" || '''' END || ', ' ||
+               CASE WHEN ass."state"  IS NULL THEN 'NULL' ELSE '''' || ass."state" || '''' END || ', ' ||
+               CASE WHEN ass."competenceId"  IS NULL THEN 'NULL' ELSE '''' || ass."competenceId" || '''' END || ', ' ||
+               'campaignparticipation_' || cpp."id" || '.id, ' ||
+               CASE WHEN ass."isImproving" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+               CASE WHEN ass."certificationCourseId" IS NULL THEN 'NULL' ELSE '''' || ass."certificationCourseId" || '''' END ||
+        ' FROM campaignparticipation_' || cpp."id" || ' RETURNING "id"
+      )' AS assessment_cte,
+
+      'answer_' || ans."id" || ' AS (
+        INSERT INTO "answers" ("value", "result", "assessmentId", "challengeId", "createdAt", "updatedAt", "timeout", "elapsedTime", "resultDetails")
+        SELECT ' ||
+               CASE WHEN ans."value" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."value", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ans."result" IS NULL THEN 'NULL' ELSE '''' || ans."result" || '''' END || ', ' ||
+               'assessment_' || ass."id" || '.id, ' ||
+               CASE WHEN ans."challengeId" IS NULL THEN 'NULL' ELSE '''' || ans."challengeId" || '''' END || ', ' ||
+               CASE WHEN ans."createdAt"  IS NULL THEN 'NULL' ELSE '''' || ans."createdAt" || '''' END || ', ' ||
+               CASE WHEN ans."updatedAt"  IS NULL THEN 'NULL' ELSE '''' || ans."updatedAt" || '''' END || ', ' ||
+               CASE WHEN ans."timeout" IS NULL THEN 'NULL' ELSE '''' || ans."timeout" || '''' END || ', ' ||
+               CASE WHEN ans."elapsedTime" IS NULL THEN 'NULL' ELSE '''' || ans."elapsedTime" || '''' END || ', ' ||
+               CASE WHEN ans."resultDetails" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."resultDetails", '''', '''''', 'g' ) || '''' END ||
+        ' FROM assessment_' || ass."id" || ' RETURNING "id"
+      )' AS answer_cte,
+
+      'knowledgeelement_' || ke."id" || ' AS (
+        INSERT INTO "knowledge-elements" ("source", "status", "assessmentId", "answerId", "skillId", "createdAt", "earnedPix", "userId", "competenceId")
+        SELECT ' ||
+               CASE WHEN ke."source" IS NULL THEN 'NULL' ELSE '''' || ke."source" || '''' END || ', ' ||
+               CASE WHEN ke."status" IS NULL THEN 'NULL' ELSE '''' || ke."status" || '''' END || ', ' ||
+               'assessment_' || ass."id" || '.id, ' ||
+               'answer_' || ans."id" || '.id, ' ||
+               CASE WHEN ke."skillId" IS NULL THEN 'NULL' ELSE '''' || ke."skillId" || '''' END || ', ' ||
+               CASE WHEN ke."createdAt"  IS NULL THEN 'NULL' ELSE '''' || ke."createdAt" || '''' END || ', ' ||
+               CASE WHEN ke."earnedPix"  IS NULL THEN 'NULL' ELSE '''' || ke."earnedPix" || '''' END || ', ' ||
+               current_setting('copy_profile.dest_userid') || ', ' ||
+               CASE WHEN ke."competenceId" IS NULL THEN 'NULL' ELSE '''' || ke."competenceId" || '''' END ||
+        ' FROM answer_' || ans."id" || ', assessment_' || ass."id" || ' RETURNING "id"
+      )' AS knowledgeelement_cte
+    FROM "knowledge-elements" AS ke
+    LEFT JOIN "answers" AS ans ON ans."id" = ke."answerId"
+    LEFT JOIN "assessments" AS ass ON ass."id" = ans."assessmentId"
+    LEFT JOIN "campaign-participations" AS cpp ON cpp."id" = ass."campaignParticipationId"
+    LEFT JOIN "campaigns" AS cmp ON cmp."id" = cpp."campaignId"
+    WHERE ke."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+      AND ass."type" = 'SMART_PLACEMENT'
+  ),
+
+  GROUPED_TARGET_PROFILES_SKILLS AS (
+    SELECT
+      distinct "targetprofile_cte",
+      STRING_AGG("targetprofileskill_cte", ' , ') OVER (PARTITION BY "targetprofile_cte") AS "tps_ctes"
+    FROM TARGET_PROFILES_ALL_DATA
+  ), CONCATENED_TARGET_PROFILES_SKILLS AS (
+    SELECT
+      'WITH ' || "targetprofile_cte" || ', ' || "tps_ctes" || ' SELECT ''DATA OK'';' AS "tpf_with_tps_ctes"
+    FROM GROUPED_TARGET_PROFILES_SKILLS
+  ), PREPARATION_PARCOURS_DATA AS (
+    SELECT
+      STRING_AGG(tpf_with_tps_ctes, '${SPLIT_MARKER}') AS data
+    FROM CONCATENED_TARGET_PROFILES_SKILLS
+  ),
+
+  GROUPED_KNOWLEDGE_ELEMENTS AS (
+    SELECT
+      distinct "answer_cte",
+      "assessment_cte",
+      "campaignparticipation_cte",
+      "campaign_cte",
+      STRING_AGG("knowledgeelement_cte", ' , ') OVER (PARTITION BY "answer_cte") AS "ke_ctes"
+    FROM PARCOURS_ALL_DATA
+  ), CONCATENED_KNOWLEDGE_ELEMENTS AS (
+    SELECT
+      "answer_cte" || ', ' || "ke_ctes" AS "answer_with_ke_ctes",
+      "assessment_cte" ,
+      "campaignparticipation_cte",
+      "campaign_cte"
+    FROM GROUPED_KNOWLEDGE_ELEMENTS
+  ), GROUPED_ANSWERS AS (
+    SELECT
+      distinct "assessment_cte",
+      "campaignparticipation_cte",
+      "campaign_cte",
+      STRING_AGG("answer_with_ke_ctes", ' , ') OVER (PARTITION BY "assessment_cte") AS "answers_with_ke_ctes"
+    FROM CONCATENED_KNOWLEDGE_ELEMENTS
+  ), CONCATENED_ANSWERS AS (
+    SELECT
+      "assessment_cte" || ', ' || "answers_with_ke_ctes" AS "full_assessment_cte",
+      "campaignparticipation_cte",
+      "campaign_cte"
+    FROM GROUPED_ANSWERS
+  ), GROUPED_ASSESSMENTS AS (
+    SELECT
+      distinct "campaignparticipation_cte",
+      "campaign_cte",
+      STRING_AGG("full_assessment_cte", ' , ') OVER (PARTITION BY "campaignparticipation_cte") AS "full_assessment_ctes"
+    FROM CONCATENED_ANSWERS
+  ), CONCATENED_ASSESSMENTS AS (
+    SELECT
+      "campaignparticipation_cte" || ', ' || "full_assessment_ctes" AS "full_cp_cte",
+      "campaign_cte"
+    FROM GROUPED_ASSESSMENTS
+  ), GROUPED_CAMPAIGN_PARTICIPATIONS AS (
+    SELECT
+      distinct "campaign_cte",
+      STRING_AGG("full_cp_cte", ' , ') OVER (PARTITION BY "campaign_cte") AS "full_cp_ctes"
+    FROM CONCATENED_ASSESSMENTS
+  ), CONCATENED_CAMPAIGN_PARTICIPATIONS AS (
+    SELECT
+      'WITH ' || "campaign_cte" || ', ' || "full_cp_ctes" || ' SELECT ''DATA OK'';' AS "full_cmp_cte"
+    FROM GROUPED_CAMPAIGN_PARTICIPATIONS
+  ), PARCOURS_DATA AS (
+    SELECT
+      STRING_AGG(full_cmp_cte, '${SPLIT_MARKER}') AS data
+    FROM CONCATENED_CAMPAIGN_PARTICIPATIONS
+  )
+
+  SELECT CONCAT(PREPARATION_PARCOURS_DATA.data, PARCOURS_DATA.data) AS data
+  FROM PREPARATION_PARCOURS_DATA, PARCOURS_DATA
+),
+
+
+CERTIFICATION AS (
+
+
+  WITH SESSIONS_AND_CERTIFICATION_COURSES_AND_ASSESSMENTS_ALL_DATA AS (
+    SELECT
+
+      'session_' || ses."id" || ' AS (
+        INSERT INTO "sessions" ("certificationCenter", "address", "room", "examiner", "date", "time", "description", "createdAt", "accessCode", "certificationCenterId", "examinerGlobalComment", "finalizedAt", "resultsSentToPrescriberAt", "publishedAt", "assignedCertificationOfficerId")
+        VALUES(' ||
+               CASE WHEN ses."certificationCenter" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."certificationCenter", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."address" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."address", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."room" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."room", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."examiner" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."examiner", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."date" IS NULL THEN 'NULL' ELSE '''' || ses."date" || '''' END || ', ' ||
+               CASE WHEN ses."time" IS NULL THEN 'NULL' ELSE '''' || ses."time" || '''' END || ', ' ||
+               CASE WHEN ses."description" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."description", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."createdAt" IS NULL THEN 'NULL' ELSE '''' || ses."createdAt" || '''' END || ', ' ||
+               CASE WHEN ses."accessCode" IS NULL THEN 'NULL' ELSE '''' || ses."accessCode" || '''' END || ', ' ||
+               current_setting('copy_profile.dest_certificationcenterid') || ', ' ||
+               CASE WHEN ses."examinerGlobalComment" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ses."examinerGlobalComment", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ses."finalizedAt" IS NULL THEN 'NULL' ELSE '''' || ses."finalizedAt" || '''' END || ', ' ||
+               CASE WHEN ses."resultsSentToPrescriberAt" IS NULL THEN 'NULL' ELSE '''' || ses."resultsSentToPrescriberAt" || '''' END || ', ' ||
+               CASE WHEN ses."publishedAt" IS NULL THEN 'NULL' ELSE '''' || ses."publishedAt" || '''' END || ', ' ||
+               'NULL' ||
+        ')
+        RETURNING "id"
+      )' AS session_cte,
+
+      'certificationcourse_' || cc."id" || ' AS (
+        INSERT INTO "certification-courses" ("createdAt", "updatedAt", "userId", "completedAt", "firstName", "lastName", "birthdate", "birthplace", "sessionId", "externalId", "isPublished", "isV2Certification", "examinerComment", "hasSeenEndTestScreen" )
+        SELECT ' ||
+                 CASE WHEN cc."createdAt" IS NULL THEN 'NULL' ELSE '''' || cc."createdAt" || '''' END || ', ' ||
+                 CASE WHEN cc."updatedAt" IS NULL THEN 'NULL' ELSE '''' || cc."updatedAt" || '''' END || ', ' ||
+                 current_setting('copy_profile.dest_userid') || ', ' ||
+                 CASE WHEN cc."completedAt" IS NULL THEN 'NULL' ELSE '''' || cc."completedAt" || '''' END || ', ' ||
+                 '''firstName'', ''lastName'', ''2020-01-01'', ''birthplace'', ' ||
+                 'session_' || ses."id" || '.id, ' ||
+                 '''externalId'', ' ||
+                 CASE WHEN cc."isPublished" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+                 CASE WHEN cc."isV2Certification" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+                 CASE WHEN cc."examinerComment" IS NULL THEN 'NULL' ELSE '''' || cc."examinerComment" || '''' END || ', ' ||
+                 CASE WHEN cc."hasSeenEndTestScreen" IS TRUE THEN 'true' ELSE 'false' END ||
+        ' FROM session_' || ses."id" || ' RETURNING "id"
+      ),
+      certificationcourse_' || cc."id" || '_record AS ( INSERT INTO "certification_course_link" ("src_certification_course_id", "dest_certification_course_id") SELECT ' || cc."id" || ', certificationcourse_' || cc."id" || '.id FROM certificationcourse_' || cc."id" ||
+      ')' AS certificationcourse_cte,
+
+      'assessment_' || ass."id" || ' AS (
+        INSERT INTO "assessments" ("courseId", "createdAt", "updatedAt", "userId", "type", "state", "competenceId", "campaignParticipationId", "isImproving", "certificationCourseId")
+        SELECT ' ||
+                 CASE WHEN ass."courseId" IS NULL THEN 'NULL' ELSE '''' || ass."courseId" || '''' END || ', ' ||
+                 CASE WHEN ass."createdAt" IS NULL THEN 'NULL' ELSE '''' || ass."createdAt" || '''' END || ', ' ||
+                 CASE WHEN ass."updatedAt" IS NULL THEN 'NULL' ELSE '''' || ass."updatedAt" || '''' END || ', ' ||
+                 current_setting('copy_profile.dest_userid') || ', ' ||
+                 CASE WHEN ass."type" IS NULL THEN 'NULL' ELSE '''' || ass."type" || '''' END || ', ' ||
+                 CASE WHEN ass."state"  IS NULL THEN 'NULL' ELSE '''' || ass."state" || '''' END || ', ' ||
+                 CASE WHEN ass."competenceId"  IS NULL THEN 'NULL' ELSE '''' || ass."competenceId" || '''' END || ', ' ||
+                 CASE WHEN ass."campaignParticipationId"  IS NULL THEN 'NULL' ELSE '''' || ass."campaignParticipationId" || '''' END || ', ' ||
+                 CASE WHEN ass."isImproving" IS TRUE THEN 'true' ELSE 'false' END || ', ' ||
+                 'certificationcourse_' || ass."certificationCourseId" || '.id ' ||
+        ' FROM certificationcourse_' || cc."id" || ' RETURNING "id"
+      ),
+      assessment_' || cc."id" || '_record AS ( INSERT INTO "certification_assessment_link" ("src_assessment_id", "dest_assessment_id") SELECT ' || ass."id" || ', assessment_' || ass."id" || '.id FROM assessment_' || ass."id" ||
+      ')' AS assessment_cte
+    FROM "assessments" AS ass
+    JOIN "certification-courses" AS cc ON cc."id" = ass."certificationCourseId"
+    JOIN "sessions" AS ses ON ses."id" = cc."sessionId"
+    WHERE cc."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+  ),
+
+
+  CERTIFICATION_SCORING_ALL_DATA AS (
+    SELECT
+
+      'assessmentresult_' || asr."id" || ' AS (
+        INSERT INTO "assessment-results" ("createdAt", "level", "pixScore", "emitter", "commentForJury", "commentForOrganization", "commentForCandidate", "status", "juryId", "assessmentId")
+        SELECT ' ||
+                 CASE WHEN asr."createdAt" IS NULL THEN 'NULL' ELSE '''' || asr."createdAt" || '''' END || ', ' ||
+                 CASE WHEN asr."level" IS NULL THEN 'NULL' ELSE '''' || asr."level" || '''' END || ', ' ||
+                 CASE WHEN asr."pixScore" IS NULL THEN 'NULL' ELSE '''' || asr."pixScore" || '''' END || ', ' ||
+                 CASE WHEN asr."emitter" IS NULL THEN 'NULL' ELSE '''' || asr."emitter" || '''' END || ', ' ||
+                 CASE WHEN asr."commentForJury" IS NULL THEN 'NULL' ELSE '''' || asr."commentForJury" || '''' END || ', ' ||
+                 CASE WHEN asr."commentForOrganization" IS NULL THEN 'NULL' ELSE '''' || asr."commentForOrganization" || '''' END || ', ' ||
+                 CASE WHEN asr."commentForCandidate" IS NULL THEN 'NULL' ELSE '''' || asr."commentForCandidate" || '''' END || ', ' ||
+                 CASE WHEN asr."status" IS NULL THEN 'NULL' ELSE '''' || asr."status" || '''' END || ', ' ||
+                 'NULL, ' ||
+                 'certification_assessment_link.dest_assessment_id ' ||
+        ' FROM certification_assessment_link WHERE certification_assessment_link.src_assessment_id = ' || ass."id" || ' RETURNING "id"
+      )' AS assessmentresult_cte,
+
+      'competencemark_' || cm."id" || ' AS (
+        INSERT INTO "competence-marks" ("level", "score", "area_code", "competence_code", "createdAt", "assessmentResultId", "competenceId")
+        SELECT ' ||
+                 CASE WHEN cm."level" IS NULL THEN 'NULL' ELSE '''' || cm."level" || '''' END || ', ' ||
+                 CASE WHEN cm."score" IS NULL THEN 'NULL' ELSE '''' || cm."score" || '''' END || ', ' ||
+                 CASE WHEN cm."area_code" IS NULL THEN 'NULL' ELSE '''' || cm."area_code" || '''' END || ', ' ||
+                 CASE WHEN cm."competence_code" IS NULL THEN 'NULL' ELSE '''' || cm."competence_code" || '''' END || ', ' ||
+                 CASE WHEN cm."createdAt" IS NULL THEN 'NULL' ELSE '''' || cm."createdAt" || '''' END || ', ' ||
+                 'assessmentresult_' || asr."id" || '.id, ' ||
+                 CASE WHEN cm."competenceId" IS NULL THEN 'NULL' ELSE '''' || cm."competenceId" || '''' END ||
+        ' FROM assessmentresult_' || asr."id" || ' RETURNING "id"
+      )' AS competencemark_cte
+    FROM "competence-marks" AS cm
+    JOIN "assessment-results" AS asr ON asr."id" = cm."assessmentResultId"
+    JOIN "assessments" AS ass ON ass."id" = asr."assessmentId"
+    JOIN "certification-courses" AS cc ON cc."id" = ass."certificationCourseId"
+    WHERE cc."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+      AND ass."type" = 'CERTIFICATION'
+  ),
+
+
+  CERTIFICATION_ANSWERS_ALL_DATA AS (
+    SELECT
+
+      'answer_' || ans."id" || ' AS (
+        INSERT INTO "answers" ("value", "result", "assessmentId", "challengeId", "createdAt", "updatedAt", "timeout", "elapsedTime", "resultDetails")
+        SELECT ' ||
+               CASE WHEN ans."value" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."value", '''', '''''', 'g' ) || '''' END || ', ' ||
+               CASE WHEN ans."result" IS NULL THEN 'NULL' ELSE '''' || ans."result" || '''' END || ', ' ||
+               'certification_assessment_link.dest_assessment_id, ' ||
+               CASE WHEN ans."challengeId" IS NULL THEN 'NULL' ELSE '''' || ans."challengeId" || '''' END || ', ' ||
+               CASE WHEN ans."createdAt"  IS NULL THEN 'NULL' ELSE '''' || ans."createdAt" || '''' END || ', ' ||
+               CASE WHEN ans."updatedAt"  IS NULL THEN 'NULL' ELSE '''' || ans."updatedAt" || '''' END || ', ' ||
+               CASE WHEN ans."timeout" IS NULL THEN 'NULL' ELSE '''' || ans."timeout" || '''' END || ', ' ||
+               CASE WHEN ans."elapsedTime" IS NULL THEN 'NULL' ELSE '''' || ans."elapsedTime" || '''' END || ', ' ||
+               CASE WHEN ans."resultDetails" IS NULL THEN 'NULL' ELSE '''' || regexp_replace(ans."resultDetails", '''', '''''', 'g' ) || '''' END ||
+        ' FROM certification_assessment_link WHERE certification_assessment_link.src_assessment_id = ' || ass."id" || ' RETURNING "id"
+      )' AS answer_cte
+    FROM "answers" AS ans
+    JOIN "assessments" AS ass ON ass."id" = ans."assessmentId"
+    JOIN "certification-courses" AS cc ON cc."id" = ass."certificationCourseId"
+    WHERE cc."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+      AND ass."type" = 'CERTIFICATION'
+  ),
+
+
+  CERTIFICATION_CHALLENGES_ALL_DATA AS (
+    SELECT
+
+      'certificationchallenge_' || cch."id" || ' AS (
+        INSERT INTO "certification-challenges" ("challengeId", "competenceId", "associatedSkillName", "courseId", "createdAt", "updatedAt", "associatedSkillId")
+        SELECT ' ||
+               CASE WHEN cch."challengeId" IS NULL THEN 'NULL' ELSE '''' || cch."challengeId" || '''' END || ', ' ||
+               CASE WHEN cch."competenceId" IS NULL THEN 'NULL' ELSE '''' || cch."competenceId" || '''' END || ', ' ||
+               CASE WHEN cch."associatedSkillName" IS NULL THEN 'NULL' ELSE '''' || cch."associatedSkillName" || '''' END || ', ' ||
+               'certification_course_link.dest_certification_course_id, ' ||
+               CASE WHEN cch."createdAt"  IS NULL THEN 'NULL' ELSE '''' || cch."createdAt" || '''' END || ', ' ||
+               CASE WHEN cch."updatedAt"  IS NULL THEN 'NULL' ELSE '''' || cch."updatedAt" || '''' END || ', ' ||
+               CASE WHEN cch."associatedSkillId" IS NULL THEN 'NULL' ELSE '''' || cch."associatedSkillId" || '''' END ||
+        ' FROM certification_course_link WHERE certification_course_link.src_certification_course_id = ' || cc."id" || ' RETURNING "id"
+      )' AS certificationchallenge_cte
+    FROM "certification-challenges" AS cch
+    JOIN "certification-courses" AS cc ON cc."id" = cch."courseId"
+    WHERE cc."userId" = CAST( current_setting('copy_profile.src_userid') AS integer )
+  ),
+
+  GROUPED_ASSESSMENTS AS (
+    SELECT
+      distinct "certificationcourse_cte",
+      "session_cte",
+      STRING_AGG("assessment_cte", ' , ') OVER (PARTITION BY "certificationcourse_cte") AS "ass_ctes"
+    FROM SESSIONS_AND_CERTIFICATION_COURSES_AND_ASSESSMENTS_ALL_DATA
+  ), CONCATENED_ASSESSMENTS AS (
+    SELECT
+      "certificationcourse_cte" || ', ' || "ass_ctes" AS "cc_with_ass_ctes",
+      "session_cte"
+    FROM GROUPED_ASSESSMENTS
+  ),
+  GROUPED_CERTIFICATION_COURSES AS (
+    SELECT
+      distinct "session_cte",
+      STRING_AGG("cc_with_ass_ctes", ' , ') OVER (PARTITION BY "session_cte") AS "cc_ctes"
+    FROM CONCATENED_ASSESSMENTS
+  ), CONCATENED_CERTIFICATION_COURSES AS (
+    SELECT
+      'WITH ' || "session_cte" || ', ' || "cc_ctes" || ' SELECT ''CERTIFICATION PREPARATION OK'';' AS "ses_with_cc_ctes"
+    FROM GROUPED_CERTIFICATION_COURSES
+  ), PREPARATION_CERTIFICATION_DATA AS (
+    SELECT
+      STRING_AGG(ses_with_cc_ctes, '${SPLIT_MARKER}') AS data
+    FROM CONCATENED_CERTIFICATION_COURSES
+  ),
+
+  GROUPED_COMPETENCE_MARKS AS (
+    SELECT
+      distinct "assessmentresult_cte",
+      STRING_AGG("competencemark_cte", ' , ') OVER (PARTITION BY "assessmentresult_cte") AS "cm_ctes"
+    FROM CERTIFICATION_SCORING_ALL_DATA
+  ), CONCATENED_COMPETENCE_MARKS AS (
+    SELECT
+      'WITH ' || "assessmentresult_cte" || ', ' || "cm_ctes"|| ' SELECT ''CERTIFICATION SCORING OK'';' AS "asr_with_cm_ctes"
+    FROM GROUPED_COMPETENCE_MARKS
+  ), SCORING_DATA AS (
+    SELECT
+      STRING_AGG(asr_with_cm_ctes, '${SPLIT_MARKER}') AS data
+    FROM CONCATENED_COMPETENCE_MARKS
+  ),
+
+  ANSWERS_DATA AS (
+    SELECT
+      'WITH ' || STRING_AGG("answer_cte", ', ') || ' SELECT ''CERTIFICATION ANSWERS OK'';' AS data
+    FROM CERTIFICATION_ANSWERS_ALL_DATA
+  ),
+
+  CERTIFICATION_CHALLENGES_DATA AS (
+    SELECT
+      'WITH ' || STRING_AGG("certificationchallenge_cte", ', ') || ' SELECT ''CERTIFICATION CHALLENGES OK'';' AS data
+    FROM CERTIFICATION_CHALLENGES_ALL_DATA
+  )
+
+  SELECT CONCAT(CONCAT(CONCAT(PREPARATION_CERTIFICATION_DATA.data, SCORING_DATA.data), ANSWERS_DATA.data), CERTIFICATION_CHALLENGES_DATA.data) AS data
+  FROM PREPARATION_CERTIFICATION_DATA, SCORING_DATA, ANSWERS_DATA, CERTIFICATION_CHALLENGES_DATA
+)
+
+SELECT
+  TEMP_TABLE_TARGET_PROFILE.query ||
+  '${SPLIT_MARKER}' ||
+  TEMP_TABLE_CERTIFICATION_ASSESSMENT.query ||
+  '${SPLIT_MARKER}' ||
+  TEMP_TABLE_CERTIFICATION_COURSE.query ||
+  '${SPLIT_MARKER}' ||
+  POSITIONNEMENT.data ||
+  '${SPLIT_MARKER}' ||
+  PARCOURS.data ||
+  '${SPLIT_MARKER}' ||
+  CERTIFICATION.data AS query_to_execute
+FROM POSITIONNEMENT, PARCOURS, CERTIFICATION, TEMP_TABLE_TARGET_PROFILE, TEMP_TABLE_CERTIFICATION_ASSESSMENT, TEMP_TABLE_CERTIFICATION_COURSE;
+`;
+
+module.exports = {
+  QUERY,
+  SPLIT_MARKER,
+};

--- a/api/tests/integration/application/system/system-controller_test.js
+++ b/api/tests/integration/application/system/system-controller_test.js
@@ -1,9 +1,10 @@
 const os = require('os');
-const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const { expect, sinon, HttpTestServer, databaseBuilder, knex } = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/system');
 const heapdump = require('heapdump');
 const heapProfile = require('heap-profile');
+const _ = require('lodash');
 const { system } = require('../../../../lib/config');
 
 describe('Integration | Application | System | system-controller', () => {
@@ -131,6 +132,185 @@ describe('Integration | Application | System | system-controller', () => {
       it('should resolve a 403 HTTP response', () => {
         // when
         const promise = httpTestServer.request('GET', `/api/system/heap-profile/${os.hostname()}`);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
+  });
+
+  describe('#copyProfile', () => {
+
+    context('when user is PixMaster', () => {
+      beforeEach(() => {
+        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+      });
+
+      context('when data from payload is invalid', () => {
+
+        it('should return a 422 HTTP response with some details about the error', async () => {
+          // when
+          const response = await httpTestServer.request('POST', '/api/system/profile-copy', { srcUserId: 'invalidAttribute' });
+
+          // then
+          expect(response.statusCode).to.equal(422);
+          expect(response.result.errors).to.not.have.length(0);
+        });
+      });
+
+      context('when data from payload is valid', () => {
+        context('when one of the database is not reachable', () => {
+          const databaseUrl = 'invalid DB url';
+
+          it('should return a 400 HTTP response with error message related to unreachable database', async () => {
+            // when
+            const response = await httpTestServer.request('POST', '/api/system/profile-copy',
+              { srcUserId: 1, destUserId: 1, srcDatabaseUrl: databaseUrl, destDatabaseUrl: databaseUrl, destOrganizationId: 1, destCreatorId: 1, destCertificationCenterId: 1 }
+            );
+
+            // then
+            expect(response.statusCode).to.equal(400);
+            expect(response.result.errors[0].detail).to.include('n\'existe pas ou bien est impossible à contacter.');
+          });
+        });
+
+        context('when databases are reachable', () => {
+          const srcDatabaseUrl = process.env.TEST_DATABASE_URL;
+          const destDatabaseUrl = process.env.TEST_DATABASE_URL;
+          let srcUserId;
+          let destUserId;
+          let destOrganizationId;
+          let destCreatorId;
+          let destCertificationCenterId;
+          let expectedAssessmentEvaluation, expectedAnswerEvaluation, expectedKnowledgeElementEvaluation,
+            expectedCampaign, expectedCampaignParticipation, expectedAssessmentCampaign, expectedAnswerCampaign,
+            expectedKnowledgeElementCampaign, expectedSession, expectedCertificationCourse, expectedAssessmentCertification,
+            expectedAnswerCertification, expectedAssessmentResult, expectedCompetenceMark, expectedCertificationChallenge,
+            expectedTargetProfile, expectedTargetProfileSkill;
+          let data;
+
+          beforeEach(() => {
+            const dbf = databaseBuilder.factory;
+            srcUserId = dbf.buildUser().id;
+            destUserId = dbf.buildUser().id;
+
+            // Competence evaluation
+            expectedAssessmentEvaluation = dbf.buildAssessment({ userId: srcUserId, type: 'COMPETENCE_EVALUATION', certificationCourseId: null });
+            expectedAnswerEvaluation = dbf.buildAnswer({ assessmentId: expectedAssessmentEvaluation.id });
+            expectedKnowledgeElementEvaluation = dbf.buildKnowledgeElement({ answerId: expectedAnswerEvaluation.id, assessmentId: expectedAssessmentEvaluation.id, userId: srcUserId });
+
+            // Smart placement
+            destCreatorId = dbf.buildUser().id;
+            destOrganizationId = dbf.buildOrganization().id;
+            dbf.buildMembership({ userId: destCreatorId, organizationId: destOrganizationId });
+            expectedTargetProfile = dbf.buildTargetProfile({ organizationId: null });
+            expectedTargetProfileSkill = dbf.buildTargetProfileSkill({ targetProfileId: expectedTargetProfile.id });
+            expectedCampaign = dbf.buildCampaign({ organization: destOrganizationId, targetProfileId: expectedTargetProfile.id, archivedAt: null });
+            expectedCampaignParticipation = dbf.buildCampaignParticipation({ campaignId: expectedCampaign.id, userId: srcUserId });
+            expectedAssessmentCampaign = dbf.buildAssessment({ userId: srcUserId, type: 'SMART_PLACEMENT', campaignParticipationId: expectedCampaignParticipation.id, certificationCourseId: null });
+            expectedAnswerCampaign = dbf.buildAnswer({ assessmentId: expectedAssessmentCampaign.id });
+            expectedKnowledgeElementCampaign = dbf.buildKnowledgeElement({ answerId: expectedAnswerCampaign.id, assessmentId: expectedAssessmentCampaign.id, userId: srcUserId });
+
+            // Certification
+            destCertificationCenterId = dbf.buildCertificationCenter().id;
+            expectedSession = dbf.buildSession({ certificationCenterId: destCertificationCenterId });
+            expectedCertificationCourse = dbf.buildCertificationCourse({ sessionId: expectedSession.id, userId: srcUserId });
+            expectedAssessmentCertification = dbf.buildAssessment({ userId: srcUserId, type: 'CERTIFICATION', certificationCourseId: expectedCertificationCourse.id });
+            expectedAnswerCertification = dbf.buildAnswer({ assessmentId: expectedAssessmentCertification.id });
+            expectedAssessmentResult = dbf.buildAssessmentResult({ assessmentId: expectedAssessmentCertification.id });
+            expectedCompetenceMark = dbf.buildCompetenceMark({ assessmentResultId: expectedAssessmentResult.id });
+            expectedCertificationChallenge = dbf.buildCertificationChallenge({ courseId: expectedCertificationCourse.id });
+
+            data = { srcUserId, destUserId, destOrganizationId, destCreatorId, destCertificationCenterId, destDatabaseUrl, srcDatabaseUrl };
+            return databaseBuilder.commit();
+          });
+
+          afterEach(async () => {
+            await knex('knowledge-elements').delete();
+            await knex('answers').delete();
+            await knex('competence-marks').delete();
+            await knex('assessment-results').delete();
+            await knex('certification-challenges').delete();
+            await knex('assessments').delete();
+            await knex('campaign-participations').delete();
+            await knex('certification-courses').delete();
+            await knex('sessions').delete();
+            await knex('campaigns').delete();
+            await knex('target-profiles_skills').delete();
+            return knex('target-profiles').delete();
+          });
+
+          it('should return a 204 HTTP response', async () => {
+            // when
+            const response = await httpTestServer.request('POST', '/api/system/profile-copy', data);
+
+            // then
+            expect(response.statusCode).to.equal(204);
+          });
+
+          it('should copy data from srcUser to destUser', async () => {
+            // when
+            await httpTestServer.request('POST', '/api/system/profile-copy', data);
+
+            // then
+            // Competence evaluation
+            const actualAssessmentEvaluation = (await knex('assessments').where({ userId: destUserId, type: 'COMPETENCE_EVALUATION' }))[0];
+            const actualAnswerEvaluation = (await knex('answers').where({ assessmentId: actualAssessmentEvaluation.id }))[0];
+            const actualKnowledgeElementEvaluation = (await knex('knowledge-elements').where({ answerId: actualAnswerEvaluation.id }))[0];
+            expect(_.omit(actualAssessmentEvaluation, ['id', 'userId'])).to.deep.equal(_.omit(expectedAssessmentEvaluation, ['id', 'userId']));
+            expect(_.omit(actualAnswerEvaluation, ['id', 'assessmentId'])).to.deep.equal(_.omit(expectedAnswerEvaluation, ['id', 'assessmentId']));
+            expect(_.omit(actualKnowledgeElementEvaluation, ['id', 'userId', 'answerId', 'assessmentId'])).to.deep.equal(_.omit(expectedKnowledgeElementEvaluation, ['id', 'userId', 'answerId', 'assessmentId']));
+
+            // Smart placement
+            const actualCampaignParticipation = (await knex('campaign-participations').where({ userId: destUserId }))[0];
+            const actualCampaign = (await knex('campaigns').where({ id: actualCampaignParticipation.campaignId }))[0];
+            const actualTargetProfile = (await knex('target-profiles').where({ id: actualCampaign.targetProfileId }))[0];
+            const actualTargetProfileSkill = (await knex('target-profiles_skills').where({ targetProfileId: actualTargetProfile.id }))[0];
+            const actualAssessmentCampaign = (await knex('assessments').where({ campaignParticipationId: actualCampaignParticipation.id }))[0];
+            const actualAnswerCampaign = (await knex('answers').where({ assessmentId: actualAssessmentCampaign.id }))[0];
+            const actualKnowledgeElementCampaign = (await knex('knowledge-elements').where({ answerId: actualAnswerCampaign.id }))[0];
+            expect(_.omit(actualAssessmentCampaign, ['id', 'userId', 'campaignParticipationId'])).to.deep.equal(_.omit(expectedAssessmentCampaign, ['id', 'userId', 'campaignParticipationId']));
+            expect(_.omit(actualAnswerCampaign, ['id', 'assessmentId'])).to.deep.equal(_.omit(expectedAnswerCampaign, ['id', 'assessmentId']));
+            expect(_.omit(actualKnowledgeElementCampaign, ['id', 'userId', 'answerId', 'assessmentId'])).to.deep.equal(_.omit(expectedKnowledgeElementCampaign, ['id', 'userId', 'answerId', 'assessmentId']));
+            expect(_.omit(actualTargetProfileSkill, ['id', 'targetProfileId'])).to.deep.equal(_.omit(expectedTargetProfileSkill, ['id', 'targetProfileId']));
+            expect(_.omit(actualTargetProfile, ['id'])).to.deep.equal(_.omit(expectedTargetProfile, ['id']));
+            expect(_.omit(actualCampaign, ['id', 'organizationId', 'creatorId', 'targetProfileId'])).to.deep.equal(_.omit(expectedCampaign, ['id', 'organizationId', 'creatorId', 'targetProfileId']));
+            expect(_.omit(actualCampaignParticipation, ['id', 'campaignId', 'userId'])).to.deep.equal(_.omit(expectedCampaignParticipation, ['id', 'campaignId', 'userId']));
+
+            // Certification
+            const actualCertificationCourse = (await knex('certification-courses').where({ userId: destUserId }))[0];
+            const actualSession = (await knex('sessions').where({ id: actualCertificationCourse.sessionId }))[0];
+            const actualCertificationChallenge = (await knex('certification-challenges').where({ courseId: actualCertificationCourse.id }))[0];
+            const actualAssessmentCertification = (await knex('assessments').where({ certificationCourseId: actualCertificationCourse.id }))[0];
+            const actualAnswerCertification = (await knex('answers').where({ assessmentId: actualAssessmentCertification.id }))[0];
+            const actualAssessmentResult = (await knex('assessment-results').where({ assessmentId: actualAssessmentCertification.id }))[0];
+            const actualCompetenceMark = (await knex('competence-marks').where({ assessmentResultId: actualAssessmentResult.id }))[0];
+            expect(_.omit(actualCertificationCourse, ['id', 'userId', 'sessionId', 'lastName', 'firstName', 'birthdate', 'birthplace', 'externalId']))
+              .to.deep.equal(_.omit(expectedCertificationCourse, ['id', 'userId', 'sessionId', 'lastName', 'firstName', 'birthdate', 'birthplace', 'externalId']));
+            expect(_.omit(actualSession, ['id', 'certificationCenterId', 'assignedCertificationOfficerId'])).to.deep.equal(_.omit(expectedSession, ['id', 'certificationCenterId', 'assignedCertificationOfficerId']));
+            expect(_.omit(actualCertificationChallenge, ['id', 'courseId'])).to.deep.equal(_.omit(expectedCertificationChallenge, ['id', 'courseId']));
+            expect(_.omit(actualAssessmentCertification, ['id', 'userId', 'certificationCourseId'])).to.deep.equal(_.omit(actualAssessmentCertification, ['id', 'userId', 'certificationCourseId']));
+            expect(_.omit(actualAnswerCertification, ['id', 'assessmentId'])).to.deep.equal(_.omit(expectedAnswerCertification, ['id', 'assessmentId']));
+            expect(_.omit(actualAssessmentResult, ['id', 'assessmentId', 'juryId'])).to.deep.equal(_.omit(expectedAssessmentResult, ['id', 'assessmentId', 'juryId']));
+            expect(_.omit(actualCompetenceMark, ['id', 'assessmentResultId'])).to.deep.equal(_.omit(expectedCompetenceMark, ['id', 'assessmentResultId']));
+          });
+        });
+      });
+    });
+
+    context('when user is not PixMaster', () => {
+
+      beforeEach(() => {
+        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
+          return Promise.resolve(h.response().code(403).takeover());
+        });
+      });
+
+      it('should resolve a 403 HTTP response', () => {
+        // when
+        const promise = httpTestServer.request('POST', '/api/system/profile-copy');
 
         // then
         return promise.then((response) => {


### PR DESCRIPTION
## :unicorn: Problème
Pour des raisons de support ou de débug (principalement), il est parfois nécessaire de pouvoir "explorer" le compte d'un utilisateur afin de mieux comprendre le problème éventuel.
Pour ce faire, jusqu'à présent on faisait un peu (beaucoup) de la bidouille :
- Ou bien on connectait une RA à la base de réplication, en prenant soin d'anonymiser l'utilisateur à explorer (+ remplacement de MDP)
- Ou bien on faisait un dump en local puis on lançait en local l'ensemble

Bref, tout un tas de stratégies officieuses portant plusieurs défauts :
- Beaucoup de manipulations et d'opérations
- Stratégies réservées aux techos

## :robot: Solution
On propose ici à un utilisateur avec le rôle ADMIN d'accéder à un outil dans la section Tools de PixAdmin.
C'est un formulaire qui propose de copier un utilisateur d'un base à l'autre à condition de remplir le formulaire correctement :smile_cat: .
Il faut fournir :
- l'URL de la base depuis laquelle on copie l'utilisateur
- l'URL de la base vers laquelle on veut copier les données (àa peut évidemment être la même que la base juste au-dessus)
- l'ID de l'utilisateur à copier
- l'ID de l'utilisateur qui va "recevoir" les données
- l'ID d'une organisation qui va "recevoir" les campagnes copiées
- l'ID d'un membre de ladite organisation qui va être le "créateur" des campagnes copiées
- l'ID d'un centre de certification qui va "recevoir" les sessions de certification copiées

La copie proposée ici est assez large. En effet, cela comprend :
1. Le positionnement
  * Copie des `assessments`, `answers` et `knowledge-elements`
2. Les parcours
  * Copie des `campaign-participations` ainsi que leurs `campaigns` + `target-profile`, `target-profile_skills`, `assessments`, `answers` et `knowledge-elements`
3. La certification
  * Copie des `certification-courses` ainsi que leurs `sessions`,  `assessments`, `answers`, `certification-challenges`, `assessment-results` et `competence-marks`

## :rainbow: Remarques
Plusieurs améliorations peuvent être apportées à cette PR. D'abord de l'amélioration de "look" (je suis pas la meilleure sur le sujet, je suis ouverte à toutes les propositions), mais aussi de l'amélioration de sécu (comment empêcher de mettre l'adresse de bases de données sensibles ?...), etc...
:warning: Pour tester en local c'est un peu plus tricky, deux solutions :
- Pour pouvoir tester avec des bases de PR par exemple, il faut modifier le code pour pouvoir passer un certification d'autorité
- Vous pouvez tester en lançant deux bases en local. Pour cela, modifiez le docker-compose en changeant le port côté utilisateur pour l'une d'entre elles (pingez-moi si vous voulez de l'aide)

## :100: Pour tester
RDV sur PixAdmin en vous munissant :
- D'une BDD source (celle que vous voulez sauf la prod of course)
- L'id d'un utilisateur de la base source que vous souhaitez copier
- D'une BDD destination (ça peut être celle de la PR courante par exemple)
- L'id d'un utilisateur pour recevoir la copie (créez-vous un utilisateur tout vide sur la RA mon-pix de cette PR par exemple)
- L'id d'une organisation de la base destination (sur cette PR, prenez une seed, id: 1 par exemple)
- L'id d'un membre d'une organisation de la base destination (sur cette PR, prenez une seed, id: 2 (daenerys targaryen) par exemple)
- L'id d'un centre de certification de la base destination (sur cette PR, prenez une seed, id: 1 par exemple)
Allez dans le menu "Outils" (le dernier item à gauche avant celui pour se déconnecter), remplissez le formulaire de copie, appuyez sur Copier le profil, attendez la fin de la requête, puis connectez-vous sur le mon-pix lié à la BDD de destination pour observer que votre utilisateur de destination a bien été rempli !
