### PR TITLE
[FEATURE] Filtrer les élèves par nom dans pix-orga (PIX-719).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -88,11 +88,12 @@ module.exports = {
     return h.response().code(204);
   },
 
-  findUserWithSchoolingRegistrations: async (request) => {
+  async findUserWithSchoolingRegistrations(request) {
     const organizationId = parseInt(request.params.id);
+    const { filter } = queryParamsUtils.extractParameters(request.query);
 
-    return usecases.findUserWithSchoolingRegistrations({ organizationId })
-      .then(userWithSchoolingRegistrationSerializer.serialize);
+    const students = await usecases.findUserWithSchoolingRegistrations({ organizationId, filter });
+    return userWithSchoolingRegistrationSerializer.serialize(students);
   },
 
   importSchoolingRegistrationsFromSIECLE(request) {

--- a/api/lib/domain/usecases/find-user-with-schooling-registrations.js
+++ b/api/lib/domain/usecases/find-user-with-schooling-registrations.js
@@ -1,5 +1,10 @@
-module.exports =  function findUserWithSchoolingRegistrations({ organizationId, schoolingRegistrationRepository }) {
-
-  return schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId({ organizationId });
-
+module.exports =  function findUserWithSchoolingRegistrations({ 
+  organizationId,
+  filter,
+  schoolingRegistrationRepository,
+}) {
+  return schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId({
+    organizationId,
+    filter,
+  });
 };

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -35,7 +35,7 @@ function _extractObjectParameter(query, regex) {
 }
 
 function _extractArrayParameter(query, parameterName) {
-  return query[parameterName] ? query[parameterName].split(',') : [];
+  return _.has(query, parameterName) ? query[parameterName].split(',') : [];
 }
 
 function _convertObjectValueToInt(params) {

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -553,7 +553,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
-  describe('#findSchoolingRegistrationsWithUserInfoByOrganizationId', () => {
+  describe('#findUserWithSchoolingRegistrationsByOrganizationId', () => {
 
     it('should return instances of UserWithSchoolingRegistration', async () => {
       // given
@@ -616,10 +616,31 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const schoolingRegistrations = await schoolingRegistrationRepository.findByOrganizationId({ organizationId: organization.id });
+      const schoolingRegistrations = await schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId({
+        organizationId: organization.id
+      });
 
       // then
       expect(_.map(schoolingRegistrations, 'id')).to.deep.include.ordered.members([schoolingRegistration_3.id, schoolingRegistration_4.id, schoolingRegistration_2.id, schoolingRegistration_1.id]);
+    });
+
+    it('should return school registrations filtered by lastname', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+
+      databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: 'Grenier' });
+      databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: 'Avatar' });
+      databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: 'UvAtur' });
+      await databaseBuilder.commit();
+
+      // when
+      const schoolingRegistrations = await schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId({
+        organizationId: organization.id,
+        filter: { lastName: 'Vat' },
+      });
+
+      // then
+      expect(_.map(schoolingRegistrations, 'lastName')).to.deep.equal(['Avatar', 'UvAtur']);
     });
 
     describe('When schoolingRegistration is reconciled and authenticated by email (and/or) username' , () => {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -445,7 +445,19 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       await organizationController.findUserWithSchoolingRegistrations(request, hFake);
 
       // then
-      expect(usecases.findUserWithSchoolingRegistrations).to.have.been.calledWith({ organizationId });
+      expect(usecases.findUserWithSchoolingRegistrations).to.have.been.calledWith({ organizationId, filter: {} });
+    });
+
+    it('should call the usecase to find students with users infos related to the lastName filter', async () => {
+      // given
+      request = { ...request, query: { 'filter[lastName]': 'Bob' } };
+      usecases.findUserWithSchoolingRegistrations.resolves();
+
+      // when
+      await organizationController.findUserWithSchoolingRegistrations(request, hFake);
+
+      // then
+      expect(usecases.findUserWithSchoolingRegistrations).to.have.been.calledWith({ organizationId, filter: { lastName: 'Bob' } });
     });
 
     it('should return the serialized students belonging to the organization', async () => {

--- a/api/tests/unit/domain/usecases/find-organization-students_with-users-infos-test.js
+++ b/api/tests/unit/domain/usecases/find-organization-students_with-users-infos-test.js
@@ -15,19 +15,13 @@ describe('Unit | UseCase | findUserWithSchoolingRegistrations', () => {
   const expectedReconciledSchoolingRegistrationFromGAR = { id: 5, userId , isAuthenticatedFromGAR };
   let foundOrganizationSchoolingRegistrations;
   const expectedSchoolingRegistrations = [expectedSchoolingRegistrationNotYetReconciled, expectedReconciledSchoolingRegistrationWithUsername, expectedReconciledSchoolingRegistrationWithEmail ,expectedReconciledSchoolingRegistrationFromGAR ];
-  const schoolingRegistrationRepository = { findUserWithSchoolingRegistrationsByOrganizationId: sinon.stub().withArgs({ organizationId }).returns(expectedSchoolingRegistrations) };
+  const schoolingRegistrationRepository = { findUserWithSchoolingRegistrationsByOrganizationId: sinon.stub().returns(expectedSchoolingRegistrations) };
 
-  before(async function() {
-    foundOrganizationSchoolingRegistrations = await findUserWithSchoolingRegistrations({ organizationId, schoolingRegistrationRepository });
-  });
+  it('should fetch students matching organization', async function() {
+    foundOrganizationSchoolingRegistrations = await findUserWithSchoolingRegistrations({ organizationId, filter: { lastName: 'A' }, schoolingRegistrationRepository });
 
-  it('should fetch students matching organization', function() {
-    expect(schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId).to.have.been.calledWithExactly({ organizationId });
-  });
-
-  it('should return reconcilied and not reconcilied students', function() {
+    expect(schoolingRegistrationRepository.findUserWithSchoolingRegistrationsByOrganizationId).to.have.been.calledWithExactly({ organizationId, filter: { lastName: 'A' } });
     expect(foundOrganizationSchoolingRegistrations).to.deep.equal(expectedSchoolingRegistrations);
   });
-
 });
 

--- a/orga/app/adapters/student.js
+++ b/orga/app/adapters/student.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from './application';
+
+export default class Student extends ApplicationAdapter {
+  urlForQuery(query) {
+    const { organizationId } = query.filter;
+    delete query.filter.organizationId;
+
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/students`;
+  }
+}

--- a/orga/app/components/password-reset-modal.js
+++ b/orga/app/components/password-reset-modal.js
@@ -46,7 +46,7 @@ export default class PasswordResetModal extends Component {
   async resetPassword(event) {
     event.preventDefault();
     const schoolingRegistrationDependentUser = this.store.createRecord('schooling-registration-dependent-user', {
-      organizationId: this.args.student.organization.get('id'),
+      organizationId: this.args.organizationId,
       schoolingRegistrationId: this.args.student.id
     });
 

--- a/orga/app/routes/authenticated/students/list.js
+++ b/orga/app/routes/authenticated/students/list.js
@@ -1,11 +1,35 @@
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
 import Route from '@ember/routing/route';
 
 export default class ListRoute extends Route {
 
+  queryParams = {
+    lastName: {
+      refreshModel: true
+    },
+  };
+
   @service currentUser;
 
-  model() {
-    return this.currentUser.organization.students;
+  model(params) {
+    return this.store.query('student', {
+      filter: {
+        organizationId: this.currentUser.organization.id,
+        lastName: params.lastName,
+      },
+    });
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('lastName', null);
+    }
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/orga/app/templates/authenticated/students/list.hbs
+++ b/orga/app/templates/authenticated/students/list.hbs
@@ -1,4 +1,9 @@
 <div class="list-students-page">
-
-  <Routes::Authenticated::Students::ListItems @students={{this.model}} @isLoading={{this.isLoading}} @importStudents={{this.importStudents}} />
+  <Routes::Authenticated::Students::ListItems
+    @students={{this.model}}
+    @isLoading={{this.isLoading}}
+    @importStudents={{this.importStudents}}
+    @triggerFiltering={{this.triggerFiltering}}
+    @lastNameFilter={{this.lastName}}
+  />
 </div>

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -13,13 +13,28 @@
   <div class="table content-text content-text--small">
     <table>
       <thead>
-      <tr>
-        <th>Nom</th>
-        <th>Prénom</th>
-        <th>Date de naissance</th>
-        <th>Connecté avec</th>
-        <th></th>
-      </tr>
+        <tr>
+          <th>Nom</th>
+          <th>Prénom</th>
+          <th>Date de naissance</th>
+          <th>Connecté avec</th>
+          <th></th>
+        </tr>
+        <tr>
+            <th>
+              <SearchInput
+                @inputName="lastName"
+                @class="input table__input search-input"
+                @value={{@lastNameFilter}}
+                @placeholder="Rechercher par nom"
+                @filterFunction={{fn @triggerFiltering "lastName"}}
+              />
+            </th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+          </tr>
       </thead>
 
       {{#if @students}}
@@ -56,6 +71,7 @@
   </div>
 
   <PasswordResetModal
+    @organizationId={{this.currentUser.organization.id}}
     @student={{this.student}}
     @display={{this.isShowingModal}}
     @close={{this.closePasswordReset}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -151,6 +151,12 @@ export default function() {
 
   this.get('/organizations/:id/students', (schema, request) => {
     const organizationId = request.params.id;
+    
+    const lastNameFilter = request.queryParams['filter[lastName]'];
+    if (lastNameFilter) {
+      return schema.students.where(({ lastName }) => lastName.includes(lastNameFilter));
+    }
+
     return schema.students.where({ organizationId });
   });
 

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { find, currentURL, triggerEvent, visit, click } from '@ember/test-helpers';
+import { find, currentURL, triggerEvent, visit, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -60,6 +60,35 @@ module('Acceptance | Student List', function(hooks) {
 
         // then
         assert.equal(currentURL(), '/campagnes');
+      });
+    });
+
+    module('When prescriber is looking for students', function(hooks) {
+      hooks.beforeEach(async () => {
+        user = createUserManagingStudents();
+        createPrescriberByUser(user);
+
+        organizationId = user.memberships.models.firstObject.organizationId;
+
+        server.create('student', { organizationId, firstName: 'Chuck', lastName: 'Norris' });
+        server.create('student', { organizationId, firstName: 'John', lastName: 'Rambo' });
+
+        await authenticateSession({
+          user_id: user.id,
+          access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+          expires_in: 3600,
+          token_type: 'Bearer token type',
+        });
+      });
+
+      test('it should display the filtered list of students', async function(assert) {
+        // when
+        await visit('/eleves');
+        await fillIn('[placeholder="Rechercher par nom"]', 'ambo');
+      
+        // then
+        assert.contains('Rambo');
+        assert.notContains('Norris');
       });
     });
 
@@ -175,7 +204,7 @@ module('Acceptance | Student List', function(hooks) {
       });
     });
 
-    module('When prescriber is admin in organization', function(hooks) {
+    module('When admin uploads a file', function(hooks) {
 
       hooks.beforeEach(async () => {
         user = createUserManagingStudents('ADMIN');

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -1,16 +1,20 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import Service from '@ember/service';
-import { run } from '@ember/runloop';
+import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/students | list-items', function(hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function() {
+    this.set('noop', sinon.stub());
+  });
+
   test('it should show title of team page', async function(assert) {
     // when
-    await render(hbs`<Routes::Authenticated::Students::ListItems/>`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @triggerFiltering={{noop}}/>`);
 
     // then
     assert.contains('Élèves');
@@ -21,10 +25,9 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     this.set('students', []);
 
     // when
-    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
     // then
-    assert.dom('th').exists({ count: 5 });
     assert.contains('Nom');
     assert.contains('Prénom');
     assert.contains('Date de naissance');
@@ -41,7 +44,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     this.set('students', students);
 
     // when
-    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
     // then
     assert.dom('[aria-label="Élève"]').exists({ count: 2 });
@@ -54,12 +57,30 @@ module('Integration | Component | routes/authenticated/students | list-items', f
     this.set('students', students);
 
     // when
-    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+    await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
     // then
     assert.contains('La Terreur');
     assert.contains('Gigi');
     assert.contains('01/02/2010');
+  });
+
+  module('when user is filtering some users', function() {
+    test('it should trigger filtering with lastname', async function(assert) {
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+  
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
+
+      await fillIn('[placeholder="Rechercher par nom"]', 'bob');
+
+      // then
+      const call = triggerFiltering.getCall(0);
+      assert.equal(call.args[0], 'lastName');
+      assert.equal(call.args[1].target.value, 'bob');
+    });
   });
 
   module('when user is not reconciled', function({ beforeEach }) {
@@ -72,7 +93,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
         firstName: 'Gigi',
         birthdate: '2010-01-01',
       }].forEach((student) => {
-        storedStudents.push(run(() => store.createRecord('student', student)));
+        storedStudents.push(store.createRecord('student', student));
       });
     });
 
@@ -82,7 +103,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Élève"]').containsText(dash);
@@ -92,7 +113,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Afficher les actions"]').doesNotExist();
@@ -111,7 +132,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
         username: 'blueivy.carter0701',
         isAuthenticatedFromGar: false,
       }].forEach((student) => {
-        storedStudents.push(run(() => store.createRecord('student', student)));
+        storedStudents.push(store.createRecord('student', student));
       });
     });
 
