### PR TITLE
[FEATURE] Modification dans le design des badges sur la page de résultat (PIX-778).

### DIFF
--- a/mon-pix/app/controllers/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/assessment/skill-review.js
@@ -14,9 +14,12 @@ export default class SkillReviewController extends Controller {
   }
 
   get showBadges() {
+    return this.acquiredBadges.length > 0;
+  }
+
+  get acquiredBadges() {
     const badges = this.model.campaignParticipation.campaignParticipationResult.get('campaignParticipationBadges');
-    const acquiredBadges = badges.filter((badge) => badge.isAcquired);
-    return acquiredBadges.length > 0;
+    return badges.filter((badge) => badge.isAcquired);
   }
 
   @action

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -20,8 +20,9 @@
 @import 'globals/text';
 @import 'globals/titles';
 /* components */
-@import 'components/background-banner';
 @import 'components/assessment-banner';
+@import 'components/background-banner';
+@import 'components/badge-acquired-card';
 @import 'components/certification-starter';
 @import 'components/certification-joiner';
 @import 'components/certification-banner';

--- a/mon-pix/app/styles/components/_badge-acquired-card.scss
+++ b/mon-pix/app/styles/components/_badge-acquired-card.scss
@@ -1,0 +1,65 @@
+.badge-acquired-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-column-gap: 32px;
+  grid-row-gap: 24px;
+  padding: 48px 14px;
+
+  @include device-is('tablet') {
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 32px;
+    padding: 48px 0;
+  }
+}
+
+.badge-acquired-card {
+  display: flex;
+  flex-direction: row;
+  box-shadow: $box-shadow-competence-cards;
+  min-height: 150px;
+  justify-content: space-between;
+  border-radius: 10px;
+  overflow: hidden;
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+    padding-right: 16px;
+  }
+
+  &-text {
+    &__title {
+      margin: 0;
+      color: $grey-100;
+      font-family: $font-roboto;
+      font-size: 1.12rem;
+      font-weight: $font-medium;
+      letter-spacing: 0.028rem;
+    }
+
+    &__message {
+      margin-bottom: 0;
+      color: $grey-45;
+      font-family: $font-roboto;
+      font-size: 0.75rem;
+      font-weight: $font-normal;
+      letter-spacing: 0.0093rem;
+      line-height: 1.2rem;
+    }
+  }
+
+  &__image {
+    min-width: 120px;
+    max-width: 120px;
+    padding: 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $grey-10;
+
+    img {
+      width: 90px;
+    }
+  }
+}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -107,20 +107,6 @@
     margin: 16px 0;
   }
 
-  &__badge {
-    text-align: center;
-    display: inline-block;
-    padding: 16px 16px;
-
-    &-information {
-      font-family: $font-roboto;
-      font-weight: $font-light;
-      font-size: 1.25rem;
-      line-height: 2rem;
-      margin: auto;
-    }
-  }
-
   &__dash-line {
     height: 1px;
     top: 0;
@@ -159,16 +145,6 @@
       flex-direction: row;
     }
   }
-}
-
-.skill-review-result__badges-container {
-  margin-top: 16px;
-  box-shadow: -2px 5px 6px 3px rgba(0, 0, 0, 0.11);
-  border-radius: 15px;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
 .skill-review-result-abstract {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -139,11 +139,20 @@
     justify-content: space-between;
     align-items: center;
     text-align: center;
-    padding: 20px;
+    padding: 0;
 
     @include device-is('tablet') {
       flex-direction: row;
+      padding: 20px 0;
     }
+  }
+
+  &__subtitle {
+    color: $grey-100;
+    font-family: $font-open-sans;
+    font-size: 1.5rem;
+    font-weight: $font-normal;
+    margin: 28px 0 24px;
   }
 }
 

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -5,22 +5,6 @@
     <AssessmentBanner @title={{this.model.assessment.title}} @displayHomeLink={{false}} />
   </div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner skill-review__result-container">
