### PR TITLE
[FEATURE] Cacher le bouton Retenter quand l'utilisateur a terminé une compétence avec le niveau max (PIX-759).

### DIFF
--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -20,6 +20,10 @@ export default class ScorecardDetails extends Component {
     return !(this.args.scorecard.isFinished || this.args.scorecard.isMaxLevel || this.args.scorecard.isNotStarted);
   }
 
+  get canImprove() {
+    return !this.args.scorecard.isFinishedWithMaxLevel;
+  }
+
   get displayWaitSentence() {
     return this.args.scorecard.remainingDaysBeforeReset > 0;
   }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -55,7 +55,8 @@
     padding: 14px 14px 0 14px;
   }
 
-  &__resume-or-start-button {
+  &__resume-or-start-button,
+  &__improve-button {
     margin-top: 30px;
   }
 

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -59,11 +59,13 @@
 
       {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
-          <button class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button" {{action "improveCompetenceEvaluation"}}>
-            Retenter
-            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
-          </button>
-          <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
+          {{#if this.canImprove}}
+            <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action "improveCompetenceEvaluation"}}>
+              Retenter
+              <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+            </button>
+            <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
+          {{/if}}
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume"

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -10,22 +10,22 @@
 
   <div class="scorecard-details__content">
     <div class="scorecard-details-content__left">
-      <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{this.args.scorecard.area.color}}">
-        {{this.args.scorecard.area.title}}
+      <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{@scorecard.area.color}}">
+        {{@scorecard.area.title}}
       </div>
       <h3 class="scorecard-details-content-left__name">
-        {{this.args.scorecard.name}}
+        {{@scorecard.name}}
       </h3>
       <div class="scorecard-details-content-left__description">
-        {{this.args.scorecard.description}}
+        {{@scorecard.description}}
       </div>
     </div>
 
     <div class="scorecard-details-content__right">
 
