### PR TITLE
[TECH] Montée de la BDD en version 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:12.18.0
-      - image: postgres:11.7-alpine
+      - image: postgres:12.2-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -190,7 +190,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node12.18.0-chrome83-ff77
-      - image: postgres:11.7-alpine
+      - image: postgres:12.2-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -114,16 +114,22 @@ describe('Integration | Repository | Badge', () => {
       const badges = await badgeRepository.findByTargetProfileId(targetProfileId);
 
       expect(badges.length).to.equal(2);
-      expect(badges[0]).to.deep.equal({
-        ...badgeWithSameTargetProfile_2,
-        badgeCriteria: [ badgeCriterionForBadgeWithSameTargetProfile_2 ],
-        badgePartnerCompetences: [],
-      });
-      expect(badges[1]).to.deep.equal({
+
+      const firstBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_1.id);
+      expect(firstBadge).deep.equal({
         ...badgeWithSameTargetProfile_1,
-        badgeCriteria: [ badgeCriterionForBadgeWithSameTargetProfile_1 ],
+        badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_1],
         badgePartnerCompetences: [],
       });
+
+      const secondBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_2.id);
+      expect(secondBadge).deep.equal(
+        {
+          ...badgeWithSameTargetProfile_2,
+          badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_2],
+          badgePartnerCompetences: [],
+        });
+
     });
 
     it('should return the badge linked to the given target profile with related badge criteria and badge partner competences', async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:11.7-alpine
+    image: postgres:12.2-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## :unicorn: Problème
La BDD est un service fourni par Scalingo, qui met à disposition un service de mise à jour de version. En local, les développeurs utilisent une BDD dans un conteneur, configurée via le fichier `docker-compose.yml.` Dans l'intégration continue, la version de BDD est également conditionnée par une configuration Docker `.circleci/config.yml`
Il est donc possible d'effectuer une montée de version dans Scalingo sans tester que cette montée de version n'introduire de régression.

Scalingo propose actuellement une montée de 11.7.0 vers 12.2.0-6 ([CHANGELOG](https://www.postgresql.org/docs/release/12.2/))

Suite à [discussion](https://1024pix.slack.com/archives/CVAMDQYHY/p1590415078003200) avec @jbuget et @jonathanperret, il est souhaitable d'effectuer cette montée de version. 
 
## :robot: Solution
Description exhaustive [dans le wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1549434939)

Indiquer la nouvelle version dans le `docker-compose.yml` et `.circleci/config.yml` afin que le développeur/CI puisse vérifier la non-régression et introduire les changements si nécessaire.

## :rainbow: Remarques
Un problème sur l'ordre des données renvoyées par Bookshelf a été résolu en modifiant l'implémentation du test.

## :warning: Actions manuelles après merge
La BDD d'intégration est déjà en version 12.2-6. La BDD de recette est toujours en version 12.2-1.

Prévoir de faire l'upgrade des envrironnements dans Scalingo de :
- recette après la MER;
- production après la MEP.

Bien coordoner les intervenants car il y aura un downtime.
Réuniuon prévue avec @laura-bergoens et @jonathanperret pour caler les détails.

## :100: Pour tester
Exécuter les tests:
* en local
* sur la CI