### PR TITLE
[BUGFIX] Vérifier qu'un membre désactivé n'accede pas aux routes de campagnes (PIX-857).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -180,18 +180,19 @@ module.exports = {
     return { models: campaignsWithReports, meta: { ...pagination, hasCampaigns } };
   },
 
-  checkIfUserOrganizationHasAccessToCampaign(campaignId, userId) {
-    return BookshelfCampaign
-      .query((qb) => {
-        qb.where({ 'campaigns.id': campaignId, 'memberships.userId': userId });
-        qb.innerJoin('memberships', 'memberships.organizationId', 'campaigns.organizationId');
-        qb.innerJoin('organizations', 'organizations.id', 'campaigns.organizationId');
-      })
-      .fetch({
-        require: true,
-      })
-      .then(() => true)
-      .catch(() => false);
+  async checkIfUserOrganizationHasAccessToCampaign(campaignId, userId) {
+    try {
+      await BookshelfCampaign
+        .query((qb) => {
+          qb.where({ 'campaigns.id': campaignId, 'memberships.userId': userId, 'memberships.disabledAt': null });
+          qb.innerJoin('memberships', 'memberships.organizationId', 'campaigns.organizationId');
+          qb.innerJoin('organizations', 'organizations.id', 'campaigns.organizationId');
+        })
+        .fetch({ require: true });
+    } catch (e) {
+      return false;
+    }
+    return true;
   },
 
   async checkIfCampaignIsArchived(campaignId) {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -532,7 +532,7 @@ describe('Integration | Repository | Campaign', () => {
   });
 
   describe('#checkIfUserOrganizationHasAccessToCampaign', () => {
-    let userId, ownerId, organizationId, forbiddenUserId, forbiddenOrganizationId, campaignId;
+    let userId, ownerId, organizationId, userWithDisabledMembershipId, forbiddenUserId, forbiddenOrganizationId, campaignId;
     beforeEach(async () => {
 
       // given
@@ -544,6 +544,9 @@ describe('Integration | Repository | Campaign', () => {
       forbiddenUserId = databaseBuilder.factory.buildUser().id;
       forbiddenOrganizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({ userId: forbiddenUserId, organizationId: forbiddenOrganizationId });
+
+      userWithDisabledMembershipId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({ userId: userWithDisabledMembershipId, organizationId, disabledAt: new Date('2020-01-01') });
 
       campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
 
@@ -561,6 +564,14 @@ describe('Integration | Repository | Campaign', () => {
     it('should return false when the user is not a member of an organization that owns campaign', async () => {
       //when
       const access = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, forbiddenUserId);
+
+      //then
+      expect(access).to.be.false;
+    });
+
+    it('should return false when the user is a disabled membership of the organization that owns campaign', async () => {
+      //when
+      const access = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userWithDisabledMembershipId);
 
       //then
       expect(access).to.be.false;


### PR DESCRIPTION
## :unicorn: Problème
Quand un membre d'une organisation est désactivé, il peut toujours accéder à certaines routes de campagnes (archivage...)

## :robot: Solution
Ajouter une condition dans la méthode `checkIfUserOrganizationHasAccessToCampaign` en prenant en compte que le membre est désactivé.

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Se connecter à PIX-ORGA et désactiver un membre sur l'organisation
3. Essayer d'archiver une campagne avec ce membre en exécutant directement une requête API d'archivage sur une campagne de la l'organisation.
