### PR TITLE
[TECH] Manage errors from api (JSONAPI)

### DIFF
--- a/admin/app/routes/authenticated/certifications/certification.js
+++ b/admin/app/routes/authenticated/certifications/certification.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class CertificationRoute extends Route {
-  @service notifications
+  @service errorNotifier
 
   setupController(controller, model) {
     super.setupController(controller, model);
@@ -12,7 +12,8 @@ export default class CertificationRoute extends Route {
 
   @action
   error(anError) {
-    this.notifications.error(anError);
+    this.errorNotifier.notify(anError);
     this.transitionTo('authenticated.certifications');
   }
 }
+

--- a/admin/app/routes/authenticated/sessions/session.js
+++ b/admin/app/routes/authenticated/sessions/session.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class SessionRoute extends Route {
-  @service notifications;
+  @service errorNotifier;
 
   setupController(controller, model) {
     super.setupController(controller, model);
@@ -12,7 +12,7 @@ export default class SessionRoute extends Route {
 
   @action
   error(anError) {
-    this.notifications.error(anError);
+    this.errorNotifier.notify(anError);
     this.transitionTo('authenticated.sessions.list');
   }
 }

--- a/admin/app/services/error-notifier.js
+++ b/admin/app/services/error-notifier.js
@@ -1,0 +1,19 @@
+import { every, isEmpty } from 'lodash';
+import { inject as service } from '@ember/service';
+import Service from '@ember/service';
+
+export default class ErrorNotifierService extends Service  {
+  @service notifications
+
+  notify(anError) {
+    if (_isJSONAPIError(anError)) {
+      anError.errors.forEach((e) => this.notifications.error(new Error(`${e.title} : ${e.detail}`)));
+    } else {
+      this.notifications.error(anError);
+    }
+  }
+}
+
+function _isJSONAPIError(anError) {
+  return !isEmpty(anError.errors) && every(anError.errors, (e) => e.title);
+}

--- a/admin/tests/unit/routes/authenticated/certifications/certification-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification-test.js
@@ -23,18 +23,17 @@ module('Unit | Route | authenticated/certifications/certification', function(hoo
   test('#error', function(assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certifications/certification');
-    const notificationsStub = {
-      anError: 'an Error',
-      error: sinon.stub().resolves(),
+    const errorNotifierStub = {
+      notify: sinon.stub().resolves(),
     };
-    route.notifications = notificationsStub;
+    route.errorNotifier = errorNotifierStub;
     route.transitionTo = () => {};
 
     // when
     route.send('error');
 
     // then
-    sinon.assert.called(notificationsStub.error);
+    sinon.assert.called(errorNotifierStub.notify);
     assert.ok(route);
   });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/session-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session-test.js
@@ -23,18 +23,17 @@ module('Unit | Route | authenticated/sessions/session', function(hooks) {
   test('#error', function(assert) {
     // given
     const route = this.owner.lookup('route:authenticated/sessions/session');
-    const notificationsStub = {
-      anError: 'an Error',
-      error: sinon.stub().resolves(),
+    const errorNotifierStub = {
+      notify: sinon.stub().resolves(),
     };
-    route.notifications = notificationsStub;
+    route.errorNotifier = errorNotifierStub;
     route.transitionTo = () => {};
 
     // when
     route.send('error');
 
     // then
-    sinon.assert.called(notificationsStub.error);
+    sinon.assert.called(errorNotifierStub.notify);
     assert.ok(route);
   });
 });

--- a/admin/tests/unit/services/error-notifier-test.js
+++ b/admin/tests/unit/services/error-notifier-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | error-notifier', function(hooks) {
+  setupTest(hooks);
+
+  test('it notifies a non-JSONAPI error as a single notification', function(assert) {
+    // given
+    const service = this.owner.lookup('service:error-notifier');
+    const errorMock = sinon.stub();
+    service.notifications = {
+      error: errorMock
+    };
+    const anError = new Error('a generic error');
+
+    // when
+    service.notify(anError);
+
+    // then
+    assert.ok(errorMock.calledWith(anError));
+  });
+
+  test('it notifies JSONAPI bundled errors as several notifications', function(assert) {
+    // given
+    const service = this.owner.lookup('service:error-notifier');
+    const errorMock = sinon.stub();
+    service.notifications = {
+      error: errorMock
+    };
+    const anError = {
+      errors: [
+        {
+          title: 'Something went wrong',
+          detail: 'the provided id is invalid'
+        },
+        {
+          title: 'Something else went wrong too !'
+        }
+      ]
+    };
+
+    // when
+    service.notify(anError);
+
+    // then
+    assert.ok(errorMock.calledWith(
+      sinon.match.has(
+        'message',
+        'Something went wrong : the provided id is invalid'
+      )
+    ));
+    assert.ok(errorMock.calledWith(
+      sinon.match.has(
+        'message',
+        'Something else went wrong too ! : undefined'
+      )
+    ));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les erreurs JSONAPI ne sont pas remonté correctement par ember data.
## :robot: Solution
Utiliser un service qui récupère le message de l'erreur/des erreurs renvoyé par JSONAPI (api) et les affiche via le service de notification

## :rainbow: Remarques
Les erreurs hors JSONAPI sont notifiés tel-quel (le comportement est inchangé)

## :100: Pour tester
Faire une erreur 422 sur la page des certifications. Verifier le message