### PR TITLE
[BUGFIX] Bloquer les double-clics sur l'envoi de signalements (PIX-704).

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -2,18 +2,13 @@ import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 import $ from 'jquery';
 import config from 'mon-pix/config/environment';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 
 import { topLevelLabels, questions } from 'mon-pix/static-data/feedback-panel-issue-labels';
-
-const buttonStatusTypes = {
-  unrecorded: 'unrecorded',
-  pending: 'pending',
-  recorded: 'recorded',
-};
 
 @classic
 @classNames('feedback-panel')

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -17,16 +17,18 @@ export default class FeedbackPanel extends Component {
 
   assessment = null;
   challenge = null;
-  isFormOpened = false;
-  _content = null;
-  _category = null;
-  _error = null;
-  _isSubmitted = false;
-  nextCategory = null;
-  quickHelpInstructions = null;
-  displayTextBox = null;
+
   displayQuestionDropdown = false;
+  displayTextBox = null;
+  emptyTextBoxMessageError = null;
+  nextCategory = null;
+  isFormOpened = false;
+  quickHelpInstructions = null;
   sendButtonStatus = buttonStatusTypes.unrecorded;
+
+  _category = null;
+  _content = null;
+  _isSubmitted = false;
   _questions = questions;
 
   @computed('context')
@@ -47,7 +49,7 @@ export default class FeedbackPanel extends Component {
 
   _resetPanel() {
     this.set('_isSubmitted', false);
-    this.set('_error', null);
+    this.set('emptyTextBoxMessageError', null);
   }
 
   didReceiveAttrs() {
@@ -89,7 +91,7 @@ export default class FeedbackPanel extends Component {
     const answer = this.answer ? this.answer.value : null;
 
     if (isEmpty(content) || isEmpty(content.trim())) {
-      this.set('_error', 'Vous devez saisir un message.');
+      this.set('emptyTextBoxMessageError', 'Vous devez saisir un message.');
       return;
     }
 
@@ -120,7 +122,7 @@ export default class FeedbackPanel extends Component {
   displayCategoryOptions() {
     this.set('displayTextBox', false);
     this.set('quickHelpInstructions', null);
-    this.set('_error', null);
+    this.set('emptyTextBoxMessageError', null);
     this.set('displayQuestionDropdown', false);
 
     this.set('nextCategory', this._questions[event.target.value]);
@@ -138,10 +140,10 @@ export default class FeedbackPanel extends Component {
     if (event.target.value === 'default') {
       this.set('displayTextBox', false);
       this.set('quickHelpInstructions', null);
-      this.set('_error', null);
+      this.set('emptyTextBoxMessageError', null);
     }
 
-    this.set('_error', null);
+    this.set('emptyTextBoxMessageError', null);
     this.set('_category', this.nextCategory[event.target.value].name);
     this._showFeedbackActionBasedOnCategoryType(this.nextCategory[event.target.value]);
   }

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -3,8 +3,6 @@ import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
-import $ from 'jquery';
-import config from 'mon-pix/config/environment';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 
@@ -41,12 +39,6 @@ export default class FeedbackPanel extends Component {
     return this.sendButtonStatus === buttonStatusTypes.pending;
   }
 
-  _scrollToPanel() {
-    $('html,body').animate({
-      scrollTop: $('.feedback-panel__view').offset().top - 15
-    }, config.APP.SCROLL_DURATION);
-  }
-
   _resetPanel() {
     this.set('_isSubmitted', false);
     this.set('emptyTextBoxMessageError', null);
@@ -69,6 +61,13 @@ export default class FeedbackPanel extends Component {
     }
   }
 
+  _scrollIntoFeedbackPanel() {
+    const feedbackPanelElements = document.getElementsByClassName('feedback-panel__view');
+    if (feedbackPanelElements && feedbackPanelElements[0]) {
+      feedbackPanelElements[0].scrollIntoView();
+    }
+  }
+
   @action
   toggleFeedbackForm() {
     if (this.isFormOpened) {
@@ -76,7 +75,7 @@ export default class FeedbackPanel extends Component {
       this._resetPanel();
     } else {
       this.set('isFormOpened', true);
-      this._scrollToPanel();
+      this._scrollIntoFeedbackPanel();
     }
   }
 

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -35,7 +35,7 @@ export default class FeedbackPanel extends Component {
     return topLevelLabels.filter((label) => !label[context]);
   }
 
-  get isSaveButtonDisabled() {
+  get isSendButtonDisabled() {
     return this.sendButtonStatus === buttonStatusTypes.pending;
   }
 
@@ -81,7 +81,7 @@ export default class FeedbackPanel extends Component {
 
   @action
   async sendFeedback() {
-    if (this.isSaveButtonDisabled) {
+    if (this.isSendButtonDisabled) {
       return;
     }
     this.set('sendButtonStatus', buttonStatusTypes.pending);

--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -2,12 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
-const buttonStatusTypes = {
-  unrecorded: 'unrecorded',
-  pending: 'pending',
-  recorded: 'recorded',
-};
+import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 
 export default class TutorialItemComponent extends Component {
   @service store;

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -52,7 +52,12 @@
                   {{_error}}
                 </div>
               {{/if}}
-              <button class="feedback-panel__button feedback-panel__button--send" {{action "sendFeedback"}}>Envoyer</button>
+              <button
+                class="feedback-panel__button feedback-panel__button--send"
+                {{action "sendFeedback"}}
+                disabled={{this.isSaveButtonDisabled}}>
+                  Envoyer
+              </button>
             {{/if}}
           </form>
         </div>

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -47,9 +47,9 @@
                 <p>Votre message est limité à 10 000 caractères.</p>
                 <Textarea class="feedback-panel__field feedback-panel__field--content" @value={{_content}} placeholder="Précisez" @maxlength="10000" @rows={{5}} />
               </div>
-              {{#if _error}}
+              {{#if emptyTextBoxMessageError}}
                 <div class="alert alert-danger" role="alert">
-                  {{_error}}
+                  {{emptyTextBoxMessageError}}
                 </div>
               {{/if}}
               <button

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -55,7 +55,7 @@
               <button
                 class="feedback-panel__button feedback-panel__button--send"
                 {{action "sendFeedback"}}
-                disabled={{this.isSaveButtonDisabled}}>
+                disabled={{this.isSendButtonDisabled}}>
                   Envoyer
               </button>
             {{/if}}

--- a/mon-pix/app/utils/button-status-types.js
+++ b/mon-pix/app/utils/button-status-types.js
@@ -1,0 +1,5 @@
+export default {
+  unrecorded: 'unrecorded',
+  pending: 'pending',
+  recorded: 'recorded',
+};

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -39,7 +39,6 @@ module.exports = function(environment) {
       isMessageStatusTogglingEnabled: true,
       LOAD_EXTERNAL_SCRIPT: true,
       GOOGLE_RECAPTCHA_KEY: '6LdPdiIUAAAAADhuSc8524XPDWVynfmcmHjaoSRO',
-      SCROLL_DURATION: 800,
       NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS: 5,
       IS_RECAPTCHA_ENABLED: process.env.IS_RECAPTCHA_ENABLED === 'true',
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -12,7 +12,7 @@ describe('Unit | Component | feedback-panel', function() {
     it('should open form', function() {
       // given
       const component = this.owner.lookup('component:feedback-panel');
-      component.set('_scrollToPanel', () => {});
+      component.set('_scrollIntoFeedbackPanel', () => {});
 
       // when
       component.send('toggleFeedbackForm');

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -25,7 +25,7 @@ describe('Unit | Component | feedback-panel', function() {
       // given
       const component = this.owner.lookup('component:feedback-panel');
       component.set('isFormOpened', true);
-      component.set('_error', '10, 9, 8, ...');
+      component.set('emptyTextBoxMessageError', '10, 9, 8, ...');
       component.set('_isSubmitted', true);
 
       // when
@@ -34,7 +34,7 @@ describe('Unit | Component | feedback-panel', function() {
       // then
       expect(component.isFormOpened).to.be.false;
       expect(component._isSubmitted).to.be.false;
-      expect(component._error).to.be.null;
+      expect(component.emptyTextBoxMessageError).to.be.null;
     });
   });
 

--- a/mon-pix/tests/unit/components/feedback-panel-test.js
+++ b/mon-pix/tests/unit/components/feedback-panel-test.js
@@ -38,6 +38,46 @@ describe('Unit | Component | feedback-panel', function() {
     });
   });
 
+  describe('#isSendButtonDisabled', function() {
+
+    it('should return false when the feedback has not already been sent', function() {
+      // given
+      const component = this.owner.lookup('component:feedback-panel');
+      component.set('sendButtonStatus', 'unrecorded');
+
+      // when
+      const result = component.isSendButtonDisabled;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return false when the feedback has already been sent', function() {
+      // given
+      const component = this.owner.lookup('component:feedback-panel');
+      component.set('sendButtonStatus', 'recorded');
+
+      // when
+      const result = component.isSendButtonDisabled;
+
+      // then
+      expect(result).to.equal(false);
+    });
+
+    it('should return true when the send operation is in progress', function() {
+      // given
+      const component = this.owner.lookup('component:feedback-panel');
+      component.set('sendButtonStatus', 'pending');
+
+      // when
+      const result = component.isSendButtonDisabled;
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+  });
+
   describe('#sendFeedback', function() {
     let feedback;
     let store;


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur double-clique sur l'envoi de signalement, nous enregistrons deux entrées en base de données.

## :robot: Solution
Ajouter un statut au bouton d'envoi de signalement

## :rainbow: Remarques
- Nous en avons profité pour enlever jQuery du fichier.
Pour cela, nous utilisons https://developer.mozilla.org/fr/docs/Web/API/Element/scrollIntoView.

Ce nettoyage se fait au prix de l'animation douce lors de l'ouverture du formulaire de signalement.
Les options d'animation proposées par la méthode `scrollIntoView` ne nous ont pas permis d'obtenir un résultat similaire. 

La variable d'environnement `SCROLL_DURATION` est alors supprimée.
À voir si on conserve comme cela. 

## :100: Pour tester
1 - Se rendre sur une épreuve
2 - Ouvrir le feedback + le panel de network du browser
3 - Double-cliquer sur le bouton d'envoi et constater qu'il n'y a qu'une requête

Éventuellement, faire l'essai en simulation de connexion lente
