### PR TITLE
[BUGFIX] Éviter de reposer un challenge auquel on a déjà répondu (PIX-210).

### DIFF
--- a/api/lib/domain/services/smart-random/data-fetcher.js
+++ b/api/lib/domain/services/smart-random/data-fetcher.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 async function fetchForCampaigns({
   assessment,
   answerRepository,
@@ -9,20 +11,21 @@ async function fetchForCampaigns({
   const targetProfileId = assessment.campaignParticipation.getTargetProfileId();
 
   const [
-    lastAnswer,
+    allAnswers,
     knowledgeElements,
     [
       targetSkills,
       challenges,
     ],
   ] = await Promise.all([
-    answerRepository.findLastByAssessment(assessment.id),
+    answerRepository.findByAssessment(assessment.id),
     _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService }),
     _fetchSkillsAndChallenges({ targetProfileId, targetProfileRepository, challengeRepository })
   ]);
 
   return {
-    lastAnswer,
+    allAnswers,
+    lastAnswer: _.isEmpty(allAnswers) ? null : _.last(allAnswers),
     targetSkills,
     challenges,
     knowledgeElements,
@@ -58,19 +61,20 @@ async function fetchForCompetenceEvaluations({
 }) {
 
   const [
-    lastAnswer,
+    allAnswers,
     targetSkills,
     challenges,
     knowledgeElements
   ] = await Promise.all([
-    answerRepository.findLastByAssessment(assessment.id),
+    answerRepository.findByAssessment(assessment.id),
     skillRepository.findByCompetenceId(assessment.competenceId),
     challengeRepository.findByCompetenceId(assessment.competenceId),
     _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService })
   ]);
 
   return {
-    lastAnswer,
+    allAnswers,
+    lastAnswer: _.isEmpty(allAnswers) ? null : _.last(allAnswers),
     targetSkills,
     challenges,
     knowledgeElements,

--- a/api/lib/domain/services/smart-random/skills-filter.js
+++ b/api/lib/domain/services/smart-random/skills-filter.js
@@ -9,6 +9,7 @@ module.exports = {
 
 function getFilteredSkillsForFirstChallenge({ knowledgeElements, tubes, targetSkills }) {
   return pipe(
+    _getPlayableSkill,
     _getUntestedSkills.bind(null, knowledgeElements),
     _keepSkillsFromEasyTubes.bind(null, tubes),
     _removeTimedSkillsIfNeeded.bind(null, true),
@@ -18,6 +19,7 @@ function getFilteredSkillsForFirstChallenge({ knowledgeElements, tubes, targetSk
 
 function getFilteredSkillsForNextChallenge({ knowledgeElements, tubes, predictedLevel, isLastChallengeTimed, targetSkills }) {
   return pipe(
+    _getPlayableSkill,
     _getUntestedSkills.bind(null,knowledgeElements),
     _keepSkillsFromEasyTubes.bind(null, tubes),
     _removeTimedSkillsIfNeeded.bind(null, isLastChallengeTimed),
@@ -27,6 +29,10 @@ function getFilteredSkillsForNextChallenge({ knowledgeElements, tubes, predicted
 
 function _getUntestedSkills(knowledgeElements, skills) {
   return _.filter(skills, _skillNotAlreadyTested(knowledgeElements));
+}
+
+function _getPlayableSkill(skills) {
+  return _.filter(skills, (skill) => skill.isPlayable);
 }
 
 function _getPrioritySkills(tubes) {

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -23,17 +23,12 @@ function duplicateChallengeOfSameDifficulty(challenge) {
   return _.assign(_.cloneDeep(challenge), { id: 'rec' + challengeId });
 }
 
-function _expectSkillsToBeDeepEquals(skills, expectedSkills) {
-  return expect(_.map(skills, (skill) => skill.__proto__)).to.be.deep.equal(expectedSkills);
-
-}
-
 describe('Integration | Domain | Stategies | SmartRandom', () => {
   let challenges, targetSkills, knowledgeElements, lastAnswer, web1, web2, web3, web4, web5,
-    web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil2, challengeWeb_1,
+    web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
     challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6, challengeWeb_7,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
-    challengeRechInfo_7, challengeInfo_2, challengeCnil_2;
+    challengeRechInfo_7, challengeInfo_2, challengeCnil_1, challengeCnil_2;
 
   beforeEach(() => {
     targetSkills = null;
@@ -56,6 +51,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     rechInfo5 = domainBuilder.buildSkill({ name: '@rechInfo5' });
     rechInfo7 = domainBuilder.buildSkill({ name: '@rechInfo7' });
     info2 = domainBuilder.buildSkill({ name: '@info2' });
+    cnil1 = domainBuilder.buildSkill({ name: '@cnil1' });
     cnil2 = domainBuilder.buildSkill({ name: '@cnil2' });
 
     // Challenges
@@ -74,6 +70,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     challengeUrl_6 = domainBuilder.buildChallenge({ id: 'recurl6', skills: [url6] });
     challengeRechInfo_5 = domainBuilder.buildChallenge({ id: 'recinfo5', skills: [rechInfo5] });
     challengeRechInfo_7 = domainBuilder.buildChallenge({ id: 'recinfo7', skills: [rechInfo7] });
+    challengeCnil_1 = domainBuilder.buildChallenge({ id: 'reccnil1', skills: [cnil1] });
     challengeCnil_2 = domainBuilder.buildChallenge({ id: 'reccnil2', skills: [cnil2] });
     challengeInfo_2 = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2] });
   });
@@ -99,15 +96,15 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       });
 
       // then
-      _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[]);
+      expect(possibleSkillsForNextChallenge).to.be.deep.equal([]);
     });
 
     context('when it is the first question only', () => {
 
       it('should ideally start with an untimed, default starting level skill', function() {
         // given
-        targetSkills = [web1, url3, cnil2];
-        challenges = [challengeWeb_1, challengeWeb_3, challengeCnil_2];
+        targetSkills = [web1, url3, cnil1, cnil2];
+        challenges = [challengeWeb_1, challengeWeb_3, challengeCnil_1, challengeCnil_2];
 
         // when
         const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
@@ -118,7 +115,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[cnil2]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(cnil2.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeCnil_2.id);
+        expect(possibleSkillsForNextChallenge[0].timed).to.be.equal(false);
       });
 
       it('should prioritize and find an untimed skill if the last challenge is timed, to avoid starting with a timed one', function() {
@@ -138,7 +139,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web1]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
+        expect(possibleSkillsForNextChallenge[0].timed).to.be.equal(false);
       });
 
       it('should start with an untimed skill 1 challenge when no default level challenge exists', function() {
@@ -155,7 +160,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web1]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
+        expect(possibleSkillsForNextChallenge[0].timed).to.be.equal(false);
       });
 
       it('should start with a not timed level 4 challenge when level 1, 2 and 3 dont exist', function() {
@@ -172,7 +181,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web4]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web4.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_4.id);
+        expect(possibleSkillsForNextChallenge[0].timed).to.be.equal(false);
       });
 
       it('should start with a timed challenge anyway when no untimed challenges were found', function() {
@@ -190,13 +203,17 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
+        expect(possibleSkillsForNextChallenge[0].timed).to.be.equal(true);
       });
 
     });
 
-    // Some challenges can be archived. Such challenges may be ruled out whn they haven't been answered yet, but at the same time
-    // must be taken into account when the user has already answered them, since they give useful information to the adaptive algorithlm.
+    // Some challenges can be archived. Such challenges may be ruled out when they haven't been answered yet, but at the same time
+    // must be taken into account when the user has already answered them, since they give useful information to the adaptive algorithm.
     context('when one challenge has been archived', () => {
       let challengeWeb_3_Archived, challengeWeb_4_Archived;
 
@@ -234,7 +251,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web4]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web4.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_4.id);
 
       });
 
@@ -266,7 +286,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
       });
 
       it('should return a challenge of level 4 if user got levels 1, 2, 3 and 3 was archived afterwards', function() {
@@ -302,10 +325,13 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web4]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web4.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_4.id);
       });
 
