### PR TITLE
[FEATURE] Permettre l'anonymisation d'un utilisateur depuis Pix Admin (PIX-729)

### DIFF
--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -18,4 +18,12 @@ export default class UserAdapter extends ApplicationAdapter {
   urlForUpdateRecord(id) {
     return `${this.host}/${this.namespace}/admin/users/${id}`;
   }
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions && snapshot.adapterOptions.anonymizeUser) {
+      const url = this.urlForUpdateRecord(snapshot.id) + '/anonymize';
+      return this.ajax(url, 'POST');
+    }
+    return super.updateRecord(...arguments);
+  }
 }

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -104,8 +104,15 @@
         {{#if canAdministratorModifyUserDetails}}
         <button class="btn btn-outline-default" aria-label="Modifier" {{on "click" this.changeEditionMode}}>Modifier
         </button>
+        <button class="btn btn-outline-default btn-outline-default--danger" aria-label="Anonymiser" {{on "click" this.toggleDisplayConfirm}}>Anonymiser cet utilisateur
+        </button>
         {{/if}}
       </div>
     </form>
   {{/if}}
 </section>
+
+<ConfirmPopup @message="Etes-vous sûr de vouloir anonymiser cet utilisateur? Ceci n’est pas réversible"
+              @confirm={{this.anonymizeUser}}
+              @cancel={{this.toggleDisplayConfirm}}
+              @show={{displayConfirm}} />

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -63,6 +63,8 @@ class Form extends Object.extend(Validations) {
 export default class UserDetailPersonalInformationComponent extends Component {
 
   @tracked isEditionMode = false;
+  @tracked displayConfirm = false;
+
   @service notifications;
 
   constructor() {
@@ -79,6 +81,21 @@ export default class UserDetailPersonalInformationComponent extends Component {
     event.preventDefault();
     this._initForm();
     this.isEditionMode = !this.isEditionMode;
+  }
+
+  @action
+  toggleDisplayConfirm(event) {
+    if (event) {
+      event.preventDefault();
+    }
+    this.displayConfirm = !this.displayConfirm;
+  }
+
+  @action
+  async anonymizeUser() {
+    await this.args.user.save({ adapterOptions: { anonymizeUser: true } });
+    await this.args.user.reload();
+    this.toggleDisplayConfirm();
   }
 
   @action

--- a/admin/app/styles/misc/button.scss
+++ b/admin/app/styles/misc/button.scss
@@ -21,6 +21,11 @@
     background: $grey-15;
     color: inherit !important;
   }
+
+  &--danger {
+    background: $information-dark;
+    color: $white;
+  }
 }
 
 .btn-thin {

--- a/admin/app/styles/misc/palette.scss
+++ b/admin/app/styles/misc/palette.scss
@@ -42,7 +42,7 @@ $communication-gradient: linear-gradient(0deg, #12A3FF 0%, #3D68FF 100%);
 $security-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
 $environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
 // solids
-$information-dark: #F24645;
+$information-dark: #f24645;
 $information-light: #F1A141;
 $content-dark: #1A8C89;
 $content-light: #52D987;

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -87,4 +87,16 @@ export default function() {
     };
     return userUpdated;
   });
+
+  this.post('/admin/users/:id/anonymize', (schema, request) => {
+    const userId = request.params.id;
+    const expectedUpdatedUser = {
+      firstName: `prenom_${userId}`,
+      lastName: `nom_${userId}`,
+      email: `email_${userId}@example.net`,
+    };
+
+    const organization = schema.users.findBy({ id: userId });
+    return organization.update(expectedUpdatedUser);
+  });
 }

--- a/admin/tests/acceptance/user-details-personal-information-test.js
+++ b/admin/tests/acceptance/user-details-personal-information-test.js
@@ -50,4 +50,21 @@ module('Acceptance | user details personal information', function(hooks) {
     });
   });
 
+  module('when administrator click on anonymize button and confirm modal', function() {
+
+    test('should anonymize the user', async function(assert) {
+      // given
+      await visit(`/users/${user.id}`);
+      await click('button[aria-label="Anonymiser"]');
+
+      // when
+      await click('.modal-dialog .btn-primary');
+
+      // then
+      assert.contains(`prenom_${user.id}`);
+      assert.contains(`nom_${user.id}`);
+      assert.contains(`email_${user.id}@example.net`);
+    });
+  });
+
 });

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -275,4 +275,37 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
   });
 
