### PR TITLE
[BUGFIX] Corriger le pourcentage de la barre de progression lorsque la compétence est retentée (PIX-841).

### DIFF
--- a/api/lib/domain/usecases/get-progression.js
+++ b/api/lib/domain/usecases/get-progression.js
@@ -39,11 +39,15 @@ module.exports = async function getProgression(
       skillRepository.findByCompetenceId(competenceEvaluation.competenceId),
       knowledgeElementRepository.findUniqByUserId({ userId })]
     );
+    const knowledgeElementsForProgression = await improvementService.filterKnowledgeElementsIfImproving({
+      knowledgeElements,
+      assessment
+    });
 
     progression = new Progression({
       id: progressionId,
       targetedSkills,
-      knowledgeElements,
+      knowledgeElements: knowledgeElementsForProgression,
       isProfileCompleted: assessment.isCompleted()
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on retente une compétence, la barre de progression au checkpoint est toujours à 100%.

## :robot: Solution
Filtrer les KE des challenges déjà passés pour n'avoir que les KE à retenter.

## :100: Pour tester
- Retenter une compétence
- Arrivé au checkpoint: la barre de progression n'est plus à 100% si on est pas au bout du challenge