-      it('should return a challenge of level 3 if user got levels 1, 2, but failed 4, and 4 was archived afterwards', function() {
+      it('should return a challenge of level 3 if user got levels 1, 2, but failed 5, and 4 was archived afterwards', function() {
         // given
         targetSkills = [web1, web2, web3, web4, web5, web6];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_4.id, result: AnswerStatus.KO });
@@ -338,12 +364,15 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
       });
 
     });
 
-    // These tests verify the adaptive behavior of the algorithm : that it can increase/decrease the difficulty accordingly, can reach
+    // These tests verify the adaptive behavior of the algorithm: that it can increase/decrease the difficulty accordingly, can reach
     // the maximum level, can end when no challenges are available etc.
     context('when the difficulty must be adapted based on the answer to the previous question', () => {
 
@@ -375,7 +404,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({ targetSkills, challenges, knowledgeElements, lastAnswer });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(0);
 
       });
 
@@ -460,7 +489,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[rechInfo5]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(rechInfo5.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeRechInfo_5.id);
       });
 
       it('should ask a challenge of maximum difficulty when maximum difficulty (minus 1) was correctly answered (edge case test)', function() {
@@ -505,7 +537,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web7]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web7.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_7.id);
       });
 
       it('should end the test if the only available challenges are too hard (above maximum gap allowed)', function() {
@@ -540,7 +575,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge[0].difficulty).not.to.be.deep.equal(6);
       });
 
