### PR TITLE
[FEATURE] Dissocier les comptes utilisateurs des élèves depuis Pix ORGA (Pix-718).

### DIFF
--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -89,7 +89,28 @@ exports.register = async function(server) {
         ],
         tags: ['api', 'schoolingRegistrationUserAssociation']
       }
-    }
+    },
+    {
+      method: 'DELETE',
+      path: '/api/schooling-registration-user-associations',
+      config: {
+        handler: schoolingRegistrationUserAssociationController.dissociate,
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'schooling-registration-id': Joi.number(),
+              }
+            }
+          })
+        },
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés et admin au sein de l\'orga**\n' +
+          '- Elle dissocie un utilisateur d\'une inscription d’élève'
+        ],
+        tags: ['api', 'schoolingRegistrationUserAssociation']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -52,5 +52,12 @@ module.exports = {
       }
     };
     return h.response(schoolingRegistrationWithUsernameResponse).code(200);
+  },
+
+  async dissociate(request, h) {
+    const payload = request.payload.data.attributes;
+    const { userId } = request.auth.credentials;
+    await usecases.dissociateUserFromSchoolingRegistration({ userId, schoolingRegistrationId: payload['schooling-registration-id'] });
+    return h.response().code(204);
   }
 };

--- a/api/lib/domain/usecases/dissociate-user-from-schooling-registration.js
+++ b/api/lib/domain/usecases/dissociate-user-from-schooling-registration.js
@@ -1,0 +1,24 @@
+const { ForbiddenAccess } = require('../errors');
+const _ = require('lodash');
+
+module.exports = async function dissociateUserFromSchoolingRegistrationData({
+  schoolingRegistrationRepository,
+  membershipRepository,
+  userId,
+  schoolingRegistrationId
+}) {
+  await _checkUserCanDissociateUserFromSchoolingRegistration(userId, schoolingRegistrationId, schoolingRegistrationRepository, membershipRepository);
+
+  await schoolingRegistrationRepository.dissociateUserFromSchoolingRegistration(schoolingRegistrationId);
+};
+
+async function _checkUserCanDissociateUserFromSchoolingRegistration(userId, schoolingRegistrationId, schoolingRegistrationRepository, membershipRepository) {
+  const schoolingRegistration = await schoolingRegistrationRepository.get(schoolingRegistrationId);
+  const memberships = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId: schoolingRegistration.organizationId, includeOrganization: true });
+
+  if (!_.some(memberships, 'isAdmin')) {
+    throw new ForbiddenAccess();
+  }
+
+}
+

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -101,6 +101,7 @@ module.exports = injectDependencies({
   createSession: require('./create-session'),
   createUser: require('./create-user'),
   deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
+  dissociateUserFromSchoolingRegistration: require('./dissociate-user-from-schooling-registration'),
   finalizeSession: require('./finalize-session'),
   findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),
   findAnswerByAssessment: require('./find-answer-by-assessment'),

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -81,13 +81,22 @@ module.exports = {
       .then((schoolingRegistrations) => bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations));
   },
 
