### PR TITLE
[FEATURE] Permettre l'édition de l'e-mail d'une organisation dans Pix Admin (PIX-880).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -59,6 +59,18 @@
                  class={{if (v-get this.form 'provinceCode' 'isInvalid') "form-control is-invalid" "form-control"}}
                  @value={{this.form.provinceCode}} />
         </div>
+        <div class="form-field">
+          <label for="email" class="form-field__label">Adresse e-mail (SCO)</label>
+          {{#if (v-get this.form 'email' 'isInvalid')}}
+            <div class="form-field__error" aria-label="Message d'erreur du champ adresse email">
+              {{v-get this.form 'email' 'message'}}
+            </div>
+          {{/if}}
+          <Input id="email"
+                 @type="text"
+                 class={{if (v-get this.form 'email' 'isInvalid') "form-control is-invalid" "form-control"}}
+                 @value={{this.form.email}} />
+        </div>
         <div class="form-actions">
           <button class="btn btn-outline-default" aria-label="Annuler" type="button" {{on "click" this.cancel}}>Annuler</button>
           <button class="btn btn-success" aria-label="Enregistrer" type="submit">Enregistrer</button>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -38,12 +38,26 @@ const Validations = buildValidations({
       })
     ]
   },
+  email: {
+    validators: [
+      validator('length', {
+        max: 255,
+        message: 'La longueur de l\'email ne doit pas excéder 255 caractères.'
+      }),
+      validator('format', {
+        allowBlank: true,
+        type: 'email',
+        message: 'L\'e-mail n\'a pas le bon format.'
+      })
+    ]
+  },
 });
 
 class Form extends Object.extend(Validations) {
   @tracked name;
   @tracked externalId;
   @tracked provinceCode;
+  @tracked email;
 }
 
 export default class OrganizationInformationSection extends Component {
@@ -99,6 +113,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('name', this.form.name.trim());
     this.args.organization.set('externalId', !this.form.externalId ? null : this.form.externalId.trim());
     this.args.organization.set('provinceCode', !this.form.provinceCode ? null : this.form.provinceCode.trim());
+    this.args.organization.set('email', !this.form.email ? null : this.form.email.trim());
 
     this.isEditMode = false;
     return this.args.onSubmit();
@@ -108,5 +123,7 @@ export default class OrganizationInformationSection extends Component {
     this.form.name = this.args.organization.name;
     this.form.externalId = this.args.organization.externalId;
     this.form.provinceCode = this.args.organization.provinceCode;
+    this.form.email = this.args.organization.email;
+
   }
 }

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -14,7 +14,7 @@ module('Acceptance | organization information management', function(hooks) {
 
   module('editing organization', function() {
 
-    test('should edit organization\'s name, externalId and provinceCode', async function(assert) {
+    test('should edit organization\'s name, externalId, provinceCode and email', async function(assert) {
       // given
       const organization = this.server.create('organization', { name: 'oldOrganizationName', externalId: 'oldOrganizationExternalId', provinceCode: 'oldProvinceCode' });
       await visit(`/organizations/${organization.id}`);
@@ -24,12 +24,16 @@ module('Acceptance | organization information management', function(hooks) {
       await fillIn('#name', 'newOrganizationName');
       await fillIn('#externalId', 'newOrganizationExternalId');
       await fillIn('#provinceCode', 'newOrganizationProvinceCode');
+      await fillIn('#email', 'sco.generic.newaccount@example.net');
+
       await click('button[aria-label="Enregistrer"]');
 
       // then
       assert.contains('newOrganizationName');
       assert.contains('newOrganizationExternalId');
       assert.contains('newOrganizationProvinceCode');
+      assert.contains('sco.generic.newaccount@example.net');
+
     });
   });
 });

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -132,6 +132,30 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('div[aria-label="Message d\'erreur du champ département"]').hasText('La longueur du département ne doit pas excéder 255 caractères');
     });
 
+    test('it should show error message if organization\'s email is longer than 255 characters', async function(assert) {
+      // given
+      await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
+      // when
+      await click('button[aria-label=\'Editer\'');
+      await fillIn('#email', 'a'.repeat(256));
+
+      // then
+      assert.dom('div[aria-label="Message d\'erreur du champ adresse email"]').hasText('La longueur de l\'email ne doit pas excéder 255 caractères.');
+    });
+
+    test('it should show error message if organization\'s email is not valid', async function(assert) {
+      // given
+      await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
+      // when
+      await click('button[aria-label=\'Editer\'');
+      await fillIn('#email', 'not-valid-email-format');
+
+      // then
+      assert.dom('div[aria-label="Message d\'erreur du champ adresse email"]').hasText('L\'e-mail n\'a pas le bon format.');
+    });
+
     test('it should toggle display mode on click to cancel button', async function(assert) {
       // given
       await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | organization-information-section', function(ho
     let organization;
 
     hooks.beforeEach(function() {
-      organization = EmberObject.create({ id: 1, name: 'Organization SCO', externalId: 'VELIT', provinceCode: 'h50' });
+      organization = EmberObject.create({ id: 1, name: 'Organization SCO', externalId: 'VELIT', provinceCode: 'h50', email: 'sco.generic.account@example.net' });
       this.set('organization', organization);
     });
 
@@ -82,6 +82,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('input#name').hasValue(organization.name);
       assert.dom('input#externalId').hasValue(organization.externalId);
       assert.dom('input#provinceCode').hasValue(organization.provinceCode);
+      assert.dom('input#email').hasValue(organization.email);
     });
 
     test('it should show error message if organization\'s name is empty', async function(assert) {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -23,12 +23,13 @@ module.exports = {
     const {
       name,
       type,
+      email,
       'external-id': externalId,
       'province-code': provinceCode,
       'logo-url': logoUrl,
     } = request.payload.data.attributes;
 
-    return usecases.createOrganization({ name, type, externalId, provinceCode, logoUrl })
+    return usecases.createOrganization({ name, type, externalId, provinceCode, logoUrl, email })
       .then(organizationSerializer.serialize);
   },
 
@@ -37,13 +38,14 @@ module.exports = {
     const {
       name,
       type,
+      email,
       'logo-url': logoUrl,
       'external-id': externalId,
       'province-code': provinceCode,
       'is-managing-students': isManagingStudents,
     } = request.payload.data.attributes;
 
-    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents })
+    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, email })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -6,6 +6,7 @@ module.exports = async function updateOrganizationInformation({
   externalId,
   provinceCode,
   isManagingStudents,
+  email,
   organizationRepository
 }) {
   const organization = await organizationRepository.get(id);
@@ -13,6 +14,7 @@ module.exports = async function updateOrganizationInformation({
   if (name) organization.name = name;
   if (type) organization.type = type;
   if (logoUrl) organization.logoUrl = logoUrl;
+  organization.email = email;
   organization.externalId = externalId;
   organization.provinceCode = provinceCode;
   if (isManagingStudents) organization.isManagingStudents = isManagingStudents;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -66,7 +66,7 @@ module.exports = {
 
   update(organization) {
 
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents']);
+    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'email']);
 
     return new BookshelfOrganization({ id: organization.id })
       .save(organizationRawData, { patch: true })

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -179,6 +179,7 @@ describe('Acceptance | Application | organization-controller', () => {
           attributes: {
             'external-id': '0446758F',
             'province-code': '044',
+            'email': 'sco.generic.newaccount@example.net',
           }
         }
       };

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -49,6 +49,7 @@ describe('Integration | Application | Organizations | organization-controller', 
           'logo-url': 'http://log.url',
           'external-id': '02A2145V',
           'province-code': '02A',
+          'email': 'sco.generic.newaccount@example.net'
         }
       }
     };
@@ -84,7 +85,7 @@ describe('Integration | Application | Organizations | organization-controller', 
 
     context('Error cases', () => {
 
-      context('when user is allowed to access resource', () => {
+      context('when user is not allowed to access resource', () => {
 
         beforeEach(() => {
           securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {

--- a/api/tests/integration/domain/usecases/update-organization-information-test.js
+++ b/api/tests/integration/domain/usecases/update-organization-information-test.js
@@ -1,0 +1,57 @@
+const { expect,catchErr, databaseBuilder } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const Organization = require('../../../../lib/domain/models/Organization');
+const updateOrganizationInformation = require('../../../../lib/domain/usecases/update-organization-information');
+
+describe('Integration | UseCases | updateOrganizationInformation', () => {
+
+  let organizationId;
+
+  beforeEach(async () => {
+    organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+    await databaseBuilder.commit();
+  });
+
+  it('should allow to update the organization email', async () => {
+    // given
+    const newEmail = 'sco.generic.newaccount@example.net';
+
+    // when
+    const result = await updateOrganizationInformation({ id: organizationId, email: newEmail, organizationRepository });
+
+    // then
+    expect(result).to.be.an.instanceOf(Organization);
+    expect(result.email).equal(newEmail);
+  });
+
+  it('should allow to update the organization email with null value', async () => {
+    // given
+    const newEmail = null;
+
+    // when
+    const result = await updateOrganizationInformation({ id: organizationId, email: newEmail, organizationRepository });
+
+    // then
+    expect(result).to.be.an.instanceOf(Organization);
+    expect(result.email).equal(newEmail);
+  });
+
+  it('should throw NotFoundError when organization identifier is not found ', async () => {
+    // given
+    const newEmail = 'sco.generic.newaccount@example.net';
+
+    // when
+    const NOT_EXIST_ORGANIZATION_ID = 99999;
+    const error = await catchErr(updateOrganizationInformation)({
+      organizationRepository,
+      id: NOT_EXIST_ORGANIZATION_ID,
+      email: newEmail,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
+    expect(error.message).to.equal('Not found organization for ID 99999');
+  });
+
+});

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -37,7 +37,7 @@ function buildOrganization(
     isManagingStudents = false,
     credit = 500,
     canCollectProfiles = false,
-    email,
+    email = faker.internet.exampleEmail(),
     createdAt = new Date('2018-01-12T01:02:03Z'),
     memberships = [],
     targetProfileShares = []

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -121,10 +121,11 @@ describe('Unit | Application | Organizations | organization-controller', () => {
             id: organization.id,
             attributes: {
               name: 'Acme',
-              type: 'PRO',
+              type: 'SCO',
               'logo-url': 'logo',
               'external-id': '02A2145V',
-              'province-code': '02A'
+              'province-code': '02A',
+              email: 'sco.generic.newaccount@example.net'
             }
           }
         }
@@ -148,7 +149,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
         // then
         expect(usecases.updateOrganizationInformation).to.have.been.calledOnce;
-        expect(usecases.updateOrganizationInformation).to.have.been.calledWithMatch({ id: organization.id, name: 'Acme', type: 'PRO', logoUrl: 'logo', externalId: '02A2145V', provinceCode: '02A' });
+        expect(usecases.updateOrganizationInformation).to.have.been.calledWithMatch({ id: organization.id, name: 'Acme', type: 'SCO', logoUrl: 'logo', externalId: '02A2145V', provinceCode: '02A', email: 'sco.generic.newaccount@example.net' });
       });
 
       it('should serialized organization into JSON:API', async () => {

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | update-organization-information', () => {
       externalId: 'extId',
       provinceCode: '666',
       isManagingStudents: false,
+      email: null,
     });
     organizationRepository = {
       get: sinon.stub().resolves(originalOrganization),
@@ -175,6 +176,27 @@ describe('Unit | UseCase | update-organization-information', () => {
       expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
       expect(resultOrganization.isManagingStudents).to.equal(isManagingStudents);
     });
+
+    it('should allow to update the organization email', async () => {
+      // given
+      const newEmail = 'sco.generic.newaccount@example.net';
+
+      // when
+      const resultOrganization = await updateOrganizationInformation({
+        id: originalOrganization.id,
+        email: newEmail,
+        organizationRepository
+      });
+
+      // then
+      expect(resultOrganization.name).to.equal(originalOrganization.name);
+      expect(resultOrganization.type).to.equal(originalOrganization.type);
+      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
+      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
+      expect(resultOrganization.isManagingStudents).to.equal(originalOrganization.isManagingStudents);
+      expect(resultOrganization.email).to.equal(newEmail);
+    });
+
   });
 
   context('when an error occurred', () => {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas éditer le champ e-mail d'une organisation SCO dans Pix Admin.

## :robot: Solution
Rajouter le champ e-mail dans l'édition des informations d'une organisation SCO.

## :rainbow: Remarques
Le champ est optionnel et peut être vidé lors de la mise à jour.
Pas de règle de gestion au niveau de l'affichage de l'e-mail pour l'instant, on l'édite pour toutes les organisations.

## :100: Pour tester
Aller dans Pix Admin, dans la vue détail d'une organisation, puis cliquer sur Editer.
Vérifier que le champ e-mail est présent et le modifier.
Vérifier que la mise à jour s'est bien effectuée.
