### PR TITLE
[BUGFIX] Les certification sans cleaCompetenceMarks ne passent pas en completed (PIX-915)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -466,6 +466,12 @@ class WrongDateFormatError extends DomainError {
   }
 }
 
+class NotImplementedError extends Error {
+  constructor(message = 'Not implemented error.') {
+    super(message);
+  }
+}
+
 module.exports = {
   DomainError,
   AlreadyExistingCampaignParticipationError,
@@ -532,4 +538,5 @@ module.exports = {
   UserOrgaSettingsCreationError,
   UserShouldChangePasswordError,
   WrongDateFormatError,
+  NotImplementedError,
 };

--- a/api/lib/domain/models/CleaCertification.js
+++ b/api/lib/domain/models/CleaCertification.js
@@ -54,7 +54,7 @@ class CleaCertification extends PartnerCertification {
       hasAcquiredBadge: Joi.boolean().required(),
       reproducibilityRate: Joi.number().required(),
       cleaCompetenceMarks: Joi.array().required(),
-      maxReachablePixByCompetenceForClea: Joi.object().min(1).required(),
+      maxReachablePixByCompetenceForClea: Joi.object().required(),
     }).unknown();
 
     validateEntity(schema, this);

--- a/api/lib/domain/models/CleaCertification.js
+++ b/api/lib/domain/models/CleaCertification.js
@@ -14,11 +14,11 @@ function _isOverPercentage(value = 0, total, percentage = MIN_PERCENTAGE) {
   return value >= (total * percentage / 100);
 }
 
