### PR TITLE
[FEATURE] Empêcher la connexion à Pix Orga pour un utilisateur dont le membership a été supprimé (PIX-766).

### DIFF
--- a/api/db/migrations/20200612093847_add-column-disabledAt-to-memberships.js
+++ b/api/db/migrations/20200612093847_add-column-disabledAt-to-memberships.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'memberships';
+const DISABLED_AT_COLUMN = 'disabledAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(DISABLED_AT_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(DISABLED_AT_COLUMN);
+  });
+};

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -61,7 +61,7 @@ module.exports = {
         .fetch({ require: true,
           columns: ['id','firstName','lastName', 'pixOrgaTermsOfServiceAccepted'],
           withRelated: [
-            'memberships',
+            { 'memberships': (qb) => qb.where({ disabledAt: null }) },
             'memberships.organization',
             'userOrgaSettings',
             'userOrgaSettings.currentOrganization',

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -152,7 +152,7 @@ module.exports = {
       .query((qb) => qb.where({ email: username.toLowerCase() }).orWhere({ 'username': username }))
       .fetch({
         withRelated: [
-          'memberships',
+          { 'memberships': (qb) => qb.where({ disabledAt: null }) },
           'memberships.organization',
           'pixRoles',
           'certificationCenterMemberships.certificationCenter',

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -211,7 +211,7 @@ module.exports = {
       .where({ id: userId })
       .fetch({
         withRelated: [
-          'memberships',
+          { 'memberships': (qb) => qb.where({ disabledAt: null }) },
           'memberships.organization',
         ]
       })

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -94,6 +94,23 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       expect(associatedOrganization.type).to.equal(organization.type);
     });
 
+    context('when the membership associated to the prescriber has been disabled', () => {
+
+      it('should not return membership', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
+        await databaseBuilder.commit();
+
+        // when
+        const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+
+        // then
+        expect(foundPrescriber.memberships).to.be.empty;
+      });
+    });
+
     it('should return user-orga-settings associated to the prescriber', async () => {
       // given
       expectedPrescriber.userOrgaSettings = userOrgaSettings;

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -360,6 +360,28 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         expect(membership.organizationRole).to.equal(membershipInDB.organizationRole);
       });
 
+      context('when the membership associated to the user has been disabled', () => {
+
+        it('should not return the membership', async () => {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({
+            userId,
+            organizationId,
+            disabledAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const user = await userRepository.getWithMemberships(userId);
+
+          // then
+          expect(user.memberships).to.be.an('array');
+          expect(user.memberships).to.be.empty;
+        });
+      });
+
       it('should reject with a UserNotFound error when no user was found with the given id', async () => {
         // given
         const unknownUserId = 666;

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -179,7 +179,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       });
     });
 
-    describe('#getByUsernameWithRoles', () => {
+    describe('#getByUsernameOrEmailWithRoles', () => {
 
       beforeEach(() => {
         return _insertUserWithOrganizationsAndCertificationCenterAccesses();
@@ -255,6 +255,28 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         expect(associatedOrganization.type).to.equal(organizationInDB.type);
 
         expect(firstMembership.organizationRole).to.equal(membershipInDB.organizationRole);
+      });
+
+      context('when the membership associated to the user has been disabled', () => {
+
+        it('should not return the membership', async () => {
+          // given
+          const userInDB = databaseBuilder.factory.buildUser();
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({
+            userId: userInDB.id,
+            organizationId,
+            disabledAt: new Date(),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const user = await userRepository.getByUsernameOrEmailWithRoles(userInDB.email);
+
+          // then
+          expect(user.memberships).to.be.an('array');
+          expect(user.memberships).to.be.empty;
+        });
       });
 
       it('should return certification center membership associated to the user', async () => {

--- a/api/tests/tooling/database-builder/factory/build-membership.js
+++ b/api/tests/tooling/database-builder/factory/build-membership.js
@@ -10,6 +10,7 @@ module.exports = function buildMembership(
     organizationRole = Membership.roles.MEMBER,
     organizationId,
     userId,
+    disabledAt,
   } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -19,7 +20,8 @@ module.exports = function buildMembership(
     id,
     organizationId,
     organizationRole,
-    userId
+    userId,
+    disabledAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'memberships',


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur ne fait plus partie d'une organisation, la solution utilisée consistait à supprimer le membership directement en base de donnée. Cette suppression de donnée n'est pas satisfaisante car on perd l'historique des appartenances à une organisation. 

## :robot: Solution
Ajouter une date de désactivation dans la table `memberships` et alimenter cette date lorsque l'on souhaite désactiver l'appartenance d'un utilisateur à une organisation. Cette nouvelle façon de procéder implique que la présence d'un membership pour un utilisateur n'est plus suffisant pour valider l'appartenance à une organisation. Cette PR concerne :   
- L'ajout de la colonne en base
- La prise en compte de la date de désactivation lors de la connexion d'un utlisateur à Pix Orga
- La prise en compte de la date de désactivation lors de la récupération du prescriber dans Pix Orga

## :rainbow: Remarques
Seront pris en compte dans une autre PR, la prise en compte de de la date de désactivation lors de:
- l'affichage des membres d'une organisation dans Pix Orga/Pix Admin 
- la récupération d'une invitation
- la création et mise à jour d'une campagne
- la mise à jour de l'organisation courante (multi-orgas) ainsi que les checks de sécurité 

## :100: Pour tester
- Ajouter une date de désactivation en base au membership d'un utilisateur n'appartenant qu'à une seule organisation et vérifier qu'il ne peut plus accéder à Pix Orga.
- Ajouter une date de désactivation en base à l'un des memberships d'un utilisateur appartenant à plusieurs organisation et vérifier qu'il peut toujours accéder à Pix Orga mais que son membership supprimé à disparu.  

L'utilisateur sco@example.net était lié à deux organisations. Son membership à l'organisation d'id 1 a été désactivé.