### PR TITLE
[BUGFIX] Retirer le message de contexte sur la double mire de Pix Orga (PIX-912).

### DIFF
--- a/orga/app/templates/components/routes/login-form.hbs
+++ b/orga/app/templates/components/routes/login-form.hbs
@@ -1,7 +1,9 @@
 <div class="login-form">
-  <div class="login-form__information">
-    L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.
-  </div>
+  {{#unless this.isWithInvitation }}
+    <div class="login-form__information">
+      L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.
+    </div>
+  {{/unless}}
 
   {{#if @hasInvitationError}}
       <div class="login-form__invitation-error">

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -153,6 +153,10 @@ module('Integration | Component | routes/login-form', function(hooks) {
     assert.dom('#login-form-error-message').hasText(errorMessages.NOT_LINKED_ORGANIZATION_MSG);
   });
 
+  test('it should not display context message', async function(assert) {
+    assert.dom('login-form__information').doesNotExist();
+  });
+
   module('when password is hidden', function(hooks) {
 
     hooks.beforeEach(async function() {


### PR DESCRIPTION
## :unicorn: Problème
On ne souhaite pas avoir le message de contexte de Pix Orga sur la double mire.  

## :robot: Solution
Retirer le message
![remove-context-message](https://user-images.githubusercontent.com/26384707/85859974-4eaf4500-b7be-11ea-84e9-6759eca36bbc.gif)

## :100: Pour tester
Aller sur la page : https://orga-pr1574.review.pix.fr/rejoindre?code=DZWMP7L5UM&invitationId=100047