-  associateUserAndSchoolingRegistration({ userId, schoolingRegistrationId }) {
-    return BookshelfSchoolingRegistration
+  async associateUserAndSchoolingRegistration({ userId, schoolingRegistrationId }) {
+    const schoolingRegistration = await BookshelfSchoolingRegistration
       .where({ id: schoolingRegistrationId })
       .save({ userId }, {
         patch: true,
-      })
-      .then((schoolingRegistration) => bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration));
+      });
+
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration);
+  },
+
+  async dissociateUserFromSchoolingRegistration(schoolingRegistrationId) {
+    await BookshelfSchoolingRegistration
+      .where({ id: schoolingRegistrationId })
+      .save({ userId: null }, {
+        patch: true,
+      });
   },
 
   findOneByUserIdAndOrganizationId({ userId, organizationId }) {

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(students) {
     return new Serializer('students', {
       attributes: [
-        'lastName', 'firstName', 'birthdate', 'username', 'email', 'isAuthenticatedFromGAR',
+        'lastName', 'firstName', 'birthdate', 'username', 'userId', 'email', 'isAuthenticatedFromGAR',
       ],
     }).serialize(students);
   }

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -786,6 +786,7 @@ describe('Acceptance | Application | organization-controller', () => {
                 'last-name': schoolingRegistration.lastName,
                 'first-name': schoolingRegistration.firstName,
                 'birthdate': schoolingRegistration.birthdate,
+                'user-id': user.id,
                 'username': user.username,
                 'email': user.email,
                 'is-authenticated-from-gar': true,

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -420,6 +420,26 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
+  describe('#dissociateUserAndSchoolingRegistration', () => {
+
+    let schoolingRegistration;
+
+    beforeEach(async () => {
+      const user = databaseBuilder.factory.buildUser();
+      schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: user.id });
+      await databaseBuilder.commit();
+    });
+
+    it('should delete association between user and schoolingRegistration', async () => {
+      // when
+      await schoolingRegistrationRepository.dissociateUserFromSchoolingRegistration(schoolingRegistration.id);
+
+      // then
+      const schoolingRegistrationPatched = await schoolingRegistrationRepository.get(schoolingRegistration.id);
+      expect(schoolingRegistrationPatched.userId).to.equal(null);
+    });
+  });
+
   describe('#associateUserAndSchoolingRegistration', () => {
 
     afterEach(() => {

--- a/api/tests/tooling/domain-builder/factory/build-schooling-registration.js
+++ b/api/tests/tooling/domain-builder/factory/build-schooling-registration.js
@@ -39,6 +39,6 @@ module.exports = function buildSchoolingRegistration(
     status,
     nationalStudentId,
     division,
-    organization,
+    organizationId: organization.id,
   });
 };

--- a/api/tests/unit/domain/usecases/dissociate-user-from-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/dissociate-user-from-schooling-registration_test.js
@@ -1,0 +1,97 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const { ForbiddenAccess } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
+
+  let schoolingRegistrationRepositoryStub;
+  let membershipRepositoryStub;
+  let schoolingRegistration;
+  const organizationId = 1;
+  const schoolingRegistrationId = 2;
+
+  context('when the user is an admin of the organization which manage the student', () => {
+    const userId = 12;
+
+    beforeEach(() => {
+
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+
+      schoolingRegistrationRepositoryStub =  {
+        dissociateUserFromSchoolingRegistration: sinon.stub(),
+        get: sinon.stub().resolves(schoolingRegistration)
+      };
+      membershipRepositoryStub =  { findByUserIdAndOrganizationId: sinon.stub().withArgs({ userId, organizationId: 9, includeOrganization: true }).resolves([{ isAdmin: true }]) };
+    });
+
+    it('should dissociate user from the schooling registration', async () => {
+
+      await usecases.dissociateUserFromSchoolingRegistration({
+        userId,
+        schoolingRegistrationId,
+        membershipRepository: membershipRepositoryStub,
+        schoolingRegistrationRepository: schoolingRegistrationRepositoryStub
+      });
+
+      // then
+      expect(schoolingRegistrationRepositoryStub.get).to.be.have.been.calledWith(schoolingRegistrationId);
+      expect(schoolingRegistrationRepositoryStub.dissociateUserFromSchoolingRegistration).to.be.have.been.calledWith(schoolingRegistrationId);
+      expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.be.have.been.called;
+    });
+  });
+
+  context('when the user is not a member of the organization which manages the student', () => {
+    const userId = 12;
+
+    beforeEach(() => {
+
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+
+      schoolingRegistrationRepositoryStub =  {
+        dissociateUserFromSchoolingRegistration: sinon.stub(),
+        get: sinon.stub().resolves(schoolingRegistration)
+      };
+      membershipRepositoryStub =  { findByUserIdAndOrganizationId: sinon.stub().resolves([]) };
+    });
+
+    it('throws a ForbiddenAccess error', async () => {
+
+      const error = await catchErr(usecases.dissociateUserFromSchoolingRegistration)({
+        userId,
+        schoolingRegistrationId,
+        membershipRepository: membershipRepositoryStub,
+        schoolingRegistrationRepository: schoolingRegistrationRepositoryStub
+      });
+
+      expect(error).to.be.instanceof(ForbiddenAccess);
+    });
+  });
+
+  context('when the user is not a admin of the organization which manages the student', () => {
+    const userId = 1;
+
+    beforeEach(() => {
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+
+      schoolingRegistrationRepositoryStub =  {
+        dissociateUserFromSchoolingRegistration: sinon.stub(),
+        get: sinon.stub().resolves(schoolingRegistration)
+      };
+      membershipRepositoryStub =  { findByUserIdAndOrganizationId: sinon.stub().resolves([{ idAdmin: false }]) };
+    });
+
+    it('throws a ForbiddenAccess error', async () => {
+
+      const error = await catchErr(usecases.dissociateUserFromSchoolingRegistration)({
+        userId,
+        schoolingRegistrationId,
+        membershipRepository: membershipRepositoryStub,
+        schoolingRegistrationRepository: schoolingRegistrationRepositoryStub
+      });
+
+      expect(error).to.be.instanceof(ForbiddenAccess);
+    });
+  });
+
+});
+

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | UserWithSchoolingRegistration-serializer
             'last-name': userWithSchoolingRegistration.lastName,
             'birthdate': userWithSchoolingRegistration.birthdate,
             'username': userWithSchoolingRegistration.username,
+            'user-id': userWithSchoolingRegistration.userId,
             'email': userWithSchoolingRegistration.email,
             'is-authenticated-from-gar': false,
           }

