### PR TITLE
[BUGFIX] Empêcher l'édition des informations d'un utilisateur connecté via le GAR depuis Pix Admin(PIX-861)

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -79,7 +79,7 @@
             <div class="attribute authenticated-from-gar">
               <span class="attibute__label">Connecté via le GAR : </span>
               <span class="attribute__value user__is-authenticated-from-gar">
-                {{if @user.isAuthenticatedFromGar 'OUI''NON'}}
+                {{if @user.isAuthenticatedFromGAR 'OUI''NON'}}
               </span>
             </div>
             <br>
@@ -106,7 +106,7 @@
         </div>
       </section>
       <div class="col-md-4">
-        {{#if canAdministratorModifyUserDetails}}
+        {{#if this.canAdministratorModifyUserDetails}}
         <button class="btn btn-outline-default" aria-label="Modifier" {{on "click" this.changeEditionMode}}>Modifier
         </button>
         <button class="btn btn-outline-default btn-outline-default--danger" aria-label="Anonymiser" {{on "click" this.toggleDisplayConfirm}}>Anonymiser cet utilisateur

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -10,7 +10,7 @@ export default class User extends Model {
   @attr('boolean') cgu;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
   @attr('boolean') pixCertifTermsOfServiceAccepted;
-  @attr('boolean') isAuthenticatedFromGar;
+  @attr('boolean') isAuthenticatedFromGAR;
 
   @hasMany('membership') memberships;
 

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -200,7 +200,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('.user__is-authenticated-from-gar').hasText('NON');
+      assert.dom('.user__is-authenticated-from-gar').hasText('OUI');
     });
 
     test('should display that user is not authenticated from GAR ', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Empêcher l'édition du nom, prénom, email d'un utilisateur connecté via le GAR dans Pix Admin.

## :robot: Solution
Uniformiser l'écriture de la variable  isAuthenticatedFromGAR entre l'API et l'IHM.

## :100: Pour tester
Dans la vue utiliisateur dans Pix Admin, afficher le détail d'un utilisateur connecté via le GAR. 
Vérifier que le bouton Modifier n'est pas affiché dans la page de détail des utilisateurs.
