### PR TITLE
[FEATURE] Ne plus afficher les membres désactivés dans PixOrga et PixAdmin (PIX-409).

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -6,7 +6,6 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     type: 'SUP',
     name: 'Tyrion SUP',
   });
-
   databaseBuilder.factory.buildMembership({
     userId: 3,
     organizationId: 2,
@@ -20,19 +19,16 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     isManagingStudents: true,
     canCollectProfiles: true,
   });
-
   databaseBuilder.factory.buildMembership({
     userId: 4,
     organizationId: 3,
     organizationRole: Membership.roles.ADMIN,
   });
-
   databaseBuilder.factory.buildMembership({
     userId: 9,
     organizationId: 3,
     organizationRole: Membership.roles.MEMBER,
   });
-
   databaseBuilder.factory.buildSchoolingRegistration({
     id: 1,
     firstName: 'First',
@@ -40,6 +36,18 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     birthdate: '2010-10-10',
     organizationId: 3,
     userId: null
+  });
+  const disabledUserId = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'Mance',
+    lastName: 'Rayder',
+    email: 'mance.rayder@example.net',
+    rawPassword: 'Pix123',
+  }).id;
+  databaseBuilder.factory.buildMembership({
+    userId: disabledUserId,
+    organizationId: 3,
+    organizationRole: Membership.roles.MEMBER,
+    removedAt: new Date()
   });
 
   const user1Id = databaseBuilder.factory.buildUser.withUnencryptedPassword({
@@ -58,7 +66,6 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     rawPassword: 'Pix123',
     cgu: false
   }).id;
