### PR TITLE
[FEATURE] Retenter des acquis de compétence échoués au bout de 4 jours (PIX-758).

### DIFF
--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -25,6 +25,7 @@ class Scorecard {
     exactlyEarnedPix,
     status,
     remainingDaysBeforeReset,
+    remainingDaysBeforeImproving,
     tutorials,
   } = {}) {
 
@@ -41,6 +42,7 @@ class Scorecard {
     this.pixScoreAheadOfNextLevel = pixScoreAheadOfNextLevel;
     this.status = status;
     this.remainingDaysBeforeReset = remainingDaysBeforeReset;
+    this.remainingDaysBeforeImproving = remainingDaysBeforeImproving;
     this.tutorials = tutorials;
   }
 
@@ -57,6 +59,7 @@ class Scorecard {
       pixAheadForNextLevel
     } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements, allowExcessPix, allowExcessLevel });
     const remainingDaysBeforeReset = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeReset(knowledgeElements);
+    const remainingDaysBeforeImproving = _.isEmpty(knowledgeElements) ? null : Scorecard.computeRemainingDaysBeforeImproving(knowledgeElements);
 
     return new Scorecard({
       id: `${userId}_${competence.id}`,
@@ -71,12 +74,20 @@ class Scorecard {
       pixScoreAheadOfNextLevel: pixAheadForNextLevel,
       status: _getScorecardStatus(competenceEvaluation, knowledgeElements),
       remainingDaysBeforeReset,
+      remainingDaysBeforeImproving,
     });
   }
 
   static computeRemainingDaysBeforeReset(knowledgeElements) {
     const daysSinceLastKnowledgeElement = KnowledgeElement.computeDaysSinceLastKnowledgeElement(knowledgeElements);
     const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET - daysSinceLastKnowledgeElement);
+
+    return remainingDaysToWait > 0 ? remainingDaysToWait : 0;
+  }
+
+  static computeRemainingDaysBeforeImproving(knowledgeElements) {
+    const daysSinceLastKnowledgeElement = KnowledgeElement.computeDaysSinceLastKnowledgeElement(knowledgeElements);
+    const remainingDaysToWait = Math.ceil(constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING - daysSinceLastKnowledgeElement);
 
     return remainingDaysToWait > 0 ? remainingDaysToWait : 0;
   }

