### PR TITLE
[FEATURE] Ajouter un système d'onglets dans le détail d'une organisation dans Pix Admin (PIX-827).

### DIFF
--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -52,7 +52,7 @@
     <h2 class="page-section__title">Membres</h2>
   </header>
   <div class="member-list">
-    <ModelsTable @data={{@organization.memberships}}
+    <ModelsTable @data={{@memberships}}
       @columns={{this.columns}}
       @showColumnsDropdown={{false}}
       @showGlobalFilter={{false}}

--- a/admin/app/controllers/authenticated/organizations/get.js
+++ b/admin/app/controllers/authenticated/organizations/get.js
@@ -1,18 +1,8 @@
-import _ from 'lodash';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
-import isEmailValid from '../../../utils/email-validator';
 
 export default class GetController extends Controller {
-
-  @tracked userEmailToAdd = null;
-  @tracked userEmailToInvite = null;
-  @tracked userEmailToInviteError;
-  @tracked targetProfilesToAttach = [];
-  @tracked isLoading = false;
-
   @service notifications;
 
   @action
@@ -26,93 +16,4 @@ export default class GetController extends Controller {
         this.notifications.error('Une erreur est survenue.');
       });
   }
-
-  @action
-  attachTargetProfiles() {
-    const organization = this.model;
-    return organization.attachTargetProfiles({ 'target-profiles-to-attach' : this._toArrayWithUnique(this.targetProfilesToAttach) })
-      .then(async () => {
-        this.targetProfilesToAttach = null;
-        return this.notifications.success('Profil(s) cible(s) rattaché avec succès.');
-      })
-      .catch((errorResponse) => {
-        if (!errorResponse.errors) {
-          return this.notifications.error('Une erreur est survenue.');
-        }
-
-        errorResponse.errors.forEach((error) => {
-          if (error.status === '404') {
-            return this.notifications.error(error.detail);
-          }
-        });
-      });
-  }
-
-  @action
-  async addMembership() {
-    const email = this.userEmailToAdd.trim();
-    const organization = this.model;
-    const matchingUsers = await this.store.query('user', { filter: { email } });
-
-    // GET /users?filter[email] makes an approximative request ("LIKE %email%") and not a strict request
-    const user = matchingUsers.findBy('email', email);
-
-    if (!user) {
-      return this.notifications.error('Compte inconnu.');
-    }
-
-    if (await organization.hasMember(email)) {
-      return this.notifications.error('Compte déjà associé.');
-    }
-
-    return this.store.createRecord('membership', { organization, user })
-      .save()
-      .then(async () => {
-        this.userEmailToAdd = null;
-        this.notifications.success('Accès attribué avec succès.');
-      })
-      .catch(() => {
-        this.notifications.error('Une erreur est survenue.');
-      });
-  }
-
-  @action
-  createOrganizationInvitation() {
-    this.isLoading = true;
-    if (!this._isEmailToInviteValid(this.userEmailToInvite)) {
-      this.isLoading = false;
-      return;
-    }
-    const email = this.userEmailToInvite.trim();
-
-    return this.store.createRecord('organization-invitation', { email })
-      .save({ adapterOptions: { organizationId: this.model.id } })
-      .then((organizationInvitation) => {
-        this.notifications.success(`Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`);
-        this.userEmailToInvite = null;
-      })
-      .catch(() => this.notifications.error('Une erreur s’est produite, veuillez réessayer.'))
-      .finally(() => this.isLoading = false);
-  }
-
-  _toArrayWithUnique(targetProfilesToAttach) {
-    const trimedTargetProfilesToAttach = targetProfilesToAttach.split(',').map((targetProfileId) => targetProfileId.trim());
-    return _.uniq(trimedTargetProfilesToAttach);
-  }
-
-  _isEmailToInviteValid(email) {
-    if (!email || !email.trim()) {
-      this.userEmailToInviteError = 'Ce champ est requis.';
-      return false;
-    }
-
-    if (!isEmailValid(email)) {
-      this.userEmailToInviteError = 'L\'adresse email saisie n\'est pas valide.';
-      return false;
-    }
-
-    this.userEmailToInviteError = null;
-    return true;
-  }
-
 }

