### PR TITLE
[FEATURE] Ajouter lien vers BI sur le détail d'une organisation (PIX-605).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -18,22 +18,30 @@
     {{#if (not this.isEditMode) }}
     <div class="organization__data">
       <h1 class="organization__name">{{@organization.name}}</h1>
-      <p>
-        Type : <span class="organization__type">{{@organization.type}}</span><br>
-        {{#if @organization.externalId}}
-          Identifiant externe : <span class="organization__externalId">{{@organization.externalId}}</span><br>
-        {{/if}}
-        {{#if @organization.provinceCode}}
-          Département : <span class="organization__provinceCode">{{@organization.provinceCode}}</span><br>
-        {{/if}}
-        {{#if @organization.isOrganizationSCO}}
-          Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
-        {{/if}}
-        A accès aux campagnes de collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
-        Crédits : <span class="organization__credit">{{@organization.credit}}</span>
-      </p>
-      <button class="btn btn-outline-default" aria-label="Editer" {{on "click" this.toggleEditMode}}>Editer</button>
-    </div>
+        <div class="organization-information-section__content">
+          <div>
+            <p>
+              Type : <span class="organization__type">{{@organization.type}}</span><br>
+              {{#if @organization.externalId}}
+                Identifiant externe : <span class="organization__externalId">{{@organization.externalId}}</span><br>
+              {{/if}}
+              {{#if @organization.provinceCode}}
+                Département : <span class="organization__provinceCode">{{@organization.provinceCode}}</span><br>
+              {{/if}}
+              {{#if @organization.isOrganizationSCO}}
+                Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
+              {{/if}}
+              A accès aux campagnes de collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
+              Crédits : <span class="organization__credit">{{@organization.credit}}</span>
+            </p>
+            <button class="btn btn-outline-default" aria-label="Editer" {{on "click" this.toggleEditMode}}>Editer</button>
+          </div>
+          <div>
+            <a class="btn btn-outline-default" aria-label="Tableau de bord" href="{{this.externalURL}}" target="_blank">Tableau
+              de bord</a>
+          </div>
+        </div>
+      </div>
     {{else}}
     <div class="organization__edit-form">
       <form class="form" {{on "submit" this.updateOrganization}}>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -1,4 +1,5 @@
 import Object, { action } from '@ember/object';
+import ENV from 'pix-admin/config/environment';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -52,6 +53,11 @@ export default class OrganizationInformationSection extends Component {
   constructor() {
     super(...arguments);
     this.form = Form.create(getOwner(this).ownerInjection());
+  }
+
+  get externalURL() {
+    const urlDashboardPrefix = ENV.APP.ORGANIZATION_DASHBOARD_URL;
+    return urlDashboardPrefix && (urlDashboardPrefix + this.args.organization.id);
   }
 
   get isManagingStudents() {

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -37,5 +37,5 @@
 @import 'components/certification-list';
 @import 'components/confirm-popup';
 @import 'components/menu-bar';
+@import 'components/organization-information-section';
 @import 'components/pagination-control';
-

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -1,0 +1,9 @@
+.organization-information-section{
+
+  &__content {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+}

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -45,6 +45,7 @@ module.exports = function(environment) {
         NOT_FOUND: '404',
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
+      ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
     },
 
     googleFonts: [

--- a/admin/tests/helpers/create-glimmer-component.js
+++ b/admin/tests/helpers/create-glimmer-component.js
@@ -1,0 +1,9 @@
+import { getContext } from '@ember/test-helpers';
+import GlimmerComponentManager from '@glimmer/component/-private/ember-component-manager';
+
+export default function createComponent(lookupPath, named = {}) {
+  const { owner } = getContext();
+  const { class: componentClass } = owner.factoryFor(lookupPath);
+  const componentManager = new GlimmerComponentManager(owner);
+  return componentManager.createComponent(componentClass, { named });
+}

--- a/admin/tests/unit/components/organization-information-section-test.js
+++ b/admin/tests/unit/components/organization-information-section-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import ENV from 'pix-admin/config/environment';
+
+module('Unit | Component | organization-information-section', function(hooks) {
+
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createGlimmerComponent('component:organization-information-section');
+  });
+
+  test('it exists', function(assert) {
+    assert.ok(component);
+  });
+
+  test('it should generate link based on environment and object', async function(assert) {
+    // given
+    const args = { organization: { id: 1 } };
+    const baseURL = 'https://metabase.pix.fr/dashboard/137/?id=';
+    const expectedURL = baseURL + args.organization.id;
+
+    ENV.APP.ORGANIZATION_DASHBOARD_URL = baseURL;
+    component.args = args;
+
+    // when
+    // then
+    assert.equal(component.externalURL, expectedURL);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
La page de détail d'un organisation dans Pix admin manque d'informations.
Ces information sont disponibles dans Metabase, dans l'URL https://metabase.pix.fr/dashboard/137/?id={orga_id}

## :robot: Solution
Ajouter un lien de la page PixAdmin vers Metabase

## :rainbow: Remarques
Il n'existe pas d'environnement de test Metabase, le lien redirigera toujours vers la base de production. L'authentification Metabase est à charge de l'utilisateur.

## :100: Pour tester
Local:
* démarrer l'application avec la variable  `ORGANIZATION_DASHBOARD_URL=https://metabase.pix.fr/dashboard/137/?id= npm start `
* aller sur le membre 4 dans [PixAdmin](http://localhost:4202/organizations/4/members)

RA:
* application Scalingo pix-**front**-review-pr1496 / Section "Environnement": ajouter une ligne `ORGANIZATION_DASHBOARD_URL=https://metabase.pix.fr/dashboard/137/?id=`   puis redémarrer le conteneur
* vérifier qu'elle est bien positionnée avec `scalingo --app pix-front-review-pr1496 run echo '$ORGANIZATION_DASHBOARD_URL'`
* aller sur le membre 4 dans [PixAdmin](https://admin-pr1496.review.pix.fr/organizations/4/members)

Cliquer sur"Tableau de bord" et vérifier que:
* l'URL est bien https://metabase.pix.fr/dashboard/137/?id=4
* les données sont cohérentes