-function _hasRequiredPixValue({ maxReachablePixByCompetenceForClea, competenceMarks }) {
-  const certifiableCompetenceIds = _.map(competenceMarks, 'competenceId');
+function _hasRequiredPixValue({ maxReachablePixByCompetenceForClea, cleaCompetenceMarks }) {
+  const certifiableCompetenceIds = _.map(cleaCompetenceMarks, 'competenceId');
   return !_.isEmpty(certifiableCompetenceIds)
     && _.every(certifiableCompetenceIds, (competenceId) => _isOverPercentage(
-      _.find(competenceMarks, { competenceId }).score,
+      _.find(cleaCompetenceMarks, { competenceId }).score,
       maxReachablePixByCompetenceForClea[competenceId]
     ));
 }
@@ -37,7 +37,7 @@ class CleaCertification extends PartnerCertification {
     certificationCourseId,
     hasAcquiredBadge,
     reproducibilityRate,
-    competenceMarks,
+    cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea,
   } = {}) {
     super({
@@ -47,13 +47,13 @@ class CleaCertification extends PartnerCertification {
 
     this.hasAcquiredBadge = hasAcquiredBadge;
     this.reproducibilityRate = reproducibilityRate;
-    this.competenceMarks = competenceMarks;
+    this.cleaCompetenceMarks = cleaCompetenceMarks;
     this.maxReachablePixByCompetenceForClea = maxReachablePixByCompetenceForClea;
 
     const schema = Joi.object({
       hasAcquiredBadge: Joi.boolean().required(),
       reproducibilityRate: Joi.number().required(),
-      competenceMarks: Joi.array().min(1).required(),
+      cleaCompetenceMarks: Joi.array().required(),
       maxReachablePixByCompetenceForClea: Joi.object().min(1).required(),
     }).unknown();
 
@@ -72,7 +72,7 @@ class CleaCertification extends PartnerCertification {
     if (_hasSufficientReproducibilityRateToBeTrusted(this.reproducibilityRate)) return true;
 
     return _hasRequiredPixValue({
-      competenceMarks: this.competenceMarks,
+      cleaCompetenceMarks: this.cleaCompetenceMarks,
       maxReachablePixByCompetenceForClea: this.maxReachablePixByCompetenceForClea
     });
   }

--- a/api/lib/domain/models/PartnerCertification.js
+++ b/api/lib/domain/models/PartnerCertification.js
@@ -1,6 +1,7 @@
 const Joi = require('@hapi/joi')
   .extend(require('@hapi/joi-date'));
 const { validateEntity } = require('../validators/entity-validator');
+const { NotImplementedError } = require('../errors');
 
 class PartnerCertification {
   constructor(
@@ -17,9 +18,13 @@ class PartnerCertification {
     validateEntity(schema, this);
   }
 
-  isEligible() {}
+  isEligible() {
+    throw new NotImplementedError();
+  }
 
-  isAcquired() {}
+  isAcquired() {
+    throw new NotImplementedError();
+  }
 }
 
 module.exports = PartnerCertification;

--- a/api/lib/infrastructure/repositories/partner-certification-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-repository.js
@@ -28,7 +28,7 @@ module.exports = {
     return new CleaCertification({
       certificationCourseId,
       hasAcquiredBadge,
-      competenceMarks: cleaCompetenceMarks,
+      cleaCompetenceMarks,
       maxReachablePixByCompetenceForClea,
       reproducibilityRate
     });

--- a/api/tests/integration/infrastructure/models/assessment_result_test.js
+++ b/api/tests/integration/infrastructure/models/assessment_result_test.js
@@ -22,10 +22,10 @@ describe('Integration | Infrastructure | Models | BookshelfAssessmentResult', ()
         it('should be saved when organisation type is ${organizationType}', () => {
           // given
           rawData.status = status;
-          const certification = new BookshelfAssessmentResults(rawData);
+          const assessmentResult = new BookshelfAssessmentResults(rawData);
 
           // when
-          const promise = certification.save();
+          const promise = assessmentResult.save();
 
           // then
           return promise.catch((_) => {

--- a/api/tests/integration/infrastructure/repositories/partner-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/partner-certification-repository_test.js
@@ -64,7 +64,29 @@ describe('Integration | Repository | Partner Certification', function() {
       return cache.flushAll();
     });
 
-    it('should successfully build a cleaCertification with badge', async () => {
+    it('should successfully build a CleaCertification with no clea competenceMarks', async () => {
+      // given
+      const { userId } = await _setUpCleaCertificationWithBadge({ certificationCourseId, competenceId: 'otherCompetenceId', skill });
+
+      const expectedCleaCertification = new CleaCertification({
+        certificationCourseId,
+        hasAcquiredBadge: true,
+        reproducibilityRate,
+        cleaCompetenceMarks: [],
+        maxReachablePixByCompetenceForClea: { [competenceId]: pixValue },
+      });
+
+      // when
+      const cleaCertification = await partnerCertificationRepository.buildCleaCertification({
+        certificationCourseId, userId, reproducibilityRate, skillRepository
+      });
+
+      // then
+      expect(cleaCertification).to.be.instanceOf(CleaCertification);
+      expect(cleaCertification).to.deep.equal(expectedCleaCertification);
+    });
+
+    it('should successfully build a CleaCertification with badge', async () => {
       // given
 
       const { userId, competenceMark } = await _setUpCleaCertificationWithBadge({ certificationCourseId, competenceId, skill });
@@ -73,7 +95,7 @@ describe('Integration | Repository | Partner Certification', function() {
         certificationCourseId,
         hasAcquiredBadge: true,
         reproducibilityRate,
-        competenceMarks: [_.omit(competenceMark, 'createdAt')],
+        cleaCompetenceMarks: [_.omit(competenceMark, 'createdAt')],
         maxReachablePixByCompetenceForClea: { [competenceId]: pixValue },
       });
 
@@ -95,7 +117,7 @@ describe('Integration | Repository | Partner Certification', function() {
         certificationCourseId,
         hasAcquiredBadge: false,
         reproducibilityRate,
-        competenceMarks: [_.omit(competenceMark, 'createdAt')],
+        cleaCompetenceMarks: [_.omit(competenceMark, 'createdAt')],
         maxReachablePixByCompetenceForClea: { [competenceId]: pixValue },
       });
 

--- a/api/tests/tooling/domain-builder/factory/build-clea-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certification.js
@@ -5,7 +5,7 @@ module.exports = function buildCompetence({
   certificationCourseId = 42,
   hasAcquiredBadge = true,
   reproducibilityRate = 50,
-  competenceMarks = [buildCompetenceMark()],
+  cleaCompetenceMarks = [buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1: 51 }
 } = {}) {
 
@@ -13,7 +13,7 @@ module.exports = function buildCompetence({
     certificationCourseId,
     hasAcquiredBadge,
     reproducibilityRate,
-    competenceMarks,
+    cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea
   });
 };

--- a/api/tests/unit/domain/models/CleaCertification_test.js
+++ b/api/tests/unit/domain/models/CleaCertification_test.js
@@ -49,7 +49,7 @@ describe('Unit | Domain | Models | CleaCertification', () => {
       // when
       expect(() => new CleaCertification({
         ...validArguments,
-        maxReachablePixByCompetenceForClea: []
+        maxReachablePixByCompetenceForClea: null
       })).to.throw(ObjectValidationError);
     });
   });

--- a/api/tests/unit/domain/models/CleaCertification_test.js
+++ b/api/tests/unit/domain/models/CleaCertification_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | CleaCertification', () => {
         partnerKey: 'partnerKey',
         hasAcquiredBadge: true,
         reproducibilityRate: 80,
-        competenceMarks: [1],
+        cleaCompetenceMarks: [1],
         maxReachablePixByCompetenceForClea: { competence1:1 },
       };
     });
@@ -40,9 +40,9 @@ describe('Unit | Domain | Models | CleaCertification', () => {
       })).to.throw(ObjectValidationError);
     });
 
-    it('should throw an ObjectValidationError when competenceMarks is not valid', () => {
+    it('should throw an ObjectValidationError when cleaCompetenceMarks is not valid', () => {
       // when
-      expect(() => new CleaCertification({ ...validArguments, competenceMarks: [] })).to.throw(ObjectValidationError);
+      expect(() => new CleaCertification({ ...validArguments, cleaCompetenceMarks: null })).to.throw(ObjectValidationError);
     });
 
     it('should throw an ObjectValidationError when maxReachablePixByCompetenceForClea is not valid', () => {
@@ -173,7 +173,7 @@ function _buildCleaCertificationInGreyZoneAndCertifiableCompetences() {
     ['competenceId4']: 30,
   };
 
-  const competenceMarks = [
+  const cleaCompetenceMarks = [
     domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId1,
@@ -191,7 +191,7 @@ function _buildCleaCertificationInGreyZoneAndCertifiableCompetences() {
     {
       withBadge: true,
       reproducibilityRate: 70,
-      competenceMarks,
+      cleaCompetenceMarks,
       maxReachablePixByCompetenceForClea
     });
 }
@@ -205,7 +205,7 @@ function _buildCleaCertificationInGreyZoneAndNonCertifiableCompetences() {
     ['competenceId4']: 30,
   };
 
-  const competenceMarks = [
+  const cleaCompetenceMarks = [
     domainBuilder.buildCompetenceMark(
       {
         competenceId: competenceId1,
@@ -222,7 +222,7 @@ function _buildCleaCertificationInGreyZoneAndNonCertifiableCompetences() {
   return _buildCleaCertification({
     withBadge: true,
     reproducibilityRate: 70,
-    competenceMarks,
+    cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea
   });
 }
@@ -230,7 +230,7 @@ function _buildCleaCertificationInGreyZoneAndNonCertifiableCompetences() {
 function _buildCleaCertification({
   withBadge = false,
   reproducibilityRate = 0,
-  competenceMarks = [domainBuilder.buildCompetenceMark()],
+  cleaCompetenceMarks = [domainBuilder.buildCompetenceMark()],
   maxReachablePixByCompetenceForClea = { competence1:1 }
 }) {
   const certificationCourseId = 42;
@@ -239,7 +239,7 @@ function _buildCleaCertification({
     certificationCourseId,
     hasAcquiredBadge: withBadge,
     reproducibilityRate,
-    competenceMarks,
+    cleaCompetenceMarks,
     maxReachablePixByCompetenceForClea,
   });
 }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un candidat passe une certification et qu'aucune question ne porte sur un tube lié au Clea, une erreur (422) survient 

## :robot: Solution
Permettre de créer CleaCertification avec cleaCompetenceMarks vide via la validation JOI

## :100: Pour tester
Passer une certif avec un profil certifiable avec 0 tubes lié au Cléa
