### PR TITLE
[FEATURE] PART-1 : Nouveau visuel certificat (PIX-597)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -1,9 +1,0 @@
-import { classNames } from '@ember-decorators/component';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
-
-@classic
-@classNames('user-certifications-detail-header')
-export default class UserCertificationsDetailHeader extends Component {
-  certification = null;
-}

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -1,5 +1,6 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
+import capitalize from 'lodash/capitalize';
 
 export const ACQUIRED = 'acquired';
 
@@ -18,6 +19,7 @@ export default class Certification extends Model {
   @attr('number') pixScore;
   @attr('string') status;
   @attr() cleaCertificationStatus;
+  @attr() deliveredAt;
 
   // includes
   @belongsTo('resultCompetenceTree') resultCompetenceTree;
@@ -26,5 +28,10 @@ export default class Certification extends Model {
   @computed('cleaCertificationStatus')
   get hasCleaCertif() {
     return this.cleaCertificationStatus === ACQUIRED;
+  }
+
+  @computed('firstName', 'lastName')
+  get fullName() {
+    return capitalize(this.firstName) + ' ' + capitalize(this.lastName);
   }
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -79,6 +79,7 @@
 @import 'components/user-certifications-detail-header';
 @import 'components/user-certifications-detail-profile';
 @import 'components/user-certifications-detail-result';
+@import 'components/user-certifications-detail-banner';
 @import 'components/user-logged-menu';
 @import 'components/communication-banner';
 @import 'components/warning-timing-page';

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -77,6 +77,7 @@
 @import 'components/user-certifications-detail-area';
 @import 'components/user-certifications-detail-competence';
 @import 'components/user-certifications-detail-header';
+@import 'components/user-certification-hexagon-score';
 @import 'components/user-certifications-detail-profile';
 @import 'components/user-certifications-detail-result';
 @import 'components/user-certifications-detail-banner';

--- a/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
+++ b/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
@@ -1,0 +1,42 @@
+.user-certification-hexagon-score {
+  min-width: 180px;
+  height: 194px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: url('/images/macaron-certif.svg') no-repeat center center;
+  background-size: 100% 100%;
+  margin: 0 22px;
+
+  p { margin: 0; }
+
+  &__content {
+    padding-bottom: 7%;
+    text-align: center;
+
+    &-title {
+      color: $grey-60;
+      font-family: $font-roboto;
+      font-weight: lighter;
+      font-size: 0.8rem;
+      letter-spacing: 0.219rem;
+    }
+
+    &-pix-score {
+      color: $grey-70;
+      font-family: $font-open-sans;
+      font-weight: $font-semi-bold;
+      font-size: 2.3rem;
+    }
+
+    &-certified {
+      color: $grey-60;
+      text-transform: uppercase;
+      font-family: $font-roboto;
+      font-weight: $font-medium;
+      font-size: 0.7rem;
+      width: 70px;
+    }
+  }
+}

--- a/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
@@ -1,0 +1,23 @@
+.certification-background-banner {
+  width: 100%;
+  min-height: 270px;
+  background: $default-gradient;
+  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+  color: $white;
+  position: absolute;
+  top: 0; left :0;
+}
+
+.certification-background-banner-wrapper {
+  position: relative;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+@include device-is('mobile') {
+  .certification-background-banner-wrapper {
+    padding: 0 24px;
+  }
+}

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -2,38 +2,39 @@
   font-family: $font-open-sans;
   display: flex;
   flex-direction: row;
-}
+  padding: 32px 16px;
 
-.user-certifications-detail-header__data-box {
-  padding-left: 2rem;
-  color: $grey-80;
+  .user-certifications-detail-header__info-certificate {
+
+    color: $grey-80;
+    align-self: center;
 
     & > * {
       margin: 0;
       font-size: 1rem;
     }
 
-  p {
-    padding-bottom: 0.313rem;
-    margin: 0;
-    margin-block-start: 0;
-    margin-block-end: 0;
+    h1 {
+      font-weight: lighter;
+      font-size: 2rem;
+    }
+
+    p:nth-child(4) {
+      font-weight: bold ;
+    }
+
+    &--grey {
+      color: $grey-45;
+      font-size: 0.875rem;
+
+      &:nth-child(2) {
+        margin-top: 10px;
+      }
+      &:nth-child(3) {
+        margin-bottom: 10px
+      }
+    }
   }
-}
-
-.user-certifications-detail-header__data-box-title {
-  line-height: 1.5rem;
-  font-size: 1.25rem;
-  font-weight: normal;
-  padding-bottom: 0.375rem;
-}
-
-.user-certifications-detail-header__data-box-title-big {
-  font-family: $font-open-sans;
-
-  line-height: 2rem;
-  font-size: 1.75rem;
-  font-weight: 600;
 }
 
 @include device-is('mobile') {
@@ -42,7 +43,7 @@
     justify-content: center;
   }
 
-  .user-certifications-detail-header__data-box {
+  .user-certifications-detail-header__info-certificate {
     padding: 14px 24px;
   }
 }
@@ -51,14 +52,10 @@
   .user-certifications-detail-header {
     flex-wrap: wrap;
   }
-
-  .user-certifications-detail-header__data-box {
-    padding: 14px 24px;
-  }
 }
 
 @include device-is('desktop') {
   .user-certifications-detail-header {
-    margin: 0 0 40px;
+    flex-wrap: nowrap;
   }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -2,19 +2,16 @@
   font-family: $font-open-sans;
   display: flex;
   flex-direction: row;
-  margin: 0 10px 40px;
-
-  @include device-is('desktop') {
-    margin: 0 0 40px;
-  }
 }
 
 .user-certifications-detail-header__data-box {
   padding-left: 2rem;
   color: $grey-80;
 
-  font-size: 1.125rem;
-  line-height: 1.25rem;
+    & > * {
+      margin: 0;
+      font-size: 1rem;
+    }
 
   p {
     padding-bottom: 0.313rem;
@@ -37,4 +34,31 @@
   line-height: 2rem;
   font-size: 1.75rem;
   font-weight: 600;
+}
+
+@include device-is('mobile') {
+  .user-certifications-detail-header {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .user-certifications-detail-header__data-box {
+    padding: 14px 24px;
+  }
+}
+
+@include device-is('tablet') {
+  .user-certifications-detail-header {
+    flex-wrap: wrap;
+  }
+
+  .user-certifications-detail-header__data-box {
+    padding: 14px 24px;
+  }
+}
+
+@include device-is('desktop') {
+  .user-certifications-detail-header {
+    margin: 0 0 40px;
+  }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -2,9 +2,9 @@
   font-family: $font-open-sans;
   display: flex;
   flex-direction: row;
-  padding: 32px 16px;
+  padding: 32px 0px;
 
-  .user-certifications-detail-header__info-certificate {
+  &__info-certificate {
 
     color: $grey-80;
     align-self: center;
@@ -35,27 +35,18 @@
       }
     }
   }
-}
 
-@include device-is('mobile') {
-  .user-certifications-detail-header {
-    flex-wrap: wrap;
-    justify-content: center;
+  @include device-is('mobile') {
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 16px;
   }
 
-  .user-certifications-detail-header__info-certificate {
-    padding: 14px 24px;
+  @include device-is('tablet') {
+      flex-wrap: wrap;
   }
-}
 
-@include device-is('tablet') {
-  .user-certifications-detail-header {
-    flex-wrap: wrap;
-  }
-}
-
-@include device-is('desktop') {
-  .user-certifications-detail-header {
-    flex-wrap: nowrap;
+  @include device-is('desktop') {
+      flex-wrap: nowrap;
   }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -5,15 +5,25 @@
   flex-direction: column;
   flex-wrap: wrap;
   justify-content: flex-start;
-  max-width:370px;
+  max-width: 370px;
+  height: 100%;
 
   color: $grey-80;
   font-size: 1.125rem;
   line-height: 1.625rem;
   margin-bottom: 40px;
 
+  @include device-is('mobile') {
+    min-width: 100%;
+  }
+
+  @include device-is('tablet') {
+    min-width: 100%;
+  }
+
   @include device-is('desktop') {
-    margin-right: 20px;
+    min-width: 30%;
+    margin-left: 20px;
   }
 
   &__pix-score{

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -1,11 +1,77 @@
-.user-certifications-page-get__top-bar {
-  margin: 0 10px 40px;
+.user-certifications-page-get {
+  position: relative;
 
-  @include device-is('desktop') {
-    margin: 0 0 10px;
+  .link__return-to {
+    position: absolute;
+    margin-left: -6px;
+    top: 28px;
+    align-self: start;
+    color: $white;
+
+    span {
+      color: $white;
+    }
+  }
+
+  &--over-background-banner {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-top: -205px;
+  }
+
+  &--details-body {
+    display: flex;
+    width: 100%;
+    max-width: 980px;
+    margin: 0 10px;
   }
 }
 
-.user-certifications-page-get__link-return-to {
-  padding-top: 14px;
+@include device-is('mobile') {
+  .user-certifications-page-get {
+
+    .link__return-to {
+      top: calc(-0.813rem - 20px);
+    }
+
+    &--over-background-banner {
+      z-index: 1;
+      margin-top: 68px;
+      position: relative;
+    }
+  
+    &--details-body {
+      flex-wrap: wrap;
+    }
+  }
+}
+
+@include device-is('tablet') {
+  .user-certifications-page-get {
+
+    .link__return-to {
+      top: calc(-0.813rem - 20px);
+    }
+
+    &--over-background-banner {
+      max-width: 980px;
+      z-index: 1;
+      margin-top: 68px;
+      position: relative;
+    }
+
+    &--details-body {
+      flex-wrap: wrap;
+    }
+  }
+}
+
+@include device-is('desktop') {
+  .user-certifications-page-get {
+
+    &--details-body {
+      flex-wrap: nowrap;
+    }
+  }
 }

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -2,13 +2,14 @@
   position: relative;
 
   .link__return-to {
+    top: calc(-0.813rem - 20px);
     position: absolute;
     margin-left: -6px;
-    top: 28px;
     align-self: start;
     color: $white;
 
-    span {
+    .icon-button {
+      margin-right: 0;
       color: $white;
     }
   }
@@ -17,7 +18,10 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    margin-top: -205px;
+    max-width: 980px;
+    z-index: 1;
+    margin-top: 68px;
+    position: relative;
   }
 
   &--details-body {
@@ -40,7 +44,7 @@
       margin-top: 68px;
       position: relative;
     }
-  
+
     &--details-body {
       flex-wrap: wrap;
     }
@@ -49,17 +53,6 @@
 
 @include device-is('tablet') {
   .user-certifications-page-get {
-
-    .link__return-to {
-      top: calc(-0.813rem - 20px);
-    }
-
-    &--over-background-banner {
-      max-width: 980px;
-      z-index: 1;
-      margin-top: 68px;
-      position: relative;
-    }
 
     &--details-body {
       flex-wrap: wrap;

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -1,6 +1,6 @@
 {{#if @certification.date}}
   <div class="user-certifications-detail-header">
-    <UserCertificationsHexagoneScore @score={{@certification.pixScore}} />
+    <UserCertificationsHexagonScore @score={{@certification.pixScore}} />
     <div class="user-certifications-detail-header__info-certificate">
 
       <h1>Certificat Pix</h1>

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -1,18 +1,24 @@
-<img src="{{rootURL}}/images/icons/icon-certification.svg"
-     alt=""
-     class="user-certifications-detail-header__icon">
+{{#if @certification.date}}
+  <div class="user-certifications-detail-header">
+    <UserCertificationsHexagoneScore @score={{@certification.pixScore}} />
+    <div class="user-certifications-detail-header__info-certificate">
 
-<div class="user-certifications-detail-header__data-box">
-  {{#if certification.date}}
-    <p class="user-certifications-detail-header__data-box-title">
-      <span class="user-certifications-detail-header__data-box-title-big">CERTIFICAT</span>
-      obtenu le {{moment-format certification.date 'LL' locale='fr' allow-empty=true}}
-    </p>
-    <p>Nom : {{certification.firstName}} {{certification.lastName}}</p>
-    <p>Date de naissance : {{moment-format certification.birthdate 'LL' locale='fr' allow-empty=true}}</p>
-    <p>Lieu de naissance : {{certification.birthplace}}</p>
-    {{#if certification.certificationCenter}}
-      <p>Centre de certification : {{certification.certificationCenter}}</p>
-    {{/if}}
-  {{/if}}
-</div>
+      <h1>Certificat Pix</h1>
+
+      <p class="user-certifications-detail-header__info-certificate--grey">
+        Délivré le {{moment-format @certification.deliveredAt 'LL' locale='fr' allow-empty=true}}
+      </p>
+      <p class="user-certifications-detail-header__info-certificate--grey">
+        Certificat valable 3 ans
+      </p>
+
+      <p>{{@certification.fullName}}</p>
+      <p>Né(e) le {{moment-format @certification.birthdate 'LL' locale='fr' allow-empty=true}} à {{@certification.birthplace}}</p>
+      {{#if @certification.certificationCenter}}
+      <p>Centre de certification : {{@certification.certificationCenter}}</p>
+      {{/if}}
+      <p>Date de passage : {{moment-format @certification.date 'LL' locale='fr' allow-empty=true}}</p>
+
+    </div>
+  </div>
+{{/if}}

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,18 +1,7 @@
-<div class="user-certifications-detail-result__pix-score">
-  <div class="user-certifications-detail-result__badge-pix-score">
-    <span>{{ certification.pixScore }}</span>
-  </div>
-  <div class="user-certifications-detail-result__pix-certified">
-    Pix certifiés
-  </div>
-</div>
-
 <div class="user-certifications-detail-result__text-pix-certified">
   Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification.
   Il peut donc différer de votre nombre de Pix affiché dans votre profil.
 </div>
-
-
 
 {{#if certification.hasCleaCertif}}
   <hr>
@@ -28,4 +17,3 @@
     </div>
   {{/if}}
 </div>
-

--- a/mon-pix/app/templates/components/user-certifications-hexagon-score.hbs
+++ b/mon-pix/app/templates/components/user-certifications-hexagon-score.hbs
@@ -1,0 +1,7 @@
+<div class="user-certification-hexagon-score">
+  <div class="user-certification-hexagon-score__content">
+    <p class="user-certification-hexagon-score__content-title">PIX</p>
+    <p class="user-certification-hexagon-score__content-pix-score">{{@score}}</p>
+    <p class="user-certification-hexagon-score__content-certified">certifiés</p>
+  </div>
+</div>

--- a/mon-pix/app/templates/user-certifications.hbs
+++ b/mon-pix/app/templates/user-certifications.hbs
@@ -3,9 +3,7 @@
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
 
-    <div class="user-certifications-page__container">
-      {{outlet}}
-    </div>
+    {{outlet}}
 
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -10,8 +10,8 @@
     <UserCertificationsDetailHeader @certification={{@model}} />
   </div>
 
-  <div class="user-certifications-page__detail-content">
-    <UserCertificationsDetailResult @certification={{@model}} />
+  <div class="user-certifications-page-get--details-body">
     <UserCertificationsDetailProfile @resultCompetenceTree={{@model.resultCompetenceTree}} />
+    <UserCertificationsDetailResult @certification={{@model}} />
   </div>
 </div>

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -1,18 +1,17 @@
-<div class="user-certifications-page-get__top-bar">
-  <LinkTo @route="user-certifications" class="link__return-to user-certifications-page-get__link-return-to">
-    <span class="icon-button">
-      {{fa-icon 'arrow-left'}}
-    </span>
-    Retour à la liste
-  </LinkTo>
-</div>
+<div class="user-certifications-page-get certification-background-banner-wrapper">
 
-<UserCertificationsDetailHeader @certification={{@model}} />
+  <div class="certification-background-banner"></div>
 
-<div class="user-certifications-page__detail-content">
+  <div class="rounded-panel user-certifications-page-get--over-background-banner">
+    <LinkTo @route="user-certifications" class="link__return-to">
+      <span class="icon-button"> {{fa-icon 'arrow-left'}} </span>
+      Retour à la liste des certifications
+    </LinkTo>
+    <UserCertificationsDetailHeader @certification={{@model}} />
+  </div>
 
-  <UserCertificationsDetailResult @certification={{@model}} />
-
-  <UserCertificationsDetailProfile @resultCompetenceTree={{@model.resultCompetenceTree}} />
-
+  <div class="user-certifications-page__detail-content">
+    <UserCertificationsDetailResult @certification={{@model}} />
+    <UserCertificationsDetailProfile @resultCompetenceTree={{@model.resultCompetenceTree}} />
+  </div>
 </div>

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -5,7 +5,7 @@
   <div class="rounded-panel user-certifications-page-get--over-background-banner">
     <LinkTo @route="user-certifications" class="link__return-to">
       <span class="icon-button"> {{fa-icon 'arrow-left'}} </span>
-      Retour à la liste des certifications
+      Retour à mes certifications
     </LinkTo>
     <UserCertificationsDetailHeader @certification={{@model}} />
   </div>

--- a/mon-pix/app/templates/user-certifications/index.hbs
+++ b/mon-pix/app/templates/user-certifications/index.hbs
@@ -1,3 +1,5 @@
-<h1 class="user-certifications-page__title">Mes Certifications</h1>
+<div class="user-certifications-page__container">
+    <h1 class="user-certifications-page__title">Mes Certifications</h1>
 
-<UserCertificationsPanel @certifications={{@model}} />
+    <UserCertificationsPanel @certifications={{@model}} />
+</div>

--- a/mon-pix/public/images/macaron-certif.svg
+++ b/mon-pix/public/images/macaron-certif.svg
@@ -1,0 +1,29 @@
+<svg width="200" height="216" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient x1="68.643%" y1="0%" x2="68.643%" y2="100%" id="c">
+      <stop stop-color="#FFBE00" offset="0%"/>
+      <stop stop-color="#FF9F00" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="50%" y1="9.534%" x2="50%" y2="100%" id="d">
+      <stop stop-color="#FFBE00" offset="0%"/>
+      <stop stop-color="#FF9F00" offset="100%"/>
+    </linearGradient>
+    <filter x="-27.5%" y="-22.4%" width="155%" height="149.9%" filterUnits="objectBoundingBox" id="a">
+      <feMorphology radius="6.156" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"/>
+      <feOffset dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="10.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 1 0 0 0 0 0.636582168 0 0 0 0 0 0 0 0 0.5 0" in="shadowBlurOuter1"/>
+    </filter>
+    <path d="M60.044 3.228L12.047 30.939A24.09 24.09 0 000 51.803v55.424a24.09 24.09 0 0012.047 20.864l47.997 27.711a24.09 24.09 0 0024.091 0l48-27.711a24.092 24.092 0 0012.045-20.864V51.803c0-8.607-4.592-16.56-12.046-20.864L84.135 3.228a24.09 24.09 0 00-24.09 0z" id="b"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <g fill-rule="nonzero" transform="translate(28 24.256)">
+      <use fill="#000" filter="url(#a)" xlink:href="#b"/>
+      <use fill="#FFF" xlink:href="#b"/>
+      <path stroke="#FFF" stroke-width="6.156" d="M10.508 28.274a27.152 27.152 0 00-9.946 9.944 27.15 27.15 0 00-3.64 13.585v55.424a27.15 27.15 0 003.64 13.585 27.152 27.152 0 009.946 9.944l47.997 27.712a27.15 27.15 0 0013.585 3.64 27.15 27.15 0 0013.584-3.64l48-27.712a27.17 27.17 0 0013.584-23.53V51.804a27.17 27.17 0 00-13.585-23.53L85.674.563a27.15 27.15 0 00-13.584-3.64A27.15 27.15 0 0058.505.562L10.508 28.274z"/>
+      <path stroke="url(#c)" stroke-width="6.156" d="M13.586 33.605a21 21 0 00-7.693 7.692 20.998 20.998 0 00-2.815 10.506v55.424c0 3.754 1.001 7.365 2.815 10.506a21 21 0 007.693 7.692l47.997 27.712a20.999 20.999 0 0010.507 2.815c3.628 0 7.256-.938 10.506-2.815l48-27.712a21.014 21.014 0 0010.506-18.198V51.803a21.014 21.014 0 00-10.507-18.198L82.596 5.893A20.999 20.999 0 0072.09 3.078c-3.628 0-7.256.938-10.507 2.815L13.586 33.605z" stroke-linejoin="square"/>
+    </g>
+    <path d="M110.945 107.788l1.36 2.756a.154.154 0 00.115.084l3.042.442a.154.154 0 01.085.262l-2.2 2.145a.154.154 0 00-.045.136l.52 3.03a.154.154 0 01-.223.161l-2.72-1.43a.154.154 0 00-.144 0l-2.72 1.43a.154.154 0 01-.223-.162l.52-3.03a.154.154 0 00-.045-.135l-2.2-2.145a.154.154 0 01.085-.262l3.041-.442a.154.154 0 00.116-.084l1.36-2.756a.154.154 0 01.276 0M32.855 107.788l1.36 2.756a.154.154 0 00.115.084l3.042.442a.154.154 0 01.085.262l-2.2 2.145a.154.154 0 00-.045.136l.52 3.03a.154.154 0 01-.223.161l-2.72-1.43a.154.154 0 00-.144 0l-2.72 1.43a.154.154 0 01-.223-.162l.52-3.03a.154.154 0 00-.045-.135l-2.2-2.145a.154.154 0 01.085-.262l3.041-.442a.154.154 0 00.116-.084l1.36-2.756a.154.154 0 01.276 0" fill="url(#d)" transform="translate(28 24.256)"/>
+  </g>
+</svg>

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -9,11 +9,8 @@ describe('Integration | Component | user certifications detail header', function
   setupRenderingTest();
 
   let certification;
-
-  it('renders', async function() {
-    await render(hbs`{{user-certifications-detail-header certification=certification}}`);
-    expect(find('.user-certifications-detail-header')).to.exist;
-  });
+  const PARENT_SELECTOR = '.user-certifications-detail-header';
+  const CONTENT_SELECTOR = `${PARENT_SELECTOR}__info-certificate`;
 
   context('when certification is complete', function() {
 
@@ -23,9 +20,11 @@ describe('Integration | Component | user certifications detail header', function
         id: 1,
         birthdate: '2000-01-22',
         birthplace: 'Paris',
-        firstName: 'Jean',
-        lastName: 'Bon',
+        firstName: 'jean',
+        lastName: 'bon',
+        fullName: 'Jean Bon',
         date: new Date('2018-02-15T15:15:52Z'),
+        deliveredAt: new Date('2018-02-17T15:15:52Z'),
         certificationCenter: 'Université de Lyon',
         isPublished: true,
         pixScore: 654,
@@ -38,32 +37,40 @@ describe('Integration | Component | user certifications detail header', function
       await render(hbs`{{user-certifications-detail-header certification=certification}}`);
     });
 
-    // then
-    it('should show the certification icon', function() {
-      expect(find('.user-certifications-detail-header__icon')).to.exist;
+    it('renders', async function() {
+      expect(find(PARENT_SELECTOR)).to.exist;
     });
 
-    it('should show the certification date', function() {
-      expect(find('.user-certifications-detail-header__data-box')).to.exist;
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('15 février 2018');
+    it('should show the certification published date', function() {
+      expect(find(CONTENT_SELECTOR)).to.exist;
+      expect(find(`${CONTENT_SELECTOR} :nth-child(2)`).textContent)
+        .to.include('Délivré le 17 février 2018');
+    });
+
+    it('should show the certification exam date', function() {
+      expect(find(`${CONTENT_SELECTOR} :nth-child(7)`).textContent)
+        .to.include('Date de passage : 15 février 2018');
     });
 
     it('should show the certification user full name', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Nom : Jean Bon');
+      expect(find(`${CONTENT_SELECTOR} :nth-child(4)`).textContent)
+        .to.include('Jean Bon');
     });
 
-    it('should show the certification user birthdate', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Date de naissance : 22' +
-        ' janvier 2000');
-    });
-
-    it('should show the certification user birthplace', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Lieu de naissance : Paris');
+    it('should show the certification user birthdate and birthplace', function() {
+      expect(find(`${CONTENT_SELECTOR} :nth-child(5)`).textContent)
+        .to.include('Né(e) le 22 janvier 2000 à Paris');
     });
 
     it('should show the certification center', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.include('Centre de' +
-        ' certification : Université de Lyon');
+      expect(find(`${CONTENT_SELECTOR} :nth-child(6)`).textContent)
+        .to.include('Centre de certification : Université de Lyon');
+    });
+
+    it('should show the pix score', function() {
+      const scoreHexagon = find(`${PARENT_SELECTOR} .user-certification-hexagon-score__content-pix-score`);
+      expect(scoreHexagon).to.exist;
+      expect(scoreHexagon.textContent).to.include('654');
     });
   });
 
@@ -91,25 +98,8 @@ describe('Integration | Component | user certifications detail header', function
     });
 
     // then
-    it('should not show the certification date', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('obtenue le');
-    });
-
-    it('should not show the certification user full name', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Nom :');
-    });
-
-    it('should not show the certification user birthdate', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Date de naissance :');
-    });
-
-    it('should not show the certification user birthplace', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Lieu de naissance :');
-    });
-
-    it('should not show the certification center', function() {
-      expect(find('.user-certifications-detail-header__data-box').textContent).to.not.include('Centre de' +
-        ' certification :');
+    it('should not render the user-certifications-detail-header component', function() {
+      expect(find(PARENT_SELECTOR)).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
@@ -37,12 +37,6 @@ describe('Integration | Component | user certifications detail result', function
       await render(hbs`{{user-certifications-detail-result certification=certification}}`);
     });
 
-    // then
-    it('should show the pix score', function() {
-      expect(find('.user-certifications-detail-result__pix-score')).to.exist;
-      expect(find('.user-certifications-detail-result__pix-score').textContent).to.include('654');
-    });
-
     it('should show the comment for candidate', function() {
       expect(find('.user-certifications-detail-result__comment-jury')).to.exist;
       expect(find('.user-certifications-detail-result__comment-jury').textContent).to.include('Comment for candidate');
@@ -69,12 +63,6 @@ describe('Integration | Component | user certifications detail result', function
 
       // when
       await render(hbs`{{user-certifications-detail-result certification=certification}}`);
-    });
-
-    // then
-    it('should show the pix score', function() {
-      expect(find('.user-certifications-detail-result__pix-score')).to.exist;
-      expect(find('.user-certifications-detail-result__pix-score').textContent).to.include('654');
     });
 
     it('should not show the comment for candidate', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'epix "Partage et contrôle du certificat" un nouveau design de certificat a été créé.
Ce nouveau design permettra d'aider au partage du certificat (notamment avec une vérification par code).

## :robot: Solution
Cette première partie permet de changer le "header"/haut du certificat : 
- ajout de la bannière bleu de fond
- modification du contenu du premier bloc blanc (ajout d'un nouveau hexagone de certif + formatage du texte)
- suppression de l'ancien macaron et inversement des deux panels du bas

Résultat attendu pour cette PR : 
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/38167520/85122832-7d11ab00-b227-11ea-9760-340965093748.png">


## :rainbow: Remarques
Modèles responsives ici : https://app.abstract.com/projects/3e4937ef-48a8-408b-9edd-1f69dab81b39/branches/288b95d2-6697-44a9-a4ba-2339a4480aad/collections/4ea4253d-5685-4ffc-afaa-632e144ec8f4

## :100: Pour tester
- lancer l'app mon-pix
- se connecter avec un compte ayant passé une certif et l'ayant obtenue (ex: `certif-success@example.net`)
- aller sur la page de détail d'une certification (ex: `http://localhost:4200/mes-certifications/104093`)
- constater le nouveau header du certificat
- redimensionner la page, constater que sous mobile et tablette l'affichage reste 

TODO : 
- [ ] test cypress
- [x] enlever code mort