-      it('should prioritze a challenge from an easy tube if given the possibility', function() {
+      it('should prioritize a challenge from an easy tube if given the possibility', function() {
         // given
         targetSkills = [url4, url5, web3, info2];
         challenges = [challengeUrl_4, challengeUrl_5, challengeInfo_2, challengeWeb_3];
@@ -562,7 +597,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
       });
 
       it('should nevertheless target a challenge from any tubes when there is no easy tube', function() {
@@ -587,7 +625,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[url4]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(url4.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeUrl_4.id);
+
       });
 
     });
@@ -625,7 +667,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(0);
+
       });
 
       it('should do a deterministic selection of a challenge among challenges of equal reward', function() {
@@ -657,7 +700,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
       });
     });
 
@@ -701,7 +747,10 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
 
         // This is where we assert the randomness behavior to have deterministic test
       });
@@ -732,7 +781,14 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         });
 
         // then
-        _expectSkillsToBeDeepEquals(possibleSkillsForNextChallenge,[web2, web3]);
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(2);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[1].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web2.id);
+        expect(possibleSkillsForNextChallenge[1].id).to.be.equal(web3.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_2_3.id);
+        expect(possibleSkillsForNextChallenge[1].challenges[0].id).to.be.equal(challengeWeb_2_3.id);
+
       });
     });
 

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -24,7 +24,7 @@ function duplicateChallengeOfSameDifficulty(challenge) {
 }
 
 describe('Integration | Domain | Stategies | SmartRandom', () => {
-  let challenges, targetSkills, knowledgeElements, lastAnswer, web1, web2, web3, web4, web5,
+  let challenges, targetSkills, knowledgeElements, lastAnswer, allAnswers, web1, web2, web3, web4, web5,
     web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
     challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6, challengeWeb_7,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
@@ -34,6 +34,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     targetSkills = null;
     knowledgeElements = null;
     lastAnswer = null;
+    allAnswers = [];
 
     // Acquis (skills)
     web1 = domainBuilder.buildSkill({ name: '@web1' });
@@ -92,7 +93,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         targetSkills: [skill1],
         challenges,
         knowledgeElements: [],
-        lastAnswer
+        lastAnswer,
+        allAnswers
       });
 
       // then
@@ -111,7 +113,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements: [],
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -135,7 +138,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements: [],
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -156,7 +160,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements: [],
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -177,7 +182,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements: [],
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -199,7 +205,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements: [],
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -227,6 +234,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, web4, web5, web6];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -247,7 +255,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -262,6 +271,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, web4, web5, web6];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -282,7 +292,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -296,6 +307,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, web4, web5, web6];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_3.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -321,7 +333,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -335,6 +348,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, web4, web5, web6];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_4.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -360,7 +374,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -382,6 +397,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         challenges = [challengeUrl_2, challengeUrl_3, challengeRechInfo_5, challengeWeb_7];
 
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeRechInfo_5.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: url2.id,
@@ -401,20 +417,24 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         ];
 
         // when
-        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({ targetSkills, challenges, knowledgeElements, lastAnswer });
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          lastAnswer,
+          allAnswers,
+        });
 
         // then
         expect(possibleSkillsForNextChallenge.length).to.be.equal(0);
-
       });
 
       it('should consider skipping a challenge equivalent to not knowing and decrease difficulty when it happens', function() {
         // given
         targetSkills =  [web1, web2, web3];
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_2, challengeWeb_3];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.SKIPPED })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.SKIPPED });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web2.id,
@@ -433,7 +453,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -474,10 +495,11 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           })
         ];
 