-
   databaseBuilder.factory.buildSchoolingRegistration({
     firstName: 'George',
     lastName: 'De Cambridge',

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -30,7 +30,7 @@ module.exports = {
 
   findByOrganizationId({ organizationId, orderByName = false }) {
     return BookshelfMembership
-      .where({ organizationId })
+      .where({ organizationId, disabledAt: null })
       .query((qb) => {
         if (orderByName) {
           qb.innerJoin('users', 'memberships.userId', 'users.id');
@@ -45,7 +45,7 @@ module.exports = {
 
   findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization = false }) {
     return BookshelfMembership
-      .where({ userId, organizationId })
+      .where({ userId, organizationId, disabledAt: null })
       .fetchAll({ withRelated: includeOrganization ? ['organization'] : [] })
       .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
   },

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -79,6 +79,7 @@ module.exports = {
       .fetch({
         require: true,
         withRelated: [
+          { 'memberships': (qb) => qb.where({ disabledAt: null }) },
           'memberships.user',
           'targetProfileShares.targetProfile',
         ],

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -2,7 +2,15 @@ const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = req
 const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
 
-describe('Acceptance | Application | SecurityPreHandlers', function() {
+describe('Acceptance | Application | SecurityPreHandlers', () => {
+
+  const jsonApiError403 = {
+    errors: [{
+      code: 403,
+      title: 'Forbidden access',
+      detail: 'Missing or insufficient permissions.'
+    }]
+  };
 
   let server;
 
@@ -50,15 +58,8 @@ describe('Acceptance | Application | SecurityPreHandlers', function() {
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
   });
@@ -77,258 +78,308 @@ describe('Acceptance | Application | SecurityPreHandlers', function() {
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
   });
 
   describe('#checkUserBelongsToScoOrganizationAndManagesStudents', () => {
+
     let userId;
     let organizationId;
+    let options;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
-      return databaseBuilder.commit();
+      options = {
+        method: 'GET',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) }
+      };
+
+      await databaseBuilder.commit();
     });
 
     it('should return a well formed JSON API error when user is in a not sco organization', async () => {
       // given
       organizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
-      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+      options.url = `/api/organizations/${organizationId}/students`;
+
       await databaseBuilder.commit();
-      const options = {
-        method: 'GET',
-        url: `/api/organizations/${organizationId}/students`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-      };
 
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
     it('should return a well formed JSON API error when user is in a sco orga that does not manage students', async () => {
       // given
       organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false }).id;
-      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+      options.url = `/api/organizations/${organizationId}/students`;
+
       await databaseBuilder.commit();
-      const options = {
-        method: 'GET',
-        url: `/api/organizations/${organizationId}/students`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-      };
 
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
+
+    it('should return a well formed JSON API error when membership is disabled', async () => {
+      // given
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
+
+      options.url = `/api/organizations/${organizationId}/students`;
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
   });
 
   describe('#checkUserIsAdminInOrganization', () => {
 
-    it('should return a well formed JSON API error when user is not admin in orga', async () => {
-      // given
-      const notAdminUserId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({
-        userId: notAdminUserId,
-        organizationId,
-        organizationRole: Membership.roles.MEMBER,
-      });
-      await databaseBuilder.commit();
-      const options = {
+    let userId;
+    let organizationId;
+    let options;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      options = {
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         method: 'GET',
         url: `/api/organizations/${organizationId}/invitations`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
       };
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is not admin in the organization', async () => {
+      // given
+      databaseBuilder.factory.buildMembership({
+        userId, organizationId, organizationRole: Membership.roles.MEMBER,
+      });
+
+      await databaseBuilder.commit();
 
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
+    it('should return a well formed JSON API error when user is admin in the organization, but membership is disabled', async () => {
+      // given
+      databaseBuilder.factory.buildMembership({
+        userId, organizationId, organizationRole: Membership.roles.ADMIN,
+        disabledAt: new Date()
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
   });
 
   describe('#checkUserIsAdminInOrganizationOrHasRolePixMaster', () => {
 
-    it('should return a well formed JSON API error when user is neither admin nor pix_master', async () => {
-      // given
-      const notAdminUserId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({
-        userId: notAdminUserId,
-        organizationId,
-        organizationRole: Membership.roles.MEMBER,
-      });
-      await databaseBuilder.commit();
-      const options = {
+    let userId;
+    let organizationId;
+    let options;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      options = {
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         method: 'POST',
         url: `/api/organizations/${organizationId}/invitations`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
         payload: {
           data: {
             type: 'organization-invitations',
             attributes: {
-              email: 'truc@example.net'
-            },
+              email: 'member@example.net'
+            }
           }
         }
       };
 
+      await databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is neither admin nor pix_master', async () => {
+      // given
+      databaseBuilder.factory.buildMembership({
+        userId, organizationId, organizationRole: Membership.roles.MEMBER,
+      });
+
+      await databaseBuilder.commit();
+
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
+    it('should return a well formed JSON API error when user is admin, but membership is disabled', async () => {
+      // given
+      databaseBuilder.factory.buildMembership({
+        userId, organizationId, organizationRole: Membership.roles.ADMIN,
+        disabledAt: new Date()
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
   });
 
   describe('#checkUserIsAdminInScoOrganizationAndManagesStudents', () => {
 
+    let userId;
+    let organizationId;
+    let options;
+
+    beforeEach(async () => {
+      userId = databaseBuilder.factory.buildUser().id;
+
+      options = {
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        method: 'POST',
+      };
+
+      await databaseBuilder.commit();
+    });
+
     it('should return a well formed JSON API error when user is not in sco managing students orga', async () => {
       // given
-      const notAdminUserId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
       databaseBuilder.factory.buildMembership({
-        userId: notAdminUserId,
-        organizationId,
-        organizationRole: Membership.roles.MEMBER,
+        userId, organizationId, organizationRole: Membership.roles.ADMIN,
       });
+
+      options.url = `/api/organizations/${organizationId}/import-students`;
+
       await databaseBuilder.commit();
-      const options = {
-        method: 'POST',
-        url: `/api/organizations/${organizationId}/import-students`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
-      };
 
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
     it('should return a well formed JSON API error when user is in sco managing students orga but not admin', async () => {
       // given
-      const notAdminUserId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
       databaseBuilder.factory.buildMembership({
-        userId: notAdminUserId,
-        organizationId,
-        organizationRole: Membership.roles.MEMBER,
+        userId, organizationId, organizationRole: Membership.roles.MEMBER,
       });
+
+      options.url = `/api/organizations/${organizationId}/import-students`;
+
       await databaseBuilder.commit();
-      const options = {
-        method: 'POST',
-        url: `/api/organizations/${organizationId}/import-students`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(notAdminUserId) },
-      };
 
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
 
+    it('should return a well formed JSON API error when user is in sco managing students orga and admin, but membership is disabled', async () => {
+      // given
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      databaseBuilder.factory.buildMembership({
+        userId, organizationId, organizationRole: Membership.roles.ADMIN,
+        disabledAt: new Date()
+      });
+
+      options.url = `/api/organizations/${organizationId}/import-students`;
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
   });
 
   describe('#checkUserBelongsToOrganizationOrHasRolePixMaster', () => {
+
     let userId;
     let organizationId;
+    let options;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
-      return databaseBuilder.commit();
-    });
-
-    it('should return a well formed JSON API error when user is neither in the organization nor PIXMASTER', async () => {
-      // given
       organizationId = databaseBuilder.factory.buildOrganization().id;
-      await databaseBuilder.commit();
-      const options = {
+
+      options = {
         method: 'GET',
         url: `/api/organizations/${organizationId}/memberships`,
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
 
+      await databaseBuilder.commit();
+    });
+
+    it('should return a well formed JSON API error when user is neither in the organization nor PIXMASTER', async () => {
       // when
       const response = await server.inject(options);
 
       // then
-      const jsonApiError = {
-        errors: [{
-          code: 403,
-          title: 'Forbidden access',
-          detail: 'Missing or insufficient permissions.'
-        }]
-      };
       expect(response.statusCode).to.equal(403);
-      expect(response.result).to.deep.equal(jsonApiError);
+      expect(response.result).to.deep.equal(jsonApiError403);
+    });
+
+    it('should return a well formed JSON API error when user is in the orga, but membership is disabled', async () => {
+      // given
+      databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal(jsonApiError403);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -165,7 +165,6 @@ describe('Integration | Repository | Organization', function() {
           expect(err.message).to.equal('Not found organization for ID 10083');
         });
       });
-
     });
 
     describe('when a target profile is shared with the organisation', () => {
@@ -186,7 +185,7 @@ describe('Integration | Repository | Organization', function() {
         await databaseBuilder.commit();
       });
 
-      it('should return an list of profile containing the shared profile', async () => {
+      it('should return a list of profile containing the shared profile', async () => {
         // when
         const organization = await organizationRepository.get(insertedOrganization.id);
 
@@ -196,6 +195,35 @@ describe('Integration | Repository | Organization', function() {
         expect(firstTargetProfileShare.organizationId).to.deep.equal(insertedOrganization.id);
 
         expect(firstTargetProfileShare.targetProfile).to.deep.equal(sharedProfile);
+      });
+    });
+
+    context('when organization have memberships', () => {
+
+      it('should return a list of active members', async () => {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+        const membershipActive = {
+          organizationId,
+          userId: databaseBuilder.factory.buildUser().id
+        };
+        const membershipDisabled = {
+          organizationId,
+          userId: databaseBuilder.factory.buildUser().id,
+          disabledAt: new Date(),
+        };
+        databaseBuilder.factory.buildMembership(membershipActive);
+        databaseBuilder.factory.buildMembership(membershipDisabled);
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundOrganization = await organizationRepository.get(organizationId);
+
+        // then
+        expect(foundOrganization.members).to.have.lengthOf(1);
+        expect(foundOrganization.members[0].id).to.deep.equal(membershipActive.userId);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur ne fait plus partie d'une organisation, il apparait néanmoins
- dans Pix Admin (liste des membres d'une organisation),
- dans Pix Orga (Equipe)
Il ne devra plus apparaitre dans ces listes.

## :robot: Solution
- Lorsque la liste des membres d'une organisation doit être récupérée, 
côté API, remonter uniquement les memberships dont le champ removedAt est vide.
- Dans l'API, les fonctions du `securityPreHandlers`, qui vérifient qu'un utilisateur est bien membre d'une organisation, tiendront compte de ce paramètre.

## :rainbow: Remarques
Cette branche est issue de la branche `pix-766-add-removedAt-to-memberships`.

## :100: Pour tester
L'utilisateur **mance.rayder@example.net** qui était membre de l'organisation **The Night Watch**, a été désactivé.
Vérifier qu'il n'apparait pas dans les listes citées plus haut.