### PR TITLE
[BUGFIX] Déconnecter un utilisateur qui n'a plus de membership dans Pix Orga (PIX-837).

### DIFF
--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -13,6 +13,10 @@ export default class CurrentUserService extends Service {
         const userMemberships = await prescriber.get('memberships');
         const userOrgaSettings = await prescriber.get('userOrgaSettings');
 
+        if (!userMemberships || userMemberships.length === 0) {
+          return this.session.invalidate();
+        }
+
         this.set('prescriber', prescriber);
         this.set('memberships', userMemberships);
 


### PR DESCRIPTION
## :unicorn: Problème
Il arrive parfois que l'on ait besoin de désactiver un `membership` afin de couper l'accès à Pix Orga. Cependant, si l'utilisateur est toujours connecté quand cette désactivation arrive et qu'il rafraîchit la page, alors une page blanche apparaît (avec une erreur dans la console). 

## :robot: Solution
Déconnecter l'utilisateur qui n'a plus de `membership`.

## :100: Pour tester
- Se connecter à Pix Orga
- Supprimer en base son `membership`
`select id from users where email = 'sco@example.net';  ` => 4
`delete from memberships where "userId" = 4;`
- Rafraîchir la page (F5) et vérifier que l'on est bien déconnecté