### PR TITLE
[TECH] Assurer que la version de node installée est 12.18.x.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
 
   e2e_test:
     docker:
-      - image: cypress/browsers:node12.16.2-chrome81-ff75
+      - image: cypress/browsers:node12.18.0-chrome83-ff77
       - image: postgres:11.7-alpine
         environment:
           POSTGRES_USER: circleci

--- a/admin/package.json
+++ b/admin/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "repository": {

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "repository": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "repository": {

--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -10,5 +10,6 @@
   "screenshotsFolder": "cypress/snapshots/actual",
   "trashAssetsBeforeRuns": true,
   "projectId": "g2rfqp",
-  "numTestsKeptInMemory": 0
+  "numTestsKeptInMemory": 0,
+  "viewportWidth": 1500
 }

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -26,6 +26,7 @@
     "cy:test:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test run-p start:api start:mon-pix start:orga start:certif cy:open",
     "db:empty": "cd ../../api && npm run db:empty",
     "db:initialize": "cd ../../api && npm run db:prepare",
+    "preinstall": "npx check-engine",
     "start:api": "cd ../../api && DATABASE_URL=postgresql://postgres@localhost/pix_test npm run start:watch",
     "start:mon-pix": "cd ../../mon-pix && npm start",
     "start:orga": "cd ../../orga && npm start",

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "scripts": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -9,6 +9,7 @@
     "npm": "6.14.x"
   },
   "scripts": {
+    "preinstall": "npx check-engine",
     "report": "artillery report report/index.json",
     "start": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml"
   },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "ember": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "ember": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "12.x.x",
+    "node": "12.18.x",
     "npm": "6.14.x"
   },
   "repository": {


### PR DESCRIPTION
## :unicorn: Problème
Dans la PR de montée de version de node vers 12.18.0, la version de node vérifiée (via la clé `engines` du `package.json`) était 12.x.x.

## :robot: Solution
Spécifier la version `12.18.x` et utiliser la bonne image docker cypress pour le job de la CI.

## :rainbow: Remarques
On en profite pour ajouter la vérification dans les applications `high-level-tests`.

## :100: Pour tester
La CI passe, c'est tout ✅ 