### PR TITLE
[FEATURE] Ajouter lien sur le tableau de bord d'un utilisateur (PIX-606).

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -58,45 +58,50 @@
   {{else}}
     <form class="form user-read-only-form">
       <section class="page-section mb_10">
-        <div>
-          <div class="attribute first-name">
-            <span class="attibute__label">Prénom : </span>
-            <span class="attribute__value user__first-name">{{@user.firstName}}</span>
+        <div class="user-detail-personal-information-section__content">
+          <div class="user-detail-personal-information-section__item">
+            <div class="attribute first-name">
+              <span class="attibute__label">Prénom : </span>
+              <span class="attribute__value user__first-name">{{@user.firstName}}</span>
+            </div>
+            <div class="attribute last-name">
+              <span class="attibute__label">Nom : </span>
+              <span class="attribute__value user__last-name">{{@user.lastName}}</span>
+            </div>
+            <div class="attribute email">
+              <span class="attibute__label">E-mail : </span>
+              <span class="attribute__value user__email">{{@user.email}}</span>
+            </div>
+            <div class="attribute username">
+              <span class="attibute__label">Identifiant : </span>
+              <span class="attribute__value user__username">{{@user.username}}</span>
+            </div>
+            <div class="attribute authenticated-from-gar">
+              <span class="attibute__label">Connecté via le GAR : </span>
+              <span class="attribute__value user__is-authenticated-from-gar">
+                {{if @user.isAuthenticatedFromGar 'OUI''NON'}}
+              </span>
+            </div>
+            <br>
+            <div class="attribute cgu">
+              <span class="attibute__label">CGU Pix App validé : </span>
+              <span class="attribute__value user__cgu">{{if @user.cgu 'OUI' 'NON'}}</span>
+            </div>
+            <div class="attribute pix-orga-terms-of-service-accepted">
+              <span class="attibute__label">CGU Pix Orga validé : </span>
+              <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if
+                      @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}
+              </span>
+            </div>
+            <div class="attribute pix-certif-terms-of-service-accepted">
+              <span class="attibute__label">CGU Pix Certif validé : </span>
+              <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if
+                      @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}
+              </span>
+            </div>
           </div>
-          <div class="attribute last-name">
-            <span class="attibute__label">Nom : </span>
-            <span class="attribute__value user__last-name">{{@user.lastName}}</span>
-          </div>
-          <div class="attribute email">
-            <span class="attibute__label">E-mail : </span>
-            <span class="attribute__value user__email">{{@user.email}}</span>
-          </div>
-          <div class="attribute username">
-            <span class="attibute__label">Identifiant : </span>
-            <span class="attribute__value user__username">{{@user.username}}</span>
-          </div>
-          <div class="attribute authenticated-from-gar">
-            <span class="attibute__label">Connecté via le GAR : </span>
-            <span class="attribute__value user__is-authenticated-from-gar">
-              {{if @user.isAuthenticatedFromGar 'OUI''NON'}}
-            </span>
-          </div>
-          <br>
-          <div class="attribute cgu">
-            <span class="attibute__label">CGU Pix App validé : </span>
-            <span class="attribute__value user__cgu">{{if @user.cgu 'OUI' 'NON'}}</span>
-          </div>
-          <div class="attribute pix-orga-terms-of-service-accepted">
-            <span class="attibute__label">CGU Pix Orga validé : </span>
-            <span class="attribute__value user__pix-orga-terms-of-service-accepted">{{if
-                    @user.pixOrgaTermsOfServiceAccepted 'OUI' 'NON'}}
-            </span>
-          </div>
-          <div class="attribute pix-certif-terms-of-service-accepted">
-            <span class="attibute__label">CGU Pix Certif validé : </span>
-            <span class="attribute__value user__pix-certif-terms-of-service-accepted">{{if
-                    @user.pixCertifTermsOfServiceAccepted 'OUI' 'NON'}}
-            </span>
+          <div class="user-detail-personal-information-section__item">
+            <a class="btn btn-outline-default" aria-label="Tableau de bord" href="{{this.externalURL}}" target="_blank">Tableau de bord</a>
           </div>
         </div>
       </section>

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -4,6 +4,7 @@ import Object, { action } from '@ember/object';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
+import ENV from 'pix-admin/config/environment';
 
 const Validations = buildValidations({
   firstName: {
@@ -74,6 +75,11 @@ export default class UserDetailPersonalInformationComponent extends Component {
 
   get canAdministratorModifyUserDetails() {
     return !((this.args.user.username !== null) || this.args.user.isAuthenticatedFromGAR);
+  }
+
+  get externalURL() {
+    const urlDashboardPrefix = ENV.APP.USER_DASHBOARD_URL;
+    return urlDashboardPrefix && (urlDashboardPrefix + this.args.user.id);
   }
 
   @action

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -39,3 +39,4 @@
 @import 'components/menu-bar';
 @import 'components/organization-information-section';
 @import 'components/pagination-control';
+@import 'components/user-detail-personal-information-section';

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -1,4 +1,4 @@
-.organization-information-section{
+.user-detail-personal-information-section{
 
   &__content {
     display: flex;

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function(environment) {
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
+      USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL
     },
 
     googleFonts: [

--- a/admin/tests/unit/components/user-detail-personal-information-test.js
+++ b/admin/tests/unit/components/user-detail-personal-information-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import ENV from 'pix-admin/config/environment';
+
+module('Unit | Component | user-detail-personal-information', function(hooks) {
+
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createGlimmerComponent('component:user-detail-personal-information');
+  });
+
+  test('it should generate dashboard URL based on environment and object', async function(assert) {
+    // given
+    const args = { user: { id: 1 } };
+    const baseUrl = 'https://metabase.pix.fr/dashboard/132?id=';
+    const expectedUrl = baseUrl + args.user.id;
+
+    ENV.APP.USER_DASHBOARD_URL = baseUrl;
+    component.args = args;
+
+    // when
+    const actualUrl = component.externalURL;
+
+    // then
+    assert.equal(actualUrl, expectedUrl);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
La page de détail d'un utilisateur dans Pix admin manque d'informations.
Ces information sont disponibles dans Metabase, dans l'URL `https://metabase.pix.fr/dashboard/132?id={user_id}`

## :robot: Solution
Ajouter un lien de la page PixAdmin vers Metabase

## :rainbow: Remarques
Il n'existe pas d'environnement de test Metabase, le lien redirigera toujours vers l'environnement Metaase de production, qui utilise des données répliquées de la production. L'authentification Metabase est à charge de l'utilisateur.

## :100: Pour tester
Local:
* démarraer l'application avec la variable => `USER_DASHBOARD_URL=https://metabase.pix.fr/dashboard/132/?id= npm start `
* aller sur le membre 4 dans [PixAdmin](http://localhost:4202/users/3)

RA:
* application Scalingo pix-**front**-review-pr1496 / Section "Environnement": ajouter une ligne `USER_DASHBOARD_URL=https://metabase.pix.fr/dashboard/132/?id=` puis redéployer la branche
* aller sur l'utilisateur 3 dans [PixAdmin](https://admin-pr1496.review.pix.fr/users/3)

Cliquer sur"Tableau de bord" et vérifier que:
* l'URL est bien `https://metabase.pix.fr/dashboard/132?id=3`
* les données sont cohérentes

Il est possible d'alimenter les variables d'environnement en intrégration/recette/production AVANT la MEP, pour éviter de redéployer