--- a/admin/app/controllers/authenticated/organizations/get/members.js
+++ b/admin/app/controllers/authenticated/organizations/get/members.js
@@ -1,0 +1,81 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import Controller from '@ember/controller';
+import isEmailValid from '../../../../utils/email-validator';
+
+export default class GetMembersController extends Controller {
+
+  @tracked userEmailToAdd = null;
+  @tracked userEmailToInvite = null;
+  @tracked userEmailToInviteError;
+  @tracked isLoading = false;
+
+  @service notifications;
+
+  async _getUser(email) {
+    const matchingUsers = await this.store.query('user', { filter: { email } });
+
+    // GET /users?filter[email] makes an approximative request ("LIKE %email%") and not a strict request
+    return matchingUsers.findBy('email', email);
+  }
+
+  @action
+  async addMembership() {
+    const organization = this.model;
+    const email = this.userEmailToAdd.trim();
+    if (await organization.hasMember(email)) {
+      return this.notifications.error('Compte déjà associé.');
+    }
+
+    const user = await this._getUser(email);
+    if (!user) {
+      return this.notifications.error('Compte inconnu.');
+    }
+    
+    try {
+      await this.store.createRecord('membership', { organization, user }).save();
+      this.userEmailToAdd = null;
+      this.notifications.success('Accès attribué avec succès.');
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue.');
+    }
+  }
+
+  @action
+  async createOrganizationInvitation() {
+    this.isLoading = true;
+    const email = this.userEmailToInvite ? this.userEmailToInvite.trim() : null;
+    if (!this._isEmailToInviteValid(email)) {
+      this.isLoading = false;
+      return;
+    }
+
+    try {
+      const organizationInvitation = await this.store.createRecord('organization-invitation', { email })
+        .save({ adapterOptions: { organizationId: this.model.id } });
+        
+      this.notifications.success(`Un email a bien a été envoyé à l'adresse ${organizationInvitation.email}.`);
+      this.userEmailToInvite = null;
+    } catch (e) {
+      this.notifications.error('Une erreur s’est produite, veuillez réessayer.');
+    }
+    this.isLoading = false;
+  }
+
+  _isEmailToInviteValid(email) {
+    if (!email) {
+      this.userEmailToInviteError = 'Ce champ est requis.';
+      return false;
+    }
+
+    if (!isEmailValid(email)) {
+      this.userEmailToInviteError = 'L\'adresse email saisie n\'est pas valide.';
+      return false;
+    }
+
+    this.userEmailToInviteError = null;
+    return true;
+  }
+
+}

