### PR TITLE
[FEATURE] Amélioration des formulations lors de la réconciliation (PIX-816).

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -161,7 +161,7 @@ export default class RegisterForm extends Component {
         this.set('isLoading', false);
         errorResponse.errors.forEach((error) => {
           if (error.status === '404') {
-            return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
+            return this.set('errorMessage', 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
           }
           if (error.status === '409') {
             return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -90,7 +90,7 @@ export default class JoinRestrictedCampaignController extends Controller {
       return this.set('isLoading', false);
     }
 
-    const campaignCode = this.model;
+    const campaignCode = this.model.code;
     const studentUserAssociation = this.store.createRecord('student-user-association', {
       id: campaignCode + '_' + this.lastName,
       firstName: this.firstName,
@@ -101,7 +101,7 @@ export default class JoinRestrictedCampaignController extends Controller {
 
     return studentUserAssociation.save().then(() => {
       this.set('isLoading', false);
-      this.transitionToRoute('campaigns.start-or-resume', this.model, {
+      this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
         queryParams: { associationDone: true, participantExternalId: this.participantExternalId }
       });
     }, (errorResponse) => {

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -140,10 +140,10 @@ export default class JoinRestrictedCampaignController extends Controller {
   _setErrorMessageForAttemptNextAction(errorResponse) {
     errorResponse.errors.forEach((error) => {
       if (error.status === '409') {
-        return this.set('errorMessage', 'Les informations saisies ont déjà été utilisées. Prévenez l’organisateur.');
+        return this.set('errorMessage', 'Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.');
       }
       if (error.status === '404') {
-        return this.set('errorMessage', 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
+        return this.set('errorMessage', 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
       }
       return this.set('errorMessage', error.detail);
     });

--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -8,14 +8,14 @@ export default class JoinRoute extends Route.extend(SecuredRouteMixin) {
   @service session;
 
   model() {
-    return this.paramsFor('campaigns').code;
+    return this.modelFor('campaigns');
   }
 
-  async redirect(campaignCode) {
-    const student = await this.store.queryRecord('student-user-association', { userId: this.currentUser.user.id, campaignCode });
+  async redirect(campaign) {
+    const student = await this.store.queryRecord('student-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code });
 
     if (!isEmpty(student)) {
-      return this.replaceWith('campaigns.start-or-resume', campaignCode, {
+      return this.replaceWith('campaigns.start-or-resume', campaign.code, {
         queryParams: { associationDone: true }
       });
     }

--- a/mon-pix/app/templates/campaigns/restricted/join.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/join.hbs
@@ -5,7 +5,7 @@
   <div
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container">
     <div class="join-restricted-campaign">
-      <div class="join-restricted-campaign__title">Un tout petit détail !</div>
+      <div class="join-restricted-campaign__title">Rejoignez l'organisation {{@model.organizationName}}</div>
       <div class="join-restricted-campaign__subtitle">Remplissez les informations manquantes</div>
       <form>
 

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -270,7 +270,7 @@ describe('Integration | Component | routes/register-form', function() {
     });
 
     [
-      { status: '404', errorMessage: 'Vérifiez vos informations afin de continuer ou prévenez l’organisateur.' },
+      { status: '404', errorMessage: 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.' },
       { status: '409', errorMessage: 'Vous possédez déjà un compte Pix. Veuillez vous connecter.' },
     ].forEach(({ status, errorMessage }) => {
       it(`should display an error message if user saves with an error response status ${status}`, async function() {

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join.js
@@ -463,7 +463,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Vérifiez vos informations afin de continuer ou prévenez l’organisateur.');
+      expect(controller.get('errorMessage')).to.equal('Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });
@@ -477,7 +477,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Les informations saisies ont déjà été utilisées. Prévenez l’organisateur.');
+      expect(controller.get('errorMessage')).to.equal('Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });


### PR DESCRIPTION
## :unicorn: Problème
Les formulations d'erreurs et de titre ne sont pas très explicite lors de la réconciliation entre un compte Pix et une inscription d'élève.

## :robot: Solution
Améliorer ces wordings : 
- Les informations saisies ont déjà été utilisées. Prévenez l’organisateur. > **Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.** (1)
- Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours. > **Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.** (2)
- Un tout petit détail > **Rejoignez l’organisation NOM_DE_LORGANISATION** (3)

## :100: Pour tester
1 : Se connecter à Pix avec un premier compte, saisir un code campagne restreinte (RESTRICTD), se réconcilier (first, last, 10-10-2010), sortir. Se connecter à Pix avec un second compte, saisir un code campagne restreinte (RESTRICTD), saisir les même infos (first, last, 10-10-2010), vérifier le bon affichage du message -> **Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.**
2 : Se connecter à Pix, saisir un code campagne restreinte (RESTRICTD), saisir n'importe quoi sur la page de réconciliation (nom, prénom et date de naissance), vérifier le bon affichage du message d'erreur -> **Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.**
2 bis : En étant pas connecté, saisir un code campagne restreinte (RESTRICTD), saisir d'importe quoi sur la double mire (nom, prénom et date de naissance), vérifier le bon affichage du message d'erreur -> **Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.**
3 : Se connecter à Pix, saisir un code campagne restreinte (RESTRICTD), vérifier le bon affichage du titre de la page de réconciliation (où on demande nom prénom et date de naissance) -> **Rejoignez l’organisation NOM_DE_LORGANISATION**
