### PR TITLE
[CLEANUP] Corriger les erreurs signalées dans Pix Admin par le linter (PIX-889).

### DIFF
--- a/admin/.template-lintrc.js
+++ b/admin/.template-lintrc.js
@@ -2,9 +2,4 @@
 
 module.exports = {
   extends: 'octane',
-
-  ignore: [
-    'app/templates/components/**',
-    'pix-admin/templates/components/**',
-  ]
 };

--- a/admin/app/components/certification-details-competence.js
+++ b/admin/app/components/certification-details-competence.js
@@ -4,15 +4,12 @@ import { htmlSafe } from '@ember/string';
 
 export default class CertificationDetailsCompetence extends Component {
 
-  // Elements
   classNames = ['card', 'border-primary', 'certification-details-competence'];
 
-  // Properties
   competence = null;
   rate = 0;
   juryRate = false;
 
-  // Computed properties
   @computed('competence')
   get certifiedWidth() {
     const obtainedLevel = this.competence.obtainedLevel;
@@ -57,7 +54,6 @@ export default class CertificationDetailsCompetence extends Component {
     }
   }
 
-  // Private methods
   _computeScore(rate) {
     if (rate < 50) {
       return { score: 0, level: -1 };

--- a/admin/app/components/certification-info-competences.js
+++ b/admin/app/components/certification-info-competences.js
@@ -1,23 +1,11 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 
-export default class CertificationInfoCompetence extends Component {
+export default class CertificationInfoCompetences extends Component {
 
-  // Elements
   classNames = ['certification-info-competences'];
-  //Actions
-  actions = {
-    onScoreChange(index, event) {
-      const list = this.competenceList;
-      this.onUpdateScore(list[index], event.target.value);
-    },
-    onLevelChange(index, event) {
-      const list = this.competenceList;
-      this.onUpdateLevel(list[index], event.target.value);
-    }
-  }
+  competenceList = ['1.1', '1.2', '1.3', '2.1', '2.2', '2.3', '2.4', '3.1', '3.2', '3.3', '3.4', '4.1', '4.2', '4.3', '5.1', '5.2'];
 
-  // Computed properties
   @computed('competences')
   get indexedValues() {
     const competences = this.competences;
@@ -40,9 +28,15 @@ export default class CertificationInfoCompetence extends Component {
     };
   }
 
-  // Properties
-  init() {
-    super.init();
-    this.set('competenceList', ['1.1', '1.2', '1.3', '2.1', '2.2', '2.3', '2.4', '3.1', '3.2', '3.3', '3.4', '4.1', '4.2', '4.3', '5.1', '5.2']);
+  @action
+  onScoreChange(index, event) {
+    const list = this.competenceList;
+    this.onUpdateScore(list[index], event.target.value);
+  }
+
+  @action
+  onLevelChange(index, event) {
+    const list = this.competenceList;
+    this.onUpdateLevel(list[index], event.target.value);
   }
 }

--- a/admin/app/components/certification-info-field.js
+++ b/admin/app/components/certification-info-field.js
@@ -1,26 +1,27 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-export default Component.extend({
+export default class CertificationInfoField extends Component {
 
-  // Properties
-  large: false,
+  large = false;
 
-  // Computed properties
-  leftWidth: computed('large', function() {
+  @computed('large')
+  get leftWidth() {
     const large = this.large;
     if (large) {
       return 'col-sm-3';
     } else {
       return 'col-sm-5';
     }
-  }),
-  rightWidth: computed('large', function() {
+  }
+
+  @computed('large')
+  get rightWidth() {
     const large = this.large;
     if (large) {
       return 'col-sm-9';
     } else {
       return 'col-sm-7';
     }
-  })
-});
+  }
+}

--- a/admin/app/components/pagination-control.js
+++ b/admin/app/components/pagination-control.js
@@ -15,7 +15,8 @@ export default class PaginationControl extends Component {
   }
 
   @action
-  changePageSize(pageSize) {
+  changePageSize(event) {
+    const pageSize = event.target.value;
     this.router.transitionTo({ queryParams: { pageSize, pageNumber: 1 } });
   }
 }

--- a/admin/app/templates/components/certification-details-answer.hbs
+++ b/admin/app/templates/components/certification-details-answer.hbs
@@ -1,23 +1,25 @@
+{{!-- template-lint-disable no-action --}}
+
 <div class="card-body">
   <div class="certification-details-answer-skill">
-    {{answer.skill}}
+    {{this.answer.skill}}
   </div>
   <div class="certification-details-answer-id">
-    {{answer.challengeId}}
+    {{this.answer.challengeId}}
   </div>
   <div class="certification-details-answer-order">
-    (numéro : {{answer.order}})
+    (numéro : {{this.answer.order}})
   </div>
 </div>
 <div class="card-footer">
-  <div class={{resultClass}}>
-    {{#x-select value=answer.result onChange=(action "onSetResult") as |xs|}}
-      {{#xs.option value="ok"}}Ok{{/xs.option}}
-      {{#xs.option value="ko"}}Ko{{/xs.option}}
-      {{#xs.option value="partially"}}Partially{{/xs.option}}
-      {{#xs.option value="timedout"}}Timed out{{/xs.option}}
-      {{#xs.option value="aband"}}Abandon{{/xs.option}}
-      {{#xs.option value="skip"}}Neutralisée{{/xs.option}}
-    {{/x-select}}
+  <div class={{this.resultClass}}>
+    <XSelect @value={{this.answer.result}} @onChange={{action 'onSetResult'}} as |xs|>
+      <xs.option @value="ok">Ok</xs.option>
+      <xs.option @value="ko">Ko</xs.option>
+      <xs.option @value="partially">Partially</xs.option>
+      <xs.option @value="timedout">Timed out</xs.option>
+      <xs.option @value="aband">Abandon</xs.option>
+      <xs.option @value="skip">Neutralisée</xs.option>
+    </XSelect>
   </div>
 </div>

--- a/admin/app/templates/components/certification-details-competence.hbs
+++ b/admin/app/templates/components/certification-details-competence.hbs
@@ -1,5 +1,5 @@
 <div class="card-body">
-  <div class="card-title">{{competence.index}} {{competence.name}}</div>
+  <div class="card-title">{{this.competence.index}} {{this.competence.name}}</div>
   <div class="card-text">
     <div class="container">
       <div class="row">
@@ -7,39 +7,39 @@
         <div class="col">
           <div class="progress">
             <div class="progress-bar competence-level" role="progressbar"
-                 aria-valuenow="{{ competence.positionedLevel }}" aria-valuemin="0" aria-valuemax="8"
-                 style= {{positionedWidth}}>{{ competence.positionedLevel }}</div>
+                 aria-valuenow="{{this.competence.positionedLevel}}" aria-valuemin="0" aria-valuemax="8"
+                 style={{this.positionedWidth}}>{{this.competence.positionedLevel}}</div>
           </div>
         </div>
-        <div class="col-2 competence-score">{{competence.positionedScore}} Pix</div>
+        <div class="col-2 competence-score">{{this.competence.positionedScore}} Pix</div>
       </div>
       <div class="row">
         <div class="col-3">Certifié :</div>
         <div class="col">
           <div class="progress">
             <div class="progress-bar competence-level certificate" role="progressbar"
-                 aria-valuenow="{{ competence.obtainedLevel }}" aria-valuemin="0" aria-valuemax="8"
-                 style= {{certifiedWidth}}>{{ competence.obtainedLevel }}</div>
+                 aria-valuenow="{{this.competence.obtainedLevel}}" aria-valuemin="0" aria-valuemax="8"
+                 style={{this.certifiedWidth}}>{{this.competence.obtainedLeve }}</div>
           </div>
         </div>
-        <div class="col-2 certificate">{{competence.obtainedScore}} Pix</div>
+        <div class="col-2 certificate">{{this.competence.obtainedScore}} Pix</div>
       </div>
-      {{#if competenceJury}}
+      {{#if this.competenceJury}}
         <div class="row jury">
           <div class="col-3">Corrigé :</div>
           <div class="col">
             <div class="progress">
               <div class="progress-bar jury competence-level" role="progressbar"
-                   aria-valuenow="{{ competenceJury.level }}" aria-valuemin="0" aria-valuemax="8"
-                   style= {{competenceJury.width}}>{{competenceJury.level}}</div>
+                   aria-valuenow="{{this.competenceJury.level}}" aria-valuemin="0" aria-valuemax="8"
+                   style={{this.competenceJury.width}}>{{this.competenceJury.level}}</div>
             </div>
           </div>
-          <div class="col-2 jury competence-score">{{competenceJury.score}} Pix</div>
+          <div class="col-2 jury competence-score">{{this.competenceJury.score}} Pix</div>
         </div>
       {{/if}}
       <div class="card-deck">
-        {{#each answers as |answer|}}
-          {{certification-details-answer answer=answer onUpdateRate=(action onUpdateRate)}}
+        {{#each this.answers as |answer|}}
+          <CertificationDetailsAnswer @answer={{answer}} @onUpdateRate={{@onUpdateRate}} />
         {{/each}}
       </div>
     </div>

--- a/admin/app/templates/components/certification-info-competences.hbs
+++ b/admin/app/templates/components/certification-info-competences.hbs
@@ -1,29 +1,29 @@
-{{#if edition}}
-  {{#each competenceList as |competenceItem key|}}
-    <div class='row form-group certification-info-field'>
-      <label class='col-sm-3 col-form-label' for={{concat 'certification-info-score_' key}}>{{competenceItem}}</label>
-      <div class='col-sm-2 certificate'>
-        {{input type="text"
-                class="form-control"
-                id=(concat 'certification-info-score_' key)
-                value=(get indexedValues.scores key)
-                change=(action 'onScoreChange' key)}}
+{{#if @edition}}
+  {{#each this.competenceList as |competenceItem key|}}
+    <div class="row form-group certification-info-field">
+      <label class="col-sm-3 col-form-label" for={{concat 'certification-info-score_' key}}>{{competenceItem}}</label>
+      <div class="col-sm-2 certificate">
+        <Input @type="text"
+               id={{concat 'certification-info-score_' key}}
+               @value={{get this.indexedValues.scores key}}
+               class="form-control"
+               {{on 'change' (fn this.onScoreChange key)}} />
       </div>
       <label class='col-sm-1 certificate col-form-label'>Pix</label>
       <label class='col-sm-2 certificate text-right col-form-label' for={{concat 'certification-info-level_' key}}>
         Niveau :
       </label>
       <div class='col-sm-4 certificate'>
-        {{input type="text"
-                class="form-control"
-                value=(get indexedValues.levels key)
-                id=(concat 'certification-info-level_' key)
-                change=(action 'onLevelChange' key)}}
+        <Input @type="text"
+               id={{concat 'certification-info-level_' key}}
+               @value={{get this.indexedValues.levels key}}
+               class="form-control"
+               {{on 'change' (fn this.onLevelChange key)}} />
       </div>
     </div>
   {{/each}}
 {{else}}
-  {{#each competences as |competence|}}
+  {{#each @competences as |competence|}}
     <div class="row certification-info-field">
       <div class="col-sm-3 certification-info-competence-index">
         {{competence.index}}

--- a/admin/app/templates/components/certification-info-field.hbs
+++ b/admin/app/templates/components/certification-info-field.hbs
@@ -1,36 +1,38 @@
-{{#if edition}}
-  <div class='row form-group certification-info-field'>
-    <label class='{{leftWidth}} col-form-label' for={{id}}>{{label}}</label>
-    <div class='{{rightWidth}} certificate'>
-      {{#if isDate}}
-        {{ember-flatpickr id=fieldId
-                          altFormat='d/m/Y'
-                          altInput=true
-                          onChange=(action onUpdateCertificationBirthdate)
-                          dateFormat='Y-m-d'
-                          locale='fr'
-                          date=value
-                          name=fieldId
-                          class='form-control'
-        }}
+{{!-- template-lint-disable no-action --}}
+
+{{#if @edition}}
+  <div class="row form-group certification-info-field">
+    <label class="{{this.leftWidth}} col-form-label" for={{@id}}>{{@label}}</label>
+    <div class="{{this.rightWidth}} certificate">
+      {{#if @isDate}}
+        <EmberFlatpickr
+          @id={{@fieldId}}
+          @altFormat="d/m/Y"
+          @altInput={{true}}
+          @onChange={{action @onUpdateCertificationBirthdate}}
+          @dateFormat="Y-m-d"
+          @locale="fr"
+          @date={{@value}}
+          @name={{@fieldId}}
+          @class="form-control" />
       {{else}}
-        {{input type="text" class="form-control" value=value id=fieldId}}
+        <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" />
       {{/if}}
     </div>
   </div>
 {{else}}
-  <div class='row certification-info-field'>
-    <div class='{{leftWidth}} certification-info-label'>{{label}}</div>
-    <div class='{{rightWidth}} certification-info-value'>
-      {{#if linkRoute}}
-        {{#link-to linkRoute value}}
-          {{value}} {{suffix}}
-        {{/link-to}}
+  <div class="row certification-info-field">
+    <div class="{{this.leftWidth}} certification-info-label">{{@label}}</div>
+    <div class="{{this.rightWidth}} certification-info-value">
+      {{#if @linkRoute}}
+        <LinkTo @route={{@linkRoute}} @model={{@value}}>
+          {{@value}} {{@suffix}}
+        </LinkTo>
       {{else}}
-        {{#if isDate}}
-          {{moment-format value 'DD/MM/YYYY' allow-empty=true}}
+        {{#if @isDate}}
+          {{moment-format @value 'DD/MM/YYYY' allow-empty=true}}
         {{else}}
-          {{value}} {{suffix}}
+          {{@value}} {{@suffix}}
         {{/if}}
       {{/if}}
     </div>

--- a/admin/app/templates/components/certification-info-published.hbs
+++ b/admin/app/templates/components/certification-info-published.hbs
@@ -1,3 +1,3 @@
 <svg height="16" width="16">
-  <circle cx="8" cy="8" r="7" stroke="#fff" stroke-width="1" fill={{color}} />
+  <circle cx="8" cy="8" r="7" stroke="#fff" stroke-width="1" fill={{this.color}} />
 </svg>

--- a/admin/app/templates/components/certification-status-select.hbs
+++ b/admin/app/templates/components/certification-status-select.hbs
@@ -1,20 +1,22 @@
-{{#if edition}}
-  <div class='row form-group certification-status-select'>
-    <label class='{{leftWidth}} col-form-label' for={{id}}>Statut :</label>
-    <div class='{{rightWidth}} certificate'>
-      {{#x-select value=value onChange=(action 'selectOption') as |xs|}}
-        {{#xs.option value="started"}}started{{/xs.option}}
-        {{#xs.option value="error"}}error{{/xs.option}}
-        {{#xs.option value="validated"}}validated{{/xs.option}}
-        {{#xs.option value="rejected"}}rejected{{/xs.option}}
-      {{/x-select}}
+{{!-- template-lint-disable no-action --}}
+
+{{#if @edition}}
+  <div class="row form-group certification-status-select">
+    <label class="{{this.leftWidth}} col-form-label" for={{this.id}}>Statut :</label>
+    <div class="{{this.rightWidth}} certificate">
+      <XSelect @value={{this.value}} @onChange={{action 'selectOption'}} as |xs|>
+        <xs.option @value="started">started</xs.option>
+        <xs.option @value="error">error</xs.option>
+        <xs.option @value="validated">validated</xs.option>
+        <xs.option @value="rejected">rejected</xs.option>
+      </XSelect>>
     </div>
   </div>
 {{else}}
-  <div class='row certification-status-select'>
-    <div class='{{leftWidth}} certification-info-label'>{{label}}</div>
-    <div class='{{rightWidth}} certification-info-value'>
-      {{value}}
+  <div class="row certification-status-select">
+    <div class="{{this.leftWidth}} certification-info-label">{{this.label}}</div>
+    <div class="{{this.rightWidth}} certification-info-value">
+      {{this.value}}
     </div>
   </div>
 {{/if}}

--- a/admin/app/templates/components/confirm-popup.hbs
+++ b/admin/app/templates/components/confirm-popup.hbs
@@ -1,13 +1,14 @@
-{{#bs-modal-simple
-  title="Merci de confirmer"
-  closeTitle="Annuler"
-  submitTitle="Confirmer"
-  size=null
-  fade=false
-  open=show
-  position="center"
-  onSubmit=(action confirm)
-  onHide=(action cancel)}}
-  <p>{{message}}</p>
-  <p class="confirm-popup__errors">{{error}}</p>
-{{/bs-modal-simple}}
+<BsModalSimple
+  @title="Merci de confirmer"
+  @closeTitle="Annuler"
+  @submitTitle="Confirmer"
+  @size={{null}}
+  @fade={{false}}
+  @open={{@show}}
+  @position="center"
+  @onSubmit={{@confirm}}
+  @onHide={{@cancel}}
+>
+  <p>{{@message}}</p>
+  <p class="confirm-popup__errors">{{@error}}</p>
+</BsModalSimple>

--- a/admin/app/templates/components/pagination-control.hbs
+++ b/admin/app/templates/components/pagination-control.hbs
@@ -2,7 +2,7 @@
   <div class="page-size">
     <div class="page-size__label">Voir</div>
     <div class="page-size__choice">
-      <select id="pageSize" class="select content-text content-text--small" onchange={{action 'changePageSize' value='target.value'}}>
+      <select id="pageSize" class="select content-text content-text--small" {{on 'change' this.changePageSize}}>
         <option value="10" selected="{{if (eq @pagination.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq @pagination.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq @pagination.pageSize 50) true}}">50</option>
@@ -11,13 +11,13 @@
     </div>
   </div>
   <div class="page-navigation">
-    <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq @pagination.page 1) "page-navigation__arrow--disabled"}}">
+    <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq @pagination.page 1) 'page-navigation__arrow--disabled'}}">
       <LinkTo aria-label="Aller à la page précédente"
-              @query={{hash pageNumber=previousPage}}
+              @query={{hash pageNumber=this.previousPage}}
               @disabledWhen={{eq @pagination.page 1}}
               @replace={{true}}
               class="icon-button icon-button--link">
-        <FaIcon @icon='arrow-left'></FaIcon>
+        <FaIcon @icon="arrow-left" />
       </LinkTo>
     </div>
     <div class="page-navigation__body">
@@ -25,13 +25,13 @@
       <div class="page-navigation__current-page">{{@pagination.page}}</div>
       <div class="page-navigation__last-page">/&nbsp;{{@pagination.pageCount}}</div>
     </div>
-    <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq @pagination.page @pagination.pageCount) "page-navigation__arrow--disabled"}}">
+    <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq @pagination.page @pagination.pageCount) 'page-navigation__arrow--disabled'}}">
       <LinkTo aria-label="Aller à la page suivante"
-              @query={{hash pageNumber=nextPage}}
+              @query={{hash pageNumber=this.nextPage}}
               @disabledWhen={{eq @pagination.page @pagination.pageCount}}
               @replace={{true}}
               class="icon-button icon-button--link">
-        <FaIcon @icon='arrow-right'></FaIcon>
+        <FaIcon @icon="arrow-right" />
       </LinkTo>
     </div>
   </div>

--- a/admin/package.json
+++ b/admin/package.json
@@ -27,7 +27,7 @@
     "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
-    "test": "ember exam",
+    "test": "ember exam --reporter dot",
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {

--- a/admin/tests/integration/components/certification-info-competences-test.js
+++ b/admin/tests/integration/components/certification-info-competences-test.js
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | certification-info-competences', function(hooks) {
+
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
@@ -13,53 +14,50 @@ module('Integration | Component | certification-info-competences', function(hook
   });
 
   test('it should display an entry per competence', async function(assert) {
-    // Given
+    // given
     this.set('competences', [{ index:'1.1', score:'30', level:'3' }, { index:'2.1', score:'30', level:'3' }, { index:'5.2', score:'30', level:'3' }]);
-    assert.expect(3);
 
-    // When
-    await render(hbs`{{certification-info-competences competences=competences edition=false}}`);
+    // when
+    await render(hbs`<CertificationInfoCompetences @competences={{this.competences}} @edition={{false}} />`);
 
-    // Then
+    // then
     assert.dom('.certification-info-competence-index').exists({ count:3 });
     assert.dom('.certification-info-competence-level').exists({ count:3 });
     assert.dom('.certification-info-competence-score').exists({ count:3 });
   });
 
   test('it should display competence index, score and level', async function(assert) {
-    // Given
+    // given
     this.set('competences', [{ index:'1.1', score:'30', level:'3' }]);
-    assert.expect(3);
 
-    // When
-    await render(hbs`{{certification-info-competences competences=competences edition=false}}`);
+    // when
+    await render(hbs`<CertificationInfoCompetences @competences={{this.competences}} @edition={{false}} />`);
 
-    // Then
+    // then
     assert.dom('.certification-info-competence-index').hasText('1.1');
     assert.dom('.certification-info-competence-level').hasText('Niveau : 3');
     assert.dom('.certification-info-competence-score').hasText('30 Pix');
   });
 
   test('it should display 16 entries in edition mode', async function(assert) {
-    // Given
+    // given
     this.set('competences', [{ index:'1.1', score:'30', level:'3' }, { index:'2.1', score:'30', level:'3' }, { index:'5.2', score:'30', level:'3' }]);
 
-    // When
-    await render(hbs`{{certification-info-competences competences=competences edition=true}}`);
+    // when
+    await render(hbs`<CertificationInfoCompetences @competences={{this.competences}} @edition={{true}} />`);
 
-    // Then
+    // then
     assert.dom('.certification-info-field').exists({ count:16 });
   });
 
   test('it should display competence levels and scores at the right places in edition mode', async function(assert) {
-    // Given
+    // given
     this.set('competences', [{ index:'1.1', score:'30', level:'3' }, { index:'2.1', score:'16', level:'2' }, { index:'5.2', score:'42', level:'5' }]);
-    assert.expect(6);
 
-    // When
-    await render(hbs`{{certification-info-competences competences=competences edition=true}}`);
+    // when
+    await render(hbs`<CertificationInfoCompetences @competences={{this.competences}} @edition={{true}} />`);
 
-    // Then
+    // then
     assert.dom('#certification-info-score_0').hasValue('30');
     assert.dom('#certification-info-level_0').hasValue('3');
     assert.dom('#certification-info-score_3').hasValue('16');

--- a/admin/tests/integration/components/certification-status-select-test.js
+++ b/admin/tests/integration/components/certification-status-select-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | certification-status-select', function(hooks) 
 
       test('it renders the select', async function(assert) {
         // when
-        await render(hbs`{{certification-status-select edition=true}}`);
+        await render(hbs`<CertificationStatusSelect @edition={{true}} />`);
 
         // then
         assert.dom('.certification-status-select select').exists();
@@ -49,7 +49,7 @@ module('Integration | Component | certification-status-select', function(hooks) 
         // given
         const certification = EmberObject.create({ status: 'started' });
         this.set('certification', certification);
-        await render(hbs`{{certification-status-select edition=true value=certification.status}}`);
+        await render(hbs`<CertificationStatusSelect @edition={{true}} @value={{certification.status}} />`);
 
         // when
         await xselect.select('validated');


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, de nombreuses erreurs existent dans les templates (linter hbs).

## :robot: Solution
Effectuer la correction de ces erreurs.

## :rainbow: Remarques
* Trois templates contiennent un marqueur pour désactiver la `no-action rule`.
* Le composant [emberx-select](https://www.npmjs.com/package/emberx-select) est utilisé dans Pix Admin. Il n'est pas Octane compatible, et n'est pas maintenu depuis 2 ans.

## :100: Pour tester
Exécuter le linter `npm run lint`.

: warning: Il est nécessaire d'effectuer une recette fonctionnelle générale de Pix Admin.