--- a/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scorecard-serializer.js
@@ -15,6 +15,7 @@ module.exports = {
         'pixScoreAheadOfNextLevel',
         'status',
         'remainingDaysBeforeReset',
+        'remainingDaysBeforeImproving',
         'tutorials',
       ],
 

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -138,6 +138,7 @@ describe('Acceptance | Controller | scorecard-controller', () => {
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
               status: 'STARTED',
               'remaining-days-before-reset': 7,
+              'remaining-days-before-improving': 4,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-scorecard_test.js
@@ -140,6 +140,7 @@ describe('Acceptance | Controller | users-controller-get-user-scorecards', () =>
               'pix-score-ahead-of-next-level': knowledgeElement.earnedPix,
               status: 'STARTED',
               'remaining-days-before-reset': 7,
+              'remaining-days-before-improving': 4,
             },
             relationships: {
               area: {

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -200,6 +200,7 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
               'pix-score-ahead-of-next-level': 0,
               status: 'NOT_STARTED',
               'remaining-days-before-reset': null,
+              'remaining-days-before-improving': null,
             },
             relationships: {
               area: {

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -233,7 +233,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
     });
   });
 
-  describe('#computeDaysSinceLastKnowledgeElement', () => {
+  describe('#computeRemainingDaysBeforeReset', () => {
 
     let testCurrentDate;
 
@@ -265,6 +265,40 @@ describe('Unit | Domain | Models | Scorecard', () => {
 
         // then
         expect(remainingDaysBeforeReset).to.equal(expectedDaysBeforeReset);
+      });
+    });
+  });
+
+  describe('#computeRemainingDaysBeforeImproving', () => {
+
+    let testCurrentDate;
+
+    beforeEach(() => {
+      testCurrentDate = new Date('2018-01-10T05:00:00Z');
+      sinon.useFakeTimers(testCurrentDate.getTime());
+    });
+
+    [
+      { daysSinceLastKnowledgeElement: 0.0833, expectedDaysBeforeImproving: 4 },
+      { daysSinceLastKnowledgeElement: 0, expectedDaysBeforeImproving: 4 },
+      { daysSinceLastKnowledgeElement: 1, expectedDaysBeforeImproving: 3 },
+      { daysSinceLastKnowledgeElement: 1.5, expectedDaysBeforeImproving: 3 },
+      { daysSinceLastKnowledgeElement: 2.4583, expectedDaysBeforeImproving: 2 },
+      { daysSinceLastKnowledgeElement: 4, expectedDaysBeforeImproving: 0 },
+      { daysSinceLastKnowledgeElement: 7, expectedDaysBeforeImproving: 0 },
+      { daysSinceLastKnowledgeElement: 10, expectedDaysBeforeImproving: 0 },
+    ].forEach(({ daysSinceLastKnowledgeElement, expectedDaysBeforeImproving }) => {
+      it(`should return ${expectedDaysBeforeImproving} days when ${daysSinceLastKnowledgeElement} days passed since last knowledge element`, () => {
+        const date = moment(testCurrentDate).toDate();
+        const knowledgeElements = [{ createdAt: date }];
+
+        computeDaysSinceLastKnowledgeElementStub.returns(daysSinceLastKnowledgeElement);
+
+        // when
+        const remainingDaysBeforeImproving = Scorecard.computeRemainingDaysBeforeImproving(knowledgeElements);
+
+        // then
+        expect(remainingDaysBeforeImproving).to.equal(expectedDaysBeforeImproving);
       });
     });
   });

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -236,10 +236,19 @@ describe('Unit | Domain | Models | Scorecard', () => {
   describe('#computeRemainingDaysBeforeReset', () => {
 
     let testCurrentDate;
+    const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET;
 
     beforeEach(() => {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
       sinon.useFakeTimers(testCurrentDate.getTime());
+    });
+
+    before(() => {
+      constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET = 7;
+    });
+
+    after(() => {
+      constants.MINIMUM_DELAY_IN_DAYS_FOR_RESET = originalConstantValue;
     });
 
     [
@@ -272,10 +281,19 @@ describe('Unit | Domain | Models | Scorecard', () => {
   describe('#computeRemainingDaysBeforeImproving', () => {
 
     let testCurrentDate;
+    const originalConstantValue = constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
 
     beforeEach(() => {
       testCurrentDate = new Date('2018-01-10T05:00:00Z');
       sinon.useFakeTimers(testCurrentDate.getTime());
+    });
+
+    before(() => {
+      constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING = 4;
+    });
+
+    after(() => {
+      constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING = originalConstantValue;
     });
 
     [

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -75,6 +75,9 @@ describe('Unit | Domain | Models | Scorecard', () => {
       it('should have set the scorecard remainingDaysBeforeReset based on last knowledge element date', () => {
         expect(actualScorecard.remainingDaysBeforeReset).to.equal(7);
       });
+      it('should have set the scorecard remainingDaysBeforeImproving based on last knowledge element date', () => {
+        expect(actualScorecard.remainingDaysBeforeImproving).to.equal(4);
+      });
     });
 
     context('when the competence evaluation has never been started', () => {
@@ -157,6 +160,10 @@ describe('Unit | Domain | Models | Scorecard', () => {
       it('should have a dayBeforeReset at null', () => {
         expect(actualScorecard.remainingDaysBeforeReset).to.be.null;
       });
+
+      it('should have a dayBeforeImproving at null', () => {
+        expect(actualScorecard.remainingDaysBeforeImproving).to.be.null;
+      });
     });
 
     context('when the user level is beyond the upper limit allowed', () => {
@@ -221,7 +228,7 @@ describe('Unit | Domain | Models | Scorecard', () => {
     });
 
     context('when there is no knowledge elements', () => {
-      it('should return null', () => {
+      it('should return null when looking for remainingDaysBeforeReset', () => {
         const knowledgeElements = [];
 
         // when
@@ -230,6 +237,17 @@ describe('Unit | Domain | Models | Scorecard', () => {
         // then
         expect(actualScorecard.remainingDaysBeforeReset).to.equal(null);
       });
+
+      it('should return null when looking for remainingDaysBeforeImproving', () => {
+        const knowledgeElements = [];
+
+        // when
+        actualScorecard = Scorecard.buildFrom({ userId, knowledgeElements, competenceEvaluation, competence });
+
+        // then
+        expect(actualScorecard.remainingDaysBeforeImproving).to.equal(null);
+      });
+
     });
   });
 

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -8,6 +8,16 @@ export default class CompetenceCardDefault extends Component {
   @service store;
   @service router;
 
+  get computeRemainingDaysBeforeImproving() {
+    const _remainingDaysBeforeImproving = this.args.scorecard.remainingDaysBeforeImproving;
+
+    if (_remainingDaysBeforeImproving > 1) {
+      return _remainingDaysBeforeImproving + ' jours';
+    } else {
+      return _remainingDaysBeforeImproving + ' jour';
+    }
+  }
+
   get displayImproveButton() {
     return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
   }
@@ -17,6 +27,10 @@ export default class CompetenceCardDefault extends Component {
       return null;
     }
     return this.args.scorecard.level;
+  }
+
+  get shouldWaitBeforeImproving() {
+    return this.args.scorecard.remainingDaysBeforeImproving > 0;
   }
 
   @action

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -12,6 +12,16 @@ export default class ScorecardDetails extends Component {
 
   @tracked showResetModal = false;
 
+  get computeRemainingDaysBeforeImproving() {
+    const _remainingDaysBeforeImproving = this.args.scorecard.remainingDaysBeforeImproving;
+
+    if (_remainingDaysBeforeImproving > 1) {
+      return _remainingDaysBeforeImproving + ' jours';
+    } else {
+      return _remainingDaysBeforeImproving + ' jour';
+    }
+  }
+
   get level() {
     return this.args.scorecard.isNotStarted ? null : this.args.scorecard.level;
   }
@@ -34,6 +44,10 @@ export default class ScorecardDetails extends Component {
 
   get displayImproveButton() {
     return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+  }
+
+  get shouldWaitBeforeImproving() {
+    return this.args.scorecard.remainingDaysBeforeImproving > 0;
   }
 
   get remainingDaysText() {

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -14,6 +14,7 @@ export default class Scorecard extends Model {
   @attr('string') name;
   @attr('number') pixScoreAheadOfNextLevel;
   @attr('number') remainingDaysBeforeReset;
+  @attr('number') remainingDaysBeforeImproving;
   @attr('string') status;
 
   // references

--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -222,4 +222,28 @@
       transition: all 0.1s linear;
     }
   }
+
+  .competence-card-interactions {
+    &__improvement-countdown {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      cursor: default;
+    }
+  }
+
+  .competence-card-improvement-countdown {
+    &__label {
+      font-size: 0.6875rem;
+      letter-spacing: 0.0075rem;
+      color: $grey-60;
+    }
+
+    &__count {
+      font-size: 1rem;
+      letter-spacing: 0.010rem;
+      color: $grey-90;
+      margin-top: 6px;
+    }
+  }
 }

--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -82,7 +82,7 @@
     opacity: 1;
   }
 
-  .competence-card:hover .competence-card__footer {
+  .competence-card:hover .competence-card__interactions {
     bottom: 0px;
     height: 70px;
   }
@@ -178,7 +178,7 @@
     letter-spacing: 0.5px;
   }
 
-  .competence-card__footer {
+  .competence-card__interactions {
     position: absolute;
     bottom: -34px;
     display: flex;

--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -5,7 +5,7 @@
     height: 310px;
   }
 
-  .competence-card__header {
+  .competence-card__title {
     height: 110px;
     overflow: hidden;
     text-align: center;
@@ -106,7 +106,7 @@
     box-shadow: $box-shadow-competence-cards-hover;
   }
 
-  .competence-card:hover .competence-card__header {
+  .competence-card:hover .competence-card__title {
     height: 179px;
     transition: height 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.competence-card__header {
+.competence-card__title {
   display: flex;
   flex-direction: column;
   color: $white;

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -78,6 +78,14 @@
     font-size: 0.8rem;
     letter-spacing: 0.0075rem;
   }
+
+  &__improvement-countdown {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    cursor: default;
+    margin-top: 30px;
+  }
 }
 
 .scorecard-details-content {
@@ -200,5 +208,20 @@
     font-family: $font-roboto;
     font-weight: $font-light;
     font-size: 1rem;
+  }
+}
+
+.scorecard-details-improvement-countdown {
+  &__label {
+    font-size: 0.6875rem;
+    letter-spacing: 0.0075rem;
+    color: $grey-60;
+  }
+
+  &__count {
+    font-size: 1rem;
+    letter-spacing: 0.010rem;
+    color: $grey-90;
+    margin-top: 6px;
   }
 }

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -40,7 +40,7 @@
             <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{@scorecard.name}}"</span>
             </span>
             <span class="competence-card-button__arrow">
-              {{fa-icon 'long-arrow-alt-right'}}
+            <FaIcon @icon='long-arrow-alt-right'></FaIcon>
             </span>
           </button>
         {{/if}}
@@ -54,7 +54,7 @@
             {{/if}}
           </span>
           <span class="competence-card-button__arrow">
-            {{fa-icon 'long-arrow-alt-right'}}
+            <FaIcon @icon='long-arrow-alt-right'></FaIcon>
           </span>
         </LinkTo>
       {{/if}}

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -36,13 +36,20 @@
     <div class="competence-card__interactions">
       {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
-          <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
-            <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{@scorecard.name}}"</span>
-            </span>
-            <span class="competence-card-button__arrow">
-            <FaIcon @icon='long-arrow-alt-right'></FaIcon>
-            </span>
-          </button>
+          {{#if this.shouldWaitBeforeImproving}}
+            <div class="competence-card-interactions__improvement-countdown">
+              <span class="competence-card-improvement-countdown__label">Tenter le niveau supérieur dans</span>
+              <span class="competence-card-improvement-countdown__count">{{this.computeRemainingDaysBeforeImproving}}</span>
+            </div>
+          {{else}}
+            <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
+              <span class="competence-card-button__label">Retenter <span class="sr-only">la compétence "{{@scorecard.name}}"</span>
+              </span>
+              <span class="competence-card-button__arrow">
+              <FaIcon @icon='long-arrow-alt-right'></FaIcon>
+              </span>
+            </button>
+          {{/if}}
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume" @model={{@scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -1,10 +1,10 @@
 <article class="competence-card {{if @interactive "competence-card--interactive"}}">
   <LinkTo @route="competences.details" @model={{@scorecard.competenceId}}>
-    <header class="competence-card__header">
+    <div class="competence-card__title">
       <span class="competence-card__color competence-card__color--{{@scorecard.area.color}}"></span>
       <span class="competence-card__area-name">{{@scorecard.area.title}}</span>
       <span class="competence-card__competence-name">{{@scorecard.name}}</span>
-    </header>
+    </div>
 
     <div class="competence-card__body">
       {{#if @scorecard.isFinishedWithMaxLevel}}

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -29,11 +29,11 @@
   </LinkTo>
 
   {{#if @scorecard.isFinishedWithMaxLevel}}
-    <footer class="competence-card__congrats-message">
+    <div class="competence-card__congrats-message">
       Bravo !
-    </footer>
+    </div>
   {{else}}
-    <footer class="competence-card__footer">
+    <div class="competence-card__interactions">
       {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
           <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}}>
@@ -58,6 +58,6 @@
           </span>
         </LinkTo>
       {{/if}}
-    </footer>
+    </div>
   {{/if}}
 </article>

--- a/mon-pix/app/templates/components/competence-card-mobile.hbs
+++ b/mon-pix/app/templates/components/competence-card-mobile.hbs
@@ -1,10 +1,10 @@
 <article class="competence-card {{if @interactive "competence-card--interactive"}}">
   <LinkTo @route="competences.details" @model={{scorecard.competenceId}} class="competence-card__link">
     <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
-    <header class="competence-card__header">
+    <div class="competence-card__title">
       <span class="competence-card__area-name">{{scorecard.area.title}}</span>
       <span class="competence-card__competence-name">{{scorecard.name}}</span>
-    </header>
+    </div>
     <div class="competence-card__body">
       {{#if scorecard.isFinishedWithMaxLevel}}
         <div class="competence-card__congrats competence-card__congrats--small">

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -60,11 +60,18 @@
       {{#if @scorecard.isFinished}}
         {{#if this.displayImproveButton}}
           {{#if this.canImprove}}
-            <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action "improveCompetenceEvaluation"}}>
-              Retenter
-              <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
-            </button>
-            <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
+            {{#if this.shouldWaitBeforeImproving}}
+              <div class="scorecard-details__improvement-countdown">
+                <span class="scorecard-details-improvement-countdown__label">Tenter le niveau supérieur dans</span>
+                <span class="scorecard-details-improvement-countdown__count">{{this.computeRemainingDaysBeforeImproving}}</span>
+              </div>
+            {{else}}
+              <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action "improveCompetenceEvaluation"}}>
+                Retenter
+                <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+              </button>
+              <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
+            {{/if}}
           {{/if}}
         {{/if}}
       {{else}}

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -33,6 +33,7 @@ function _addDefaultScorecards(user, server) {
       competenceId: 'competence_1_1_id',
       index : `${areas[0].code}.1`,
       remainingDaysBeforeReset: 0,
+      remainingDaysBeforeImproving: 0,
       status: 'STARTED',
       tutorials: [tutorial],
     }));
@@ -47,6 +48,7 @@ function _addDefaultScorecards(user, server) {
       competenceId: 'competence_2_1_id',
       index : `${areas[1].code}.1`,
       remainingDaysBeforeReset: 5,
+      remainingDaysBeforeImproving: 0,
       status: 'STARTED',
     }));
     scorecards.push(server.create('scorecard', {
@@ -60,6 +62,7 @@ function _addDefaultScorecards(user, server) {
       competenceId: 'competence_2_2_id',
       index : `${areas[1].code}.2`,
       remainingDaysBeforeReset: null,
+      remainingDaysBeforeImproving: null,
       status: 'NOT_STARTED',
     }));
     scorecards.push(server.create('scorecard', {
@@ -73,6 +76,35 @@ function _addDefaultScorecards(user, server) {
       competenceId: 'competence_3_1_id',
       index : `${areas[1].code}.1`,
       remainingDaysBeforeReset: 0,
+      remainingDaysBeforeImproving: 0,
+      status: 'COMPLETED',
+    }));
+    scorecards.push(server.create('scorecard', {
+      id: `${user.id}_competence_4_1_id`,
+      name: 'Area_4_Competence_1_name',
+      description : 'Area_4_Competence_1_description',
+      earnedPix: 0,
+      level: 0,
+      pixScoreAheadOfNextLevel: 0,
+      area: areas[3],
+      competenceId: 'competence_4_1_id',
+      index : `${areas[3].code}.1`,
+      remainingDaysBeforeReset: 0,
+      remainingDaysBeforeImproving: 3,
+      status: 'COMPLETED',
+    }));
+    scorecards.push(server.create('scorecard', {
+      id: `${user.id}_competence_4_2_id`,
+      name: 'Area_4_Competence_2_name',
+      description : 'Area_4_Competence_2_description',
+      earnedPix: 0,
+      level: 0,
+      pixScoreAheadOfNextLevel: 0,
+      area: areas[3],
+      competenceId: 'competence_4_2_id',
+      index : `${areas[3].code}.2`,
+      remainingDaysBeforeReset: 0,
+      remainingDaysBeforeImproving: 0,
       status: 'COMPLETED',
     }));
     user.update({ scorecards });
@@ -84,6 +116,7 @@ function _createAreas(server) {
   areas.push(server.create('area', { code: 1, title: 'Area_1_title', color: 'jaffa' }));
   areas.push(server.create('area', { code: 2, title: 'Area_2_title', color: 'emerald' }));
   areas.push(server.create('area', { code: 3, title: 'Area_3_title', color: 'cerulean' }));
+  areas.push(server.create('area', { code: 4, title: 'Area_4_title', color: 'wild-strawberry' }));
   return areas;
 }
 

--- a/mon-pix/mirage/routes/users/reset-scorecard.js
+++ b/mon-pix/mirage/routes/users/reset-scorecard.js
@@ -13,6 +13,7 @@ export default function(schema, request) {
     earnedPix: 0,
     pixScoreAheadOfNextLevel: 0,
     remainingDaysBeforeReset: null,
+    remainingDaysBeforeImproving: null,
   });
 
   return scorecard;

--- a/mon-pix/mirage/serializers/scorecard.js
+++ b/mon-pix/mirage/serializers/scorecard.js
@@ -11,6 +11,7 @@ export default ApplicationSerializer.extend({
     'pixScoreAheadOfNextLevel',
     'status',
     'remainingDaysBeforeReset',
+    'remainingDaysBeforeImproving',
   ],
   include: ['area'],
   links(record) {

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -5,6 +5,7 @@ import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import config from 'mon-pix/config/environment';
 
 describe('Acceptance | Competence details | Afficher la page de détails d\'une compétence', () => {
   setupApplicationTest();
@@ -22,6 +23,8 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
     let scorecardWithRemainingDaysBeforeReset;
     let scorecardWithoutPoints;
     let scorecardWithMaxLevel;
+    let scorecardWithRemainingDaysBeforeImproving;
+    let scorecardWithoutRemainingDaysBeforeImproving;
 
     beforeEach(async () => {
       await authenticateByEmail(user);
@@ -29,6 +32,8 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
       scorecardWithRemainingDaysBeforeReset = user.scorecards.models[1];
       scorecardWithoutPoints = user.scorecards.models[2];
       scorecardWithMaxLevel = user.scorecards.models[3];
+      scorecardWithRemainingDaysBeforeImproving = user.scorecards.models[4];
+      scorecardWithoutRemainingDaysBeforeImproving = user.scorecards.models[5];
     });
 
     it('should be able to visit URL of competence details page', async () => {
@@ -115,7 +120,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
         expect(findAll('.tutorial-item')).to.have.lengthOf(nbTutos);
       });
 
-      context('when it is remaining some days before reset', () => {
+      context('when it has remaining some days before reset', () => {
 
         it('should display remaining days before reset', async () => {
           // when
@@ -175,6 +180,55 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
           expect(findAll('.competence-card__level .score-value')).to.have.lengthOf(0);
           expect(findAll('.scorecard-details-content-right-score-container__pix-earned .score-value')).to.have.lengthOf(0);
           expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
+        });
+
+      });
+
+      context('when it has remaining some days before improving', () => {
+        let configurationForImprovingCompetence;
+
+        before(() => {
+          configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+        });
+
+        after(function() {
+          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
+        });
+
+        it('should display remaining days before improving', async () => {
+          // given
+          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
+
+          // when
+          await visit(`/competences/${scorecardWithRemainingDaysBeforeImproving.competenceId}/details`);
+
+          // then
+          expect(find('.scorecard-details__improvement-countdown').textContent)
+            .to.contain(`${scorecardWithRemainingDaysBeforeImproving.remainingDaysBeforeImproving} jours`);
+          expect(find('.scorecard-details__improve-button')).to.not.exist;
+        });
+      });
+
+      context('when it has no remaining days before improving', () => {
+        let configurationForImprovingCompetence;
+
+        before(() => {
+          configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+        });
+
+        after(function() {
+          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
+        });
+
+        it('should display improving button', async () => {
+          // given
+          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
+
+          // when
+          await visit(`/competences/${scorecardWithoutRemainingDaysBeforeImproving.competenceId}/details`);
+
+          // then
+          expect(findAll('.scorecard-details__improve-button')).to.exist;
         });
 
       });

--- a/mon-pix/tests/acceptance/tutorial-actions-test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions-test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Tutorial | Actions', function() {
     it('should display tutorial item in competence page with actions', async function() {
       // when
       await visit('/profil');
-      await click(`.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__header`);
+      await click(`.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__title`);
 
       // then
       expect(find('.tutorial__content')).to.exist;
@@ -44,7 +44,7 @@ describe('Acceptance | Tutorial | Actions', function() {
     it('should disable evaluate action on click', async function() {
       // when
       await visit('/profil');
-      await click(`.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__header`);
+      await click(`.rounded-panel-body__areas:nth-child(${firstScorecard.area.code}) .rounded-panel-body__competence-card:nth-child(${competenceNumber}) .competence-card__title`);
       await click('.tutorial-content-actions__evaluate');
 
       // then

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | competence-card-default', function() {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+      await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
       expect(find('.competence-card')).to.exist;
@@ -38,7 +38,7 @@ describe('Integration | Component | competence-card-default', function() {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+      await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
       expect(find('.competence-card__color').getAttribute('class'))
@@ -51,7 +51,7 @@ describe('Integration | Component | competence-card-default', function() {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+      await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
       expect(find('.competence-card__area-name').textContent).to.equal(scorecard.area.title);
@@ -63,7 +63,7 @@ describe('Integration | Component | competence-card-default', function() {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+      await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
       expect(find('.competence-card__competence-name').textContent).to.equal(scorecard.name);
@@ -75,7 +75,7 @@ describe('Integration | Component | competence-card-default', function() {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+      await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
       expect(find('.score-label').textContent).to.equal('Niveau');
@@ -90,7 +90,7 @@ describe('Integration | Component | competence-card-default', function() {
         this.set('scorecard', scorecard);
 
         // when
-        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
         // then
         expect(find('.competence-card__button').textContent).to.contains('Commencer');
@@ -105,7 +105,7 @@ describe('Integration | Component | competence-card-default', function() {
         this.set('scorecard', scorecard);
 
         // when
-        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
         // then
         expect(find('.competence-card__button').textContent).to.contains('Reprendre');
@@ -118,7 +118,7 @@ describe('Integration | Component | competence-card-default', function() {
           this.set('scorecard', scorecard);
 
           // when
-          await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+          await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
         });
 
         it('should not show congrats design', function() {
@@ -145,24 +145,38 @@ describe('Integration | Component | competence-card-default', function() {
         this.set('scorecard', scorecard);
 
         // when
-        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
         // then
         expect(find('.competence-card-button__label')).to.be.null;
       });
 
-      it('should show the improving button', async function() {
+      it('should show the improving button when there is no remaining days before improving', async function() {
         // given
-        const scorecard = { area, level: 3, isFinished: true, isStarted: false };
+        const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 0 };
         this.set('scorecard', scorecard);
         config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
 
         // when
-        await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
         // then
         expect(find('.competence-card__button')).to.exist;
         expect(find('.competence-card__button').textContent).to.contains('Retenter');
+      });
+
+      it('should show the improving countdown when there is some remaining days before improving', async function() {
+        // given
+        const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 3 };
+        this.set('scorecard', scorecard);
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
+
+        // when
+        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
+
+        // then
+        expect(find('.competence-card-interactions__improvement-countdown')).to.exist;
+        expect(find('.competence-card-interactions__improvement-countdown').textContent).to.contains('3 jours');
       });
 
       context('and the user has reached the maximum level', function() {
@@ -172,7 +186,7 @@ describe('Integration | Component | competence-card-default', function() {
           this.set('scorecard', scorecard);
 
           // when
-          await render(hbs`{{competence-card-default scorecard=scorecard}}`);
+          await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
         });
 
         it('should show congrats design', function() {

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -65,7 +65,7 @@ describe('Integration | Component | Profile-content', function() {
         // then
         expect(find('.competence-card')).to.exist;
         expect(find('.score-label')).to.exist;
-        expect(find('.competence-card__footer')).to.exist;
+        expect(find('.competence-card__interactions')).to.exist;
       });
     });
 
@@ -80,7 +80,7 @@ describe('Integration | Component | Profile-content', function() {
         // then
         expect(find('.competence-card')).to.exist;
         expect(find('.score-label')).to.not.exist;
-        expect(find('.competence-card__footer')).to.not.exist;
+        expect(find('.competence-card__interactions')).to.not.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -99,39 +99,64 @@ describe('Integration | Component | scorecard-details', function() {
     });
 
     context('When the user has finished a competence', async function() {
+      let scorecard;
       const configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
+
       afterEach(function() {
         config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
       });
 
-      beforeEach(async function() {
+      beforeEach(function() {
         // given
-        const scorecard = {
+        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
+        scorecard = {
           remainingPixToNextLevel: 1,
           isFinished: true,
           tutorials: [],
         };
-
-        this.set('scorecard', scorecard);
-
-        // when
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
-        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
       });
 
       it('should not display remainingPixToNextLevel', async function() {
+        // when
+        this.set('scorecard', scorecard);
+        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
         // then
         expect(find('.scorecard-details-content-right__level-info')).to.not.exist;
       });
 
       it('should not display a button', async function() {
+        // when
+        this.set('scorecard', scorecard);
+        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
         // then
         expect(find('.scorecard-details__resume-or-start-button')).to.not.exist;
       });
 
-      it('should show the improving button', function() {
+      it('should show the improving button if the remaining days before improving are equal to 0', async function() {
+        // given
+        scorecard.remainingDaysBeforeImproving = 0;
+
+        // when
+        this.set('scorecard', scorecard);
+        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
         // then
         expect(find('.scorecard-details__improve-button')).to.exist;
+      });
+
+      it('should show the improving countdown if the remaining days before improving are different than 0', async function() {
+        // given
+        scorecard.remainingDaysBeforeImproving = 3;
+
+        // when
+        this.set('scorecard', scorecard);
+        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+
+        // then
+        expect(find('.scorecard-details__improvement-countdown')).to.exist;
+        expect(find('.scorecard-details__improvement-countdown').textContent).to.contains('3 jours');
       });
 
       context('and the user has reached the max level', async function() {

--- a/mon-pix/tests/unit/components/competence-card-default-test.js
+++ b/mon-pix/tests/unit/components/competence-card-default-test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
+import { expect } from 'chai';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -42,4 +43,69 @@ describe('Unit | Component | competence-card-default ', function() {
     });
 
   });
+
+  describe('#computeRemainingDaysBeforeImproving', function() {
+    let component, scorecard;
+
+    beforeEach(() => {
+      const competenceId = 'recCompetenceId';
+      scorecard = EmberObject.create({ competenceId });
+      component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
+    });
+
+    it('should return a singular sentence when remaining days before improving are equal to 1', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 1;
+
+      // when
+      const result = component.computeRemainingDaysBeforeImproving;
+
+      // then
+      expect(result).to.be.equal('1 jour');
+    });
+
+    it('should return a plural sentence when remaining days before improving are different than 1', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 3;
+
+      // when
+      const result = component.computeRemainingDaysBeforeImproving;
+
+      // then
+      expect(result).to.be.equal('3 jours');
+    });
+  });
+
+  describe('#shouldWaitBeforeImproving', function() {
+    let component, scorecard;
+
+    beforeEach(() => {
+      const competenceId = 'recCompetenceId';
+      scorecard = EmberObject.create({ competenceId });
+      component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
+    });
+
+    it('should return true when remaining days before improving are different than 0', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 3;
+
+      // when
+      const result = component.shouldWaitBeforeImproving;
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when remaining days before improving are equal to 0', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 0;
+
+      // when
+      const result = component.shouldWaitBeforeImproving;
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
 });

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -191,4 +191,69 @@ describe('Unit | Component | scorecard-details ', function() {
     });
 
   });
+
+  describe('#computeRemainingDaysBeforeImproving', function() {
+    let component, scorecard;
+
+    beforeEach(() => {
+      const competenceId = 'recCompetenceId';
+      scorecard = EmberObject.create({ competenceId });
+      component = createGlimmerComponent('component:scorecard-details', { scorecard });
+    });
+
+    it('should return a singular sentence when remaining days before improving are equal to 1', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 1;
+
+      // when
+      const result = component.computeRemainingDaysBeforeImproving;
+
+      // then
+      expect(result).to.be.equal('1 jour');
+    });
+
+    it('should return a plural sentence when remaining days before improving are different than 1', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 3;
+
+      // when
+      const result = component.computeRemainingDaysBeforeImproving;
+
+      // then
+      expect(result).to.be.equal('3 jours');
+    });
+  });
+
+  describe('#shouldWaitBeforeImproving', function() {
+    let component, scorecard;
+
+    beforeEach(() => {
+      const competenceId = 'recCompetenceId';
+      scorecard = EmberObject.create({ competenceId });
+      component = createGlimmerComponent('component:competence-card-default', { scorecard });
+    });
+
+    it('should return true when remaining days before improving are different than 0', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 3;
+
+      // when
+      const result = component.shouldWaitBeforeImproving;
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when remaining days before improving are equal to 0', () => {
+      // given
+      scorecard.remainingDaysBeforeImproving = 0;
+
+      // when
+      const result = component.shouldWaitBeforeImproving;
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'utilisateur n'est pas en mesure de re-valoriser ses apprentissages sur une compétence de l'univers Pix.

## :robot: Solution
Sur chaque compétence, permettre à l'utilisateur de retenter des acquis de compétence échoués au bout de 4 jours. 

Dans le cadre de cette PR, nous mettons en place un décompte de 4 jours au bout duquel l'utilisateur sera en capacité présenter le fruit de sa progression et ainsi améliorer son score de Pix.

## :rainbow: Remarques
Quelques commits de BSR ont été exécutés au passage : 
- utiliser `<FaIcon>` au lieu de `{{fa-icon}}`;
- délier nos tests automatisés pour le décompte de jours des variables d'environnement locales ; 
- remplacer par des `<div>` les `<header>` et `<footer>` utilisés à mauvais escient et de surcroît néfastes aux travaux engagés pour améliorer l'accessibilité de l'univers Pix. 

## :100: Pour tester
- Commencer une compétence 
- S'épanouir dans l'univers Pix jusqu'à la fin de la compétence
- Observer le compteur de jour au survol sur la carte compétence que l'on vient de terminer et dans le détail de celle-ci