### PR TITLE
[FEATURE] Afficher les competences avec score et niveau pour un participant (PIX-622)

### DIFF
--- a/api/lib/domain/read-models/CampaignProfile.js
+++ b/api/lib/domain/read-models/CampaignProfile.js
@@ -1,3 +1,5 @@
+const CampaignProfileCompetence = require('./CampaignProfileCompetence');
+
 class CampaignProfile {
 
   constructor({
@@ -48,6 +50,15 @@ class CampaignProfile {
       return this.certificationProfile.getCompetencesCount();
     }
     return null;
+  }
+
+  get competences() {
+    if (this.isShared) {
+      return this.certificationProfile.userCompetences.map((competence) => {
+        return new CampaignProfileCompetence(competence);
+      });
+    }
+    return [];
   }
 }
 

--- a/api/lib/domain/read-models/CampaignProfileCompetence.js
+++ b/api/lib/domain/read-models/CampaignProfileCompetence.js
@@ -1,0 +1,19 @@
+class CampaignProfileCompetence {
+  constructor({
+    id,
+    index,
+    name,
+    pixScore,
+    estimatedLevel,
+    area
+  } = {}) {
+    this.id = id;
+    this.index = index;
+    this.name = name;
+    this.pixScore = pixScore;
+    this.estimatedLevel = estimatedLevel;
+    this.areaColor = area && area.color;
+  }
+}
+
+module.exports = CampaignProfileCompetence;

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
@@ -17,7 +17,21 @@ module.exports = {
         'competencesCount',
         'certifiableCompetencesCount',
         'isCertifiable',
+        'competences'
       ],
+      typeForAttribute: (attribute) => {
+        if (attribute === 'competences') return 'campaign-profile-competences';
+      },
+      competences: {
+        ref: 'id',
+        attributes: [
+          'name',
+          'index',
+          'pixScore',
+          'estimatedLevel',
+          'areaColor'
+        ],
+      },
     }).serialize(campaignProfile);
   },
 };

--- a/api/tests/unit/domain/read-models/CampaignProfile_test.js
+++ b/api/tests/unit/domain/read-models/CampaignProfile_test.js
@@ -97,6 +97,45 @@ describe('Unit | Domain | Read-Models | CampaignProfile', () => {
     });
   });
 
