### PR TITLE
[FEATURE] Filtrer les élèves par type de connexion dans pix-orga (PIX-722)

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -19,12 +19,23 @@ function _toUserWithSchoolingRegistrationDTO(BookshelfSchoolingRegistration) {
   });
 }
 
-function _setSchoolingRegistrationFilters(qb, { lastName, firstName } = {}) {
+function _setSchoolingRegistrationFilters(qb, { lastName, firstName, connexionType } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("schooling-registrations"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
   if (firstName) {
     qb.whereRaw('LOWER("schooling-registrations"."firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+  }
+  if (connexionType === 'none') {
+    qb.whereRaw('"users"."username" IS NULL');
+    qb.whereRaw('"users"."email" IS NULL');
+    qb.whereRaw('"users"."samlId" IS NULL');
+  } else if (connexionType === 'identifiant') {
+    qb.whereRaw('"users"."username" IS NOT NULL');
+  } else if (connexionType === 'email') {
+    qb.whereRaw('"users"."email" IS NOT NULL');
+  } else if (connexionType === 'mediacentre') {
+    qb.whereRaw('"users"."samlId" IS NOT NULL');
   }
 }
 

--- a/api/tests/tooling/database-builder/factory/build-schooling-registration-with-user.js
+++ b/api/tests/tooling/database-builder/factory/build-schooling-registration-with-user.js
@@ -1,0 +1,54 @@
+const faker = require('faker');
+const moment = require('moment');
+const buildOrganization = require('./build-organization');
+const buildUser = require('./build-user');
+const databaseBuffer = require('../database-buffer');
+const _ = require('lodash');
+
+module.exports = function buildSchoolingRegistration({
+  id,
+  firstName = faker.name.firstName(),
+  preferredLastName = faker.name.lastName(),
+  lastName = faker.name.lastName(),
+  middleName = faker.name.firstName(),
+  thirdName = faker.name.firstName(),
+  birthdate = moment(faker.date.past(2, '2009-12-31')).format('YYYY-MM-DD'),
+  birthCity = faker.address.city(),
+  birthCityCode = faker.address.zipCode(),
+  birthCountryCode = faker.random.number(3).toString(),
+  birthProvinceCode = faker.random.alphaNumeric(3),
+  MEFCode = faker.random.number(11).toString(),
+  status = 'AP',
+  nationalStudentId = faker.random.alphaNumeric(11),
+  division = faker.random.alphaNumeric(2),
+  organizationId,
+  user,
+} = {}) {
+  organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
+  const { id: userId } = buildUser(user);
+
+  const values = {
+    id,
+    lastName,
+    preferredLastName,
+    firstName,
+    middleName,
+    thirdName,
+    birthdate,
+    birthCity,
+    birthCityCode,
+    birthCountryCode,
+    birthProvinceCode,
+    MEFCode,
+    status,
+    nationalStudentId,
+    division,
+    organizationId,
+    userId,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'schooling-registrations',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -30,6 +30,7 @@ module.exports = {
   buildPixRole: require('./build-pix-role'),
   buildSession: require('./build-session'),
   buildSchoolingRegistration: require('./build-schooling-registration'),
+  buildSchoolingRegistrationWithUser: require('./build-schooling-registration-with-user'),
   buildTargetProfile: require('./build-target-profile'),
   buildTargetProfileSkill: require('./build-target-profile-skill'),
   buildTargetProfileShare: require('./build-target-profile-share'),

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -450,14 +450,17 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
     it('should call the usecase to find students with users infos related to filters', async () => {
       // given
-      request = { ...request, query: { 'filter[lastName]': 'Bob', 'filter[firstName]': 'Tom' } };
+      request = { ...request, query: { 'filter[lastName]': 'Bob', 'filter[firstName]': 'Tom', 'filter[connexionType]': 'email' } };
       usecases.findUserWithSchoolingRegistrations.resolves();
 
       // when
       await organizationController.findUserWithSchoolingRegistrations(request, hFake);
 
       // then
-      expect(usecases.findUserWithSchoolingRegistrations).to.have.been.calledWith({ organizationId, filter: { lastName: 'Bob', firstName: 'Tom' } });
+      expect(usecases.findUserWithSchoolingRegistrations).to.have.been.calledWith({
+        organizationId,
+        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: 'email' }
+      });
     });
 
     it('should return the serialized students belonging to the organization', async () => {

--- a/orga/app/components/search-input.hbs
+++ b/orga/app/components/search-input.hbs
@@ -1,0 +1,12 @@
+<div class="input search-input" ...attributes>
+  <FaIcon @icon='search' />
+  <input 
+    id={{@inputName}}
+    name={{@inputName}}
+    placeholder={{@placeholder}}
+    value={{@value}}
+    oninput={{@filterFunction}}
+    class="search-input__invisible-field"
+  />
+</div>
+

--- a/orga/app/components/search-input.js
+++ b/orga/app/components/search-input.js
@@ -1,3 +1,0 @@
-import Component from '@ember/component';
-
-export default class SearchInput extends Component {}

--- a/orga/app/components/select-input.hbs
+++ b/orga/app/components/select-input.hbs
@@ -1,0 +1,10 @@
+<label class="select-input__wrapper">
+  <select class={{concat "select select-input__select " @class}} {{on 'change' @onChange}}>
+    {{#each @options as |opt|}}
+      <option value={{opt.value}} selected={{eq @selectedOption opt.value}}>
+        {{opt.label}}
+      </option>
+    {{/each}}
+  </select>
+  <FaIcon class='select-input__chevron' @icon='chevron-down' />
+</label>

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -5,6 +5,7 @@ import { debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'pix-orga/config/environment';
+import get from 'lodash/get';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
@@ -23,6 +24,16 @@ export default class ListController extends Controller {
   @computed('model')
   get displayNoCampaignPanel() {
     return !this.model.meta.hasCampaigns;
+  }
+
+  @computed('currentUser.organization.memberships')
+  get membersOptions() {
+    const members = get(this.currentUser,'organization.memberships', []);
+    const options = members.map(({ user }) => ({
+      value: user.get('id'),
+      label: `${user.get('firstName')} ${user.get('lastName')}`,
+    }));
+    return [{ value: '', label: 'Tous' }, ...options];
   }
 
   @equal('status', 'archived') isArchived;

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -2,21 +2,14 @@ import { notEmpty } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-const dash = '\u2013';
+const DASH = '\u2013';
+const SPACING_CHARACTER = '\n';
 
-const StudentAuthMethod = {
-  studentNotReconcilied: {
-    message: dash,
-  },
-  hasEmail: {
-    message: 'Adresse e-mail'
-  },
-  isAuthenticatedFromGar: {
-    message: 'Mediacentre'
-  },
-  hasUsername: {
-    message: 'Identifiant'
-  },
+export const CONNEXION_TYPES = {
+  none: 'Non connecté',
+  email: 'Adresse e-mail',
+  identifiant: 'Identifiant',
+  mediacentre: 'Mediacentre',
 };
 
 export default class Student extends Model {
@@ -31,19 +24,16 @@ export default class Student extends Model {
   @notEmpty('email') hasEmail;
 
   @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
+  
   get authenticationMethods() {
-    const SPACING_CHARACTER = '\n';
-    let message = '';
-    const props = ['hasEmail', 'hasUsername', 'isAuthenticatedFromGar'];
+    const messages = [];
 
-    props.forEach((prop) => {
-      if (this[prop]) {
-        message = message.concat(StudentAuthMethod[prop].message, SPACING_CHARACTER);
-      }
-    });
+    if (!this.isStudentAssociated) messages.push(DASH);
+    if (this.hasEmail) messages.push(CONNEXION_TYPES['email']);
+    if (this.hasUsername) messages.push(CONNEXION_TYPES['identifiant']);
+    if (this.isAuthenticatedFromGar) messages.push(CONNEXION_TYPES['mediacentre']);
 
-    return message ?  message.trim() : StudentAuthMethod['studentNotReconcilied'].message;
-
+    return messages.length > 0 ? messages.join(SPACING_CHARACTER) : '';
   }
 
   @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')

--- a/orga/app/routes/authenticated/students/list.js
+++ b/orga/app/routes/authenticated/students/list.js
@@ -8,6 +8,7 @@ export default class ListRoute extends Route {
   queryParams = {
     lastName: { refreshModel: true },
     firstName: { refreshModel: true },
+    connexionType: { refreshModel: true },
   };
 
   @service currentUser;
@@ -18,6 +19,7 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         lastName: params.lastName,
         firstName: params.firstName,
+        connexionType: params.connexionType,
       },
     });
   }
@@ -26,6 +28,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.lastName = null;
       controller.firstName = null;
+      controller.connexionType = null;
     }
   }
 

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -30,10 +30,10 @@
 @import "components/recommendation-indicator";
 @import "components/register-form";
 @import "components/search-input";
+@import "components/select-input";
 @import "components/sidebar-menu";
 @import "components/login-or-register";
 @import "components/user-logged-menu";
-@import "components/select-creator";
 @import "components/password-reset-modal";
 @import "components/modal";
 @import "pages/login";

--- a/orga/app/styles/components/select-input.scss
+++ b/orga/app/styles/components/select-input.scss
@@ -1,4 +1,4 @@
-.select-creator {
+.select-input {
   &__select {
     padding-left: 10px;
     -webkit-appearance:none;

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -151,6 +151,7 @@
   border: 2px $grey-20 solid;
   height: 46px;
   background-color: $white;
+  border-radius: 3px;
   outline: none;
 
   &:focus {

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -10,11 +10,13 @@
       </div>
     </div>
     <Routes::Authenticated::Campaigns::ListItems
-            @campaigns={{@model}} @campaignName={{this.name}}
-            @organizationMembers={{this.currentUser.organization.memberships}}
-            @campaignCreatorId={{this.creatorId}}
-            @triggerFiltering={{this.triggerFiltering}}
-            @updateCampaignCreator={{this.updateCampaignCreator}}
-            @goToCampaignPage={{this.goToCampaignPage}} />
+      @campaigns={{@model}}
+      @campaignName={{this.name}}
+      @organizationMembers={{this.membersOptions}}
+      @campaignCreatorId={{this.creatorId}}
+      @triggerFiltering={{this.triggerFiltering}}
+      @updateCampaignCreator={{this.updateCampaignCreator}}
+      @goToCampaignPage={{this.goToCampaignPage}}
+    />
   {{/if}}
 </div>

--- a/orga/app/templates/authenticated/students/list.hbs
+++ b/orga/app/templates/authenticated/students/list.hbs
@@ -3,9 +3,11 @@
     @students={{this.model}}
     @isLoading={{this.isLoading}}
     @importStudents={{this.importStudents}}
+    @connexionTypesOptions={{this.connexionTypesOptions}}
     @triggerFiltering={{this.triggerFiltering}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
+    @connexionTypeFilter={{this.connexionType}}
     @refreshModel={{this.refresh}}
   />
 </div>

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -21,10 +21,12 @@
               />
             </th>
             <th>
-              <Routes::Authenticated::Campaigns::SelectCreator
-                @organizationMembers={{@organizationMembers}}
-                @campaignCreatorId={{@campaignCreatorId}}
-                @selectCampaignCreator={{this.selectCampaignCreator}} />
+              <SelectInput
+                @class="table__input"
+                @onChange={{this.selectCampaignCreator}}
+                @options={{@organizationMembers}}
+                @selectedOption={{@campaignCreatorId}}
+              />
             </th>
             <th></th>
             <th></th>

--- a/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/list-items.hbs
@@ -12,7 +12,13 @@
           </tr>
           <tr>
             <th>
-              <SearchInput @inputName="campaignName" @class="input table__input search-input" @value={{@campaignName}} @placeholder="Rechercher une campagne" @filterFunction={{fn @triggerFiltering "name"}}/>
+              <SearchInput 
+                class="table__input" 
+                @inputName="campaignName" 
+                @value={{@campaignName}} 
+                @placeholder="Rechercher une campagne" 
+                @filterFunction={{fn @triggerFiltering "name"}}
+              />
             </th>
             <th>
               <Routes::Authenticated::Campaigns::SelectCreator

--- a/orga/app/templates/components/routes/authenticated/campaigns/select-creator.hbs
+++ b/orga/app/templates/components/routes/authenticated/campaigns/select-creator.hbs
@@ -1,9 +1,0 @@
-<label class="select-creator__wrapper">
-  <select class="select table__input select-creator__select" {{on 'change' @selectCampaignCreator}}>
-    <option value="">Tous</option>
-    {{#each @organizationMembers as |member|}}
-      <option value="{{member.user.id}}" selected={{eq @campaignCreatorId member.user.id}}>{{member.user.firstName}} {{member.user.lastName}}</option>
-    {{/each}}
-  </select>
-  <FaIcon class='select-creator__chevron' @icon='chevron-down'></FaIcon>
-</label>

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -27,7 +27,7 @@
                 @inputName="lastName"
                 @value={{@lastNameFilter}}
                 @placeholder="Rechercher par nom"
-                @filterFunction={{fn @triggerFiltering "lastName"}}
+                @filterFunction={{fn @triggerFiltering "lastName" true}}
               />
             </th>
             <th>
@@ -36,11 +36,18 @@
                 @inputName="firstName"
                 @value={{@firstNameFilter}}
                 @placeholder="Rechercher par prénom"
-                @filterFunction={{fn @triggerFiltering "firstName"}}
+                @filterFunction={{fn @triggerFiltering "firstName" true}}
               />
             </th>
             <th></th>
-            <th></th>
+            <th>
+              <SelectInput
+                @class="table__input"
+                @onChange={{fn @triggerFiltering "connexionType" false}}
+                @options={{@connexionTypesOptions}}
+                @selectedOption={{@connexionTypeFilter}}
+              />
+            </th>
             <th></th>
           </tr>
       </thead>
@@ -79,7 +86,7 @@
     </table>
 
     {{#unless @students}}
-      <div class="table__empty content-text">En attente d'élèves</div>
+      <div class="table__empty content-text">Aucun élève.</div>
     {{/unless}}
   </div>
 

--- a/orga/app/templates/components/routes/authenticated/students/list-items.hbs
+++ b/orga/app/templates/components/routes/authenticated/students/list-items.hbs
@@ -23,8 +23,8 @@
         <tr>
             <th>
               <SearchInput
+                class="table__input"
                 @inputName="lastName"
-                @class="input table__input search-input"
                 @value={{@lastNameFilter}}
                 @placeholder="Rechercher par nom"
                 @filterFunction={{fn @triggerFiltering "lastName"}}
@@ -32,8 +32,8 @@
             </th>
             <th>
               <SearchInput
+                class="table__input"
                 @inputName="firstName"
-                @class="input table__input search-input"
                 @value={{@firstNameFilter}}
                 @placeholder="Rechercher par prénom"
                 @filterFunction={{fn @triggerFiltering "firstName"}}

--- a/orga/app/templates/components/search-input.hbs
+++ b/orga/app/templates/components/search-input.hbs
@@ -1,7 +1,0 @@
-<FaIcon @icon='search'></FaIcon>
-<input id={{@inputName}}
-       name={{@inputName}}
-       placeholder={{@placeholder}}
-       value={{@value}}
-       oninput={{@filterFunction}}
-       class="search-input__invisible-field" />

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -163,6 +163,17 @@ export default function() {
       return schema.students.where(({ firstName }) => firstName.includes(firstNameFilter));
     }
 
+    const connexionTypeFilter = request.queryParams['filter[connexionType]'];
+    if (connexionTypeFilter) {
+      return schema.students.where((student) => {
+        if (connexionTypeFilter === '') return true;
+        if (connexionTypeFilter === 'identifiant' && student.hasUsername) return true;
+        if (connexionTypeFilter === 'email' && student.hasEmail) return true;
+        if (connexionTypeFilter === 'mediacentre' && student.isAuthenticatedFromGar) return true;
+        return false;
+      });
+    }
+
     return schema.students.where({ organizationId });
   });
 

--- a/orga/tests/acceptance/student-list-test.js
+++ b/orga/tests/acceptance/student-list-test.js
@@ -70,8 +70,8 @@ module('Acceptance | Student List', function(hooks) {
 
         organizationId = user.memberships.models.firstObject.organizationId;
 
-        server.create('student', { organizationId, firstName: 'Chuck', lastName: 'Norris' });
-        server.create('student', { organizationId, firstName: 'John', lastName: 'Rambo' });
+        server.create('student', { organizationId, firstName: 'Chuck', lastName: 'Norris', hasEmail: false });
+        server.create('student', { organizationId, firstName: 'John', lastName: 'Rambo', hasEmail: true });
 
         await authenticateSession({
           user_id: user.id,
@@ -87,6 +87,7 @@ module('Acceptance | Student List', function(hooks) {
         await fillIn('[placeholder="Rechercher par nom"]', 'ambo');
       
         // then
+        assert.equal(currentURL(), '/eleves?lastName=ambo');
         assert.contains('Rambo');
         assert.notContains('Norris');
       });
@@ -97,6 +98,18 @@ module('Acceptance | Student List', function(hooks) {
         await fillIn('[placeholder="Rechercher par prénom"]', 'Jo');
       
         // then
+        assert.equal(currentURL(), '/eleves?firstName=Jo');
+        assert.contains('Rambo');
+        assert.notContains('Norris');
+      });
+
+      test('it should display the students list filtered by connexion type', async function(assert) {
+        // when
+        await visit('/eleves');
+        await fillIn('select', 'email');
+
+        // then
+        assert.equal(currentURL(), '/eleves?connexionType=email');
         assert.contains('Rambo');
         assert.notContains('Norris');
       });

--- a/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/list-items-test.js
@@ -125,16 +125,16 @@ module('Integration | Component | routes/authenticated/campaign | list-items', f
   
     test('it should display the list of memberships from the organization', async function(assert) {
       // given
-      const store = this.owner.lookup('service:store');
-      const user1 = store.createRecord('user', { firstName: 'Harry', lastName: 'Covert' });
-      const user2 = store.createRecord('user', { firstName: 'Jean-Michel', lastName: 'Jarre' });
-  
       const campaigns = [];
       campaigns.meta = {
         rowCount: 0
       };
   
-      const organizationMembers = [{ user: user1 }, { user:  user2 }];
+      const organizationMembers = [
+        { label: 'Tous' },
+        { label: 'Harry Covert' },
+        { label: 'Jean-Michel Jarre' }
+      ];
   
       this.set('campaigns', campaigns);
       this.set('organizationMembers', organizationMembers);

--- a/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/students/list-items-test.js
@@ -79,7 +79,8 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'lastName');
-      assert.equal(call.args[1].target.value, 'bob');
+      assert.equal(call.args[1], true);
+      assert.equal(call.args[2].target.value, 'bob');
     });
     
     test('it should trigger filtering with firstname', async function(assert) {
@@ -95,7 +96,26 @@ module('Integration | Component | routes/authenticated/students | list-items', f
       // then
       const call = triggerFiltering.getCall(0);
       assert.equal(call.args[0], 'firstName');
-      assert.equal(call.args[1].target.value, 'bob');
+      assert.equal(call.args[1], true);
+      assert.equal(call.args[2].target.value, 'bob');
+    });
+
+    test('it should trigger filtering with connexionType', async function(assert) {
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+      this.set('connexionTypesOptions', [{ value: '', label: 'Tous' }, { value: 'email', label: 'email' }]);
+      
+      // when
+      await render(hbs`<Routes::Authenticated::Students::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}} @connexionTypesOptions={{connexionTypesOptions}} />`);
+      
+      await fillIn('select', 'email');
+      
+      // then
+      const call = triggerFiltering.getCall(0);
+      assert.equal(call.args[0], 'connexionType');
+      assert.equal(call.args[1], false);
+      assert.equal(call.args[2].target.value, 'email');
     });
   });
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
+import ObjectProxy from '@ember/object/proxy';
 import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
@@ -62,6 +63,41 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
         // then
         assert.equal(displayNoCampaignPanel, false);
       });
+    });
+  });
+
+  module('#get membersOptions', function() {
+    test('it should returns default option if no organization members', function(assert) {
+      // given
+      controller.currentUser = {
+        organization: {
+          memberships: [],
+        },
+      };
+
+      // then
+      assert.deepEqual(controller.membersOptions, [
+        { value: '', label: 'Tous' },
+      ]);
+    });
+
+    test('it should returns members options from organization members', function(assert) {
+      // given
+      controller.currentUser = {
+        organization: {
+          memberships: [{
+            user: ObjectProxy.create({
+              content: { id: '1', firstName: 'John', lastName: 'Rambo' }
+            })
+          }],
+        },
+      };
+
+      // then
+      assert.deepEqual(controller.membersOptions, [
+        { value: '', label: 'Tous' },
+        { value: '1', label: 'John Rambo' },
+      ]);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas filtrer la liste des élèves par type de connexion dans pix-orga.

## :robot: Solution
Ajout d'un filtre sur la colonne type de connexion dans la liste des élèves.

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Se connecter sur pix-orga avec sco@example.net
2. Cliquer sur "Elèves" dans le menu de gauche
3. Sélectionner un type de connexion dans le champ de filtre des élèves dans la colonne "connecté avec"
> Observer que la liste est filtré en rapport avec le filtre saisi