### PR TITLE
[CLEANUP] Ajout d'une transaction lors de la remise à zéro (PIX-829).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -10,6 +10,7 @@ const userSerializer = require('../../infrastructure/serializers/jsonapi/user-se
 const userDetailsForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 const usecases = require('../../domain/usecases');
 
@@ -157,12 +158,14 @@ module.exports = {
       .then(scorecardSerializer.serialize);
   },
 
-  resetScorecard(request) {
+  async resetScorecard(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const competenceId = request.params.competenceId;
+    const scorecard = await DomainTransaction.execute((domainTransaction) =>
+      usecases.resetScorecard({ userId: authenticatedUserId, competenceId, domainTransaction })
+    );
 
-    return usecases.resetScorecard({ userId: authenticatedUserId, competenceId })
-      .then(scorecardSerializer.serialize);
+    return scorecardSerializer.serialize(scorecard);
   },
 
   getUserOrgaSettings(request) {
@@ -185,7 +188,7 @@ module.exports = {
     const campaignId = request.params.campaignId;
 
     const sharedProfileForCampaign = await usecases.getUserProfileSharedForCampaign({ userId: authenticatedUserId, campaignId });
-    
+
     return sharedProfileForCampaignSerializer.serialize(sharedProfileForCampaign);
   }
 };

--- a/api/lib/domain/usecases/reset-scorecard.js
+++ b/api/lib/domain/usecases/reset-scorecard.js
@@ -11,6 +11,7 @@ module.exports = async function resetScorecard({
   knowledgeElementRepository,
   assessmentRepository,
   campaignParticipationRepository,
+  domainTransaction
 }) {
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({
     userId,
@@ -41,6 +42,7 @@ module.exports = async function resetScorecard({
     competenceRepository,
     competenceEvaluationRepository,
     knowledgeElementRepository,
+    domainTransaction
   });
 
   return scorecardService.computeScorecard({

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -103,15 +103,15 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
-  abortByAssessmentId(assessmentId) {
-    return this._updateStateById({ id: assessmentId, state: Assessment.states.ABORTED });
+  abortByAssessmentId(assessmentId, knexTransaction = DomainTransaction.emptyTransaction()) {
+    return this._updateStateById({ id: assessmentId, state: Assessment.states.ABORTED }, knexTransaction);
   },
 
   completeByAssessmentId(assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
     return this._updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }, domainTransaction.knexTransaction);
   },
 
-  async _updateStateById({ id, state }, knexTransaction) {
+  async _updateStateById({ id, state }, knexTransaction = DomainTransaction.emptyTransaction()) {
     const assessment = await BookshelfAssessment
       .where({ id })
       .save({ state }, { require: true, patch: true, transacting: knexTransaction });

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -1,5 +1,6 @@
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const BookshelfCompetenceEvaluation = require('../data/competence-evaluation');
+const DomainTransaction = require('../DomainTransaction');
 const _ = require('lodash');
 const { NotFoundError } = require('../../domain/errors');
 const queryBuilder = require('../utils/query-builder');
@@ -20,10 +21,10 @@ module.exports = {
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
 
-  updateStatusByUserIdAndCompetenceId({ userId, competenceId, status }) {
+  updateStatusByUserIdAndCompetenceId({ userId, competenceId, status }, knexTransaction = DomainTransaction.emptyTransaction()) {
     return BookshelfCompetenceEvaluation
       .where({ userId, competenceId })
-      .save({ status }, { require: true, patch: true })
+      .save({ status }, { require: true, patch: true, transacting: knexTransaction })
       .then((updatedCompetenceEvaluation) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, updatedCompetenceEvaluation));
   },
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -5,6 +5,7 @@ const { knex } = require('../bookshelf');
 const KnowledgeElement = require('../../domain/models/KnowledgeElement');
 const BookshelfKnowledgeElement = require('../data/knowledge-element');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 function _getUniqMostRecents(knowledgeElements) {
   return _(knowledgeElements)
@@ -58,9 +59,10 @@ async function _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, 
 
 module.exports = {
 
-  async save(knowledgeElement) {
+  async save(knowledgeElement, knexTransaction = DomainTransaction.emptyTransaction()) {
     const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
-    const savedKnowledgeElement = await new BookshelfKnowledgeElement(knowledgeElementToSave).save();
+    const savedKnowledgeElement = await new BookshelfKnowledgeElement(knowledgeElementToSave)
+      .save(null, { transacting: knexTransaction });
 
     return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
   },

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -4,9 +4,9 @@ const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const CompetenceEvaluation = require('../../../../lib/domain/models/CompetenceEvaluation');
 const scorecardService = require('../../../../lib/domain/services/scorecard-service');
 
-describe('Unit | Service | ScorecardService', function() {
+describe('Unit | Service | ScorecardService', () => {
 
-  describe('#computeScorecard', function() {
+  describe('#computeScorecard', () => {
 
     let competenceRepository;
     let knowledgeElementRepository;
@@ -78,7 +78,7 @@ describe('Unit | Service | ScorecardService', function() {
           competenceId,
           competenceRepository,
           competenceEvaluationRepository,
-          knowledgeElementRepository
+          knowledgeElementRepository,
         });
 
         //then
@@ -87,7 +87,7 @@ describe('Unit | Service | ScorecardService', function() {
     });
   });
 
-  describe('#resetScorecard', function() {
+  describe('#resetScorecard', () => {
 
     let resetCampaignParticipation;
     let resetKnowledgeElements;
@@ -98,6 +98,7 @@ describe('Unit | Service | ScorecardService', function() {
     let campaignParticipationRepository;
     let resetKnowledgeElement1;
     let resetKnowledgeElement2;
+    let domainTransaction = null;
 
     const userId = 1;
     const competenceId = 2;
@@ -105,6 +106,7 @@ describe('Unit | Service | ScorecardService', function() {
     const updatedCompetenceEvaluation = Symbol('updated competence evaluation');
     resetKnowledgeElement2 = Symbol('reset knowledge element 2');
     resetKnowledgeElement1 = Symbol('reset knowledge element 1');
+    domainTransaction = { knexTransaction : {} };
 
     context('when competence evaluation exists', function() {
 
@@ -119,7 +121,7 @@ describe('Unit | Service | ScorecardService', function() {
         };
 
         competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId
-          .withArgs({ userId, competenceId, status: CompetenceEvaluation.statuses.RESET })
+          .withArgs({ userId, competenceId, status: CompetenceEvaluation.statuses.RESET }, domainTransaction.knexTransaction)
           .resolves(updatedCompetenceEvaluation);
 
         knowledgeElementRepository.findUniqByUserIdAndCompetenceId
@@ -130,14 +132,14 @@ describe('Unit | Service | ScorecardService', function() {
           .onSecondCall().resolves(resetKnowledgeElement2);
 
         [resetKnowledgeElements, resetCampaignParticipation, resetCompetenceEvaluation] = await scorecardService.resetScorecard({
-          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository, campaignParticipationRepository
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository, campaignParticipationRepository, domainTransaction,
         });
       });
 
       // then
       it('should reset each knowledge elements', async () => {
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
 
@@ -146,7 +148,7 @@ describe('Unit | Service | ScorecardService', function() {
       });
     });
 
-    context('when competence evaluation does not exists - there is only knowledge elements thanks to campaign', function() {
+    context('when competence evaluation does not exists - there is only knowledge elements thanks to campaign', () => {
 
       beforeEach(async () => {
         // when
@@ -165,19 +167,19 @@ describe('Unit | Service | ScorecardService', function() {
           .onSecondCall().resolves(resetKnowledgeElement2);
 
         [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
-          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository, campaignParticipationRepository,
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository, campaignParticipationRepository, domainTransaction
         });
       });
 
       // then
       it('should reset each knowledge elements', async () => {
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
     });
 
-    context('when campaign exists', function() {
+    context('when campaign exists', () => {
 
       let oldAssessment1;
       let oldAssessment2;
@@ -256,11 +258,11 @@ describe('Unit | Service | ScorecardService', function() {
       it('should reset each knowledge Element', async () => {
 
         [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
-          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository, domainTransaction
         });
 
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
 
@@ -268,16 +270,18 @@ describe('Unit | Service | ScorecardService', function() {
 
         // when
         await scorecardService.resetScorecard({
-          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository, domainTransaction
         });
         // given
         expect(assessmentRepository.save.args[0][0].assessment).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 1 });
+        expect(assessmentRepository.save.args[0][0].domainTransaction).to.equal(domainTransaction);
         expect(assessmentRepository.save.args[1][0].assessment).to.include({ type: 'SMART_PLACEMENT', state: 'started', userId, campaignParticipationId: 2 });
+        expect(assessmentRepository.save.args[1][0].domainTransaction).to.equal(domainTransaction);
       });
 
-      context('when campaign is already shared', function() {
+      context('when campaign is already shared', () => {
 
-        it('should return null for campaign participation', async function() {
+        it('should return null for campaign participation', async () => {
           //given
           const campaignParticipation3 = domainBuilder.buildCampaignParticipation({ assessmentId: assessmentId1, campaign, campaignId: campaign.id, isShared: true });
           const campaignParticipation4 = domainBuilder.buildCampaignParticipation({ assessmentId: assessmentId2, campaign, campaignId: campaign.id, isShared: true });
@@ -286,16 +290,16 @@ describe('Unit | Service | ScorecardService', function() {
 
           //when
           [resetKnowledgeElements, resetCampaignParticipation] =  await scorecardService.resetScorecard({
-            userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
+            userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository, domainTransaction
           });
           //then
           expect(resetCampaignParticipation).to.deep.equal([null, null]);
         });
       });
 
-      context('when dosen \'t intersection between target skills and reset skills', function() {
+      context('when dosen \'t intersection between target skills and reset skills', () => {
 
-        it('should return null for campaign participation', async function() {
+        it('should return null for campaign participation', async () => {
           //given
           resetKnowledgeElement1 = domainBuilder.buildKnowledgeElement({ skillId: 'recAloevera' });
           resetKnowledgeElement2 = domainBuilder.buildKnowledgeElement({ skillId: 'recDing' });
@@ -306,7 +310,7 @@ describe('Unit | Service | ScorecardService', function() {
 
           //when
           [resetKnowledgeElements, resetCampaignParticipation] =  await scorecardService.resetScorecard({
-            userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository,
+            userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, campaignParticipationRepository, competenceEvaluationRepository, domainTransaction
           });
 
           //then
@@ -316,7 +320,7 @@ describe('Unit | Service | ScorecardService', function() {
 
     });
 
-    context('when campaign does not exists', function() {
+    context('when campaign does not exists', () => {
 
       beforeEach(async () => {
         // when
@@ -341,14 +345,14 @@ describe('Unit | Service | ScorecardService', function() {
           .onSecondCall().resolves(resetKnowledgeElement2);
 
         [resetKnowledgeElements, resetCampaignParticipation] = await scorecardService.resetScorecard({
-          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository,
+          userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, knowledgeElementRepository, competenceEvaluationRepository, domainTransaction
         });
       });
 
       // then
       it('should reset each assessments', async () => {
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 });
-        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 });
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 1, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
+        expect(knowledgeElementRepository.save).to.have.been.calledWithExactly({ id: 2, status: 'reset', earnedPix: 0 }, domainTransaction.knexTransaction);
         expect(resetKnowledgeElements).to.deep.equal([resetKnowledgeElement1, resetKnowledgeElement2]);
       });
 
@@ -361,9 +365,9 @@ describe('Unit | Service | ScorecardService', function() {
 
   });
 
-  describe('#_computeResetSkillsNotIncludedInTargetProfile', function() {
+  describe('#_computeResetSkillsNotIncludedInTargetProfile', () => {
 
-    it('should return true when no skill is in common between target profile and reset skills', function() {
+    it('should return true when no skill is in common between target profile and reset skills', () => {
       // given
       const targetObjectSkills = [{ id: 'recmoustache' }, { id: 'recherisson' }];
       const resetSkills = ['recbarbe', 'rectaupe'];

--- a/api/tests/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/reset-scorecard_test.js
@@ -29,7 +29,7 @@ describe('Unit | UseCase | reset-scorecard', () => {
     knowledgeElements = [{}, {}];
   });
 
-  afterEach(function() {
+  afterEach(() => {
     sinon.restore();
   });
 
@@ -37,6 +37,7 @@ describe('Unit | UseCase | reset-scorecard', () => {
     it('should reset the competenceEvaluation', async () => {
       // given
       const shouldResetCompetenceEvaluation = true;
+      const domainTransaction = Symbol('domain transaction');
 
       competenceEvaluationRepository.existsByCompetenceIdAndUserId
         .withArgs({ competenceId, userId })
@@ -67,12 +68,13 @@ describe('Unit | UseCase | reset-scorecard', () => {
         campaignParticipationRepository,
         competenceRepository,
         competenceEvaluationRepository,
-        knowledgeElementRepository
+        knowledgeElementRepository,
+        domainTransaction
       });
 
       // then
       expect(scorecardService.resetScorecard).to.have.been.calledWithExactly({
-        userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, campaignParticipationRepository, competenceRepository, knowledgeElementRepository, competenceEvaluationRepository
+        userId, competenceId, shouldResetCompetenceEvaluation, assessmentRepository, campaignParticipationRepository, competenceRepository, knowledgeElementRepository, competenceEvaluationRepository, domainTransaction
       });
       expect(response).to.equal(scorecard);
     });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la remise à zéro, il y a plusieurs ajouts à faire en base de données. Il n'y a pas de transaction pour être sûr que toutes ces données soient bien ajoutées.

## :robot: Solution
Ajout d'une transaction

## :rainbow: Remarques
- EN COURS - 

## :100: Pour tester
- Vérifier que la remise à zéro fonctionne toujours