### PR TITLE
[TECH] Montée de version de Node (12.18.0) et NPM (6.14.4).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
 jobs:
   checkout:
     docker:
-      - image: circleci/node:12.14.0
+      - image: circleci/node:12.18.0
     working_directory: ~/pix
     steps:
       - checkout
@@ -79,7 +79,7 @@ jobs:
 
   api_build_and_test:
     docker:
-      - image: circleci/node:12.14.0
+      - image: circleci/node:12.18.0
       - image: postgres:11.7-alpine
         environment:
           POSTGRES_USER: circleci
@@ -106,7 +106,7 @@ jobs:
 
   mon_pix_build_and_test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:12.18.0-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
@@ -129,7 +129,7 @@ jobs:
 
   orga_build_and_test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:12.18.0-browsers
         environment:
           JOBS: 2
     working_directory: ~/pix/orga
@@ -149,7 +149,7 @@ jobs:
 
   certif_build_and_test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:12.18.0-browsers
         environment:
           JOBS: 2
     working_directory: ~/pix/certif
@@ -169,7 +169,7 @@ jobs:
 
   admin_build_and_test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:12.18.0-browsers
         environment:
           JOBS: 2
     working_directory: ~/pix/admin
@@ -189,7 +189,7 @@ jobs:
 
   e2e_test:
     docker:
-      - image: cypress/browsers:node12.14.0-chrome79-ff71
+      - image: cypress/browsers:node12.16.2-chrome81-ff75
       - image: postgres:11.7-alpine
         environment:
           POSTGRES_USER: circleci

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -5,7 +5,7 @@
 Vous devez au préalable avoir correctement installé les logiciels suivants :
 
 * [Git](https://git-scm.com/) (2.6.4)
-* [Node.js](https://nodejs.org/) (v12.14.1) et NPM (6.13.4)
+* [Node.js](https://nodejs.org/) (v12.18.0) et NPM (6.14.0)
 * [Docker](https://docs.docker.com/get-started/) (19.03.5) avec [Docker Compose](https://docs.docker.com/compose/install/)
 
 > ⚠️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que l'application fonctionne avec des versions différentes.

--- a/admin/package.json
+++ b/admin/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
     "lint": "eslint .",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember exam",

--- a/admin/package.json
+++ b/admin/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
     "lint": "eslint .",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember exam",

--- a/api/package.json
+++ b/api/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "repository": {
     "type": "git",
@@ -107,7 +107,7 @@
     "lint": "eslint lib scripts tests db",
     "lint:fix": "eslint lib scripts tests db --fix",
     "postdeploy": "npm run db:migrate",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",
     "scalingo-postbuild": "echo 'nothing to do'",
     "scalingo-post-ra-creation": "npm run postdeploy && npm run db:seed",

--- a/api/package.json
+++ b/api/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "repository": {
     "type": "git",
@@ -107,7 +107,7 @@
     "lint": "eslint lib scripts tests db",
     "lint:fix": "eslint lib scripts tests db --fix",
     "postdeploy": "npm run db:migrate",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",
     "scalingo-postbuild": "echo 'nothing to do'",
     "scalingo-post-ra-creation": "npm run postdeploy && npm run db:seed",

--- a/certif/package.json
+++ b/certif/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "dev": "ember serve",
     "lint": "eslint ./*.js app config mirage tests",
     "lint:hbs": "ember-template-lint .",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"

--- a/certif/package.json
+++ b/certif/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "dev": "ember serve",
     "lint": "eslint ./*.js app config mirage tests",
     "lint:hbs": "ember-template-lint .",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "license": "AGPL-3.0",
   "repository": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "license": "AGPL-3.0",
   "repository": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "scripts": {
     "report": "artillery report report/index.json",

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "scripts": {
     "report": "artillery report report/index.json",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "ember": {
     "edition": "octane"
@@ -28,7 +28,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "ember": {
     "edition": "octane"
@@ -28,7 +28,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",

--- a/orga/package.json
+++ b/orga/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "ember": {
     "edition": "octane"
@@ -26,7 +26,7 @@
     "dev": "ember serve",
     "lint": "eslint ./*.js app config mirage tests",
     "lint:hbs": "ember-template-lint .",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"

--- a/orga/package.json
+++ b/orga/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "ember": {
     "edition": "octane"
@@ -26,7 +26,7 @@
     "dev": "ember serve",
     "lint": "eslint ./*.js app config mirage tests",
     "lint:hbs": "ember-template-lint .",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.14.1",
-    "npm": "6.13.4"
+    "node": "12.18.0",
+    "npm": "6.14.4"
   },
   "repository": {
     "type": "git",
@@ -72,7 +72,7 @@
     "lint:mon-pix": "cd mon-pix && npm run lint",
     "lint:orga": "cd orga && npm run lint",
     "lint:scripts": "cd scripts && eslint .",
-    "preinstall": "test \"$(npm --version)\" = 6.13.4",
+    "preinstall": "test \"$(npm --version)\" = 6.14.4",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "run-p --print-label start:api start:mon-pix start:orga start:certif start:admin",
     "start:admin": "cd admin && npm start",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.18.0",
-    "npm": "6.14.4"
+    "node": "12.x.x",
+    "npm": "6.14.x"
   },
   "repository": {
     "type": "git",
@@ -72,7 +72,7 @@
     "lint:mon-pix": "cd mon-pix && npm run lint",
     "lint:orga": "cd orga && npm run lint",
     "lint:scripts": "cd scripts && eslint .",
-    "preinstall": "test \"$(npm --version)\" = 6.14.4",
+    "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "run-p --print-label start:api start:mon-pix start:orga start:certif start:admin",
     "start:admin": "cd admin && npm start",

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -32,7 +32,7 @@ function display_banner() {
 function display_header {
   echo "👋 Welcome to the Pix developer environment installation & configuration procedure."
   echo "The good news is that the procedure is fully automated!"
-  echo "The bad news is that it will take up to 15mn (as 7 000 tests should be run)."
+  echo "The bad news is that it will take up to 15mn (as 7,000 tests should be run)."
   echo "So, please take a ☕️ and enjoy this awesome moment."
   echo "If you get bored, you can always visit or website https://pix.fr or follow us on Twitter https://twitter.com/pix_officiel 😉"
   echo ""

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -3,8 +3,8 @@
 set -e
 set -o pipefail
 
-EXPECTED_NODE_VERSION="v12.14.1"
-EXPECTED_NPM_VERSION="6.13.4"
+EXPECTED_NODE_VERSION="v12.18.0"
+EXPECTED_NPM_VERSION="6.14.4"
 
 function display_banner() {
   echo "                                                    "


### PR DESCRIPTION
## :unicorn: Problème
Les versions LTS de node et npm ont été mises à jour mais nous n'avons pas effectué ces montées de versions.

## :robot: Solution
Mettre à jour node vers la version 10.18.0.
Mettre à jour npm vers la version 6.14.4.

## :rainbow: Remarques
RAS

## :100: Pour tester
Les tests automatiques passent ➡️  🆗 