+  module('when the administrator click on anonymize button', async function() {
+    let user = null;
+
+    hooks.beforeEach(function() {
+      user = EmberObject.create({
+        lastName: 'Harry',
+        firstName: 'John',
+        email: 'john.harry@gmail.com',
+        username: null,
+        isAuthenticatedFromGAR: false
+      });
+    });
+
+    test('should show modal', async function(assert) {
+      this.set('user', user);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      await click('button[aria-label=\'Anonymiser\']');
+
+      assert.dom('.modal-dialog').exists();
+      assert.contains('Etes-vous sûr de vouloir anonymiser cet utilisateur? Ceci n’est pas réversible');
+    });
+
+    test('should close the modal to cancel action', async function(assert) {
+      this.set('user', user);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      await click('button[aria-label=\'Anonymiser\']');
+
+      await click('.modal-dialog .btn-secondary');
+
+      assert.dom('.modal-dialog').doesNotExist();
+    });
+  });
 });

--- a/admin/tests/unit/adapters/user-test.js
+++ b/admin/tests/unit/adapters/user-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | user', function(hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:user');
+  });
+
+  module('#urlForFindRecord', function() {
+    test('should add /admin inside the default find record url', function(assert) {
+      // when
+      const url = adapter.urlForFindRecord(123, 'users');
+
+      // then
+      assert.ok(url.endsWith('/admin/users/123'));
+    });
+  });
+
+  module('#urlForUpdateRecord', function() {
+    test('should add /admin inside the default update record url', function(assert) {
+      // when
+      const url = adapter.urlForUpdateRecord(123);
+
+      // then
+      assert.ok(url.endsWith('/admin/users/123'));
+    });
+  });
+
+  module('#updateRecord', function() {
+
+    module('when anonymizeUser adapterOptions is passed', function(hooks) {
+
+      hooks.beforeEach(function() {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function() {
+        adapter.ajax.restore();
+      });
+
+      test('should send a POST request to user endpoint', async function(assert) {
+        // given
+        adapter.ajax.resolves();
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'user' }, { id: 123, adapterOptions: { anonymizeUser: true } });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/users/123/anonymize', 'POST');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
+});

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -57,7 +57,7 @@ exports.register = async function(server) {
           failAction: (request, h) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
+              status: errorHttpStatusCode.toString(),
               title: 'Bad request',
               detail: 'L\'identifiant de l\'utilisateur n\'est pas au bon format.',
             });
@@ -76,7 +76,6 @@ exports.register = async function(server) {
         tags: ['api', 'administration' , 'user'],
       }
     },
-
     {
       method: 'PATCH',
       path: '/api/admin/users/{id}',
@@ -109,8 +108,8 @@ exports.register = async function(server) {
           failAction: (request, h , err) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
-              title: 'Bad request', 
+              status: errorHttpStatusCode.toString(),
+              title: 'Bad request',
               detail: err.details[0].message,
             });
             return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
@@ -123,7 +122,6 @@ exports.register = async function(server) {
         tags: ['api', 'administration' , 'user'],
       }
     },
-
     {
       method: 'GET',
       path: '/api/users/{id}/memberships',
@@ -408,6 +406,35 @@ exports.register = async function(server) {
           '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api', 'user', 'campaign', 'campaign-participations']
+      }
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/users/{id}/anonymize',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().positive().required(),
+          }),
+          failAction: (request, h , err) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              status: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: err.details[0].message,
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          }
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster'
+        }],
+        handler: userController.anonymizeUser,
+        notes : [
+          '- Permet à un administrateur d\'anonymiser un utilisateur',
+        ],
+        tags: ['api', 'administration' , 'user'],
       }
     },
   ]);

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -185,7 +185,13 @@ module.exports = {
     const campaignId = request.params.campaignId;
 
     const sharedProfileForCampaign = await usecases.getUserProfileSharedForCampaign({ userId: authenticatedUserId, campaignId });
-    
+
     return sharedProfileForCampaignSerializer.serialize(sharedProfileForCampaign);
+  },
+
+  async anonymizeUser(request, h) {
+    const userId = parseInt(request.params.id);
+    await usecases.anonymizeUser({ userId });
+    return h.response({}).code(204);
   }
 };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -1,0 +1,13 @@
