### PR TITLE
[FEATURE] Ajout d'un email de récupération pour les organisations (PIX-843).

### DIFF
--- a/api/db/migrations/20200625113402_add-column-email-to-organizations.js
+++ b/api/db/migrations/20200625113402_add-column-email-to-organizations.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'email';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la mise en place d'un accès simplifié à Pix Orga, nous avons besoin de stocker pour chaque organisation SCO un email de récupération.

## :robot: Solution
Ajout d'une colonne `email` dans la table `organizatons`.

## :100: Pour tester
Vérifier la présence de la colonne en base de données.