### PR TITLE
[BUGFIX] Format de date invalide lors de la création d'un utilisateur SCO (PIX-834).

### DIFF
--- a/api/lib/application/student-dependent-users/index.js
+++ b/api/lib/application/student-dependent-users/index.js
@@ -1,4 +1,7 @@
 const schoolingRegistrationDependentUserController = require('./../schooling-registration-dependent-users/schooling-registration-dependent-user-controller');
+const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const { passwordValidationPattern } = require('../../config').account;
+const XRegExp = require('xregexp');
 
 exports.register = async function(server) {
   server.route([
@@ -8,6 +11,23 @@ exports.register = async function(server) {
       config: {
         auth: false,
         handler: schoolingRegistrationDependentUserController.createAndAssociateUserToSchoolingRegistration,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'first-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                'birthdate': Joi.date().format('YYYY-MM-DD').raw().required(),
+                'campaign-code': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
+                password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
+                'with-username': Joi.boolean().required(),
+              },
+            },
+          })
+        },
         notes: [
           'Cette route crée un utilisateur et l\'associe à l\'inscription de l\'élève, celle-ci étant recherchée dans l\'organisation à laquelle ' +
           'appartient la campagne spécifiée' +

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -17,28 +17,102 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
   describe('POST /api/schooling-registration-dependent-users', () => {
 
-    it('should succeed', async () => {
+    let method;
+    let url;
+    let payload;
+    let response;
+
+    beforeEach(async () => {
       // given
-      const method = 'POST';
-      const url = '/api/schooling-registration-dependent-users';
-      const payload = {
+      method = 'POST';
+      url = '/api/schooling-registration-dependent-users';
+      payload = {
         data: {
           attributes: {
-            'campaign-code': 'RESTRICD',
+            'campaign-code': 'RESTRICTD',
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: '2012-12-12',
             username: 'robert.smith1212',
-            password: 'P@ssw0rd'
+            password: 'P@ssw0rd',
+            'with-username': true,
           }
         }
       };
+    });
 
+    it('should succeed', async () => {
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      response = await httpTestServer.request(method, url, payload);
 
       // then
       expect(response.statusCode).to.equal(201);
+    });
+
+    it('should return 400 when firstName is empty', async () => {
+      // given
+      payload.data.attributes['first-name'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when lastName is empty', async () => {
+      // given
+      payload.data.attributes['last-name'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when birthDate is not a valid date', async () => {
+      // given
+      payload.data.attributes.birthdate = '2012*-12-12';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when campaignCode is empty', async () => {
+      // given
+      payload.data.attributes['campaign-code'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when password is not valid', async () => {
+      // given
+      payload.data.attributes.password = 'not_valid';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when withUsername is not a boolean', async () => {
+      // given
+      payload.data.attributes['with-username'] = 'not_a_boolean';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -34,6 +34,8 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
         'birthdate': '2012-12-12',
         'campaign-code': 'RESTRICTD',
         'password': 'P@ssw0rd',
+        'username': 'Robert.Smith1212',
+        'with-username': true,
       };
     });
 

--- a/api/tests/integration/application/student-dependent-users/index_test.js
+++ b/api/tests/integration/application/student-dependent-users/index_test.js
@@ -16,28 +16,102 @@ describe('Integration | Application | Route | student-dependent-users', () => {
 
   describe('POST /api/student-dependent-users', () => {
 
-    it('should succeed', async () => {
+    let method;
+    let url;
+    let payload;
+    let response;
+
+    beforeEach(async () => {
       // given
-      const method = 'POST';
-      const url = '/api/student-dependent-users';
-      const payload = {
+      method = 'POST';
+      url = '/api/student-dependent-users';
+      payload = {
         data: {
           attributes: {
-            'campaign-code': 'RESTRICD',
+            'campaign-code': 'RESTRICTD',
             'first-name': 'Robert',
             'last-name': 'Smith',
             birthdate: '2012-12-12',
             username: 'robert.smith1212',
-            password: 'P@ssw0rd'
+            password: 'P@ssw0rd',
+            'with-username': true,
           }
         }
       };
+    });
 
+    it('should succeed', async () => {
       // when
-      const response = await httpTestServer.request(method, url, payload);
+      response = await httpTestServer.request(method, url, payload);
 
       // then
       expect(response.statusCode).to.equal(201);
+    });
+
+    it('should return 400 when firstName is empty', async () => {
+      // given
+      payload.data.attributes['first-name'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when lastName is empty', async () => {
+      // given
+      payload.data.attributes['last-name'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when birthDate is not a valid date', async () => {
+      // given
+      payload.data.attributes.birthdate = '2012*-12-12';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when campaignCode is empty', async () => {
+      // given
+      payload.data.attributes['campaign-code'] = '';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when password is not a valid', async () => {
+      // given
+      payload.data.attributes.password = 'not_valid';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when withUsername is not a boolean', async () => {
+      // given
+      payload.data.attributes['with-username'] = 'not_a_boolean';
+
+      // when
+      response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Une erreur 500 a été remontée suite à l'envoi d'une date invalide à l'API ("2005*-06-14") :
https://sentry.io/organizations/pix/issues/1704634340/events/454a8ab48deb407a9eefede275bea8dc/?project=1398749

Je n'ai malheureusement pas été en mesure de reproduire "normalement" cette erreur. Le processus d'inscription d'un élève s'effectue en deux étapes:
- Vérification de la possibilité d'associer un utilisateur à une `schooling-registration` via son nom, prénom et date de naissance (`PUT /api/student-user-associations/possibilities`). Cette route possède une validation front et back vérifiant le format de la date.
- Création de l'utilisateur et association de celui-ci à sa `schooling-registration` (`POST /api/student-dependent-users`). Cette route ne possède pas de validation et cette dernière est l'objet de cette PR.
Cependant, suite au premier appel et à son succès, le champ date est `disabled` empêchant, normalement, de la modifier.

Afin de reproduire le problème, j'ai inspecter l'élément représentant l'année et j'ai supprimé l'attribut `disabled`. Je doute cependant que ce soit ce qu'à fait l'utilisateur.
 
![Capture d’écran de 2020-06-12 15-46-08](https://user-images.githubusercontent.com/1216570/84515516-dbd9a080-accc-11ea-8ecc-ad96b7a00389.png)

Si quelqu'un a une idée pour reproduire le problème je suis preneur.
 
## :robot: Solution
Rajouter une validation Joi aux routes:
- `POST /api/student-dependent-users`
- `POST /api/schooling-registration-dependent-users`
Ces deux routes sont les mêmes (elles pointent sur le même controller) et existent car `student` a été renommé en `schooling-registration`. Cependant, ce changement de nom n'a pas encore été effectué dans le front.  

## :rainbow: Remarques
Lien Datadog du processus : https://app.datadoghq.eu/logs?cols=core_host%2Ccore_service&event&from_ts=1591952400000&index=main&live=false&messageDisplay=inline&query=host%3Arouter+status%3A%28error+OR+ok%29+%28%40http.url_details.path%3A%22%2Fapi%2Fstudent-dependent-users%22+OR+%22%2Fapi%2Fstudent-user-associations%22%29+-service%3Apix-app-production+%40http.referer_details.path%3A%22%2Fcampagnes%2FXFDGGZ773%2Frestreinte%2Fidentification%22&stream_sort=desc&to_ts=1591956000000

## :100: Pour tester
A part par un curl/Postman ou via la manip expliquée plus haut, je ne vois pas.