+module.exports = function anonymizeUser({
+  userId,
+  userRepository,
+}) {
+
+  const anonymizedUser = {
+    firstName: `prenom_${userId}`,
+    lastName: `nom_${userId}`,
+    email: `email_${userId}@example.net`,
+  };
+
+  return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,3 @@
-const { injectDependencies } = require('../../infrastructure/utils/dependency-injection');
-
 const dependencies = {
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
@@ -71,6 +69,8 @@ const dependencies = {
   userTutorialRepository: require('../../infrastructure/repositories/user-tutorial-repository'),
 };
 
+const { injectDependencies } = require('../../infrastructure/utils/dependency-injection');
+
 module.exports = injectDependencies({
   acceptPixLastTermsOfService: require('./accept-pix-last-terms-of-service'),
   acceptPixCertifTermsOfService: require('./accept-pix-certif-terms-of-service'),
@@ -78,6 +78,7 @@ module.exports = injectDependencies({
   addCertificationCandidateToSession: require('./add-certification-candidate-to-session'),
   addTutorialEvaluation: require('./add-tutorial-evaluation'),
   addTutorialToUser: require('./add-tutorial-to-user'),
+  anonymizeUser: require('./anonymize-user'),
   answerToOrganizationInvitation: require('./answer-to-organization-invitation'),
   attachTargetProfilesToOrganization: require('./attach-target-profiles-to-organization'),
   archiveCampaign: require('./archive-campaign'),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -323,10 +323,9 @@ module.exports = {
 
   async updateUserDetailsForAdministration(id, userAttributes) {
     try {
-      let updatedUser = await BookshelfUser
+      const updatedUser = await BookshelfUser
         .where({ id })
         .save(userAttributes, { patch: true, method: 'update' });
-      updatedUser = await updatedUser.refresh();
       return _toUserDetailsForAdminDomain(updatedUser);
     } catch (err) {
       if (err instanceof BookshelfUser.NoRowsUpdatedError) {

--- a/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
@@ -1,0 +1,46 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-anonymize-user', () => {
+
+  let server;
+  let user;
+  let options;
+
+  beforeEach(async () => {
+    server = await createServer();
+    user = databaseBuilder.factory.buildUser();
+    const pixMaster = await insertUserWithRolePixMaster();
+    options = {
+      method: 'POST',
+      url: `/api/admin/users/${user.id}/anonymize`,
+      payload: {},
+      headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+    };
+    return databaseBuilder.commit();
+  });
+
+  describe('POST /admin/users/:id/anonymize', () => {
+
+    it('should return 204', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should update user in Database', async () => {
+      // when
+      await server.inject(options);
+
+      // then
+      const users = await knex.select('*').from('users').where({ id: user.id });
+      const updatedUser = users[0];
+      expect(updatedUser.firstName).to.equal(`prenom_${user.id}`);
+      expect(updatedUser.lastName).to.equal(`nom_${user.id}`);
+      expect(updatedUser.email).to.equal(`email_${user.id}@example.net`);
+      expect(updatedUser.updatedAt).to.be.above(user.updatedAt);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -10,8 +10,8 @@ const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repos
 
 describe('Integration | Repository | UserOrgaSettings', function() {
 
-  const USER_OMITTED_PROPERTIES = ['campaignParticipations', 'certificationCenterMemberships', 'knowledgeElements',
-    'memberships', 'pixRoles', 'pixScore', 'samlId', 'scorecards', 'userOrgaSettings', 'shouldChangePassword'];
+  const USER_PICKED_PROPERTIES = ['id', 'firstName', 'lastName', 'email', 'username', 'password', 'cgu',
+    'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted'];
 
   const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares',
     'createdAt', 'updatedAt'];
@@ -57,7 +57,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
 
       // then
       expect(userOrgaSettingsSaved.id).to.not.be.undefined;
-      expect(_.omit(userOrgaSettingsSaved.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.pick(userOrgaSettingsSaved.user, USER_PICKED_PROPERTIES)).to.deep.equal(_.pick(user, USER_PICKED_PROPERTIES));
       expect(_.omit(userOrgaSettingsSaved.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(organization, ORGANIZATION_OMITTED_PROPERTIES));
     });
 
@@ -91,7 +91,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
 
       // then
       expect(updatedUserOrgaSettings.id).to.deep.equal(userOrgaSettingsId);
-      expect(_.omit(updatedUserOrgaSettings.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.pick(updatedUserOrgaSettings.user, USER_PICKED_PROPERTIES)).to.deep.equal(_.pick(user, USER_PICKED_PROPERTIES));
       expect(_.omit(updatedUserOrgaSettings.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(expectedOrganization, ORGANIZATION_OMITTED_PROPERTIES));
     });
   });
@@ -119,7 +119,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
 
       // then
       expect(foundUserOrgaSettings.id).to.deep.equal(userOrgaSettingsId);
-      expect(_.omit(foundUserOrgaSettings.user, USER_OMITTED_PROPERTIES)).to.deep.equal(_.omit(user, USER_OMITTED_PROPERTIES));
+      expect(_.pick(foundUserOrgaSettings.user, USER_PICKED_PROPERTIES)).to.deep.equal(_.pick(user, USER_PICKED_PROPERTIES));
       expect(_.omit(foundUserOrgaSettings.currentOrganization, ORGANIZATION_OMITTED_PROPERTIES)).to.deep.equal(_.omit(organization, ORGANIZATION_OMITTED_PROPERTIES));
     });
 

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -24,6 +24,8 @@ const buildUser = function buildUser({
   hasSeenAssessmentInstructions = false,
   samlId,
   shouldChangePassword = false,
+  createdAt = new Date(),
+  updatedAt = new Date(),
 } = {}) {
 
   password = _.isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
@@ -31,7 +33,7 @@ const buildUser = function buildUser({
 
   const values = {
     id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword, createdAt, updatedAt
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -414,4 +414,42 @@ describe('Unit | Router | user-router', () => {
 
     });
   });
+
+  describe('POST /api/admin/users/{id}/anonymize', () => {
+
+    beforeEach(() => {
+      sinon.stub(userController, 'anonymizeUser').callsFake((request, h) => h.response({}).code(204));
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      startServer();
+    });
+
+    it('should exist', async () => {
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/admin/users/1/anonymize',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 400 when id is not a number', async () => {
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/admin/users/wrongId/anonymize',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+      expect(JSON.parse(response.payload).errors[0].detail).to.equal('"id" must be a number');
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -751,4 +751,32 @@ describe('Unit | Controller | user-controller', () => {
       expect(response).to.equal(expectedCampaignParticipation);
     });
   });
+
+  describe('#anonymizeUser', () => {
+
+    const userId = 1;
+    const request = {
+      auth: {
+        credentials: {
+          userId
+        }
+      },
+      params: {
+        id: userId
+      },
+    };
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'anonymizeUser').resolves();
+    });
+
+    it('should call the anonymize user usecase', async () => {
+      // when
+      const response = await userController.anonymizeUser(request, hFake);
+
+      // then
+      expect(usecases.anonymizeUser).to.have.been.calledWith({ userId });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -1,0 +1,26 @@
+const { expect, sinon } = require('../../../test-helper');
+const anonymizeUser = require('../../../../lib/domain/usecases/anonymize-user');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+describe('Unit | UseCase | anonymize-user', () => {
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'updateUserDetailsForAdministration').resolves();
+  });
+
+  it('should anonymize user', async () => {
+    // given
+    const userId = 1;
+    const expectedAnonymizedUser = {
+      firstName: `prenom_${userId}`,
+      lastName: `nom_${userId}`,
+      email: `email_${userId}@example.net`,
+    };
+
+    // when
+    await anonymizeUser({ userId, userRepository });
+
+    // then
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly(userId, expectedAnonymizedUser);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le processus d'anonymisation d'un utilisateur consiste à modifier ses attributs nom, prénom et email sous la forme:
- Prénom: `prenom_{userId}`
- Nom: `nom_{userId}` 
- Email: `email_{userId}@example.net`
Cette modification est faite directement en base de donnée ce qui peut générer des erreurs.  

## :robot: Solution
Ajouter un bouton `Anonymiser cet utilisateur` depuis la page de détail d'un utilisateur dans Pix Admin afin d'effectuer ce processus d'anonymisation.
