### PR TITLE
[BUGFIX] Mauvais affichage des notifications après la finalisation (PIX-848)

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -6405,18 +6405,18 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
-      "integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.0.tgz",
+      "integrity": "sha512-D96ZiIHXbDmU02dBaemyAg53ez+6F5yZmapmgKcjm35yEe1uVDYI8hGW3VYoGRaG290ZFf91YxHrR518vC0u/A==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.0",
-        "caniuse-lite": "^1.0.30001012",
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001061",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.23",
-        "postcss-value-parser": "^4.0.2"
+        "postcss": "^7.0.30",
+        "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6427,6 +6427,24 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
+        },
+        "browserslist": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001043",
+            "electron-to-chromium": "^1.3.413",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001084",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz",
+          "integrity": "sha512-ftdc5oGmhEbLUuMZ/Qp3mOpzfZLCxPYKcvGv6v2dJJ+8EdqcvZRbAGOiLmkM/PV1QGta/uwBs8/nCl6sokDW6w==",
+          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -6454,10 +6472,28 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "electron-to-chromium": {
+          "version": "1.3.474",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.474.tgz",
+          "integrity": "sha512-fPkSgT9IBKmVJz02XioNsIpg0WYmkPrvU1lUJblMMJALxyE7/32NGvbJQKKxpNokozPvqfqkuUqVClYsvetcLw==",
+          "dev": true
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.58",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
+          "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
+          "dev": true
+        },
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
           "dev": true
         },
         "supports-color": {
@@ -9172,28 +9208,117 @@
       }
     },
     "broccoli-postcss": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-postcss/-/broccoli-postcss-5.0.0.tgz",
-      "integrity": "sha512-iJk+meVt0Oe33iaaE0T6z2lxSs349BRD7pz2kk/I6MuSjjWrZSzP/2txmEHQN7LyQGZjbC222MzBgSQj/O8kTw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-postcss/-/broccoli-postcss-5.1.0.tgz",
+      "integrity": "sha512-f5cHP5g7EFidu9w88WOLTtbk4dd/W7amK0nek08FkmUII2h4W/Je4EV26HtMEm9nb1hKI301wwuEQ5AQRsVYog==",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "^2.0.1",
+        "broccoli-funnel": "^3.0.0",
         "broccoli-persistent-filter": "^2.1.0",
+        "minimist": ">=1.2.5",
         "object-assign": "^4.1.1",
         "postcss": "^7.0.5"
-      }
-    },
-    "broccoli-postcss-single": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-postcss-single/-/broccoli-postcss-single-3.0.0.tgz",
-      "integrity": "sha512-+CsV6zdK9CXTplZvQeAsZm7mEh+BwIN6GBzpqm7agqsMZTvW6kkcWDaL2ahG1+Aq2HfLYk1Sam6iQ3jdESNmPA==",
-      "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "^3.0.3",
-        "include-path-searcher": "^0.1.0",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.1",
-        "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
+          "integrity": "sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^4.0.1",
+            "debug": "^4.1.1",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "path-posix": "^1.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-output-wrapper": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.1.tgz",
+          "integrity": "sha512-mhOTy8AyzEsqgefR2ejbv5QTy3dbY2bvDfkARo55Xml52r2MU0CehQu4T/CH6oPcAXkdVYG/hGm9UpV1vU9Ohg==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "heimdalljs-logger": "^0.1.10",
+            "symlink-or-copy": "^1.2.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^3.2.1",
+            "fs-merger": "^3.1.0",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-merger": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.1.0.tgz",
+          "integrity": "sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-node-info": "^2.1.0",
+            "fs-extra": "^8.0.1",
+            "fs-tree-diff": "^2.0.1",
+            "rimraf": "^2.6.3",
+            "walk-sync": "^2.0.2"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "broccoli-rollup": {
@@ -14793,16 +14918,125 @@
       }
     },
     "ember-cli-notifications": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-notifications/-/ember-cli-notifications-6.0.0.tgz",
