### PR TITLE
[BUGFIX] Corrige la numérotation des épreuves de certif dans Pix Admin (PIX-869)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -12,7 +12,7 @@ const certificationAssessmentSchema = Joi.object({
   state: Joi.string().valid(states.COMPLETED, states.STARTED, states.ABORTED).required(),
   isV2Certification: Joi.boolean().required(),
   certificationChallenges: Joi.array().min(1).required(),
-  certificationAnswers: Joi.array().min(0).required(),
+  certificationAnswersByDate: Joi.array().min(0).required(),
 });
 
 class CertificationAssessment {
@@ -25,7 +25,7 @@ class CertificationAssessment {
     state,
     isV2Certification,
     certificationChallenges,
-    certificationAnswers,
+    certificationAnswersByDate,
   } = {}) {
     this.id = id;
     this.userId = userId;
@@ -35,7 +35,7 @@ class CertificationAssessment {
     this.state = state;
     this.isV2Certification = isV2Certification;
     this.certificationChallenges = certificationChallenges;
-    this.certificationAnswers = certificationAnswers;
+    this.certificationAnswersByDate = certificationAnswersByDate;
 
     validateEntity(certificationAssessmentSchema, this);
   }

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -207,7 +207,7 @@ module.exports = {
       certifChallenge.type = challenge ? challenge.type : 'EmptyType';
     });
 
-    const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswers, matchingCertificationChallenges);
+    const matchingAnswers = _selectAnswersMatchingCertificationChallenges(certificationAssessment.certificationAnswersByDate, matchingCertificationChallenges);
 
     const result = _getResult(matchingAnswers, matchingCertificationChallenges, testedCompetences, continueOnError);
 

--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -4,7 +4,7 @@ module.exports = function getNextChallengeForCertification({
   assessment,
 }) {
 
-  return certificationChallengeRepository.getNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)
+  return certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId(assessment.id, assessment.certificationCourseId)
     .then((certificationChallenge) => {
       return challengeRepository.get(certificationChallenge.challengeId);
     });

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -18,7 +18,8 @@ async function _getCertificationChallenges(certificationCourseId) {
 
 async function _getCertificationAnswers(certificationAssessmentId) {
   const answerRows = await knex('answers')
-    .where({ assessmentId: certificationAssessmentId });
+    .where({ assessmentId: certificationAssessmentId })
+    .orderBy('createdAt');
 
   return _.map(answerRows, (answerRow) => new Answer({
     ...answerRow,
@@ -74,7 +75,7 @@ module.exports = {
     }
     const certificationChallenges = await _getCertificationChallenges(certificationAssessmentRows[0].certificationCourseId);
     const certificationAnswers = await _getCertificationAnswers(certificationAssessmentRows[0].id);
-    
+
     return new CertificationAssessment({
       ...certificationAssessmentRows[0],
       certificationChallenges,

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -16,7 +16,7 @@ async function _getCertificationChallenges(certificationCourseId) {
   }));
 }
 
-async function _getCertificationAnswers(certificationAssessmentId) {
+async function _getCertificationAnswersByDate(certificationAssessmentId) {
   const answerRows = await knex('answers')
     .where({ assessmentId: certificationAssessmentId })
     .orderBy('createdAt');
@@ -47,12 +47,12 @@ module.exports = {
       throw new NotFoundError(`L'assessment de certification ${id} n'existe pas ou son accès est restreint`);
     }
     const certificationChallenges = await _getCertificationChallenges(certificationAssessmentRows[0].certificationCourseId);
-    const certificationAnswers = await _getCertificationAnswers(certificationAssessmentRows[0].id);
+    const certificationAnswersByDate = await _getCertificationAnswersByDate(certificationAssessmentRows[0].id);
 
     return new CertificationAssessment({
       ...certificationAssessmentRows[0],
       certificationChallenges,
-      certificationAnswers,
+      certificationAnswersByDate,
     });
   },
 
@@ -74,12 +74,12 @@ module.exports = {
       throw new NotFoundError(`L'assessment de certification avec un certificationCourseId de ${certificationCourseId} n'existe pas ou son accès est restreint`);
     }
     const certificationChallenges = await _getCertificationChallenges(certificationAssessmentRows[0].certificationCourseId);
-    const certificationAnswers = await _getCertificationAnswers(certificationAssessmentRows[0].id);
+    const certificationAnswersByDate = await _getCertificationAnswersByDate(certificationAssessmentRows[0].id);
 
     return new CertificationAssessment({
       ...certificationAssessmentRows[0],
       certificationChallenges,
-      certificationAnswers,
+      certificationAnswersByDate,
     });
   },
 

--- a/api/lib/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/certification-challenge-repository.js
@@ -7,7 +7,7 @@ const logger = require('../../infrastructure/logger');
 const { AssessmentEndedError } = require('../../domain/errors');
 
 const logContext = {
-  zone: 'certificationChallengeRepository.getNonAnsweredChallengeByCourseId',
+  zone: 'certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId',
   type: 'repository',
 };
 
@@ -25,7 +25,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(CertificationChallengeBookshelf, savedCertificationChallenge);
   },
 
-  async getNonAnsweredChallengeByCourseId(assessmentId, courseId) {
+  async getNextNonAnsweredChallengeByCourseId(assessmentId, courseId) {
     const answeredChallengeIds = Bookshelf.knex('answers')
       .select('challengeId')
       .where({ assessmentId });
@@ -33,6 +33,7 @@ module.exports = {
     const certificationChallenge = await CertificationChallengeBookshelf
       .where({ courseId })
       .query((knex) => knex.whereNotIn('challengeId', answeredChallengeIds))
+      .orderBy('id', 'asc')
       .fetch();
 
     if (certificationChallenge === null) {

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -51,7 +51,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.state).to.equal(expectedState);
         expect(certificationAssessment.isV2Certification).to.be.true;
 
-        expect(certificationAssessment.certificationAnswers).to.have.length(2);
+        expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
         expect(certificationAssessment.certificationChallenges).to.have.length(2);
       });
     });
@@ -124,7 +124,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         expect(certificationAssessment.state).to.equal(expectedState);
         expect(certificationAssessment.isV2Certification).to.be.true;
 
-        expect(certificationAssessment.certificationAnswers).to.have.length(2);
+        expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
         expect(certificationAssessment.certificationChallenges).to.have.length(2);
       });
 
