### PR TITLE
[FEATURE] Permettre à un prescripteur d'obtenir un e-mail d'invitation en fonction de sa région (PIX-810).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -8,6 +8,7 @@ const organizationInvitationSerializer = require('../../infrastructure/serialize
 const targetProfileSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-serializer');
 const userWithSchoolingRegistrationSerializer = require('../../infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -108,8 +109,9 @@ module.exports = {
   async sendInvitations(request, h) {
     const organizationId = request.params.id;
     const emails = request.payload.data.attributes.email.split(',');
+    const locale = extractLocaleFromRequest(request);
 
-    const organizationInvitations = await usecases.createOrganizationInvitations({ organizationId, emails });
+    const organizationInvitations = await usecases.createOrganizationInvitations({ organizationId, emails, locale });
     return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();
   },
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -39,6 +39,13 @@ module.exports = (function() {
       domainOrg: process.env.DOMAIN_NAME_ORG || 'pix.org',
     },
 
+    domain: {
+      tldFr: process.env.TLD_FR || '.fr',
+      tldOrg: process.env.TLD_ORG || '.org',
+      pix: process.env.DOMAIN_PIX || 'https://pix',
+      pixOrga: process.env.DOMAIN_PIX_ORGA || 'https://orga.pix',
+    },
+
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
@@ -117,8 +124,6 @@ module.exports = (function() {
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),
     },
 
-    pixOrgaUrl: process.env.PIXORGA_URL,
-
     sentry: {
       enabled: isFeatureEnabled(process.env.SENTRY_ENABLED),
       dsn: process.env.SENTRY_DSN,
@@ -136,6 +141,11 @@ module.exports = (function() {
 
     config.airtable.apiKey = 'test-api-key';
     config.airtable.base = 'test-base';
+
+    config.domain.tldFr = '.fr';
+    config.domain.tldOrg = '.org';
+    config.domain.pix = 'https://pix';
+    config.domain.pixOrga = 'https://orga.pix';
 
     config.mailing.enabled = false;
     config.mailing.provider = 'mailjet';
@@ -163,8 +173,6 @@ module.exports = (function() {
     config.caching.redisUrl = null;
     config.caching.redisCacheKeyLockTTL = 0;
     config.caching.redisCacheLockedWaitBeforeRetry = 0;
-
-    config.pixOrgaUrl = 'http://dev.pix-orga.fr';
 
     config.sentry.enabled = false;
   }

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -63,19 +63,37 @@ function sendOrganizationInvitationEmail({
   organizationName,
   organizationInvitationId,
   code,
+  locale,
   tags
 }) {
-  const pixOrgaBaseUrl = settings.pixOrgaUrl;
+  locale = locale ? locale : 'fr-fr';
+
+  let variables = {
+    organizationName,
+    pixHomeName: `pix${settings.domain.tldFr}`,
+    pixHomeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+    pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldFr}`,
+    redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldFr}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+    locale
+  };
+  if (locale === 'fr') {
+    variables = {
+      organizationName,
+      pixHomeName: `pix${settings.domain.tldOrg}`,
+      pixHomeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
+      pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}`,
+      redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+      locale
+    };
+  }
+
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
     fromName: PIX_ORGA_NAME,
     to: email,
     subject: 'Invitation à rejoindre Pix Orga',
     template: mailer.organizationInvitationTemplateId,
-    variables: {
-      organizationName,
-      responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-    },
+    variables,
     tags: tags || null
   });
 }

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -8,7 +8,7 @@ const _generateCode = () => {
 };
 
 const createOrganizationInvitation = async ({
-  organizationRepository, organizationInvitationRepository, organizationId, email, tags
+  organizationRepository, organizationInvitationRepository, organizationId, email, locale, tags
 }) => {
   let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
 
@@ -24,6 +24,7 @@ const createOrganizationInvitation = async ({
     organizationName,
     organizationInvitationId: organizationInvitation.id,
     code: organizationInvitation.code,
+    locale,
     tags
   });
 

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -3,14 +3,14 @@ const bluebird = require('bluebird');
 const organizationInvitationService = require('../../domain/services/organization-invitation-service');
 
 module.exports = async function createOrganizationInvitations({
-  organizationRepository, organizationInvitationRepository, organizationId, emails
+  organizationRepository, organizationInvitationRepository, organizationId, emails, locale
 }) {
   const trimedEmails = emails.map((email) => email.trim());
   const uniqueEmails = [...new Set(trimedEmails)];
 
   return bluebird.mapSeries(uniqueEmails, (email) => {
     return organizationInvitationService.createOrganizationInvitation({
-      organizationRepository, organizationInvitationRepository, organizationId, email
+      organizationRepository, organizationInvitationRepository, organizationId, email, locale
     });
   });
 };

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -525,6 +525,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
     const organizationId = invitation.organizationId;
     const emails = [invitation.email];
+    const locale = 'fr-fr';
 
     beforeEach(() => {
       request = {
@@ -543,12 +544,12 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       sinon.stub(usecases, 'createOrganizationInvitations').resolves([{ id: 1 }]);
     });
 
-    it('should call the usecase to create invitation with organizationId and email', async () => {
+    it('should call the usecase to create invitation with organizationId, email and locale', async () => {
       // when
       await organizationController.sendInvitations(request, hFake);
 
       // then
-      expect(usecases.createOrganizationInvitations).to.have.been.calledWith({ organizationId, emails });
+      expect(usecases.createOrganizationInvitations).to.have.been.calledWith({ organizationId, emails, locale });
     });
   });
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -134,7 +134,9 @@ describe('Unit | Service | MailService', () => {
     const template = 'test-organization-invitation-demand-template-id';
 
     const organizationName = 'Organization Name';
-    const pixOrgaBaseUrl = 'http://dev.pix-orga.fr';
+    const pixHomeName = 'pix.fr';
+    const pixHomeUrl = 'https://pix.fr';
+    const pixOrgaUrl = 'https://orga.pix.fr';
     const organizationInvitationId = 1;
     const code = 'ABCDEFGH01';
 
@@ -149,7 +151,11 @@ describe('Unit | Service | MailService', () => {
           subject, template,
           variables: {
             organizationName,
-            responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
+            pixHomeName,
+            pixHomeUrl,
+            pixOrgaHomeUrl: pixOrgaUrl,
+            locale: 'fr-fr',
+            redirectionUrl: `${pixOrgaUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
           },
           tags: null
         };
@@ -157,6 +163,37 @@ describe('Unit | Service | MailService', () => {
         // when
         await mailService.sendOrganizationInvitationEmail({
           email: userEmailAddress, organizationName, organizationInvitationId, code
+        });
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+
+      it('should use locale pass in paramaters to construct url', async () => {
+        // given
+        const locale = 'fr';
+        const pixHomeName = 'pix.org';
+        const pixHomeUrl = 'https://pix.org';
+        const pixOrgaUrl = 'https://orga.pix.org';
+        const expectedOptions = {
+          from: senderEmailAddress,
+          fromName,
+          to: userEmailAddress,
+          subject, template,
+          variables: {
+            organizationName,
+            pixHomeName,
+            pixHomeUrl,
+            pixOrgaHomeUrl: pixOrgaUrl,
+            locale: 'fr',
+            redirectionUrl: `${pixOrgaUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
+          },
+          tags: null
+        };
+
+        // when
+        await mailService.sendOrganizationInvitationEmail({
+          email: userEmailAddress, organizationName, organizationInvitationId, code, locale
         });
 
         // then
@@ -177,7 +214,11 @@ describe('Unit | Service | MailService', () => {
           subject, template,
           variables: {
             organizationName,
-            responseUrl: `${pixOrgaBaseUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
+            pixHomeName,
+            pixHomeUrl,
+            pixOrgaHomeUrl: pixOrgaUrl,
+            locale: 'fr-fr',
+            redirectionUrl: `${pixOrgaUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
           },
           tags
         };

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -37,17 +37,18 @@ describe('Unit | Service | Organization-Invitation Service', () => {
         }).resolves({ id: organizationInvitationId, code });
       });
 
-      it('should create a new organization-invitation and send an email with organizationId, email and code', async () => {
+      it('should create a new organization-invitation and send an email with organizationId, email, code and locale', async () => {
         // given
         const tags = undefined;
+        const locale = 'fr-fr';
 
         const expectedParameters = {
-          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+          email: userEmailAddress, organizationName, organizationInvitationId, code, locale, tags
         };
 
         // when
         await createOrganizationInvitation({
-          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress, locale
         });
 
         // then
@@ -57,14 +58,15 @@ describe('Unit | Service | Organization-Invitation Service', () => {
       it('should send an email with organizationId, email, code and tags', async () => {
         // given
         const tags = ['JOIN_ORGA'];
+        const locale = 'fr-fr';
 
         const expectedParameters = {
-          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+          email: userEmailAddress, organizationName, organizationInvitationId, code, locale, tags
         };
 
         // when
         await createOrganizationInvitation({
-          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress, tags
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress, locale, tags
         });
 
         // then
@@ -76,6 +78,7 @@ describe('Unit | Service | Organization-Invitation Service', () => {
 
       const isPending = true;
       const tags = undefined;
+      const locale = 'fr-fr';
 
       beforeEach(async () => {
         // given
@@ -85,14 +88,14 @@ describe('Unit | Service | Organization-Invitation Service', () => {
 
         // when
         await createOrganizationInvitation({
-          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress
+          organizationRepository, organizationInvitationRepository, organizationId, email: userEmailAddress, locale
         });
       });
 
       it('should re-send an email with same code', async () => {
         // then
         const expectedParameters = {
-          email: userEmailAddress, organizationName, organizationInvitationId, code, tags
+          email: userEmailAddress, organizationName, organizationInvitationId, code, locale, tags
         };
 
         expect(mailService.sendOrganizationInvitationEmail).to.has.been.calledWith(expectedParameters);

--- a/api/tests/unit/domain/usecases/create-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitations_test.js
@@ -19,15 +19,16 @@ describe('Unit | UseCase | create-organization-invitations', () => {
       // given
       const organizationId = 1;
       const emails = ['member@organization.org'];
+      const locale = 'fr-fr';
 
       // when
-      await createOrganizationInvitations({ organizationRepository, organizationInvitationRepository, organizationId, emails });
+      await createOrganizationInvitations({ organizationRepository, organizationInvitationRepository, organizationId, emails, locale });
 
       // then
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
       expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
         organizationRepository, organizationInvitationRepository,
-        organizationId, email: emails[0]
+        organizationId, email: emails[0], locale
       });
     });
 

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -3,7 +3,12 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import { inject as service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
+const FRENCH_DOMAIN_EXTENSION = 'fr';
+const FRENCH_LOCALE = 'fr-fr';
+const FRENCHSPOKEN_LOCALE = 'fr';
+
 export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapterMixin) {
+  @service currentDomain;
   @service ajaxQueue;
   host = ENV.APP.API_HOST;
   namespace = 'api';
@@ -13,6 +18,9 @@ export default class ApplicationAdapter extends JSONAPIAdapter.extend(DataAdapte
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
+    headers['Accept-Language'] = this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION ?
+      FRENCH_LOCALE
+      : FRENCHSPOKEN_LOCALE;
 
     return headers;
   }

--- a/orga/tests/unit/adapters/application-test.js
+++ b/orga/tests/unit/adapters/application-test.js
@@ -37,6 +37,28 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
       // Then
       assert.notOk(applicationAdapter.headers['Authorization']);
     });
+
+    test('should add Accept-Language header set to fr-fr when the current domain contains pix.fr', function(assert) {
+      // Given
+      const applicationAdapter = this.owner.lookup('adapter:application');
+
+      // When
+      applicationAdapter.set('currentDomain', { getExtension() { return 'fr'; } });
+
+      // Then
+      assert.equal(applicationAdapter.headers['Accept-Language'], 'fr-fr');
+    });
+
+    test('should add Accept-Language header set to fr-fr when the current domain contains pix.org', function(assert) {
+      // Given
+      const applicationAdapter = this.owner.lookup('adapter:application');
+
+      // When
+      applicationAdapter.set('currentDomain', { getExtension() { return 'org'; } });
+
+      // Then
+      assert.equal(applicationAdapter.headers['Accept-Language'], 'fr');
+    });
   });
 
   module('ajax()', function() {

--- a/scalingo.json
+++ b/scalingo.json
@@ -5,9 +5,9 @@
       "description": "Indicates that the application is a review app",
       "value": "true"
     },
-    "PIXORGA_URL": {
+    "DOMAIN_PIX_ORGA": {
       "generator": "template",
-      "template": "https://orga-pr%PR_NUMBER%.review.pix.fr"
+      "template": "https://orga-pr%PR_NUMBER%.review"
     }
   },
   "scripts": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment mis en place orga.pix.org. Nous souhaitons que lorsqu'un administrateur est sur ce nouveau domaine, que les mails d'invitations redirigent vers ce même domaine. 

## :robot: Solution
- Envoyer le header Accept-language pour tous les requêtes de Pix Orga.
- Récupérer la locale grâce à la méthode `extractLocaleFromRequest` et la passer au mail service pour qu'il construise la bonne url de redirection.

## :100: Pour tester
S'inviter dans une organisation depuis les différents domaines et voir que les liens sont différents en fonction de ce dernier. 