### PR TITLE
[CLEANUP] Clarifier la log du script de création des centres de certification.

### DIFF
--- a/api/scripts/create-sco-certification-centers.js
+++ b/api/scripts/create-sco-certification-centers.js
@@ -17,7 +17,7 @@ function createScoCertificationCenters(certificationCenters) {
 }
 
 async function main() {
-  console.log('Starting creating or updating SCO organizations.');
+  console.log('Starting creating SCO certification centers.');
 
   try {
     const filePath = process.argv[2];


### PR DESCRIPTION
## :unicorn: Problème
Le script de création des centres de certification écrit dans la log
`Starting creating or updating SCO organizations.`

Or, ce qui sera créé est un centre de certification (certification-center) , pas une organisation (organization). Cela peut causer de la confusion, ce dont on n'a pas besoin quand on insère en masse des données dans une table en production.

## :robot: Solution
Remplacer la mention de l'organisation par celle du centre de certification (certification-center)