### PR TITLE
 [FEATURE] Afficher un message d'erreur approprié lors de la connexion à Pix App (PIX-367).

### DIFF
--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -22,7 +22,7 @@ exports.register = async (server) => {
           failAction: (request, h, err) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
+              status: errorHttpStatusCode.toString(),
               title: 'Bad request',
               detail: err.details[0].message,
             });

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -19,12 +19,12 @@ exports.register = async (server) => {
             password: Joi.string().required(),
             scope: Joi.string(),
           }),
-          failAction: (request, h) => {
+          failAction: (request, h, err) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
               code: errorHttpStatusCode.toString(),
               title: 'Bad request',
-              detail: 'Les données envoyées ne sont pas au bon format.',
+              detail: err.details[0].message,
             });
             return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
           }

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -1,12 +1,18 @@
+import _ from 'lodash';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import ENV from 'mon-pix/config/environment';
+
 export default class SigninForm extends Component {
 
   @service url;
+  @service intl;
   @tracked hasFailed = false;
+  @tracked errorMessage;
+
   username = '';
   password = '';
 
@@ -17,17 +23,37 @@ export default class SigninForm extends Component {
   @action
   async signin(event) {
     event && event.preventDefault();
-    
     this.hasFailed = false;
     try {
       await this.args.authenticateUser(this.username, this.password);
-    } catch (err) {
-      const title = ('errors' in err) ? err.errors.get('firstObject').title : null;
-
-      if (title === 'PasswordShouldChange') {
+    } catch (response) {
+      const error = _.get(response, 'errors[0]');
+      const isPasswordExpiredError = (_.get(error, 'title') === 'PasswordShouldChange');
+      if (isPasswordExpiredError) {
         await this.args.updateExpiredPassword(this.username, this.password);
+      } else {
+        this._manageErrorsApi(error);
       }
+
       this.hasFailed = true;
     }
   }
+
+  _manageErrorsApi(firstError) {
+    const statusCode = _.get(firstError, 'status');
+    this.errorMessage = this._showErrorMessages(statusCode);
+  }
+
+  _showErrorMessages(statusCode) {
+    const httpStatusCodeMessages = {
+      '400': ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
+      '401': ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.MESSAGE,
+      '500': ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+      '502': ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+      '504': ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
+      'default': ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+    };
+    return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);
+  }
+
 }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -10,7 +10,6 @@
   abbr {
     text-decoration: none;
   }
-
 }
 
 .sign-form {
@@ -23,18 +22,14 @@
     width: 95%;
     max-width: 609px;
     border-radius: 10px;
-    padding-top: 10px;
     background-color: $white;
-    margin: 10px auto;
+    margin: 0 auto;
+    padding: 20px 10px;
 
     @include device-is('tablet') {
       width: 609px;
       margin: 20px 0;
       padding: 40px 80px;
-    }
-
-    @include device-is('mobile'){
-      padding: 20px 0;
     }
   }
 
