### PR TITLE
[BUGFIX] Rediriger le prescrit vers son parcours après inscription (PIX-886).

### DIFF
--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -138,7 +138,7 @@ export default Component.extend({
 
       this._trimNamesAndEmailOfUser();
 
-      const campaignCode = _.get(this.session, 'attemptedTransition.from.parent.params.campaign_code');
+      const campaignCode = _.get(this.session, 'attemptedTransition.from.parent.params.code');
 
       this.user.save({ adapterOptions: { campaignCode } }).then(() => {
         const credentials = { login: this.user.email, password: this.user.password };

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -76,6 +76,48 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               // then
               expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
             });
+
+            context('When user create its account', function() {
+
+              it('should send campaignCode to API', async function() {
+
+                let sentCampaignCode;
+
+                const prescritUser = {
+                  firstName: 'firstName',
+                  lastName: 'lastName',
+                  email: 'firstName.lastName@email.com',
+                  password: 'Pix12345',
+                };
+
+                this.server.post('/users', (schema, request) => {
+                  sentCampaignCode = (JSON.parse(request.requestBody)).meta['campaign-code'];
+                  return schema.users.create({});
+                }, 201);
+
+                // given
+                const campaign = server.create('campaign', { isRestricted: false, type: ASSESSMENT });
+                await visit('/campagnes');
+                await fillIn('#campaign-code', campaign.code);
+                await click('.fill-in-campaign-code__start-button');
+                expect(currentURL().toLowerCase()).to.equal(`/campagnes/${campaign.code}/presentation`.toLowerCase());
+                await click('.campaign-landing-page__start-button');
+                expect(currentURL().toLowerCase()).to.equal('/inscription'.toLowerCase());
+                await fillIn('#firstName', prescritUser.firstName);
+                await fillIn('#lastName', prescritUser.lastName);
+                await fillIn('#email', prescritUser.email);
+                await fillIn('#password', prescritUser.password);
+                await click('#pix-cgu');
+
+                // when
+                await click('.button');
+
+                // then
+                expect(sentCampaignCode).to.equal(campaign.code);
+
+              });
+            });
+
           });
 
           context('When campaign is restricted', function() {

--- a/mon-pix/tests/unit/components/signup-form-test.js
+++ b/mon-pix/tests/unit/components/signup-form-test.js
@@ -65,7 +65,7 @@ describe('Unit | Component | signup-form', function() {
       component.set('user', userWithSpaces);
 
       const campaignCode = 'AZERTY123';
-      component.session.attemptedTransition.from.parent.params.campaign_code = campaignCode;
+      component.session.attemptedTransition.from.parent.params.code = campaignCode;
 
       // when
       component.send('signup');


### PR DESCRIPTION
## :unicorn: Problème
La PR #1516 ne se comporte pas comme attendu suite à un changement concommitant : le fragment d'URL campaign_code a été remplacé par code dans `http://<HOST>/campagnes/<CAMPAIGN_CODE>`.

## :robot: Solution
Mettre à jour le fragment de route lu dans le code.
Rajouter un test pour prendre en charge ce cas.

## :100: Pour tester
Etapes:
* activer le mailing: ajouter la variable d'environnement `MAILING_ENABLED=true`
* aller sur la [campagne AZERTY123](https://app-pr1558.review.pix.fr/campagnes/AZERTY123/presentation)
* créer un compte
* démarrer le parcours
* ouvrir l'email d'inscription et cliquer sur le lien
* vérifier l'on est redirirgé sur le parcours
