### PR TITLE
[FEATURE] Ajout de la colonne Réponse Automatique (PIX-899).

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -40,6 +40,7 @@ class Challenge {
    * @param competenceId
    * @param format
    * @param locales
+   * @param autoReply
    */
   constructor(
     {
@@ -58,6 +59,7 @@ class Challenge {
       timer,
       type,
       locales,
+      autoReply,
       // includes
       answer,
       skills = [],
@@ -81,6 +83,7 @@ class Challenge {
     this.status = status;
     this.type = type;
     this.locales = locales;
+    this.autoReply = autoReply;
     // includes
     this.skills = skills;
     this.validator = validator;

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -33,6 +33,7 @@ module.exports = datasource.extend({
     'Texte alternatif illustration',
     'Format',
     'Langues',
+    'Réponse automatique',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -79,6 +80,7 @@ module.exports = datasource.extend({
       competenceId,
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
+      autoReply: Boolean(airtableRecord.get('Réponse automatique')) || false,
       locales: _convertLanguagesToLocales(airtableRecord.get('Langues') || [])
     };
   },

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -93,5 +93,6 @@ function _adaptChallengeFromDataObjects({ challengeDataObject, skillDataObjects 
     illustrationAlt: challengeDataObject.illustrationAlt,
     format: challengeDataObject.format,
     locales: challengeDataObject.locales,
+    autoReply: challengeDataObject.autoReply,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -19,6 +19,7 @@ module.exports = {
         'embedHeight',
         'illustrationAlt',
         'format',
+        'autoReply',
       ],
       transform: (record) => {
         const challenge = _.pickBy(record, (value) => !_.isUndefined(value));

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -106,6 +106,7 @@ const buildChallenge = function buildChallenge({
   langues = [
     'Francophone'
   ],
+  autoReply = false,
 } = {}) {
 
   return rawBuildChallenge({
@@ -142,6 +143,7 @@ const buildChallenge = function buildChallenge({
     illustrationAlt,
     format,
     langues,
+    autoReply,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -19,6 +19,7 @@ module.exports = function buildChallenge(
     timer,
     type = Challenge.Type.QCM,
     locales = ['fr'],
+    autReply = false,
     // includes
     answer,
     validator = new Validator(),
@@ -42,6 +43,7 @@ module.exports = function buildChallenge(
     timer,
     type,
     locales,
+    autReply,
     // includes
     answer,
     validator,

--- a/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
@@ -24,6 +24,7 @@ module.exports = function ChallengeAirtableDataObjectFixture({
   embedHeight = 500,
   format = 'petit',
   locales = ['fr'],
+  autoReply = false,
 } = {}) {
   return {
     id,
@@ -48,5 +49,6 @@ module.exports = function ChallengeAirtableDataObjectFixture({
     embedHeight,
     format,
     locales,
+    autoReply
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeRawAirTableFixture.js
@@ -124,6 +124,7 @@ module.exports = function challengeRawAirTableFixture({ id, fields } = { id: 're
         'recsvLz0W2ShyfD63',
       ],
       'Format': 'petit',
+      'Réponse automatique': false,
       'Langues': [
         'Francophone'
       ]

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -30,6 +30,7 @@ describe('Unit | Domain | Models | Challenge', () => {
         illustrationAlt: 'Texte alternatif à l\'image',
         format: 'phrase',
         locales: ['fr'],
+        autoReply: true,
       };
 
       // when

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -18,6 +18,7 @@ export default class Challenge extends Model {
   @attr('string') proposals;
   @attr('number') timer;
   @attr('string') type;
+  @attr('boolean') autoReply;
 
   // includes
   @belongsTo('answer') answer;


### PR DESCRIPTION
## :unicorn: Problème
Certaines épreuves avec des Embed vont avoir une "Réponse automatique", qui fera que l'utilisateur n'aura pas à remplir de champ réponse

## :robot: Solution
- Ajout d'une colonne "Réponse automatique" dans Airtable, avec une case à cocher
- Ajout de l'attribut `autoReply` dans le model Challenge en back et en front

## :100: Pour tester
- Aller sur l'épreuve recab7EiQWXfuVKqI et voir qu'elle a l'attribut `autoReply` à true en front
- Aller sur une autre épreuve et voir que l'attribut `autoReply` est à false