### PR TITLE
[FEATURE] Permettre la mise à jour du prénom, nom et l'email d'un utilisateur connecté par email dans Pix Admin (PIX-458).

### DIFF
--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -14,4 +14,8 @@ export default class UserAdapter extends ApplicationAdapter {
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/admin/users/${id}`;
   }
+
+  urlForUpdateRecord(id) {
+    return `${this.host}/${this.namespace}/admin/users/${id}`;
+  }
 }

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -1,13 +1,15 @@
 <section class="page-section mb_10">
   {{#if this.isEditionMode}}
-    <form class="form user-edit-form">
+    <form class="form user-edit-form" {{on "submit" this.updateUserDetails}}>
         <span class="form__instructions col-md-4">
           Les champs marqués de <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> sont obligatoires.
         </span>
       <div class="form-field col-md-4">
-        <label for="firstName" class="form-field__label"> <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Prénom :</label>
+        <label for="firstName" class="form-field__label">
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Prénom :
+        </label>
         {{#if (v-get form 'firstName' 'isInvalid')}}
-          <div class="form-field__error" aria-label="Message d'erreur du champ firstName">
+          <div class="form-field__error" aria-label="Message d'erreur du champ prénom">
             {{v-get form 'firstName' 'message'}}
           </div>
         {{/if}}
@@ -18,9 +20,11 @@
                @value={{this.form.firstName}}/>
       </div>
       <div class="form-field col-md-4">
-        <label for="lastName" class="form-field__label"> <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Nom :</label>
+        <label for="lastName" class="form-field__label">
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Nom :
+        </label>
         {{#if (v-get form 'lastName' 'isInvalid')}}
-          <div class="form-field__error" aria-label="Message d'erreur du champ lastName">
+          <div class="form-field__error" aria-label="Message d'erreur du champ nom">
             {{v-get form 'lastName' 'message'}}
           </div>
         {{/if}}
@@ -31,7 +35,9 @@
                @value={{this.form.lastName}}/>
       </div>
       <div class="form-field col-md-4">
-        <label for="email" class="form-field__label">E-mail : </label>
+        <label for="email" class="form-field__label">
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> E-mail :
+        </label>
         {{#if (v-get form 'email' 'isInvalid')}}
           <div class="form-field__error" aria-label="Message d'erreur du champ email">
             {{v-get form 'email' 'message'}}
@@ -71,8 +77,9 @@
           </div>
           <div class="attribute authenticated-from-gar">
             <span class="attibute__label">Connecté via le GAR : </span>
-            <span class="attribute__value user__is-authenticated-from-gar">{{if @user.isAuthenticatedFromGar 'OUI'
-                                                                                'NON'}}</span>
+            <span class="attribute__value user__is-authenticated-from-gar">
+              {{if @user.isAuthenticatedFromGar 'OUI''NON'}}
+            </span>
           </div>
           <br>
           <div class="attribute cgu">
@@ -82,17 +89,22 @@
           <div class="attribute pix-orga-terms-of-service-accepted">
             <span class="attibute__label">CGU Pix Orga validé : </span>
             <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if
-                    @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+                    @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}
+            </span>
           </div>
           <div class="attribute pix-certif-terms-of-service-accepted">
             <span class="attibute__label">CGU Pix Certif validé : </span>
-            <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+            <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if
+                    @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}
+            </span>
           </div>
         </div>
       </section>
       <div class="col-md-4">
+        {{#if canAdministratorModifyUserDetails}}
         <button class="btn btn-outline-default" aria-label="Modifier" {{on "click" this.changeEditionMode}}>Modifier
         </button>
+        {{/if}}
       </div>
     </form>
   {{/if}}

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -1,37 +1,99 @@
 <section class="page-section mb_10">
-  <div>
-    <div class="attribute first-name">
-      <span class="attibute__label">Prénom : </span>
-      <span class="attribute__value user__first-name">{{@user.firstName}}</span>
-    </div>
-    <div class="attribute last-name">
-      <span class="attibute__label">Nom : </span>
-      <span class="attribute__value user__last-name">{{@user.lastName}}</span>
-    </div>
-    <div class="attribute email">
-      <span class="attibute__label">E-mail : </span>
-      <span class="attribute__value user__email">{{@user.email}}</span>
-    </div>
-    <div class="attribute username">
-      <span class="attibute__label">Identifiant : </span>
-      <span class="attribute__value user__username">{{@user.username}}</span>
-    </div>
-    <div class="attribute authenticated-from-gar">
-      <span class="attibute__label">Connecté via le GAR : </span>
-      <span class="attribute__value user__is-authenticated-from-gar">{{if @user.isAuthenticatedFromGar 'OUI' 'NON'}}</span>
-    </div>
-    <br>
-    <div class="attribute cgu">
-      <span class="attibute__label">CGU Pix App validé : </span>
-      <span class="attribute__value user__cgu">{{if @user.cgu 'OUI' 'NON'}}</span>
-    </div>
-    <div class="attribute pix-orga-terms-of-service-accepted">
-      <span class="attibute__label">CGU Pix Orga validé : </span>
-      <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}</span>
-    </div>
-    <div class="attribute pix-certif-terms-of-service-accepted">
-      <span class="attibute__label">CGU Pix Certif validé : </span>
-      <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}</span>
-    </div>
-  </div>
+  {{#if this.isEditionMode}}
+    <form class="form user-edit-form">
+        <span class="form__instructions col-md-4">
+          Les champs marqués de <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> sont obligatoires.
+        </span>
+      <div class="form-field col-md-4">
+        <label for="firstName" class="form-field__label"> <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Prénom :</label>
+        {{#if (v-get form 'firstName' 'isInvalid')}}
+          <div class="form-field__error" aria-label="Message d'erreur du champ firstName">
+            {{v-get form 'firstName' 'message'}}
+          </div>
+        {{/if}}
+        <Input id="firstName"
+               type="text"
+               class={{if (v-get form 'firstName' 'isInvalid') "user-edit-form__first-name form-control is-invalid"
+                          "user-edit-form__first-name form-control"}}
+               @value={{this.form.firstName}}/>
+      </div>
+      <div class="form-field col-md-4">
+        <label for="lastName" class="form-field__label"> <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr> Nom :</label>
+        {{#if (v-get form 'lastName' 'isInvalid')}}
+          <div class="form-field__error" aria-label="Message d'erreur du champ lastName">
+            {{v-get form 'lastName' 'message'}}
+          </div>
+        {{/if}}
+        <Input id="lastName"
+               type="text"
+               class={{if (v-get form 'lastName' 'isInvalid') "user-edit-form__last-name form-control is-invalid"
+                          "user-edit-form__last-name form-control"}}
+               @value={{this.form.lastName}}/>
+      </div>
+      <div class="form-field col-md-4">
+        <label for="email" class="form-field__label">E-mail : </label>
+        {{#if (v-get form 'email' 'isInvalid')}}
+          <div class="form-field__error" aria-label="Message d'erreur du champ email">
+            {{v-get form 'email' 'message'}}
+          </div>
+        {{/if}}
+        <Input id="email"
+               type="email"
+               class={{if (v-get form 'email' 'isInvalid') "user-edit-form__email  form-control is-invalid"
+                          "user-edit-form__email  form-control"}}
+               @value={{this.form.email}}/>
+      </div>
+
+      <div class="col-md-4">
+        <button class="btn btn-outline-default" aria-label="Annuler" {{on "click" this.cancelEdit}}>Annuler</button>
+        <button class="btn btn-success" aria-label="Editer">Editer</button>
+      </div>
+    </form>
+  {{else}}
+    <form class="form user-read-only-form">
+      <section class="page-section mb_10">
+        <div>
+          <div class="attribute first-name">
+            <span class="attibute__label">Prénom : </span>
+            <span class="attribute__value user__first-name">{{@user.firstName}}</span>
+          </div>
+          <div class="attribute last-name">
+            <span class="attibute__label">Nom : </span>
+            <span class="attribute__value user__last-name">{{@user.lastName}}</span>
+          </div>
+          <div class="attribute email">
+            <span class="attibute__label">E-mail : </span>
+            <span class="attribute__value user__email">{{@user.email}}</span>
+          </div>
+          <div class="attribute username">
+            <span class="attibute__label">Identifiant : </span>
+            <span class="attribute__value user__username">{{@user.username}}</span>
+          </div>
+          <div class="attribute authenticated-from-gar">
+            <span class="attibute__label">Connecté via le GAR : </span>
+            <span class="attribute__value user__is-authenticated-from-gar">{{if @user.isAuthenticatedFromGar 'OUI'
+                                                                                'NON'}}</span>
+          </div>
+          <br>
+          <div class="attribute cgu">
+            <span class="attibute__label">CGU Pix App validé : </span>
+            <span class="attribute__value user__cgu">{{if @user.cgu 'OUI' 'NON'}}</span>
+          </div>
+          <div class="attribute pix-orga-terms-of-service-accepted">
+            <span class="attibute__label">CGU Pix Orga validé : </span>
+            <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if
+                    @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+          </div>
+          <div class="attribute pix-certif-terms-of-service-accepted">
+            <span class="attibute__label">CGU Pix Certif validé : </span>
+            <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}</span>
+          </div>
+        </div>
+      </section>
+      <div class="col-md-4">
+        <button class="btn btn-outline-default" aria-label="Modifier" {{on "click" this.changeEditionMode}}>Modifier
+        </button>
+      </div>
+    </form>
+  {{/if}}
 </section>

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -1,0 +1,87 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import Object, { action } from '@ember/object';
+import { validator, buildValidations } from 'ember-cp-validations';
+import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
+
+const Validations = buildValidations({
+  firstName: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        ignoreBlank: true,
+        message: 'Le prénom ne peut pas être vide.'
+      }),
+      validator('length', {
+        min: 1,
+        max: 255,
+        message: 'La longueur du prénom ne doit pas excéder 255 caractères.'
+      })
+    ]
+  },
+  lastName: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        ignoreBlank: true,
+        message: 'Le nom ne peut pas être vide.'
+      }),
+      validator('length', {
+        min: 0,
+        max: 255,
+        message: 'La longueur du nom ne doit pas excéder 255 caractères.'
+      })
+    ]
+  },
+  email: {
+    validators: [
+      validator('presence', {
+        presence: true,
+        ignoreBlank: true,
+        message: 'L\'e-mail ne peut pas être vide.'
+      }),
+      validator('length', {
+        min: 0,
+        max: 255,
+        message: 'La longueur de l\'email ne doit pas excéder 255 caractères.'
+      })
+    ]
+  },
+});
+
+class Form extends Object.extend(Validations) {
+  @tracked firstName;
+  @tracked lastName;
+  @tracked email;
+}
+
+export default class UserDetailPersonalInformationComponent extends Component {
+
+  @tracked isEditionMode = false;
+
+  constructor() {
+    super(...arguments);
+    this.form = Form.create(getOwner(this).ownerInjection());
+  }
+
+  @action
+  changeEditionMode(event) {
+    event.preventDefault();
+    this._initForm();
+    this.isEditionMode = !this.isEditionMode;
+  }
+
+  @action
+  cancelEdit() {
+    this._initForm();
+    this.model.rollbackAttributes();
+    this.isEditionMode = true;
+  }
+
+  _initForm() {
+    this.form.firstName = this.args.user.firstName;
+    this.form.lastName = this.args.user.lastName;
+    this.form.email = this.args.user.email;
+  }
+}

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -46,6 +46,7 @@ const Validations = buildValidations({
         message: 'La longueur de l\'email ne doit pas excéder 255 caractères.'
       }),
       validator('format', {
+        ignoreBlank: true,
         type: 'email',
         message: 'L\'e-mail n\'a pas le bon format.'
       })

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -7,7 +7,5 @@
 </header>
 
 <main class="page-body" id="organizations-get-page">
-
-  <UserDetailPersonalInformation @user={{@model}} />
-
+  <UserDetailPersonalInformation @user={{@model}}/>
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -64,4 +64,27 @@ export default function() {
     const organization = schema.organizations.findBy({ id: organizationId });
     return organization.update({ params });
   });
+
+  this.patch('/admin/users/:id', (schema, request) => {
+    const userId = request.params.id;
+    const params = JSON.parse(request.requestBody);
+
+    const userUpdated = {
+      'data': {
+        'type': 'users',
+        'id': userId,
+        'attributes': {
+          'first-name': params.data.attributes['first-name'],
+          'last-name': params.data.attributes['last-name'],
+          'email': params.data.attributes['email'],
+          'username': params.data.attributes['username'],
+          'cgu': params.data.attributes['cgu'],
+          'is-authenticated-from-gar': params.data.attributes['is-authenticated-from-gar'],
+          'pix-orga-terms-of-service-accepted': params.data.attributes['pix-orga-terms-of-service-accepted'],
+          'pix-certif-terms-of-service-accepted': params.data.attributes['pix-certif-terms-of-service-accepted']
+        }
+      }
+    };
+    return userUpdated;
+  });
 }

--- a/admin/tests/acceptance/user-details-personal-information-test.js
+++ b/admin/tests/acceptance/user-details-personal-information-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { currentURL, click, fillIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | user details personal information', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let user = null;
+
+  hooks.beforeEach(async function() {
+    user = this.server.create('user', {
+      'first-name': 'john',
+      'last-name': 'harry',
+      username: null,
+      'is-authenticated-from-gar': false
+    });
+    await createAuthenticateSession({ userId: user.id });
+  });
+
+  test('visiting /users/:id', async function(assert) {
+
+    // when
+    await visit(`/users/${user.id}`);
+
+    // then
+    assert.equal(currentURL(), `/users/${user.id}`);
+  });
+
+  module('when administrator click to edit users details', function() {
+
+    test('should update user firstName, lastName and email', async function(assert) {
+      // given
+      await visit(`/users/${user.id}`);
+      await click('button[aria-label="Modifier"]');
+
+      // when
+      await fillIn('#firstName', 'john');
+      await fillIn('#lastName', 'doe');
+      await fillIn('#email', 'john.doe@example.net');
+
+      await click('button[aria-label="Editer"]');
+
+      // then
+      assert.dom('.user__first-name').hasText('john');
+      assert.dom('.user__last-name').hasText('doe');
+      assert.dom('.user__email').hasText('john.doe@example.net');
+    });
+  });
+
+});

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -7,10 +7,16 @@ import EmberObject from '@ember/object';
 module('Integration | Component | user-detail-personal-information', function(hooks) {
   setupRenderingTest(hooks);
 
-  module('should display by default the form in read only mode', async function() {
+  module('When the administrator click on user details', async function() {
 
-    test('should display the update button', async function(assert) {
-      this.set('user', { firstName: 'John' });
+    test('should display the update button when user is connected by email only', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: null,
+        isAuthenticatedFromGAR: false
+      });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -18,7 +24,97 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
     });
 
-    test('should display user’s first name in read only mode', async function(assert) {
+    test('should not display the update button when user is connected from GAR only', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: null,
+        username: null,
+        isAuthenticatedFromGAR: true
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should not display the update button when user is connected with username only', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: null,
+        username: 'john.harry2018',
+        isAuthenticatedFromGAR: false,
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should not display the update button when user is connected with username,email', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: 'john.harry2018',
+        isAuthenticatedFromGAR: false
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should not display the update button when user is connected with email and GAR', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: null,
+        isAuthenticatedFromGAR: true
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should not display the update button when user is connected with username and GAR', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: null,
+        username: 'john.harry2018',
+        isAuthenticatedFromGAR: true
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should not display the update button when user is connected with username, email and GAR', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: 'john.harry2018',
+        isAuthenticatedFromGAR: true
+      });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+
+    });
+
+    test('should display user’s first name ', async function(assert) {
       this.set('user', { firstName: 'John' });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -27,7 +123,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
     });
 
-    test('should display user’s last name in read only mode', async function(assert) {
+    test('should display user’s last name ', async function(assert) {
       this.set('user', { lastName: 'Snow' });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -35,7 +131,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__last-name').hasText(this.user.lastName);
     });
 
-    test('should display user’s email in read only mode', async function(assert) {
+    test('should display user’s email ', async function(assert) {
       this.set('user', { email: 'john.snow@winterfell.got' });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -43,7 +139,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__email').hasText(this.user.email);
     });
 
-    test('should display user’s username in read only mode', async function(assert) {
+    test('should display user’s username ', async function(assert) {
       this.set('user', { username: 'kingofthenorth' });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -51,7 +147,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__username').hasText(this.user.username);
     });
 
-    test('should display "OUI" when user accepted Pix App terms of service in read only mode', async function(assert) {
+    test('should display "OUI" when user accepted Pix App terms of service ', async function(assert) {
       this.set('user', { cgu: true });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -59,7 +155,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__cgu').hasText('OUI');
     });
 
-    test('should display "NON" when user not accepted Pix App terms of service in read only mode', async function(assert) {
+    test('should display "NON" when user not accepted Pix App terms of service ', async function(assert) {
       this.set('user', { cgu: false });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -67,7 +163,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__cgu').hasText('NON');
     });
 
-    test('should display "OUI" when user accepted Pix Orga terms of service in read only mode', async function(assert) {
+    test('should display "OUI" when user accepted Pix Orga terms of service ', async function(assert) {
       this.set('user', { pixOrgaTermsOfServiceAccepted: true });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -75,7 +171,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
     });
 
-    test('should display "NON" when user not accepted Pix Orga terms of service in read only mode', async function(assert) {
+    test('should display "NON" when user not accepted Pix Orga terms of service ', async function(assert) {
       this.set('user', { pixOrgaTermsOfServiceAccepted: false });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -83,7 +179,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
     });
 
-    test('should display "OUI" when user accepted Pix Certif terms of service in read only mode', async function(assert) {
+    test('should display "OUI" when user accepted Pix Certif terms of service ', async function(assert) {
       this.set('user', { pixCertifTermsOfServiceAccepted: true });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -91,7 +187,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
     });
 
-    test('should display "NON" when user not accepted Pix Certif terms of service in read only mode', async function(assert) {
+    test('should display "NON" when user not accepted Pix Certif terms of service ', async function(assert) {
       this.set('user', { pixCertifTermsOfServiceAccepted: false });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -99,7 +195,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
     });
 
-    test('should display that user is authenticated from GAR in read only mode', async function(assert) {
+    test('should display that user is authenticated from GAR ', async function(assert) {
       this.set('user', { isAuthenticatedFromGAR: true });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -107,7 +203,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__is-authenticated-from-gar').hasText('NON');
     });
 
-    test('should display that user is not authenticated from GAR in read only mode', async function(assert) {
+    test('should display that user is not authenticated from GAR ', async function(assert) {
       this.set('user', { isAuthenticatedFromGAR: false });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -115,9 +211,31 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__is-authenticated-from-gar').hasText('NON');
     });
 
-    test('should display the edit and cancel buttons when click on update button', async function(assert) {
+  });
 
-      this.set('user', { email: 'john.snow@winterfell.got' });
+  module('When the administrator click to update user details', async function() {
+
+    let user = null;
+
+    hooks.beforeEach(function() {
+      user = EmberObject.create({
+        lastName: 'Harry',
+        firstName: 'John',
+        email: 'john.harry@gmail.com',
+        username: null,
+        isAuthenticatedFromGAR: false
+      });
+    });
+
+    test('should display the edit and cancel buttons', async function(assert) {
+
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: null,
+        isAuthenticatedFromGAR: false
+      });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -126,171 +244,35 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('button[aria-label=\'Editer\'').exists();
       assert.dom('button[aria-label=\'Annuler\'').exists();
     });
-  });
 
-  module('should display the form in editable mode when admin click on update user details', async function() {
-
-    module('should display only fields allowed for update', async function() {
-
-      let user = null;
-
-      hooks.beforeEach(function() {
-        user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
-      });
-
-      test('should display display the edit and cancel buttons when click on update button', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        // then
-        assert.dom('button[aria-label=\'Editer\'').exists();
-        assert.dom('button[aria-label=\'Annuler\'').exists();
-      });
-
-      test('should display user’s first name in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
-
-      });
-
-      test('should display user’s last name in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
-      });
-
-      test('should display user’s email in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user-edit-form__email').hasValue(this.user.email);
-      });
-
-    });
-
-    module('should not display fields not allowed for update', async function() {
-
-      let user = null;
-
-      hooks.beforeEach(function() {
-        user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
-      });
-
-      test('should not display user’s username in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
-
-      });
-
-      test('should not display user’s authenticated-from-gar in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
-      });
-
-      test('should not display user’s cgu in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user__cgu').doesNotExist();
-      });
-
-      test('should not display user’s pix-orga-terms-of-service-accepted in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user__pix-orga-terms-of-service-accepted').doesNotExist();
-      });
-
-      test('should not display user’s pix-certif-terms-of-service-accepted in edit mode', async function(assert) {
-
-        this.set('user', user);
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        await click('button[aria-label=\'Modifier\'');
-
-        assert.dom('.user__pix-certif-terms-of-service-accepted').doesNotExist();
-      });
-
-    });
-
-  });
-
-  module('should change the edition mode when admin click on update, edit and cancel buttons', async function() {
-
-    let user = null;
-
-    hooks.beforeEach(function() {
-      user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
-    });
-
-    test('should display the update button when admin cancel modification ', async function(assert) {
+    test('should display user’s first name,last name and email in edit mode', async function(assert) {
 
       this.set('user', user);
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Annuler\'');
+      await click('button[aria-label=\'Modifier\'');
 
-      // then
-      assert.dom('button[aria-label=\'Modifier\'').exists();
-      assert.dom('button[aria-label=\'Editer\'').doesNotExist();
-      assert.dom('button[aria-label=\'Annuler\'').doesNotExist();
+      assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
+      assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
+      assert.dom('.user-edit-form__email').hasValue(this.user.email);
+
     });
 
-    test('should display the update button when admin click on edit button ', async function(assert) {
+    test('should not display user’s terms of service', async function(assert) {
 
       this.set('user', user);
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Editer\'');
+      await click('button[aria-label=\'Modifier\'');
 
-      assert.dom('button[aria-label=\'Modifier\'').exists();
-      assert.dom('button[aria-label=\'Editer\'').doesNotExist();
-      assert.dom('button[aria-label=\'Annuler\'').doesNotExist();
+      assert.dom('.user__cgu').doesNotExist();
+      assert.dom('.user__pix-orga-terms-of-service-accepted').doesNotExist();
+      assert.dom('.user__pix-certif-terms-of-service-accepted').doesNotExist();
+
     });
 
   });
 
 });
-

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,105 +1,295 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | user-detail-personal-information', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('should display user’s first name', async function(assert) {
-    this.set('user', { firstName: 'John' });
+  module('should display by default the form in read only mode', async function() {
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+    test('should display the update button', async function(assert) {
+      this.set('user', { firstName: 'John' });
 
-    assert.dom('.user__first-name').hasText(this.user.firstName);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('button[aria-label=\'Modifier\'').exists();
+
+    });
+
+    test('should display user’s first name in read only mode', async function(assert) {
+      this.set('user', { firstName: 'John' });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__first-name').hasText(this.user.firstName);
+
+    });
+
+    test('should display user’s last name in read only mode', async function(assert) {
+      this.set('user', { lastName: 'Snow' });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__last-name').hasText(this.user.lastName);
+    });
+
+    test('should display user’s email in read only mode', async function(assert) {
+      this.set('user', { email: 'john.snow@winterfell.got' });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__email').hasText(this.user.email);
+    });
+
+    test('should display user’s username in read only mode', async function(assert) {
+      this.set('user', { username: 'kingofthenorth' });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__username').hasText(this.user.username);
+    });
+
+    test('should display "OUI" when user accepted Pix App terms of service in read only mode', async function(assert) {
+      this.set('user', { cgu: true });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__cgu').hasText('OUI');
+    });
+
+    test('should display "NON" when user not accepted Pix App terms of service in read only mode', async function(assert) {
+      this.set('user', { cgu: false });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__cgu').hasText('NON');
+    });
+
+    test('should display "OUI" when user accepted Pix Orga terms of service in read only mode', async function(assert) {
+      this.set('user', { pixOrgaTermsOfServiceAccepted: true });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
+    });
+
+    test('should display "NON" when user not accepted Pix Orga terms of service in read only mode', async function(assert) {
+      this.set('user', { pixOrgaTermsOfServiceAccepted: false });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
+    });
+
+    test('should display "OUI" when user accepted Pix Certif terms of service in read only mode', async function(assert) {
+      this.set('user', { pixCertifTermsOfServiceAccepted: true });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
+    });
+
+    test('should display "NON" when user not accepted Pix Certif terms of service in read only mode', async function(assert) {
+      this.set('user', { pixCertifTermsOfServiceAccepted: false });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
+    });
+
+    test('should display that user is authenticated from GAR in read only mode', async function(assert) {
+      this.set('user', { isAuthenticatedFromGAR: true });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__is-authenticated-from-gar').hasText('NON');
+    });
+
+    test('should display that user is not authenticated from GAR in read only mode', async function(assert) {
+      this.set('user', { isAuthenticatedFromGAR: false });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      assert.dom('.user__is-authenticated-from-gar').hasText('NON');
+    });
+
+    test('should display the edit and cancel buttons when click on update button', async function(assert) {
+
+      this.set('user', { email: 'john.snow@winterfell.got' });
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      await click('button[aria-label=\'Modifier\'');
+
+      assert.dom('button[aria-label=\'Editer\'').exists();
+      assert.dom('button[aria-label=\'Annuler\'').exists();
+    });
   });
 
-  test('should display user’s last name', async function(assert) {
-    this.set('user', { lastName: 'Snow' });
+  module('should display the form in editable mode when admin click on update user details', async function() {
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+    module('should display only fields allowed for update', async function() {
 
-    assert.dom('.user__last-name').hasText(this.user.lastName);
+      let user = null;
+
+      hooks.beforeEach(function() {
+        user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
+      });
+
+      test('should display display the edit and cancel buttons when click on update button', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        // then
+        assert.dom('button[aria-label=\'Editer\'').exists();
+        assert.dom('button[aria-label=\'Annuler\'').exists();
+      });
+
+      test('should display user’s first name in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
+
+      });
+
+      test('should display user’s last name in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
+      });
+
+      test('should display user’s email in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user-edit-form__email').hasValue(this.user.email);
+      });
+
+    });
+
+    module('should not display fields not allowed for update', async function() {
+
+      let user = null;
+
+      hooks.beforeEach(function() {
+        user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
+      });
+
+      test('should not display user’s username in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
+
+      });
+
+      test('should not display user’s authenticated-from-gar in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
+      });
+
+      test('should not display user’s cgu in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user__cgu').doesNotExist();
+      });
+
+      test('should not display user’s pix-orga-terms-of-service-accepted in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user__pix-orga-terms-of-service-accepted').doesNotExist();
+      });
+
+      test('should not display user’s pix-certif-terms-of-service-accepted in edit mode', async function(assert) {
+
+        this.set('user', user);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        await click('button[aria-label=\'Modifier\'');
+
+        assert.dom('.user__pix-certif-terms-of-service-accepted').doesNotExist();
+      });
+
+    });
+
   });
 
-  test('should display user’s email', async function(assert) {
-    this.set('user', { email: 'john.snow@winterfell.got' });
+  module('should change the edition mode when admin click on update, edit and cancel buttons', async function() {
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+    let user = null;
 
-    assert.dom('.user__email').hasText(this.user.email);
-  });
+    hooks.beforeEach(function() {
+      user = EmberObject.create({ lastName: 'harry', firstName: 'John', email: 'john.harry@gmail.com' });
+    });
 
-  test('should display user’s username', async function(assert) {
-    this.set('user', { username: 'kingofthenorth' });
+    test('should display the update button when admin cancel modification ', async function(assert) {
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      this.set('user', user);
 
-    assert.dom('.user__username').hasText(this.user.username);
-  });
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-  test('should display "OUI" when user accepted Pix App terms of service', async function(assert) {
-    this.set('user', { cgu: true });
+      await click('button[aria-label=\'Annuler\'');
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      // then
+      assert.dom('button[aria-label=\'Modifier\'').exists();
+      assert.dom('button[aria-label=\'Editer\'').doesNotExist();
+      assert.dom('button[aria-label=\'Annuler\'').doesNotExist();
+    });
 
-    assert.dom('.user__cgu').hasText('OUI');
-  });
+    test('should display the update button when admin click on edit button ', async function(assert) {
 
-  test('should display "NON" when user not accepted Pix App terms of service', async function(assert) {
-    this.set('user', { cgu: false });
+      this.set('user', user);
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    assert.dom('.user__cgu').hasText('NON');
-  });
+      await click('button[aria-label=\'Editer\'');
 
-  test('should display "OUI" when user accepted Pix Orga terms of service', async function(assert) {
-    this.set('user', { pixOrgaTermsOfServiceAccepted: true });
+      assert.dom('button[aria-label=\'Modifier\'').exists();
+      assert.dom('button[aria-label=\'Editer\'').doesNotExist();
+      assert.dom('button[aria-label=\'Annuler\'').doesNotExist();
+    });
 
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
-  });
-
-  test('should display "NON" when user not accepted Pix Orga terms of service', async function(assert) {
-    this.set('user', { pixOrgaTermsOfServiceAccepted: false });
-
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
-  });
-
-  test('should display "OUI" when user accepted Pix Certif terms of service', async function(assert) {
-    this.set('user', { pixCertifTermsOfServiceAccepted: true });
-
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
-  });
-
-  test('should display "NON" when user not accepted Pix Certif terms of service', async function(assert) {
-    this.set('user', { pixCertifTermsOfServiceAccepted: false });
-
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
-  });
-
-  test('should display that user is authenticated from GAR', async function(assert) {
-    this.set('user', { isAuthenticatedFromGAR: true });
-
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__is-authenticated-from-gar').hasText('NON');
-  });
-
-  test('should display that user is not authenticated from GAR', async function(assert) {
-    this.set('user', { isAuthenticatedFromGAR: false });
-
-    await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-    assert.dom('.user__is-authenticated-from-gar').hasText('NON');
   });
 
 });

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -110,8 +110,8 @@ exports.register = async function(server) {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
               code: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details,
+              title: 'Bad request', 
+              detail: err.details[0].message,
             });
             return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
           }

--- a/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
+++ b/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
@@ -39,7 +39,7 @@ describe('Acceptance | Controller | users-controller-update-user-details-for-adm
       // then
       expect(response.statusCode).to.equal(400);
       const firstError = response.result.errors[0];
-      expect(firstError.detail[0].message).to.equal('"data.attributes.first-name" is required');
+      expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
     });
 
     it('should reply with not authorized error', async () => {

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -91,7 +91,7 @@ describe('Integration | Application | Users | Routes', () => {
       // then
       expect(response.statusCode).to.equal(400);
       const firstError = response.result.errors[0];
-      expect(firstError.detail[0].message).to.equal('"data.attributes.first-name" is required');
+      expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
 
     });
 
@@ -115,7 +115,7 @@ describe('Integration | Application | Users | Routes', () => {
       // then
       expect(response.statusCode).to.equal(400);
       const firstError = response.result.errors[0];
-      expect(firstError.detail[0].message).to.equal('"data.attributes.first-name" is required');
+      expect(firstError.detail).to.equal('"data.attributes.first-name" is required');
 
     });
 


### PR DESCRIPTION
## :unicorn: Problème
L'aministrateur ne peut pas modifier les informations personnelles d'un utilisateur dans Pix Admin.

## :robot: Solution
Proposer une page d'édition pour modifier le nom, prénom et l'email par un administrateur.

## :rainbow: Remarques
La modification n'est permise que pour les utilisateurs utilisant _exclusivement_ la méthode de connexion email.
Les autres informations personnelles ne sont pas ouvertes à la modification. 
Elles ne sont pas affichées dans la page d'édition.
Utilisation de ember-cp-validation pour gérer la validation.

## :100: Pour tester
Aller dans vue utilisateurs, cliquer sur une ligne.
Cliquer sur le bouton modifier pour voir le formulaire d'édition, modifier le contenu des champs, puis cliquer sur Editer.
