### PR TITLE
[FEATURE] Afficher l'email de l'organisation dans Pix Admin (PIX-844).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -82,6 +82,7 @@
             {{#if @organization.isOrganizationSCO}}
               Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
             {{/if}}
+            Adresse e-mail: <span class ="organization'__email">{{@organization.email}}</span><br>
             A accès aux campagnes de collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
             Crédits : <span class="organization__credit">{{@organization.credit}}</span>
           </p>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -12,6 +12,7 @@ export default class Organization extends Model {
   @attr() isManagingStudents;
   @attr() canCollectProfiles;
   @attr() credit;
+  @attr() email;
 
   @equal('type', 'SCO') isOrganizationSCO;
 

--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -17,7 +17,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     name: 'The Night Watch',
     isManagingStudents: true,
     canCollectProfiles: true,
-    email: 'generic.account@sco.net'
+    email: 'sco.generic.account@example.net'
   });
   databaseBuilder.factory.buildMembership({
     userId: 4,

--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -11,13 +11,13 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     organizationId: 2,
     organizationRole: Membership.roles.ADMIN,
   });
-
   databaseBuilder.factory.buildOrganization({
     id: 3,
     type: 'SCO',
     name: 'The Night Watch',
     isManagingStudents: true,
     canCollectProfiles: true,
+    email: 'generic.account@sco.net'
   });
   databaseBuilder.factory.buildMembership({
     userId: 4,

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -11,6 +11,7 @@ class Organization {
     isManagingStudents,
     credit,
     canCollectProfiles,
+    email,
     // includes
     memberships = [],
     targetProfileShares = [],
@@ -28,6 +29,7 @@ class Organization {
     this.isManagingStudents = isManagingStudents;
     this.credit = credit;
     this.canCollectProfiles = canCollectProfiles;
+    this.email = email;
     // includes
     this.memberships = memberships;
     this.targetProfileShares = targetProfileShares;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -19,6 +19,7 @@ function _toDomain(bookshelfOrganization) {
     isManagingStudents: Boolean(rawOrganization.isManagingStudents),
     credit: rawOrganization.credit,
     canCollectProfiles: Boolean(rawOrganization.canCollectProfiles),
+    email: rawOrganization.email
   });
 
   let members = [];

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
         record.targetProfiles = [];
         return record;
       },
-      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'memberships', 'students', 'targetProfiles'],
+      attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles'],
       memberships: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -524,6 +524,7 @@ describe('Acceptance | Application | organization-controller', () => {
           provinceCode: '45',
           isManagingStudents: true,
           credit: 666,
+          email: 'generic.account@sco.net'
         });
 
         await databaseBuilder.commit();
@@ -549,6 +550,7 @@ describe('Acceptance | Application | organization-controller', () => {
               'is-managing-students': organization.isManagingStudents,
               'can-collect-profiles': organization.canCollectProfiles,
               'credit': organization.credit,
+              'email': organization.email,
             },
             'id': organization.id.toString(),
             'relationships': {

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -524,7 +524,7 @@ describe('Acceptance | Application | organization-controller', () => {
           provinceCode: '45',
           isManagingStudents: true,
           credit: 666,
-          email: 'generic.account@sco.net'
+          email: 'sco.generic.account@example.net'
         });
 
         await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -118,6 +118,7 @@ describe('Integration | Repository | Organization', function() {
         provinceCode: '75',
         isManagingStudents: 'true',
         canCollectProfiles: 'true',
+        email: 'generic.account@sco.net'
       };
 
       let expectedAttributes;
@@ -134,6 +135,7 @@ describe('Integration | Repository | Organization', function() {
           provinceCode: '75',
           isManagingStudents: true,
           canCollectProfiles: true,
+          email: 'generic.account@sco.net',
           members: [],
           memberships: [],
           students: [],

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -118,7 +118,7 @@ describe('Integration | Repository | Organization', function() {
         provinceCode: '75',
         isManagingStudents: 'true',
         canCollectProfiles: 'true',
-        email: 'generic.account@sco.net'
+        email: 'sco.generic.account@example.net'
       };
 
       let expectedAttributes;
@@ -135,7 +135,7 @@ describe('Integration | Repository | Organization', function() {
           provinceCode: '75',
           isManagingStudents: true,
           canCollectProfiles: true,
-          email: 'generic.account@sco.net',
+          email: 'sco.generic.account@example.net',
           members: [],
           memberships: [],
           students: [],

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -23,7 +23,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       const result = await getOrganizationByExternalId(externalId);
 
       // then
-      expect(_.omit(result, ['memberships', 'organizationInvitations', 'students', 'targetProfileShares']))
+      expect(_.omit(result, ['email', 'memberships', 'organizationInvitations', 'students', 'targetProfileShares']))
         .to.deep.equal(expectedOrganization);
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -37,11 +37,12 @@ function buildOrganization(
     isManagingStudents = false,
     credit = 500,
     canCollectProfiles = false,
+    email,
     createdAt = new Date('2018-01-12T01:02:03Z'),
     memberships = [],
     targetProfileShares = []
   } = {}) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, canCollectProfiles, createdAt, memberships, targetProfileShares });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, email, canCollectProfiles, createdAt, memberships, targetProfileShares });
 }
 
 buildOrganization.withMembers = function(

--- a/api/tests/unit/domain/usecases/get-organization-details_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-details_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-organization-details', () => {
   it('should return the Organization matching the given organization ID', () => {
     // given
     const organizationId = 1234;
-    const foundOrganization = domainBuilder.buildOrganization({ id: organizationId, email: 'generic.account@sco.net' });
+    const foundOrganization = domainBuilder.buildOrganization({ id: organizationId, email: 'sco.generic.account@example.net' });
     const organizationRepository = {
       get: sinon.stub().resolves(foundOrganization)
     };

--- a/api/tests/unit/domain/usecases/get-organization-details_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-details_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-organization-details', () => {
   it('should return the Organization matching the given organization ID', () => {
     // given
     const organizationId = 1234;
-    const foundOrganization = domainBuilder.buildOrganization({ id: organizationId });
+    const foundOrganization = domainBuilder.buildOrganization({ id: organizationId, email: 'generic.account@sco.net' });
     const organizationRepository = {
       get: sinon.stub().resolves(foundOrganization)
     };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -7,7 +7,7 @@ describe('Unit | Serializer | organization-serializer', () => {
 
     it('should return a JSON API serialized organization', () => {
       // given
-      const organization = domainBuilder.buildOrganization();
+      const organization = domainBuilder.buildOrganization({ email: 'generic.account@sco.net' });
       const meta = { some: 'meta' };
       // when
       const serializedOrganization = serializer.serialize(organization, meta);
@@ -25,7 +25,8 @@ describe('Unit | Serializer | organization-serializer', () => {
             'province-code': organization.provinceCode,
             'is-managing-students': organization.isManagingStudents,
             'credit': organization.credit,
-            'can-collect-profiles': organization.canCollectProfiles
+            'can-collect-profiles': organization.canCollectProfiles,
+            'email': organization.email
           },
           relationships: {
             memberships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-serializer_test.js
@@ -7,7 +7,7 @@ describe('Unit | Serializer | organization-serializer', () => {
 
     it('should return a JSON API serialized organization', () => {
       // given
-      const organization = domainBuilder.buildOrganization({ email: 'generic.account@sco.net' });
+      const organization = domainBuilder.buildOrganization({ email: 'sco.generic.account@example.net' });
       const meta = { some: 'meta' };
       // when
       const serializedOrganization = serializer.serialize(organization, meta);


### PR DESCRIPTION
## :unicorn: Problème
Afin de permettre la continuité pédagogique, le professeur qui remplaçe celui qui tenait le rôle d'administrateur de PixOrga doit pouvoir obtenir un rôle administrateur. Cela doit pouvoir se faire sans intervention du professeur précédent. 

Le but est d'envoyer une demande de rattachement, via PixOrga, à une adresse email générique, accessible à l'organisation.
Cette adresse email générique a été initilisée dans la PR #1567 
Si cette adresse email est incorrecte, le support sera contacté, et il doit pouvoir vérifier si c'est le cas.

## :robot: Solution
Afficher l'adresse mail de l'organization dans PixAdmin

## :100: Pour tester
Etapes:
* localiser une organisation possédant une adresse, par exemple The Night Watch 
`SELECT  id, name, email FROM organizations WHERE email IS NOT NULL; `
* se rendre sur [la page de détail](https://admin-pr1571.review.pix.fr/organizations/3/members) de cette organisation
* vérifier que l'adresse est correcte (champ `Adresse e-mail`)