--- a/orga/app/adapters/student.js
+++ b/orga/app/adapters/student.js
@@ -7,4 +7,17 @@ export default class Student extends ApplicationAdapter {
 
     return `${this.host}/${this.namespace}/organizations/${organizationId}/students`;
   }
+
+  dissociateUser(model) {
+    const data = {
+      data: {
+        attributes: {
+          'schooling-registration-id': model.id,
+        }
+      }
+    };
+
+    const url = `${this.host}/${this.namespace}/schooling-registration-user-associations`;
+    return this.ajax(url, 'DELETE', { data });
+  }
 }

--- a/orga/app/components/dissociate-user-modal.js
+++ b/orga/app/components/dissociate-user-modal.js
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class DissociateUserModal extends Component {
+
+  @service store;
+
+  @action
+  async dissociateUser() {
+    const adapter = this.store.adapterFor('student');
+    await adapter.dissociateUser(this.args.student);
+    this.args.close();
+    this.args.refreshModel();
+  }
+}

--- a/orga/app/components/routes/authenticated/students/list-items.js
+++ b/orga/app/components/routes/authenticated/students/list-items.js
@@ -8,6 +8,7 @@ export default class ListItems extends Component {
 
   student = null;
   isShowingModal = false;
+  isShowingDissociateModal = false;
 
   @action
   openPasswordReset(student) {
@@ -18,5 +19,16 @@ export default class ListItems extends Component {
   @action
   closePasswordReset() {
     this.set('isShowingModal', false);
+  }
+
+  @action
+  openDissociateModal(student) {
+    this.set('student', student);
+    this.set('isShowingDissociateModal', true);
+  }
+
+  @action
+  closeDissociateModal() {
+    this.set('isShowingDissociateModal', false);
   }
 }

--- a/orga/app/controllers/authenticated/students/list.js
+++ b/orga/app/controllers/authenticated/students/list.js
@@ -40,7 +40,7 @@ export default class ListController extends Controller {
           Authorization: `Bearer ${access_token}`,
         }
       });
-      this.send('refreshModel');
+      this.refresh();
       this.set('isLoading', false);
       this.get('notifications').sendSuccess('La liste a été importée avec succès.');
 
