### PR TITLE
[TECH] Simplification de la création de badge en BDD (PIX-736).

### DIFF
--- a/api/db/migrations/20200608170256_alter_table_badgePartnerCompetences_column_color_from_notNullable_to_nullable.js
+++ b/api/db/migrations/20200608170256_alter_table_badgePartnerCompetences_column_color_from_notNullable_to_nullable.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'badge-partner-competences';
+
+exports.up = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('color').nullable().alter();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('color').notNullable().alter();
+  });
+};

--- a/api/db/seeds/data/badge-target-profile-builder.js
+++ b/api/db/seeds/data/badge-target-profile-builder.js
@@ -50,7 +50,7 @@ function badgeTargetProfileBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name : 'Rechercher des informations sur internet',
-    color : 'jaffa',
+    color : null,
     skillIds : [
       targetProfileSkills[0].skillId,
       targetProfileSkills[1].skillId,
@@ -68,7 +68,7 @@ function badgeTargetProfileBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name : 'Utiliser des outils informatiques',
-    color : 'wild-strawberry',
+    color : null,
     skillIds : [
       targetProfileSkills[10].skillId,
       targetProfileSkills[11].skillId,
@@ -82,7 +82,7 @@ function badgeTargetProfileBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name : 'Naviguer sur internet',
-    color : 'jaffa',
+    color : null,
     skillIds : [
       targetProfileSkills[16].skillId,
       targetProfileSkills[17].skillId,
@@ -96,7 +96,7 @@ function badgeTargetProfileBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name : 'Partager sur les réseaux sociaux',
-    color : 'emerald',
+    color : null,
     skillIds : [
       targetProfileSkills[22].skillId,
       targetProfileSkills[23].skillId,

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -122,7 +122,7 @@ function _getTestedCompetenceResults(competence, targetedKnowledgeElements) {
 
 function _getCompetenceColor(competence) {
   let areaColor;
-  const isBadgePartnerCompetenceColorAvailable = !_.isEmpty(competence.color);
+  const isBadgePartnerCompetenceColorAvailable = competence.color !== undefined;
 
   if (isBadgePartnerCompetenceColorAvailable) {
     areaColor = competence.color;

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -55,7 +55,7 @@ describe('Integration | Repository | Badge', () => {
 
     badgePartnerCompetence_2 = {
       id: 2,
-      color: 'jaffa',
+      color: null,
       name: 'Rechercher des éléments',
       skillIds: ['recABC1', 'recDEF2'],
     };

--- a/api/tests/tooling/database-builder/factory/build-badge-partner-competence.js
+++ b/api/tests/tooling/database-builder/factory/build-badge-partner-competence.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 module.exports = function buildBadgePartnerCompetence({
   id,
   name = faker.random.word(),
-  color = faker.random.word(),
+  color = null,
   skillIds = [],
   badgeId,
 } = {}) {

--- a/api/tests/tooling/domain-builder/factory/build-badge-partner-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-partner-competence.js
@@ -5,7 +5,7 @@ module.exports = function buildBadgePartnerCompetence(
   {
     id = 1,
     name = faker.lorem.words(),
-    color = 'jaffa',
+    color = null,
     skillIds = [
       faker.random.number(2),
       faker.random.number(2),


### PR DESCRIPTION
## :unicorn: Problème
L'implémentation impose de créer des `BadgePartnerCompetence` avec une couleur. C'était valable pour Pix Emploi. Avec l'introduction des nouveaux badges, c'est une règle qui n'est plus valable et contraignante.

## :robot: Solution
Appliquer la modification en base de données 

## :rainbow: Remarques
Quelques questions en suspens : 
- est-ce qu'on doit tester davantage le cas null ?
- est-ce qu'on doit lui attribuer une couleur par défaut sachant qu'on ne l'exploitera jamais ?

## :100: Pour tester
C'est purement technique donc transparent. 
Éventuellement ajouter une nouvelle partner compétence sans couleur à un badge qui n'est pas celui de PixEmploi pour être sûr qu'il n'y a pas de bugs