-        lastAnswer = [
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeUrl_6.id, result: AnswerStatus.KO });
+        allAnswers = [
+          lastAnswer,
           domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK }),
           domainBuilder.buildAnswer({ challengeId: challengeUrl_4.id, result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: challengeUrl_6.id, result: AnswerStatus.KO })
         ];
 
         // when
@@ -485,7 +507,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -501,10 +524,12 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
 
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_6, challengeWeb_7];
 
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK }),
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_6.id, result: AnswerStatus.OK })
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_6.id, result: AnswerStatus.OK });
+        allAnswers = [
+          lastAnswer,
+          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
         ];
+
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -533,7 +558,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -547,9 +573,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web4, web6];
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_6];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -568,7 +593,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -580,6 +606,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         targetSkills = [url4, url5, web3, info2];
         challenges = [challengeUrl_4, challengeUrl_5, challengeInfo_2, challengeWeb_3];
         lastAnswer = [domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.OK })];
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: info2.id,
@@ -593,7 +620,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -607,7 +635,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [url4, url6, info2];
         challenges = [challengeUrl_4, challengeUrl_6, challengeInfo_2];
-        lastAnswer = [domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.OK })];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: info2.id,
@@ -621,7 +650,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -642,9 +672,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2];
         challenges = [challengeWeb_1, challengeWeb_2, duplicateChallengeOfSameDifficulty(challengeWeb_2)];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -663,7 +692,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -675,9 +705,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, url3];
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -696,7 +725,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -712,9 +742,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web3, url3];
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -743,7 +772,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers,
         });
 
         // then
@@ -761,9 +791,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [url2, web2, web3];
         challenges = [challengeWeb_2_3, challengeUrl_2];
-        lastAnswer = [
-          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.KO })
-        ];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
             skillId: web1.id,
@@ -777,7 +806,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           targetSkills,
           challenges,
           knowledgeElements,
-          lastAnswer
+          lastAnswer,
+          allAnswers
         });
 
         // then
@@ -788,9 +818,57 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge[1].id).to.be.equal(web3.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_2_3.id);
         expect(possibleSkillsForNextChallenge[1].challenges[0].id).to.be.equal(challengeWeb_2_3.id);
-
       });
     });
 
+    context('when one challenge has already been answered but its learning content has been updated', function() {
+      it('should not be asked again and ask another challenge from same skill', function() {
+        // given
+        targetSkills = [web2];
+        challenges = [challengeWeb_2_3, challengeWeb_2];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2_3.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
+        knowledgeElements = [];
+
+        // when
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          allAnswers,
+          lastAnswer,
+        });
+
+        // then
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web2.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_2.id);
+      });
+
+      it('should not be asked again and ask another challenge from another skill', function() {
+        // given
+        targetSkills = [web1, web2]; //web1, web2: une question possible mais déjà répondu => web1
+        challenges = [challengeWeb_1, challengeWeb_2];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
+        knowledgeElements = [];
+
+        // when
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          allAnswers,
+          lastAnswer,
+        });
+
+        // then
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -13,7 +13,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
 
     beforeEach(() => {
       answerRepository = {
-        findLastByAssessment: sinon.stub(),
+        findByAssessment: sinon.stub(),
       };
       targetProfileRepository = {
         get: sinon.stub(),
@@ -29,7 +29,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       };
     });
 
-    it('fetches answers, targetsSkills challenges and knowledgeElements', async () => {
+    it('fetches answers, lastAnswer, targetsSkills challenges and knowledgeElements', async () => {
       // given
       const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ state: 'started' });
       const answer = domainBuilder.buildAnswer();
@@ -42,7 +42,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       const targetProfile = domainBuilder.buildTargetProfile();
 
       assessment.campaignParticipation.getTargetProfileId = () => 1;
-      answerRepository.findLastByAssessment.withArgs(assessment.id).resolves(answer);
+      answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       targetProfileRepository.get.withArgs(1).resolves(targetProfile);
       challengeRepository.findBySkills.withArgs(targetProfile.skills).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
@@ -59,6 +59,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       });
 
       // then
+      expect(data.allAnswers).to.deep.equal([answer]);
       expect(data.lastAnswer).to.deep.equal(answer);
       expect(data.targetSkills).to.deep.equal(targetProfile.skills);
       expect(data.challenges).to.deep.equal(challenges);
