### PR TITLE
[FEATURE] Afficher l'url d'une campagne dans Pix Orga suivant l'extension sur laquelle on est (fr ou org) (PIX-826).

### DIFF
--- a/orga/app/components/routes/authenticated/campaigns/details/parameters-tab.js
+++ b/orga/app/components/routes/authenticated/campaigns/details/parameters-tab.js
@@ -6,8 +6,13 @@ export default class ParametersTab extends Component {
 
   @service store;
   @service notifications;
+  @service url;
 
   tooltipText = 'Copier le lien direct';
+
+  get campaignsRootUrl() {
+    return `${this.url.campaignsRootUrl}${this.campaign.code}`;
+  }
 
   @action
   clipboardSuccess() {

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -69,12 +69,6 @@ export default class Campaign extends Model {
     return this.isTypeProfilesCollection ? PROFILES_COLLECTION_TEXT : ASSESSMENT_TEXT;
   }
 
-  @computed('code')
-  get url() {
-    const code = this.code;
-    return `${ENV.APP.CAMPAIGNS_ROOT_URL}${code}`;
-  }
-
   @computed('id', 'tokenForCampaignResults')
   get urlToResult() {
     if (this.isTypeAssessment) {

--- a/orga/app/services/current-domain.js
+++ b/orga/app/services/current-domain.js
@@ -1,0 +1,8 @@
+import Service  from '@ember/service';
+import { last } from 'lodash';
+
+export default class CurrentDomainService extends Service {
+  getExtension() {
+    return last(location.hostname.split('.'));
+  }
+}

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -1,0 +1,15 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import ENV from 'pix-orga/config/environment';
+
+export default class Url extends Service {
+  @service currentDomain;
+  definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
+  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
+
+  get campaignsRootUrl() {
+    return this.definedCampaignsRootUrl ?
+      this.definedCampaignsRootUrl :
+      `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/campagnes/`;
+  }
+}

--- a/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -15,12 +15,12 @@
     <div class="campaign-details-content">
       <h4 class="label-text campaign-details-content__label">Lien direct</h4>
       <div class="campaign-details-content__clipboard">
-        <p class="content-text campaign-details-content__text">{{@campaign.url}}</p>
+        <p class="content-text campaign-details-content__text">{{this.campaignsRootUrl}}</p>
         {{#if (is-clipboard-supported)}}
           <div class="tooltip content-text content-text--small">
             <span class="tooltip-text campaign-details-content__tooltip-text">{{this.tooltipText}}</span>
             <CopyButton
-              @clipboardText={{@campaign.url}}
+              @clipboardText={{this.campaignsRootUrl}}
               @success={{this.clipboardSuccess}}
               {{on 'mouseLeave' this.clipboardOut}}
               @classNames="icon-button campaign-details-content__clipboard-button"

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -28,7 +28,8 @@ module.exports = function(environment) {
 
     APP: {
       API_HOST: process.env.API_HOST || '',
-      CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL || 'https://app.pix.fr/campagnes/',
+      CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
     },
 
@@ -100,7 +101,7 @@ module.exports = function(environment) {
       autoClear: null,
       clearDuration: null,
     };
-    
+
     ENV.pagination.debounce = 0;
   }
 

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/parameters-tab-test.js
@@ -93,9 +93,7 @@ module('Integration | Component | routes/authenticated/campaign/details | parame
   module('on campaign url display', function() {
     test('it should display the campaign url', async function(assert) {
       // given
-      const campaign = store.createRecord('campaign', {
-        url: 'pix.fr/1234'
-      });
+      const campaign = store.createRecord('campaign', { code: '1234' });
 
       this.set('campaign', campaign);
 
@@ -103,7 +101,7 @@ module('Integration | Component | routes/authenticated/campaign/details | parame
       await render(hbs`<Routes::Authenticated::Campaigns::Details::ParametersTab @campaign={{campaign}}/>`);
 
       // then
-      assert.dom('[aria-label="Détails de la campagne"]').includesText('pix.fr/1234');
+      assert.dom('[aria-label="Détails de la campagne"]').includesText('/campagnes/1234');
     });
   });
 

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | url', function(hooks) {
+  setupTest(hooks);
+
+  module('#campaignsRootUrl', function() {
+
+    test('should get default campaigns root url when is defined', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      service.definedCampaignsRootUrl = 'pix.test.fr';
+
+      // when
+      const campaignsRootUrl = service.campaignsRootUrl;
+
+      // then
+      assert.equal(campaignsRootUrl, service.definedCampaignsRootUrl);
+    });
+
+    test('should get "pix.test" url when current domain contains pix.test', function(assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCampaignsRootUrl = 'https://app.pix.test/campagnes/';
+      service.definedCampaignsRootUrl = undefined;
+      service.currentDomain = { getExtension: sinon.stub().returns('test') };
+
+      // when
+      const campaignsRootUrl = service.campaignsRootUrl;
+
+      // then
+      assert.equal(campaignsRootUrl, expectedCampaignsRootUrl);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
app.pix est maintenant disponible en .org. Or, l'url de campagnes que l'on fourni sur Pix Orga est toujours en .fr !

## :robot: Solution
- Faire un alias de orga.pix.fr en orga.pix.org ✔️ 
- Conditionner l'url sur l'extension du site sur lequel on est (cette PR)

## :rainbow: Remarques
La logique a été inspirée de ce qui a été fait sur app.pix par la team Expérience d'évaluation

## :100: Pour tester
Sur https://orga-pr1534.review.pix.fr et sur https://orga-pr1534.review.pix.org :
- Aller voir le détail d'une campagne
- Vérifier que l'affichage du lien est correct
- Vérifier que lors de la copie (petit bouton copier) la copie est correcte
![image](https://user-images.githubusercontent.com/23451175/84902959-c211d200-b0ad-11ea-8063-52daa5c6e7c1.png)