@@ -67,5 +67,10 @@ export default class ListController extends Controller {
       }
       return this.get('notifications').sendError(globalErrorMessage);
     });
+  }
+
+  @action
+  refresh() {
+    this.send('refreshModel');
   }
 }

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
 import { notEmpty } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import Model, { belongsTo, attr } from '@ember-data/model';
 
 const dash = '\u2013';
 
@@ -19,18 +19,19 @@ const StudentAuthMethod = {
   },
 };
 
-export default DS.Model.extend({
-  lastName: DS.attr('string'),
-  firstName: DS.attr('string'),
-  birthdate: DS.attr('date-only'),
-  organization: DS.belongsTo('organization'),
-  username: DS.attr('string'),
-  email: DS.attr('string'),
-  isAuthenticatedFromGar: DS.attr('boolean'),
-  hasUsername: notEmpty('username'),
-  hasEmail: notEmpty('email'),
-  authenticationMethods : computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar', function() {
+export default class Student extends Model {
+  @attr('string')lastName;
+  @attr('string') firstName;
+  @attr('date-only') birthdate;
+  @attr('string') username;
+  @attr('string') email;
+  @attr('boolean') isAuthenticatedFromGar;
+  @belongsTo('organization') organization;
+  @notEmpty('username') hasUsername;
+  @notEmpty('email') hasEmail;
 
+  @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
+  get authenticationMethods() {
     const SPACING_CHARACTER = '\n';
     let message = '';
     const props = ['hasEmail', 'hasUsername', 'isAuthenticatedFromGar'];
@@ -43,5 +44,10 @@ export default DS.Model.extend({
 
     return message ?  message.trim() : StudentAuthMethod['studentNotReconcilied'].message;
 
-  }),
-});
+  }
+
+  @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
+  get isStudentAssociated() {
+    return Boolean(this.email || this.username || this.isAuthenticatedFromGar);
+  }
+}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -21,6 +21,7 @@
 @import "components/campaign-list";
 @import "components/circle-chart";
 @import "components/current-organization";
+@import "components/dissociate-user-modal";
 @import "components/dropdown";
 @import "components/pagination-control";
 @import "components/previous-page-button";

--- a/orga/app/styles/components/dissociate-user-modal.scss
+++ b/orga/app/styles/components/dissociate-user-modal.scss
@@ -1,0 +1,58 @@
+.dissociate-user-modal {
+  .content-text {
+    color: $grey-90;
+
+    &--info {
+      font-size: 0.875rem;
+      color: $grey-60;
+    }
+  }
+
+  .button--bordered {
+    color: $blue;
+    border-color: $blue;
+
+    &:hover, &:active, &:focus  {
+      background-color: $blue;
+      color: $white;
+    }
+  }
+
+  .button--bordered-grey {
+    color: $grey-90;
+    border-color: $grey-80;
+    background-color: transparent;
+
+    &:hover, &:active, &:focus  {
+      background-color: $grey-20;
+    }
+  }
+
+  &__content, &__actions {
+    background: $grey-10;
+  }
+
+  &__content{
+    padding-top: 37px;
+    padding-bottom: 10px;
+
+    .content-text:first-child {
+      margin-top: 0;
+      margin-bottom: 33px;
+    }
+    .content-text:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+
+    button:first-child {
+      margin-right: 25px;
+    }
+  }
+}
+
+