@@ -46,6 +41,7 @@
   }
 
   &__body {
+    align-items: center;
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -78,7 +74,7 @@
 
   &__subtitle {
     display: flex;
-    padding: 5px 20px;
+    padding: 5px 20px 24px 20px;
     flex-direction: column;
     text-align: center;
     font-family: $font-open-sans;

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -14,7 +14,7 @@
 
   {{#if this.hasFailed}}
     <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
-      {{t 'signin-form.error.message'}}
+      {{this.errorMessage}}
     </div>
   {{/if}}
 
@@ -24,14 +24,18 @@
       <FormTextfield @label="{{t 'signin-form.fields.login.label'}}"
                      @textfieldName="login"
                      @validationStatus="default"
-                     @inputBindingValue={{this.username}} @autocomplete="username" />
+                     @inputBindingValue={{this.username}}
+                     @autocomplete="username"
+                     @require=true />
     </div>
 
     <div class="sign-form-body__input">
       <FormTextfield @label="{{t 'signin-form.fields.password.label'}}"
                      @textfieldName="password"
                      @validationStatus="default"
-                     @inputBindingValue={{this.password}} @autocomplete="current-password" />
+                     @inputBindingValue={{this.password}}
+                     @autocomplete="current-password"
+                     @require=true />
     </div>
 
     <LinkTo @route="password-reset-demand" class="link link--grey sign-form-link sign-form-body__forgotten-password-link">

--- a/mon-pix/config/ember-intl.js
+++ b/mon-pix/config/ember-intl.js
@@ -89,7 +89,7 @@ module.exports = function(/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    errorOnMissingTranslations: false,
+    errorOnMissingTranslations: true,
 
     /**
      * removes empty translations from the build output.

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -11,6 +11,7 @@ function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue
 
 /* eslint max-statements: off */
 module.exports = function(environment) {
+
   const ENV = {
     modulePrefix: 'mon-pix',
     environment: environment,
@@ -46,6 +47,29 @@ module.exports = function(environment) {
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       LOCALE: process.env.LOCALE || 'fr-fr',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
+
+      API_ERROR_MESSAGES: {
+        BAD_REQUEST: {
+          CODE: '400',
+          MESSAGE: 'api-error-messages.bad-request-error'
+        },
+        LOGIN_UNAUTHORIZED: {
+          CODE: '401',
+          MESSAGE: 'api-error-messages.login-unauthorized-error'
+        },
+        INTERNAL_SERVER_ERROR: {
+          CODE: '500',
+          MESSAGE: 'api-error-messages.internal-server-error',
+        },
+        BAD_GATEWAY: {
+          CODE: '502',
+          MESSAGE: 'api-error-messages.internal-server-error'
+        },
+        GATEWAY_TIMEOUT: {
+          CODE: '504',
+          MESSAGE: 'api-error-messages.internal-server-error'
+        },
+      },
     },
 
     googleFonts: [

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -5,16 +5,27 @@ import { setupRenderingTest } from 'ember-mocha';
 import {
   click,
   fillIn,
+  find,
   render,
-  triggerEvent
+  triggerEvent,
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+
+import setupIntl from '../../helpers/setup-intl';
+import ENV from '../../../config/environment';
+
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 describe('Integration | Component | signin form', function() {
 
   setupRenderingTest();
+  setupIntl();
 
   describe('Rendering', async function() {
+
+    beforeEach(function() {
+      this.intl.setLocale('fr-fr');
+    });
 
     it('should display an input for identifiant field', async function() {
       // when
@@ -53,20 +64,139 @@ describe('Integration | Component | signin form', function() {
       await render(hbs`<SigninForm />`);
 
       // then
-      expect(document.querySelector('div.sign-form__notification-message')).to.not.exist;
+      expect(document.querySelector('div.sign-form__error-message')).to.not.exist;
     });
 
-    it('should display an error if authentication failed', async function() {
-      // given
-      this.set('authenticateUser', sinon.stub().rejects());
-      await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+    context('When error api occurs', function() {
 
-      // when
-      await click('button.button');
+      it('should display related error message if unauthorized error', async function() {
+        // given
+        const expectedErrorMessage = ApiErrorMessages.LOGIN_UNAUTHORIZED.MESSAGE;
+        const apiReturn = {
+          errors: [{
+            status: 401,
+            detail: expectedErrorMessage,
+            title: 'Unauthorized error'
+          }]
+        };
+        this.set('authenticateUser', sinon.stub().rejects(apiReturn));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
 
-      // then
-      expect(document.querySelector('div.sign-form__notification-message--error')).to.exist;
+        // when
+        await fillIn('input#login', 'usernotexist@example.net');
+        await fillIn('input#password', 'password');
+        await click('button.button');
+
+        // then
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
+      });
+
+      it('should display an error if api cannot be reached', async function() {
+        // given
+        const stubCatchedApiErrorInternetDisconnected = undefined;
+        this.set('authenticateUser', sinon.stub().rejects(stubCatchedApiErrorInternetDisconnected));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+
+        // when
+        await fillIn('input#login', 'johnharry@example.net');
+        await fillIn('input#password', 'password123');
+        await click('button.button');
+
+        // then
+        expect(document.querySelector('div.sign-form__notification-message--error')).to.exist;
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE));
+
+      });
+
+      it('should display related error message if internal server error', async function() {
+        // given
+        const expectedErrorMessage = ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE;
+        const apiReturn = {
+          errors: [{
+            status: 500,
+            detail: expectedErrorMessage,
+            title: 'Internal server error'
+          }]
+        };
+        this.set('authenticateUser', sinon.stub().rejects(apiReturn));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+
+        // when
+        await fillIn('input#login', 'johnharry@example.net');
+        await fillIn('input#password', 'password123');
+        await click('button.button');
+
+        // then
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
+      });
+
+      it('should display related error message if bad gateway error', async function() {
+        // given
+        const expectedErrorMessage = ApiErrorMessages.BAD_GATEWAY.MESSAGE;
+        const apiReturn = {
+          errors: [{
+            status: 502,
+            detail: expectedErrorMessage,
+            title: 'Bad gateway error'
+          }]
+        };
+        this.set('authenticateUser', sinon.stub().rejects(apiReturn));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+
+        // when
+        await fillIn('input#login', 'johnharry@example.net');
+        await fillIn('input#password', 'password123');
+        await click('button.button');
+
+        // then
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
+      });
+
+      it('should display related error message if gateway timeout error', async function() {
+        // given
+        const expectedErrorMessage = ApiErrorMessages.GATEWAY_TIMEOUT.MESSAGE;
+        const apiReturn = {
+          errors: [{
+            status: 504,
+            detail: expectedErrorMessage,
+            title: 'Gateway timeout error'
+          }]
+        };
+        this.set('authenticateUser', sinon.stub().rejects(apiReturn));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+
+        // when
+        await fillIn('input#login', 'johnharry@example.net');
+        await fillIn('input#password', 'password123');
+        await click('button.button');
+
+        // then
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(expectedErrorMessage));
+      });
+
+      it('should display related error message if not implemented error', async function() {
+        // given
+        const apiReturn = {
+          errors: [{
+            status: 501,
+            detail: 'Not implemented Error',
+            title: 'Not implemented error'
+          }]
+        };
+        this.set('authenticateUser', sinon.stub().rejects(apiReturn));
+        await render(hbs`<SigninForm @authenticateUser={{this.authenticateUser}} />`);
+
+        // when
+        await fillIn('input#login', 'johnharry@example.net');
+        await fillIn('input#password', 'password123');
+        await click('button.button');
+
+        // then
+        expect(find('.sign-form__notification-message--error').textContent.trim()).to.equal(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE));
+      });
+
     });
+
   });
 
   describe('Behaviours', function() {

--- a/mon-pix/translations/en-us.json
+++ b/mon-pix/translations/en-us.json
@@ -18,7 +18,11 @@
     "signup": "Sign up",
     "suffix": "Pix"
   },
-
+  "api-error-messages": {
+    "login-unauthorized-error": "Wrong email address, username and/or password.",
+    "bad-request-error": "The information input is not in the correct format.",
+    "internal-server-error": "The service is temporarily unavailable. Please try again later."
+  },
   "signin-form": {
     "actions": {
       "submit": "Sign in"

--- a/mon-pix/translations/fr-fr.json
+++ b/mon-pix/translations/fr-fr.json
@@ -19,6 +19,12 @@
     "suffix": "Pix"
   },
 
+  "api-error-messages": {
+    "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+    "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+    "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement."
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Je me connecte"


### PR DESCRIPTION
## :unicorn: Problème
A date d'aujourd'hui, il existe un seul message affiché pour l'ensemble des erreurs générées lors de la connexion et de la demande de réinitilisation de mot de passe  dans Pix App `L'adresse e-mail et/ou le mot de passe saisis sont incorrects.`

Ce fonctionnement induit l'utilisateur final en erreur , ce qui pourrait le pousser à mener des actions en vain telle que la modification de son MDP même si ses  identifiants sont corrects.

En outre, les champs du formulaire n'étaient pas obligatoires, ce qui engendrait un appel inutile ( générer le token avec des identifiants vides).

## :robot: Solution
Catcher coté IHM les messages d'erreurs d'api et afficher un message d'erreur adapté par rapport à chaque famille d'erreur.
```javascript
"api-error-messages": {
    "unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
    "bad-request-error": "Les données envoyées ne sont pas au bon format.",
    "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train résoudre le problème. Veuillez réessayer ultérieurement."
  }
```
Ajouter un required au niveau des inputs pour éviter un appel api non valide et avoir un message d'erreur correct.

Activer l'option errorOnMissingTranslations pour avoir une error lors du build si jamais une traduction est manquante.
```
   /**
     * Cause a build error if missing translations are detected.
     *
     * See https://ember-intl.github.io/ember-intl/docs/guide/missing-translations#throwing-a-build-error-on-missing-required-translation
     *
     * @property errorOnMissingTranslations
     * @type {Boolean}
     * @default "false"
     */
    errorOnMissingTranslations: true,
```
[
![image](https://user-images.githubusercontent.com/10045497/84993391-89273b00-b149-11ea-9bd9-14a6b8e2d465.png)
](url)

## :rainbow: Remarques
Cette PR est une  continuité pour gérer correctement les messages d'erreur coté Pix.
D'autre PR suivront pour avoir cette gestion coté globale dans les applications.
Ce qui a été décidé est de tester le component avec une locale en Fr et d'activer l'option qui fait échouer le build lors de message de traduction manquante.

## :100: Pour tester
3 cas connexion:
* identifiant incorrect: utiliser nom/email ou MDP incorrect
* message d'indisponibilité: empêcher le front de contacter API (mode offline ou exécuter local sans API)
* données au mauvais format: rendre saisie email vide possible (editer html, enlever required de `<input name="login")`

Cas MDP oublié:
* Aller sur la page Mot de passe oublié, et utiliser une adresse e-mail qui n'existe pas, pour voir le message d'erreur.

