### PR TITLE
[FEATURE] Permettre à l'utilisateur de rejoindre son parcours grâce à l'e-mail de création de compte (PIX-429).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -18,10 +18,12 @@ module.exports = {
   save(request, h) {
 
     const reCaptchaToken = request.payload.data.attributes['recaptcha-token'];
+    const campaignCode = request.payload.meta ? request.payload.meta['campaign-code'] : null;
     const user = userSerializer.deserialize(request.payload);
     const locale = extractLocaleFromRequest(request);
     return usecases.createUser({
       user,
+      campaignCode,
       reCaptchaToken,
       locale,
     })

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -5,18 +5,18 @@ const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_NAME = 'PIX - Ne pas répondre';
 const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
 
-function sendAccountCreationEmail(email, locale) {
+function sendAccountCreationEmail(email, locale, redirectionUrl) {
   let variables = {
     homeName: `${settings.app.domainFr}`,
     homeUrl: `https://${settings.app.domainFr}`,
-    loginUrl: `https://app.${settings.app.domainFr}/connexion`,
+    redirectionUrl: redirectionUrl || `https://app.${settings.app.domainFr}/connexion`,
     locale
   };
   if (locale === 'fr') {
     variables = {
       homeName: `${settings.app.domainOrg}`,
       homeUrl: `https://${settings.app.domainOrg}`,
-      loginUrl: `https://app.${settings.app.domainOrg}/connexion`,
+      redirectionUrl: redirectionUrl || `https://app.${settings.app.domainOrg}/connexion`,
       locale
     };
   }

--- a/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
@@ -2,6 +2,7 @@ const { AlreadyRegisteredEmailError, AlreadyRegisteredUsernameError, CampaignCod
 const User = require('../models/User');
 
 const userValidator = require('../validators/user-validator');
+const { getCampaignUrl } = require('../../infrastructure/utils/url-builder');
 
 function _encryptPassword(userPassword, encryptionService) {
   const encryptedPassword = encryptionService.hashPassword(userPassword);
@@ -102,6 +103,9 @@ module.exports = async function createAndAssociateUserToSchoolingRegistration({
   const userId = await userRepository.createAndAssociateUserToSchoolingRegistration({ domainUser, schoolingRegistrationId });
 
   const createdUser = await userRepository.get(userId);
-  if (!isUsernameMode) await mailService.sendAccountCreationEmail(createdUser.email, locale);
+  if (!isUsernameMode) {
+    const redirectionUrl = getCampaignUrl(locale, campaignCode);
+    await mailService.sendAccountCreationEmail(createdUser.email, locale, redirectionUrl);
+  }
   return createdUser;
 };

--- a/api/lib/infrastructure/utils/url-builder.js
+++ b/api/lib/infrastructure/utils/url-builder.js
@@ -1,0 +1,11 @@
+const settings = require('../../config');
+
+module.exports = { getCampaignUrl };
+
+function getCampaignUrl(locale, campaignCode) {
+  if (!campaignCode) {
+    return null;
+  }
+  const domain = locale === 'fr' ? settings.app.domainOrg : settings.app.domainFr;
+  return `https://app.${domain}/campagnes/${campaignCode}`;
+}

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -100,7 +100,7 @@ describe('Acceptance | Controller | users-controller', () => {
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
             locale: 'fr-fr',
-            loginUrl: 'https://app.pix.fr/connexion',
+            redirectionUrl: 'https://app.pix.fr/connexion',
           }
         };
 

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -83,6 +83,7 @@ describe('Unit | Controller | user-controller', () => {
           user: deserializedUser,
           reCaptchaToken,
           locale,
+          campaignCode: null,
         };
 
         // when

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -27,13 +27,39 @@ describe('Unit | Service | MailService', () => {
         variables: {
           homeName: `${domainFr}`,
           homeUrl: `https://${domainFr}`,
-          loginUrl: `https://app.${domainFr}/connexion`,
+          redirectionUrl: `https://app.${domainFr}/connexion`,
           locale
         }
       };
 
       // when
       await mailService.sendAccountCreationEmail(userEmailAddress, locale);
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+    });
+
+    it('should use mailer to send an email with redirectionUrl from parameters', async () => {
+      // given
+      const redirectionUrl = 'https://pix.fr';
+      const locale = 'fr-fr';
+      const domainFr = 'pix.fr';
+      const expectedOptions = {
+        from: senderEmailAddress,
+        fromName: 'PIX - Ne pas répondre',
+        to: userEmailAddress,
+        subject: 'Création de votre compte PIX',
+        template: 'test-account-creation-template-id',
+        variables: {
+          homeName: `${domainFr}`,
+          homeUrl: `https://${domainFr}`,
+          redirectionUrl,
+          locale
+        }
+      };
+
+      // when
+      await mailService.sendAccountCreationEmail(userEmailAddress, locale, redirectionUrl);
 
       // then
       expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);

--- a/api/tests/unit/domain/usecases/create-and-associate-user-to-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/create-and-associate-user-to-schooling-registration_test.js
@@ -89,7 +89,7 @@ describe('Unit | UseCase | create-and-associate-user-to-schooling-registration',
     context('When creation is with email', () => {
 
       beforeEach(() => {
-        userAttributes.email = 'joe.doe@example.net';
+        userAttributes.email = createdUser.email;
         userAttributes.withUsername = false;
         sinon.stub(userRepository, 'isEmailAvailable');
         sinon.stub(mailService, 'sendAccountCreationEmail');
@@ -157,6 +157,22 @@ describe('Unit | UseCase | create-and-associate-user-to-schooling-registration',
 
           // then
           expect(result).to.deep.equal(createdUser);
+        });
+
+        it('should call mailService', async () => {
+          // given
+          const locale = 'fr-fr';
+          const expectedRedirectionUrl = `https://app.pix.fr/campagnes/${campaignCode}`;
+
+          // when
+          await usecases.createAndAssociateUserToSchoolingRegistration({
+            userAttributes,
+            campaignCode,
+            locale,
+          });
+
+          // then
+          expect(mailService.sendAccountCreationEmail).to.have.been.calledWith(userAttributes.email, locale, expectedRedirectionUrl);
         });
 
         context('But association is already done', () => {

--- a/api/tests/unit/infrastructure/utils/url-builder_test.js
+++ b/api/tests/unit/infrastructure/utils/url-builder_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const { getCampaignUrl } = require('../../../../lib/infrastructure/utils/url-builder');
+
+describe('Unit | Utils | url-builder', () => {
+
+  describe('#getCampaignUrl', () => {
+
+    it('should return null if campaignCode is not defined', () => {
+      expect(getCampaignUrl('fr', null)).to.be.null;
+    });
+
+    describe('when campaignCode is defined', () => {
+      const campaignCode = 'AZERTY123';
+
+      it('should return campaignUrl with fr domain when locale is fr-fr', () => {
+        expect(getCampaignUrl('fr-fr', campaignCode)).to.be.equal(`https://app.pix.fr/campagnes/${campaignCode}`);
+      });
+
+      it('should return campaignUrl with org domain when locale is fr', () => {
+        expect(getCampaignUrl('fr', campaignCode)).to.be.equal(`https://app.pix.org/campagnes/${campaignCode}`);
+      });
+    });
+  });
+
+});

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -45,6 +45,13 @@ export default class User extends ApplicationAdapter {
       return this.ajax(url, 'POST', { data: payload });
     }
 
+    if (adapterOptions && adapterOptions.campaignCode) {
+      const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+      const { data } = this.serialize(snapshot);
+      const payload = {  data: { data, meta: { 'campaign-code': adapterOptions.campaignCode } } };
+      return this.ajax(url, 'POST', payload);
+    }
+
     return super.createRecord(...arguments);
   }
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import isEmailValid from 'mon-pix/utils/email-validator';
 import isPasswordValid from '../utils/password-validator';
 import ENV from 'mon-pix/config/environment';
+const _ = require('lodash');
 
 const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'signup-form.fields.firstname.error',
@@ -137,7 +138,9 @@ export default Component.extend({
 
       this._trimNamesAndEmailOfUser();
 
-      this.user.save().then(() => {
+      const campaignCode = _.get(this.session, 'attemptedTransition.from.parent.params.campaign_code');
+
+      this.user.save({ adapterOptions: { campaignCode } }).then(() => {
         const credentials = { login: this.user.email, password: this.user.password };
         this.authenticateUser(credentials);
         this.set('_tokenHasBeenUsed', true);

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -100,6 +100,32 @@ describe('Unit | Adapters | user', function() {
       // then
       sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
     });
+
+    context('when campaignCode adapterOption is defined', () => {
+      it('should add campaign-code meta', async () => {
+        // given
+        const campaignCode = 'AZERTY123';
+        const expectedUrl = 'http://localhost:3000/api/users';
+        const expectedMethod = 'POST';
+        const expectedData = {
+          data: {
+            meta: { 'campaign-code': campaignCode },
+            data: {}
+          }
+        };
+        const snapshot = {
+          record: { },
+          adapterOptions: { campaignCode },
+          serialize: function() { return { data: {} };},
+        };
+
+        // when
+        await adapter.createRecord(null, { modelName: 'user' }, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
+      });
+    });
   });
 
 });

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -74,31 +74,72 @@ describe('Unit | Adapters | user', function() {
 
   describe('#createRecord', () => {
 
-    it('should call expired-password-updates when updateExpiredPassword is true', async () => {
-      // given
-      const username = 'username123';
-      const expiredPassword = 'Password123';
-      const newPassword = 'Password456';
+    context('when isStudentDependentUser is true', () => {
 
-      const expectedUrl = 'http://localhost:3000/api/expired-password-updates';
-      const expectedMethod = 'POST';
-      const expectedData = {
-        data: {
+      let expectedUrl, expectedMethod, expectedData, snapshot;
+
+      beforeEach(() => {
+        expectedUrl = 'http://localhost:3000/api/student-dependent-users';
+        expectedMethod = 'POST';
+        expectedData = {
           data: {
-            attributes: { username, expiredPassword, newPassword }
+            data: {
+              attributes: {
+                'campaign-code': 'AZERTY123',
+                birthdate: '2020-06-15',
+                'with-username': true
+              }
+            }
           }
-        }
-      };
+        };
+        snapshot = {
+          record: { },
+          adapterOptions: {
+            isStudentDependentUser: true,
+            campaignCode: 'AZERTY123',
+            birthdate: '2020-06-15',
+            withUsername: true
+          },
+          serialize: function() { return { data: { attributes: {} } }; },
+        };
+      });
 
-      // when
-      const snapshot = {
-        record: { username, password: expiredPassword },
-        adapterOptions: { updateExpiredPassword: true, newPassword }
-      };
-      await adapter.createRecord(null, null, snapshot);
+      it('should add attributes after serialization', async () => {
+        // when
+        await adapter.createRecord(null, { modelName: 'user' }, snapshot);
 
-      // then
-      sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
+      });
+    });
+
+    context('when updateExpiredPassword is true', () => {
+      it('should call expired-password-updates ', async () => {
+        // given
+        const username = 'username123';
+        const expiredPassword = 'Password123';
+        const newPassword = 'Password456';
+
+        const expectedUrl = 'http://localhost:3000/api/expired-password-updates';
+        const expectedMethod = 'POST';
+        const expectedData = {
+          data: {
+            data: {
+              attributes: { username, expiredPassword, newPassword }
+            }
+          }
+        };
+
+        // when
+        const snapshot = {
+          record: { username, password: expiredPassword },
+          adapterOptions: { updateExpiredPassword: true, newPassword }
+        };
+        await adapter.createRecord(null, null, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
+      });
     });
 
     context('when campaignCode adapterOption is defined', () => {

--- a/mon-pix/tests/unit/components/signup-form-test.js
+++ b/mon-pix/tests/unit/components/signup-form-test.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
 
 describe('Unit | Component | signup-form', function() {
 
@@ -13,6 +14,15 @@ describe('Unit | Component | signup-form', function() {
   let component;
 
   beforeEach(function() {
+    this.owner.register('service:session', Service.extend({
+      attemptedTransition: {
+        from: {
+          parent: {
+            params: {}
+          }
+        }
+      }
+    }));
     component = this.owner.lookup('component:signup-form');
   });
 
@@ -41,6 +51,27 @@ describe('Unit | Component | signup-form', function() {
       // then
       const user = component.get('user');
       expect(_.pick(user, ['firstName', 'lastName', 'email'])).to.deep.equal(expectedUser);
+    });
+
+    it('should send campaignCode when is defined', () => {
+      // given
+      const userWithSpaces = EmberObject.create({
+        firstName: '  Chris  ',
+        lastName: '  MylastName  ',
+        email: '    user@example.net  ',
+        password: 'Pix12345',
+        save: sinon.stub().resolves()
+      });
+      component.set('user', userWithSpaces);
+
+      const campaignCode = 'AZERTY123';
+      component.session.attemptedTransition.from.parent.params.campaign_code = campaignCode;
+
+      // when
+      component.send('signup');
+
+      // then
+      sinon.assert.calledWith(userWithSpaces.save, { adapterOptions: { campaignCode } });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Certains utilisateurs créent leur compte en voulant rejoindre un parcours. 
Lorsqu'ils reçoivent l'e-mail, le lien dans celui-ci les redirige vers la page de profil. Ils commencent alors un positionnement et non leur parcours. 

## :robot: Solution
Modifier le lien présent dans l'e-mail pour ces utilisateurs par celui de leur parcours. 
Pour cela : 
- Passer dans le payload en meta le code de la campagne 
- Créer un url-builder qui nous permet d'obtenir l'url de la campagne grâce au code campagne
- Remplacer le lien par défaut dans le service d'envoie d'e-mail par celui de la campagne.

## :100: Pour tester
- Créer un compte depuis la page d'inscription.
- Créer un compte en voulant rejoindre un parcours aussi bien en tant qu'utilisateur lambda ou comme étudiant. 