--- a/admin/app/controllers/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/controllers/authenticated/organizations/get/target-profiles.js
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import Controller from '@ember/controller';
+
+export default class GetTargetProfilesController extends Controller {
+
+  @tracked targetProfilesToAttach = [];
+
+  @service notifications;
+
+  @action
+  async attachTargetProfiles() {
+    const organization = this.model;
+    try {
+      await organization.attachTargetProfiles({ 'target-profiles-to-attach' : this._getUniqueTargetProfiles() });
+      this.targetProfilesToAttach = null;
+      return this.notifications.success('Profil(s) cible(s) rattaché avec succès.');
+    } catch (responseError) {
+      this._handleResponseError(responseError);
+    }
+  }
+
+  _handleResponseError({ errors }) {
+    if (!errors) {
+      return this.notifications.error('Une erreur est survenue.');
+    }
+    const error404 = errors.find(({ status }) => status === '404');
+    if (error404) {
+      this.notifications.error(error404.detail);
+    }
+  }
+
+  _getUniqueTargetProfiles() {
+    const targetProfileIds = this.targetProfilesToAttach.split(',').map((targetProfileId) => targetProfileId.trim());
+    return _.uniq(targetProfileIds);
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -28,7 +28,10 @@ Router.map(function() {
     this.route('organizations', function() {
       this.route('new');
       this.route('list');
-      this.route('get', { path: '/:organization_id' });
+      this.route('get', { path: '/:organization_id' }, function() {
+        this.route('members');
+        this.route('target-profiles');
+      });
     });
 
     this.route('users', function() {

--- a/admin/app/routes/authenticated/organizations/get/index.js
+++ b/admin/app/routes/authenticated/organizations/get/index.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class IndexRoute extends Route {
+
+  beforeModel() {
+    this.replaceWith('authenticated.organizations.get.members');
+  }
+}

--- a/admin/app/routes/authenticated/organizations/get/members.js
+++ b/admin/app/routes/authenticated/organizations/get/members.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class OrganizationMembersRoute extends Route {
+
+  model() {
+    return this.modelFor('authenticated.organizations.get');
+  }
+}

--- a/admin/app/routes/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/routes/authenticated/organizations/get/target-profiles.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class OrganizationTargetProfilesRoute extends Route {
+
+  model() {
+    return this.modelFor('authenticated.organizations.get');
+  }
+}

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -20,14 +20,15 @@
                                   @onLogoUpdated={{this.updateOrganizationInformation}}
                                   @onSubmit={{this.updateOrganizationInformation}} />
 
-  <OrganizationMembersSection @organization={{@model}}
-                              @userEmailToAdd={{this.userEmailToAdd}}
-                              @userEmailToInvite={{this.userEmailToInvite}}
-                              @addMembership={{this.addMembership}}
-                              @createOrganizationInvitation={{this.createOrganizationInvitation}}
-                              @userEmailToInviteError={{this.userEmailToInviteError}}
-                              @isLoading={{this.isLoading}}/>
+  <nav class="navbar">
+    <LinkTo @route="authenticated.organizations.get.members" @model={{@model}} class="navbar-item">
+      Membres
+    </LinkTo>
 
-  <OrganizationTargetProfilesSection @targetProfiles={{@model.targetProfiles}} @targetProfilesToAttach={{this.targetProfilesToAttach}} @attachTargetProfiles={{this.attachTargetProfiles}} />
+    <LinkTo @route="authenticated.organizations.get.target-profiles" @model={{@model}} class="navbar-item">
+      Profils cibles
+    </LinkTo>
+  </nav>
 
+  {{outlet}}
 </main>

--- a/admin/app/templates/authenticated/organizations/get/members.hbs
+++ b/admin/app/templates/authenticated/organizations/get/members.hbs
@@ -1,0 +1,9 @@
+<OrganizationMembersSection 
+  @memberships={{@model.memberships}}
+  @userEmailToAdd={{this.userEmailToAdd}}
+  @userEmailToInvite={{this.userEmailToInvite}}
+  @addMembership={{this.addMembership}}
+  @createOrganizationInvitation={{this.createOrganizationInvitation}}
+  @userEmailToInviteError={{this.userEmailToInviteError}}
+  @isLoading={{this.isLoading}}
+/>

--- a/admin/app/templates/authenticated/organizations/get/target-profiles.hbs
+++ b/admin/app/templates/authenticated/organizations/get/target-profiles.hbs
@@ -1,0 +1,4 @@
+<OrganizationTargetProfilesSection @targetProfiles={{@model.targetProfiles}}
+                                   @targetProfilesToAttach={{this.targetProfilesToAttach}}
+                                   @attachTargetProfiles={{this.attachTargetProfiles}}
+/>

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,17 +10,6 @@ module('Acceptance | organization information management', function(hooks) {
 
   hooks.beforeEach(async function() {
     await createAuthenticateSession({ userId: 1 });
-  });
-
-  test('visiting /organizations/:id', async function(assert) {
-    // given
-    const organization = this.server.create('organization');
-
-    // when
-    await visit(`/organizations/${organization.id}`);
-
-    // then
-    assert.equal(currentURL(), `/organizations/${organization.id}`);
   });
 
   module('editing organization', function() {

--- a/admin/tests/acceptance/organization-list-test.js
+++ b/admin/tests/acceptance/organization-list-test.js
@@ -86,7 +86,7 @@ module('Acceptance | Organization List', function(hooks) {
       await click('.organization-list .table-admin tbody tr:first-child');
 
       // then
-      assert.equal(currentURL(), '/organizations/1');
+      assert.equal(currentURL(), '/organizations/1/members');
     });
   });
 });

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -12,7 +12,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     await createAuthenticateSession({ userId: 1 });
   });
 
-  test('visiting /organizations/:id', async function(assert) {
+  test('should redirect to organization members page', async function(assert) {
     // given
     const organization = this.server.create('organization');
 
@@ -20,7 +20,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     await visit(`/organizations/${organization.id}`);
 
     // then
-    assert.equal(currentURL(), `/organizations/${organization.id}`);
+    assert.equal(currentURL(), `/organizations/${organization.id}/members`);
   });
 
   module('listing members', function() {

--- a/admin/tests/acceptance/organization-target-profiles-management-test.js
+++ b/admin/tests/acceptance/organization-target-profiles-management-test.js
@@ -18,7 +18,7 @@ module('Acceptance | organization target profiles management', function(hooks) {
     this.server.create('target-profile', { name: 'Profil cible du ghetto', organization });
 
     // when
-    await visit(`/organizations/${organization.id}`);
+    await visit(`/organizations/${organization.id}/target-profiles`);
 
     // then
     assert.dom('[aria-label="Profil cible"]').includesText('Profil cible du ghetto');
@@ -29,7 +29,7 @@ module('Acceptance | organization target profiles management', function(hooks) {
     const organization = this.server.create('organization');
 
     // when
-    await visit(`/organizations/${organization.id}`);
+    await visit(`/organizations/${organization.id}/target-profiles`);
     await fillIn('[aria-label="ID du ou des profil(s) cible(s)"]', '66');
     await click('[aria-label="Rattacher un ou plusieurs profil(s) cible(s)"] button');
 

--- a/admin/tests/unit/controllers/authenticated/organizations/get/members-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/members-test.js
@@ -3,14 +3,12 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Controller | authenticated/organizations/list', function(hooks) {
-
+module('Unit | Controller | authenticated/organizations/get/members', function(hooks) {
   setupTest(hooks);
 
   let controller;
-
   hooks.beforeEach(function() {
-    controller = this.owner.lookup('controller:authenticated/organizations/get');
+    controller = this.owner.lookup('controller:authenticated/organizations/get/members');
   });
 
   module('#createOrganizationInvitation', function() {


### PR DESCRIPTION
## :unicorn: Problème
Trop d'informations sont contenues dans une seule et même page. Il existe plusieurs tableaux sur cette page, on si l'on veut faire une pagination pour chacun des tableaux, cela pose problème, car c'est la même url.

## :robot: Solution
Ajouter un menu dans Pix Admin pour séparer les usages actuels de cette page :
- Les membres
- Les profils cibles

## :100: Pour tester
- Aller sur Pix Admin
- Aller dans l'onglet "organisations"
- Choisir une organisation et cliquer dessus
- Voir apparaître par défaut la page de membres
- Cliquer sur l'onglet "profils cibles" et vérifier le bon affichage
- Re-cliquer sur l'onglet "membres" et vérifier le bon affichage