### PR TITLE
[FEATURE] Ne pas autoriser un utilisateur à retenter une compétence quand le niveau maximum de la compétence est atteint (PIX-898).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -50,6 +50,9 @@ function _mapToHttpError(error) {
     return error;
   }
 
+  if (error instanceof DomainErrors.ImproveCompetenceEvaluationForbiddenError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.CampaignAlreadyArchivedError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -51,7 +51,7 @@ function _mapToHttpError(error) {
   }
 
   if (error instanceof DomainErrors.ImproveCompetenceEvaluationForbiddenError) {
-    return new HttpErrors.ForbiddenError(error.message);
+    return new HttpErrors.ImproveCompetenceEvaluationForbiddenError(error.message);
   }
   if (error instanceof DomainErrors.CampaignAlreadyArchivedError) {
     return new HttpErrors.PreconditionFailedError(error.message);

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -71,6 +71,14 @@ class ForbiddenError extends BaseHttpError {
   }
 }
 
+class ImproveCompetenceEvaluationForbiddenError extends BaseHttpError {
+  constructor(message) {
+    super(message);
+    this.title = 'ImproveCompetenceEvaluationForbidden';
+    this.status = 403;
+  }
+}
+
 class BadRequestError extends BaseHttpError {
   constructor(message) {
     super(message);
@@ -84,6 +92,7 @@ module.exports = {
   BaseHttpError,
   ConflictError,
   ForbiddenError,
+  ImproveCompetenceEvaluationForbiddenError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -270,6 +270,12 @@ class ForbiddenAccess extends DomainError {
   }
 }
 
+class ImproveCompetenceEvaluationForbiddenError extends DomainError {
+  constructor(message = 'Le niveau maximum est déjà atteint pour cette compétence.') {
+    super(message);
+  }
+}
+
 class InvalidCertificationCandidate extends DomainError {
   constructor(message = 'Candidat de certification invalide.') {
     super(message);
@@ -505,6 +511,7 @@ module.exports = {
   EntityValidationError,
   FileValidationError,
   ForbiddenAccess,
+  ImproveCompetenceEvaluationForbiddenError,
   InvalidCertificationCandidate,
   InvalidCertificationReportForFinalization,
   InvalidParametersForSessionPublication,

--- a/api/lib/domain/services/get-competence-level.js
+++ b/api/lib/domain/services/get-competence-level.js
@@ -1,0 +1,12 @@
+const knowledgeElementRepository = require('../../infrastructure/repositories/knowledge-element-repository');
+const scoringService = require('./scoring/scoring-service');
+
+module.exports = async function getCompetenceLevel({
+  userId,
+  competenceId
+}) {
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+  const { currentLevel } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
+  return currentLevel;
+};
+

--- a/api/lib/domain/services/get-competence-level.js
+++ b/api/lib/domain/services/get-competence-level.js
@@ -3,9 +3,10 @@ const scoringService = require('./scoring/scoring-service');
 
 module.exports = async function getCompetenceLevel({
   userId,
-  competenceId
+  competenceId,
+  domainTransaction
 }) {
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId, domainTransaction });
   const { currentLevel } = scoringService.calculateScoringInformationForCompetence({ knowledgeElements });
   return currentLevel;
 };

--- a/api/lib/domain/usecases/improve-competence-evaluation.js
+++ b/api/lib/domain/usecases/improve-competence-evaluation.js
@@ -1,4 +1,6 @@
 const Assessment = require('../models/Assessment');
+const { MAX_REACHABLE_LEVEL } = require('../constants');
+const { ImproveCompetenceEvaluationForbiddenError } = require('../errors');
 
 module.exports = async function improveCompetenceEvaluation({
   competenceEvaluationRepository,
@@ -9,7 +11,12 @@ module.exports = async function improveCompetenceEvaluation({
   domainTransaction
 }) {
   const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({ userId, competenceId });
-  await getCompetenceLevel({ userId, competenceId });
+  const competenceLevel = await getCompetenceLevel({ userId, competenceId });
+
+  if (competenceLevel === MAX_REACHABLE_LEVEL) {
+    throw new ImproveCompetenceEvaluationForbiddenError();
+  }
+
   const assessment = new Assessment({
     userId,
     competenceId,

--- a/api/lib/domain/usecases/improve-competence-evaluation.js
+++ b/api/lib/domain/usecases/improve-competence-evaluation.js
@@ -1,7 +1,15 @@
 const Assessment = require('../models/Assessment');
 
-module.exports = async function improveCompetenceEvaluation({ competenceEvaluationRepository, assessmentRepository, userId, competenceId, domainTransaction }) {
-  const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({ competenceId, userId });
+module.exports = async function improveCompetenceEvaluation({
+  competenceEvaluationRepository,
+  getCompetenceLevel,
+  assessmentRepository,
+  userId,
+  competenceId,
+  domainTransaction
+}) {
+  const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({ userId, competenceId });
+  await getCompetenceLevel({ userId, competenceId });
   const assessment = new Assessment({
     userId,
     competenceId,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -33,6 +33,7 @@ const dependencies = {
   correctionRepository: require('../../infrastructure/repositories/correction-repository'),
   courseRepository: require('../../infrastructure/repositories/course-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
+  getCompetenceLevel: require('../../domain/services/get-competence-level'),
   improvementService: require('../../domain/services/improvement-service'),
   juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),
   jurySessionRepository: require('../../infrastructure/repositories/jury-session-repository'),

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -47,10 +47,10 @@ module.exports = {
       });
   },
 
-  getByCompetenceIdAndUserId({ competenceId, userId }) {
+  getByCompetenceIdAndUserId({ competenceId, userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     return BookshelfCompetenceEvaluation
       .where({ competenceId, userId })
-      .fetch({ require: true, withRelated: ['assessment'] })
+      .fetch({ require: true, withRelated: ['assessment'], transacting: domainTransaction.knexTransaction })
       .then((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfCompetenceEvaluation, result))
       .catch((bookshelfError) => {
         if (bookshelfError instanceof BookshelfCompetenceEvaluation.NotFoundError) {

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -5,6 +5,7 @@ const { knex } = require('../bookshelf');
 const KnowledgeElement = require('../../domain/models/KnowledgeElement');
 const BookshelfKnowledgeElement = require('../data/knowledge-element');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 function _getUniqMostRecents(knowledgeElements) {
   return _(knowledgeElements)
@@ -80,9 +81,9 @@ module.exports = {
     return _applyFilters(knowledgeElements);
   },
 
-  async findUniqByUserIdAndCompetenceId({ userId, competenceId }) {
+  async findUniqByUserIdAndCompetenceId({ userId, competenceId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const query = _findByUserIdAndLimitDateQuery({ userId });
-    const knowledgeElementRows = await query.where({ competenceId });
+    const knowledgeElementRows = await query.where({ competenceId }, { transacting: domainTransaction });
 
     const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
     return _applyFilters(knowledgeElements);

--- a/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
+++ b/api/tests/acceptance/application/competence-evaluation-controller-improve_test.js
@@ -52,24 +52,31 @@ describe('Acceptance | API | Improve Competence Evaluation', () => {
           options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
           databaseBuilder.factory.buildCompetenceEvaluation({ competenceId, userId });
           await databaseBuilder.commit();
-
-          // when
-          response = await server.inject(options);
-          assessment = response.result.data.relationships.assessment.data;
         });
 
-        it('should return 200 and the competence evaluation', async () => {
-          // then
-          expect(response.statusCode).to.equal(200);
-          expect(response.result.data.id).to.exist;
-          expect(assessment.id).to.be.not.null;
-          expect(assessment).to.be.not.undefined;
-        });
+        context('and user has not reached maximum level of given competence', () => {
 
-        it('should create an improving assessment', async () => {
-          // then
-          const [createdAssessment] = await knex('assessments').select().where({ id: assessment.id });
-          expect(createdAssessment.isImproving).to.equal(true);
+          beforeEach(async () => {
+            await databaseBuilder.commit();
+
+            // when
+            response = await server.inject(options);
+            assessment = response.result.data.relationships.assessment.data;
+          });
+
+          it('should return 200 and the competence evaluation', async () => {
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.data.id).to.exist;
+            expect(assessment.id).to.be.not.null;
+            expect(assessment).to.exist;
+          });
+
+          it('should create an improving assessment', async () => {
+            // then
+            const [createdAssessment] = await knex('assessments').select().where({ id: assessment.id });
+            expect(createdAssessment.isImproving).to.equal(true);
+          });
         });
 
       });

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -13,6 +13,11 @@ describe('Integration | API | Controller Error', () => {
     return payload.errors[0].detail;
   }
 
+  function responseTitle(response) {
+    const payload = JSON.parse(response.payload);
+    return payload.errors[0].title;
+  }
+
   beforeEach(async () => {
     server = await createServer();
     server.route({ method: 'GET', path: '/test_route', handler: routeHandler, config: { auth: false } });
@@ -183,7 +188,6 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Utilisateur non autorisé à créer une campagne');
-
     });
 
     it('responds Forbidden when a UserNotAuthorizedToGetCertificationCoursesError error occurs', async () => {
@@ -264,6 +268,7 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Le niveau maximum est déjà atteint pour cette compétence.');
+      expect(responseTitle(response)).to.equal('ImproveCompetenceEvaluationForbidden');
     });
   });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -257,6 +257,14 @@ describe('Integration | API | Controller Error', () => {
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Cet utilisateur n\'est pas autorisé à créer la ressource.');
     });
+
+    it('responds Forbidden when a ImproveCompetenceEvaluationForbiddenError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.ImproveCompetenceEvaluationForbiddenError());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
+      expect(responseDetail(response)).to.equal('Le niveau maximum est déjà atteint pour cette compétence.');
+    });
   });
 
   context('400 Bad Request', () => {

--- a/api/tests/integration/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/integration/domain/usecases/improve-competence-evaluation_test.js
@@ -3,6 +3,7 @@ const improveCompetenceEvaluation = require('../../../../lib/domain/usecases/imp
 
 const competenceEvaluationRepository = require('../../../../lib/infrastructure/repositories/competence-evaluation-repository');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const getCompetenceLevel = require('../../../../lib/domain/services/get-competence-level');
 
 describe('Integration | UseCase | Improve Competence Evaluation', () => {
   const competenceId = 'recCompetenceId';
@@ -16,7 +17,7 @@ describe('Integration | UseCase | Improve Competence Evaluation', () => {
 
   it('should create an improving assessment', async () => {
     // when
-    await improveCompetenceEvaluation({ competenceEvaluationRepository, assessmentRepository, userId, competenceId });
+    await improveCompetenceEvaluation({ competenceEvaluationRepository, assessmentRepository, getCompetenceLevel, userId, competenceId });
 
     // then
     const [updatedCompetenceEvaluation] = await knex('competence-evaluations').where({ id: competenceEvaluation.id });

--- a/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-evaluation.js
@@ -20,7 +20,7 @@ module.exports = function buildCompetenceEvaluation(
     assessmentId = assessment.id;
   }
   if (assessmentId && !assessment) {
-    assessmentId = buildAssessment({ id: assessmentId });
+    assessment = buildAssessment({ id: assessmentId });
   }
   if (!assessmentId && !assessment) {
     assessment = buildAssessment();

--- a/api/tests/unit/domain/services/get-competence-level_test.js
+++ b/api/tests/unit/domain/services/get-competence-level_test.js
@@ -9,6 +9,7 @@ describe('Unit | Domain | Service | Get Competence Level', function() {
     const userId = 'userId';
     const competenceId = 'competenceId';
     const knowledgeElements = Symbol('knowledgeElements');
+    const domainTransaction = Symbol('domainTransaction');
     const level = 3;
     let competenceLevel;
 
@@ -18,12 +19,12 @@ describe('Unit | Domain | Service | Get Competence Level', function() {
       sinon.stub(scoringService, 'calculateScoringInformationForCompetence').returns({ currentLevel: level });
 
       // when
-      competenceLevel = await getCompetenceLevel({ knowledgeElementRepository, scoringService, userId, competenceId });
+      competenceLevel = await getCompetenceLevel({ knowledgeElementRepository, scoringService, userId, competenceId, domainTransaction });
     });
 
     it('should retrieve knowledgeElements for competence and user', () => {
       // then
-      expect(knowledgeElementRepository.findUniqByUserIdAndCompetenceId).to.be.calledWith({ userId, competenceId });
+      expect(knowledgeElementRepository.findUniqByUserIdAndCompetenceId).to.be.calledWith({ userId, competenceId, domainTransaction });
     });
 
     it('should use scoringService to compute competence level', () => {

--- a/api/tests/unit/domain/services/get-competence-level_test.js
+++ b/api/tests/unit/domain/services/get-competence-level_test.js
@@ -1,0 +1,40 @@
+const { expect, sinon } = require('../../../test-helper');
+const getCompetenceLevel = require('../../../../lib/domain/services/get-competence-level');
+const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const scoringService = require('../../../../lib/domain/services/scoring/scoring-service');
+
+describe('Unit | Domain | Service | Get Competence Level', function() {
+
+  describe('#getCompetenceLevel', () => {
+    const userId = 'userId';
+    const competenceId = 'competenceId';
+    const knowledgeElements = Symbol('knowledgeElements');
+    const level = 3;
+    let competenceLevel;
+
+    beforeEach(async () => {
+      // given
+      sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndCompetenceId').resolves(knowledgeElements);
+      sinon.stub(scoringService, 'calculateScoringInformationForCompetence').returns({ currentLevel: level });
+
+      // when
+      competenceLevel = await getCompetenceLevel({ knowledgeElementRepository, scoringService, userId, competenceId });
+    });
+
+    it('should retrieve knowledgeElements for competence and user', () => {
+      // then
+      expect(knowledgeElementRepository.findUniqByUserIdAndCompetenceId).to.be.calledWith({ userId, competenceId });
+    });
+
+    it('should use scoringService to compute competence level', () => {
+      // then
+      expect(scoringService.calculateScoringInformationForCompetence).to.be.calledWith({ knowledgeElements });
+    });
+
+    it('should return competence level', () => {
+      // then
+      expect(competenceLevel).to.equal(level);
+    });
+  });
+});
+

--- a/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
@@ -4,6 +4,7 @@ const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Unit | UseCase | Improve Competence Evaluation', () => {
   let competenceEvaluation, userId, competenceEvaluationRepository, assessmentRepository;
+  let getCompetenceLevel;
   let competenceId;
   let expectedAssessment;
   let createdAssessment;
@@ -29,11 +30,12 @@ describe('Unit | UseCase | Improve Competence Evaluation', () => {
       updateAssessmentId: sinon.stub().resolves({ ...competenceEvaluation, assessmentId })
     };
     assessmentRepository = { save: sinon.stub().resolves(createdAssessment) };
+    getCompetenceLevel = sinon.stub().resolves(3);
   });
 
   it('should retrieve competence evaluation from id', async () => {
     // when
-    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, userId, competenceId, domainTransaction });
+    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, getCompetenceLevel, userId, competenceId, domainTransaction });
 
     // then
     expect(competenceEvaluationRepository.getByCompetenceIdAndUserId).to.be.calledWith({ competenceId, userId });
@@ -41,7 +43,7 @@ describe('Unit | UseCase | Improve Competence Evaluation', () => {
 
   it('should create an improving assessment', async () => {
     // when
-    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, userId, competenceId, domainTransaction });
+    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, getCompetenceLevel, userId, competenceId, domainTransaction });
 
     // then
     expect(assessmentRepository.save).to.be.calledWith({ assessment: expectedAssessment, domainTransaction });
@@ -49,7 +51,7 @@ describe('Unit | UseCase | Improve Competence Evaluation', () => {
 
   it('should update competence evaluation with newly created assessment', async () => {
     // when
-    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, userId, competenceId, domainTransaction });
+    await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, getCompetenceLevel, userId, competenceId, domainTransaction });
 
     // then
     expect(competenceEvaluationRepository.updateAssessmentId).to.be.calledWith({
@@ -65,7 +67,7 @@ describe('Unit | UseCase | Improve Competence Evaluation', () => {
     expectedCompetenceEvaluation.assessmentId = createdAssessment.id;
 
     // when
-    const result = await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, userId, competenceId, domainTransaction });
+    const result = await improveCompetenceEvaluation({ assessmentRepository, competenceEvaluationRepository, getCompetenceLevel, userId, competenceId, domainTransaction });
 
     // then
     expect(result).to.deep.equal(expectedCompetenceEvaluation);

--- a/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
@@ -1,6 +1,8 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const improveCompetenceEvaluation = require('../../../../lib/domain/usecases/improve-competence-evaluation');
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { MAX_REACHABLE_LEVEL } = require('../../../../lib/domain/constants');
+const { ImproveCompetenceEvaluationForbiddenError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | Improve Competence Evaluation', () => {
   let competenceEvaluation, userId, competenceEvaluationRepository, assessmentRepository;
@@ -71,6 +73,27 @@ describe('Unit | UseCase | Improve Competence Evaluation', () => {
 
     // then
     expect(result).to.deep.equal(expectedCompetenceEvaluation);
+  });
+
+  context('when user has reached maximum level for given competence', () => {
+    beforeEach(() => {
+      getCompetenceLevel.resolves(MAX_REACHABLE_LEVEL);
+    });
+
+    it('should throw a Forbidden error', async () => {
+      // when
+      const error = await catchErr(improveCompetenceEvaluation)({
+        assessmentRepository,
+        competenceEvaluationRepository,
+        getCompetenceLevel,
+        userId,
+        competenceId,
+        domainTransaction
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ImproveCompetenceEvaluationForbiddenError);
+    });
   });
 
 });

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -7,6 +7,7 @@ export default class CompetenceCardDefault extends Component {
   @service currentUser;
   @service store;
   @service router;
+  @service competenceEvaluation;
 
   get computeRemainingDaysBeforeImproving() {
     const _remainingDaysBeforeImproving = this.args.scorecard.remainingDaysBeforeImproving;
@@ -35,13 +36,11 @@ export default class CompetenceCardDefault extends Component {
 
   @action
   async improveCompetenceEvaluation() {
-    await this.store.queryRecord('competence-evaluation', {
-      improve: true,
-      userId: this.currentUser.user.id,
-      competenceId: this.args.scorecard.competenceId
-    });
+    const userId = this.currentUser.user.id;
+    const competenceId = this.args.scorecard.competenceId;
+    const scorecardId = this.args.scorecard.id;
 
-    this.router.transitionTo('competences.resume', this.args.scorecard.competenceId);
+    this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
   }
 
 }

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -9,6 +9,7 @@ export default class ScorecardDetails extends Component {
   @service currentUser;
   @service store;
   @service router;
+  @service competenceEvaluation;
 
   @tracked showResetModal = false;
 
@@ -97,11 +98,11 @@ export default class ScorecardDetails extends Component {
 
   @action
   async improveCompetenceEvaluation() {
-    await this.store.queryRecord('competence-evaluation', {
-      improve: true,
-      userId:this.currentUser.user.id,
-      competenceId: this.args.scorecard.competenceId
-    });
-    this.router.transitionTo('competences.resume', this.args.scorecard.competenceId);
+    const userId = this.currentUser.user.id;
+    const competenceId = this.args.scorecard.competenceId;
+    const scorecardId = this.args.scorecard.id;
+
+    this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
   }
+
 }

--- a/mon-pix/app/services/competence-evaluation.js
+++ b/mon-pix/app/services/competence-evaluation.js
@@ -1,0 +1,24 @@
+import Service, { inject as service }  from '@ember/service';
+
+export default class CompetenceEvaluationService extends Service {
+  @service store;
+  @service router;
+
+  async improve({ userId, competenceId, scorecardId }) {
+    try {
+      await this.store.queryRecord('competence-evaluation', { improve: true, userId, competenceId });
+      return this.router.transitionTo('competences.resume', competenceId);
+    } catch (error) {
+      const title = ('errors' in error) ? error.errors.get('firstObject').title : null;
+      if (title === 'ImproveCompetenceEvaluationForbidden') {
+        return this._reloadScorecard(scorecardId);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async _reloadScorecard(scorecardId) {
+    return this.store.findRecord('scorecard', scorecardId, { include: 'competence-evaluation', reload: true });
+  }
+}

--- a/mon-pix/tests/unit/components/competence-card-default-test.js
+++ b/mon-pix/tests/unit/components/competence-card-default-test.js
@@ -10,38 +10,25 @@ describe('Unit | Component | competence-card-default ', function() {
   setupTest();
 
   describe('#improveCompetenceEvaluation', function() {
-    let store, userId, competenceId, router;
+    const competenceId = 'recCompetenceId';
+    const userId = 'userId';
+    const scorecardId = 'scorecardId';
+    const scorecard = EmberObject.create({ competenceId, id: scorecardId });
+    let competenceEvaluation, component;
 
-    beforeEach(async function() {
+    it('calls competenceEvaluation service for improving', async function() {
       // given
-      competenceId = 'recCompetenceId';
-      const scorecard = EmberObject.create({ competenceId });
-      const component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
-      store = Service.create({ queryRecord: sinon.stub().resolves() });
-      component.store = store;
-      userId = 'userId';
+      component = createGlimmerComponent('component:competence-card-default', { scorecard });
+      competenceEvaluation = Service.create({ improve: sinon.stub() });
       component.currentUser = EmberObject.create({ user: { id: userId } });
-      router = EmberObject.create({ transitionTo: sinon.stub() });
-      component.router = router;
+      component.competenceEvaluation = competenceEvaluation;
 
       // when
       await component.improveCompetenceEvaluation();
-    });
 
-    it('creates a competence-evaluation for improving', async function() {
       // then
-      sinon.assert.calledWith(store.queryRecord, 'competence-evaluation', {
-        improve: true,
-        userId,
-        competenceId
-      });
+      sinon.assert.calledWith(competenceEvaluation.improve, { userId, competenceId, scorecardId });
     });
-
-    it('redirects to competences.resume route', async function() {
-      // then
-      sinon.assert.calledWith(router.transitionTo, 'competences.resume', competenceId);
-    });
-
   });
 
   describe('#computeRemainingDaysBeforeImproving', function() {

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -158,38 +158,25 @@ describe('Unit | Component | scorecard-details ', function() {
   });
 
   describe('#improveCompetenceEvaluation', function() {
-    let store, userId, competenceId, router;
+    const competenceId = 'recCompetenceId';
+    const userId = 'userId';
+    const scorecardId = 'scorecardId';
+    const scorecard = EmberObject.create({ competenceId, id: scorecardId });
+    let competenceEvaluation, component;
 
-    beforeEach(async function() {
+    it('calls competenceEvaluation service for improving', async function() {
       // given
-      competenceId = 'recCompetenceId';
-      const scorecard = EmberObject.create({ competenceId });
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard });
-      store = Service.create({ queryRecord: sinon.stub().resolves() });
-      component.store = store;
-      userId = 'userId';
+      component = createGlimmerComponent('component:scorecard-details', { scorecard });
+      competenceEvaluation = Service.create({ improve: sinon.stub() });
       component.currentUser = EmberObject.create({ user: { id: userId } });
-      router = EmberObject.create({ transitionTo: sinon.stub() });
-      component.router = router;
+      component.competenceEvaluation = competenceEvaluation;
 
       // when
       await component.improveCompetenceEvaluation();
-    });
 
-    it('creates a competence-evaluation for improving', async function() {
       // then
-      sinon.assert.calledWith(store.queryRecord, 'competence-evaluation', {
-        improve: true,
-        userId,
-        competenceId
-      });
+      sinon.assert.calledWith(competenceEvaluation.improve, { userId, competenceId, scorecardId });
     });
-
-    it('redirects to competences.resume route', async function() {
-      // then
-      sinon.assert.calledWith(router.transitionTo, 'competences.resume', competenceId);
-    });
-
   });
 
   describe('#computeRemainingDaysBeforeImproving', function() {

--- a/mon-pix/tests/unit/services/competence-evaluation-test.js
+++ b/mon-pix/tests/unit/services/competence-evaluation-test.js
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { reject  } from 'rsvp';
+
+describe('Unit | Service | competence-evaluation', function() {
+  setupTest();
+  let competenceEvaluationService;
+
+  describe('#improve()', function() {
+    const competenceId = 'recCompetenceId';
+    const userId = 'userId';
+    const scorecardId = 'scorecardId';
+    let store, router;
+
+    beforeEach(async function() {
+      // given
+      competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
+      store = Service.create({
+        queryRecord: sinon.stub().resolves(),
+        findRecord: sinon.stub().resolves(),
+      });
+      router = EmberObject.create({ transitionTo: sinon.stub() });
+      competenceEvaluationService.set('router', router);
+      competenceEvaluationService.set('store', store);
+    });
+
+    context('nominal case', function() {
+      beforeEach(async function() {
+        // when
+        await competenceEvaluationService.improve({ userId, competenceId });
+      });
+
+      it('creates a competence-evaluation for improving', async function() {
+        // then
+        sinon.assert.calledWith(store.queryRecord, 'competence-evaluation', {
+          improve: true,
+          userId,
+          competenceId
+        });
+      });
+
+      it('redirects to competences.resume route', async function() {
+        // then
+        sinon.assert.calledWith(router.transitionTo, 'competences.resume', competenceId);
+      });
+    });
+
+    context('when improving fails with ImproveCompetenceEvaluationForbidden error', async function() {
+      beforeEach(async function() {
+        // given
+        competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
+        store = Service.create({
+          queryRecord: () => reject({ errors: [{ title: 'ImproveCompetenceEvaluationForbidden' }] }),
+          findRecord: sinon.stub().resolves(),
+        });
+        router = EmberObject.create({ transitionTo: sinon.stub() });
+        competenceEvaluationService.set('router', router);
+        competenceEvaluationService.set('store', store);
+
+        // when
+        await competenceEvaluationService.improve({ userId, competenceId, scorecardId });
+      });
+
+      it('does not redirect to competence.resume route', async function() {
+        // then
+        sinon.assert.notCalled(router.transitionTo);
+      });
+    });
+
+    context('when improving fails with another error', async function() {
+      const error = new Error();
+
+      beforeEach(async function() {
+        // given
+        competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
+        store = Service.create({
+          queryRecord: () => reject(error),
+          findRecord: sinon.stub().resolves(),
+        });
+        competenceEvaluationService.set('router', router);
+        competenceEvaluationService.set('store', store);
+      });
+
+      it('throws error', async function() {
+        // when
+        try {
+          await competenceEvaluationService.improve({ userId, competenceId });
+        } catch (err) {
+          // then
+          expect(err).to.equal(err);
+          return;
+        }
+        sinon.assert.fail('Improve Competence Evaluation should have throw an error.');
+      });
+
+      it('does not redirect to competence.resume route', async function() {
+        // when
+        try {
+          await competenceEvaluationService.improve({ userId, competenceId });
+        } catch (err) {
+          // then
+          sinon.assert.notCalled(router.transitionTo);
+          return;
+        }
+        sinon.assert.fail('Improve Competence Evaluation should have throw an error.');
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Le bouton permettant de retenter une compétence n'est pas visible quand la personne a atteint le niveau maximum.
Pourtant, en gardant un onglet ouvert ou en passant par l'API, ça reste possible.

## :robot: Solution
Création du service `getCompetenceLevel` qui calcule le niveau d'un utilisateur pour une compétence donnée.
Si le niveau maximum est atteint alors une erreur `403 - Forbidden` est renvoyée par l'API.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Mettre 0 jour pour pouvoir retenter dans les variables d'env.
- Finir une compétence en étant niveau 3 ou 4.
- Voir que le bouton retenter est là.
- Garder l'onglet ouvert (onglet 1)
- Dans un autre onglet (onglet 2), remettre à zéro la même compétence et la repasser en ayant un niveau 5.
- Voir qu'à la fin, le bouton n'est pas là sur l'onglet 2.
- Revenir sur l'onglet 1, et cliquer sur Retenter > Ca ne devrait pas marcher.
