### PR TITLE
[FEATURE] Remonter les acquis/épreuves archivés lors d'une campagne ou certification (PIX-820)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -7,9 +7,6 @@ const ValidatorQROC = require('./ValidatorQROC');
 const ValidatorQROCMDep = require('./ValidatorQROCMDep');
 const ValidatorQROCMInd = require('./ValidatorQROCMInd');
 
-const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
-const OPERATIVE_CHALLENGES = ['validé', 'validé sans test', 'pré-validé', 'archivé'];
-
 const ChallengeType = Object.freeze({
   QCU: 'QCU',
   QCM: 'QCM',
@@ -106,11 +103,6 @@ class Challenge {
     return this.skills.filter((skill) => skill.name === searchedSkill.name).length > 0;
   }
 
-  // Same than isActive for algo
-  isPublished({ validatedOnly }) {
-    return validatedOnly ? VALIDATED_CHALLENGES.includes(this.status) : OPERATIVE_CHALLENGES.includes(this.status);
-  }
-
   get hardestSkill() {
     return this.skills.reduce((s1, s2) => (s1.difficulty > s2.difficulty) ? s1 : s2);
   }
@@ -158,8 +150,8 @@ class Challenge {
     return _(challenges).find({ id });
   }
 
-  static findPublishedBySkill({ challenges, skill, validatedOnly }) {
-    return _.filter(challenges, (challenge) => challenge.hasSkill(skill) && challenge.isPublished({ validatedOnly }));
+  static findBySkill({ challenges, skill }) {
+    return _.filter(challenges, (challenge) => challenge.hasSkill(skill));
   }
 }
 

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -7,6 +7,9 @@ const ValidatorQROC = require('./ValidatorQROC');
 const ValidatorQROCMDep = require('./ValidatorQROCMDep');
 const ValidatorQROCMInd = require('./ValidatorQROCMInd');
 
+const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
+const OPERATIVE_CHALLENGES = ['validé', 'validé sans test', 'pré-validé', 'archivé'];
+
 const ChallengeType = Object.freeze({
   QCU: 'QCU',
   QCM: 'QCM',
@@ -104,8 +107,8 @@ class Challenge {
   }
 
   // Same than isActive for algo
-  isPublished() {
-    return ['validé', 'validé sans test', 'pré-validé'].includes(this.status);
+  isPublished({ validatedOnly }) {
+    return validatedOnly ? VALIDATED_CHALLENGES.includes(this.status) : OPERATIVE_CHALLENGES.includes(this.status);
   }
 
   get hardestSkill() {
@@ -155,8 +158,8 @@ class Challenge {
     return _(challenges).find({ id });
   }
 
-  static findPublishedBySkill(challenges, skill) {
-    return _.filter(challenges, (challenge) => challenge.hasSkill(skill) && challenge.isPublished());
+  static findPublishedBySkill({ challenges, skill, validatedOnly }) {
+    return _.filter(challenges, (challenge) => challenge.hasSkill(skill) && challenge.isPublished({ validatedOnly }));
   }
 }
 

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -191,7 +191,7 @@ module.exports = {
 
   async getCertificationResult({ certificationAssessment, continueOnError }) {
     const allCompetences = await competenceRepository.list();
-    const allChallenges = await challengeRepository.findValidated();
+    const allChallenges = await challengeRepository.findOperative();
 
     const testedCompetences = await _getTestedCompetences({
       userId: certificationAssessment.userId,

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -191,7 +191,7 @@ module.exports = {
 
   async getCertificationResult({ certificationAssessment, continueOnError }) {
     const allCompetences = await competenceRepository.list();
-    const allChallenges = await challengeRepository.list();
+    const allChallenges = await challengeRepository.findValidated();
 
     const testedCompetences = await _getTestedCompetences({
       userId: certificationAssessment.userId,

--- a/api/lib/domain/services/smart-random/data-fetcher.js
+++ b/api/lib/domain/services/smart-random/data-fetcher.js
@@ -67,7 +67,7 @@ async function fetchForCompetenceEvaluations({
     knowledgeElements
   ] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
-    skillRepository.findByCompetenceId(assessment.competenceId),
+    skillRepository.findActiveByCompetenceId(assessment.competenceId),
     challengeRepository.findByCompetenceId(assessment.competenceId),
     _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService })
   ]);

--- a/api/lib/domain/services/smart-random/data-fetcher.js
+++ b/api/lib/domain/services/smart-random/data-fetcher.js
@@ -47,7 +47,7 @@ async function _fetchSkillsAndChallenges({
   challengeRepository,
 }) {
   const targetProfile = await targetProfileRepository.get(targetProfileId);
-  const challenges = await challengeRepository.findBySkills(targetProfile.skills);
+  const challenges = await challengeRepository.findOperativeBySkills(targetProfile.skills);
   return [ targetProfile.skills, challenges ];
 }
 

--- a/api/lib/domain/services/smart-random/data-fetcher.js
+++ b/api/lib/domain/services/smart-random/data-fetcher.js
@@ -68,7 +68,7 @@ async function fetchForCompetenceEvaluations({
   ] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
     skillRepository.findActiveByCompetenceId(assessment.competenceId),
-    challengeRepository.findByCompetenceId(assessment.competenceId),
+    challengeRepository.findValidatedByCompetenceId(assessment.competenceId),
     _fetchKnowledgeElements({ assessment, knowledgeElementRepository, improvementService })
   ]);
 

--- a/api/lib/domain/services/smart-random/smart-random.js
+++ b/api/lib/domain/services/smart-random/smart-random.js
@@ -6,7 +6,7 @@ const { computeTubesFromSkills } = require('./../tube-service');
 
 module.exports = { getPossibleSkillsForNextChallenge };
 
-function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers } = {}) {
+function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers, validatedOnly = true } = {}) {
 
   const isUserStartingTheTest = !lastAnswer;
   const isLastChallengeTimed = _wasLastChallengeTimed(lastAnswer);
@@ -14,7 +14,7 @@ function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targ
   const knowledgeElementsOfTargetSkills = knowledgeElements.filter((ke) => {
     return targetSkills.find((skill) => skill.id === ke.skillId);
   });
-  const filteredChallenges = _filterChallenges({ challenges, allAnswers });
+  const filteredChallenges = _filterChallenges({ challenges, allAnswers, validatedOnly });
   targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges });
 
   // First challenge has specific rules
@@ -72,18 +72,18 @@ function _getSkillsWithAddedInformations({ targetSkills, filteredChallenges }) {
   });
 }
 
-function _filterChallenges({ challenges, allAnswers }) {
+function _filterChallenges({ challenges, allAnswers, validatedOnly }) {
   return pipe(
     _removeChallengesWithAnswer,
     _removeUnpublishedChallenges,
-  )({ challenges, allAnswers });
+  )({ challenges, allAnswers, validatedOnly });
 }
 
-function _removeChallengesWithAnswer({ challenges, allAnswers }) {
+function _removeChallengesWithAnswer({ challenges, allAnswers, validatedOnly }) {
   const challengeIdsWithAnswer = allAnswers.map((answer) => answer.challengeId);
-  return challenges.filter((challenge) => !_.includes(challengeIdsWithAnswer, challenge.id));
+  return { challenges: challenges.filter((challenge) => !_.includes(challengeIdsWithAnswer, challenge.id)), validatedOnly };
 }
 
-function _removeUnpublishedChallenges(challenges) {
-  return _.filter(challenges, (challenge) => challenge.isPublished());
+function _removeUnpublishedChallenges({ challenges, validatedOnly }) {
+  return _.filter(challenges, (challenge) => challenge.isPublished({ validatedOnly }));
 }

--- a/api/lib/domain/services/smart-random/smart-random.js
+++ b/api/lib/domain/services/smart-random/smart-random.js
@@ -1,12 +1,11 @@
 const _ = require('lodash');
-const { pipe } = require('lodash/fp');
 const catAlgorithm = require('./cat-algorithm');
 const { getFilteredSkillsForNextChallenge, getFilteredSkillsForFirstChallenge } = require('./skills-filter');
 const { computeTubesFromSkills } = require('./../tube-service');
 
 module.exports = { getPossibleSkillsForNextChallenge };
 
-function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers, validatedOnly = true } = {}) {
+function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers } = {}) {
 
   const isUserStartingTheTest = !lastAnswer;
   const isLastChallengeTimed = _wasLastChallengeTimed(lastAnswer);
@@ -14,7 +13,7 @@ function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targ
   const knowledgeElementsOfTargetSkills = knowledgeElements.filter((ke) => {
     return targetSkills.find((skill) => skill.id === ke.skillId);
   });
-  const filteredChallenges = _filterChallenges({ challenges, allAnswers, validatedOnly });
+  const filteredChallenges = _removeChallengesWithAnswer({ challenges, allAnswers });
   targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges });
 
   // First challenge has specific rules
@@ -72,18 +71,7 @@ function _getSkillsWithAddedInformations({ targetSkills, filteredChallenges }) {
   });
 }
 
