### PR TITLE
[BUGFIX] Correction d'un test aléatoire sur les filtres des élèves

### DIFF
--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -687,7 +687,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         // given
         const organization = databaseBuilder.factory.buildOrganization();
 
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, lastName: 'Rambo' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'John', lastName: 'Rambo' });
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'Jane', lastName: 'Rambo' });
         databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: 'Chuck', lastName: 'Norris' });
         await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
Le test suivant plante aléatoirement dans la CI
![image](https://user-images.githubusercontent.com/516360/85391094-08ea4680-b54a-11ea-81af-257abff347b1.png)

Suite à un merge malencontreux, le firstName d'un jeu de donnée a été effacé

Avant le merge:
![image](https://user-images.githubusercontent.com/516360/85391386-61b9df00-b54a-11ea-83e9-c901ab5aa8a0.png)

Après le merge:
![image](https://user-images.githubusercontent.com/516360/85391331-4ea70f00-b54a-11ea-9124-ba30a89584fb.png)

Le firstName est alors généré par faker ce qui peut parfois faire planter le test.

# :robot: Solution

Remettre le firstName en dur dans le jeu de donnée.

## :rainbow: Remarques
N/A

