### PR TITLE
[BUGFIX] Rollback Ember lint compatibilité (PIX-890)

### DIFF
--- a/admin/app/components/certification-details-competence.js
+++ b/admin/app/components/certification-details-competence.js
@@ -2,30 +2,37 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 
-export default Component.extend({
+export default class CertificationDetailsCompetence extends Component {
 
   // Elements
-  classNames: ['card', 'border-primary', 'certification-details-competence'],
+  classNames = ['card', 'border-primary', 'certification-details-competence'];
 
   // Properties
-  competence: null,
-  rate: 0,
-  juryRate: false,
+  competence = null;
+  rate = 0;
+  juryRate = false;
 
   // Computed properties
-  certifiedWidth: computed('competence', function() {
+  @computed('competence')
+  get certifiedWidth() {
     const obtainedLevel = this.competence.obtainedLevel;
     return htmlSafe('width:' + Math.round((obtainedLevel / 8) * 100) + '%');
-  }),
-  positionedWidth: computed('competence', function() {
+  }
+
+  @computed('competence')
+  get positionedWidth() {
     const positionedLevel = this.competence.positionedLevel;
     return htmlSafe('width:' + Math.round((positionedLevel / 8) * 100) + '%');
-  }),
-  answers: computed('competence', function() {
+  }
+
+  @computed('competence')
+  get answers() {
     const competence = this.competence;
     return competence.answers;
-  }),
-  competenceJury: computed('juryRate', function() {
+  }
+
+  @computed('juryRate')
+  get competenceJury() {
     const juryRate = this.juryRate;
     const competence = this.competence;
     if (juryRate === false) {
@@ -48,10 +55,10 @@ export default Component.extend({
       competence.juryLevel = false;
       return false;
     }
-  }),
+  }
 
   // Private methods
-  _computeScore: function(rate) {
+  _computeScore(rate) {
     if (rate < 50) {
       return { score: 0, level: -1 };
     }
@@ -109,4 +116,4 @@ export default Component.extend({
         return { score: 0, level: -1 };
     }
   }
-});
+}

--- a/admin/app/components/certification-info-competences.js
+++ b/admin/app/components/certification-info-competences.js
@@ -1,19 +1,25 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-export default Component.extend({
+export default class CertificationInfoCompetence extends Component {
 
   // Elements
-  classNames: ['certification-info-competences'],
-
-  // Properties
-  init() {
-    this._super();
-    this.set('competenceList', ['1.1', '1.2', '1.3', '2.1', '2.2', '2.3', '2.4', '3.1', '3.2', '3.3', '3.4', '4.1', '4.2', '4.3', '5.1', '5.2']);
-  },
+  classNames = ['certification-info-competences'];
+  //Actions
+  actions = {
+    onScoreChange(index, event) {
+      const list = this.competenceList;
+      this.onUpdateScore(list[index], event.target.value);
+    },
+    onLevelChange(index, event) {
+      const list = this.competenceList;
+      this.onUpdateLevel(list[index], event.target.value);
+    }
+  }
 
   // Computed properties
-  indexedValues: computed('competences', function() {
+  @computed('competences')
+  get indexedValues() {
     const competences = this.competences;
     const indexedCompetences = competences.reduce((result, value) => {
       result[value.index] = value;
@@ -32,17 +38,11 @@ export default Component.extend({
       scores: scores,
       levels: levels
     };
-  }),
-
-  //Actions
-  actions: {
-    onScoreChange(index, event) {
-      const list = this.competenceList;
-      this.onUpdateScore(list[index], event.target.value);
-    },
-    onLevelChange(index, event) {
-      const list = this.competenceList;
-      this.onUpdateLevel(list[index], event.target.value);
-    }
   }
-});
+
+  // Properties
+  init() {
+    super.init();
+    this.set('competenceList', ['1.1', '1.2', '1.3', '2.1', '2.2', '2.3', '2.4', '3.1', '3.2', '3.3', '3.4', '4.1', '4.2', '4.3', '5.1', '5.2']);
+  }
+}

--- a/admin/app/components/confirm-popup.js
+++ b/admin/app/components/confirm-popup.js
@@ -1,3 +1,4 @@
 import Component from '@ember/component';
 
-export default Component.extend({});
+export default class ConfirmPopup extends Component {
+}

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-action --}}
 <div class="certification-informations">
   <div class="row">
     <div class="col">
@@ -93,7 +94,7 @@
   <ConfirmPopup
           @message={{this.confirmMessage}}
           @error={{this.confirmErrorMessage}}
-          @confirm={{this.confirmAction}}
-          @cancel={{this.onCancelConfirm}}
+          @confirm={{action this.confirmAction}}
+          @cancel={{action this.onCancelConfirm}}
           @show={{this.displayConfirm}} />
 </div>

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-action --}}
 <div class="certification-list-page">
 
   <header class="certification-list-page__header">
@@ -31,6 +32,6 @@
 </div>
 
 <ConfirmPopup @message={{this.confirmMessage}}
-              @confirm={{this.toggleSessionPublication}}
-              @cancel={{this.onCancelConfirm}}
+              @confirm={{action this.toggleSessionPublication}}
+              @cancel={{action this.onCancelConfirm}}
               @show={{this.displayConfirm}} />


### PR DESCRIPTION
## :unicorn: Problème
Certains fichiers modifiés dans la PR #1552 (fix lint), ne fonctionnent pas avec la notation Octane.

## :robot: Solution
Revenir en arrière et désactiver le linter pour ces fichiers.

## :rainbow: Remarques
Potentiel problèmes sur des montées de version d'Ember

## :100: Pour tester
Mettre à jour une certification dans admin