@@ -120,7 +141,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Élève"]').containsText('Identifiant');
@@ -130,7 +151,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Afficher les actions"]').exists();
@@ -149,7 +170,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
         email: 'firstname.lastname@example.net',
         isAuthenticatedFromGar: false,
       }].forEach((student) => {
-        storedStudents.push(run(() => store.createRecord('student', student)));
+        storedStudents.push(store.createRecord('student', student));
       });
     });
 
@@ -158,7 +179,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Élève"]').containsText('Adresse e-mail');
@@ -168,7 +189,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', storedStudents);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.dom('[aria-label="Afficher les actions"]').exists();
@@ -185,7 +206,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
 
     test('it should display import button', async function(assert) {
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.contains('Importer (.xml)');
@@ -201,7 +222,7 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       this.set('students', []);
 
       // when
-      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}}/>`);
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // then
       assert.notContains('Importer (.xml)');

--- a/orga/tests/unit/adapters/student-test.js
+++ b/orga/tests/unit/adapters/student-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapters | student', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:student');
+    adapter.ajax = sinon.stub().resolves();
+  });
+
+  module('#urlForQuery', () => {
+    test('should build query url from organization id', async function(assert) {
+      const query = { filter: { organizationId: 'organizationId1' } };
+      const url = await adapter.urlForQuery(query);
+
+      assert.ok(url.endsWith('/api/organizations/organizationId1/students'));
+      assert.equal(query.organizationId, undefined);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas filtrer la liste des élèves par nom dans pix-orga.

## :robot: Solution
Ajout d'un filtre sur la colonne nom dans la liste des élèves.

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Se connecter sur pix-orga avec sco@example.net
2. Cliquer sur "Elèves" dans le menu de gauche
3. Saisir un nom dans le champ de filtre des élèves dans la colonne nom
> Observer que la liste est filtré en rapport avec le filtre saisi
