### PR TITLE
[TECH] Suppression de la route dépréciée `/campaigns/id/csvResults` (PIX-832).

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -41,21 +41,6 @@ exports.register = async function(server) {
     },
     {
       method: 'GET',
-      path: '/api/campaigns/{id}/csvResults',
-      config: {
-        auth: false,
-        handler: campaignController.getCsvAssessmentResults,
-        notes: [
-          '- **Cette route est restreinte via un token dédié passé en paramètre avec l\'id de l\'utilisateur.**\n' +
-          '- Récupération d\'un CSV avec les résultats de la campagne\n' +
-          '- L‘utilisateur doit avoir les droits d‘accès à l‘organisation liée à la campagne à créer\n' +
-          '- L‘usage de cette route est dépréciée'
-        ],
-        tags: ['api', 'campaign']
-      }
-    },
-    {
-      method: 'GET',
       path: '/api/campaigns/{id}/csv-assessment-results',
       config: {
         auth: false,

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -40,24 +40,6 @@ describe('Integration | Application | Route | campaignRouter', () => {
 
   });
 
-  describe('GET /api/campaigns/{id}/csvResults', () => {
-
-    it('should exist', () => {
-      // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/campaigns/FAKE_ID/csvResults',
-      });
-
-      // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
-
-    });
-
-  });
-
   describe('GET /api/campaigns/{id}/csv-assessment-results', () => {
 
     it('should exist', () => {


### PR DESCRIPTION
## :unicorn: Problème
La route /campaigns/id/csvResults est une route dépréciée, plus utilisée. J'ai vérifié sur datadog, plus aucune utilisation de cette route depuis le début des logs.

## :robot: Solution
Supprimer cette route.
