### PR TITLE
[BUGFIX] Afficher un message d'erreur dans Pix Orga lorsque l'e-mail d'invitation est incorrect (PIX-471).

### DIFF
--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -24,7 +24,7 @@ const userValidationJoiSchema = Joi.object({
     .email()
     .messages({
       'string.empty': 'Votre adresse e-mail n’est pas renseignée.',
-      'string.email': 'Votre adresse e-mail n’est pas correcte.',
+      'string.email': 'Le format de l\'adresse e-mail est incorrect.',
     }),
 
   username: Joi.string()

--- a/api/tests/unit/domain/validators/user-validator_test.js
+++ b/api/tests/unit/domain/validators/user-validator_test.js
@@ -167,7 +167,7 @@ describe('Unit | Domain | Validators | user-validator', function() {
           // given
           const expectedError = {
             attribute: 'email',
-            message: 'Votre adresse e-mail n’est pas correcte.'
+            message: 'Le format de l\'adresse e-mail est incorrect.'
           };
           user.email = 'invalid_email';
 

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -23,6 +23,9 @@ export default class NewController extends Controller {
       .catch((errorResponse) => {
         if (errorResponse.errors && errorResponse.errors.length > 0) {
           errorResponse.errors.forEach((error) => {
+            if (error.status === '400') {
+              return this.get('notifications').sendError('Le format de l\'adresse e-mail est incorrect.');
+            }
             if (error.status === '412') {
               return this.get('notifications').sendError('Ce membre a déjà été ajouté.');
             }

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -200,6 +200,30 @@ module('Acceptance | Team Creation', function(hooks) {
         assert.dom('[data-test-notification-message="error"]').exists();
         assert.dom('[data-test-notification-message="error"]').hasText('Cet email n\'appartient à aucun utilisateur.');
       });
+
+      test('it should display error on global form when error 400 is returned from backend', async function(assert) {
+        // given
+        await visit('/equipe/creation');
+        server.post(`/organizations/${organizationId}/invitations`,
+          {
+            errors: [
+              {
+                detail: '',
+                status: '400',
+                title: 'Bad Request',
+              }
+            ]
+          }, 400);
+        await fillIn('#email', 'fake@email');
+
+        // when
+        await click('button[type="submit"]');
+
+        // then
+        assert.equal(currentURL(), '/equipe/creation');
+        assert.dom('[data-test-notification-message="error"]').exists();
+        assert.dom('[data-test-notification-message="error"]').hasText('Le format de l\'adresse e-mail est incorrect.');
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible, dans Pix Orga, d'inviter des membres à rejoindre une organisation. Néanmoins, lorsque l'adresse email est invalide, aucune invitation n'est envoyée mais aucun message d'erreur n'est affiché afin d'informer l'utilisateur.

## :robot: Solution
Rajouter une notification "Le format de l'adresse e-mail est incorrect."

## :rainbow: Remarques
Le message renvoyé lorsqu'un utilisateur tente de se créer un compte avec une adresse e-mail incorrecte à été modifié en conséquence.
Dans le validateur Joi, un e-mail est invalide (entre autres) lorsque: 
- Il ne possède pas d'@ (ou plus d'un @)
- Il possède des caractères non ASCII
- Il ne possède rien avant et/ou après l'@
- Il fait plus de 254 caractères ou la partie avant l'@ fait plus de 64 caractères
- La dernière partie du domaine ne fait pas partie de la liste: https://github.com/hapijs/address/blob/master/lib/tlds.js (exemple: ".toto")

Voir: https://github.com/hapijs/address/blob/master/lib/email.js  

## :100: Pour tester
- Se connecter à Pix Orga, et tenter d'inviter un membre en spécifiant un e-mail incorrect. Vérifier qu'une notification est bien affichée.
- Tenter de s'inscrire avec un e-mail invalide (inscription classique ou double mire) et vérifier que le message d'erreur est bien affiché.