### PR TITLE
[BUGFIX] Correction de l'affichage du macaron Cléa sur la certif (PIX-879)

### DIFF
--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -1,7 +1,5 @@
 .certification-joiner {
   margin-top: 32px;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
 
   &__label {
     color: rgb(88, 95, 117);
@@ -15,7 +13,7 @@
   &__title {
     color: $grey-100;
     font-family: $font-open-sans;
-    font-size: 2.625rem;
+    font-size: 2rem;
     font-weight: $font-light;
     text-align: center;
     margin-bottom: 32px;
@@ -48,9 +46,9 @@
     width: 100%;
     height: 50px;
     border-radius: 4px;
-    border: 2px solid rgb(221, 221, 221);
+    border: 2px solid $grey-20;
     padding-left: 10px;
-    margin-bottom: 20px;
+    margin-bottom: 16px;
     min-width: 0px;
 
     &:hover {
@@ -63,7 +61,7 @@
   }
 
   button {
-    margin: 24px 0 0 0;
+    margin-top: 8px;
     width: 100%;
   }
 

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -15,11 +15,12 @@
 .congratulations-banner__icon {
   color: $white;
   position: absolute;
-  top: 8px;
-  right: 10px;
+  top: 12px;
+  right: 12px;
+  display: flex;
   left: auto;
   bottom: auto;
-  font-size: 0.625rem;
+  font-size: 1.25rem;
   cursor: pointer;
   opacity: .5;
   &:hover, &:active {
@@ -31,7 +32,7 @@
   color: $grey-10;
   font-weight: $font-normal;
   font-family: $font-open-sans;
-  line-height: 0.875em;
-  font-size: 1.5em;
+  font-size: 1.5rem;
+  line-height: 2rem;
   text-align: center;
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -27,53 +27,6 @@
     margin-top: calc(25px + 8px);
   }
 
-  &__pix-score{
-    margin-bottom: 0.781rem;
-    width: 16.875rem;
-  }
-
-  &__badge-pix-score{
-    width: 8.125rem;
-    height: 8.125rem;
-    padding-top: 2.938rem;
-    float: left;
-
-    background: url('/images/pix-pastille-certif.svg') no-repeat;
-    background-size: cover;
-
-    text-align: center;
-    display: table;
-
-    span {
-      height: 1.094rem;
-      width: 1.756rem;
-      color: $grey-70;
-      font-size: 1.875rem;
-      font-weight: bold;
-      line-height: 1.288rem;
-      text-align: center;
-
-    }
-  }
-
-  &__pix-certified {
-    color: $grey-70;
-    font-size: 1.563rem;
-    font-weight: bold;
-    line-height: 1.094rem;
-    margin-top: 3rem;
-    text-align: right;
-  }
-
-  &__separation{
-    clear: both;
-    position: absolute;
-    height: 8.75rem;
-    margin-top: 0.5rem;
-    width : 0.156rem;
-    background: black;
-  }
-
   &__text-pix-certified {
     padding-left: 0.781rem;
 
@@ -82,8 +35,7 @@
     border-left-width: 3px;
   }
 
-  &__badge {
-    max-width: 250px;
+  &__badge-clea {
     align-self: center;
   }
 
@@ -101,15 +53,5 @@
     width: 100%;
     background-color: $grey-15;
     height: 3px;
-  }
-
-  h3 {
-    color: $grey-70;
-    font-size: larger;
-  }
-
-  p {
-    margin: 0;
-    color: $grey-70;
   }
 }

--- a/mon-pix/app/styles/pages/_certification-start.scss
+++ b/mon-pix/app/styles/pages/_certification-start.scss
@@ -15,5 +15,5 @@
 }
 
 .certification-stepper {
-  padding-bottom: 40px;
+  padding-bottom: 18px;
 }

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -3,52 +3,55 @@
 {{/if}}
 
 <section class="certification-joiner">
-  <div class="certification-joiner__title">Rejoindre une session</div>
+  <h1 class="certification-joiner__title">Rejoindre une session</h1>
     <form autocomplete="off">
         <div class="certification-joiner__row">
-            <label class="certification-joiner__label">Numéro de session</label>
+          <label class="certification-joiner__label" for="certificationJoinerSessionId">Numéro de session</label>
           <Input {{autofocus}} @type="text" @size="6" @value={{this.sessionId}} @id="certificationJoinerSessionId" />
         </div>
         <div class="certification-joiner__row">
-            <label class="certification-joiner__label">Prénom</label>
+          <label class="certification-joiner__label" for="certificationJoinerFirstName">Prénom</label>
           <Input @type="text" @value={{this.firstName}} @id="certificationJoinerFirstName" />
         </div>
         <div class="certification-joiner__row">
-            <label class="certification-joiner__label">Nom de naissance</label>
+          <label class="certification-joiner__label" for="certificationJoinerLastName">Nom de naissance</label>
           <Input @type="text" @value={{this.lastName}} @id="certificationJoinerLastName" />
         </div>
         <div class="certification-joiner__row">
-            <label class="certification-joiner__label">Date de naissance</label>
-            <div class="certification-joiner__birthdate">
-              <Input @min="1"
-                     @max="31"
-                     @type="number"
-                     @value={{this.dayOfBirth}} placeholder="JJ"
-                     @id="certificationJoinerDayOfBirth"
-                     @input={{action "handleDayInputChange"}}
-                     @focus-in={{action "handleInputFocus"}} />
-                <div class="certification-joiner__divider"></div>
-              <Input @min="1"
-                     @max="12"
-                     @type="number"
-                     @value={{this.monthOfBirth}} placeholder="MM"
-                     @id="certificationJoinerMonthOfBirth"
-                     @input={{action "handleMonthInputChange"}}
-                     @focus-in={{action "handleInputFocus"}} />
-                <div class="certification-joiner__divider"></div>
-              <Input @min="1900"
-                     @type="number"
-                     @value={{this.yearOfBirth}} placeholder="AAAA"
-                     @id="certificationJoinerYearOfBirth"
-                     @focus-in={{action "handleInputFocus"}} />
-            </div>
+          <label class="certification-joiner__label" for="certificationJoinerDayOfBirth">Date de naissance</label>
+          <div class="certification-joiner__birthdate" id="certificationJoinerBirthDate">
+            <Input @min="1"
+                    @max="31"
+                    @type="number"
+                    @value={{this.dayOfBirth}} placeholder="JJ"
+                    @id="certificationJoinerDayOfBirth"
+                    @input={{action "handleDayInputChange"}}
+                    @focus-in={{action "handleInputFocus"}}
+                    aria-label="jour de naissance (JJ)" />
+              <div class="certification-joiner__divider"></div>
+            <Input @min="1"
+                    @max="12"
+                    @type="number"
+                    @value={{this.monthOfBirth}} placeholder="MM"
+                    @id="certificationJoinerMonthOfBirth"
+                    @input={{action "handleMonthInputChange"}}
+                    @focus-in={{action "handleInputFocus"}}
+                    aria-label="mois de naissance (MM)"/>
+              <div class="certification-joiner__divider"></div>
+            <Input @min="1900"
+                    @type="number"
+                    @value={{this.yearOfBirth}} placeholder="AAAA"
+                    @id="certificationJoinerYearOfBirth"
+                    @focus-in={{action "handleInputFocus"}}
+                    aria-label="année de naissance (AAAA)"/>
+          </div>
         </div>
       {{#if this.errorMessage}}
           <div class="certification-course-page__errors">{{this.errorMessage}}</div>
       {{/if}}
       {{#if this.isLoading}}
-          <button class="button button--big button--thin certification-course-page__submit_button"><span
-                  class="loader-in-button">&nbsp;</span>
+          <button class="button button--big button--thin certification-course-page__submit_button">
+            <span class="loader-in-button">&nbsp;</span>
           </button>
       {{else}}
           <button type="submit" class="button button--big button--thin certification-joiner__attempt-next-btn" {{ action "attemptNext" }}>

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -1,6 +1,6 @@
 <div class="congratulations-banner" >
-  <div class="icon-button congratulations-banner__icon" {{ action 'closeBanner' }} >
+  <button aria-label="Fermer" class="icon-button congratulations-banner__icon" {{ action 'closeBanner' }} >
     {{fa-icon 'times'}}
-  </div>
-  <h2 class="congratulations-banner__message">Bravo {{@fullName}},<br>votre profil est certifiable.</h2>
+  </button>
+  <p class="congratulations-banner__message">Bravo {{@fullName}},<br>votre profil est certifiable.</p>
 </div>

--- a/mon-pix/app/templates/components/navbar-header.hbs
+++ b/mon-pix/app/templates/components/navbar-header.hbs
@@ -1,7 +1,7 @@
-<div class="navbar-header">
+<nav class="navbar-header">
   {{#if (media 'isDesktop')}}
     <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}}/>
   {{else}}
     <NavbarMobileHeader @burger={{@burger}} @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} />
   {{/if}}
-</div>
+</nav>

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,19 +1,19 @@
-<div class="user-certifications-detail-result__text-pix-certified">
+<p class="user-certifications-detail-result__text-pix-certified">
   Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification.
   Il peut donc différer de votre nombre de Pix affiché dans votre profil.
-</div>
+</p>
 
 {{#if certification.hasCleaCertif}}
   <hr>
   <img src="https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images/badges/CleA_Num_certif.svg" alt="Badge cléA numérique" class="user-certifications-detail-result__badge-clea">
 {{/if}}
 
+<hr>
 <div>
   {{#if certification.commentForCandidate}}
-    <hr>
-    <div class="user-certifications-detail-result__title-comment-jury">Intervention du jury</div>
-    <div class="user-certifications-detail-result__comment-jury">
+    <p class="user-certifications-detail-result__title-comment-jury">Intervention du jury</p>
+    <p class="user-certifications-detail-result__comment-jury">
       {{certification.commentForCandidate}}
-    </div>
+    </p>
   {{/if}}
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Le macaron cléa ne s'affiche pas comme prévu sous IE (trop large) et Edge (trop grand).
![image](https://user-images.githubusercontent.com/38167520/85847376-8d85d080-b7a7-11ea-9fca-9526c76c5f82.png)

## :robot: Solution
Nettoyer les styles obsolètes et corriger le nom de la classe appelée pour l'image.
<img width="1572" alt="image" src="https://user-images.githubusercontent.com/38167520/85847353-83fc6880-b7a7-11ea-844c-81f7f0cb12c6.png">


## :rainbow: Remarques
J'en ai profité pour fixer 2/3 ptits trucs vus avec @QuentinChapelain-ui  : 
- Le line-height & font-size du bandeau vert (sur la page pour rejoindre une session de certif)
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/38167520/85847538-d76eb680-b7a7-11ea-8dc4-63cee7c842ca.png">

- La taille du boutton "X" du bandeau vert
- Les marges entre les inputs
- La sémantique des balises de la même page (pour rejoindre une session de certif) = améliore l'accessibilité de la page


## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
