### PR TITLE
[FEATURE] Ajout d'un retour utilisateur lors de la dissociation d'un élève (PIX-865)

### DIFF
--- a/orga/app/components/dissociate-user-modal.js
+++ b/orga/app/components/dissociate-user-modal.js
@@ -3,13 +3,20 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class DissociateUserModal extends Component {
-
+  @service notifications;
   @service store;
 
   @action
   async dissociateUser() {
     const adapter = this.store.adapterFor('student');
-    await adapter.dissociateUser(this.args.student);
+
+    try {
+      await adapter.dissociateUser(this.args.student);
+      this.notifications.sendSuccess(`La dissociation du compte de l’élève ${this.args.student.lastName} ${this.args.student.firstName} est réussie.`);
+    } catch (e) {
+      this.notifications.sendError(`La dissociation du compte de l’élève ${this.args.student.lastName} ${this.args.student.firstName} a échoué. Veuillez réessayer.`);
+    }
+
     this.args.close();
     this.args.refreshModel();
   }

--- a/orga/tests/integration/components/dissociate-user-modal-test.js
+++ b/orga/tests/integration/components/dissociate-user-modal-test.js
@@ -44,11 +44,15 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
 
   module('dissociate button', function() {
     let studentAdapter;
+    let notifications;
 
     hooks.beforeEach(function() {
       const store = this.owner.lookup('service:store');
+      notifications = this.owner.lookup('service:notifications');
       studentAdapter = store.adapterFor('student');
       sinon.stub(studentAdapter, 'dissociateUser');
+      sinon.stub(notifications, 'sendSuccess');
+      sinon.stub(notifications, 'sendError');
     });
 
     hooks.afterEach(function() {
@@ -62,6 +66,25 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
       await click('.dissociate-user-modal__actions button:last-child');
 
       assert.ok(studentAdapter.dissociateUser.calledWith(student));
+    });
+
+    test('it should display a successful notification', async function(assert) {
+      const student = { id: 12345, lastName: 'Dupont', firstName: 'Jean' };
+      this.set('student', student);
+
+      await click('.dissociate-user-modal__actions button:last-child');
+
+      assert.ok(notifications.sendSuccess.calledWith('La dissociation du compte de l’élève Dupont Jean est réussie.'));
+    });
+
+    test('it should display an error notification', async function(assert) {
+      studentAdapter.dissociateUser.rejects();
+      const student = { id: 12345, lastName: 'Dupont', firstName: 'Jean' };
+      this.set('student', student);
+
+      await click('.dissociate-user-modal__actions button:last-child');
+
+      assert.ok(notifications.sendError.calledWith('La dissociation du compte de l’élève Dupont Jean a échoué. Veuillez réessayer.'));
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à la dissociation d'un élève, l'utilisateur n'a pas de retour clair sur la réussite ou l'échec de l'opération.

## :robot: Solution
Ajout d'un notification qui informe l'utilisateur de si la dissociation a bien réussie ou échoué.

## :100: Pour tester
Se connecter avec le compte sco@example.net
Allez sur la page "Eleves"
Dissocier un élève et constater la présence d'une notification de succès

Pour l'erreur il faut se mettre en local : 
Throw une erreur dans le usecase de la dissociation
Se connecter avec le compte sco@example.net
Allez sur la page "Eleves"
Dissocier un élève et constater la présence d'une notification d'erreur