### PR TITLE
[FEATURE] Afficher le bouton retenter sur la carte de la competence (PIX-757).

### DIFF
--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,14 +1,10 @@
-import { computed } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 export default class CompetenceCardDefault extends Component {
-  scorecard = null;
-
-  @computed('scorecard.{level,isNotStarted}')
   get displayedLevel() {
-    if (this.scorecard.isNotStarted) {
+    if (this.args.scorecard.isNotStarted) {
       return null;
     }
-    return this.scorecard.level;
+    return this.args.scorecard.level;
   }
 }

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,7 +1,13 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import config from 'mon-pix/config/environment';
 
 export default class CompetenceCardDefault extends Component {
+  @service currentUser;
+  @service store;
+  @service router;
+
   get displayImproveButton() {
     return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
   }
@@ -12,4 +18,16 @@ export default class CompetenceCardDefault extends Component {
     }
     return this.args.scorecard.level;
   }
+
+  @action
+  async improveCompetenceEvaluation() {
+    await this.store.queryRecord('competence-evaluation', {
+      improve: true,
+      userId: this.currentUser.user.id,
+      competenceId: this.args.scorecard.competenceId
+    });
+
+    this.router.transitionTo('competences.resume', this.args.scorecard.competenceId);
+  }
+
 }

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,6 +1,11 @@
 import Component from '@glimmer/component';
