### PR TITLE
[BUGFIX] Erreur lorsqu'on tente de modifier une certification sur PixAdmin (PIX-866)

### DIFF
--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -19,8 +19,8 @@ function _deserializeResultsAdd(json) {
     return new CompetenceMark({
       level: competenceMark.level,
       score: competenceMark.score,
-      area_code: competenceMark['area_code'],
-      competence_code: competenceMark['competence_code'],
+      area_code: competenceMark.area_code,
+      competence_code: competenceMark.competence_code,
       competenceId: competenceMark['competence-id'],
     });
   });

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -29,13 +29,12 @@ function _deserializeResultsAdd(json) {
 
 module.exports = {
 
-  save(request) {
+  async save(request) {
     const jsonResult = request.payload.data.attributes;
-
     const { assessmentResult, competenceMarks } = _deserializeResultsAdd(jsonResult);
-    assessmentResult.juryId = request.auth.credentials.userId;
-    // FIXME (re)calculate partner certification acquisitions
-    return assessmentResultService.save(assessmentResult, competenceMarks)
-      .then(() => null);
+    const juryId = request.auth.credentials.userId;
+    // FIXME (re)calculate partner certifications which may be invalidated/validated
+    await assessmentResultService.save({ ...assessmentResult, juryId }, competenceMarks);
+    return null;
   },
 };

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -19,8 +19,8 @@ function _deserializeResultsAdd(json) {
     return new CompetenceMark({
       level: competenceMark.level,
       score: competenceMark.score,
-      area_code: competenceMark['area-code'],
-      competence_code: competenceMark['competence-code'],
+      area_code: competenceMark['area_code'],
+      competence_code: competenceMark['competence_code'],
       competenceId: competenceMark['competence-id'],
     });
   });

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -10,20 +10,19 @@ module.exports = {
 
   computeResult(request) {
     const certificationCourseId = request.params.id;
-
     return certificationService.calculateCertificationResultByCertificationCourseId(certificationCourseId);
   },
 
-  getResult(request) {
+  async getResult(request) {
     const certificationCourseId = request.params.id;
-    return certificationService.getCertificationResult(certificationCourseId)
-      .then(certificationResultSerializer.serialize);
+    const certificationResult = await certificationService.getCertificationResult(certificationCourseId);
+    return certificationResultSerializer.serialize(certificationResult);
   },
 
-  update(request) {
-    return certificationSerializer.deserialize(request.payload)
-      .then((certificationCourse) => certificationCourseService.update(certificationCourse))
-      .then(certificationSerializer.serializeFromCertificationCourse);
+  async update(request) {
+    const certificationCourse = await certificationSerializer.deserialize(request.payload);
+    const updatedCertificationCourse = await certificationCourseService.update(certificationCourse);
+    return certificationSerializer.serializeFromCertificationCourse(updatedCertificationCourse);
   },
 
   async save(request, h) {

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -25,6 +25,7 @@ class CertificationResult {
       examinerComment,
       hasSeenEndTestScreen,
       // references
+      assessmentId,
       juryId,
       sessionId,
     } = {}) {
@@ -52,6 +53,7 @@ class CertificationResult {
     this.examinerComment = examinerComment;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     // references
+    this.assessmentId = assessmentId;
     this.juryId = juryId;
     this.sessionId = sessionId;
   }

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
-const { ObjectValidationError } = require('../errors');
+const { validateEntity } = require('../validators/entity-validator');
 
-const schemaValidateCompetenceMark = Joi.object({
+const schema = Joi.object({
   id: Joi.number().integer().optional(),
   level: Joi.number().integer().min(-1).max(8).required(),
   score: Joi.number().integer().min(0).max(64).required(),
@@ -37,13 +37,9 @@ class CompetenceMark {
   }
 
   validate() {
-    const { error } = schemaValidateCompetenceMark.validate(this);
-    if (error) {
-      return Promise.reject(new ObjectValidationError(error));
-    } else {
-      return Promise.resolve();
-    }
+    validateEntity(schema, this);
   }
+
 }
 
 module.exports = CompetenceMark;

--- a/api/lib/domain/models/ResultCompetenceTree.js
+++ b/api/lib/domain/models/ResultCompetenceTree.js
@@ -1,5 +1,4 @@
 const Area = require('./Area');
-const CompetenceMark = require('./CompetenceMark');
 const ResultCompetence = require('./ResultCompetence');
 
 const NOT_PASSED_LEVEL = -1;
@@ -28,11 +27,10 @@ class ResultCompetenceTree {
       const areaWithResultCompetences = new Area(area);
 
       areaWithResultCompetences.resultCompetences = area.competences.map((competence) => {
-        const noLevelCompetenceMark = new CompetenceMark({ level: NOT_PASSED_LEVEL, score: NOT_PASSED_SCORE });
+        const noLevelCompetenceMarkData = { level: NOT_PASSED_LEVEL, score: NOT_PASSED_SCORE };
 
-        const associatedCompetenceMark = competenceMarks.find((competenceMark) => {
-          return competenceMark.competence_code === competence.index;
-        }) || noLevelCompetenceMark;
+        const associatedCompetenceMark = competenceMarks
+          .find((competenceMark) => competenceMark.competence_code === competence.index) || noLevelCompetenceMarkData;
 
         return new ResultCompetence({
           id: competence.id,

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -8,10 +8,9 @@ const certificationResultService = require('./certification-result-service');
 
 module.exports = {
 
-  calculateCertificationResultByCertificationCourseId(certificationCourseId) {
-    return certificationAssessmentRepository
-      .getByCertificationCourseId(certificationCourseId)
-      .then((certificationAssessment) => certificationResultService.getCertificationResult({ certificationAssessment, continueOnError: true }));
+  async calculateCertificationResultByCertificationCourseId(certificationCourseId) {
+    const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
+    return certificationResultService.getCertificationResult({ certificationAssessment, continueOnError: true });
   },
 
   async getCertificationResult(certificationCourseId) {

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -1,5 +1,6 @@
 const CertificationResult = require('../models/CertificationResult');
 const Assessment = require('../models/Assessment');
+const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const certificationAssessmentRepository = require('../../../lib/infrastructure/repositories/certification-assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository');
@@ -16,6 +17,7 @@ module.exports = {
   async getCertificationResult(certificationCourseId) {
     const certification = await certificationCourseRepository.get(certificationCourseId);
     const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
+    const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
     let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
     if (!lastAssessmentResultFull) {
       lastAssessmentResultFull = { competenceMarks: [], status: Assessment.states.STARTED };
@@ -23,6 +25,7 @@ module.exports = {
 
     return new CertificationResult({
       id: certification.id,
+      assessmentId,
       firstName: certification.firstName,
       lastName: certification.lastName,
       birthdate: certification.birthdate,

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -63,6 +63,13 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
+  getIdByCertificationCourseId(certificationCourseId) {
+    return BookshelfAssessment
+      .where({ certificationCourseId, type: 'CERTIFICATION' })
+      .fetch({ columns: 'id' })
+      .then((result) => result ? result.attributes.id : null);
+  },
+
   getByCampaignParticipationId(campaignParticipationId) {
     return BookshelfAssessment
       .where({ 'campaign-participations.id': campaignParticipationId, 'assessments.type': 'SMART_PLACEMENT' })

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -6,16 +6,17 @@ function _toDomain(bookshelfCompetenceMark) {
 }
 
 module.exports = {
-  save: (competenceMark, domainTransaction = {}) => {
-    return competenceMark.validate()
-      .then(() => new BookshelfCompetenceMark(competenceMark).save(null, { transacting: domainTransaction.knexTransaction }))
-      .then((savedCompetenceMark) => savedCompetenceMark.toDomainEntity());
+  async save(competenceMark, domainTransaction = {}) {
+    await competenceMark.validate();
+    const savedCompetenceMark = await new BookshelfCompetenceMark(competenceMark)
+      .save(null, { transacting: domainTransaction.knexTransaction });
+    return savedCompetenceMark.toDomainEntity();
   },
 
-  findByAssessmentResultId(assessmentResultId) {
-    return BookshelfCompetenceMark
+  async findByAssessmentResultId(assessmentResultId) {
+    const competenceMarks = await BookshelfCompetenceMark
       .where({ assessmentResultId })
-      .fetchAll()
-      .then((competenceMarks) => competenceMarks.models.map(_toDomain));
+      .fetchAll();
+    return competenceMarks.models.map(_toDomain);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
@@ -5,6 +5,7 @@ module.exports = {
   serialize(certificationResult) {
     return new Serializer('results', {
       attributes: [
+        'assessmentId',
         'level',
         'pixScore',
         'createdAt',

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -42,7 +42,7 @@ function buildCertificationRequest(baseUrl, authToken, certificationId) {
 }
 
 function findCompetence(profile, competenceName) {
-  const result = profile.find((competence) => competence['competence-code'] === competenceName);
+  const result = profile.find((competence) => competence['competence_code'] === competenceName);
   return (result || { level: '' }).level;
 }
 

--- a/api/scripts/get-results-certifications.js
+++ b/api/scripts/get-results-certifications.js
@@ -42,7 +42,7 @@ function buildCertificationRequest(baseUrl, authToken, certificationId) {
 }
 
 function findCompetence(profile, competenceName) {
-  const result = profile.find((competence) => competence['competence_code'] === competenceName);
+  const result = profile.find((competence) => competence.competence_code === competenceName);
   return (result || { level: '' }).level;
 }
 

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -40,17 +40,20 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
                   level: 2,
                   score: 18,
                   'area_code': 2,
-                  'competence_code': 2.1
+                  'competence_code': 2.1,
+                  'competence-id': '2.1',
                 },{
                   level: 3,
                   score: 27,
                   'area_code': 3,
-                  'competence_code': 3.2
+                  'competence_code': 3.2,
+                  'competence-id': '3.2',
                 },{
                   level: 1,
                   score: 9,
                   'area_code': 1,
-                  'competence_code': 1.3
+                  'competence_code': 1.3,
+                  'competence-id': '1.3',
                 }
               ]
             }
@@ -66,90 +69,79 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
       await knex('assessment-results').delete();
       await knex('assessments').delete();
       await knex('certification-courses').delete();
+      await knex('users_pix_roles').delete();
+      await knex('users').delete();
     });
 
-    it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', () => {
+    it('should respond with a 403 - forbidden access - if user has not role PIX_MASTER', async () => {
       // given
       const nonPixMAsterUserId = 9999;
       options.headers.authorization = generateValidRequestAuthorizationHeader(nonPixMAsterUserId);
 
       // when
-      const promise = server.inject(options);
+      const response = await server.inject(options);
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(403);
-      });
+      expect(response.statusCode).to.equal(403);
     });
 
-    it('should return a 204 after saving in database', () => {
+    it('should return a 204 after saving in database', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await server.inject(options);
 
       // then
-      return promise
-        .then((response) => {
-          expect(response.statusCode).to.equal(204);
-        });
+      expect(response.statusCode).to.equal(204);
     });
 
-    it('should save a assessment-results and 3 marks', () => {
+    it('should save a assessment-results and 3 marks', async () => {
       // when
-      const promise = server.inject(options);
+      await server.inject(options);
 
       // then
-      return promise
-        .then(() => knex('assessment-results').select())
-        .then((result) => {
-          expect(result).to.have.lengthOf(1);
-        })
-        .then(() => knex('competence-marks').select())
-        .then((marks) => {
-          expect(marks).to.have.lengthOf(3);
-        });
+      const assessmentResults = await knex('assessment-results').select();
+      const marks = await knex('competence-marks').select();
+
+      expect(assessmentResults).to.have.lengthOf(1);
+      expect(marks).to.have.lengthOf(3);
     });
 
     context('when assessment has already the assessment-result compute', () => {
-      before(() => {
-        return knex('assessment-results')
+      before(async () => {
+        const results = await knex('assessment-results')
           .insert({
             level: -1,
             pixScore: 0,
             status: 'rejected',
             emitter: 'PIX-ALGO',
             commentForJury: 'Computed'
-          }, 'id').then((result) => {
-            const resultId = result[0];
-            return knex('competence-marks')
-              .insert({
-                assessmentResultId: resultId,
-                level: -1,
-                score: 0,
-                area_code: 2,
-                competence_code: 2.1
-              });
+          }, 'id');
+
+        const resultId = results[0];
+        await knex('competence-marks')
+          .insert({
+            assessmentResultId: resultId,
+            level: -1,
+            score: 0,
+            area_code: 2,
+            competence_code: 2.1
           });
       });
 
-      it('should save a assessment-results and 3 marks', () => {
+      it('should save a assessment-results and 3 marks', async () => {
         // when
-        const promise = server.inject(options);
+        await server.inject(options);
 
         // then
-        return promise
-          .then(() => knex('assessment-results').select())
-          .then((result) => {
-            expect(result).to.have.lengthOf(2);
-          })
-          .then(() => knex('competence-marks').select())
-          .then((marks) => {
-            expect(marks).to.have.lengthOf(4);
-          });
+        const assessmentResults = await knex('assessment-results').select();
+        const marks = await knex('competence-marks').select();
+
+        expect(assessmentResults).to.have.lengthOf(2);
+        expect(marks).to.have.lengthOf(4);
       });
     });
 
     context('when the correction to be applied has a mistake', () => {
-      it('should return a 422 error', () => {
+      it('should return a 422 error', async () => {
         const wrongScore = 9999999999;
 
         const options = {
@@ -192,18 +184,15 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
         };
 
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise
-          .then((response) => {
-            expect(response.statusCode).to.equal(422);
-            expect(response.result.errors[0]).to.deep.equal({
-              'title': 'Unprocessable entity',
-              'detail': 'ValidationError: "score" must be less than or equal to 64',
-              'status': '422'
-            });
-          });
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0]).to.deep.equal({
+          'title': 'Unprocessable entity',
+          'detail': 'ValidationError: "score" must be less than or equal to 64',
+          'status': '422'
+        });
       });
     });
   });

--- a/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
+++ b/api/tests/acceptance/application/assessment-results/assessment-result-admin-controller_test.js
@@ -39,18 +39,18 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
                 {
                   level: 2,
                   score: 18,
-                  'area-code': 2,
-                  'competence-code': 2.1
+                  'area_code': 2,
+                  'competence_code': 2.1
                 },{
                   level: 3,
                   score: 27,
-                  'area-code': 3,
-                  'competence-code': 3.2
+                  'area_code': 3,
+                  'competence_code': 3.2
                 },{
                   level: 1,
                   score: 9,
-                  'area-code': 1,
-                  'competence-code': 1.3
+                  'area_code': 1,
+                  'competence_code': 1.3
                 }
               ]
             }
@@ -172,18 +172,18 @@ describe('Acceptance | Controller | assessment-results-controller', function() {
                   {
                     level: 2,
                     score: 18,
-                    'area-code': 2,
-                    'competence-code': 2.1
+                    'area_code': 2,
+                    'competence_code': 2.1
                   },{
                     level: 3,
                     score: wrongScore,
-                    'area-code': 3,
-                    'competence-code': 3.2
+                    'area_code': 3,
+                    'competence_code': 3.2
                   },{
                     level: 1,
                     score: 218158186,
-                    'area-code': 1,
-                    'competence-code': 1.3
+                    'area_code': 1,
+                    'competence_code': 1.3
                   }
                 ]
               }

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -310,6 +310,54 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
   });
 
+  describe('#getIdByCertificationCourseId', async () => {
+
+    let userId;
+    let certificationCourseId;
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ userId }).id;
+      return databaseBuilder.commit();
+    });
+
+    context('When the assessment for this certificationCourseId exists', () => {
+      let assessmentId;
+
+      beforeEach(() => {
+        assessmentId = databaseBuilder.factory.buildAssessment({
+          userId,
+          certificationCourseId,
+          type: Assessment.types.CERTIFICATION,
+        }).id;
+
+        return databaseBuilder.commit();
+      });
+
+      it('should return the assessment for the given certificationCourseId', async () => {
+
+        // when
+        const returnedAssessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
+
+        // then
+        expect(returnedAssessmentId).to.equal(assessmentId);
+      });
+
+    });
+
+    context('When there are no assessment for this certification course id', () => {
+
+      it('should return null', async () => {
+        // when
+        const assessment = await assessmentRepository.getIdByCertificationCourseId(1);
+
+        // then
+        expect(assessment).to.equal(null);
+      });
+    });
+
+  });
+
   describe('#getByCampaignParticipationId', () => {
 
     let campaignParticipationId;

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -7,86 +7,52 @@ const competenceMarkRepository = require('../../../../lib/infrastructure/reposit
 describe('Integration | Repository | CompetenceMark', () => {
 
   describe('#save', () => {
+    let assessmentResultId;
     let competenceMark;
     beforeEach(async () => {
-      // given
+      assessmentResultId = await databaseBuilder.factory.buildAssessmentResult().id;
+      await databaseBuilder.commit();
+
       competenceMark = domainBuilder.buildCompetenceMark({
         score: 13,
         level: 1,
         area_code: '4',
         competence_code: '4.2',
+        assessmentResultId,
       });
     });
 
     afterEach(async () => {
       await knex('competence-marks').delete();
+      await knex('assessment-results').delete();
     });
 
-    it('should persist the mark in db', () => {
+    it('should persist the mark in db', async () => {
       // when
-      const promise = competenceMarkRepository.save(competenceMark);
+      await competenceMarkRepository.save(competenceMark);
 
       // then
-      return promise.then(() => knex('competence-marks').select())
-        .then((marks) => {
-          expect(marks).to.have.lengthOf(1);
-        });
+      const marks = await knex('competence-marks').select();
+      expect(marks).to.have.lengthOf(1);
+
     });
 
-    it('should return the saved mark', () => {
+    it('should return the saved mark', async () => {
       // given
       const mark = domainBuilder.buildCompetenceMark({
         score: 13,
         level: 1,
         area_code: '4',
         competence_code: '4.2',
+        assessmentResultId,
       });
 
       // when
-      const promise = competenceMarkRepository.save(mark);
+      const savedMark = await competenceMarkRepository.save(mark);
 
       // then
-      return promise.then((mark) => {
-        expect(mark).to.be.an.instanceOf(CompetenceMark);
-
-        expect(mark).to.have.property('id').and.not.to.be.null;
-      });
-    });
-
-    context('when competenceMark is not validated', () => {
-      it('should return an error', () => {
-        // given
-        const expectedValidationErrorMessage = 'ValidationError: "level" must be less than or equal to 8';
-        const markWithLevelGreaterThanEight = domainBuilder.buildCompetenceMark({
-          score: 13,
-          level: 10,
-        });
-
-        // when
-        const promise = competenceMarkRepository.save(markWithLevelGreaterThanEight);
-
-        // then
-        return promise.catch((error) => {
-          expect(error.message).to.be.equal(expectedValidationErrorMessage);
-        });
-      });
-
-      it('should not saved the competenceMark', () => {
-        // given
-        const markWithLevelGreaterThanEight = domainBuilder.buildCompetenceMark({
-          score: 13,
-          level: 10,
-        });
-
-        // when
-        const promise = competenceMarkRepository.save(markWithLevelGreaterThanEight);
-
-        // then
-        return promise.catch(() => knex('competence-marks').select())
-          .then((marks) => {
-            expect(marks).to.have.lengthOf(0);
-          });
-      });
+      expect(savedMark).to.be.an.instanceOf(CompetenceMark);
+      expect(savedMark).to.have.property('id').and.not.to.be.null;
     });
   });
 

--- a/api/tests/tooling/database-builder/factory/build-competence-mark.js
+++ b/api/tests/tooling/database-builder/factory/build-competence-mark.js
@@ -5,8 +5,8 @@ const _ = require('lodash');
 
 module.exports = function buildCompetenceMark({
   id,
-  level = faker.random.number(),
-  score = faker.random.number(),
+  level = faker.random.number() % 8,
+  score = faker.random.number() % 64,
   area_code = faker.random.number().toString(),
   competence_code = `${faker.random.number()}_${faker.random.number()}`,
   competenceId = `rec${faker.random.uuid()}`,

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -27,18 +27,18 @@ describe('Unit | Controller | assessment-results', () => {
               {
                 level: 2,
                 score: 18,
-                'area-code': 2,
-                'competence-code': 2.1
+                'area_code': 2,
+                'competence_code': 2.1
               }, {
                 level: 3,
                 score: 27,
-                'area-code': 3,
-                'competence-code': 3.2
+                'area_code': 3,
+                'competence_code': 3.2
               }, {
                 level: 1,
                 score: 9,
-                'area-code': 1,
-                'competence-code': 1.3
+                'area_code': 1,
+                'competence_code': 1.3
               }
             ]
           },

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -95,7 +95,7 @@ describe('Unit | Controller | assessment-results', () => {
 
       // then
       expect(response).to.be.null;
-      expect(assessmentResultService.save).to.have.been.calledWith(expectedAssessmentResult, [competenceMark1, competenceMark2, competenceMark3]);
+      expect(assessmentResultService.save).to.have.been.calledWithMatch(expectedAssessmentResult, [competenceMark1, competenceMark2, competenceMark3]);
     });
   });
 });

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { expect, sinon, catchErr } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const { handleCertificationScoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const { CertificationComputeError } = require('../../../../lib/domain/errors');
@@ -135,10 +135,10 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
     });
 
     context('when scoring is successful', () => {
-      const competenceMarkData1 = { dummyAttr: 'cm1' };
-      const competenceMarkData2 = { dummyAttr: 'cm2' };
       const assessmentResult = Symbol('AssessmentResult');
-      const assessmentResultId = 'assessmentResultId';
+      const assessmentResultId = 99;
+      const competenceMarkData1 = domainBuilder.buildCompetenceMark({ assessmentResultId });
+      const competenceMarkData2 = domainBuilder.buildCompetenceMark({ assessmentResultId });
       const savedAssessmentResult = { id: assessmentResultId };
       const nbPix = Symbol('nbPix');
       const level = Symbol('level');

--- a/api/tests/unit/domain/models/CleaCertification_test.js
+++ b/api/tests/unit/domain/models/CleaCertification_test.js
@@ -1,6 +1,5 @@
 const CleaCertification = require('../../../../lib/domain/models/CleaCertification');
-const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
-const { expect, catchErr } = require('../../../test-helper');
+const { expect, catchErr, domainBuilder, } = require('../../../test-helper');
 const { ObjectValidationError, NotEligibleCandidateError } = require('../../../../lib/domain/errors');
 
 const GREEN_ZONE_REPRO = [80, 90, 100];
@@ -175,16 +174,16 @@ function _buildCleaCertificationInGreyZoneAndCertifiableCompetences() {
   };
 
   const competenceMarks = [
-    new CompetenceMark(
+    domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId1,
-        score: 15
+        score: 15,
       }
     ),
-    new CompetenceMark(
+    domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId2,
-        score: 7.5
+        score: 8
       }
     ),
   ];
@@ -207,16 +206,16 @@ function _buildCleaCertificationInGreyZoneAndNonCertifiableCompetences() {
   };
 
   const competenceMarks = [
-    new CompetenceMark(
+    domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId1,
         score: 15
       }
     ),
-    new CompetenceMark(
+    domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId2,
-        score: 7.4
+        score: 7
       }
     ),
   ];
@@ -231,7 +230,7 @@ function _buildCleaCertificationInGreyZoneAndNonCertifiableCompetences() {
 function _buildCleaCertification({
   withBadge = false,
   reproducibilityRate = 0,
-  competenceMarks = [new CompetenceMark()],
+  competenceMarks = [domainBuilder.buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1:1 }
 }) {
   const certificationCourseId = 42;

--- a/api/tests/unit/domain/models/CompetenceMark_test.js
+++ b/api/tests/unit/domain/models/CompetenceMark_test.js
@@ -1,4 +1,4 @@
-const { expect, domainBuilder } = require('../../../test-helper');
+const { catchErr, expect, domainBuilder } = require('../../../test-helper');
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
 
@@ -28,58 +28,50 @@ describe('Unit | Domain | Models | Competence Mark', () => {
 
   describe('validate', () => {
 
-    it('should return a resolved promise when the object is valide', () => {
+    it('should return a resolved promise when the object is valid', () => {
       // given
       const competenceMark = domainBuilder.buildCompetenceMark();
 
       // when
-      const promise = competenceMark.validate();
+      const valid = competenceMark.validate();
 
       // then
-      return expect(promise).not.to.be.rejected;
+      expect(valid).not.to.true;
     });
 
-    it('should return an error if level is > 8', () => {
+    it('should return an error if level is > 8', async () => {
       // given
       const competenceMark = domainBuilder.buildCompetenceMark({ level: 10 });
 
       // when
-      const promise = competenceMark.validate();
-
+      const error = await catchErr(competenceMark.validate.bind(competenceMark))();
       // then
-      return promise
-        .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: "level" must be less than or equal to 8');
-        });
+      expect(error).to.be.instanceOf(ObjectValidationError);
+      expect(error.message).to.be.equal('ValidationError: "level" must be less than or equal to 8');
     });
 
-    it('should return an error if level is < -1', () => {
+    it('should return an error if level is < -1', async () => {
       // given
       const competenceMark = domainBuilder.buildCompetenceMark({ level: -2 });
 
       // when
-      const promise = competenceMark.validate();
+      const error = await catchErr(competenceMark.validate.bind(competenceMark))();
 
       // then
-      return promise
-        .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: "level" must be larger than or equal to -1');
-        });
+      expect(error).to.be.instanceOf(ObjectValidationError);
+      expect(error.message).to.be.equal('ValidationError: "level" must be larger than or equal to -1');
     });
 
-    it('should return an error if score > 64', () => {
-      // given
+    it('should return an error if score > 64', async () => {
+      // when
       const competenceMark = domainBuilder.buildCompetenceMark({ score: 65 });
 
       // when
-      const promise = competenceMark.validate();
+      const error = await catchErr(competenceMark.validate.bind(competenceMark))();
 
       // then
-      return promise
-        .catch((error) => {
-          expect(error.message).to.be.equal('ValidationError: "score" must be less than or equal to 64');
-          expect(error).to.be.instanceOf(ObjectValidationError);
-        });
+      expect(error).to.be.instanceOf(ObjectValidationError);
+      expect(error.message).to.be.equal('ValidationError: "score" must be less than or equal to 64');
     });
   });
 });

--- a/api/tests/unit/domain/services/assessment-result-service_test.js
+++ b/api/tests/unit/domain/services/assessment-result-service_test.js
@@ -8,8 +8,6 @@ const competenceMarkRepository = require('../../../../lib/infrastructure/reposit
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
 
-const { ObjectValidationError } = require('../../../../lib/domain/errors');
-
 describe('Unit | Domain | Services | assessment-results', () => {
 
   describe('#save', () => {
@@ -44,78 +42,37 @@ describe('Unit | Domain | Services | assessment-results', () => {
       sinon.stub(competenceMarkRepository, 'save').resolves();
     });
 
-    it('should save the assessment results', () => {
+    it('should save the assessment results', async () => {
       // when
-      const promise = service.save(assessmentResult, competenceMarks);
+      await service.save(assessmentResult, competenceMarks);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(assessmentResultRepository.save);
-        sinon.assert.calledWith(assessmentResultRepository.save, assessmentResult);
-      });
+      expect(assessmentResultRepository.save).to.have.been.calledOnce;
+      expect(assessmentResultRepository.save).to.have.been.calledWithMatch(assessmentResult);
+
     });
 
-    it('should save all competenceMarks', () => {
+    it('should save all competenceMarks', async () => {
       // when
-      const promise = service.save(assessmentResult, competenceMarks);
+      await service.save(assessmentResult, competenceMarks);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledTwice(competenceMarkRepository.save);
-        sinon.assert.calledWith(competenceMarkRepository.save, new CompetenceMark({
-          assessmentResultId: 1,
-          level: 2,
-          score: 18,
-          area_code: 2,
-          competence_code: 2.1,
-        }));
-        sinon.assert.calledWith(competenceMarkRepository.save, new CompetenceMark({
-          assessmentResultId: 1,
-          level: 3,
-          score: 27,
-          area_code: 3,
-          competence_code: 3.2,
-        }));
-      });
-    });
+      expect(competenceMarkRepository.save).to.have.been.calledTwice;
+      expect(competenceMarkRepository.save).to.have.been.calledWithMatch(new CompetenceMark({
+        assessmentResultId: 1,
+        level: 2,
+        score: 18,
+        area_code: 2,
+        competence_code: 2.1,
+      }));
+      expect(competenceMarkRepository.save).to.have.been.calledWithMatch(new CompetenceMark({
+        assessmentResultId: 1,
+        level: 3,
+        score: 27,
+        area_code: 3,
+        competence_code: 3.2,
+      }));
 
-    context('when one competence is not valided', () => {
-
-      const competenceMarksWithOneInvalid = [
-        new CompetenceMark({
-          level: 20,
-          score: 18,
-          area_code: 2,
-          competence_code: 2.1,
-        }),
-        new CompetenceMark({
-          level: 3,
-          score: 27,
-          area_code: 3,
-          competence_code: 3.2,
-        }),
-      ];
-
-      it('should not saved assessmentResult and competenceMarks', () => {
-        // when
-        const promise = service.save(assessmentResult, competenceMarksWithOneInvalid);
-
-        // then
-        return promise.catch(() => {
-          expect(competenceMarkRepository.save).to.have.been.not.called;
-          expect(assessmentResultRepository.save).to.have.been.not.called;
-        });
-      });
-
-      it('should return a ObjectValidationError', () => {
-        // when
-        const promise = service.save(assessmentResult, competenceMarksWithOneInvalid);
-
-        // then
-        return promise.catch((error) => {
-          expect(error).to.be.instanceOf(ObjectValidationError);
-        });
-      });
     });
   });
 });

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -5,6 +5,7 @@ const AssessmentResult = require('../../../../../lib/domain/models/AssessmentRes
 const CompetenceMarks = require('../../../../../lib/domain/models/CompetenceMark');
 const CertificationCourse = require('../../../../../lib/domain/models/CertificationCourse');
 
+const assessmentRepository = require('../../../../../lib/infrastructure/repositories/assessment-repository');
 const assessmentResultRepository = require('../../../../../lib/infrastructure/repositories/assessment-result-repository');
 const certificationAssessmentRepository = require('../../../../../lib/infrastructure/repositories/certification-assessment-repository');
 const certificationCourseRepository = require('../../../../../lib/infrastructure/repositories/certification-course-repository');
@@ -65,6 +66,7 @@ describe('Unit | Service | Certification Service', function() {
 
     context('when certification is finished', () => {
       let certificationCourse;
+      const assessmentId = Symbol('assessmentId');
 
       beforeEach(() => {
         certificationCourse = new CertificationCourse({
@@ -85,6 +87,8 @@ describe('Unit | Service | Certification Service', function() {
         assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1', 'rec2.1')];
         sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks')
           .withArgs({ certificationCourseId }).resolves(assessmentResult);
+        sinon.stub(assessmentRepository, 'getIdByCertificationCourseId')
+          .withArgs(certificationCourseId).resolves(assessmentId);
       });
 
       it('should return certification results with pix score, date and certified competences levels', async () => {
@@ -92,6 +96,7 @@ describe('Unit | Service | Certification Service', function() {
         const certification = await certificationService.getCertificationResult(certificationCourseId);
 
         // then
+        expect(certification.assessmentId).to.equal(assessmentId);
         expect(certification.pixScore).to.deep.equal(20);
         expect(certification.createdAt).to.deep.equal(new Date('2017-12-23T15:23:12Z'));
         expect(certification.completedAt).to.deep.equal(new Date('2017-12-23T16:23:12Z'));

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
@@ -33,6 +33,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
         competencesWithMark: [],
         juryId: 21,
         sessionId: 22,
+        assessmentId: 99
       });
 
       // when
@@ -66,6 +67,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
             'pix-score': certificationResult.pixScore,
             'result-created-at': new Date('2017-02-20T01:02:03Z'),
             'session-id': certificationResult.sessionId,
+            'assessment-id': certificationResult.assessmentId,
             status: certificationResult.status,
           }
         }

--- a/api/tests/unit/scripts/get-results-certifications_test.js
+++ b/api/tests/unit/scripts/get-results-certifications_test.js
@@ -118,7 +118,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
           attributes: {
             'competences-with-mark': [
               {
-                'competence-code': '1.1',
+                'competence_code': '1.1',
                 level: 9001
               }
             ]
@@ -140,11 +140,11 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
           attributes: {
             'competences-with-mark': [
               {
-                'competence-code': '1.1',
+                'competence_code': '1.1',
                 level: 4
               },
               {
-                'competence-code': '1.2',
+                'competence_code': '1.2',
                 level: 6
               }
             ]
@@ -180,7 +180,7 @@ describe('Unit | Scripts | get-results-certifications.js', () => {
       // given
       const competenceCode = '1.1';
       const profile = [{
-        'competence-code': competenceCode,
+        'competence_code': competenceCode,
         level: 9
       }];
 


### PR DESCRIPTION
## :unicorn: Problème
Bug introduit par la PR https://github.com/1024pix/pix/pull/1468
Petit oubli de renommage. Un des commits provoque le renommage de `area-code` et `competence-code` (attributs de CompetenceMark) en respectivement `area_code` et `competence_code`

## :robot: Solution
Corriger la coquille.
Aucun test auto n'a détecté ce problème, donc il faudrait peut-être trouvé où est-ce qu'on peut l'introduire.
Après, je sais que la tâche n'est pas aisée (la modification de résultats de certif dans PA n'est pas le code le plus carré de la base de code...)

## :rainbow: Remarques
Si on change le statut d'une certif en _started_, on a un crash 500. C'est dû à la spécification Bookshelf qu'on a donné d'un `AssessmentResult`. Dans le fichier `lib/infrastructure/data/assessment-result.js` on définit une liste finie de valeurs possibles pour le statut. Cette liste **NE CONTIENT PAS** le statut _started_, et pour cause, ce statut n'est logiquement pas possible pour un assessmentResult (ben ouais, si la certif n'est pas "finie", alors aucun résultat n'a encore été calculé... :grimacing: )
Du coup, si le jury veut passer la certif en _started_ ça plante. 3 propositions sur le sujet (à débattre) :
1. "On s'en fiche, jamais le jury voudrait passer une certif en started (et ne l'a certainement jamais fait sinon on aurait eu des retours depuis le temps !)
2. "Ajoutons le statut dans la liste, ça mange pas de pain même si c'est pas très cohérent !
3. "Hmmm :thinking: ça mérite bien un petit coup de balai cette activité de jury ! Mikado tiiiiime :musical_note: "

## :100: Pour tester
Reproduire le bug :
Se rendre sur PixAdmin, plus particulièrement sur le détail d'une certification. Cliquer sur Modifier tout en bas, changer le statut de la certification (de validated en error par exemple), enregistrer et constater une erreur 422.
