### PR TITLE
[BUGFIX] Permettre à un utilisateur connecté d'aller sur la page de changement de mot de passe (PIX-516).

### DIFF
--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -1,10 +1,9 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';
 
 @classic
-export default class ResetPasswordRoute extends Route.extend(UnauthenticatedRouteMixin) {
+export default class ResetPasswordRoute extends Route {
   @service session;
 
   async model(params) {

--- a/mon-pix/tests/acceptance/reset-password-test.js
+++ b/mon-pix/tests/acceptance/reset-password-test.js
@@ -1,6 +1,7 @@
 import { click, currentURL, fillIn, find } from '@ember/test-helpers';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -41,6 +42,29 @@ describe('Acceptance | Reset Password Form', function() {
     // then
     expect(currentURL()).to.equal('/changer-mot-de-passe/brandone-reset-key');
     expect(find('.sign-form__body').textContent).to.contain('Votre mot de passe a été modifié avec succès');
+  });
 
+  it('should allow connected user to visit reset-password page', async () => {
+    // given
+    const user = server.create('user', {
+      id: 1000,
+      firstName: 'Brandone',
+      lastName: 'Martins',
+      email: 'brandone.martins@pix.com',
+      password: '1024pix!'
+    });
+
+    server.create('password-reset-demand', {
+      temporaryKey: 'brandone-reset-key',
+      email: 'brandone.martins@pix.com',
+    });
+
+    await authenticateByEmail(user);
+
+    // when
+    await visit('/changer-mot-de-passe/brandone-reset-key');
+
+    // then
+    expect(currentURL()).to.equal('/changer-mot-de-passe/brandone-reset-key');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur fait une demande de réinitialisation de mot passe. Si celui-ci clique dans le lien dans l'email en étant connecté alors il est redirigé dans vers son profil. 

## :robot: Solution
Enlever l`UnauthenticadtedRouteMixin` de la route de changement de mot de passe. 

## :100: Pour tester
- Faire une demande de changement de mot de passe 
- Etre connecté et cliquer dans le lien dans l'email
- Vérifier que l'on peut bien accéder à la page et changer son mot de passe. 