### PR TITLE
[FEATURE] Alimenter les adresses e-mail des organisations (PIX-874).

### DIFF
--- a/api/scripts/populate-organizations-email.js
+++ b/api/scripts/populate-organizations-email.js
@@ -1,0 +1,62 @@
+const bluebird = require('bluebird');
+
+const { NotFoundError } = require('../lib/domain/errors');
+
+const { parseCsvWithHeader } = require('../scripts/helpers/csvHelpers');
+
+const BookshelfOrganization = require('../lib/infrastructure/data/organization');
+
+async function updateOrganizationEmailByExternalId(externalId, email) {
+  return BookshelfOrganization
+    .where({ externalId })
+    .save({ email }, { patch: true })
+    .catch((err) => {
+      if (err instanceof BookshelfOrganization.NotFoundError) {
+        throw new NotFoundError(`Organization not found for External ID ${externalId}`);
+      }
+      throw err;
+    });
+}
+
+async function populateOrganizations(objectsFromFile) {
+  return bluebird.mapSeries(objectsFromFile, ({ uai, email }) => {
+    return updateOrganizationEmailByExternalId(uai, email);
+  });
+}
+
+async function main() {
+  console.log('Start populating organization\'s email');
+
+  try {
+    const filePath = process.argv[2];
+
+    if (!filePath) {
+      console.log('Usage: populate-organizations-email.js <FILE_NAME>.csv');
+      process.exit(1);
+    }
+
+    console.log('Reading and parsing csv file (checking headers)... ');
+    const csvData = parseCsvWithHeader(filePath);
+    console.log(`Successfully read ${csvData.length} records.`);
+
+    console.log('Populating organizations (existing emails will be updated)... ');
+    await populateOrganizations(csvData);
+    console.log('\nOrganization successfully populated.');
+
+  } catch (error) {
+    console.error('\n', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = populateOrganizations;

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -13,7 +13,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
   const USER_PICKED_PROPERTIES = ['id', 'firstName', 'lastName', 'email', 'username', 'password', 'cgu',
     'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted'];
 
-  const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares',
+  const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'email',
     'createdAt', 'updatedAt'];
 
   let user;

--- a/api/tests/integration/scripts/populate-organizations-email_test.js
+++ b/api/tests/integration/scripts/populate-organizations-email_test.js
@@ -1,0 +1,35 @@
+const { expect, databaseBuilder, knex } = require('../../test-helper');
+
+const populateOrganizations = require('../../../scripts/populate-organizations-email');
+
+describe('Integration | Scripts | populate-organizations-email.js', () => {
+
+  describe('#populateOrganizations', () => {
+
+    const externalId1 = 'uai1';
+    const externalId2 = 'uai2';
+
+    beforeEach(async () => {
+      databaseBuilder.factory.buildOrganization({ externalId: externalId1, email: 'first.last@example.net' });
+      databaseBuilder.factory.buildOrganization({ externalId: externalId2 });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should populate organization\'s email', async () => {
+      // given
+      const csvData = [
+        { uai: 'uai1', email: 'uai1@example.net' },
+        { uai: 'uai2', email: 'uai2@example.net' },
+      ];
+
+      // when
+      await populateOrganizations(csvData);
+
+      // then
+      const organizations = await knex('organizations').select('externalId as uai', 'email');
+      expect(organizations).to.have.deep.members(csvData);
+    });
+
+  });
+});

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -15,7 +15,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       // given
       const externalId = '1234567A';
       const organization = databaseBuilder.factory.buildOrganization({ externalId });
-      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt']);
+      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email']);
 
       await databaseBuilder.commit();
 

--- a/api/tests/tooling/database-builder/factory/build-organization.js
+++ b/api/tests/tooling/database-builder/factory/build-organization.js
@@ -13,6 +13,7 @@ const buildOrganization = function buildOrganization({
   canCollectProfiles = false,
   createdAt = faker.date.recent(),
   updatedAt = faker.date.recent(),
+  email
 } = {}) {
 
   const values = {
@@ -25,6 +26,7 @@ const buildOrganization = function buildOrganization({
     isManagingStudents,
     credit,
     canCollectProfiles,
+    email,
     createdAt,
     updatedAt,
   };


### PR DESCRIPTION
## :unicorn: Problème
Afin de permettre la continuité pédagogique, le professeur qui remplaçe celui qui tenait le rôle d'administrateur de PixOrga doit pouvoir obtenir un rôle administrateur. Cela doit pouvoir se faire sans intervention du professeur précédent. 

## :robot: Solution
Envoyer une demande de rattachement, via PixOrga, à une adresse email générique, accessible à l'organisation.
La liste des adresses génériques est fournie pour initialisation, elle sera chargée par un script qui est l'objet de cette PR.

## :rainbow: Remarques
Le fichier de données doit contenir l'UAI de l'organisation et l'adresse e-mail.
Le script sera lancé en ligne de commande en production.
Une vérification des en-têtes est effectuée.
L'adresse e-mail, si elle existe, sera remplacée.

## :100: Pour tester
Créer un fichier nommé organization-email.csv
>uai;email
>AUT;uai1@example.net
>NESCIUNT;uai2@example.net

Exécuter la commande CLI
```shell
scalingo -app pix-api-review-pr1567 run --file organization-email.csv node scripts/populate-organizations-email.js /tmp/uploads/organization-email.csv
```

Vérifier les résultats
```sql
select "externalId","email" FROM organizations;
```