### PR TITLE
[BUGFIX] La flèche de checkpoint doit s'afficher en plus grand (PIX-811).

### DIFF
--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -81,7 +81,7 @@
   & > svg {
     margin-left: 30px;
     padding-top: 6px;
-    font-size: 0.938em;
+    font-size: 1.5em;
     position: relative;
     left: 0;
     transition: all 0.25s ease-in-out;


### PR DESCRIPTION
## :unicorn: Problème
La flèche de checkpoint doit s'afficher en plus grand
<img width="251" alt="Screenshot 2020-06-08 at 21 31 12" src="https://user-images.githubusercontent.com/46371288/84072486-856c1980-a9cf-11ea-9c49-ce153868ab53.png">

## :robot: Solution
Restaurer l'ancienne valeur
<img width="245" alt="Screenshot 2020-06-08 at 21 31 31" src="https://user-images.githubusercontent.com/46371288/84072559-a92f5f80-a9cf-11ea-8c37-5e7437f97a57.png">

## :100: Pour tester
Aller jusqu'à un checkpoint
