### PR TITLE
[BUGFIX] Corrige une erreur 500 en 404 quand un test de démo n'est pas trouvé

### DIFF
--- a/api/lib/domain/services/course-service.js
+++ b/api/lib/domain/services/course-service.js
@@ -2,9 +2,7 @@ const _ = require('lodash');
 const Course = require('../models/Course');
 const { NotFoundError } = require('../../domain/errors');
 
-const { BaseHttpError } = require('../../application/http-errors');
 const courseRepository = require('../../infrastructure/repositories/course-repository');
-const logger = require('../../infrastructure/logger');
 
 module.exports = {
 
@@ -17,16 +15,7 @@ module.exports = {
 
     // TODO This repo switch should not be here because we make a technical discrimination on the course id
     if (_.startsWith(courseId, 'rec')) {
-      return courseRepository.get(courseId)
-        .then((airtableCourse) => {
-          return new Course(airtableCourse);
-        }).catch((err) => {
-          logger.error(err);
-          if ('NOT_FOUND' === err.error || (_.has(err, 'error.type') && 'MODEL_ID_NOT_FOUND' === err.error.type)) {
-            throw new NotFoundError();
-          }
-          throw new BaseHttpError(err.message);
-        });
+      return courseRepository.get(courseId);
     }
 
     throw new NotFoundError();

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -1,5 +1,6 @@
 const Course = require('../../domain/models/Course');
 const courseDatasource = require('../datasources/airtable/course-datasource');
+const AirtableResourceNotFound = require('../datasources/airtable/AirtableResourceNotFound');
 const { NotFoundError } = require('../../domain/errors');
 
 function _toDomain(courseDataObject) {
@@ -15,8 +16,17 @@ function _toDomain(courseDataObject) {
 
 module.exports = {
 
-  get(id) {
-    return courseDatasource.get(id).then(_toDomain);
+  async get(id) {
+    try {
+      const courseDataObject = await courseDatasource.get(id);
+      return _toDomain(courseDataObject);
+    }
+    catch (error) {
+      if (error instanceof AirtableResourceNotFound) {
+        throw new NotFoundError();
+      }
+      throw error;
+    }
   },
 
   getCourseName(id) {

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -65,47 +65,74 @@ describe('Acceptance | API | Courses', () => {
       return cache.flushAll();
     });
 
-    const options = {
-      method: 'GET',
-      url: '/api/courses/rec_course_id',
-      headers: {
-        authorization: generateValidRequestAuthorizationHeader(userId),
-      },
-    };
+    context('when the course exists', () => {
+      let options;
 
-    it('should return 200 HTTP status code', () => {
-      // when
-      const promise = server.inject(options);
-
-      // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(200);
+      beforeEach(() => {
+        options = {
+          method: 'GET',
+          url: '/api/courses/rec_course_id',
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+        };
       });
+
+      it('should return 200 HTTP status code', () => {
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(200);
+        });
+      });
+
+      it('should return application/json', () => {
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          const contentType = response.headers['content-type'];
+          expect(contentType).to.contain('application/json');
+        });
+      });
+
+      it('should return the expected course', () => {
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          const course = response.result.data;
+          expect(course.id).to.equal('rec_course_id');
+          expect(course.attributes.name).to.equal('A la recherche de l\'information #01');
+          expect(course.attributes.description).to.equal('Mener une recherche et une veille d\'information');
+        });
+      });
+
     });
 
-    it('should return application/json', () => {
-      // when
-      const promise = server.inject(options);
+    context('when the course does not exist', () => {
+      let options;
 
-      // then
-      return promise.then((response) => {
-        const contentType = response.headers['content-type'];
-        expect(contentType).to.contain('application/json');
+      beforeEach(() => {
+        options = {
+          method: 'GET',
+          url: '/api/courses/rec_i_dont_exist',
+        };
+      });
+
+      it('should return 404 HTTP status code', () => {
+        // when
+        const promise = server.inject(options);
+
+        // then
+        return promise.then((response) => {
+          expect(response.statusCode).to.equal(404);
+        });
       });
     });
-
-    it('should return the expected course', () => {
-      // when
-      const promise = server.inject(options);
-
-      // then
-      return promise.then((response) => {
-        const course = response.result.data;
-        expect(course.id).to.equal('rec_course_id');
-        expect(course.attributes.name).to.equal('A la recherche de l\'information #01');
-        expect(course.attributes.description).to.equal('Mener une recherche et une veille d\'information');
-      });
-    });
-
   });
 });

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -1,12 +1,8 @@
 const courseService = require('../../../../lib/domain/services/course-service');
 
-const Course = require('../../../../lib/domain/models/Course');
-const { NotFoundError } = require('../../../../lib/domain/errors');
-const { BaseHttpError } = require('../../../../lib/application/http-errors');
-
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
 const logger = require('../../../../lib/infrastructure/logger');
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 
 describe('Unit | Service | Course Service', () => {
 
@@ -35,74 +31,21 @@ describe('Unit | Service | Course Service', () => {
       });
     });
 
-    context('when the course exist', () => {
+    context('when the course exists', () => {
 
-      it('should return a Course POJO', function() {
+      it('should return a Course from the repository', async function() {
         // given
-        const givenCourseId = 'recAirtableId';
-        courseRepository.get.resolves(airtableCourse);
+        const courseId = 'recAirtableId';
+        const aCourse = Symbol('A course');
+        courseRepository.get.withArgs(courseId).resolves(aCourse);
 
         // when
-        const promise = courseService.getCourse({ courseId: givenCourseId, userId });
+        const result = await courseService.getCourse({ courseId });
 
         // then
-        return promise.then((result) => {
-          expect(result).to.be.an.instanceof(Course);
-          expect(result.id).to.equal('recAirtableId');
-
-        });
+        expect(result).to.equal(aCourse);
       });
 
-    });
-
-    context('when an error occurred', () => {
-
-      it('should log the error', async () => {
-        // given
-        const givenCourseId = 'recAirtableId';
-        const error = new Error();
-        courseRepository.get.rejects(error);
-
-        try {
-          // when
-          await courseService.getCourse({ courseId: givenCourseId, userId });
-
-        } catch (err) {
-          // then
-          expect(logger.error).to.have.been.calledWith(error);
-        }
-      });
-
-      it('should throw an InfrastructureException by default', async () => {
-        // given
-        const givenCourseId = 'recAirtableId';
-        const error = new Error('Some message');
-        courseRepository.get.rejects(error);
-
-        // when
-        const err = await catchErr(courseService.getCourse)({ courseId: givenCourseId, userId });
-
-        // then
-        expect(err).to.be.an.instanceof(BaseHttpError);
-      });
-
-      it('should throw a NotFoundError if the course was not found', () => {
-        // given
-        const givenCourseId = 'recAirtableId';
-        const error = {
-          error: {
-            type: 'MODEL_ID_NOT_FOUND',
-            message: 'Could not find row by id unknown_id'
-          }
-        };
-        courseRepository.get.rejects(error);
-
-        // when
-        const promise = courseService.getCourse({ courseId: givenCourseId, userId });
-
-        // then
-        return expect(promise).to.be.rejectedWith(NotFoundError);
-      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/repositories/course-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/course-repository_test.js
@@ -1,5 +1,9 @@
 const { expect, sinon } = require('../../../test-helper');
 
+const AirtableResourceNotFound = require(
+  '../../../../lib/infrastructure/datasources/airtable/AirtableResourceNotFound');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
 const courseRepository = require('../../../../lib/infrastructure/repositories/course-repository');
 const Course = require('../../../../lib/domain/models/Course');
 const courseDatasource = require('../../../../lib/infrastructure/datasources/airtable/course-datasource');
@@ -8,33 +12,53 @@ describe('Unit | Repository | course-repository', function() {
 
   describe('#get', function() {
 
-    beforeEach(() => {
-      sinon.stub(courseDatasource, 'get')
-        .withArgs('recTest1')
-        .resolves({
-          id: 'recTest1',
-          name: 'a-course-name',
-          adaptive: false,
-          description: 'course-description',
-          imageUrl: 'http://example.org/course.png',
-          challenges: ['recChallenge1', 'recChallenge2'],
-          competences: ['recCompetence'],
+    context('when the course exists', () => {
+
+      beforeEach(() => {
+        sinon.stub(courseDatasource, 'get')
+          .withArgs('recTest1')
+          .resolves({
+            id: 'recTest1',
+            name: 'a-course-name',
+            adaptive: false,
+            description: 'course-description',
+            imageUrl: 'http://example.org/course.png',
+            challenges: ['recChallenge1', 'recChallenge2'],
+            competences: ['recCompetence'],
+          });
+      });
+
+      it('should return Course domain objects', () => {
+        // when
+        const promise = courseRepository.get('recTest1');
+
+        // then
+        return promise.then((course) => {
+          expect(course).to.be.an.instanceOf(Course);
+          expect(course.id).to.equal('recTest1');
+          expect(course.name).to.equal('a-course-name');
+          expect(course.description).to.equal('course-description');
+          expect(course.imageUrl).to.equal('http://example.org/course.png');
+          expect(course.challenges).to.deep.equal(['recChallenge1', 'recChallenge2']);
+          expect(course.competences).to.deep.equal(['recCompetence']);
         });
+      });
     });
 
-    it('should return Course domain objects', () => {
-      // when
-      const promise = courseRepository.get('recTest1');
+    context('when the course does not exist', () => {
 
-      // then
-      return promise.then((course) => {
-        expect(course).to.be.an.instanceOf(Course);
-        expect(course.id).to.equal('recTest1');
-        expect(course.name).to.equal('a-course-name');
-        expect(course.description).to.equal('course-description');
-        expect(course.imageUrl).to.equal('http://example.org/course.png');
-        expect(course.challenges).to.deep.equal(['recChallenge1', 'recChallenge2']);
-        expect(course.competences).to.deep.equal(['recCompetence']);
+      beforeEach(() => {
+        const error = new AirtableResourceNotFound();
+        sinon.stub(courseDatasource, 'get');
+        courseDatasource.get.rejects(error);
+      });
+
+      it('should reject with a NotFoundError if the course is not found', () => {
+        // when
+        const promise = courseRepository.get('rec_missing');
+
+        // then
+        return expect(promise).to.have.been.rejectedWith(NotFoundError);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème

Si on démarre un test de démo avec un courseId qui n'existe pas, l'API renvoie une erreur 500

## :robot: Solution

Renvoyer un code 404 à la place.

## :rainbow: Remarques

Le CourseService ne sert plus à grand chose, la prochaine étape serait de le supprimer maintenant qu'il est en bonne santé.

Il y a aussi quelques appels explicites pour logger les erreurs, ce serait un job à faire en middleware. 