### PR TITLE
[BUGFIX] Ne pas lever une erreur 500 lors de la recherche d'une session avec un identifiant trop grand.

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,7 +2,7 @@ const Joi = require('@hapi/joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
-const settings = require('../../config');
+const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async (server) => {
   server.route([
@@ -28,7 +28,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -45,7 +45,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -63,7 +63,7 @@ exports.register = async (server) => {
         auth: false,
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         handler: sessionController.getAttendanceSheet,
@@ -92,7 +92,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -113,7 +113,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         payload: {
@@ -139,7 +139,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -161,7 +161,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -182,7 +182,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -203,8 +203,8 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator,
-            certificationCandidateId: settings.idValidator,
+            id: idSpecification,
+            certificationCandidateId: idSpecification,
           }),
         },
         pre: [{
@@ -225,7 +225,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -246,7 +246,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -268,7 +268,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         handler: sessionController.createCandidateParticipation,
@@ -286,7 +286,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -307,7 +307,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{
@@ -330,7 +330,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: settings.idValidator
+            id: idSpecification
           }),
         },
         pre: [{

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const Joi = require('@hapi/joi');
 
 function parseJSONEnv(varName) {
   if (process.env[varName]) {
@@ -127,8 +126,6 @@ module.exports = (function() {
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
       debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
     },
-
-    idValidator: Joi.number().integer().max(2147483647).required(),
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -1,8 +1,10 @@
 const Joi = require('@hapi/joi');
 
+// Min 32 bits signed integer, our most common id type in Postgres
+const minId = -(2 ** 31);
 // Max 32 bits signed integer, our most common id type in Postgres
 const maxId = 2 ** 31 - 1;
 
 module.exports = {
-  idSpecification: Joi.number().integer().max(maxId).required(),
+  idSpecification: Joi.number().integer().min(minId).max(maxId).required(),
 };

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -1,0 +1,8 @@
+const Joi = require('@hapi/joi');
+
+// Max 32 bits signed integer, our most common id type in Postgres
+const maxId = 2 ** 31 - 1;
+
+module.exports = {
+  idSpecification: Joi.number().integer().max(maxId).required(),
+};

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
 const { statuses } = require('../models/Session');
 const { EntityValidationError } = require('../errors');
-const { idValidator } = require('../../config');
+const { idSpecification } = require('./id-specification');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
@@ -43,7 +43,7 @@ const sessionValidationJoiSchema = Joi.object({
 });
 
 const sessionFiltersValidationSchema = Joi.object({
-  id: idValidator.optional(),
+  id: idSpecification.optional(),
   status: Joi.string().trim()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
   resultsSentToPrescriberAt: Joi.boolean().optional(),

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,6 +1,7 @@
 const Joi = require('@hapi/joi');
 const { statuses } = require('../models/Session');
 const { EntityValidationError } = require('../errors');
+const { idValidator } = require('../../config');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
@@ -42,7 +43,7 @@ const sessionValidationJoiSchema = Joi.object({
 });
 
 const sessionFiltersValidationSchema = Joi.object({
-  id: Joi.number().integer().optional(),
+  id: idValidator.optional(),
   status: Joi.string().trim()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
   resultsSentToPrescriberAt: Joi.boolean().optional(),

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -77,6 +77,17 @@ describe('Acceptance | Controller | session-controller-get', () => {
         expect(response.result.meta).to.deep.equal(expectedMetaData);
         expect(response.result.data).to.have.lengthOf(0);
       });
+
+      it('should signal an entity validation error for an ID that is too large', async () => {
+        // given
+        options.url = '/api/jury/sessions?filter[id]=5656355634';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
     });
 
     context('when user is not PixMaster', () => {

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -80,7 +80,18 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should signal an entity validation error for an ID that is too large', async () => {
         // given
-        options.url = '/api/jury/sessions?filter[id]=5656355634';
+        options.url = '/api/jury/sessions?filter[id]=2147483648';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+
+      it('should signal an entity validation error for an ID that is too small', async () => {
+        // given
+        options.url = '/api/jury/sessions?filter[id]=-2147483649';
 
         // when
         const response = await server.inject(options);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -221,7 +221,7 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
-  describe('idValidator', () => {
+  describe('id validation', () => {
     [
       { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut' } },
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999' } },


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on cherche une session avec un identifiant trop grand (> 2147483647), l'api lève une erreur 500.

## :robot: Solution
Valider que l'identifiant est inférieur à la valeur max acceptée par PostgreSQL en amont de l'appel à PostgreSQL et retourner une erreur 422.

## :rainbow: Remarques
Il y avait aussi un `idValidator` dans `lib/config.js`, on l'a déplacé dans `lib/domain/validators`.

Pour aller plus loin, l'erreur 422 n'est pas la plus appropriée mais l'erreur 400 (mauvaise requête) semble meilleure.
De plus la recherche filtrant sur différents paramètres + l'identifiant semble inutile : on peut utiliser la route qui retrouve une session avec l'identifiant. (GET /jury/sessions/{id}).

## :100: Pour tester
Sur pix admin, faire une recherche de sessions avec l'identifiant 5656355634. 
