### PR TITLE
[BUGFIX] Le signalement surveillant était supprimé en enregistrant une certif (PIX-916)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-serializer.js
@@ -73,10 +73,19 @@ module.exports = {
             return Promise.reject(new WrongDateFormatError());
           }
         }
-        if (_.isEmpty(_.trim(certifications.examinerComment))) {
+
+        if (!_isOmitted(certifications.examinerComment) && _hasNoExaminerComment(certifications.examinerComment)) {
           certifications.examinerComment = NO_EXAMINER_COMMENT;
         }
         return certifications;
       }));
   },
 };
+
+function _isOmitted(aString) {
+  return _.isUndefined(aString);
+}
+
+function _hasNoExaminerComment(aString) {
+  return _.isEmpty(_.trim(aString));
+}

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -20,6 +20,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
             'birthplace': 'Namek',
             'birthdate': '1989-10-24',
             'external-id': 'xenoverse2',
+            'examiner-comment': 'Un signalement surveillant',
           },
         },
       };
@@ -31,7 +32,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
         birthplace: 'Namek',
         birthdate: '1989-10-24',
         externalId: 'xenoverse2',
-        examinerComment: null,
+        examinerComment: 'Un signalement surveillant',
       };
     });
 
@@ -67,6 +68,17 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
         // then
         expect(result.examinerComment).to.equal(NO_EXAMINER_COMMENT);
       });
+    });
+
+    it('should return undefined if no examiner comment', async function() {
+      // given
+      jsonCertificationCourse.data.attributes['examiner-comment'] = undefined;
+
+      // when
+      const result = await serializer.deserialize(jsonCertificationCourse);
+
+      // then
+      expect(result.examinerComment).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION

## :unicorn: Problème
Lorsqu'une certification était modifiée depuis sa page de détail dans Pix Admin cela supprimait son signalement de surveillant (examinerComment)

## :robot: Solution
Lors de la deserialisation de la certif le champs "examinerComment" était mis à `null` lorsque ce dernier était : null / undefined / string vide ou string contenant des espaces. 
Le champ n'est plus mis à `null` maintenant s'il était `undefined`.

## :rainbow: Remarques
Ce bug est présent depuis 4mois en prod.
Il a été découvert par Anne-C qui a constaté des différences dans le fichier avant jury avant et après avoir modifié des certifications.

## :100: Pour tester
- aller sur Pix admin et trouver une session avec des certif qui ont des examinerComment (ex: session 6)
- télécharger le fichier avant jury
- aller sur la page de détail d'une des certifs de la session
- enregistrer (en bas) + enregistrer + valider modale (sans forcément modifier quoi que ce soit)
- aller sur la page d'info de la session
- télécharger le fichier avant jury
- constater qu'il n'y a aucun changement (avant la colonne "Signalement surveillant" s'était effacée sur la certif qu'on avait enregistrée)