+  describe('#competences', () => {
+    context('when the campaign participation is shared', () => {
+      it('returns user competences', () => {
+        const params = { isShared: true };
+        const competence = {
+          id: 1,
+          name: 'competence1',
+          pixScore: 1,
+          estimatedLevel: 1,
+          area: { color: 'blue' },
+          index: '1.1',
+        };
+        const certificationProfile = { userCompetences: [competence] };
+
+        const campaignProfile = new CampaignProfile({ ...params, certificationProfile });
+
+        expect(campaignProfile.competences).to.deep.equal([{ 
+          id: 1,
+          name: 'competence1',
+          pixScore: 1,
+          estimatedLevel: 1,
+          areaColor: 'blue', 
+          index: '1.1',
+        }]);
+      });
+    });
+
+    context('when the campaign participation is not shared', () => {
+      it('does not compute the number of competence', () => {
+        const params = { isShared: false };
+        const certificationProfile = { userCompetences: [{ name: 'competence1' }] };
+
+        const campaignProfile = new CampaignProfile({ ...params, certificationProfile });
+
+        expect(campaignProfile.competences).to.be.empty;
+      });
+    });
+  });
+
   describe('#firstName', () => {
     it('returns the user first name', () => {
       const params = { firstName: 'John' };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
@@ -1,24 +1,40 @@
 const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-profile-serializer');
+const CampaignProfile = require('../../../../../lib/domain/read-models/CampaignProfile');
+const CertificationProfile = require('../../../../../lib/domain/models/CertificationProfile');
+const UserCompetence = require('../../../../../lib/domain/models/UserCompetence');
+const Area = require('../../../../../lib/domain/models/Area');
 
 describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function() {
 
   describe('#serialize', function() {
 
-    const campaignProfile = {
+    const campaignProfile = new CampaignProfile({
       campaignParticipationId: 9,
       campaignId: 8,
       firstName: 'someFirstName',
       lastName: 'someLastName',
       isShared: true,
-      externalId: 'anExternalId',
+      participantExternalId: 'anExternalId',
       createdAt: '2020-01-01',
       sharedAt: '2020-01-02',
-      pixScore: 'someParticipantExternalId',
-      competencesCount: '10',
-      certifiableCompetencesCount: '2',
-      isCertifiable: 'true',
-    };
+      certificationProfile: new CertificationProfile({
+        userCompetences: [
+          new UserCompetence({
+            id: 1,
+            name: 'competence1',
+            index: '1.1.1',
+            pixScore: 12,
+            estimatedLevel: 1,
+            area: new Area({
+              id: 1,
+              title: 'area1',
+              color: 'blue',
+            }),
+          }),
+        ],
+      }),
+    });
 
     const expectedJsonApi = {
       data: {
@@ -29,15 +45,34 @@ describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function()
           'last-name': 'someLastName',
           'campaign-id': 8,
           'external-id': 'anExternalId',
-          'pix-score': 'someParticipantExternalId',
+          'pix-score': 12,
           'created-at': '2020-01-01',
           'shared-at': '2020-01-02',
           'is-shared': true,
-          'competences-count': '10',
-          'certifiable-competences-count': '2',
-          'is-certifiable': 'true',
+          'competences-count': 1,
+          'certifiable-competences-count': 1,
+          'is-certifiable': false,
         },
-      }
+        relationships: {
+          competences: {
+            data: [{
+              id: '1',
+              type: 'campaign-profile-competences',
+            }]
+          },
+        },
+      },
+      included: [{
+        type: 'campaign-profile-competences',
+        id: '1',
+        attributes: {
+          name: 'competence1',
+          'index': '1.1.1',
+          'pix-score': 12,
+          'estimated-level': 1,
+          'area-color': 'blue',
+        },
+      }],
     };
 
     it('should convert a campaignProfile model object into JSON API data', function() {

--- a/orga/app/models/campaign-profile-competence.js
+++ b/orga/app/models/campaign-profile-competence.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+const { Model, attr } = DS;
+
+export default class CampaignProfileCompetence extends Model {
+  @attr('string') name;
+
+  @attr('string') index;
+
+  @attr('number') pixScore;
+
+  @attr('number') estimatedLevel;
+
+  @attr('string') areaColor;
+}

--- a/orga/app/models/campaign-profile.js
+++ b/orga/app/models/campaign-profile.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
-const { Model, attr } = DS;
+const { Model, attr, hasMany } = DS;
+import { computed } from '@ember/object';
 
 export default class CampaignProfile extends Model {
   @attr('string') firstName;
@@ -23,4 +24,11 @@ export default class CampaignProfile extends Model {
   @attr('number') competencesCount;
 
   @attr('boolean') isCertifiable;
+
+  @hasMany('campaignProfileCompetence') competences;
+
+  @computed('competences')
+  get sortedCompetences() {
+    return this.competences.sortBy('index');
+  }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -53,7 +53,7 @@
 @import "pages/authenticated/campaigns/details/participants/participant";
 @import "pages/authenticated/campaigns/details/participants/participant/header";
 @import "pages/authenticated/campaigns/details/participants/participant/results";
-@import "pages/authenticated/campaigns/profiles";
+@import "pages/authenticated/campaigns/profile";
 @import "pages/authenticated/team";
 @import "pages/authenticated/team/list";
 @import "pages/authenticated/team/new";

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -10,6 +10,12 @@ thead {
   width: 100%;
   color: $grey-100;
 
+  th {
+    font-family: $roboto;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
   caption {
     text-align: left;
     display: table-cell;
@@ -32,6 +38,13 @@ tbody {
       background-color: $grey-10;
       transition: 0.25s ease;
     }
+  }
+
+  td {
+    font-family: $roboto;
+    font-size: 0.875rem;
+    font-weight: 400;
+    color: $grey-80;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/campaigns/profile.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/profile.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.user {
+.profile-user {
   width: 100%;
   padding: 24px;
   box-sizing: border-box;
@@ -39,6 +39,10 @@
     margin: 0;
   }
 
+  &__certifiable {
+    margin-left: 8px;
+  }
+
   &__information {
     display: flex;
     justify-content: space-between;
@@ -47,7 +51,7 @@
   }
 }
 
-.user-data {
+.profile-user-data {
   display: flex;
   flex-direction: row;
   align-content: center;
@@ -111,3 +115,44 @@
   }
 }
 
+.profile-competences {
+  margin: 24px 0;
+}
+
+.competences-col {
+  &__name {
+    padding-left: 16px;
+    font-family: $open-sans;
+    font-size: 1rem;
+    font-weight: 600;
+    color: $grey-80;
+  }
+
+  &__border {
+    padding: 8px 0;
+    margin-right: 16px;
+    border-style: solid;
+    border-width: 1.5px;
+    border-radius: 1.5px;
+
+    &--jaffa {
+      border-color: $information-light;
+    }
+  
+    &--emerald {
+      border-color: $content-light;
+    }
+  
+    &--cerulean {
+      border-color: $communication-light;
+    }
+  
+    &--wild-strawberry {
+      border-color: $security-light;
+    }
+  
+    &--butterfly-bush {
+      border-color: $environment-light;
+    }
+  }
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/profile/profile.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/profile/profile.hbs
@@ -11,53 +11,60 @@
    </PreviousPageButton>
   </header>
 
-  <section class="user panel">
-    <header class="user__header">
-      <h2 class="user__name">
+  <section class="profile-user panel">
+    <header class="profile-user__header">
+      <h2 class="profile-user__name">
         {{@campaignProfile.firstName}} {{@campaignProfile.lastName}}
       </h2>
       {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
-        <PixTag @color="green-light">Certifiable</PixTag>
+        <PixTag @color="green-light" class="profile-user__certifiable">Certifiable</PixTag>
       {{/if}}
     </header>
 
-    <div class="user__information">
-      <ul class="user-data">
+    <div class="profile-user__information">
+      <ul class="profile-user-data">
         {{#if @campaignProfile.externalId}}
-          <li class="user-data__content">
-            <div class="user-data__content--label">Identifiant</div>
-            <div class="user-data__content--text">{{@campaignProfile.externalId}}</div>
+          <li class="profile-user-data__content">
+            <div class="profile-user-data__content--label">Identifiant</div>
+            <div class="profile-user-data__content--text">{{@campaignProfile.externalId}}</div>
           </li>
         {{/if}}
-        <li class="user-data__content">
-          <div class="user-data__content--label">Commencé le</div>
-          <div class="user-data__content--text">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</div>
+        <li class="profile-user-data__content">
+          <div class="profile-user-data__content--label">Commencé le</div>
+          <div class="profile-user-data__content--text">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</div>
         </li>
-        <li class="user-data__content">
-          <div class="user-data__content--label">Envoyé le</div>
+        <li class="profile-user-data__content">
+          <div class="profile-user-data__content--label">Envoyé le</div>
           {{#if @campaignProfile.sharedAt}}
-            <div class="user-data__content--text">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
+            <div class="profile-user-data__content--text">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
           {{else}}
-            <div class="user-data__content--text">Non disponible</div>
+            <div class="profile-user-data__content--text">Non disponible</div>
           {{/if}}
         </li>
       </ul>
 
       {{#if @campaignProfile.isShared}}
-        <ul class="user-data user-data--highlight">
-          <li class="user-data__content">
-            <span class="user-data--highlight-bold">{{@campaignProfile.pixScore}}</span>
-            <span class="user-data--highlight-label">PIX</span>
+        <ul class="profile-user-data profile-user-data--highlight">
+          <li class="profile-user-data__content">
+            <span class="profile-user-data--highlight-bold">{{@campaignProfile.pixScore}}</span>
+            <span class="profile-user-data--highlight-label">PIX</span>
           </li>
-          <li class="user-data__content">
-            <span class="user-data--highlight-text">
-              <span class="user-data--highlight-bold">{{@campaignProfile.certifiableCompetencesCount}}</span>
+          <li class="profile-user-data__content">
+            <span class="profile-user-data--highlight-text">
+              <span class="profile-user-data--highlight-bold">{{@campaignProfile.certifiableCompetencesCount}}</span>
               <span>&nbsp;/&nbsp;{{@campaignProfile.competencesCount}}</span>
             </span>
-            <span class="user-data--highlight-label">COMP. CERTIFIABLES</span>
+            <span class="profile-user-data--highlight-label">COMP. CERTIFIABLES</span>
           </li>
         </ul>
       {{/if}}
     </div>
+  </section>
+
+  <section class="profile-competences panel">
+    <Routes::Authenticated::Campaigns::Profile::Table
+      @competences={{@campaignProfile.sortedCompetences}}
+      @isShared={{@campaignProfile.isShared}}
+    />
   </section>
 </article>

--- a/orga/app/templates/components/routes/authenticated/campaigns/profile/table.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/profile/table.hbs
@@ -1,0 +1,35 @@
+<table>
+  <thead>
+    <tr>
+      <th>Compétence</th>
+      <th class="table__column table__column--center">
+        Niveau
+      </th>
+      <th class="table__column table__column--center">
+        Score Pix
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each @competences as |competence|}}
+      <tr aria-label="Competence">
+        <td class="competences-col__name">
+          <span class="competences-col__border competences-col__border--{{competence.areaColor}}" />
+          <span>
+            {{competence.name}}
+          </span>
+        </td>
+        <td class="table__column--center">
+          {{competence.estimatedLevel}}
+        </td>
+        <td class="table__column--center">
+          {{competence.pixScore}}
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+
+{{#unless @isShared }}
+  <div class="table__empty content-text">En attente de résultats</div>
+{{/unless}}

--- a/orga/tests/integration/components/routes/authenticated/campaigns/profile/table-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/profile/table-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/campaign/profile | table', function(hooks) {
+  setupRenderingTest(hooks);
+
+  module('when profile is not shared', function() {
+    test('it displays empty table message', async function(assert) {
+      this.isShared = false;
+      this.competences = [];
+
+      await render(hbs`<Routes::Authenticated::Campaigns::Profile::Table @competences={{competences}} @isShared={{isShared}} />`);
+
+      assert.contains('En attente de résultats');
+    });
+  });
+
+  module('when profile is shared', function() {
+    test('it displays area color as border', async function(assert) {
+      this.competences = [{ name: 'name1', areaColor: 'jaffa' }];
+      this.isShared = true;
+
+      await render(hbs`<Routes::Authenticated::Campaigns::Profile::Table @competences={{competences}} @isShared={{isShared}} />`);
+
+      assert.dom('.competences-col__border--jaffa').exists();
+    });
+
+    test('it displays multiple competences in the table', async function(assert) {
+      this.competences = [{ name: 'name1' }, { name: 'name2' }];
+      this.isShared = true;
+
+      await render(hbs`<Routes::Authenticated::Campaigns::Profile::Table @competences={{competences}} @isShared={{isShared}} />`);
+
+      assert.contains('name1');
+      assert.contains('name2');
+    });
+
+    test('it displays the table with competence informations', async function(assert) {
+      this.competences = [{ estimatedLevel: 999, pixScore: 666 }];
+      this.isShared = true;
+
+      await render(hbs`<Routes::Authenticated::Campaigns::Profile::Table @competences={{competences}} @isShared={{isShared}} />`);
+
+      assert.contains('666');
+      assert.contains('999');
+    });
+  });
+});

--- a/orga/tests/unit/models/campaign-profile-test.js
+++ b/orga/tests/unit/models/campaign-profile-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | campaign-profile', function(hooks) {
+  setupTest(hooks);
+
+  test('it should return the campaign-profile sorted competences', function(assert) {
+    const store = this.owner.lookup('service:store');
+  
+    const competence1 = store.createRecord('campaign-profile-competence', { index: '1.2' });
+    const competence2 = store.createRecord('campaign-profile-competence', { index: '2.1', });
+    const competence3 = store.createRecord('campaign-profile-competence', { index: '1.1.1' });
+    const competence4 = store.createRecord('campaign-profile-competence', { index: '1.1', });
+
+    const model = store.createRecord('campaign-profile', {
+      competences: [competence1, competence2, competence3, competence4]
+    });
+
+    const sortedCompetences = model.get('sortedCompetences');
+  
+    assert.equal(sortedCompetences[0].index, '1.1');
+    assert.equal(sortedCompetences[1].index, '1.1.1');
+    assert.equal(sortedCompetences[2].index, '1.2');
+    assert.equal(sortedCompetences[3].index, '2.1');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur un profil d'une collecte de profil, on ne voit pas le détail du score et des niveaux par compétences.

## :robot: Solution
Ajouter le tableau de compétence pour le profile de l'utilisateur avec le score et niveau par compétence.
(Uniquement s'il a partagé son profil, sinon indiqué qu'il n'est pas partagé).

## :100: Pour tester
1. Se connecter sur pix-orga avec le compte pro@example.net
2. Se rendre sur le campagne "Campagne Collecte Profils"
3. Cliquer sur l'onglet Participants
4. Cliquer sur un participant qui n'a pas partagé ses résultats
> Observer le message en "Attente de résultats"
5. Revenir en arrière et cliquer sur un participant qui a partagé ses résultats
> Observer la liste des compétences triée par index de compétence
> Avec un bordure de couleur pour chaque domaine
> Avec le nom de la compétence, le niveau atteint et le nombre de pix