@@ -133,7 +133,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
 
         // then
-        expect(_.map(certificationAssessment.certificationAnswers, 'id')).to.deep.equal([firstAnswerInTime, secondAnswerInTime]);
+        expect(_.map(certificationAssessment.certificationAnswersByDate, 'id')).to.deep.equal([firstAnswerInTime, secondAnswerInTime]);
       });
     });
 

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -43,7 +43,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', () => {
       sinon.stub(usecases, 'getNextChallengeForDemo').resolves();
       sinon.stub(usecases, 'getNextChallengeForCampaignAssessment').resolves();
       sinon.stub(usecases, 'getNextChallengeForCompetenceEvaluation').resolves();
-      sinon.stub(certificationChallengeRepository, 'getNonAnsweredChallengeByCourseId').resolves();
+      sinon.stub(certificationChallengeRepository, 'getNextNonAnsweredChallengeByCourseId').resolves();
     });
 
     // TODO: Que faire si l'assessment n'existe pas pas ?

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -17,7 +17,7 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         state: CertificationAssessment.states.STARTED,
         isV2Certification: true,
         certificationChallenges: ['challenge'],
-        certificationAnswers: ['answer'],
+        certificationAnswersByDate: ['answer'],
       };
     });
 
@@ -83,15 +83,15 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
         .to.throw(ObjectValidationError);
     });
 
