### PR TITLE
[INFRA] Permettre que les e-mails renvoient vers le bon environnement (PIX-888).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -43,6 +43,7 @@ module.exports = (function() {
       tldFr: process.env.TLD_FR || '.fr',
       tldOrg: process.env.TLD_ORG || '.org',
       pix: process.env.DOMAIN_PIX || 'https://pix',
+      pixApp: process.env.DOMAIN_PIX_APP || 'https://app.pix',
       pixOrga: process.env.DOMAIN_PIX_ORGA || 'https://orga.pix',
     },
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -34,11 +34,6 @@ module.exports = (function() {
       base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
     },
 
-    app: {
-      domainFr: process.env.DOMAIN_NAME_FR || 'pix.fr',
-      domainOrg: process.env.DOMAIN_NAME_ORG || 'pix.org',
-    },
-
     domain: {
       tldFr: process.env.TLD_FR || '.fr',
       tldOrg: process.env.TLD_ORG || '.org',
@@ -136,9 +131,6 @@ module.exports = (function() {
 
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
-
-    config.app.domainFr = 'pix.fr';
-    config.app.domainOrg = 'pix.org';
 
     config.airtable.apiKey = 'test-api-key';
     config.airtable.base = 'test-base';

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -7,16 +7,16 @@ const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
 
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
   let variables = {
-    homeName: `${settings.app.domainFr}`,
-    homeUrl: `https://${settings.app.domainFr}`,
-    redirectionUrl: redirectionUrl || `https://app.${settings.app.domainFr}/connexion`,
+    homeName: `pix${settings.domain.tldFr}`,
+    homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+    redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldFr}/connexion`,
     locale
   };
   if (locale === 'fr') {
     variables = {
-      homeName: `${settings.app.domainOrg}`,
-      homeUrl: `https://${settings.app.domainOrg}`,
-      redirectionUrl: redirectionUrl || `https://app.${settings.app.domainOrg}/connexion`,
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
+      redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion`,
       locale
     };
   }
@@ -33,17 +33,17 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
 function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
   let variables = {
-    homeName: `${settings.app.domainFr}`,
-    homeUrl: `https://${settings.app.domainFr}`,
-    resetUrl: `https://app.${settings.app.domainFr}/changer-mot-de-passe/${temporaryKey}`,
+    homeName: `pix${settings.domain.tldFr}`,
+    homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+    resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
     locale
   };
 
   if (locale === 'fr') {
     variables = {
-      homeName: `${settings.app.domainOrg}`,
-      homeUrl: `https://${settings.app.domainOrg}`,
-      resetUrl: `https://app.${settings.app.domainOrg}/changer-mot-de-passe/${temporaryKey}`,
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
+      resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}`,
       locale
     };
   }

--- a/api/lib/infrastructure/utils/url-builder.js
+++ b/api/lib/infrastructure/utils/url-builder.js
@@ -6,6 +6,6 @@ function getCampaignUrl(locale, campaignCode) {
   if (!campaignCode) {
     return null;
   }
-  const domain = locale === 'fr' ? settings.app.domainOrg : settings.app.domainFr;
-  return `https://app.${domain}/campagnes/${campaignCode}`;
+  const tld = locale === 'fr' ? settings.domain.tldOrg : settings.domain.tldFr;
+  return `${settings.domain.pixApp + tld}/campagnes/${campaignCode}`;
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -171,15 +171,36 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 #
 # presence: optional
 # type: String
-# default: 'pix.fr'
-# DOMAIN_NAME_FR=
+# default: '.fr'
+# TLD_FR=
 
 # String for links in emails redirect to a specific domain when user comes from international domain
 #
 # presence: optional
 # type: String
-# default: 'pix.org'
-# DOMAIN_NAME_ORG=
+# default: '.org'
+# TLD_ORG=
+
+# String for links in emails to build url with Pix domain
+#
+# presence: optional
+# type: String
+# default: 'pix'
+# DOMAIN_PIX=
+
+# String for links in emails to build url with Pix App domain
+#
+# presence: optional
+# type: String
+# default: 'app.pix'
+# DOMAIN_PIX_APP=
+
+# String for links in emails to build url with Pix Orga domain
+#
+# presence: optional
+# type: String
+# default: 'orga.pix'
+# DOMAIN_PIX_ORGA=
 
 # ================
 # LEARNING CONTENT

--- a/scalingo.json
+++ b/scalingo.json
@@ -5,9 +5,13 @@
       "description": "Indicates that the application is a review app",
       "value": "true"
     },
+    "DOMAIN_PIX_APP": {
+      "generator": "template",
+      "template": "https://app-pr%PR_NUMBER%.review.pix"
+    },
     "DOMAIN_PIX_ORGA": {
       "generator": "template",
-      "template": "https://orga-pr%PR_NUMBER%.review"
+      "template": "https://orga-pr%PR_NUMBER%.review.pix"
     }
   },
   "scripts": {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on teste l'envoie des e-mails, ceux-ci ne redirigent pas vers les review apps. 

## :robot: Solution
Ajouter une variable d'environnement générée dynamiquement grâce au fichier `scalingo.json` : 
https://github.com/1024pix/pix/blob/49b2c6d45dad29df49ffbf02e09e20dfeba3b9d4/scalingo.json#L8-L11

Et utiliser cette variable d'environnement pour la construction des url envoyées dans les e-mails.

## :100: Pour tester
Vérifier que les e-mails redirigent vers la RA : 
- Création de compte
- Changement de mot de passe