--- a/orga/app/styles/components/modal.scss
+++ b/orga/app/styles/components/modal.scss
@@ -46,7 +46,8 @@
       }
 
       .modal-body {
-        padding: 0 48px;
+        padding-left: 48px;
+        padding-right: 48px;
       }
 
       .modal-footer {

--- a/orga/app/templates/authenticated/students/list.hbs
+++ b/orga/app/templates/authenticated/students/list.hbs
@@ -6,5 +6,6 @@
     @triggerFiltering={{this.triggerFiltering}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
+    @refreshModel={{this.refresh}}
   />
 </div>

--- a/orga/app/templates/components/dissociate-user-modal.hbs
+++ b/orga/app/templates/components/dissociate-user-modal.hbs
@@ -1,0 +1,23 @@
+<Modal::Dialog class="dissociate-user-modal" @title="Dissocier le compte Pix de l'élève" @display={{@display}} @close={{@close}}>
+  <Modal::Body class="dissociate-user-modal__content">
+    <p class="content-text">
+    {{#if @student.hasEmail}}
+        Souhaitez-vous dissocier le compte <span class="content-text--bold">{{@student.email}}</span> de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
+    {{else if @student.hasUsername}}
+        Souhaitez-vous dissocier le compte <span class="content-text--bold">{{@student.username}}</span> de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
+    {{else}}
+        Souhaitez-vous dissocier le compte du médiacenter de l'ENT de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
+    {{/if}}
+      </p>
+    <p class="content-text content-text--info">
+      L’élève pourra s’associer à nouveau avec une autre méthode d’authentification lors d’une prochaine campagne.
+      <br/>
+      <br/>
+      Si l'élève a déjà participé à des campagnes, ses participations et les résultats envoyés seront conservés.
+    </p>
+  </Modal::Body>
+  <Modal::Footer class="dissociate-user-modal__actions">
+    <button type="button" class="button button--bordered-grey" {{on 'click' @close}}>Annuler</button>
+    <button type="button" class="button" {{on 'click' this.dissociateUser}}>Oui, dissocier le compte</button>
+  </Modal::Footer>
+</Modal::Dialog>

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -54,14 +54,19 @@
             <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
             <td class="list-students-page__authentication-methods">{{student.authenticationMethods}}</td>
             <td class="list-students-page__actions">
-              {{#if (or student.hasUsername student.hasEmail) }}
+              {{#if student.isStudentAssociated}}
                 <Dropdown::IconTrigger
                   @icon="ellipsis-v"
                   @dropdownButtonClass="list-students-page__dropdown-button"
                   @dropdownContentClass="list-students-page__dropdown-content"
                 >
-                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
-                    Gérer le compte
+                  {{#if (or student.hasUsername student.hasEmail)}}
+                    <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                      Gérer le compte
+                    </Dropdown::Item>
+                  {{/if}}
+                  <Dropdown::Item @onClick={{fn this.openDissociateModal student}}>
+                    Dissocier le compte
                   </Dropdown::Item>
                 </Dropdown::IconTrigger>
               {{/if}}
@@ -83,6 +88,12 @@
     @student={{this.student}}
     @display={{this.isShowingModal}}
     @close={{this.closePasswordReset}}
+  />
+  <DissociateUserModal
+    @student={{this.student}}
+    @display={{this.isShowingDissociateModal}}
+    @close={{this.closeDissociateModal}}
+    @refreshModel={{@refreshModel}}
   />
 </div>
 

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -277,4 +277,12 @@ export default function() {
   this.get('/campaigns/:campaignId/profiles-collection-participations/:campaignParticipationId', (schema, request) => {
     return schema.campaignProfiles.findBy({ ...request.params });
   });
+
+  this.delete('/schooling-registration-user-associations', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+
+    const student = schema.students.find(requestBody.data.attributes['schooling-registration-id']);
+    return student.update({ email: null });
+  });
+
 }

--- a/orga/tests/acceptance/dissociate-student-test.js
+++ b/orga/tests/acceptance/dissociate-student-test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { visit, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+import {
+  createPrescriberByUser, createUserManagingStudents
+} from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+async function createAuthenticatedSession() {
+  const user = createUserManagingStudents();
+  createPrescriberByUser(user);
+
+  await authenticateSession({
+    user_id: user.id,
+    access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+    expires_in: 3600,
+    token_type: 'Bearer token type',
+  });
+
+  return user;
+}
+
+const DASH_CHARACTER = '\u2013';
+module('Acceptance | Student List', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let user;
+  let organizationId;
+
+  hooks.beforeEach(async function() {
+    user = await createAuthenticatedSession();
+  });
+
+  module('when the student is dissociated from the user', function() {
+
+    test('it does not display the action button', async function(assert) {
+      organizationId = user.memberships.models.firstObject.organizationId;
+
+      server.create('student', {
+        organizationId,
+        id: 1,
+        firstName: 'Ellen Louise',
+        lastName: 'Ripley',
+        email: 'ellen@ripley.com',
+      });
+      // when
+      await visit('/eleves');
+      await click('[aria-label="Afficher les actions"]');
+      await click('.list-students-page__actions [role="button"]:last-child');
+      await click('.dissociate-user-modal__actions button:last-child');
+
+      // then
+      assert.dom('[aria-label="Afficher les actions"]').doesNotExist();
+      assert.notContains('Dissocier le compte Pix de l\'élève');
+      assert.contains(DASH_CHARACTER);
+    });
+  });
+});

--- a/orga/tests/integration/components/dissociate-user-modal-test.js
+++ b/orga/tests/integration/components/dissociate-user-modal-test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | dissociate-user-modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('display', true);
+    this.set('refreshModel', sinon.stub());
+    this.set('close', sinon.stub());
+
+    return render(hbs`<DissociateUserModal @refreshModel={{refreshModel}} @display={{display}} @close={{close}} @student={{student}}/>`);
+  });
+
+  module('when the user is authenticated  with an email', function() {
+
+    test('it displays a message for user authentified by email', async function(assert) {
+      this.set('student', { hasEmail: true, email: 'rocky.balboa@example.net', firstName: 'Rocky',  lastName: 'Balboa' });
+
+      assert.contains('Souhaitez-vous dissocier le compte rocky.balboa@example.net de l\'élève Rocky Balboa ?');
+    });
+  });
+
+  module('when the user is authenticated with an username', function() {
+
+    test('it displays a message for user authentified by username', async function(assert) {
+      this.set('student', { hasUsername: true, username: 'appolo.creed', firstName: 'Appolo',  lastName: 'Creed' });
+
+      assert.contains('Souhaitez-vous dissocier le compte appolo.creed de l\'élève Appolo Creed ?');
+    });
+  });
+
+  module('when the user is authenticated with GAR', function() {
+
+    test('it displays a message for user authentified with GAR', async function(assert) {
+      this.set('student', { hasEmail: false, hasUsername: false, firstName: 'Ivan', lastName: 'Drago' });
+
+      assert.contains('Souhaitez-vous dissocier le compte du médiacenter de l\'ENT de l\'élève Ivan Drago ?');
+    });
+  });
+
+  module('dissociate button', function() {
+    let studentAdapter;
+
+    hooks.beforeEach(function() {
+      const store = this.owner.lookup('service:store');
+      studentAdapter = store.adapterFor('student');
+      sinon.stub(studentAdapter, 'dissociateUser');
+    });
+
+    hooks.afterEach(function() {
+      studentAdapter.dissociateUser.restore();
+    });
+
+    test('it dissociate user form student on click', async function(assert) {
+      const student = { id: 12345 };
+      this.set('student', student);
+
+      await click('.dissociate-user-modal__actions button:last-child');
+
+      assert.ok(studentAdapter.dissociateUser.calledWith(student));
+    });
+  });
+
+});

--- a/orga/tests/unit/adapters/student-test.js
+++ b/orga/tests/unit/adapters/student-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import ENV from 'pix-orga/config/environment';
 
 module('Unit | Adapters | student', function(hooks) {
   setupTest(hooks);
@@ -19,6 +20,31 @@ module('Unit | Adapters | student', function(hooks) {
 
       assert.ok(url.endsWith('/api/organizations/organizationId1/students'));
       assert.equal(query.organizationId, undefined);
+    });
+  });
+
+  module('#dissociateUser', function() {
+    let ajaxStub;
+
+    hooks.beforeEach(function() {
+      ajaxStub = sinon.stub();
+      adapter.set('ajax', ajaxStub);
+    });
+
+    test('it performs the request to dissociate user from student', async function(assert) {
+      const model = { id: 12345 };
+      const data = {
+        data: {
+          attributes: {
+            'schooling-registration-id': model.id,
+          }
+        }
+      };
+      const url = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations`;
+
+      await adapter.dissociateUser(model);
+
+      assert.ok(ajaxStub.calledWith(url, 'DELETE', { data }));
     });
   });
 });

--- a/orga/tests/unit/models/student-test.js
+++ b/orga/tests/unit/models/student-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | student', function(hooks) {
 
@@ -13,7 +12,7 @@ module('Unit | Model | student', function(hooks) {
         const dash = '\u2013';
         const store = this.owner.lookup('service:store');
         const student = { lastName: 'Last', firstName: 'First', birthdate: '2010-10-10' };
-        const model = run(() => store.createRecord('student', student));
+        const model = store.createRecord('student', student);
 
         // when
         // then
@@ -33,7 +32,7 @@ module('Unit | Model | student', function(hooks) {
             birthdate: '2012-01-07',
             username: 'blueivy.carter0701',
           };
-          const model = run(() => store.createRecord('student', student));
+          const model = store.createRecord('student', student);
 
           // when
           // then
@@ -48,7 +47,7 @@ module('Unit | Model | student', function(hooks) {
             birthdate: '2013-07-22',
             email: 'georges.decambridge@example.net'
           };
-          const model = run(() => store.createRecord('student', student));
+          const model = store.createRecord('student', student);
 
           // when
           // then
@@ -63,7 +62,7 @@ module('Unit | Model | student', function(hooks) {
             birthdate: '2013-07-22',
             isAuthenticatedFromGar: true
           };
-          const model = run(() => store.createRecord('student', student));
+          const model = store.createRecord('student', student);
 
           // when
           // then
@@ -85,7 +84,7 @@ module('Unit | Model | student', function(hooks) {
             email: 'carter.blueivy@example.net',
             isAuthenticatedFromGar: false,
           };
-          const model = run(() => store.createRecord('student', student));
+          const model = store.createRecord('student', student);
 
           // when
           // then
@@ -96,4 +95,34 @@ module('Unit | Model | student', function(hooks) {
     });
   });
 
+  module('#isStudentAssociated', function(hooks) {
+    let store;
+    hooks.beforeEach(function() {
+      store = this.owner.lookup('service:store');
+    });
+
+    test('it returns false when the student has no email, no username or is not authenticated from GAR', function(assert) {
+      const student = store.createRecord('student', { email: null, username: null, isAuthenticatedFromGar: false });
+
+      assert.equal(student.isStudentAssociated, false);
+    });
+
+    test('it returns true when the student has an email', function(assert) {
+      const student = store.createRecord('student', { email: 'martin.riggs@example.net', username: null, isAuthenticatedFromGar: false });
+
+      assert.equal(student.isStudentAssociated, true);
+    });
+
+    test('it returns true when the student has an username', function(assert) {
+      const student = store.createRecord('student', { email: null, username: 'RogerMurtaugh', isAuthenticatedFromGar: false });
+
+      assert.equal(student.isStudentAssociated, true);
+    });
+
+    test('it returns true when the student is authenticated from GAR', function(assert) {
+      const student = store.createRecord('student', { email: null, username: null, isAuthenticatedFromGar: true });
+
+      assert.equal(student.isStudentAssociated, true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Si un élève ou un professeur s’associe avec un compte au lieu d’une autre personne, il n’y a aucun moyen de défaire cette association. Des demandes à la hotline sont crées pour réaliser la dissociation. C’est pourquoi dans cette US, les administrateurs  de chaque organisation “sco, ismanagingstudent” pourront réaliser eux même la dissociation d'élève.

## :robot: Solution
Ajouter une modal pour dissocier un compte sur Pix ORGA  

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix ORGA avec un compte ADMIN sur une orga qui gère des étudiants et essayer de dissocier le compte d'un étudiant.