### PR TITLE
[TECH] Paralléliser les tests end-to-end sur la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ workflows:
             - checkout
 
       - e2e_test:
+          context: Pix
           requires:
             - checkout
 
@@ -193,6 +194,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+    parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e
     steps:
       - attach_workspace:
@@ -290,4 +292,4 @@ jobs:
             wget --retry-connrefused -T 60 -qO- http://localhost:4200
             wget --retry-connrefused -T 60 -qO- http://localhost:4201
             wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
-            npm run cy:run
+            npm run db:initialize && npx cypress run --browser=chrome --parallel --record --group e2e-tests && exit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,4 +292,4 @@ jobs:
             wget --retry-connrefused -T 60 -qO- http://localhost:4200
             wget --retry-connrefused -T 60 -qO- http://localhost:4201
             wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
-            npm run db:initialize && npx cypress run --browser=chrome --parallel --record --group e2e-tests && exit
+            npm run cy:run:ci

--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -8,5 +8,6 @@
   "video": false,
   "blacklistHosts": "*stats.pix.fr*",
   "screenshotsFolder": "cypress/snapshots/actual",
-  "trashAssetsBeforeRuns": true
+  "trashAssetsBeforeRuns": true,
+  "projectId": "g2rfqp"
 }

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -17,6 +17,7 @@
     "cy:open": "npm run db:initialize && cypress open",
     "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
+    "cy:run:ci": "npm run db:initialize && npx cypress run --browser=chrome --parallel --record --group e2e-tests && exit",
     "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:run",
     "cy:run:base": "cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base",
     "cy:test": "run-p start:api start:mon-pix start:orga start:certif cy:run",


### PR DESCRIPTION
Cette PR fait un revival !
On l'avait mergée mais notre compte Cypress était limité et on avait atteint le plafond du plan gratuit, on a donc du revert le merge de cette PR.

Notre demande de compte OSS ayant été acceptée, nous avons un nombre d'enregistrements illimité 🚀 

## :unicorn: Problème
Le temps de build sur la CI dépasse largement les 10 minutes.
Cela ralentit la boucle de feedbacks.

## :robot: Solution
Utiliser la fonctionnalité de parallélisation de cypress.
Cela permet de diviser par deux la durée des tests end-to-end (qui est le job le plus long dans notre pipeline).
Pour pouvoir utiliser cette fonctionnalité, il est nécessaire de créer un compte sur [cypress.io](dashboard.cypress.io).
Le compte est créé avec le login github (service+github@pix.fr).

Il est ensuite nécessaire de configurer circleCI pour fournir la `record key` comme variable d'environnement.
Cela se fait dans les `Organization settings`, en créant un `Context`.
<img width="1031" alt="Screenshot 2020-06-10 at 21 41 33" src="https://user-images.githubusercontent.com/2989532/84313218-808d9e00-ab66-11ea-9d12-3cc403bdd53f.png">

<img width="1038" alt="Screenshot 2020-06-10 at 21 41 42" src="https://user-images.githubusercontent.com/2989532/84313256-8e432380-ab66-11ea-9fcd-fe9cbde73c0b.png">

Les informations de configuration sont dans le dashboard de cypress.io dans l'onglet `Organization settings`.

**Une demande de plan Open Source (qui nous donnerait un nombre d'exécutions illimitées) a été initiée auprès de cypress.**
 
## :rainbow: Remarques
Pour gagner du temps dans notre boucle de feedback, il sera surement nécessaire de revoir le périmètre des tests end-to-end ainsi que les moments auxquels sont lancés ces tests.

## :100: Pour tester
Voir les temps de builds globaux dans le pipeline de circleCI sont plus courts.