-      "integrity": "sha512-wEYRGUAqiAON4M7NS3T4DwMSsrJ3UERXAUGA5zRN45JbYR91xnCVKjnUCeNI9rRG2LYQU4unpRyyROT28N1dng==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-notifications/-/ember-cli-notifications-6.2.0.tgz",
+      "integrity": "sha512-s/XNCzRHLDLYloMGH1WqU79MFAxYWRGs6UsyuaWHQawOrYNoOnmkfUIT1DkVeQZAYxdEnHcoLCF2ptSZ0xxRFg==",
       "dev": true,
       "requires": {
+        "broccoli-funnel": "^3.0.2",
+        "broccoli-merge-trees": "^4.1.0",
+        "broccoli-postcss": "^5.0.0",
         "ember-cli-babel": "^7.13.0",
         "ember-cli-htmlbars": "^4.2.0",
-        "ember-cli-postcss": "^5.0.0",
         "ember-get-config": "^0.2.4",
+        "lodash.get": "^4.4.2",
+        "postcss-import": "^12.0.1",
         "postcss-preset-env": "^6.7.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
+          "integrity": "sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^4.0.1",
+            "debug": "^4.1.1",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "path-posix": "^1.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-output-wrapper": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.1.tgz",
+          "integrity": "sha512-mhOTy8AyzEsqgefR2ejbv5QTy3dbY2bvDfkARo55Xml52r2MU0CehQu4T/CH6oPcAXkdVYG/hGm9UpV1vU9Ohg==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "heimdalljs-logger": "^0.1.10",
+            "symlink-or-copy": "^1.2.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^3.2.1",
+            "fs-merger": "^3.1.0",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-merger": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.1.0.tgz",
+          "integrity": "sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-node-info": "^2.1.0",
+            "fs-extra": "^8.0.1",
+            "fs-tree-diff": "^2.0.1",
+            "rimraf": "^2.6.3",
+            "walk-sync": "^2.0.2"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ember-cli-path-utils": {
@@ -14810,20 +15044,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-path-utils/-/ember-cli-path-utils-1.0.0.tgz",
       "integrity": "sha1-Tjmvi1UwHN3FAXc5t3qAT7ogce0=",
       "dev": true
-    },
-    "ember-cli-postcss": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-postcss/-/ember-cli-postcss-5.0.0.tgz",
-      "integrity": "sha512-znJOyXeYmhDF3DOocfcCUrnGN0iWmDGvMJKTVPszFeBd1/cqx+lSxc1Tx25RAF1KpOyI0FqD1amp6s9lud62EQ==",
-      "dev": true,
-      "requires": {
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-merge-trees": "^3.0.0",
-        "broccoli-postcss": "^5.0.0",
-        "broccoli-postcss-single": "^3.0.0",
-        "ember-cli-babel": "^7.1.0",
-        "merge": "^1.2.0"
-      }
     },
     "ember-cli-preprocess-registry": {
       "version": "3.3.0",
@@ -20466,7 +20686,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
@@ -20489,7 +20709,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
@@ -20512,21 +20732,21 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
@@ -20645,7 +20865,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
@@ -20682,7 +20902,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -20799,7 +21019,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
@@ -20899,7 +21119,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
@@ -21001,14 +21221,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
@@ -23178,12 +23398,6 @@
         "readable-stream": "~1.0.2"
       }
     },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -24525,9 +24739,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-      "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -24599,13 +24813,32 @@
       }
     },
     "postcss-attribute-case-insensitive": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
-      "integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
+      "integrity": "sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0"
+        "postcss-selector-parser": "^6.0.2"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-color-functional-notation": {
@@ -24763,6 +24996,18 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-import": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
+      "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.1",
+        "postcss-value-parser": "^3.2.3",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
       }
     },
     "postcss-initial": {
@@ -24937,9 +25182,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
     "postcss-values-parser": {
@@ -25381,6 +25626,23 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+          "dev": true
+        }
+      }
+    },
+    "read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }

--- a/certif/package.json
+++ b/certif/package.json
@@ -54,7 +54,7 @@
     "ember-cli-matomo-tag-manager": "^1.1.2",
     "ember-cli-mirage": "^1.1.6",
     "ember-cli-moment-shim": "^3.7.1",
-    "ember-cli-notifications": "^6.0.0",
+    "ember-cli-notifications": "^6.2.0",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^2.0.2",


### PR DESCRIPTION
## :unicorn: Problème
L'affichage des notifications est cassé : les icônes sont affichées très grandes et le texte au centre de la page au lieu d'en bas à droite.

## :robot: Solution
Mettre à jour ember-cli-notification.
Cette dépendance était déjà à jour dans orga et admin.

## :100: Pour tester
- npm install
- ouvrir une session non finalisée
- la finaliser, et observer une notification en bas à droite, verte ou rouge.