### PR TITLE
[FEATURE] PART 3 - Nouveau design certificat (PIX-839)

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -1,5 +1,5 @@
 .user-certifications-detail-competence {
-  
+  margin-bottom: 32px;
   @mixin leftElement {
     position: relative;
     display: flex;
@@ -32,6 +32,7 @@
   &__competence {
     @include leftElement;
     color: $grey-80;
+    height: 100%;
     font-family: $font-open-sans;
     font-size: 1rem;
     padding: 20px 0 20px 36px;

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -22,7 +22,7 @@
     padding-left: 16px;
     line-height: 1rem;
     font-weight: normal;
-    
+
     &--level {
       @include rightElement;
       color: $grey-60;
@@ -50,6 +50,7 @@
       width: 3px;
       height: calc(100% - 20px);
       border-radius: 1.5px;
+      top: 10px;
     }
 
     &--disabled {
@@ -63,6 +64,7 @@
 
   > * {
     border-bottom: 1.5px $grey-10 solid;
+    height: 75px;
     min-height: 60px;
   }
   > :last-child {

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -1,6 +1,4 @@
 .user-certifications-detail-result {
-  background-color: $white;
-  padding: 20px;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
@@ -13,6 +11,27 @@
   line-height: 1.625rem;
   margin-bottom: 40px;
 
+  h2 {
+    color: $grey-60;
+    font-family: $font-open-sans;
+    font-size: 1.125rem;
+    margin-bottom: 8px;
+    font-weight: normal;
+  }
+
+  &__badge-clea {
+    margin: 24px;
+    text-align: center;
+  }
+
+  &__comment-jury {
+    margin: 24px 16px;
+    font-family: $font-open-sans;
+    font-size: 1rem;
+    font-weight: $font-medium;
+    line-height: 1.625rem;
+  }
+
   @include device-is('mobile') {
     min-width: 100%;
   }
@@ -24,34 +43,5 @@
   @include device-is('desktop') {
     min-width: 30%;
     margin-left: 20px;
-    margin-top: calc(25px + 8px);
-  }
-
-  &__text-pix-certified {
-    padding-left: 0.781rem;
-
-    border-left-style: solid;
-    border-left-color: $grey-80;
-    border-left-width: 3px;
-  }
-
-  &__badge-clea {
-    align-self: center;
-  }
-
-  &__title-comment-jury {
-    color: $grey-40;
-    font-family: $font-open-sans;
-    font-size: 1rem;
-    font-weight: $font-medium;
-    line-height: 1.625rem;
-  }
-
-  hr {
-    margin-top: 40px;
-    border: 0;
-    width: 100%;
-    background-color: $grey-15;
-    height: 3px;
   }
 }

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -20,7 +20,7 @@
     width: 100%;
     max-width: 980px;
     z-index: 1;
-    margin-top: 68px;
+    margin: 68px 0 40px 0;
     position: relative;
   }
 

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -29,7 +29,6 @@
     width: 100%;
     max-width: 980px;
     margin: 0 10px;
-    // background-color: salmon;
   }
 }
 

--- a/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
@@ -1,17 +1,20 @@
 <div class="rounded-panel user-certifications-detail-competence user-certifications-detail-competence--{{@area.color}}">
   <h3 class="user-certifications-detail-competence__title">
-    {{@area.title}} 
+    {{@area.title}}
     <span class="user-certifications-detail-competence__title--level">niveau</span>
   </h3>
 
   {{#each sortedCompetences as |competence index|}}
-    <p class="user-certifications-detail-competence__competence {{if (lt competence.level 0) "user-certifications-detail-competence__competence--disabled"}}">
+  <div>
+    <p
+      class="user-certifications-detail-competence__competence {{if (lt competence.level 0) "user-certifications-detail-competence__competence--disabled"}}">
       {{competence.name}}
       {{#if (eq competence.level 0)}}
-        <span class="user-certifications-detail-competence__competence--level">-</span>
+      <span class="user-certifications-detail-competence__competence--level">-</span>
       {{else}}
-        <span class="user-certifications-detail-competence__competence--level">{{competence.level}}</span>
+      <span class="user-certifications-detail-competence__competence--level">{{competence.level}}</span>
       {{/if}}
     </p>
+  </div>
   {{/each}}
 </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
@@ -9,7 +9,6 @@
 
   <p class="user-certifications-detail-competences-list__note">
   Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil.
-  <br>
   Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum.
   </p>
 </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,19 +1,19 @@
-<p class="user-certifications-detail-result__text-pix-certified">
-  Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification.
-  Il peut donc différer de votre nombre de Pix affiché dans votre profil.
-</p>
-
-{{#if certification.hasCleaCertif}}
-  <hr>
-  <img src="https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images/badges/CleA_Num_certif.svg" alt="Badge cléA numérique" class="user-certifications-detail-result__badge-clea">
-{{/if}}
-
-<hr>
-<div>
-  {{#if certification.commentForCandidate}}
-    <p class="user-certifications-detail-result__title-comment-jury">Intervention du jury</p>
+{{#if certification.commentForCandidate}}
+  <h2>Observations du jury</h2>
+  <div class="rounded-panel">
     <p class="user-certifications-detail-result__comment-jury">
       {{certification.commentForCandidate}}
     </p>
-  {{/if}}
-</div>
+  </div>
+{{/if}}
+
+{{#if certification.hasCleaCertif}}
+  <h2>Certifié Cléa</h2>
+  <div class="rounded-panel">
+    <div class="user-certifications-detail-result__badge-clea">
+      <img
+        src="https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images/badges/CleA_Num_certif.svg"
+        alt="Certification cléA numérique" />
+    </div>
+  </div>
+{{/if}}

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -12,6 +12,8 @@
 
   <div class="user-certifications-page-get__details-body">
     <UserCertificationsDetailCompetencesList @resultCompetenceTree={{@model.resultCompetenceTree}} />
-    <UserCertificationsDetailResult @certification={{@model}} />
+    {{#if (or @model.commentForCandidate @model.hasCleaCertif)}}
+      <UserCertificationsDetailResult @certification={{@model}} />
+    {{/if}}
   </div>
 </div>

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
@@ -12,7 +12,7 @@ describe('Integration | Component | user-certifications-detail-competence', func
   let area;
   const PARENT_SELECTOR = '.user-certifications-detail-competence';
   const TITLE_SELECTOR = `${PARENT_SELECTOR}__title`;
-  const COMPETENCE_SELECTOR = `${PARENT_SELECTOR}__competence`;
+  const COMPETENCE_SELECTOR = `${PARENT_SELECTOR} div`;
   const DISABLED_CLASS = 'user-certifications-detail-competence__competence--disabled';
 
   beforeEach(async function() {
@@ -75,7 +75,7 @@ describe('Integration | Component | user-certifications-detail-competence', func
 
       it('should be grayed out (almost transparent) and not show the level', function() {
         expect(find(`${COMPETENCE_SELECTOR}:nth-child(3) span`).textContent).to.equal(area.resultCompetences[1].level.toString());
-        expect(find(`${COMPETENCE_SELECTOR}:nth-child(3)`).classList.toString()).to.include(DISABLED_CLASS);
+        expect(find(`${COMPETENCE_SELECTOR}:nth-child(3) p`).classList.toString()).to.include(DISABLED_CLASS);
       });
     });
 
@@ -83,7 +83,7 @@ describe('Integration | Component | user-certifications-detail-competence', func
 
       it('should show "-" for the level (not 0)', function() {
         expect(find(`${COMPETENCE_SELECTOR}:nth-child(4) span`).textContent).to.equal('-');
-        expect(find(`${COMPETENCE_SELECTOR}:nth-child(4)`).classList.toString()).to.not.include(DISABLED_CLASS);
+        expect(find(`${COMPETENCE_SELECTOR}:nth-child(4) p`).classList.toString()).to.not.include(DISABLED_CLASS);
       });
     });
 
@@ -91,7 +91,7 @@ describe('Integration | Component | user-certifications-detail-competence', func
 
       it('should show the level', function() {
         expect(find(`${COMPETENCE_SELECTOR}:nth-child(5) span`).textContent).to.equal('3');
-        expect(find(`${COMPETENCE_SELECTOR}:nth-child(5)`).classList.toString()).to.not.include(DISABLED_CLASS);
+        expect(find(`${COMPETENCE_SELECTOR}:nth-child(5) p`).classList.toString()).to.not.include(DISABLED_CLASS);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
PART 1 : #1509
PART 2 : #1561
On implémente le nouveau design du certificat Pix au fur et à mesure.
https://1024pix.atlassian.net/browse/PIX-838

## :robot: Solution
Cette pr change l'affichage des commentaires jury et le badge CléA

## :rainbow: Remarques
-Si l'utilisateur n'as pas de badge cléa, le bloc "Certifié CléA" n'est pas affiché
-Si l'utilisateur n'as pas de commentaire jury pour son certificat, le bloc "Observation jury" n'est pas affiché
-Si il n'y a ni badge, ni commentaire, le bloc des compétences occupe 100% des 980px de large du certificat


## :100: Pour tester
- lancer l'app mon-pix
- se connecter avec un compte ayant passé une certif et l'ayant obtenue (ex: certif-success@example.net)
- A l'aide de l'extension Ember, dans "Data" -> "certification", passer hasCleaCertif à true et remplir commentForCandidate
- aller sur la page de détail d'une certification (ex: http://localhost:4200/mes-certifications/104093)
- constater les blocs badge et observations
- redimensionner la page, constater que sous mobile et tablette l'affichage reste

![image](https://user-images.githubusercontent.com/37305474/85870139-f6337400-b7cc-11ea-929f-e97587c6a1db.png)

