### PR TITLE
[TECH] Désactiver le plugin ember inspector en production (PIX-872).

### DIFF
--- a/mon-pix/app/app.js
+++ b/mon-pix/app/app.js
@@ -10,3 +10,8 @@ export default class App extends Application {
 }
 
 loadInitializers(App, config.modulePrefix);
+if (config.environment === 'production') {
+  window.NO_EMBER_DEBUG = true;
+} else {
+  window.NO_EMBER_DEBUG = false;
+}


### PR DESCRIPTION
## :unicorn: Problème
Le plugin ember inspector est activé en production. 
En modifiant les données du store via le plugin. On peut changer les vues des composants et se permettre de faire des actions avec un jeton valide.
Avec le plugin, on peut inspecter le code source et avoir beaucoup de détails sur l'application.


## :robot: Solution
Désactiver le plugin pour l'environnement de production.

## :rainbow: Remarques
On peut mettre la valeur window.NO_EMBER_DEBUG à true pour désactiver le plugin.
C'est possible d'activer cette option dans le fichier app.js ou dans l'index.html.
Il existe un bug non résolu, quand la page est chargée et que le plugin est déjà ouvert. En rafraichissant, le plugin reste activé. Sinon en ouvrant une nouvelle page, le plugin se désactive.

## :100: Pour tester
Démarrer l'application avec la variable NODE_ENV=production.
Vérifier que le plugin est bien désactivé.

![image](https://user-images.githubusercontent.com/10045497/85130296-f49a0700-b234-11ea-9ce8-b3d2aa8fe713.png)

Dans les environnements de dev et de test, le plugin reste accessible:
![image](https://user-images.githubusercontent.com/10045497/85130372-201cf180-b235-11ea-9bd5-138ecf950b20.png)