-    it('should throw an ObjectValidationError when certificationAnswers is not valid', () => {
+    it('should throw an ObjectValidationError when certificationAnswersByDate is not valid', () => {
       // when
-      expect(() => new CertificationAssessment({ ...validArguments, certificationAnswers: 'glouglou' }))
+      expect(() => new CertificationAssessment({ ...validArguments, certificationAnswersByDate: 'glouglou' }))
         .to.throw(ObjectValidationError);
     });
 
-    it('should be valid when certificationAnswers has no answer', () => {
+    it('should be valid when certificationAnswersByDate has no answer', () => {
       // when
-      expect(() => new CertificationAssessment({ ...validArguments, certificationAnswers: [] }))
+      expect(() => new CertificationAssessment({ ...validArguments, certificationAnswersByDate: [] }))
         .not.to.throw(ObjectValidationError);
     });
   });

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -146,7 +146,7 @@ describe('Unit | Service | Certification Result Service', function() {
       beforeEach(() => {
         certificationAssessment = new CertificationAssessment({
           ...certificationAssessmentData,
-          certificationAnswers: wrongAnswersForAllChallenges(),
+          certificationAnswersByDate: wrongAnswersForAllChallenges(),
           certificationChallenges: challenges,
         });
 
@@ -318,7 +318,7 @@ describe('Unit | Service | Certification Result Service', function() {
       context('when reproducibility rate is between 80% and 100%', () => {
 
         beforeEach(() => {
-          certificationAssessment.certificationAnswers = correctAnswersForAllChallenges();
+          certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
         });
 
         it('should ignore answers with no matching challenge', async () => {
@@ -389,7 +389,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should return totalScore = (all pix - one competence pix) when one competence is totally false', async () => {
           // given
-          certificationAssessment.certificationAnswers = answersToHaveOnlyTheLastCompetenceFailed();
+          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
 
           // when
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
@@ -400,7 +400,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async () => {
           // given
-          certificationAssessment.certificationAnswers = answersToHaveOnlyTheLastCompetenceFailed();
+          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
           const expectedCertifiedCompetences = [{
             index: '1.1',
             area_code: '1',
@@ -450,7 +450,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
       context('when reproducibility rate is between 50% and 80%', () => {
         beforeEach(() => {
-          certificationAssessment.certificationAnswers = answersWithReproducibilityRateLessThan80();
+          certificationAssessment.certificationAnswersByDate = answersWithReproducibilityRateLessThan80();
         });
 
         it('should return totalScore = all pix minus 8 for one competence with 1 error and minus all pix for others false competences', async () => {
@@ -686,7 +686,7 @@ describe('Unit | Service | Certification Result Service', function() {
                 _buildUserCompetence(competence_1, positionedScore, positionedLevel),
               ];
 
-              certificationAssessment.certificationAnswers = answers;
+              certificationAssessment.certificationAnswersByDate = answers;
               certificationAssessment.certificationChallenges = challenges;
               userService.getCertificationProfile.restore();
               sinon.stub(userService, 'getCertificationProfile').withArgs({
@@ -715,7 +715,7 @@ describe('Unit | Service | Certification Result Service', function() {
       const continueOnError = false;
 
       beforeEach(() => {
-        certificationAssessment.certificationAnswers = wrongAnswersForAllChallenges();
+        certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
         certificationAssessment.certificationChallenges = challenges;
         sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
         sinon.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
@@ -808,7 +808,7 @@ describe('Unit | Service | Certification Result Service', function() {
       context('when reproducibility rate is between 80% and 100%', () => {
 
         beforeEach(() => {
-          certificationAssessment.certificationAnswers = correctAnswersForAllChallenges();
+          certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
         });
 
         it('should return totalScore = all pix', async () => {
@@ -822,7 +822,7 @@ describe('Unit | Service | Certification Result Service', function() {
         it('should ignore answers with no matching challenge', async () => {
           // given
           const answerNoMatchingChallenge = domainBuilder.buildAnswer({ challengeId: 'non_existing_challenge', result: 'ok' });
-          certificationAssessment.certificationAnswers = [...correctAnswersForAllChallenges(), answerNoMatchingChallenge ];
+          certificationAssessment.certificationAnswersByDate = [...correctAnswersForAllChallenges(), answerNoMatchingChallenge ];
 
           // when
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
@@ -882,7 +882,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should return totalScore = (all pix - one competence pix) when one competence is totally false', async () => {
           // given
-          certificationAssessment.certificationAnswers = answersToHaveOnlyTheLastCompetenceFailed();
+          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
 
           // when
           const result = await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
@@ -893,7 +893,7 @@ describe('Unit | Service | Certification Result Service', function() {
 
         it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async () => {
           // given
-          certificationAssessment.certificationAnswers = answersToHaveOnlyTheLastCompetenceFailed();
+          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
           const expectedCertifiedCompetences = [{
             index: '1.1',
             area_code: '1',
@@ -943,7 +943,7 @@ describe('Unit | Service | Certification Result Service', function() {
       context('when reproducibility rate is between 50% and 80%', () => {
 
         beforeEach(() => {
-          certificationAssessment.certificationAnswers = answersWithReproducibilityRateLessThan80();
+          certificationAssessment.certificationAnswersByDate = answersWithReproducibilityRateLessThan80();
         });
 
         it('should return totalScore = all pix minus 8 for one competence with 1 error and minus all pix for others false competences', async () => {
@@ -1053,7 +1053,7 @@ describe('Unit | Service | Certification Result Service', function() {
             ({ challengeId: 'challenge_B_for_competence_6', result: 'ok' }),
             ({ challengeId: 'challenge_C_for_competence_6', result: 'ko' }),
           ], domainBuilder.buildAnswer);
-          certificationAssessment.certificationAnswers = answers;
+          certificationAssessment.certificationAnswersByDate = answers;
 
           const expectedCertifiedCompetences = [{
             index: '5.5',
@@ -1091,7 +1091,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
             { challengeId: 'challenge_C_for_competence_6', result: 'ok' },
           ], domainBuilder.buildAnswer);
-          certificationAssessment.certificationAnswers = answers;
+          certificationAssessment.certificationAnswersByDate = answers;
 
           const expectedCertifiedCompetences = [{
             index: '5.5',
@@ -1139,7 +1139,7 @@ describe('Unit | Service | Certification Result Service', function() {
             { challengeId: 'challenge_M_for_competence_5', result: 'ok' },
             { challengeId: 'challenge_N_for_competence_6', result: 'ok' },
           ], domainBuilder.buildAnswer);
-          certificationAssessment.certificationAnswers = answers;
+          certificationAssessment.certificationAnswersByDate = answers;
         });
 
         it('should not include the extra challenges when computing reproducibility', async () => {

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -11,7 +11,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
     let challengeRepository;
 
     beforeEach(() => {
-      certificationChallengeRepository = { getNonAnsweredChallengeByCourseId: sinon.stub().resolves() };
+      certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub().resolves() };
       challengeRepository = { get: sinon.stub().resolves() };
     });
 
@@ -20,13 +20,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const nextChallenge = Symbol('nextChallenge');
       const assessment = new Assessment({ id: 156, certificationCourseId: 54516 });
 
-      certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextChallenge);
+      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextChallenge);
 
       // when
       await getNextChallengeForCertification({ assessment, certificationChallengeRepository, challengeRepository });
 
       // then
-      expect(certificationChallengeRepository.getNonAnsweredChallengeByCourseId).to.have.been.calledWith(156, 54516);
+      expect(certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId).to.have.been.calledWith(156, 54516);
     });
 
     it('should return the next Challenge', async () => {
@@ -36,7 +36,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', ()
       const nextCertificationChallenge = { challengeId };
       const assessment = new Assessment({ id: 156, courseId: 54516 });
 
-      certificationChallengeRepository.getNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
+      certificationChallengeRepository.getNextNonAnsweredChallengeByCourseId.resolves(nextCertificationChallenge);
       challengeRepository.get.resolves(nextChallengeToAnswer);
 
       // when


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin, sur la page de détail d'une certification, les épreuves posées aux candidat sont numérotées dans l'ordre inverse de ses réponse (l'épreuve numérotée 1 est la dernière épreuve à laquelle le candidat a répondu, et ainsi de suite).

## :robot: Solution

Trier les réponses par ordre croissant de création lors de leur récupération.

## :rainbow: Remarques


## :100: Pour tester

- Passer une certification, par exemple avec certif5@example.net (AnneNormal5)
- En notant les épreuves et leur ordre, en sautant les 15 questions
- Afficher les détails de cette certification dans Pix Admin
- Vérifier que la numérotation des épreuves correspond à l'ordre dans lequel le candidat les a vues