### PR TITLE
[A11Y] Supprimer target='blank" des fichiers téléchargeables depuis les épreuves (PIX-835).

### DIFF
--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -18,7 +18,6 @@
         <div class="challenge-statement__action">
           <a class="challenge-statement__action-link"
              href="{{@challenge.attachments.firstObject}}"
-             target="_blank"
              rel="noopener noreferrer"
              download>
             <span class="challenge-statement__action-label">Télécharger</span>
@@ -59,7 +58,6 @@
         <div class="challenge-statement__action">
           <a class="challenge-statement__action-link"
              href="{{this.selectedAttachmentUrl}}"
-             target="_blank"
              rel="noopener noreferrer"
              download>
             <span class="challenge-statement__action-label">Télécharger</span>


### PR DESCRIPTION
## :unicorn: Problème
L'attribut `target="_blank"` sur le bouton de téléchargement de fichier d'une épreuve ouvre un nouvel onglet lors du téléchargement, ce qui change complètement le focus de l'utilisateur en situation de handicap.

## :robot: Solution
Supprimer l'attribut `target = "blank"`

## :100: Pour tester
Tester le téléchargement sur différents navigateurs.
Exemple d'épreuves avec téléchargement: rec00qXohUCqeIhmA, rec5B4raGf9qZmd40
