### PR TITLE
[FEATURE] Permettre la désactivation d'un membre depuis Pix Admin (PIX-394).

### DIFF
--- a/admin/app/adapters/membership.js
+++ b/admin/app/adapters/membership.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class MembershipAdapter extends ApplicationAdapter {
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions && snapshot.adapterOptions.disable) {
+      const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/disable';
+      return this.ajax(url, 'POST');
+    }
+    return super.updateRecord(...arguments);
+  }
+}

--- a/admin/app/components/confirm-popup.js
+++ b/admin/app/components/confirm-popup.js
@@ -1,4 +1,16 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 export default class ConfirmPopup extends Component {
+
+  get title() {
+    return this.args.title || 'Merci de confirmer';
+  }
+
+  get closeTitle() {
+    return this.args.closeTitle || 'Annuler';
+  }
+
+  get submitTitle() {
+    return this.args.submitTitle || 'Confirmer';
+  }
 }

--- a/admin/app/components/member-item.hbs
+++ b/admin/app/components/member-item.hbs
@@ -18,29 +18,49 @@
   {{/if}}
 </td>
 <td>
-  {{#if this.isEditionMode}}
-    <div class="zone-save-cancel-role">
-      <button type="button"
-              class="btn btn-primary btn-sm"
-              aria-label="Enregistrer"
-        {{on 'click' this.updateRoleOfMember}}>
-        Enregistrer
-      </button>
-      <button type="button"
-              class="btn btn-outline-default btn-sm"
-              aria-label="Annuler"
-        {{on 'click' this.cancelUpdateRoleOfMember}}>
-        <FaIcon @icon='times'></FaIcon>
-      </button>
+  <div class="member-item-actions">
+    <div>
+      {{#if this.isEditionMode}}
+        <div>
+          <button type="button"
+                  class="btn btn-primary btn-sm"
+                  aria-label="Enregistrer"
+            {{on 'click' this.updateRoleOfMember}}>
+            Enregistrer
+          </button>
+          <button type="button"
+                  class="btn btn-outline-default btn-sm"
+                  aria-label="Annuler"
+            {{on 'click' this.cancelUpdateRoleOfMember}}>
+            <FaIcon @icon='times'></FaIcon>
+          </button>
+        </div>
+      {{else}}
+        <div>
+          <button type="button"
+                  class="btn btn-primary btn-sm"
+                  aria-label="Modifier le rôle"
+                  {{on 'click' this.editRoleOfMember}}>
+            <FaIcon @icon="edit"></FaIcon>
+            Modifier le rôle
+          </button>
+        </div>
+      {{/if}}
     </div>
-  {{else}}
-    <div class="zone-edit-role">
-      <button class="btn btn-primary btn-sm"
-              aria-label="Modifier le rôle"
-              type="button" {{on 'click' this.editRoleOfMember}}>
-        <FaIcon @icon="edit"></FaIcon>
-        Modifier le rôle
-      </button>
-    </div>
-  {{/if}}
+    <button type="button"
+            class="btn btn-danger btn-sm disable-membership-button"
+            aria-label="Désactiver"
+            {{on 'click' this.toggleDisplayConfirm}}>
+      <FaIcon @icon="trash"></FaIcon>
+      Désactiver
+    </button>
+  </div>
 </td>
+
+<ConfirmPopup @message="Etes-vous sûr de vouloir désactiver ce membre de cette équipe ?"
+              @title="Désactivation d'un membre"
+              @submitTitle="Désactiver"
+              @confirm={{this.disableMembership}}
+              @cancel={{this.toggleDisplayConfirm}}
+              @show={{this.displayConfirm}}
+/>

--- a/admin/app/components/member-item.hbs
+++ b/admin/app/components/member-item.hbs
@@ -20,24 +20,24 @@
 <td>
   {{#if this.isEditionMode}}
     <div class="zone-save-cancel-role">
-      <button id='save-organization-role'
-              type="button"
+      <button type="button"
               class="btn btn-primary btn-sm"
-        {{on 'click' (fn this.updateRoleOfMember @membership)}}>
+              aria-label="Enregistrer"
+        {{on 'click' this.updateRoleOfMember}}>
         Enregistrer
       </button>
-      <button id='cancel-update-organization-role'
-              type="button"
+      <button type="button"
               class="btn btn-outline-default btn-sm"
               aria-label="Annuler"
-        {{on 'click' (fn this.cancelUpdateRoleOfMember)}}>
+        {{on 'click' this.cancelUpdateRoleOfMember}}>
         <FaIcon @icon='times'></FaIcon>
       </button>
     </div>
   {{else}}
     <div class="zone-edit-role">
-      <button id='edit-organization-role' class="btn btn-primary btn-sm"
-              type="button" {{on 'click' (fn this.editRoleOfMember @membership)}}>
+      <button class="btn btn-primary btn-sm"
+              aria-label="Modifier le rôle"
+              type="button" {{on 'click' this.editRoleOfMember}}>
         <FaIcon @icon="edit"></FaIcon>
         Modifier le rôle
       </button>

--- a/admin/app/components/member-item.hbs
+++ b/admin/app/components/member-item.hbs
@@ -25,35 +25,57 @@
           <button type="button"
                   class="btn btn-primary btn-sm"
                   aria-label="Enregistrer"
-            {{on 'click' this.updateRoleOfMember}}>
+                  {{on 'click' this.updateRoleOfMember}}>
             Enregistrer
           </button>
           <button type="button"
                   class="btn btn-outline-default btn-sm"
                   aria-label="Annuler"
-            {{on 'click' this.cancelUpdateRoleOfMember}}>
-            <FaIcon @icon='times'></FaIcon>
+                  {{on 'click' this.cancelUpdateRoleOfMember}}>
+            <FaIcon @icon='times' />
           </button>
         </div>
       {{else}}
         <div>
-          <button type="button"
-                  class="btn btn-primary btn-sm"
-                  aria-label="Modifier le rôle"
-                  {{on 'click' this.editRoleOfMember}}>
-            <FaIcon @icon="edit"></FaIcon>
-            Modifier le rôle
-          </button>
+          {{#if @membership.isSaving}}
+            <button type="button"
+                    class="btn btn-primary btn-sm"
+                    aria-label="Modifier le rôle"
+                    disabled>
+              <FaIcon @icon="edit" />
+              Modifier le rôle
+            </button>
+          {{else}}
+            <button type="button"
+                    class="btn btn-primary btn-sm"
+                    aria-label="Modifier le rôle"
+                    {{on 'click' this.editRoleOfMember}}>
+              <FaIcon @icon="edit" />
+              Modifier le rôle
+            </button>
+          {{/if}}
         </div>
       {{/if}}
     </div>
-    <button type="button"
-            class="btn btn-danger btn-sm disable-membership-button"
-            aria-label="Désactiver"
-            {{on 'click' this.toggleDisplayConfirm}}>
-      <FaIcon @icon="trash"></FaIcon>
-      Désactiver
-    </button>
+    <div>
+      {{#if @membership.isSaving}}
+        <button type="button"
+                class="btn btn-danger btn-sm disable-membership-button"
+                aria-label="Désactiver"
+                disabled>
+          <FaIcon @icon="trash" />
+          Désactiver
+        </button>
+      {{else}}
+        <button type="button"
+                class="btn btn-danger btn-sm disable-membership-button"
+                aria-label="Désactiver"
+                {{on 'click' this.toggleDisplayConfirm}}>
+          <FaIcon @icon="trash" />
+          Désactiver
+        </button>
+      {{/if }}
+    </div>
   </div>
 </td>
 

--- a/admin/app/components/member-item.js
+++ b/admin/app/components/member-item.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 const options = [
   { value: 'ADMIN', label: 'Administrateur' },
@@ -9,9 +10,12 @@ const options = [
 
 export default class MemberItem extends Component {
 
+  @service notifications;
+
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
   @tracked selectedNewRole = null;
+  @tracked displayConfirm = false;
 
   constructor() {
     super(...arguments);
@@ -43,5 +47,16 @@ export default class MemberItem extends Component {
   editRoleOfMember() {
     this.isEditionMode = true;
     this.selectedNewRole = null;
+  }
+
+  @action
+  toggleDisplayConfirm() {
+    this.displayConfirm = !this.displayConfirm;
+  }
+
+  @action
+  disableMembership() {
+    this.toggleDisplayConfirm();
+    return this.args.disableMembership(this.args.membership);
   }
 }

--- a/admin/app/components/member-item.js
+++ b/admin/app/components/member-item.js
@@ -12,7 +12,6 @@ export default class MemberItem extends Component {
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
   @tracked selectedNewRole = null;
-  @tracked currentRole = null;
 
   constructor() {
     super(...arguments);
@@ -26,27 +25,23 @@ export default class MemberItem extends Component {
   }
 
   @action
-  updateRoleOfMember(membership) {
+  updateRoleOfMember() {
     this.isEditionMode = false;
     if (!this.selectedNewRole) return false;
 
-    membership.displayRole = this.selectedNewRole.label;
-    membership.organizationRole = this.selectedNewRole.value;
-
-    return membership.save();
+    this.args.membership.organizationRole = this.selectedNewRole.value;
+    return this.args.updateMembership(this.args.membership);
   }
 
   @action
   cancelUpdateRoleOfMember() {
     this.isEditionMode = false;
     this.selectedNewRole = null;
-    this.currentRole = null;
   }
 
   @action
-  editRoleOfMember(membership) {
-    this.selectedNewRole = null;
-    this.currentRole = membership.displayedOrganizationRole;
+  editRoleOfMember() {
     this.isEditionMode = true;
+    this.selectedNewRole = null;
   }
 }

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -101,7 +101,7 @@
           <tbody>
           {{#each @memberships as |membership|}}
             <tr aria-label="Membre">
-              <MemberItem @membership={{membership}}/>
+              <MemberItem @membership={{membership}} @updateMembership={{@updateMembership}} />
             </tr>
           {{/each}}
           </tbody>

--- a/admin/app/components/organization-members-section.hbs
+++ b/admin/app/components/organization-members-section.hbs
@@ -61,7 +61,7 @@
             <th class="table__column table__column--wide">Nom</th>
             <th class="table__column table__column--wide">Adresse email</th>
             <th class="table__column">Rôle</th>
-            <th class="table__column">Action</th>
+            <th class="table__column">Actions</th>
           </tr>
           <tr>
             <th class="table__column"></th>
@@ -101,7 +101,7 @@
           <tbody>
           {{#each @memberships as |membership|}}
             <tr aria-label="Membre">
-              <MemberItem @membership={{membership}} @updateMembership={{@updateMembership}} />
+              <MemberItem @membership={{membership}} @updateMembership={{@updateMembership}} @disableMembership={{@disableMembership}} />
             </tr>
           {{/each}}
           </tbody>

--- a/admin/app/controllers/authenticated/organizations/get/members.js
+++ b/admin/app/controllers/authenticated/organizations/get/members.js
@@ -87,9 +87,20 @@ export default class GetMembersController extends Controller {
   async updateMembership(membership) {
     try {
       await membership.save();
-      this.notifications.success('Le membre a été mis à jour avec succès.');
+      this.notifications.success('Le rôle du membre a été mis à jour avec succès.');
     } catch (e) {
-      this.notifications.error('Une erreur est survenue lors de la mise à jour du membre.');
+      this.notifications.error('Une erreur est survenue lors de la mise à jour du rôle du membre.');
+    }
+  }
+
+  @action
+  async disableMembership(membership) {
+    try {
+      await membership.save({ adapterOptions: { disable: true } });
+      await this.model.memberships.reload();
+      this.notifications.success('Le membre a été désactivé avec succès.');
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue lors de la désactivation du membre.');
     }
   }
 

--- a/admin/app/controllers/authenticated/organizations/get/members.js
+++ b/admin/app/controllers/authenticated/organizations/get/members.js
@@ -84,6 +84,16 @@ export default class GetMembersController extends Controller {
   }
 
   @action
+  async updateMembership(membership) {
+    try {
+      await membership.save();
+      this.notifications.success('Le membre a été mis à jour avec succès.');
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue lors de la mise à jour du membre.');
+    }
+  }
+
+  @action
   async createOrganizationInvitation() {
     this.isLoading = true;
     const email = this.userEmailToInvite ? this.userEmailToInvite.trim() : null;

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -9,6 +9,7 @@ const displayedOrganizationRoles = {
 export default class Membership extends Model {
 
   @attr() organizationRole;
+  @attr() disabledAt;
 
   @computed('organizationRole')
   get displayedOrganizationRole() {

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -35,6 +35,7 @@
 @import 'components/certification-details-competence';
 @import 'components/certification-list';
 @import 'components/confirm-popup';
+@import 'components/member-item';
 @import 'components/menu-bar';
 @import 'components/organization-information-section';
 @import 'components/pagination-control';

--- a/admin/app/styles/components/member-item.scss
+++ b/admin/app/styles/components/member-item.scss
@@ -1,0 +1,9 @@
+.member-item-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.disable-membership-button {
+  margin-top: 5px;
+}

--- a/admin/app/styles/misc/tables.scss
+++ b/admin/app/styles/misc/tables.scss
@@ -39,6 +39,8 @@ tr {
 td, th {
   text-align: left;
   padding-left: 30px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .table__column {

--- a/admin/app/templates/authenticated/organizations/get/members.hbs
+++ b/admin/app/templates/authenticated/organizations/get/members.hbs
@@ -3,6 +3,7 @@
   @userEmailToAdd={{this.userEmailToAdd}}
   @userEmailToInvite={{this.userEmailToInvite}}
   @addMembership={{this.addMembership}}
+  @updateMembership={{this.updateMembership}}
   @createOrganizationInvitation={{this.createOrganizationInvitation}}
   @userEmailToInviteError={{this.userEmailToInviteError}}
   @isLoading={{this.isLoading}}

--- a/admin/app/templates/authenticated/organizations/get/members.hbs
+++ b/admin/app/templates/authenticated/organizations/get/members.hbs
@@ -4,6 +4,7 @@
   @userEmailToInvite={{this.userEmailToInvite}}
   @addMembership={{this.addMembership}}
   @updateMembership={{this.updateMembership}}
+  @disableMembership={{this.disableMembership}}
   @createOrganizationInvitation={{this.createOrganizationInvitation}}
   @userEmailToInviteError={{this.userEmailToInviteError}}
   @isLoading={{this.isLoading}}

--- a/admin/app/templates/components/confirm-popup.hbs
+++ b/admin/app/templates/components/confirm-popup.hbs
@@ -1,7 +1,7 @@
 <BsModalSimple
-  @title="Merci de confirmer"
-  @closeTitle="Annuler"
-  @submitTitle="Confirmer"
+  @title={{this.title}}
+  @closeTitle={{this.closeTitle}}
+  @submitTitle={{this.submitTitle}}
   @size={{null}}
   @fade={{false}}
   @open={{@show}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -51,7 +51,7 @@ export default function() {
   this.patch('/memberships/:id', (schema, request) => {
     const membershipId = request.params.id;
     const params = JSON.parse(request.requestBody);
-    const organizationRole = params.data.attributes.organizationRole;
+    const organizationRole = params.data.attributes['organization-role'];
 
     const membership = schema.memberships.findBy({ id: membershipId });
     return membership.update({ organizationRole });

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -67,9 +67,12 @@ export default function() {
   this.patch('/organizations/:id', (schema, request) => {
     const organizationId = request.params.id;
     const params = JSON.parse(request.requestBody);
+    const name = params.data.attributes.name;
+    const externalId = params.data.attributes['external-id'];
+    const provinceCode = params.data.attributes['province-code'];
 
     const organization = schema.organizations.findBy({ id: organizationId });
-    return organization.update({ params });
+    return organization.update({ name, externalId, provinceCode });
   });
 
   this.patch('/admin/users/:id', (schema, request) => {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -57,6 +57,13 @@ export default function() {
     return membership.update({ organizationRole });
   });
 
+  this.post('/memberships/:id/disable', (schema, request) => {
+    const membershipId = request.params.id;
+
+    const membership = schema.memberships.findBy({ id: membershipId });
+    return membership.update({ disabledAt: new Date() });
+  });
+
   this.patch('/organizations/:id', (schema, request) => {
     const organizationId = request.params.id;
     const params = JSON.parse(request.requestBody);

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 export function findPaginatedOrganizationMemberships(schema, request) {
   const organizationId = request.params.id;
   const queryParams = request.queryParams;
-  const memberships = schema.memberships.where({ organizationId }).models;
+  const memberships = schema.memberships.where({ organizationId, disabledAt: undefined }).models;
   const rowCount = memberships.length;
 
   const pagination = _getPaginationFromQueryParams(queryParams);

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -16,7 +16,7 @@ module('Acceptance | organization information management', function(hooks) {
 
     test('should edit organization\'s name, externalId and provinceCode', async function(assert) {
       // given
-      const organization = this.server.create('organization');
+      const organization = this.server.create('organization', { name: 'oldOrganizationName', externalId: 'oldOrganizationExternalId', provinceCode: 'oldProvinceCode' });
       await visit(`/organizations/${organization.id}`);
       await click('button[aria-label="Editer"]');
 

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | organization memberships management', function(hooks) {
@@ -140,6 +141,28 @@ module('Acceptance | organization memberships management', function(hooks) {
 
       // then
       assert.contains('Une erreur s’est produite, veuillez réessayer.');
+    });
+  });
+
+  module('editing a member\'s role', function(hooks) {
+
+    let membership;
+
+    hooks.beforeEach(async function() {
+      const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
+      membership = this.server.create('membership', { organizationRole: 'ADMIN', user, organization });
+    });
+
+    test('should update member\'s role', async function(assert) {
+      await visit(`/organizations/${organization.id}/members`);
+      await click('button[aria-label="Modifier le rôle"]');
+
+      await selectChoose('.editable-cell', 'Membre');
+      await click('button[aria-label="Enregistrer"]');
+
+      // then
+      assert.equal(membership.organizationRole, 'MEMBER');
+      assert.contains('Le membre a été mis à jour avec succès.');
     });
   });
 });

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -162,7 +162,26 @@ module('Acceptance | organization memberships management', function(hooks) {
 
       // then
       assert.equal(membership.organizationRole, 'MEMBER');
-      assert.contains('Le membre a été mis à jour avec succès.');
+      assert.contains('Le rôle du membre a été mis à jour avec succès.');
+    });
+  });
+
+  module('deactivating a member', function(hooks) {
+
+    hooks.beforeEach(async function() {
+      const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });
+      this.server.create('membership', { organizationRole: 'ADMIN', user, organization });
+    });
+
+    test('should deactivate a member', async function(assert) {
+      await visit(`/organizations/${organization.id}/members`);
+      await click('button[aria-label="Désactiver"]');
+
+      await click('.modal-footer > button.btn-primary');
+
+      // then
+      assert.contains('Le membre a été désactivé avec succès.');
+      assert.contains('Aucun résultat');
     });
   });
 });

--- a/admin/tests/integration/components/confirm-popup-test.js
+++ b/admin/tests/integration/components/confirm-popup-test.js
@@ -1,22 +1,80 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | confirm-popup', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-    this.set('display', true);
-    this.set('actionConfirm', () => {
-    });
-    this.set('actionCancel', () => {
-    });
+  hooks.beforeEach(function() {
+    this.display = true;
+  });
 
-    await render(hbs`{{confirm-popup show=display confirm=actionConfirm cancel=actionCancel }}`);
+  test('should open confirm', async function(assert) {
+    await render(hbs`<ConfirmPopup @show={{this.display}} />`);
 
     assert.dom('.modal-dialog').exists();
+  });
+
+  test('should call cancel action on click on cancel button', async function(assert) {
+    this.cancel = sinon.stub();
+
+    await render(hbs`<ConfirmPopup @show={{this.display}} @cancel={{this.cancel}} />`);
+    await click('button.btn-secondary');
+
+    assert.ok(this.cancel.called);
+    assert.dom('.modal-dialog').doesNotExist();
+  });
+
+  test('should call confirm action on click on confirm button', async function(assert) {
+    this.confirm = sinon.stub();
+
+    await render(hbs`<ConfirmPopup @show={{this.display}} @confirm={{this.confirm}} />`);
+    await click('button.btn-primary');
+
+    assert.ok(this.confirm.called);
+  });
+
+  test('should display default title if it is not defined', async function(assert) {
+    await render(hbs`<ConfirmPopup @show={{this.display}} />`);
+
+    assert.contains('Merci de confirmer');
+  });
+
+  test('should display title in parameter if it is defined', async function(assert) {
+    this.title = 'Titre de test';
+
+    await render(hbs`<ConfirmPopup @show={{this.display}} @title={{this.title}} />`);
+
+    assert.contains(this.title);
+  });
+
+  test('should display default closeTitle if it is not defined', async function(assert) {
+    await render(hbs`<ConfirmPopup @show={{this.display}} />`);
+
+    assert.contains('Annuler');
+  });
+
+  test('should display closeTitle in parameter if it is defined', async function(assert) {
+    this.closeTitle = 'Titre du bouton d\'annulation';
+
+    await render(hbs`<ConfirmPopup @show={{this.display}} @closeTitle={{this.closeTitle}} />`);
+
+    assert.contains(this.closeTitle);
+  });
+
+  test('should display default submitTitle if it is not defined', async function(assert) {
+    await render(hbs`<ConfirmPopup @show={{this.display}} />`);
+
+    assert.contains('Confirmer');
+  });
+
+  test('should display submitTitle  in parameter if it is defined', async function(assert) {
+    this.submitTitle = 'Titre du bouton dde confirmation';
+
+    await render(hbs`<ConfirmPopup @show={{this.display}} @submitTitle={{this.submitTitle}} />`);
+
+    assert.contains(this.submitTitle);
   });
 });

--- a/admin/tests/integration/components/member-item-test.js
+++ b/admin/tests/integration/components/member-item-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | member-item', function(hooks) {
 
   hooks.beforeEach(function() {
     const user = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
-    this.membership = EmberObject.create({ id: 1, user, displayedOrganizationRole: 'Administrateur', save: () => {} });
+    this.membership = EmberObject.create({ id: 1, user, displayedOrganizationRole: 'Administrateur' });
   });
 
   test('it should display a member', async function(assert) {
@@ -25,58 +25,89 @@ module('Integration | Component | member-item', function(hooks) {
     assert.contains('jojo@lagringue.fr');
     assert.contains('Administrateur');
     assert.contains('Modifier le rôle');
+    assert.contains('Désactiver');
   });
 
-  test('it should display save and cancel button on click', async function(assert) {
-    // when
-    await render(hbs`<MemberItem @membership={{this.membership}} />`);
-    await click('button[aria-label="Modifier le rôle"]');
+  module('when editing organization\'s role', function(hooks) {
 
-    // then
-    assert.contains('Enregistrer');
-    assert.dom('button[aria-label="Annuler"]');
+    hooks.beforeEach(async function() {
+      // given
+      this.updateMembership = sinon.spy();
+
+      // when
+      await render(hbs`<MemberItem @membership={{this.membership}} @updateMembership={{this.updateMembership}} />`);
+      await click('button[aria-label="Modifier le rôle"]');
+    });
+
+    test('it should display save and cancel button', function(assert) {
+      // then
+      assert.contains('Enregistrer');
+      assert.dom('button[aria-label="Annuler"]');
+    });
+
+    test('it should display the options when select is open', async function(assert) {
+      // when
+      await click('.ember-power-select-trigger');
+
+      // then
+      assert.contains('Membre');
+      assert.contains('Administrateur');
+    });
+
+    test('it should update role on save', async function(assert) {
+      // when
+      await selectChoose('.editable-cell', 'Membre');
+      await click('button[aria-label="Enregistrer"]');
+
+      // then
+      assert.notContains('Enregistrer');
+      assert.equal(this.membership.organizationRole, 'MEMBER');
+      assert.ok(this.updateMembership.called);
+    });
+
+    test('it should not update role on cancel', async function(assert) {
+      // when
+      await selectChoose('.editable-cell', 'Membre');
+      await click('button[aria-label="Annuler"]');
+
+      // then
+      assert.contains('Administrateur');
+      assert.notContains('Enregistrer');
+      assert.notOk(this.updateMembership.called);
+    });
   });
 
-  test('it should display the options when select is open', async function(assert) {
-    // when
-    await render(hbs`<MemberItem @membership={{this.membership}} />`);
-    await click('button[aria-label="Modifier le rôle"]');
-    await click('.ember-power-select-trigger');
+  module('when deactivating membership', function(hooks) {
 
-    // then
-    assert.contains('Membre');
-    assert.contains('Administrateur');
-  });
+    hooks.beforeEach(async function() {
+      // given
+      this.disableMembership = sinon.spy();
+      // when
+      await render(hbs`<MemberItem @membership={{this.membership}} @disableMembership={{this.disableMembership}} />`);
+      await click('button[aria-label="Désactiver"]');
+    });
 
-  test('it should update role on save', async function(assert) {
-    // given
-    this.updateMembership = sinon.spy();
+    test('should open confirm modal', function(assert) {
+      // then
+      assert.dom('.modal-dialog').exists();
+      assert.contains('Désactivation d\'un membre');
+      assert.contains('Etes-vous sûr de vouloir désactiver ce membre de cette équipe ?');
+    });
 
-    // when
-    await render(hbs`<MemberItem @membership={{this.membership}} @updateMembership={{this.updateMembership}} />`);
-    await click('button[aria-label="Modifier le rôle"]');
-    await selectChoose('.editable-cell', 'Membre');
-    await click('button[aria-label="Enregistrer"]');
+    test('should close confirm modal on click on cancel', async function(assert) {
+      // when
+      await click('.modal-footer > button.btn-secondary');
 
-    // then
-    assert.notContains('Enregistrer');
-    assert.equal(this.membership.organizationRole, 'MEMBER');
-    assert.ok(this.updateMembership.called);
-  });
+      // then
+      assert.dom('.modal-dialog').doesNotExist();
+    });
 
-  test('it should not update role on cancel', async function(assert) {
-    // given
-    this.updateMembership = sinon.spy();
+    test('should disable membership on click on confirm', async function(assert) {
+      // when
+      await click('.modal-footer > button.btn-primary');
 
-    // when
-    await render(hbs`<MemberItem @membership={{this.membership}} @updateMembership={{this.updateMembership}} />`);
-    await click('button[aria-label="Modifier le rôle"]');
-    await selectChoose('.editable-cell', 'Membre');
-    await click('button[aria-label="Annuler"]');
-
-    // then
-    assert.contains('Administrateur');
-    assert.notContains('Enregistrer');
-    assert.notOk(this.updateMembership.called);
+      // then
+      assert.ok(this.disableMembership.called);
+    });
   });
 });

--- a/admin/tests/integration/components/member-item-test.js
+++ b/admin/tests/integration/components/member-item-test.js
@@ -4,19 +4,19 @@ import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 module('Integration | Component | member-item', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     const user = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
-    const membership = EmberObject.create({ id: 1, user, displayedOrganizationRole: 'Administrateur', save: () => {} });
-    this.set('membership', membership);
+    this.membership = EmberObject.create({ id: 1, user, displayedOrganizationRole: 'Administrateur', save: () => {} });
   });
 
   test('it should display a member', async function(assert) {
     // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
+    await render(hbs`<MemberItem @membership={{this.membership}} />`);
 
     // then
     assert.contains('1');
@@ -29,18 +29,18 @@ module('Integration | Component | member-item', function(hooks) {
 
   test('it should display save and cancel button on click', async function(assert) {
     // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
-    await click('#edit-organization-role');
+    await render(hbs`<MemberItem @membership={{this.membership}} />`);
+    await click('button[aria-label="Modifier le rôle"]');
 
     // then
     assert.contains('Enregistrer');
-    assert.dom('[aria-label="Annuler"]');
+    assert.dom('button[aria-label="Annuler"]');
   });
 
   test('it should display the options when select is open', async function(assert) {
     // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
-    await click('#edit-organization-role');
+    await render(hbs`<MemberItem @membership={{this.membership}} />`);
+    await click('button[aria-label="Modifier le rôle"]');
     await click('.ember-power-select-trigger');
 
     // then
@@ -48,36 +48,35 @@ module('Integration | Component | member-item', function(hooks) {
     assert.contains('Administrateur');
   });
 
-  test('it should set selected value', async function(assert) {
-    // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
-    await click('#edit-organization-role');
-    await selectChoose('.editable-cell', 'Membre');
-
-    // then
-    assert.contains('Membre');
-  });
-
   test('it should update role on save', async function(assert) {
+    // given
+    this.updateMembership = sinon.spy();
+
     // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
-    await click('#edit-organization-role');
+    await render(hbs`<MemberItem @membership={{this.membership}} @updateMembership={{this.updateMembership}} />`);
+    await click('button[aria-label="Modifier le rôle"]');
     await selectChoose('.editable-cell', 'Membre');
-    await click('#save-organization-role');
+    await click('button[aria-label="Enregistrer"]');
 
     // then
     assert.notContains('Enregistrer');
+    assert.equal(this.membership.organizationRole, 'MEMBER');
+    assert.ok(this.updateMembership.called);
   });
 
   test('it should not update role on cancel', async function(assert) {
+    // given
+    this.updateMembership = sinon.spy();
+
     // when
-    await render(hbs`<MemberItem @membership={{membership}} />`);
-    await click('#edit-organization-role');
+    await render(hbs`<MemberItem @membership={{this.membership}} @updateMembership={{this.updateMembership}} />`);
+    await click('button[aria-label="Modifier le rôle"]');
     await selectChoose('.editable-cell', 'Membre');
-    await click('#cancel-update-organization-role');
+    await click('button[aria-label="Annuler"]');
 
     // then
     assert.contains('Administrateur');
     assert.notContains('Enregistrer');
+    assert.notOk(this.updateMembership.called);
   });
 });

--- a/admin/tests/unit/adapters/membership-test.js
+++ b/admin/tests/unit/adapters/membership-test.js
@@ -1,0 +1,33 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | membership', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:membership');
+    sinon.stub(adapter, 'ajax').resolves();
+  });
+
+  hooks.afterEach(function() {
+    adapter.ajax.restore();
+  });
+
+  module('#updateRecord', function() {
+
+    module('when disabled adapter option is provided', function() {
+
+      test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
+        // when
+        await adapter.updateRecord({}, { modelName: 'membership' }, { id: 1, adapterOptions: { disable: true } });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/disable', 'POST');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
+});

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -2,6 +2,7 @@ const Joi = require('@hapi/joi');
 const JSONAPIError = require('jsonapi-serializer').Error;
 const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');
+const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -63,7 +64,27 @@ exports.register = async function(server) {
         },
         tags: ['api','memberships'],
       }
-    }
+    },
+    {
+      method: 'POST',
+      path: '/api/memberships/{id}/disable',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster'
+        }],
+        validate: {
+          params: Joi.object({
+            id: idSpecification
+          })
+        },
+        handler: membershipController.disable,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet la désactivation d\'un membre'
+        ],
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -25,6 +25,14 @@ module.exports = {
       .then((membership) => {
         return h.response(membershipSerializer.serialize(membership));
       });
+  },
+
+  async disable(request, h) {
+    const membershipId = request.params.id;
+    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+
+    await usecases.disableMembership({ membershipId, userId });
+    return h.response().code(204);
   }
 
 };

--- a/api/lib/domain/usecases/disable-membership.js
+++ b/api/lib/domain/usecases/disable-membership.js
@@ -1,0 +1,8 @@
+module.exports = async function disableMembership({
+  membershipId,
+  userId,
+  membershipRepository,
+}) {
+  const membershipAttributes = { disabledAt: new Date(), updatedByUserId: userId };
+  return membershipRepository.updateById({ id: membershipId, membershipAttributes });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -100,6 +100,7 @@ module.exports = injectDependencies({
   createSession: require('./create-session'),
   createUser: require('./create-user'),
   deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
+  disableMembership: require('./disable-membership'),
   dissociateUserFromSchoolingRegistration: require('./dissociate-user-from-schooling-registration'),
   finalizeSession: require('./finalize-session'),
   findAnswerByChallengeAndAssessment: require('./find-answer-by-challenge-and-assessment'),

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
 
 const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
@@ -7,65 +7,68 @@ const Membership = require('../../../lib/domain/models/Membership');
 describe('Acceptance | Controller | membership-controller', () => {
 
   let server;
-  let options;
-  let userId;
-  let organizationId;
-  let membershipId;
-  let newOrganizationRole;
 
   beforeEach(async () => {
     server = await createServer();
-
-    organizationId = databaseBuilder.factory.buildOrganization().id;
-    const adminUserId = databaseBuilder.factory.buildUser().id;
-    databaseBuilder.factory.buildMembership({
-      organizationId,
-      userId: adminUserId,
-      organizationRole: Membership.roles.ADMIN,
-    });
-
-    userId = databaseBuilder.factory.buildUser().id;
-    membershipId = databaseBuilder.factory.buildMembership({
-      organizationId, userId,
-      organizationRole: Membership.roles.MEMBER,
-    }).id;
-
-    await databaseBuilder.commit();
-
-    newOrganizationRole = Membership.roles.ADMIN;
-    options = {
-      method: 'PATCH',
-      url: `/api/memberships/${membershipId}`,
-      payload: {
-        data: {
-          id: membershipId.toString(),
-          type: 'memberships',
-          attributes: {
-            'organization-role': newOrganizationRole,
-          },
-          relationships: {
-            user: {
-              data: {
-                type: 'users',
-                id: userId
-              }
-            },
-            organization: {
-              data : {
-                type: 'organizations',
-                id: organizationId
-              }
-            }
-          }
-        }
-      },
-      headers: {
-        authorization: generateValidRequestAuthorizationHeader(adminUserId)
-      },
-    };
   });
 
   describe('PATCH /api/memberships/{id}', () => {
+
+    let options;
+    let userId;
+    let organizationId;
+    let membershipId;
+    let newOrganizationRole;
+
+    beforeEach(async () => {
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+      const adminUserId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId: adminUserId,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      userId = databaseBuilder.factory.buildUser().id;
+      membershipId = databaseBuilder.factory.buildMembership({
+        organizationId, userId,
+        organizationRole: Membership.roles.MEMBER,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      newOrganizationRole = Membership.roles.ADMIN;
+      options = {
+        method: 'PATCH',
+        url: `/api/memberships/${membershipId}`,
+        payload: {
+          data: {
+            id: membershipId.toString(),
+            type: 'memberships',
+            attributes: {
+              'organization-role': newOrganizationRole,
+            },
+            relationships: {
+              user: {
+                data: {
+                  type: 'users',
+                  id: userId
+                }
+              },
+              organization: {
+                data : {
+                  type: 'organizations',
+                  id: organizationId
+                }
+              }
+            }
+          }
+        },
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUserId)
+        },
+      };
+    });
 
     context('Success cases', () => {
 
@@ -137,6 +140,74 @@ describe('Acceptance | Controller | membership-controller', () => {
         const firstError = response.result.errors[0];
         expect(firstError.detail).to.equal('"id" must be a number');
 
+      });
+    });
+  });
+
+  describe('POST /api/memberships/{id}/disable', () => {
+
+    let options;
+    let membershipId;
+
+    beforeEach(async () => {
+      await insertUserWithRolePixMaster();
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      membershipId = databaseBuilder.factory.buildMembership({ organizationId, userId }).id;
+
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'POST',
+        url: `/api/memberships/${membershipId}/disable`,
+        payload: {
+          data: {
+            id: membershipId.toString(),
+            type: 'memberships',
+          }
+        },
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader()
+        },
+      };
+    });
+
+    context('Success cases', () => {
+
+      it('should return a 204', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('Error cases', () => {
+
+      it('should respond with a 403 if user does not have the role PIX MASTER', async () => {
+        // given
+        const notPixMasterUserId = 1;
+        options.headers.authorization = generateValidRequestAuthorizationHeader(notPixMasterUserId);
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('should respond with a 400 if membership does not exist', async () => {
+        // given
+        const unknownMembershipId = 9999;
+        options.url = `/api/memberships/${unknownMembershipId}/disable`;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/disable-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-membership_test.js
@@ -1,0 +1,41 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+const { disableMembership } = require('../../../../lib/domain/usecases');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+const { MembershipUpdateError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | disable-membership', () => {
+
+  beforeEach(() => {
+    sinon.stub(membershipRepository, 'updateById');
+  });
+
+  it('should disable membership', async () => {
+    // given
+    const membershipId = 100;
+    const userId = 10;
+    membershipRepository.updateById.resolves();
+
+    // when
+    await disableMembership({ membershipId, userId, membershipRepository });
+
+    // then
+    const expectedMembershipAttributes = {
+      disabledAt: sinon.match.instanceOf(Date),
+      updatedByUserId: userId
+    };
+    expect(membershipRepository.updateById).to.has.been.calledWithExactly({ id: membershipId, membershipAttributes: expectedMembershipAttributes });
+  });
+
+  it('should throw a MembershipUpdateError if membership does not exist', async () => {
+    // given
+    const membershipId = 99999999;
+    const userId = 10;
+    membershipRepository.updateById.throws(new MembershipUpdateError());
+
+    // when
+    const error = await catchErr(disableMembership)({ membershipId, userId, membershipRepository });
+
+    // then
+    expect(error).to.be.instanceOf(MembershipUpdateError);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Depuis peu, la suppression d'un membre n'est plus effectuée par une suppression dans la base mais par l'ajout d'une date de désactivation. Néanmoins, cette opération devait jusque ici être effectuée directement en base de données.

## :robot: Solution
Ajout d'un bouton dans le tableau des membres de Pix Admin afin de permettre cette désactivation.

## :rainbow: Remarques
- Un refacto de la mise à jour du rôle d'un membre a été effectué afin de faire l'appel à l'API depuis le controller et non plus directement dans le composant. Cette PR s'appuie sur ce refacto afin d'effectuer la désactivation d'un membre.
- Le composant `confirm-popup` a évolué afin de permettre la surcharge du titre, du libellé du bouton de confirmation ainsi que celui d'annulation.
- Le CSS du tableau a évolué afin de faire apparaître des points de suspension lorsque le texte dépasse de la cellule.
