### PR TITLE
[TECH] Supprimer les tests unitaires Ember redondants

### DIFF
--- a/admin/tests/unit/components/certification-details-competence-test.js
+++ b/admin/tests/unit/components/certification-details-competence-test.js
@@ -26,11 +26,6 @@ module('Unit | Component | certification-details-competence', function(hooks) {
     };
   };
 
-  test('it exists', function(assert) {
-    const component = this.owner.factoryFor('component:certification-details-competence').create();
-    assert.ok(component);
-  });
-
   test('it should not give jury values when no jury rate is set', async function(assert) {
     // given
     const component = this.owner.factoryFor('component:certification-details-competence').create();

--- a/admin/tests/unit/components/certification-info-competences-test.js
+++ b/admin/tests/unit/components/certification-info-competences-test.js
@@ -4,11 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | certification-info-competences', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const component = this.owner.factoryFor('component:certification-info-competences').create();
-    assert.ok(component);
-  });
-
   test('it computes indexed values correctly', function(assert) {
     // given
     const component = this.owner.factoryFor('component:certification-info-competences').create();

--- a/admin/tests/unit/components/certification-info-field-test.js
+++ b/admin/tests/unit/components/certification-info-field-test.js
@@ -4,11 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | certification-info-field', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const component = this.owner.factoryFor('component:certification-info-field').create();
-    assert.ok(component);
-  });
-
   test('it should compute correct widths for large dimensions', function(assert) {
     // given
     const component = this.owner.factoryFor('component:certification-info-field').create();

--- a/admin/tests/unit/components/organization-information-section-test.js
+++ b/admin/tests/unit/components/organization-information-section-test.js
@@ -13,10 +13,6 @@ module('Unit | Component | organization-information-section', function(hooks) {
     component = createGlimmerComponent('component:organization-information-section');
   });
 
-  test('it exists', function(assert) {
-    assert.ok(component);
-  });
-
   test('it should generate link based on environment and object', async function(assert) {
     // given
     const args = { organization: { id: 1 } };

--- a/admin/tests/unit/serializers/certification-details-test.js
+++ b/admin/tests/unit/serializers/certification-details-test.js
@@ -5,14 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Serializer | certification details', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const serializer = store.serializerFor('certification-details');
-
-    assert.ok(serializer);
-  });
-
   test('it serializes records', function(assert) {
     const store = this.owner.lookup('service:store');
     const record = run(() => store.createRecord('certification-details', {}));

--- a/admin/tests/unit/serializers/certification-test.js
+++ b/admin/tests/unit/serializers/certification-test.js
@@ -5,14 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Serializer | certification', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const serializer = store.serializerFor('certification');
-
-    assert.ok(serializer);
-  });
-
   test('it serializes records', function(assert) {
     const store = this.owner.lookup('service:store');
     const record = run(() => store.createRecord('certification', {}));

--- a/admin/tests/unit/serializers/organization-test.js
+++ b/admin/tests/unit/serializers/organization-test.js
@@ -5,14 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Serializer | organization', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const serializer = store.serializerFor('organization');
-
-    assert.ok(serializer);
-  });
-
   test('it serializes records', function(assert) {
     const store = this.owner.lookup('service:store');
     const record = run(() => store.createRecord('organization', {}));

--- a/admin/tests/unit/services/csv-service-test.js
+++ b/admin/tests/unit/services/csv-service-test.js
@@ -10,10 +10,6 @@ module('Unit | Service | csv-service', function(hooks) {
     service = this.owner.lookup('service:csv-service');
   });
 
-  test('it exists', function(assert) {
-    assert.ok(service);
-  });
-
   module('#sanitize', function() {
 
     module('when the string is clean', function() {

--- a/certif/tests/unit/routes/application-test.js
+++ b/certif/tests/unit/routes/application-test.js
@@ -16,11 +16,6 @@ function createLoadServiceStub() {
 module('Unit | Route | application', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:application');
-    assert.ok(route);
-  });
-
   test('it should load the current user', function(assert) {
     // given
     const route = this.owner.lookup('route:application');

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -5,12 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Model | campaign', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {}));
-    assert.ok(model);
-  });
-
   test('it should return the right data in the campaign model', function(assert) {
     const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('campaign', {

--- a/orga/tests/unit/models/competence-result-test.js
+++ b/orga/tests/unit/models/competence-result-test.js
@@ -5,12 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Model | Competence-Result', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('competence-result', {}));
-    assert.ok(model);
-  });
-
   module('totalSkillsCountPercentage', function() {
 
     test('should retrieve 100 since the competence is the highest number of total skills count', function(assert) {

--- a/orga/tests/unit/models/student-test.js
+++ b/orga/tests/unit/models/student-test.js
@@ -5,16 +5,6 @@ import { run } from '@ember/runloop';
 module('Unit | Model | student', function(hooks) {
 
   setupTest(hooks);
-  test('it exists', function(assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-
-    // when
-    const model = run(() => store.createRecord('student', {}));
-
-    // then
-    assert.ok(model);
-  });
   module('#authenticationMethods', function() {
 
     module('when not reconciled', function() {

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -16,11 +16,6 @@ function createLoadServiceStub() {
 module('Unit | Route | application', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:application');
-    assert.ok(route);
-  });
-
   test('it should load the current user', function(assert) {
     // given
     const route =  this.owner.lookup('route:application');

--- a/orga/tests/unit/routes/not-found-test.js
+++ b/orga/tests/unit/routes/not-found-test.js
@@ -4,11 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Route | not-found', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const route = this.owner.lookup('route:not-found');
-    assert.ok(route);
-  });
-
   test('should redirect to application route', function(assert) {
     const route = this.owner.lookup('route:not-found');
     const expectedRedirection = 'application';


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création d'un composant, Ember génère un test modèle qui vérifie uniquement l'existence du composant.

>   test('it exists', function(assert) {
>     const route = this.owner.lookup('route:not-found');
>     assert.ok(route);
>   });

Dès l'écriture d'un autre test, l'existence du composant est implicitement couverte, et ce test modèle génère du bruit.

## :robot: Solution
Supprimer ce test dans les fichiers où au moins un autre test existe

## :100: Pour tester
Couvert par la CI