### PR TITLE
[FEATURE] Permettre l'envoi d'une invitation par une nouvelle page (1ère partie)(PIX-881).

### DIFF
--- a/orga/app/components/routes/join-request-form.js
+++ b/orga/app/components/routes/join-request-form.js
@@ -1,0 +1,26 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import InputValidator from '../../utils/input-validator';
+import isUAIValid from '../../utils/uai-validator';
+
+const isStringValid = (value) => value ? Boolean(value.trim()) : undefined;
+
+export default class JoinRequestForm extends Component {
+
+  @service session;
+  @service store;
+
+  isLoading = false;
+
+  validation = {
+    uai: new InputValidator(isUAIValid, 'L\'UAI n\'est pas correct.'),
+    firstName: new InputValidator(isStringValid, 'Votre prénom n’est pas renseigné.'),
+    lastName: new InputValidator(isStringValid, 'Votre nom n’est pas renseigné.'),
+  };
+
+  @action
+  validateInput(key, value) {
+    this.validation[key].validate({ value, resetServerMessage: true });
+  }
+}

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -17,6 +17,7 @@ Router.map(function() {
   this.route('login', { path: 'connexion' });
 
   this.route('join', { path: 'rejoindre' });
+  this.route('join-request', { path: '/demande-administration-sco' });
   this.route('join-when-authenticated');
 
   this.route('terms-of-service', { path: '/cgu' });

--- a/orga/app/routes/join-request.js
+++ b/orga/app/routes/join-request.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class JoinRequestRoute extends Route {}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "components/current-organization";
 @import "components/dissociate-user-modal";
 @import "components/dropdown";
+@import "components/join-request-form";
 @import "components/pagination-control";
 @import "components/previous-page-button";
 @import "components/pix-score-tag";
@@ -38,6 +39,7 @@
 @import "components/modal";
 @import "pages/login";
 @import "pages/join";
+@import "pages/join-request";
 @import "pages/authenticated";
 @import "pages/authenticated/campaigns";
 @import "pages/authenticated/campaigns/details";

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -1,0 +1,56 @@
+.join-request-form {
+
+  &__information {
+    font-family: $roboto;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    margin: 0 0 24px;
+  }
+
+  &__error-message {
+    margin-bottom: 10px;
+    font-size: 0.875rem;
+    text-align: center;
+  }
+
+  &__back {
+    font-size: 1rem;
+    text-align: left;
+
+    a {
+      color: $communication-dark;
+      text-decoration: none;
+
+      svg {
+        margin-right: 4px;
+        transition: all .2s ease-in-out;
+      }
+
+      &:hover {
+        text-decoration: underline;
+
+        svg {
+          transform: scale(1.2);
+        }
+      }
+    }
+  }
+
+  &__button {
+    font-weight: 600;
+    margin-top: 8px;
+  }
+
+  .input-container {
+    margin-bottom: 16px;
+  }
+
+  form {
+    margin: auto;
+    width: 300px;
+
+    @include device-is('tablet') {
+      width: 450px;
+    }
+  }
+}

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -1,0 +1,42 @@
+.join-request {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: $pix-orga-old-gradient;
+  align-items: center;
+  justify-content: center;
+  min-height: 800px;
+
+  &__panel {
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 32px 10px 40px;
+
+    @include device-is('tablet') {
+      padding: 32px 67px 40px;
+    }
+  }
+
+  &__title {
+    font-family: $open-sans;
+    font-size: 2rem;
+    letter-spacing: 0.009375rem;
+    line-height: 2.6875rem;
+    font-weight: 300;
+    text-align: center;
+    margin: 14px 0;
+  }
+
+  &__description {
+    font-family: $roboto;
+    text-align: center;
+    max-width: 497px;
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.375rem;
+    margin: 0 0 48px;
+  }
+}

--- a/orga/app/templates/components/routes/join-request-form.hbs
+++ b/orga/app/templates/components/routes/join-request-form.hbs
@@ -1,0 +1,72 @@
+<div class="join-request-form">
+  {{#if this.hasErrorMessage}}
+    <div id="join-request-form-error-message" class="join-request-form__error-message error-message">{{this.errorMessage}}</div>
+  {{/if}}
+
+  <p class="join-request-form__information">Tous les champs sont obligatoires.</p>
+
+  <form>
+
+    <div class="input-container">
+      <label for="uai" class="label">UAI/RNE de l'établissement</label>
+      {{#if this.validation.uai.hasError}}
+        <div class="alert-input alert-input--error" role="alert">{{this.validation.uai.message}}</div>
+      {{/if}}
+      <Input
+        @id="uai"
+        @name="uai"
+        @type="text"
+        class="input {{if this.validation.uai.hasError 'input--error'}}"
+        @value={{this.uai}}
+        @required='true'
+        {{on "focusout" (fn this.validateInput "uai" this.uai)}}
+      />
+    </div>
+
+    <div class="input-container">
+      <label for="firstName" class="label">Votre prénom</label>
+      {{#if this.validation.firstName.hasError}}
+        <div class="alert-input alert-input--error" role="alert">{{this.validation.firstName.message}}</div>
+      {{/if}}
+      <Input
+        @id="firstName"
+        @name="firstName"
+        @type="text"
+        class="input {{if this.validation.firstName.hasError 'input--error'}}"
+        @value={{this.firstName}}
+        @autocomplete="given-name"
+        @required='true'
+        {{on "focusout" (fn this.validateInput "firstName" this.firstName)}}
+      />
+    </div>
+
+    <div class="input-container">
+      <label for="lastName" class="label">Votre nom</label>
+      {{#if this.validation.lastName.hasError}}
+        <div class="alert-input alert-input--error" role="alert">{{this.validation.lastName.message}}</div>
+      {{/if}}
+      <Input
+        @id="lastName"
+        @name="lastName"
+        @type="text"
+        class="input {{if this.validation.lastName.hasError 'input--error'}}"
+        @value={{this.lastName}}
+        @autocomplete="family-name"
+        @required='true'
+        {{on "focusout" (fn this.validateInput "lastName" this.lastName)}}
+      />
+    </div>
+
+    <div class="input-container">
+      {{#if this.isLoading}}
+        <button type="button" class="button"><span class="loader-in-button">&nbsp;</span></button>
+      {{else}}
+        <button type="submit" class="button join-request-form__button">Envoyer</button>
+      {{/if}}
+    </div>
+
+    <div class="join-request-form__back">
+      <LinkTo @route="login"><FaIcon @icon="arrow-left" />Revenir à la page de connexion</LinkTo>
+    </div>
+  </form>
+</div>

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -1,0 +1,14 @@
+<div class="join-request">
+  <div class="panel join-request__panel">
+    <div class="panel__image">
+      <img src="/pix-orga.svg" alt="Pix Orga">
+    </div>
+    <h1 class="join-request__title">Activez ou récupérez votre espace</h1>
+    <p class="join-request__description">
+      A l'attention des personnels de direction. <br/>
+      Saisissez ces informations pour recevoir un lien d'activation à l'adresse e-mail
+      de votre établissement et devenir administrateur de l'espace Pix Orga.
+    </p>
+    <Routes::JoinRequestForm />
+  </div>
+</div>

--- a/orga/app/utils/uai-validator.js
+++ b/orga/app/utils/uai-validator.js
@@ -1,0 +1,8 @@
+export default function isUAIValid(uai) {
+
+  if (!uai) {
+    return false;
+  }
+  const pattern = /^([0-9]{7}[A-W])/s;
+  return pattern.test(uai.trim());
+}

--- a/orga/tests/integration/components/routes/join-request-form-test.js
+++ b/orga/tests/integration/components/routes/join-request-form-test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/join-request-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  module('when are not fill correctly', function() {
+
+    const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
+    const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
+    const INCORRECT_UAI_FORMAT_ERROR_MESSAGE = 'L\'UAI n\'est pas correct.';
+
+    [{ stringFilledIn: ' ' },
+      { stringFilledIn: '123456Z' },
+      { stringFilledIn: '1234A' },
+    ].forEach(function({ stringFilledIn }) {
+
+      test(`it should display an error message on uai field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+        // given
+        await render(hbs`<Routes::JoinRequestForm />`);
+
+        // when
+        await fillIn('#uai', stringFilledIn);
+        await triggerEvent('#uai', 'focusout');
+
+        // then
+        assert.contains(INCORRECT_UAI_FORMAT_ERROR_MESSAGE);
+      });
+    });
+
+    [{ stringFilledIn: '' },
+      { stringFilledIn: ' ' },
+    ].forEach(function({ stringFilledIn }) {
+      test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+        // given
+        await render(hbs`<Routes::JoinRequestForm />`);
+
+        // when
+        await fillIn('#firstName', stringFilledIn);
+        await triggerEvent('#firstName', 'focusout');
+
+        // then
+        assert.contains(EMPTY_FIRSTNAME_ERROR_MESSAGE);
+      });
+    });
+
+    [{ stringFilledIn: '' },
+      { stringFilledIn: ' ' },
+    ].forEach(function({ stringFilledIn }) {
+      test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
+        // given
+        await render(hbs`<Routes::JoinRequestForm />`);
+
+        // when
+        await fillIn('#lastName', stringFilledIn);
+        await triggerEvent('#lastName', 'focusout');
+
+        // then
+        assert.contains(EMPTY_LASTNAME_ERROR_MESSAGE);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/routes/join-request-test.js
+++ b/orga/tests/unit/routes/join-request-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | join-request', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:join-request');
+    assert.ok(route);
+  });
+});

--- a/orga/tests/unit/utils/uai-validator-test.js
+++ b/orga/tests/unit/utils/uai-validator-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import isUAIValid from 'pix-orga/utils/uai-validator';
+
+module('Unit | Utils | uai-validator', function(hooks) {
+  setupTest(hooks);
+
+  module('Invalid UAI', function() {
+    [
+      '',
+      ' ',
+      null,
+      '1253537839A',
+      '123456Z',
+      '123456X',
+      '12345A',
+      'A123456'
+    ].forEach(function(badUAI) {
+      test(`should return false when uai is invalid: ${badUAI}`, function(assert) {
+        assert.equal(isUAIValid(badUAI), false);
+      });
+    });
+  });
+
+  module('Valid UAI', function() {
+    [
+      '1234567A',
+      '1234567B ',
+      ' 1234567A',
+      ' 1234567A ',
+      ' 1234567W ',
+    ].forEach(function(validUAI) {
+      test(`should return true if provided UAI is valid: ${validUAI}`, function(assert) {
+        assert.equal(isUAIValid(validUAI), true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons faciliter l'accès à Pix Orga. 
Nous voulons qu'un nouveau directeur d'établissement n'ait pas à contacter l'ancien directeur pour l'inviter à rejoindre l'organisation puis changer son rôle en admin. 

## :robot: Solution
Nous voulons mettre en place un nouveau formulaire qui enverra un e-mail d'invitation à l'adresse e-mail de récupération de l'organisation dont aura l'accès le nouveau directeur. Cette invitation lui donnera le rôle d'administrateur de l'organisation. 

Dans cette PR, seulement la nouvelle page avec le formulaire a été fait. 

## :rainbow: Remarques
Un nouveau validateur d'input a été ajouté : `uai-validator`. 
Un UAI (Unité Administrative Immatriculée), et un code unique donnée à chaque établissement. Il se compose de 7 chiffres et d'une lettre comprise entre la position 0 et 22. Elle correspond au reste de la division des 7 premiers chiffre par 23 (cette règle de vérification n'a pas été implémentée). Voir [ici](https://fr.wikipedia.org/wiki/R%C3%A9pertoire_national_des_%C3%A9tablissements).

## :100: Pour tester
- Aller sur la page https://orga-pr1582.review.pix.fr/demande-administration-sco et tester la validation des champs. 