-      {{#unless this.args.scorecard.isNotStarted}}
+      {{#unless @scorecard.isNotStarted}}
         <div class="scorecard-details-content-right__score-container">
-          {{#if this.args.scorecard.isFinishedWithMaxLevel}}
+          {{#if @scorecard.isFinishedWithMaxLevel}}
             <div class="competence-card__congrats">
               <div class="competence-card__level competence-card__level--congrats">
                 <span class="score-label competence-card__score-label--congrats">Niveau</span>
@@ -33,8 +33,8 @@
               </div>
             </div>
           {{else}}
-            <CircleChart @value={{this.args.scorecard.percentageAheadOfNextLevel}}
-                         @sliceColor={{this.args.scorecard.area.color}}
+            <CircleChart @value={{@scorecard.percentageAheadOfNextLevel}}
+                         @sliceColor={{@scorecard.area.color}}
                          @chartClass="circle-chart__content--big"
                          @thicknessClass="circle--thick">
               <div class="competence-card__level">
@@ -46,43 +46,43 @@
 
           <div class="scorecard-details-content-right-score-container__pix-earned">
             <div class="score-label">pix</div>
-            <div class="score-value">{{replace-zero-by-dash this.args.scorecard.earnedPix}}</div>
+            <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
         </div>
       {{/unless}}
 
       {{#if this.isProgressable}}
         <div class="scorecard-details-content-right__level-info">
-          {{this.args.scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc this.args.scorecard.level}}
+          {{@scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc @scorecard.level}}
         </div>
       {{/if}}
 
-      {{#if this.args.scorecard.isFinished}}
+      {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
           <button class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button" {{action "improveCompetenceEvaluation"}}>
             Retenter
-            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
           </button>
           <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume"
-                @model={{this.args.scorecard.competenceId}}
+                @model={{@scorecard.competenceId}}
                 class={{concat "button button--big button--thin button--round button--link button--green "
-                               (if this.args.scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
-          {{#if this.args.scorecard.isStarted}}
+                               (if @scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
+          {{#if @scorecard.isStarted}}
             Reprendre
-            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
           {{else}}
             Commencer
-            <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
           {{/if}}
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
         <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
           Remettre à zéro
-          <div class="sr-only">la compétence "{{this.args.scorecard.name}}"</div>
+          <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
         </button>
       {{else if this.displayWaitSentence}}
         <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
@@ -124,15 +124,15 @@
     <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
       <div class="pix-modal-header">
         <h1 class="pix-modal-header__title pix-modal-header__title--thin">Remise à zéro de la compétence</h1>
-        <h2 class="pix-modal-header__subtitle">{{this.args.scorecard.name}}</h2>
+        <h2 class="pix-modal-header__subtitle">{{@scorecard.name}}</h2>
       </div>
 
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="scorecard-details-reset-modal__important-message">
-          {{#if this.args.scorecard.hasNotReachLevelOne}}
-            Vos {{this.args.scorecard.earnedPix}} Pix vont être supprimés.
-          {{else if this.args.scorecard.hasReachAtLeastLevelOne}}
-            Votre niveau {{this.args.scorecard.level}} et vos {{this.args.scorecard.earnedPix}} Pix vont être supprimés.
+          {{#if @scorecard.hasNotReachLevelOne}}
+            Vos {{@scorecard.earnedPix}} Pix vont être supprimés.
+          {{else if @scorecard.hasReachAtLeastLevelOne}}
+            Votre niveau {{@scorecard.level}} et vos {{@scorecard.earnedPix}} Pix vont être supprimés.
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -5,6 +5,7 @@ import { setupRenderingTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import config from '../../../config/environment';
 
 describe('Integration | Component | scorecard-details', function() {
   setupRenderingTest();
@@ -98,6 +99,11 @@ describe('Integration | Component | scorecard-details', function() {
     });
 
     context('When the user has finished a competence', async function() {
+      const configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+      afterEach(function() {
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
+      });
+
       beforeEach(async function() {
         // given
         const scorecard = {
@@ -109,6 +115,7 @@ describe('Integration | Component | scorecard-details', function() {
         this.set('scorecard', scorecard);
 
         // when
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
         await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
       });
 
@@ -120,6 +127,11 @@ describe('Integration | Component | scorecard-details', function() {
       it('should not display a button', async function() {
         // then
         expect(find('.scorecard-details__resume-or-start-button')).to.not.exist;
+      });
+
+      it('should show the improving button', function() {
+        // then
+        expect(find('.scorecard-details__improve-button')).to.exist;
       });
 
       context('and the user has reached the max level', async function() {
@@ -146,6 +158,11 @@ describe('Integration | Component | scorecard-details', function() {
         it('should show congrats design', function() {
           // then
           expect(find('.competence-card__congrats')).to.exist;
+        });
+
+        it('should not show the improving button', function() {
+          // then
+          expect(find('.scorecard-details__improve-button')).to.not.exist;
         });
       });
     });

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -62,6 +62,24 @@ describe('Unit | Component | scorecard-details ', function() {
     });
   });
 
+  describe('#canImprove', function() {
+    it('returns true if maxlevel not reached', function() {
+      // when
+      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isFinishedWithMaxLevel: false } });
+
+      // then
+      expect(component.canImprove).to.equal(true);
+    });
+
+    it('returns false if maxlevel reached', function() {
+    // when
+      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isFinishedWithMaxLevel: true } });
+
+      // then
+      expect(component.canImprove).to.equal(false);
+    });
+  });
+
   describe('#tutorialsGroupedByTubeName', function() {
     it('returns an array of tubes with related tutorials', function() {
       // given


### PR DESCRIPTION
## :unicorn: Problème
On ne veut pas afficher le bouton Retenter quand la compétence est terminée avec le niveau max.

## :robot: Solution
Cacher le bouton si le niveau max est atteint.

## :rainbow: Remarques
🐬 On a nettoyé le hbs en remplaçant `this.args` par `@` dans le .hbs
🐬 On a crée une nouvelle classe CSS pour tester vs. utiliser le helper `.contains` : 
- faciliter plus tard la traduction 
- faciliter le tracking sur Matomo


## :100: Pour tester
Terminer une compétence avec le niveau 5 et constater que le bouton n'est pas affiché sur la carte et la page de détails.
Terminer une compétence avec un niveau inférieur et constater que le bouton est affiché sur la carte et la page de détails.