-function _filterChallenges({ challenges, allAnswers, validatedOnly }) {
-  return pipe(
-    _removeChallengesWithAnswer,
-    _removeUnpublishedChallenges,
-  )({ challenges, allAnswers, validatedOnly });
-}
-
-function _removeChallengesWithAnswer({ challenges, allAnswers, validatedOnly }) {
+function _removeChallengesWithAnswer({ challenges, allAnswers }) {
   const challengeIdsWithAnswer = allAnswers.map((answer) => answer.challengeId);
-  return { challenges: challenges.filter((challenge) => !_.includes(challengeIdsWithAnswer, challenge.id)), validatedOnly };
-}
-
-function _removeUnpublishedChallenges({ challenges, validatedOnly }) {
-  return _.filter(challenges, (challenge) => challenge.isPublished({ validatedOnly }));
+  return challenges.filter((challenge) => !_.includes(challengeIdsWithAnswer, challenge.id));
 }

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -33,7 +33,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
 
   const challengeIdsCorrectlyAnswered = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
 
-  const allChallenges = await challengeRepository.findValidated();
+  const allChallenges = await challengeRepository.findOperative();
   const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
 
   challengesAlreadyAnswered.forEach((challenge) => {

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -58,7 +58,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
     const testedSkills = [];
     userCompetence.skills.forEach((skill) => {
       if (!userCompetence.hasEnoughChallenges()) {
-        const challengesToValidateCurrentSkill = Challenge.findPublishedBySkill({ challenges: allChallenges, skill, validatedOnly: false });
+        const challengesToValidateCurrentSkill = Challenge.findBySkill({ challenges: allChallenges, skill });
         const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
 
         const challengesPoolToPickChallengeFrom = (_.isEmpty(challengesLeftToAnswer)) ? challengesToValidateCurrentSkill : challengesLeftToAnswer;
@@ -81,7 +81,7 @@ function _getUserCompetenceByChallengeCompetenceId(userCompetences, challenge) {
 }
 
 function _skillHasAtLeastOneChallenge(skill, challenges) {
-  const challengesBySkill = Challenge.findPublishedBySkill({ challenges, skill, validatedOnly: false });
+  const challengesBySkill = Challenge.findBySkill({ challenges, skill });
   return challengesBySkill.length > 0;
 }
 

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -33,7 +33,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
 
   const challengeIdsCorrectlyAnswered = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
 
-  const allChallenges = await challengeRepository.list();
+  const allChallenges = await challengeRepository.findValidated();
   const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
 
   challengesAlreadyAnswered.forEach((challenge) => {

--- a/api/lib/domain/services/user-service.js
+++ b/api/lib/domain/services/user-service.js
@@ -48,7 +48,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
     }
 
     challenge.skills
-      .filter((skill) => _skillHasAtLeastOneChallengeInTheReferentiel(skill, allChallenges))
+      .filter((skill) => _skillHasAtLeastOneChallenge(skill, allChallenges))
       .forEach((publishedSkill) => userCompetence.addSkill(publishedSkill));
   });
 
@@ -58,7 +58,7 @@ async function fillCertificationProfileWithChallenges(certificationProfile) {
     const testedSkills = [];
     userCompetence.skills.forEach((skill) => {
       if (!userCompetence.hasEnoughChallenges()) {
-        const challengesToValidateCurrentSkill = Challenge.findPublishedBySkill(allChallenges, skill);
+        const challengesToValidateCurrentSkill = Challenge.findPublishedBySkill({ challenges: allChallenges, skill, validatedOnly: false });
         const challengesLeftToAnswer = _.difference(challengesToValidateCurrentSkill, challengesAlreadyAnswered);
 
         const challengesPoolToPickChallengeFrom = (_.isEmpty(challengesLeftToAnswer)) ? challengesToValidateCurrentSkill : challengesLeftToAnswer;
@@ -80,8 +80,8 @@ function _getUserCompetenceByChallengeCompetenceId(userCompetences, challenge) {
   return challenge ? userCompetences.find((userCompetence) => userCompetence.id === challenge.competenceId) : null;
 }
 
-function _skillHasAtLeastOneChallengeInTheReferentiel(skill, challenges) {
-  const challengesBySkill = Challenge.findPublishedBySkill(challenges, skill);
+function _skillHasAtLeastOneChallenge(skill, challenges) {
+  const challengesBySkill = Challenge.findPublishedBySkill({ challenges, skill, validatedOnly: false });
   return challengesBySkill.length > 0;
 }
 

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -98,7 +98,7 @@ async function _getKnowledgeElements({ assessment, answer, challenge, skillRepos
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId: assessment.userId, assessmentId: assessment.id });
   let targetSkills;
   if (assessment.isCompetenceEvaluation()) {
-    targetSkills = await skillRepository.findByCompetenceId(assessment.competenceId);
+    targetSkills = await skillRepository.findActiveByCompetenceId(assessment.competenceId);
   }
   if (assessment.isForCampaign()) {
     const targetProfile = await targetProfileRepository.getByCampaignId(assessment.campaignParticipation.campaignId);

--- a/api/lib/domain/usecases/find-tutorials.js
+++ b/api/lib/domain/usecases/find-tutorials.js
@@ -24,7 +24,7 @@ module.exports = async function findTutorials({
   if (invalidatedDirectKnowledgeElements.length === 0) {
     return [];
   }
-  const skills = await skillRepository.findByCompetenceId(competenceId);
+  const skills = await skillRepository.findActiveByCompetenceId(competenceId);
   const failedSkills = _getFailedSkills(skills, invalidatedDirectKnowledgeElements);
 
   const skillsGroupedByTube = _getSkillsGroupedByTube(failedSkills);

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -23,7 +23,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
+  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, validatedOnly: false });
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -23,7 +23,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, validatedOnly: false });
+  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -22,7 +22,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
+  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, validatedOnly: true });
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -22,7 +22,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, validatedOnly: true });
+  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/lib/domain/usecases/get-progression.js
+++ b/api/lib/domain/usecases/get-progression.js
@@ -39,7 +39,7 @@ module.exports = async function getProgression(
   if (assessment.isCompetenceEvaluation()) {
     const competenceEvaluation = await competenceEvaluationRepository.getByAssessmentId(assessmentId);
     const [targetedSkills, knowledgeElements] = await Promise.all([
-      skillRepository.findByCompetenceId(competenceEvaluation.competenceId),
+      skillRepository.findActiveByCompetenceId(competenceEvaluation.competenceId),
       knowledgeElementRepository.findUniqByUserId({ userId })]
     );
     const knowledgeElementsForProgression = await improvementService.filterKnowledgeElementsIfImproving({

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -38,7 +38,7 @@ module.exports = async function shareCampaignResult({
       improvementService,
     });
 
-    const { hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge(getNextChallengeData);
+    const { hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge({ ...getNextChallengeData, validatedOnly: false });
 
     if (!hasAssessmentEnded) {
       throw new AssessmentNotCompletedError();

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -38,7 +38,7 @@ module.exports = async function shareCampaignResult({
       improvementService,
     });
 
-    const { hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge({ ...getNextChallengeData, validatedOnly: false });
+    const { hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge(getNextChallengeData);
 
     if (!hasAssessmentEnded) {
       throw new AssessmentNotCompletedError();

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -3,6 +3,7 @@ const datasource = require('./datasource');
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../domain/constants').LOCALE;
 
 const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
+const OPERATIVE_CHALLENGES = [...VALIDATED_CHALLENGES, 'archivé'];
 
 module.exports = datasource.extend({
 
@@ -85,11 +86,11 @@ module.exports = datasource.extend({
     };
   },
 
-  async findBySkillIds(skillIds) {
+  async findOperativeBySkillIds(skillIds) {
     const foundInSkillIds = (skillId) => _.includes(skillIds, skillId);
     const challenges = await this.list();
     return challenges.filter((challengeData) =>
-      _.includes(VALIDATED_CHALLENGES, challengeData.status) &&
+      _.includes(OPERATIVE_CHALLENGES, challengeData.status) &&
       _.some(challengeData.skillIds, foundInSkillIds)
     );
   },

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -94,7 +94,7 @@ module.exports = datasource.extend({
     );
   },
 
-  async findByCompetenceId(competenceId) {
+  async findValidatedByCompetenceId(competenceId) {
     const challenges = await this.list();
     return challenges.filter((challengeData) =>
       _.includes(VALIDATED_CHALLENGES, challengeData.status)

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -88,21 +88,31 @@ module.exports = datasource.extend({
 
   async findOperativeBySkillIds(skillIds) {
     const foundInSkillIds = (skillId) => _.includes(skillIds, skillId);
-    const challenges = await this.list();
+    const challenges = await this.findOperative();
     return challenges.filter((challengeData) =>
-      _.includes(OPERATIVE_CHALLENGES, challengeData.status) &&
       _.some(challengeData.skillIds, foundInSkillIds)
     );
   },
 
   async findValidatedByCompetenceId(competenceId) {
-    const challenges = await this.list();
+    const challenges = await this.findValidated();
     return challenges.filter((challengeData) =>
-      _.includes(VALIDATED_CHALLENGES, challengeData.status)
-      && !_.isEmpty(challengeData.skillIds)
+      !_.isEmpty(challengeData.skillIds)
       && _.includes(challengeData.competenceId, competenceId)
     );
   },
+
+  async findOperative() {
+    const challenges = await this.list();
+    return challenges.filter((challengeData) =>
+      _.includes(OPERATIVE_CHALLENGES, challengeData.status));
+  },
+
+  async findValidated() {
+    const challenges = await this.list();
+    return challenges.filter((challengeData) =>
+      _.includes(VALIDATED_CHALLENGES, challengeData.status));
+  }
 });
 
 function _convertLanguagesToLocales(languages) {

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
 
-const ACTIVATED_STATUS = 'actif';
+const ACTIVE_STATUS = 'actif';
 
 module.exports = datasource.extend({
 
@@ -40,19 +40,19 @@ module.exports = datasource.extend({
 
   async findActiveSkills() {
     const skills = await this.list();
-    return _.filter(skills, { status: ACTIVATED_STATUS });
+    return _.filter(skills, { status: ACTIVE_STATUS });
   },
 
   async findByRecordIds(skillIds) {
     const skills = await this.list();
     return skills.filter((skillData) =>
-      skillData.status === ACTIVATED_STATUS &&
+      skillData.status === ACTIVE_STATUS &&
       _.includes(skillIds, skillData.id));
   },
 
-  async findByCompetenceId(competenceId) {
+  async findActiveByCompetenceId(competenceId) {
     const skills = await this.list();
-    return _.filter(skills, { status: ACTIVATED_STATUS, competenceId });
+    return _.filter(skills, { status: ACTIVE_STATUS, competenceId });
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -44,11 +44,11 @@ module.exports = datasource.extend({
     return _.filter(skills, { status: ACTIVE_STATUS });
   },
 
-  async findByRecordIds(skillIds) {
+  async findOperativeByRecordIds(skillIds) {
     const skills = await this.list();
     return skills.filter((skillData) =>
-      skillData.status === ACTIVE_STATUS &&
-      _.includes(skillIds, skillData.id));
+      _.includes(OPERATIVE_STATUSES, skillData.status)
+      && _.includes(skillIds, skillData.id));
   },
 
   async findActiveByCompetenceId(competenceId) {

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const datasource = require('./datasource');
 
 const ACTIVE_STATUS = 'actif';
+const OPERATIVE_STATUSES = ['actif', 'archivé'];
 
 module.exports = datasource.extend({
 
@@ -53,6 +54,13 @@ module.exports = datasource.extend({
   async findActiveByCompetenceId(competenceId) {
     const skills = await this.list();
     return _.filter(skills, { status: ACTIVE_STATUS, competenceId });
+  },
+
+  async findOperativeByCompetenceId(competenceId) {
+    const skills = await this.list();
+    return _.filter(skills, (skill) =>
+      skill.competenceId === competenceId
+      && _.includes(OPERATIVE_STATUSES, skill.status));
   },
 
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -39,12 +39,12 @@ module.exports = datasource.extend({
     };
   },
 
-  async findActiveSkills() {
+  async findActive() {
     const skills = await this.list();
     return _.filter(skills, { status: ACTIVE_STATUS });
   },
 
-  async findOperativeSkills() {
+  async findOperative() {
     const skills = await this.list();
     return _.filter(skills, (skill) => _.includes(OPERATIVE_STATUSES, skill.status));
   },

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -44,6 +44,11 @@ module.exports = datasource.extend({
     return _.filter(skills, { status: ACTIVE_STATUS });
   },
 
+  async findOperativeSkills() {
+    const skills = await this.list();
+    return _.filter(skills, (skill) => _.includes(OPERATIVE_STATUSES, skill.status));
+  },
+
   async findOperativeByRecordIds(skillIds) {
     const skills = await this.list();
     return skills.filter((skillData) =>

--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -31,7 +31,7 @@ async function _fetchData(campaignId) {
   ]);
 
   const targetedSkillIds = campaign.related('targetProfile').related('skillIds').map((targetProfileSkill) => targetProfileSkill.get('skillId'));
-  const targetedSkills = await skillDatasource.findByRecordIds(targetedSkillIds);
+  const targetedSkills = await skillDatasource.findOperativeByRecordIds(targetedSkillIds);
 
   return { targetedSkillIds, targetedSkills, participantCount };
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -29,9 +29,9 @@ module.exports = {
       .then(_generateChallengeDomainModels);
   },
 
-  findByCompetenceId(competenceId) {
+  findValidatedByCompetenceId(competenceId) {
 
-    return challengeDatasource.findByCompetenceId(competenceId)
+    return challengeDatasource.findValidatedByCompetenceId(competenceId)
       .then(_generateChallengeDomainModels);
   },
 

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -23,8 +23,8 @@ module.exports = {
       });
   },
 
-  async list() {
-    const challengeDataObjects = await challengeDatasource.list();
+  async findValidated() {
+    const challengeDataObjects = await challengeDatasource.findValidated();
     const activeSkills = await skillDatasource.findActiveSkills();
     return _generateChallengeDomainModels({ challengeDataObjects, skills: activeSkills });
   },

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -29,6 +29,12 @@ module.exports = {
     return _generateChallengeDomainModels({ challengeDataObjects, skills: activeSkills });
   },
 
+  async findOperative() {
+    const challengeDataObjects = await challengeDatasource.findOperative();
+    const operativeSkills = await skillDatasource.findOperativeSkills();
+    return _generateChallengeDomainModels({ challengeDataObjects, skills: operativeSkills });
+  },
+
   async findValidatedByCompetenceId(competenceId) {
     const challengeDataObjects = await challengeDatasource.findValidatedByCompetenceId(competenceId);
     const activeSkills = await skillDatasource.findActiveSkills();

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -25,26 +25,26 @@ module.exports = {
 
   async findValidated() {
     const challengeDataObjects = await challengeDatasource.findValidated();
-    const activeSkills = await skillDatasource.findActiveSkills();
+    const activeSkills = await skillDatasource.findActive();
     return _generateChallengeDomainModels({ challengeDataObjects, skills: activeSkills });
   },
 
   async findOperative() {
     const challengeDataObjects = await challengeDatasource.findOperative();
-    const operativeSkills = await skillDatasource.findOperativeSkills();
+    const operativeSkills = await skillDatasource.findOperative();
     return _generateChallengeDomainModels({ challengeDataObjects, skills: operativeSkills });
   },
 
   async findValidatedByCompetenceId(competenceId) {
     const challengeDataObjects = await challengeDatasource.findValidatedByCompetenceId(competenceId);
-    const activeSkills = await skillDatasource.findActiveSkills();
+    const activeSkills = await skillDatasource.findActive();
     return _generateChallengeDomainModels({ challengeDataObjects, skills: activeSkills });
   },
 
   async findOperativeBySkills(skills) {
     const skillIds = skills.map((skill) => skill.id);
     const challengeDataObjects = await challengeDatasource.findOperativeBySkillIds(skillIds);
-    const operativeSkills = await skillDatasource.findOperativeSkills();
+    const operativeSkills = await skillDatasource.findOperative();
     return _generateChallengeDomainModels({ challengeDataObjects, skills: operativeSkills });
   },
 };

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -35,7 +35,7 @@ module.exports = {
     return _generateChallengeDomainModels({ challengeDataObjects, skills: activeSkills });
   },
 
-  async findBySkills(skills) {
+  async findOperativeBySkills(skills) {
     const skillIds = skills.map((skill) => skill.id);
     const challengeDataObjects = await challengeDatasource.findOperativeBySkillIds(skillIds);
     const operativeSkills = await skillDatasource.findOperativeSkills();

--- a/api/lib/infrastructure/repositories/partner-certification-repository.js
+++ b/api/lib/infrastructure/repositories/partner-certification-repository.js
@@ -94,7 +94,7 @@ async function _getCleaSkills(skillRepository) {
   if (_.isEmpty(skillIds)) {
     return [];
   }
-  return skillRepository.findByIds(skillIds[0].skillIds);
+  return skillRepository.findOperativeByIds(skillIds[0].skillIds);
 }
 
 function _getMaxReachablePixByCompetenceForClea(cleaSkills) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -15,7 +15,7 @@ function _toDomain(skillData) {
 module.exports = {
 
   findByCompetenceId(competenceId) {
-    return skillDatasource.findByCompetenceId(competenceId)
+    return skillDatasource.findActiveByCompetenceId(competenceId)
       .then((skillDatas) => skillDatas.map(_toDomain));
   },
 

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -14,7 +14,7 @@ function _toDomain(skillData) {
 
 module.exports = {
 
-  findByCompetenceId(competenceId) {
+  findActiveByCompetenceId(competenceId) {
     return skillDatasource.findActiveByCompetenceId(competenceId)
       .then((skillDatas) => skillDatas.map(_toDomain));
   },

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -24,8 +24,8 @@ module.exports = {
       .then((skillDatas) => skillDatas.map(_toDomain));
   },
 
-  findByIds(skillIds) {
-    return skillDatasource.findByRecordIds(skillIds)
+  findOperativeByIds(skillIds) {
+    return skillDatasource.findOperativeByRecordIds(skillIds)
       .then((skillDatas) => skillDatas.map(_toDomain));
   },
 };

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -19,6 +19,11 @@ module.exports = {
       .then((skillDatas) => skillDatas.map(_toDomain));
   },
 
+  findOperativeByCompetenceId(competenceId) {
+    return skillDatasource.findOperativeByCompetenceId(competenceId)
+      .then((skillDatas) => skillDatas.map(_toDomain));
+  },
+
   findByIds(skillIds) {
     return skillDatasource.findByRecordIds(skillIds)
       .then((skillDatas) => skillDatas.map(_toDomain));

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -1,3 +1,4 @@
+
 const bluebird = require('bluebird');
 const BookshelfTargetProfile = require('../../infrastructure/data/target-profile');
 const skillDatasource = require('../../infrastructure/datasources/airtable/skill-datasource');
@@ -54,7 +55,7 @@ async function _getWithAirtableSkills(targetProfile) {
   });
 }
 
-function _getAirtableDataObjectsSkills(bookshelfTargetProfile) {
+async function _getAirtableDataObjectsSkills(bookshelfTargetProfile) {
   const skillRecordIds = bookshelfTargetProfile.related('skillIds').map((BookshelfSkillId) => BookshelfSkillId.get('skillId'));
-  return skillDatasource.findByRecordIds(skillRecordIds);
+  return await skillDatasource.findOperativeByRecordIds(skillRecordIds);
 }

--- a/api/scripts/extract-challenge-with-skills.js
+++ b/api/scripts/extract-challenge-with-skills.js
@@ -33,7 +33,7 @@ async function findChallengesWithSkills() {
 async function _getReferentialData() {
 
   // Récupération des challenges qui ont des acquis
-  let challenges = await challengeRepository.list();
+  let challenges = await challengeRepository.findValidated();
   challenges = _.filter(challenges,(c) => {
     return c.skills.length > 0;
   });

--- a/api/scripts/generate-certification-test-statistics.js
+++ b/api/scripts/generate-certification-test-statistics.js
@@ -9,7 +9,7 @@ const USER_COUNT = ~~process.env.USER_COUNT || 100;
 let currentCount = 0;
 
 function makeRefDataFaster() {
-  challengeRepository.list = _.memoize(challengeRepository.list);
+  challengeRepository.list = _.memoize(challengeRepository.findValidated);
   competenceRepository.list = _.memoize(competenceRepository.list);
   competenceRepository.listPixCompetencesOnly = _.memoize(competenceRepository.listPixCompetencesOnly);
 }

--- a/api/scripts/generate-certification-test-statistics.js
+++ b/api/scripts/generate-certification-test-statistics.js
@@ -9,7 +9,7 @@ const USER_COUNT = ~~process.env.USER_COUNT || 100;
 let currentCount = 0;
 
 function makeRefDataFaster() {
-  challengeRepository.list = _.memoize(challengeRepository.findValidated);
+  challengeRepository.list = _.memoize(challengeRepository.findOperative);
   competenceRepository.list = _.memoize(competenceRepository.list);
   competenceRepository.listPixCompetencesOnly = _.memoize(competenceRepository.listPixCompetencesOnly);
 }

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -14,14 +14,6 @@ function turnIntoTimedChallenge(challenge) {
   return _.assign(_.cloneDeep(challenge), { timer: ONE_MINUTE });
 }
 
-function turnIntoOutOfDateChallenge(challenge) {
-  return _.assign(_.cloneDeep(challenge), { status: 'périmé' });
-}
-
-function turnIntoArchivedChallenge(challenge) {
-  return _.assign(_.cloneDeep(challenge), { status: 'archivé' });
-}
-
 function duplicateChallengeOfSameDifficulty(challenge) {
   const challengeId = parseInt(challenge.id[0]) + 1;
   return _.assign(_.cloneDeep(challenge), { id: 'rec' + challengeId });
@@ -30,7 +22,7 @@ function duplicateChallengeOfSameDifficulty(challenge) {
 describe('Integration | Domain | Stategies | SmartRandom', () => {
   let challenges, targetSkills, knowledgeElements, lastAnswer, allAnswers, web1, web2, web3, web4, web5,
     web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
-    challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6, challengeWeb_7,
+    challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
     challengeRechInfo_7, challengeInfo_2, challengeCnil_1, challengeCnil_2;
 
@@ -65,9 +57,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     challengeWeb_2_3 = domainBuilder.buildChallenge({ id: 'recweb23', skills: [web2, web3] });
     challengeWeb_3 = domainBuilder.buildChallenge({ id: 'recweb3', skills: [web3] });
     challengeWeb_4 = domainBuilder.buildChallenge({ id: 'recweb4', skills: [web4] });
-    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb5', skills: [web5] });
-    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6] });
-    challengeWeb_7 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7] });
+    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6] });
+    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7] });
     challengeUrl_2 = domainBuilder.buildChallenge({ id: 'recurl2', skills: [url2] });
     challengeUrl_3 = domainBuilder.buildChallenge({ id: 'recurl3', skills: [url3] });
     challengeUrl_4 = domainBuilder.buildChallenge({ id: 'recurl4', skills: [url4] });
@@ -81,31 +72,6 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
   });
 
   describe('#getPossibleSkillsForNextChallenge', function() {
-
-    // The first question has specific rules. The most important is that it should not be a timed challenge to avoid user
-    // being confused into thinking that all questions will be timed. Also, the algorithm requires to start at a default
-    // expect level, that is not the minimum. When this two criterias can't be satisfied simultaneously, the untimed rule wins
-
-    it('should return empty array if challenge of only possible skill are not valid', () => {
-      // given
-      const skill1 = domainBuilder.buildSkill({ name: '@web3' });
-      const challengeAssessingSkill1 = domainBuilder.buildChallenge({ skills: [skill1], status: 'PAS VALIDE' });
-      const challenges = [challengeAssessingSkill1];
-
-      // when
-      const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-        targetSkills: [skill1],
-        challenges,
-        knowledgeElements: [],
-        lastAnswer,
-        allAnswers,
-        validatedOnly: true,
-      });
-
-      // then
-      expect(possibleSkillsForNextChallenge).to.be.deep.equal([]);
-    });
-
     context('when it is the first question only', () => {
 
       it('should ideally start with an untimed, default starting level skill', function() {
@@ -224,302 +190,12 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
 
     });
 
-    context('when we are in competenceEvaluation : validatedOnly is true', () => {
-      context('when one challenge has been archived : status "archivé"', () => {
-        let challengeWeb_1_Archived;
-
-        beforeEach(() => {
-          targetSkills = [web1];
-          challengeWeb_1_Archived = turnIntoArchivedChallenge(challengeWeb_1);
-        });
-
-        it('should return empty array', () => {
-          // given
-          const challenges = [challengeWeb_1_Archived];
-
-          // when
-          const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-            targetSkills,
-            challenges,
-            knowledgeElements: [],
-            lastAnswer,
-            allAnswers,
-            validatedOnly: true,
-          });
-
-          // then
-          expect(possibleSkillsForNextChallenge).to.be.deep.equal([]);
-        });
-      });
-
-      context('when one challenge is out of date : status "périmé"', () => {
-        let challengeWeb_1_OutOfDate;
-
-        beforeEach(() => {
-          targetSkills = [web1];
-          challengeWeb_1_OutOfDate = turnIntoOutOfDateChallenge(challengeWeb_1);
-        });
-
-        it('should return empty array', () => {
-          // given
-          const challenges = [challengeWeb_1_OutOfDate];
-
-          // when
-          const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-            targetSkills,
-            challenges,
-            knowledgeElements: [],
-            lastAnswer,
-            allAnswers,
-            validatedOnly: true,
-          });
-
-          // then
-          expect(possibleSkillsForNextChallenge).to.be.deep.equal([]);
-        });
-      });
-    });
-
-    context('when we are in campaign : validatedOnly is false', () => {
-      context('when one challenge has been archived : status "archivé"', () => {
-        let challengeWeb_1_Archived;
-
-        beforeEach(() => {
-          targetSkills = [web1];
-          challengeWeb_1_Archived = turnIntoArchivedChallenge(challengeWeb_1);
-        });
-
-        it('should return a result', () => {
-          // given
-          const challenges = [challengeWeb_1_Archived];
-
-          // when
-          const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-            targetSkills,
-            challenges,
-            knowledgeElements: [],
-            lastAnswer,
-            allAnswers,
-            validatedOnly: false,
-          });
-
-          // then
-          expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
-          expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-          expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
-          expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
-        });
-      });
-
-      context('when one challenge is out of date : status "périmé"', () => {
-        let challengeWeb_1_OutOfDate;
-
-        beforeEach(() => {
-          targetSkills = [web1];
-          challengeWeb_1_OutOfDate = turnIntoOutOfDateChallenge(challengeWeb_1);
-        });
-
-        it('should return empty array', () => {
-          // given
-          const challenges = [challengeWeb_1_OutOfDate];
-
-          // when
-          const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-            targetSkills,
-            challenges,
-            knowledgeElements: [],
-            lastAnswer,
-            allAnswers,
-            validatedOnly: false,
-          });
-
-          // then
-          expect(possibleSkillsForNextChallenge).to.be.deep.equal([]);
-        });
-      });
-    });
-
-    // Some challenges can be out of date. Such challenges may be ruled out in competenceEvaluation when they haven't been answered yet,
-    // but at the same time must be taken into account when the user has already answered them, since they give useful information
-    // to the adaptive algorithm.
-    context('when one challenge is out of date', () => {
-      let challengeWeb_3_OutOfDate, challengeWeb_4_OutOfDate;
-
-      beforeEach(() => {
-        targetSkills = [web1, web2, web3, web4, web5];
-        challengeWeb_3_OutOfDate = turnIntoOutOfDateChallenge(challengeWeb_3);
-        challengeWeb_4_OutOfDate = turnIntoOutOfDateChallenge(challengeWeb_4);
-      });
-
-      it('should return a challenge of level 4 if user got levels 1, 2 and the only possible level is 3 out if date', function() {
-        // given
-        targetSkills = [web1, web2, web3, web4, web5, web6];
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
-        allAnswers = [lastAnswer];
-        knowledgeElements = [
-          domainBuilder.buildKnowledgeElement({
-            skillId: web1.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web2.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-        ];
-
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3_OutOfDate, challengeWeb_4];
-
-        // when
-        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-          targetSkills,
-          challenges,
-          knowledgeElements,
-          lastAnswer,
-          allAnswers,
-          validatedOnly: true,
-        });
-
-        // then
-        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web4.id);
-        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_4.id);
-
-      });
-
-      it('should return a challenge of level 3 if user got levels 1, 2 and another possible level 3 is out of date', function() {
-        // given
-        targetSkills = [web1, web2, web3, web4, web5, web6];
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
-        allAnswers = [lastAnswer];
-        knowledgeElements = [
-          domainBuilder.buildKnowledgeElement({
-            skillId: web1.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web2.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-        ];
-
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3, challengeWeb_3_OutOfDate];
-
-        // when
-        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-          targetSkills,
-          challenges,
-          knowledgeElements,
-          lastAnswer,
-          allAnswers,
-          validatedOnly: true,
-        });
-
-        // then
-        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
-        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
-      });
-
-      it('should return a challenge of level 4 if user got levels 1, 2, 3 and 3 was out of date afterwards', function() {
-        // given
-        targetSkills = [web1, web2, web3, web4, web5, web6];
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_3.id, result: AnswerStatus.OK });
-        allAnswers = [lastAnswer];
-        knowledgeElements = [
-          domainBuilder.buildKnowledgeElement({
-            skillId: web1.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web2.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web3.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-        ];
-
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3, challengeWeb_3_OutOfDate, challengeWeb_4];
-
-        // when
-        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-          targetSkills,
-          challenges,
-          knowledgeElements,
-          lastAnswer,
-          allAnswers,
-          validatedOnly: true,
-        });
-
-        // then
-        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web4.id);
-        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_4.id);
-      });
-
-      it('should return a challenge of level 3 if user got levels 1, 2, but failed 5, and 4 was out of date afterwards', function() {
-        // given
-        targetSkills = [web1, web2, web3, web4, web5, web6];
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_4.id, result: AnswerStatus.KO });
-        allAnswers = [lastAnswer];
-        knowledgeElements = [
-          domainBuilder.buildKnowledgeElement({
-            skillId: web1.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web2.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
-            source: 'direct'
-          }),
-          domainBuilder.buildKnowledgeElement({
-            skillId: web5.id,
-            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
-            source: 'direct'
-          }),
-        ];
-
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3, challengeWeb_4_OutOfDate, challengeWeb_5];
-
-        // when
-        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
-          targetSkills,
-          challenges,
-          knowledgeElements,
-          lastAnswer,
-          allAnswers,
-          validatedOnly: true,
-        });
-
-        // then
-        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web3.id);
-        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_3.id);
-      });
-
-    });
-
-    // These tests verify the adaptive behavior of the algorithm: that it can increase/decrease the difficulty accordingly, can reach
-    // the maximum level, can end when no challenges are available etc.
     context('when the difficulty must be adapted based on the answer to the previous question', () => {
 
       it('should end the test when the remaining challenges have been inferred to be too hard', function() {
         // given
         targetSkills = [url2, url3, rechInfo5, web7];
-        challenges = [challengeUrl_2, challengeUrl_3, challengeRechInfo_5, challengeWeb_7];
+        challenges = [challengeUrl_2, challengeUrl_3, challengeRechInfo_5, challengeWeb_6];
 
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeRechInfo_5.id, result: AnswerStatus.KO });
         allAnswers = [lastAnswer];
@@ -647,9 +323,9 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // given
         targetSkills = [web1, web2, web4, web6, web7];
 
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_6, challengeWeb_7];
+        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_5, challengeWeb_6];
 
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_6.id, result: AnswerStatus.OK });
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_5.id, result: AnswerStatus.OK });
         allAnswers = [
           lastAnswer,
           domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK })
@@ -691,13 +367,13 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web7.id);
-        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_7.id);
+        expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_6.id);
       });
 
       it('should end the test if the only available challenges are too hard (above maximum gap allowed)', function() {
         // given
         targetSkills = [web1, web2, web4, web6];
-        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_6];
+        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_5];
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.OK });
         allAnswers = [lastAnswer];
         knowledgeElements = [
@@ -789,11 +465,9 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
 
     });
 
-    // The adaptive algorithm is based on the idea that each question must provide additionnal value and must not
-    // discriminate between challenges that bring the same knowledge on the user
     context('when the next question added knowledge value is taken into account', () => {
 
-      it('should end the test if the next challenges wont provide any additionnal knowledge on the user', function() {
+      it('should end the test if the next challenges wont provide any additional knowledge on the user', function() {
         // given
         targetSkills = [web1, web2];
         challenges = [challengeWeb_1, challengeWeb_2, duplicateChallengeOfSameDifficulty(challengeWeb_2)];

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -79,7 +79,7 @@ describe('Integration | Service | User Service', function() {
   const challengeForSkillRequin8 = _createChallenge('challengeRecordIdTen', competenceRequin.id, [skillRequin8], '@requin8');
 
   beforeEach(() => {
-    sinon.stub(challengeRepository, 'findValidated').resolves([
+    sinon.stub(challengeRepository, 'findOperative').resolves([
       challengeForSkillCitation4,
       archivedChallengeForSkillCitation4,
       challengeForSkillCitation4AndMoteur3,
@@ -382,7 +382,7 @@ describe('Integration | Service | User Service', function() {
       await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
-      sinon.assert.calledOnce(challengeRepository.findValidated);
+      sinon.assert.calledOnce(challengeRepository.findOperative);
     });
 
     it('should assign skill to related competence', async () => {
@@ -691,7 +691,7 @@ describe('Integration | Service | User Service', function() {
         // given
         certificationProfile.userCompetences = [userCompetence1, userCompetence2];
         answerRepository.findChallengeIdsFromAnswerIds.withArgs([123, 456, 789]).resolves(['challengeRecordIdFour', 'challengeRecordIdTwo', 'challenge_url1']);
-        challengeRepository.findValidated.resolves([
+        challengeRepository.findOperative.resolves([
           challengeForSkillRecherche4,
           challengeForSkillCitation4AndMoteur3,
           challengeForSkillCollaborer4,

--- a/api/tests/integration/domain/services/user-service_test.js
+++ b/api/tests/integration/domain/services/user-service_test.js
@@ -79,7 +79,7 @@ describe('Integration | Service | User Service', function() {
   const challengeForSkillRequin8 = _createChallenge('challengeRecordIdTen', competenceRequin.id, [skillRequin8], '@requin8');
 
   beforeEach(() => {
-    sinon.stub(challengeRepository, 'list').resolves([
+    sinon.stub(challengeRepository, 'findValidated').resolves([
       challengeForSkillCitation4,
       archivedChallengeForSkillCitation4,
       challengeForSkillCitation4AndMoteur3,
@@ -375,14 +375,14 @@ describe('Integration | Service | User Service', function() {
       // when
     });
 
-    it('should list available challenges', async () => {
+    it('should find validated challenges', async () => {
       answerRepository.findChallengeIdsFromAnswerIds.withArgs([123, 456, 789]).resolves(['challengeRecordIdFive']);
 
       // when
       await userService.fillCertificationProfileWithChallenges(certificationProfile);
 
       // then
-      sinon.assert.calledOnce(challengeRepository.list);
+      sinon.assert.calledOnce(challengeRepository.findValidated);
     });
 
     it('should assign skill to related competence', async () => {
@@ -691,7 +691,7 @@ describe('Integration | Service | User Service', function() {
         // given
         certificationProfile.userCompetences = [userCompetence1, userCompetence2];
         answerRepository.findChallengeIdsFromAnswerIds.withArgs([123, 456, 789]).resolves(['challengeRecordIdFour', 'challengeRecordIdTwo', 'challenge_url1']);
-        challengeRepository.list.resolves([
+        challengeRepository.findValidated.resolves([
           challengeForSkillRecherche4,
           challengeForSkillCitation4AndMoteur3,
           challengeForSkillCollaborer4,

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
@@ -9,11 +9,11 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
   describe('#findPaginatedByCampaignId', () => {
 
     beforeEach(() => {
-      sinon.stub(skillDatasource, 'findByRecordIds').resolves([]);
+      sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([]);
     });
 
     afterEach(() => {
-      skillDatasource.findByRecordIds.restore();
+      skillDatasource.findOperativeByRecordIds.restore();
     });
 
     let campaign;
@@ -103,8 +103,8 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
           { id: 'skill1', name: '@Acquis1' },
           { id: 'skill1', name: '@Acqui2' }
         ];
-        skillDatasource.findByRecordIds.restore();
-        sinon.stub(skillDatasource, 'findByRecordIds').resolves(skills);
+        skillDatasource.findOperativeByRecordIds.restore();
+        sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves(skills);
 
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, skills);
         const participation = { campaignId: campaign.id };
@@ -131,8 +131,8 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
           { id: 'skill2', name: '@Acquis2' },
           { id: 'skill3', name: '@Acquis3' }
         ];
-        skillDatasource.findByRecordIds.restore();
-        sinon.stub(skillDatasource, 'findByRecordIds').resolves(skills);
+        skillDatasource.findOperativeByRecordIds.restore();
+        sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves(skills);
 
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, skills);
 
@@ -183,8 +183,8 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
           { id: 'skill2', name: '@Acquis2' },
           { id: 'skill3', name: '@Acquis3' }
         ];
-        skillDatasource.findByRecordIds.restore();
-        sinon.stub(skillDatasource, 'findByRecordIds').resolves(skills);
+        skillDatasource.findOperativeByRecordIds.restore();
+        sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves(skills);
 
         campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({}, skills);
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -22,7 +22,7 @@ describe('Integration | Repository | Target-profile', () => {
       await databaseBuilder.commit();
 
       skillAssociatedToTargetProfile = { id: targetProfileFirstSkill.skillId, name: '@Acquis2' };
-      sinon.stub(skillDatasource, 'findByRecordIds').resolves([skillAssociatedToTargetProfile]);
+      sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([skillAssociatedToTargetProfile]);
     });
 
     it('should return the target profile with its associated skills and the list of organizations which could access it', () => {
@@ -31,7 +31,7 @@ describe('Integration | Repository | Target-profile', () => {
 
       // then
       return promise.then((foundTargetProfile) => {
-        expect(skillDatasource.findByRecordIds).to.have.been.calledWith([targetProfileFirstSkill.skillId]);
+        expect(skillDatasource.findOperativeByRecordIds).to.have.been.calledWith([targetProfileFirstSkill.skillId]);
 
         expect(foundTargetProfile).to.be.an.instanceOf(TargetProfile);
 
@@ -69,7 +69,7 @@ describe('Integration | Repository | Target-profile', () => {
       await databaseBuilder.commit();
 
       targetProfileSkill = { id: targetProfileSkillAssociation.skillId, name: '@Acquis2' };
-      sinon.stub(skillDatasource, 'findByRecordIds').resolves([targetProfileSkill]);
+      sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([targetProfileSkill]);
     });
 
     it('should return an Array', async () => {
@@ -121,7 +121,7 @@ describe('Integration | Repository | Target-profile', () => {
       const skillAssociatedToTargetProfile = { id: skillId, name: '@Acquis2' };
       databaseBuilder.factory.buildTargetProfile();
       databaseBuilder.factory.buildCampaign();
-      sinon.stub(skillDatasource, 'findByRecordIds').resolves([skillAssociatedToTargetProfile]);
+      sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([skillAssociatedToTargetProfile]);
 
       await databaseBuilder.commit();
     });

--- a/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
@@ -58,6 +58,11 @@ class SkillRawAirTableFixture extends AirtableRecord {
     return this;
   }
 
+  withArchivedStatus() {
+    this.fields[STATUS] = 'archivé';
+    return this;
+  }
+
   withInactiveStatus() {
     this.fields[STATUS] = 'périmé';
     return this;

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -86,22 +86,48 @@ describe('Unit | Domain | Models | Challenge', () => {
   });
 
   describe('#isPublished', () => {
-    [
-      { status: 'validé', expectedResult: true },
-      { status: 'validé sans test', expectedResult: true },
-      { status: 'proposé', expectedResult: false },
-      { status: 'pré-validé', expectedResult: true },
-      { status: 'archive', expectedResult: false },
-    ].forEach((testCase) => {
-      it(`should return ${testCase.expectedResult} when the status is "${testCase.status}"`, () => {
-        // given
-        const challenge = new Challenge({ status: testCase.status });
 
-        // when
-        const result = challenge.isPublished();
+    context('when validatedOnly is true', () => {
+      [
+        { status: 'validé', expectedResult: true },
+        { status: 'validé sans test', expectedResult: true },
+        { status: 'proposé', expectedResult: false },
+        { status: 'pré-validé', expectedResult: true },
+        { status: 'archivé', expectedResult: false },
+        { status: 'périmé', expectedResult: false },
+      ].forEach((testCase) => {
+        it(`should return ${testCase.expectedResult} when the status is "${testCase.status}"`, () => {
+          // given
+          const challenge = new Challenge({ status: testCase.status });
 
-        // then
-        expect(result).to.equal(testCase.expectedResult);
+          // when
+          const result = challenge.isPublished({ validatedOnly: true });
+
+          // then
+          expect(result).to.equal(testCase.expectedResult);
+        });
+      });
+    });
+
+    context('when validatedOnly is false', () => {
+      [
+        { status: 'validé', expectedResult: true },
+        { status: 'validé sans test', expectedResult: true },
+        { status: 'proposé', expectedResult: false },
+        { status: 'pré-validé', expectedResult: true },
+        { status: 'archivé', expectedResult: true },
+        { status: 'périmé', expectedResult: false },
+      ].forEach((testCase) => {
+        it(`should return ${testCase.expectedResult} when the status is "${testCase.status}"`, () => {
+          // given
+          const challenge = new Challenge({ status: testCase.status });
+
+          // when
+          const result = challenge.isPublished({ validatedOnly: false });
+
+          // then
+          expect(result).to.equal(testCase.expectedResult);
+        });
       });
     });
   });

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -85,53 +85,6 @@ describe('Unit | Domain | Models | Challenge', () => {
 
   });
 
-  describe('#isPublished', () => {
-
-    context('when validatedOnly is true', () => {
-      [
-        { status: 'validé', expectedResult: true },
-        { status: 'validé sans test', expectedResult: true },
-        { status: 'proposé', expectedResult: false },
-        { status: 'pré-validé', expectedResult: true },
-        { status: 'archivé', expectedResult: false },
-        { status: 'périmé', expectedResult: false },
-      ].forEach((testCase) => {
-        it(`should return ${testCase.expectedResult} when the status is "${testCase.status}"`, () => {
-          // given
-          const challenge = new Challenge({ status: testCase.status });
-
-          // when
-          const result = challenge.isPublished({ validatedOnly: true });
-
-          // then
-          expect(result).to.equal(testCase.expectedResult);
-        });
-      });
-    });
-
-    context('when validatedOnly is false', () => {
-      [
-        { status: 'validé', expectedResult: true },
-        { status: 'validé sans test', expectedResult: true },
-        { status: 'proposé', expectedResult: false },
-        { status: 'pré-validé', expectedResult: true },
-        { status: 'archivé', expectedResult: true },
-        { status: 'périmé', expectedResult: false },
-      ].forEach((testCase) => {
-        it(`should return ${testCase.expectedResult} when the status is "${testCase.status}"`, () => {
-          // given
-          const challenge = new Challenge({ status: testCase.status });
-
-          // when
-          const result = challenge.isPublished({ validatedOnly: false });
-
-          // then
-          expect(result).to.equal(testCase.expectedResult);
-        });
-      });
-    });
-  });
-
   describe('#hardestSkill', function() {
     it('should exist', function() {
       // given

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -151,7 +151,7 @@ describe('Unit | Service | Certification Result Service', function() {
         });
 
         sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-        sinon.stub(challengeRepository, 'findValidated').resolves(challengesFromAirTable);
+        sinon.stub(challengeRepository, 'findOperative').resolves(challengesFromAirTable);
         sinon.stub(userService, 'getCertificationProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
@@ -173,7 +173,7 @@ describe('Unit | Service | Certification Result Service', function() {
         await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
         // then
-        sinon.assert.calledOnce(challengeRepository.findValidated);
+        sinon.assert.calledOnce(challengeRepository.findOperative);
       });
 
       it('should retrieve competences list', async () => {
@@ -718,7 +718,7 @@ describe('Unit | Service | Certification Result Service', function() {
         certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
         certificationAssessment.certificationChallenges = challenges;
         sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-        sinon.stub(challengeRepository, 'findValidated').resolves(challengesFromAirTable);
+        sinon.stub(challengeRepository, 'findOperative').resolves(challengesFromAirTable);
         sinon.stub(userService, 'getCertificationProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
@@ -732,7 +732,7 @@ describe('Unit | Service | Certification Result Service', function() {
         await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
         // then
-        sinon.assert.calledOnce(challengeRepository.findValidated);
+        sinon.assert.calledOnce(challengeRepository.findOperative);
       });
 
       it('should retrieve competences list', async () => {
@@ -1032,9 +1032,9 @@ describe('Unit | Service | Certification Result Service', function() {
           ], domainBuilder.buildCertificationChallenge);
           certificationAssessment.certificationChallenges = challenges;
 
-          challengeRepository.findValidated.restore();
+          challengeRepository.findOperative.restore();
           userService.getCertificationProfile.restore();
-          sinon.stub(challengeRepository, 'findValidated').resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
+          sinon.stub(challengeRepository, 'findOperative').resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
           sinon.stub(userService, 'getCertificationProfile').withArgs({
             userId: certificationAssessment.userId,
             limitDate: certificationAssessment.createdAt,

--- a/api/tests/unit/domain/services/certification/certification-result-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-result-service_test.js
@@ -151,7 +151,7 @@ describe('Unit | Service | Certification Result Service', function() {
         });
 
         sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-        sinon.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
+        sinon.stub(challengeRepository, 'findValidated').resolves(challengesFromAirTable);
         sinon.stub(userService, 'getCertificationProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
@@ -168,12 +168,12 @@ describe('Unit | Service | Certification Result Service', function() {
         sinon.assert.calledOnce(userService.getCertificationProfile);
       });
 
-      it('should retrieve challenges list', async () => {
+      it('should retrieve validated challenges', async () => {
         // when
         await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
         // then
-        sinon.assert.calledOnce(challengeRepository.list);
+        sinon.assert.calledOnce(challengeRepository.findValidated);
       });
 
       it('should retrieve competences list', async () => {
@@ -718,7 +718,7 @@ describe('Unit | Service | Certification Result Service', function() {
         certificationAssessment.certificationAnswersByDate = wrongAnswersForAllChallenges();
         certificationAssessment.certificationChallenges = challenges;
         sinon.stub(competenceRepository, 'list').resolves(competencesFromAirtable);
-        sinon.stub(challengeRepository, 'list').resolves(challengesFromAirTable);
+        sinon.stub(challengeRepository, 'findValidated').resolves(challengesFromAirTable);
         sinon.stub(userService, 'getCertificationProfile').withArgs({
           userId: certificationAssessment.userId,
           limitDate: certificationAssessment.createdAt,
@@ -732,7 +732,7 @@ describe('Unit | Service | Certification Result Service', function() {
         await certificationResultService.getCertificationResult({ certificationAssessment, continueOnError });
 
         // then
-        sinon.assert.calledOnce(challengeRepository.list);
+        sinon.assert.calledOnce(challengeRepository.findValidated);
       });
 
       it('should retrieve competences list', async () => {
@@ -1032,9 +1032,9 @@ describe('Unit | Service | Certification Result Service', function() {
           ], domainBuilder.buildCertificationChallenge);
           certificationAssessment.certificationChallenges = challenges;
 
-          challengeRepository.list.restore();
+          challengeRepository.findValidated.restore();
           userService.getCertificationProfile.restore();
-          sinon.stub(challengeRepository, 'list').resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
+          sinon.stub(challengeRepository, 'findValidated').resolves(listChallengeComp5WithOneQROCMDEPChallengeAndAnother);
           sinon.stub(userService, 'getCertificationProfile').withArgs({
             userId: certificationAssessment.userId,
             limitDate: certificationAssessment.createdAt,

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -92,7 +92,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
         findUniqByUserId: sinon.stub(),
       };
       skillRepository = {
-        findByCompetenceId: sinon.stub(),
+        findActiveByCompetenceId: sinon.stub(),
       };
       improvementService = {
         filterKnowledgeElementsIfImproving: sinon.stub(),
@@ -111,7 +111,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       const assessment = domainBuilder.buildAssessment.ofTypeCampaign();
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
-      skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
+      skillRepository.findActiveByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
       challengeRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
       improvementService.filterKnowledgeElementsIfImproving.resolves(knowledgeElements);

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -19,7 +19,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
         get: sinon.stub(),
       };
       challengeRepository = {
-        findBySkills: sinon.stub(),answerRepository
+        findOperativeBySkills: sinon.stub(),answerRepository
       };
       knowledgeElementRepository = {
         findUniqByUserId: sinon.stub(),
@@ -44,7 +44,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
       assessment.campaignParticipation.getTargetProfileId = () => 1;
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       targetProfileRepository.get.withArgs(1).resolves(targetProfile);
-      challengeRepository.findBySkills.withArgs(targetProfile.skills).resolves(challenges);
+      challengeRepository.findOperativeBySkills.withArgs(targetProfile.skills).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
       improvementService.filterKnowledgeElementsIfImproving.resolves(knowledgeElements);
 

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -86,7 +86,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
         findByAssessment: sinon.stub(),
       };
       challengeRepository = {
-        findByCompetenceId: sinon.stub(),
+        findValidatedByCompetenceId: sinon.stub(),
       };
       knowledgeElementRepository = {
         findUniqByUserId: sinon.stub(),
@@ -112,7 +112,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', () => {
 
       answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
       skillRepository.findActiveByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
-      challengeRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
+      challengeRepository.findValidatedByCompetenceId.withArgs(assessment.competenceId).resolves(challenges);
       knowledgeElementRepository.findUniqByUserId.withArgs({ userId: assessment.userId }).resolves(knowledgeElements);
       improvementService.filterKnowledgeElementsIfImproving.resolves(knowledgeElements);
 

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
   const challengeRepository = { get: () => undefined };
   const competenceEvaluationRepository = {  };
   const targetProfileRepository = { getByCampaignId: () => undefined };
-  const skillRepository = { findByCompetenceId: () => undefined };
+  const skillRepository = { findActiveByCompetenceId: () => undefined };
   const scorecardService = { computeScorecard: () => undefined };
   const knowledgeElementRepository = {
     findUniqByUserIdAndAssessmentId: () => undefined,
@@ -39,7 +39,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
     sinon.stub(answerRepository, 'saveWithKnowledgeElements');
     sinon.stub(assessmentRepository, 'get');
     sinon.stub(challengeRepository, 'get');
-    sinon.stub(skillRepository, 'findByCompetenceId');
+    sinon.stub(skillRepository, 'findActiveByCompetenceId');
     sinon.stub(targetProfileRepository, 'getByCampaignId');
     sinon.stub(scorecardService, 'computeScorecard');
     sinon.stub(knowledgeElementRepository, 'findUniqByUserIdAndAssessmentId');
@@ -116,7 +116,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         skills = domainBuilder.buildSkillCollection();
 
         scorecard = domainBuilder.buildUserScorecard({ level: 2, earnedPix: 22, exactlyEarnedPix: 22 });
-        skillRepository.findByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
+        skillRepository.findActiveByCompetenceId.withArgs(assessment.competenceId).resolves(skills);
         knowledgeElementRepository.findUniqByUserIdAndAssessmentId.withArgs({ userId: assessment.userId, assessmentId: assessment.id }).resolves([knowledgeElement]);
         KnowledgeElement.createKnowledgeElementsForAnswer.returns([
           firstCreatedKnowledgeElement, secondCreatedKnowledgeElement,
@@ -160,7 +160,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', (
         });
 
         // then
-        expect(skillRepository.findByCompetenceId).to.have.been.calledWith(assessment.competenceId);
+        expect(skillRepository.findActiveByCompetenceId).to.have.been.calledWith(assessment.competenceId);
         expect(knowledgeElementRepository.findUniqByUserIdAndAssessmentId).to.have.been.calledWith({ userId: assessment.userId, assessmentId: assessment.id });
       });
 

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | find-tutorials', () => {
     authenticatedUserId = 1;
     parseIdStub = sinon.stub(Scorecard, 'parseId');
     knowledgeElementRepository = { findUniqByUserIdAndCompetenceId: sinon.stub() };
-    skillRepository = { findByCompetenceId: sinon.stub() };
+    skillRepository = { findActiveByCompetenceId: sinon.stub() };
     tubeRepository = { findByNames: sinon.stub() };
     tutorialRepository = { findByRecordIdsForCurrentUser: sinon.stub() };
   });
@@ -144,7 +144,7 @@ describe('Unit | UseCase | find-tutorials', () => {
 
           knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves(knowledgeElementList);
 
-          skillRepository.findByCompetenceId.withArgs(competenceId).returns([skill_1, skill_2, skill_3, skill_4, skill_5, skill_6, skill_7, skill_8]);
+          skillRepository.findActiveByCompetenceId.withArgs(competenceId).returns([skill_1, skill_2, skill_3, skill_4, skill_5, skill_6, skill_7, skill_8]);
 
           const tubeNames = ['@wikipédia', '@recherche'];
           const tubeList = [
@@ -193,7 +193,7 @@ describe('Unit | UseCase | find-tutorials', () => {
           ];
 
           knowledgeElementRepository.findUniqByUserIdAndCompetenceId.resolves(knowledgeElementList);
-          skillRepository.findByCompetenceId.withArgs(competenceId).returns([skill_1, skill_2]);
+          skillRepository.findActiveByCompetenceId.withArgs(competenceId).returns([skill_1, skill_2]);
 
           // when
           const result = await findTutorials({
@@ -207,7 +207,7 @@ describe('Unit | UseCase | find-tutorials', () => {
           });
 
           //then
-          expect(skillRepository.findByCompetenceId).to.not.have.been.called;
+          expect(skillRepository.findActiveByCompetenceId).to.not.have.been.called;
           expect(result).to.deep.equal([]);
         });
       });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -101,7 +101,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
         challenges,
         targetSkills: targetProfile.skills,
         knowledgeElements: recentKnowledgeElements,
-        validatedOnly: false,
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -24,7 +24,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
 
       answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challenges = [];
-      challengeRepository = { findBySkills: sinon.stub().resolves(challenges) };
+      challengeRepository = { findOperativeBySkills: sinon.stub().resolves(challenges) };
       campaignParticipation = { getTargetProfileId: sinon.stub().returns(targetProfileId) };
       assessment = { id: assessmentId, userId, campaignParticipation, isImproving: false };
       skills = [];
@@ -90,7 +90,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
     });
 
     it('should have fetched the challenges', () => {
-      expect(challengeRepository.findBySkills).to.have.been.calledWithExactly(skills);
+      expect(challengeRepository.findOperativeBySkills).to.have.been.calledWithExactly(skills);
     });
 
     it('should have fetched the next challenge with only most recent knowledge elements', () => {

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -101,6 +101,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
         challenges,
         targetSkills: targetProfile.skills,
         knowledgeElements: recentKnowledgeElements,
+        validatedOnly: false,
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -101,6 +101,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           challenges,
           targetSkills,
           knowledgeElements: recentKnowledgeElements,
+          validatedOnly: true,
         });
       });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -101,7 +101,6 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           challenges,
           targetSkills,
           knowledgeElements: recentKnowledgeElements,
-          validatedOnly: true,
         });
       });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -27,7 +27,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
 
       answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challengeRepository = { findByCompetenceId: sinon.stub().resolves(challenges) };
-      skillRepository = { findByCompetenceId: sinon.stub().resolves(targetSkills) };
+      skillRepository = { findActiveByCompetenceId: sinon.stub().resolves(targetSkills) };
       pickChallengeService = { pickChallenge: sinon.stub().resolves(challengeUrl22) };
 
       recentKnowledgeElements = [{ createdAt: 4, skillId: 'url2' }, { createdAt: 2, skillId: 'web1' }];

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -26,7 +26,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       lastAnswer = null;
 
       answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
-      challengeRepository = { findByCompetenceId: sinon.stub().resolves(challenges) };
+      challengeRepository = { findValidatedByCompetenceId: sinon.stub().resolves(challenges) };
       skillRepository = { findActiveByCompetenceId: sinon.stub().resolves(targetSkills) };
       pickChallengeService = { pickChallenge: sinon.stub().resolves(challengeUrl22) };
 
@@ -90,7 +90,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       });
 
       it('should have fetched the challenges', () => {
-        expect(challengeRepository.findByCompetenceId).to.have.been.calledWithExactly(competenceId);
+        expect(challengeRepository.findValidatedByCompetenceId).to.have.been.calledWithExactly(competenceId);
       });
 
       it('should have fetched the next challenge with only most recent knowledge elements', () => {

--- a/api/tests/unit/domain/usecases/get-progression_test.js
+++ b/api/tests/unit/domain/usecases/get-progression_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Use Cases | get-progression', () => {
   const knowledgeElementRepository = { findUniqByUserId: () => undefined };
   const assessmentRepository = { getByAssessmentIdAndUserId: () => undefined };
   const competenceEvaluationRepository = { getByAssessmentId: () => undefined };
-  const skillRepository = { findByCompetenceId: () => undefined };
+  const skillRepository = { findActiveByCompetenceId: () => undefined };
   const improvementService = { filterKnowledgeElementsIfImproving: () => undefined };
 
   let sandbox;
@@ -166,7 +166,7 @@ describe('Unit | Domain | Use Cases | get-progression', () => {
       beforeEach(() => {
         sandbox.stub(assessmentRepository, 'getByAssessmentIdAndUserId').resolves(competenceEvaluationAssessment);
         sandbox.stub(competenceEvaluationRepository, 'getByAssessmentId').resolves(competenceEvaluation);
-        sandbox.stub(skillRepository, 'findByCompetenceId').resolves(competenceSkills);
+        sandbox.stub(skillRepository, 'findActiveByCompetenceId').resolves(competenceSkills);
         sandbox.stub(improvementService, 'filterKnowledgeElementsIfImproving')
           .withArgs({ knowledgeElements: [], assessment: competenceEvaluationAssessment }).returns([]);
       });

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -58,7 +58,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     sinon.stub(cache, 'get').callsFake((key, generator) => generator());
   });
 
-  describe('#findBySkillIds', () => {
+  describe('#findOperativeBySkillIds', () => {
 
     beforeEach(() => {
       sinon.stub(airtable, 'findRecords').resolves([
@@ -74,7 +74,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       const skillIds = ['skill-web1', 'skill-web2'];
 
       // when
-      const promise = challengeDatasource.findBySkillIds(skillIds);
+      const promise = challengeDatasource.findOperativeBySkillIds(skillIds);
 
       // then
       return promise.then((result) => {

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -52,6 +52,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     challenge_web3 = challengeRawAirTableFixture({
       id: 'challenge-web3',
       fields: { 'Acquix (id persistant)': [web3.id] }
+    }),
+    challenge_web3_archived = challengeRawAirTableFixture({
+      id: 'challenge-web3-archived',
+      fields: { 'Acquix (id persistant)': [web3.id], Statut: 'archivé' }
     });
 
   beforeEach(() => {
@@ -69,29 +73,27 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       ]);
     });
 
-    it('should resolve an array of matching Challenges from airTable', () => {
+    it('should resolve an array of matching Challenges from airTable', async () => {
       // given
       const skillIds = ['skill-web1', 'skill-web2'];
 
       // when
-      const promise = challengeDatasource.findOperativeBySkillIds(skillIds);
+      const result = await challengeDatasource.findOperativeBySkillIds(skillIds);
 
       // then
-      return promise.then((result) => {
-        expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
-        expect(_.map(result, 'id')).to.deep.equal([
-          'challenge-web1',
-          'challenge-web2',
-        ]);
-      });
+      expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
+      expect(_.map(result, 'id')).to.deep.equal([
+        'challenge-web1',
+        'challenge-web2',
+      ]);
     });
   });
 
   describe('#findValidatedByCompetenceId', () => {
 
-    let promise;
+    let result;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // given
       sinon.stub(airtable, 'findRecords').resolves([
         challenge_competence1,
@@ -101,15 +103,62 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       ]);
 
       // when
-      promise = challengeDatasource.findValidatedByCompetenceId(competence1.id);
+      result = await challengeDatasource.findValidatedByCompetenceId(competence1.id);
     });
 
     it('should resolve to an array of matching Challenges from airTable', () => {
       // then
-      return promise.then((result) => {
-        expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
-        expect(_.map(result, 'id')).to.deep.equal(['challenge-competence1']);
-      });
+      expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
+      expect(_.map(result, 'id')).to.deep.equal(['challenge-competence1']);
+    });
+  });
+
+  describe('#findOperative', () => {
+
+    beforeEach(() => {
+      sinon.stub(airtable, 'findRecords').resolves([
+        challenge_web1,
+        challenge_web1_notValidated,
+        challenge_web2,
+        challenge_web3_archived,
+      ]);
+    });
+
+    it('should resolve an array of matching Challenges from airTable', async () => {
+      // when
+      const result = await challengeDatasource.findOperative();
+
+      // then
+      expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
+      expect(_.map(result, 'id')).to.deep.equal([
+        'challenge-web1',
+        'challenge-web2',
+        'challenge-web3-archived',
+      ]);
+    });
+  });
+
+  describe('#findValidated', () => {
+
+    beforeEach(() => {
+      sinon.stub(airtable, 'findRecords').resolves([
+        challenge_web1,
+        challenge_web1_notValidated,
+        challenge_web2,
+        challenge_web3_archived,
+      ]);
+    });
+
+    it('should resolve an array of matching Challenges from airTable', async () => {
+      // when
+      const result = await challengeDatasource.findValidated();
+
+      // then
+      expect(airtable.findRecords).to.have.been.calledWith('Epreuves', challengeDatasource.usedFields);
+      expect(_.map(result, 'id')).to.deep.equal([
+        'challenge-web1',
+        'challenge-web2',
+      ]);
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -87,7 +87,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     });
   });
 
-  describe('#findByCompetenceId', () => {
+  describe('#findValidatedByCompetenceId', () => {
 
     let promise;
 
@@ -101,7 +101,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       ]);
 
       // when
-      promise = challengeDatasource.findByCompetenceId(competence1.id);
+      promise = challengeDatasource.findValidatedByCompetenceId(competence1.id);
     });
 
     it('should resolve to an array of matching Challenges from airTable', () => {

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -49,18 +49,17 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
     });
   });
 
-  describe('#findActiveSkills', () => {
+  describe('#findActive', () => {
 
     it('should query Airtable skills with empty query', async () => {
       // given
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([]));
 
       // when
-      await skillDatasource.findActiveSkills();
+      await skillDatasource.findActive();
 
       // then
       expect(airtable.findRecords).to.have.been.calledWith('Acquis', skillDatasource.usedFields);
-
     });
 
     it('should resolve an array of Skills from airTable', async () => {
@@ -71,11 +70,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2]));
 
       // when
-      const foundSkills = await skillDatasource.findActiveSkills();
+      const foundSkills = await skillDatasource.findActive();
 
       // then
       expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);
-
     });
 
     it('should resolve an array of Skills with only activated Skillfrom airTable', async () => {
@@ -87,22 +85,21 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2, rawSkill3]));
 
       // when
-      const foundSkills = await skillDatasource.findActiveSkills();
+      const foundSkills = await skillDatasource.findActive();
 
       // then
       expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);
-
     });
   });
 
-  describe('#findOperativeSkills', () => {
+  describe('#findOperative', () => {
 
     it('should query Airtable skills with empty query', async () => {
       // given
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([]));
 
       // when
-      await skillDatasource.findOperativeSkills();
+      await skillDatasource.findOperative();
 
       // then
       expect(airtable.findRecords).to.have.been.calledWith('Acquis', skillDatasource.usedFields);
@@ -117,11 +114,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2]));
 
       // when
-      const foundSkills = await skillDatasource.findOperativeSkills();
+      const foundSkills = await skillDatasource.findOperative();
 
       // then
       expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);
-
     });
 
     it('should resolve an array of Skills with only activated Skillfrom airTable', async () => {
@@ -133,7 +129,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake([rawSkill1, rawSkill2, rawSkill3]));
 
       // when
-      const foundSkills = await skillDatasource.findOperativeSkills();
+      const foundSkills = await skillDatasource.findOperative();
 
       // then
       expect(_.map(foundSkills, 'id')).to.deep.equal([rawSkill1.id, rawSkill2.id]);

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -96,7 +96,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
     });
   });
 
-  describe('#findByCompetenceId', function() {
+  describe('#findActiveByCompetenceId', function() {
 
     beforeEach(() => {
       const acquix1 = new AirtableRecord('Acquis', 'recAcquix1', {
@@ -138,7 +138,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
 
     it('should retrieve all skills from Airtable for one competence', async function() {
       // when
-      const skills = await skillDatasource.findByCompetenceId('recCompetence');
+      const skills = await skillDatasource.findActiveByCompetenceId('recCompetence');
 
       // then
       expect(_.map(skills, 'id')).to.have.members(['recAcquix1', 'recAcquix2']);

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -28,12 +28,12 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
     });
   });
 
-  describe('#findByRecordIds', () => {
+  describe('#findOperativeByRecordIds', () => {
 
     it('should return an array of airtable skill data objects -- PARTS II -- ', async function() {
       // given
       const rawSkill1 = skillRawAirTableFixture({ id: 'FAKE_REC_ID_RAW_SKILL_1' }).withActiveStatus();
-      const rawSkill2 = skillRawAirTableFixture({ id: 'FAKE_REC_ID_RAW_SKILL_2' }).withActiveStatus();
+      const rawSkill2 = skillRawAirTableFixture({ id: 'FAKE_REC_ID_RAW_SKILL_2' }).withArchivedStatus();
       const rawSkill3 = skillRawAirTableFixture({ id: 'FAKE_REC_ID_RAW_SKILL_3' }).withActiveStatus();
       const rawSkill4 = skillRawAirTableFixture({ id: 'FAKE_REC_ID_RAW_SKILL_4' }).withInactiveStatus();
 
@@ -41,7 +41,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
       sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
 
       // when
-      const foundSkills = await skillDatasource.findByRecordIds([rawSkill1.id, rawSkill2.id, rawSkill4.id]);
+      const foundSkills = await skillDatasource.findOperativeByRecordIds([rawSkill1.id, rawSkill2.id, rawSkill4.id]);
 
       // then
       expect(foundSkills).to.be.an('array');

--- a/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/skill-datasource_test.js
@@ -145,4 +145,53 @@ describe('Unit | Infrastructure | Datasource | Airtable | SkillDatasource', () =
     });
   });
 
+  describe('#findOperativeByCompetenceId', function() {
+
+    beforeEach(() => {
+      const acquix1 = new AirtableRecord('Acquis', 'recAcquix1', {
+        fields: {
+          'id persistant': 'recAcquix1',
+          'Nom': '@acquix1',
+          'Status': 'actif',
+          'Compétence (via Tube) (id persistant)': ['recCompetence']
+        }
+      });
+      const acquix2 = new AirtableRecord('Acquis', 'recAcquix2', {
+        fields: {
+          'id persistant': 'recAcquix2',
+          'Nom': '@acquix2',
+          'Status': 'archivé',
+          'Compétence (via Tube) (id persistant)': ['recCompetence']
+        }
+      });
+      const acquix3 = new AirtableRecord('Acquis', 'recAcquix3', {
+        fields: {
+          'id persistant': 'recAcquix3',
+          'Nom': '@acquix3',
+          'Status': 'en construction',
+          'Compétence (via Tube) (id persistant)': ['recCompetence']
+        }
+      });
+      const acquix4 = new AirtableRecord('Acquis', 'recAcquix4', {
+        fields: {
+          'id persistant': 'recAcquix4',
+          'Nom': '@acquix4',
+          'Status': 'actif',
+          'Compétence (via Tube) (id persistant)': ['recOtherCompetence']
+        }
+      });
+      sinon.stub(airtable, 'findRecords')
+        .withArgs('Acquis')
+        .callsFake(makeAirtableFake([acquix1, acquix2, acquix3, acquix4]));
+    });
+
+    it('should retrieve all skills from Airtable for one competence', async function() {
+      // when
+      const skills = await skillDatasource.findOperativeByCompetenceId('recCompetence');
+
+      // then
+      expect(_.map(skills, 'id')).to.have.members(['recAcquix1', 'recAcquix2']);
+    });
+  });
+
 });

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -223,10 +223,10 @@ describe('Unit | Repository | challenge-repository', () => {
       skills = [skillWeb1, skillURL2];
       operativeSkills = [skillWeb1, skillURL2, skillURL3];
       sinon.stub(skillDatasource, 'get');
-      sinon.stub(skillDatasource, 'findActiveSkills');
-      sinon.stub(skillDatasource, 'findOperativeSkills');
-      skillDatasource.findActiveSkills.resolves(skills);
-      skillDatasource.findOperativeSkills.resolves(operativeSkills);
+      sinon.stub(skillDatasource, 'findActive');
+      sinon.stub(skillDatasource, 'findOperative');
+      skillDatasource.findActive.resolves(skills);
+      skillDatasource.findOperative.resolves(operativeSkills);
     });
 
     describe('#findValidated', () => {

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -334,14 +334,14 @@ describe('Unit | Repository | challenge-repository', () => {
       });
     });
 
-    describe('#findByCompetenceId', () => {
+    describe('#findValidatedByCompetenceId', () => {
 
       let competence;
 
       beforeEach(() => {
         competence = domainBuilder.buildCompetence();
 
-        sinon.stub(challengeDatasource, 'findByCompetenceId');
+        sinon.stub(challengeDatasource, 'findValidatedByCompetenceId');
         sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
@@ -365,13 +365,13 @@ describe('Unit | Repository | challenge-repository', () => {
             skillIds: [skillURL2.id, skillURL3.id],
           });
           solution = domainBuilder.buildSolution();
-          challengeDatasource.findByCompetenceId
+          challengeDatasource.findValidatedByCompetenceId
             .withArgs(competence.id)
             .resolves([challengeDataObject1, challengeDataObject2]);
           solutionAdapter.fromChallengeAirtableDataObject.returns(solution);
 
           // when
-          promise = challengeRepository.findByCompetenceId(competence.id);
+          promise = challengeRepository.findValidatedByCompetenceId(competence.id);
         });
 
         it('should succeed', () => {
@@ -381,7 +381,7 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should call challengeDataObjects with competence', () => {
           // then
           return promise.then(() => {
-            expect(challengeDatasource.findByCompetenceId).to.have.been.calledWith(competence.id);
+            expect(challengeDatasource.findValidatedByCompetenceId).to.have.been.calledWith(competence.id);
           });
         });
         it('should resolve an array of 2 Challenge domain objects', () => {
@@ -400,10 +400,10 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should transfer the error', () => {
           // given
           const error = new Error();
-          challengeDatasource.findByCompetenceId.rejects(error);
+          challengeDatasource.findValidatedByCompetenceId.rejects(error);
 
           // when
-          const promise = challengeRepository.findByCompetenceId(competence.id);
+          const promise = challengeRepository.findValidatedByCompetenceId(competence.id);
 
           // then
           return expect(promise).to.have.been.rejectedWith(error);

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -407,7 +407,7 @@ describe('Unit | Repository | challenge-repository', () => {
       });
     });
 
-    describe('#findBySkills', () => {
+    describe('#findOperativeBySkills', () => {
 
       beforeEach(() => {
 
@@ -444,7 +444,7 @@ describe('Unit | Repository | challenge-repository', () => {
           solutionAdapter.fromChallengeAirtableDataObject.returns(solution);
 
           // when
-          promise = challengeRepository.findBySkills(skills);
+          promise = challengeRepository.findOperativeBySkills(skills);
         });
 
         it('should succeed', () => {
@@ -476,7 +476,7 @@ describe('Unit | Repository | challenge-repository', () => {
           challengeDatasource.findOperativeBySkillIds.rejects(error);
 
           // when
-          const promise = challengeRepository.findBySkills(skills);
+          const promise = challengeRepository.findOperativeBySkills(skills);
 
           // then
           return expect(promise).to.have.been.rejectedWith(error);

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -229,10 +229,10 @@ describe('Unit | Repository | challenge-repository', () => {
       skillDatasource.findOperativeSkills.resolves(operativeSkills);
     });
 
-    describe('#list', () => {
+    describe('#findValidated', () => {
 
       beforeEach(() => {
-        sinon.stub(challengeDatasource, 'list');
+        sinon.stub(challengeDatasource, 'findValidated');
         sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
@@ -242,7 +242,7 @@ describe('Unit | Repository | challenge-repository', () => {
 
         beforeEach(() => {
           // given
-          challengeDatasource.list.resolves([
+          challengeDatasource.findValidated.resolves([
             domainBuilder.buildChallengeAirtableDataObject({
               id: 'rec_challenge_1',
               skillIds: [skillWeb1.id],
@@ -256,7 +256,7 @@ describe('Unit | Repository | challenge-repository', () => {
           solutionAdapter.fromChallengeAirtableDataObject.returns(domainBuilder.buildSolution());
 
           // when
-          promise = challengeRepository.list();
+          promise = challengeRepository.findValidated();
         });
 
         it('should succeed', () => {
@@ -267,7 +267,7 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should call challengeDataObjects with competence', () => {
           // then
           return promise.then(() => {
-            expect(challengeDatasource.list).to.have.been.calledWithExactly();
+            expect(challengeDatasource.findValidated).to.have.been.calledWithExactly();
           });
         });
 
@@ -319,10 +319,10 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should transfer the error', () => {
           // given
           const error = new Error();
-          challengeDatasource.list.rejects(error);
+          challengeDatasource.findValidated.rejects(error);
 
           // when
-          const promise = challengeRepository.list();
+          const promise = challengeRepository.findValidated();
 
           // then
           return expect(promise).to.have.been.rejectedWith(error);

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -195,6 +195,7 @@ describe('Unit | Repository | challenge-repository', () => {
     let skillURL2;
     let skillURL3;
     let skills;
+    let operativeSkills;
 
     beforeEach(() => {
 
@@ -219,10 +220,13 @@ describe('Unit | Repository | challenge-repository', () => {
         competenceId: 'rec1',
         tubeId: 'recTube3',
       });
-      skills = [skillWeb1, skillURL2, skillURL3];
+      skills = [skillWeb1, skillURL2];
+      operativeSkills = [skillWeb1, skillURL2, skillURL3];
       sinon.stub(skillDatasource, 'get');
       sinon.stub(skillDatasource, 'findActiveSkills');
+      sinon.stub(skillDatasource, 'findOperativeSkills');
       skillDatasource.findActiveSkills.resolves(skills);
+      skillDatasource.findOperativeSkills.resolves(operativeSkills);
     });
 
     describe('#list', () => {
@@ -298,14 +302,6 @@ describe('Unit | Repository | challenge-repository', () => {
                 'tutorialIds': [DEFAULT_TUTORIAL_ID],
                 'tubeId': 'recTube2',
               },
-              {
-                'id': 'recSkillURL3',
-                'name': '@url3',
-                'pixValue': 3,
-                'competenceId': 'rec1',
-                'tutorialIds': [DEFAULT_TUTORIAL_ID],
-                'tubeId': 'recTube3',
-              }
             ]);
           });
         });
@@ -415,7 +411,7 @@ describe('Unit | Repository | challenge-repository', () => {
 
       beforeEach(() => {
 
-        sinon.stub(challengeDatasource, 'findBySkillIds');
+        sinon.stub(challengeDatasource, 'findOperativeBySkillIds');
         sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
       });
 
@@ -440,7 +436,7 @@ describe('Unit | Repository | challenge-repository', () => {
           });
           solution = domainBuilder.buildSolution();
 
-          challengeDatasource.findBySkillIds.resolves([
+          challengeDatasource.findOperativeBySkillIds.resolves([
             challengeDataObject1,
             challengeDataObject2,
           ]);
@@ -458,7 +454,7 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should call challengeDataObjects with competence', () => {
           // then
           return promise.then(() => {
-            expect(challengeDatasource.findBySkillIds).to.have.been.calledWith(skills.map((skill) => skill.id));
+            expect(challengeDatasource.findOperativeBySkillIds).to.have.been.calledWith(skills.map((skill) => skill.id));
           });
         });
         it('should resolve an array of 2 Challenge domain objects', () => {
@@ -477,7 +473,7 @@ describe('Unit | Repository | challenge-repository', () => {
         it('should transfer the error', () => {
           // given
           const error = new Error();
-          challengeDatasource.findBySkillIds.rejects(error);
+          challengeDatasource.findOperativeBySkillIds.rejects(error);
 
           // when
           const promise = challengeRepository.findBySkills(skills);

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -7,6 +7,7 @@ describe('Unit | Repository | skill-repository', function() {
 
   beforeEach(() => {
     sinon.stub(skillDatasource, 'findActiveByCompetenceId');
+    sinon.stub(skillDatasource, 'findOperativeByCompetenceId');
     sinon.stub(skillDatasource, 'findActiveSkills');
     sinon.stub(skillDatasource, 'findByRecordIds');
   });
@@ -40,6 +41,44 @@ describe('Unit | Repository | skill-repository', function() {
 
       // when
       const skills = await skillRepository.findByCompetenceId(competenceID);
+
+      // then
+      expect(skills).to.have.lengthOf(2);
+      expect(skills[0]).to.be.instanceof(DomainSkill);
+      expect(skills).to.be.deep.equal([
+        { id: 'recAcquix1', name: '@acquix1', pixValue: 2.4, competenceId: 'rec1', tutorialIds: [1, 2, 3], tubeId: 'tubeRec1' },
+        { id: 'recAcquix2', name: '@acquix2', pixValue: 2.4, competenceId: 'rec1', tutorialIds: [], tubeId: 'tubeRec2' },
+      ]);
+    });
+  });
+
+  describe('#findOperativeByCompetenceId', function() {
+
+    const competenceID = 'competence_id';
+
+    beforeEach(() => {
+      skillDatasource.findOperativeByCompetenceId
+        .withArgs('competence_id')
+        .resolves([{
+          id: 'recAcquix1',
+          name: '@acquix1',
+          pixValue: 2.4,
+          competenceId: 'rec1',
+          tutorialIds: [1, 2, 3],
+          tubeId: 'tubeRec1',
+        }, {
+          id: 'recAcquix2',
+          name: '@acquix2',
+          pixValue: 2.4,
+          competenceId: 'rec1',
+          tubeId: 'tubeRec2',
+        },
+        ]);
+    });
+
+    it('should resolve all skills for one competence', async function() {
+      // when
+      const skills = await skillRepository.findOperativeByCompetenceId(competenceID);
 
       // then
       expect(skills).to.have.lengthOf(2);

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -8,7 +8,7 @@ describe('Unit | Repository | skill-repository', function() {
   beforeEach(() => {
     sinon.stub(skillDatasource, 'findActiveByCompetenceId');
     sinon.stub(skillDatasource, 'findOperativeByCompetenceId');
-    sinon.stub(skillDatasource, 'findActiveSkills');
+    sinon.stub(skillDatasource, 'findActive');
     sinon.stub(skillDatasource, 'findOperativeByRecordIds');
   });
 

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -9,7 +9,7 @@ describe('Unit | Repository | skill-repository', function() {
     sinon.stub(skillDatasource, 'findActiveByCompetenceId');
     sinon.stub(skillDatasource, 'findOperativeByCompetenceId');
     sinon.stub(skillDatasource, 'findActiveSkills');
-    sinon.stub(skillDatasource, 'findByRecordIds');
+    sinon.stub(skillDatasource, 'findOperativeByRecordIds');
   });
 
   describe('#findActiveByCompetenceId', function() {
@@ -90,12 +90,12 @@ describe('Unit | Repository | skill-repository', function() {
     });
   });
 
-  describe('#findByIds', function() {
+  describe('#findOperativeByIds', function() {
 
     const competenceIDs = ['recAcquix1', 'recAcquix2'];
 
     beforeEach(() => {
-      skillDatasource.findByRecordIds
+      skillDatasource.findOperativeByRecordIds
         .withArgs(competenceIDs)
         .resolves([{
           id: 'recAcquix1',
@@ -118,7 +118,7 @@ describe('Unit | Repository | skill-repository', function() {
       //given
 
       // when
-      const skills = await skillRepository.findByIds(competenceIDs);
+      const skills = await skillRepository.findOperativeByIds(competenceIDs);
 
       // then
       expect(skills).to.have.lengthOf(2);

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -6,7 +6,7 @@ const skillRepository = require('../../../../lib/infrastructure/repositories/ski
 describe('Unit | Repository | skill-repository', function() {
 
   beforeEach(() => {
-    sinon.stub(skillDatasource, 'findByCompetenceId');
+    sinon.stub(skillDatasource, 'findActiveByCompetenceId');
     sinon.stub(skillDatasource, 'findActiveSkills');
     sinon.stub(skillDatasource, 'findByRecordIds');
   });
@@ -16,7 +16,7 @@ describe('Unit | Repository | skill-repository', function() {
     const competenceID = 'competence_id';
 
     beforeEach(() => {
-      skillDatasource.findByCompetenceId
+      skillDatasource.findActiveByCompetenceId
         .withArgs('competence_id')
         .resolves([{
           id: 'recAcquix1',

--- a/api/tests/unit/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/skill-repository_test.js
@@ -12,7 +12,7 @@ describe('Unit | Repository | skill-repository', function() {
     sinon.stub(skillDatasource, 'findByRecordIds');
   });
 
-  describe('#findByCompetenceId', function() {
+  describe('#findActiveByCompetenceId', function() {
 
     const competenceID = 'competence_id';
 
@@ -40,7 +40,7 @@ describe('Unit | Repository | skill-repository', function() {
       //given
 
       // when
-      const skills = await skillRepository.findByCompetenceId(competenceID);
+      const skills = await skillRepository.findActiveByCompetenceId(competenceID);
 
       // then
       expect(skills).to.have.lengthOf(2);


### PR DESCRIPTION
## :unicorn: Problème
Le statut `archivés` des acquis et épreuves désignent les acquis/épreuves jouables en campagnes et certification mais pas en positionnement libre.
Ce statut a bien été mis en place côté Airtable mais pas encore pris en compte sur pix-app.

## :robot: Solution
On introduit dans cette PR la notion de `operative` (cf. `skillDatasource` et `challengeDatasource`):
| méthode  |  statuts cibles  | utilisation |
|---|---|---|
| skillDatasource.findActiveSkills | récupère les acquis au statut 'actif' | ces acquis récupérés sont jouables partout |
| skillDatasource.find**Operative**Skills | récupère les acquis au statut 'actif' ou <ins>'archivé'</ins>| ces acquis récupérés sont jouables uniquement en campagne et certif |
| challengeDatasource.findValidated | récupère les épreuves au statut 'validé', 'validé sans test', 'pré-validé'| ces épreuves récupérées sont jouables partout |
| challengeDatasource.find**Operative** | récupère les épreuves au statut 'validé', 'validé sans test', 'pré-validé' ou <ins>'archivé'</ins> | ces épreuves récupérées sont jouables uniquement en campagne et certif |

=> les `operative` ne sont jouables uniquement qu'en campagne et certif car ils ont acquis/épreuves au statut `archivé` qui ne sont jouables qu'en campagne et certif. 

## :100: Pour tester
La RA est connectée à la base Airtable "PIX - Prod copy for archivable skills":
- sur Airtable: modifier le statut des acquis / épreuves
- rafraichir le cache Airtable (via Pix Admin)
- vérifier que les acquis/épreuves "archivés" sont bien posés en campagnes/certification mais pas en positionnement libre
- vérifier que les acquis/épreuves "périmés" ne sont posés nulle part

Ce trick a déjà été fait pour les acquis seulement de la campagne AZERTY123 (correspondant à la compétence 5.1) :
- acquis recxij74P8pBL3pdq (@bluetooth1) : actif et épreuves actives -> doit être posée en parcours autonome, en parcours prescrit et en certif ;
- acquis recUQEnFmSvPBA807 (@connaissanceConnex1) : acquis archivés et épreuves archivés -> doit être posée uniquement en parcours prescrit et en certif ;
- acquis recVv1eoSLW7yFgXv (@connexionSmart1) : acquis actif et 1 épreuve archivées, les autres périmées -> doit être posée uniquement en parcours prescrit et en certif ;
- acquis recUdMS2pRSF4sgnk (@miseAJour1) : acquis actif et toutes les épreuves périmées -> NE dois PAS être posée ;
- tous les autres acquis NE doivent PAS être posés, car mis au statut périmé.