-    {{#if this.showBadges}}
-      <div>
-        <h2>Badges obtenus</h2>
-        <div class="skill-review-result__badges-container">
-          {{#each this.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges as |badge|}}
-            {{#if badge.isAcquired}}
-              <div class="skill-review-result__badge">
-                <img src="{{badge.imageUrl}}"
-                     alt="{{badge.altMessage}}">
-                <p class="skill-review-result__badge-information">{{badge.message}}</p>
-              </div>
-            {{/if}}
-          {{/each}}
-        </div>
-      </div>
-    {{/if}}
     {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
       <h3 class="rounded-panel-title skill-review-result__abstract">
         Vous maîtrisez
@@ -80,8 +64,18 @@
     {{/if}}
     <div class="skill-review-result__dash-line"></div>
 
+    {{#if this.showBadges}}
+      <div class="badge-acquired-container">
+        {{#each this.acquiredBadges as |badge|}}
+          <BadgeAcquiredCard @title="{{badge.title}}" @message="{{badge.message}}" @imageUrl="{{badge.imageUrl}}"
+                             @altMessage="{{badge.altMessage}}"/>
+        {{/each}}
+      </div>
+      <div class="skill-review-result__dash-line"></div>
+    {{/if}}
+
     <div class="skill-review-result__table-header">
-      <h2 class="rounded-panel-subtitle">Vos résultats détaillés</h2>
+      <h2 class="skill-review-result__subtitle">Vos résultats détaillés</h2>
       <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
         <span aria-label="Résultat global" class="skill-review-table-header__circle-chart-value">
           {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%

--- a/mon-pix/app/templates/components/badge-acquired-card.hbs
+++ b/mon-pix/app/templates/components/badge-acquired-card.hbs
@@ -1,0 +1,7 @@
+<div class="badge-acquired-card">
+  <div class="badge-acquired-card__text">
+    <p class="badge-acquired-card-text__title">{{@title}}</p>
+    <p class="badge-acquired-card-text__message">{{@message}}</p>
+  </div>
+  <div class="badge-acquired-card__image"><img src="{{@imageUrl}}" alt="{{@altMessage}}" /></div>
+</div>

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -15,5 +15,6 @@
     </div>
 
     <ProfileScorecards @interactive={{true}} @areasCode={{@model.areasCode}} @scorecards={{@model.scorecards}}/>
+
   </div>
 </div>

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -133,7 +133,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('.skill-review-result__badge')).to.exist;
+        expect(find('.badge-acquired-card')).to.exist;
       });
 
       it('should not display the Pix emploi badge when badge is not acquired', async function() {
@@ -164,7 +164,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(findAll('.skill-review-result__badge').length).to.equal(1);
+        expect(findAll('.badge-acquired-card').length).to.equal(1);
       });
 
       it('should share the results', async function() {

--- a/mon-pix/tests/integration/components/badge-acquired-card-test.js
+++ b/mon-pix/tests/integration/components/badge-acquired-card-test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | Badge Acquired Card', function() {
+  setupRenderingTest();
+
+  beforeEach(function() {
+    this.set('title', 'Badge de winner');
+    this.set('message', 'Bravo ! Tu as ton badge !');
+    this.set('imageUrl', '/images/hexa-pix.svg');
+    this.set('altMessage', 'Ceci est un badge.');
+  });
+
+  it('should render the badge acquired card', async function() {
+    // when
+    await render(hbs`<BadgeAcquiredCard @message={{this.message}} @title={{this.title}} @imageUrl={{this.imageUrl}} @altMessage={{this.altMessage}} />`);
+
+    // then
+    expect(find('.badge-acquired-card')).to.exist;
+    expect(find('.badge-acquired-card-text__title').textContent.trim()).to.equal('Badge de winner');
+    expect(find('.badge-acquired-card-text__message').textContent.trim()).to.equal('Bravo ! Tu as ton badge !');
+  });
+});

--- a/mon-pix/tests/unit/controllers/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/assessment/skill-review-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
-import  EmberObject  from '@ember/object';
+import EmberObject from '@ember/object';
 
 describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function() {
 
@@ -73,8 +73,8 @@ describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function()
 
     it('should showCleaCompetences when campaignParticipationResult has a clea badge', function() {
       // given
-      const cleaBadge = { id : 111 };
-      controller.model.campaignParticipation.campaignParticipationResult.cleaBadge = cleaBadge ;
+      const cleaBadge = { id: 111 };
+      controller.model.campaignParticipation.campaignParticipationResult.cleaBadge = cleaBadge;
 
       // when
       const shouldShowCleaCompetences = controller.showCleaCompetences;
@@ -99,8 +99,8 @@ describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function()
 
     it('should show badges when acquired', function() {
       // given
-      const badges = [{ id : 33, isAcquired: true }];
-      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges ;
+      const badges = [{ id: 33, isAcquired: true }];
+      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
       const shouldShowBadges = controller.showBadges;
@@ -111,8 +111,8 @@ describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function()
 
     it('should not show badges when not acquired', function() {
       // given
-      const badges = [{ id : 33, isAcquired: false }];
-      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges ;
+      const badges = [{ id: 33, isAcquired: false }];
+      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
       const shouldShowBadges = controller.showBadges;
@@ -124,7 +124,7 @@ describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function()
     it('should not show badges when none', function() {
       // given
       const badges = [];
-      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges ;
+      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
       const shouldShowBadges = controller.showBadges;
@@ -133,4 +133,21 @@ describe('Unit | Controller | Campaigns | Evaluation | Skill Review', function()
       expect(shouldShowBadges).to.equal(false);
     });
   });
+
+  describe('#acquiredBadges', function() {
+
+    it('should only display acquired badges', function() {
+      // given
+      const badges = [{ id: 33, isAcquired: true }, { id: 34, isAcquired: false }];
+      controller.model.campaignParticipation.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const acquiredBadges = controller.acquiredBadges;
+
+      // then
+      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true }]);
+    });
+
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
- Le design des badges sur la page de résultat n'était pas pensé pour plusieurs badges.

## :robot: Solution
- Ajout d'un composant `badge-acquired-card` et utilisation de ce dernier.

## :rainbow: Remarques
- Questionnement sur le titre du badge : est-ce que ça devrait être un titre ? Ou plutôt mettre tous les badges au sein d'une liste ? 

## :100: Pour tester
- Terminer la campagne `BADGES789` pour voir un badge.