### PR TITLE
[BUGFIX] Correction d'un test knex-utils aléatoire

### DIFF
--- a/api/tests/integration/infrastructure/utils/knex_utils_test.js
+++ b/api/tests/integration/infrastructure/utils/knex_utils_test.js
@@ -7,18 +7,18 @@ describe('Integration | Infrastructure | Utils | Knex utils', function() {
   describe('fetchPage', function() {
 
     beforeEach(() => {
-      _.times(20, (index) => databaseBuilder.factory.buildCampaign({ name: `campagne-${index + 1}` }));
+      _.times(20, (index) => databaseBuilder.factory.buildCampaign({ name: `campagne-${index}` }));
       return databaseBuilder.commit();
     });
 
     it('should fetch the given page and return results and pagination data', async function() {
       // when
-      const query = knex.select('name').from('campaigns');
+      const query = knex.select('name').from('campaigns').orderBy('name');
       const { results, pagination } = await fetchPage(query, { number: 2, size: 5 });
 
       // then
       expect(results).to.have.lengthOf(5);
-      expect(results[0].name).to.equal('campagne-6');
+      expect(results[0].name).to.equal('campagne-13');
       expect(pagination).to.deep.equal({
         page: 2,
         pageSize: 5,


### PR DESCRIPTION
## :unicorn: Problème
Un test unitaire de `knex-utils` échoue de façon aléatoire. Car dans le test, l'ordre des données insérées pendant l'initialisation du test n'est pas garantie et la requête testée ne contient pas d'`order by` dessus.

## :robot: Solution
Ajout d'un `order by` dans la requête pour garantir toujours le même ordre dans le résultat de la requête.