+import config from 'mon-pix/config/environment';
 
 export default class CompetenceCardDefault extends Component {
+  get displayImproveButton() {
+    return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+  }
+
   get displayedLevel() {
     if (this.args.scorecard.isNotStarted) {
       return null;

--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -94,6 +94,7 @@
   .competence-card__button:hover .competence-card-button__arrow {
     opacity: 1;
     right: 24px;
+    top: -2px;
   }
 
   .competence-card:hover .competence-card__body {

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -69,6 +69,14 @@
     left: 50%;
     transform: translate(-50%, -50%);
   }
+
+  &__improving-text {
+    margin-top: 4px;
+    color: $blue-zodiac;
+    font-family: $font-roboto;
+    font-size: 0.8rem;
+    letter-spacing: 0.0075rem;
+  }
 }
 
 .scorecard-details-content {

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -1,25 +1,25 @@
-<article class="competence-card {{if @interactive "competence-card--interactive"}}">
-  <LinkTo @route="competences.details" @model={{scorecard.competenceId}}>
+<article class="competence-card {{if this.args.interactive "competence-card--interactive"}}">
+  <LinkTo @route="competences.details" @model={{this.args.scorecard.competenceId}}>
     <header class="competence-card__header">
-      <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
-      <span class="competence-card__area-name">{{scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{scorecard.name}}</span>
+      <span class="competence-card__color competence-card__color--{{this.args.scorecard.area.color}}"></span>
+      <span class="competence-card__area-name">{{this.args.scorecard.area.title}}</span>
+      <span class="competence-card__competence-name">{{this.args.scorecard.name}}</span>
     </header>
 
     <div class="competence-card__body">
-      {{#if scorecard.isFinishedWithMaxLevel}}
+      {{#if this.args.scorecard.isFinishedWithMaxLevel}}
         <div class="competence-card__congrats competence-card__congrats--with-magnification">
           <div class="competence-card__level competence-card__level--congrats">
             <span class="score-label competence-card__score-label--congrats">Niveau</span>
-            <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{displayedLevel}}</span>
+            <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{this.displayedLevel}}</span>
           </div>
         </div>
       {{else}}
         <div class="competence-card__link">
-          <CircleChart @value={{scorecard.percentageAheadOfNextLevel}} @sliceColor={{scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
+          <CircleChart @value={{this.args.scorecard.percentageAheadOfNextLevel}} @sliceColor={{this.args.scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
             <div class="competence-card__level">
               <span class="score-label">Niveau</span>
-              <span class="score-value competence-card__score-value">{{replace-zero-by-dash displayedLevel}}</span>
+              <span class="score-value competence-card__score-value">{{replace-zero-by-dash this.displayedLevel}}</span>
               <span class="competence-card__score-details">détail</span>
             </div>
           </CircleChart>
@@ -28,16 +28,16 @@
     </div>
   </LinkTo>
 
-  {{#if scorecard.isFinishedWithMaxLevel}}
+  {{#if this.args.scorecard.isFinishedWithMaxLevel}}
     <footer class="competence-card__congrats-message">
       Bravo !
     </footer>
   {{else}}
     <footer class="competence-card__footer">
-      {{#unless scorecard.isFinished}}
-        <LinkTo @route="competences.resume" @model={{scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
+      {{#unless this.args.scorecard.isFinished}}
+        <LinkTo @route="competences.resume" @model={{this.args.scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
           <span class="competence-card-button__label">
-            {{#if scorecard.isStarted}}
+            {{#if this.args.scorecard.isStarted}}
               Reprendre
             {{else}}
               Commencer

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -1,13 +1,13 @@
-<article class="competence-card {{if this.args.interactive "competence-card--interactive"}}">
-  <LinkTo @route="competences.details" @model={{this.args.scorecard.competenceId}}>
+<article class="competence-card {{if @interactive "competence-card--interactive"}}">
+  <LinkTo @route="competences.details" @model={{@scorecard.competenceId}}>
     <header class="competence-card__header">
-      <span class="competence-card__color competence-card__color--{{this.args.scorecard.area.color}}"></span>
-      <span class="competence-card__area-name">{{this.args.scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{this.args.scorecard.name}}</span>
+      <span class="competence-card__color competence-card__color--{{@scorecard.area.color}}"></span>
+      <span class="competence-card__area-name">{{@scorecard.area.title}}</span>
+      <span class="competence-card__competence-name">{{@scorecard.name}}</span>
     </header>
 
     <div class="competence-card__body">
-      {{#if this.args.scorecard.isFinishedWithMaxLevel}}
+      {{#if @scorecard.isFinishedWithMaxLevel}}
         <div class="competence-card__congrats competence-card__congrats--with-magnification">
           <div class="competence-card__level competence-card__level--congrats">
             <span class="score-label competence-card__score-label--congrats">Niveau</span>
@@ -16,7 +16,7 @@
         </div>
       {{else}}
         <div class="competence-card__link">
-          <CircleChart @value={{this.args.scorecard.percentageAheadOfNextLevel}} @sliceColor={{this.args.scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
+          <CircleChart @value={{@scorecard.percentageAheadOfNextLevel}} @sliceColor={{@scorecard.area.color}} @chartClass="circle-chart__content--big" @thicknessClass="circle--thick">
             <div class="competence-card__level">
               <span class="score-label">Niveau</span>
               <span class="score-value competence-card__score-value">{{replace-zero-by-dash this.displayedLevel}}</span>
@@ -28,16 +28,16 @@
     </div>
   </LinkTo>
 
-  {{#if this.args.scorecard.isFinishedWithMaxLevel}}
+  {{#if @scorecard.isFinishedWithMaxLevel}}
     <footer class="competence-card__congrats-message">
       Bravo !
     </footer>
   {{else}}
     <footer class="competence-card__footer">
-      {{#if this.args.scorecard.isFinished}}
+      {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
           <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
-            <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{this.args.scorecard.name}}"</span>
+            <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{@scorecard.name}}"</span>
             </span>
             <span class="competence-card-button__arrow">
               {{fa-icon 'long-arrow-alt-right'}}
@@ -45,9 +45,9 @@
           </button>
         {{/if}}
       {{else}}
-        <LinkTo @route="competences.resume" @model={{this.args.scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
+        <LinkTo @route="competences.resume" @model={{@scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
           <span class="competence-card-button__label">
-            {{#if this.args.scorecard.isStarted}}
+            {{#if @scorecard.isStarted}}
               Reprendre
             {{else}}
               Commencer

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -36,9 +36,13 @@
     <footer class="competence-card__footer">
       {{#if this.args.scorecard.isFinished}}
         {{#if this.displayImproveButton}}
-          <span class="competence-card__retry">
+          <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
             Retenter
-          </span>
+            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+            <span class="competence-card-button__arrow">
+              {{fa-icon 'long-arrow-alt-right'}}
+            </span>
+          </button>
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume" @model={{this.args.scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -34,7 +34,13 @@
     </footer>
   {{else}}
     <footer class="competence-card__footer">
-      {{#unless this.args.scorecard.isFinished}}
+      {{#if this.args.scorecard.isFinished}}
+        {{#if this.displayImproveButton}}
+          <span class="competence-card__retry">
+            Retenter
+          </span>
+        {{/if}}
+      {{else}}
         <LinkTo @route="competences.resume" @model={{this.args.scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">
           <span class="competence-card-button__label">
             {{#if this.args.scorecard.isStarted}}
@@ -47,7 +53,7 @@
             {{fa-icon 'long-arrow-alt-right'}}
           </span>
         </LinkTo>
-      {{/unless}}
+      {{/if}}
     </footer>
   {{/if}}
 </article>

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -37,8 +37,8 @@
       {{#if this.args.scorecard.isFinished}}
         {{#if this.displayImproveButton}}
           <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
-            Retenter
-            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+            <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{this.args.scorecard.name}}"</span>
+            </span>
             <span class="competence-card-button__arrow">
               {{fa-icon 'long-arrow-alt-right'}}
             </span>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -57,7 +57,15 @@
         </div>
       {{/if}}
 
-      {{#unless this.args.scorecard.isFinished}}
+      {{#if this.args.scorecard.isFinished}}
+        {{#if this.displayImproveButton}}
+          <button class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button" {{action "improveCompetenceEvaluation"}}>
+            Retenter
+            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+          </button>
+          <span class="scorecard-details__improving-text">Essayer d'obtenir un meilleur niveau !</span>
+        {{/if}}
+      {{else}}
         <LinkTo @route="competences.resume"
                 @model={{this.args.scorecard.competenceId}}
                 class={{concat "button button--big button--thin button--round button--link button--green "
@@ -70,7 +78,7 @@
             <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
           {{/if}}
         </LinkTo>
-      {{/unless}}
+      {{/if}}
       {{#if this.displayResetButton}}
         <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
           Remettre à zéro
@@ -78,12 +86,6 @@
         </button>
       {{else if this.displayWaitSentence}}
         <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
-      {{/if}}
-      {{#if this.displayImproveButton}}
-        <button class="button button--grey" {{action "improveCompetenceEvaluation"}}>
-          Retenter
-          <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
-        </button>
       {{/if}}
     </div>
   </div>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -63,7 +63,7 @@
             Retenter
             <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
           </button>
-          <span class="scorecard-details__improving-text">Essayer d'obtenir un meilleur niveau !</span>
+          <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume"

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -134,8 +134,24 @@ describe('Integration | Component | competence-card-default', function() {
     });
 
     context('when user has finished the competence', async function() {
+      const configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+      afterEach(function() {
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
+      });
 
       it('should not show the button to start or to continue', async function() {
+        // given
+        const scorecard = { area, level: 3, isFinished: true, isStarted: false };
+        this.set('scorecard', scorecard);
+
+        // when
+        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+
+        // then
+        expect(find('.competence-card-button__label')).to.be.null;
+      });
+
+      it('should show the improving button', async function() {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false };
         this.set('scorecard', scorecard);
@@ -145,19 +161,8 @@ describe('Integration | Component | competence-card-default', function() {
         await render(hbs`{{competence-card-default scorecard=scorecard}}`);
 
         // then
-        expect(find('.competence-card-button__label')).to.be.null;
-      });
-
-      it('should show the retry button', async function() {
-        // given
-        const scorecard = { area, level: 3, isFinished: true, isStarted: false };
-        this.set('scorecard', scorecard);
-
-        // when
-        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
-
-        // then
-        expect(find('.competence-card__retry')).to.exist;
+        expect(find('.competence-card__button')).to.exist;
+        expect(find('.competence-card__button').textContent).to.contains('Retenter');
       });
 
       context('and the user has reached the maximum level', function() {

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -4,6 +4,7 @@ import  EmberObject  from '@ember/object';
 import { setupRenderingTest } from 'ember-mocha';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import config from 'mon-pix/config/environment';
 
 describe('Integration | Component | competence-card-default', function() {
   setupRenderingTest();
@@ -134,7 +135,20 @@ describe('Integration | Component | competence-card-default', function() {
 
     context('when user has finished the competence', async function() {
 
-      it('should not show the button', async function() {
+      it('should not show the button to start or to continue', async function() {
+        // given
+        const scorecard = { area, level: 3, isFinished: true, isStarted: false };
+        this.set('scorecard', scorecard);
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
+
+        // when
+        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+
+        // then
+        expect(find('.competence-card-button__label')).to.be.null;
+      });
+
+      it('should show the retry button', async function() {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false };
         this.set('scorecard', scorecard);
@@ -143,7 +157,7 @@ describe('Integration | Component | competence-card-default', function() {
         await render(hbs`{{competence-card-default scorecard=scorecard}}`);
 
         // then
-        expect(find('.competence-card__button')).to.be.null;
+        expect(find('.competence-card__retry')).to.exist;
       });
 
       context('and the user has reached the maximum level', function() {

--- a/mon-pix/tests/unit/components/competence-card-default-test.js
+++ b/mon-pix/tests/unit/components/competence-card-default-test.js
@@ -1,0 +1,45 @@
+import sinon from 'sinon';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+describe('Unit | Component | competence-card-default ', function() {
+  setupTest();
+
+  describe('#improveCompetenceEvaluation', function() {
+    let store, userId, competenceId, router;
+
+    beforeEach(async function() {
+      // given
+      competenceId = 'recCompetenceId';
+      const scorecard = EmberObject.create({ competenceId });
+      const component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
+      store = Service.create({ queryRecord: sinon.stub().resolves() });
+      component.store = store;
+      userId = 'userId';
+      component.currentUser = EmberObject.create({ user: { id: userId } });
+      router = EmberObject.create({ transitionTo: sinon.stub() });
+      component.router = router;
+
+      // when
+      await component.improveCompetenceEvaluation();
+    });
+
+    it('creates a competence-evaluation for improving', async function() {
+      // then
+      sinon.assert.calledWith(store.queryRecord, 'competence-evaluation', {
+        improve: true,
+        userId,
+        competenceId
+      });
+    });
+
+    it('redirects to competences.resume route', async function() {
+      // then
+      sinon.assert.calledWith(router.transitionTo, 'competences.resume', competenceId);
+    });
+
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
- Le bouton Retenter n'est actuellement présent que sur la page de la compétence

## :robot: Solution
- Ajouter le bouton retenter, dans le même style que Commencer, sur la carte de la compétence
- Changement de style de la même manière sur la page de détail de la compétence

## :rainbow: Remarques
- Glimmerisation de CompetenceCardDefault

## :100: Pour tester
- Finir une compétence pour avoir le bouton Retenter