@@ -82,7 +83,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
 
     beforeEach(async () => {
       answerRepository = {
-        findLastByAssessment: sinon.stub(),
+        findByAssessment: sinon.stub(),
       };
       challengeRepository = {
         findByCompetenceId: sinon.stub(),
@@ -109,7 +110,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       ];
       const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
 
-      answerRepository.findLastByAssessment.withArgs(assessment.id).resolves(answer);
+      answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
       challengeRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
@@ -134,6 +135,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
     it('fetches answers, targetsSkills challenges and knowledgeElements', async () => {
       // then
       expect(data.lastAnswer).to.deep.equal(answer);
+      expect(data.allAnswers).to.deep.equal([answer]);
       expect(data.targetSkills).to.deep.equal(skills);
       expect(data.challenges).to.deep.equal(challenges);
       expect(data.knowledgeElements).to.deep.equal(knowledgeElements);

--- a/api/tests/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/unit/domain/services/smart-random/skills-filter_test.js
@@ -8,6 +8,12 @@ const KNOWLEDGE_ELEMENT_STATUS = {
   INVALIDATED: 'invalidated'
 };
 
+function setPlayableSkills(skills) {
+  skills.forEach((skill) => {
+    skill.isPlayable = true;
+  });
+}
+
 describe('Unit | Domain | services | smart-random | skillsFilter', () => {
 
   describe('#getFilteredSkillsForFirstChallenge', () => {
@@ -19,6 +25,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       const tubes =  [
         new Tube({ skills: [skill1] })
       ];
+      setPlayableSkills(targetProfile.skills);
 
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
@@ -39,6 +46,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
       const tubes =  [
         new Tube({ skills: [skill1] })
       ];
+      setPlayableSkills(targetProfile.skills);
 
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
@@ -64,6 +72,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
         new Tube({ skills: [skillTube1Level4, skillTube1Level2] }),
         new Tube({ skills: [skillFromEasyTubeLevel2, skillFromEasyTubeLevel1] })
       ];
+      setPlayableSkills(targetProfile.skills);
 
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
@@ -87,6 +96,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
         new Tube({ skills: [skillTube1Level2Timed] }),
         new Tube({ skills: [skillTube2Level2] })
       ];
+      setPlayableSkills(targetProfile.skills);
 
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
@@ -111,6 +121,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
         new Tube({ skills: [skillTube1Level2Timed] }),
         new Tube({ skills: [skillTube2Level2Timed] })
       ];
+      setPlayableSkills(targetProfile.skills);
 
       // when
       const result = skillsFilter.getFilteredSkillsForFirstChallenge({
@@ -121,6 +132,29 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
 
       // then
       expect(result).to.deep.equal([skillTube1Level2Timed, skillTube2Level2Timed]);
+    });
+
+    it('should return only playable skills', function() {
+      // given
+      const playableSkill = domainBuilder.buildSkill({ name: '@web2' });
+      const notPlayableSkill = domainBuilder.buildSkill({ name: '@url2' });
+      const targetProfile = new TargetProfile({ skills: [playableSkill, notPlayableSkill] });
+      const knowledgeElements = [];
+      const tubes =  [
+        new Tube({ skills: [playableSkill, notPlayableSkill] })
+      ];
+      playableSkill.isPlayable = true;
+      notPlayableSkill.isPlayable = false;
+
+      // when
+      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+        knowledgeElements,
+        tubes,
+        targetSkills: targetProfile.skills
+      });
+
+      // then
+      expect(result).to.deep.equal([playableSkill]);
     });
 
   });
@@ -138,6 +172,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           domainBuilder.buildKnowledgeElement({ skillId: skill1.id, status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED, source: 'direct' }),
           domainBuilder.buildKnowledgeElement({ skillId: skill2.id, status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED, source: 'direct' }),
         ];
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -166,6 +201,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           domainBuilder.buildKnowledgeElement({ skillId: skill1.id, status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED, source: 'direct' }),
         ];
         const isLastChallengeTimed = true;
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -191,6 +227,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           domainBuilder.buildKnowledgeElement({ skillId: skill1.id, status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED, source: 'direct' }),
         ];
         const isLastChallengeTimed = true;
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -216,6 +253,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
         const tubes =  [
           new Tube({ skills: [skill1, skill2, skill3, skill4, skill5, skill6] })
         ];
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -244,6 +282,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
           new Tube({ skills: [skill3, skill4, skill5, skill6] }),
           new Tube({ skills: [easyTubeSkill1, easyTubeSkill2, easyTubeSkill3] })
         ];
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -270,6 +309,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
         const tubes =  [
           new Tube({ skills: [skill3, skill4, skill5, skill6] })
         ];
+        setPlayableSkills(targetProfile.skills);
 
         // when
         const result = skillsFilter.getFilteredSkillsForNextChallenge({
@@ -282,6 +322,30 @@ describe('Unit | Domain | services | smart-random | skillsFilter', () => {
 
         // then
         expect(result).to.deep.equal([skill4, skill5, skill6]);
+      });
+    });
+    describe('Verify rules: Remove skills not playable', function() {
+      it('should return only playable skills', function() {
+        // given
+        const [notPlayableSkill, playableSkill] = domainBuilder.buildSkillCollection({ name:'web', minLevel: 3, maxLevel: 6 });
+        const targetProfile = domainBuilder.buildTargetProfile({ skills: [ notPlayableSkill, playableSkill] });
+
+        const knowledgeElements = [];
+        const tubes =  [
+          new Tube({ skills: [notPlayableSkill, playableSkill] })
+        ];
+        notPlayableSkill.isPlayable = false;
+        playableSkill.isPlayable = true;
+
+        // when
+        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+          knowledgeElements,
+          tubes,
+          targetSkills: targetProfile.skills
+        });
+
+        // then
+        expect(result).to.deep.equal([playableSkill]);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
       assessmentId = 21;
       lastAnswer = null;
 
-      answerRepository = { findLastByAssessment: sinon.stub().resolves(lastAnswer) };
+      answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challenges = [];
       challengeRepository = { findBySkills: sinon.stub().resolves(challenges) };
       campaignParticipation = { getTargetProfileId: sinon.stub().returns(targetProfileId) };
@@ -67,7 +67,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
     });
 
     it('should have fetched the answers', () => {
-      expect(answerRepository.findLastByAssessment).to.have.been.calledWithExactly(assessmentId);
+      expect(answerRepository.findByAssessment).to.have.been.calledWithExactly(assessmentId);
     });
 
     it('should have filter the knowledge elements with an assessment improving', () => {
@@ -94,7 +94,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
     });
 
     it('should have fetched the next challenge with only most recent knowledge elements', () => {
+      const allAnswers = [lastAnswer];
       expect(smartRandom.getPossibleSkillsForNextChallenge).to.have.been.calledWithExactly({
+        allAnswers,
         lastAnswer,
         challenges,
         targetSkills: targetProfile.skills,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -25,7 +25,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       targetSkills = [];
       lastAnswer = null;
 
-      answerRepository = { findLastByAssessment: sinon.stub().resolves(lastAnswer) };
+      answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challengeRepository = { findByCompetenceId: sinon.stub().resolves(challenges) };
       skillRepository = { findByCompetenceId: sinon.stub().resolves(targetSkills) };
       pickChallengeService = { pickChallenge: sinon.stub().resolves(challengeUrl22) };
@@ -82,7 +82,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
         });
       });
       it('should have fetched the answers', () => {
-        expect(answerRepository.findLastByAssessment).to.have.been.calledWithExactly(assessmentId);
+        expect(answerRepository.findByAssessment).to.have.been.calledWithExactly(assessmentId);
       });
 
       it('should have fetched the most recent knowledge elements', () => {
@@ -94,7 +94,9 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       });
 
       it('should have fetched the next challenge with only most recent knowledge elements', () => {
+        const allAnswers = [lastAnswer];
         expect(smartRandom.getPossibleSkillsForNextChallenge).to.have.been.calledWithExactly({
+          allAnswers,
           lastAnswer,
           challenges,
           targetSkills,


### PR DESCRIPTION
## :unicorn: Problème
Suite au bug remonté mi-février, durant lequel des utilisateurs avaient des réponses (answers) enregistrées mais pas les éléments de connaissances (KE) associés, il a été remarqué que l'algorithme de choix de question posait problème lorsque la base de données n'était pas cohérente. Une première correction a été apportée en ajoutant une transaction pour s'assurer du bon enregistrement entre les deux. Malgré cela, la problématique de l'algorithme qui ne fonctionne pas quand la base n'est pas saine doit être réglée.

## :robot: Solution
On filtre les challenges sur la présence ou non d'answers. 
