### PR TITLE
[TECH] Décorréler l'utilisation de isManagingStudents du type d'organisation SCO (PIX-924).

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -5,6 +5,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     id: 2,
     type: 'SUP',
     name: 'Tyrion SUP',
+    isManagingStudents: true,
   });
   databaseBuilder.factory.buildMembership({
     userId: 3,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -123,8 +123,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/students',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
-          assign: 'belongsToScoOrganizationAndManageStudents'
+          method: securityPreHandlers.checkUserBelongsToOrganizationManagingStudents,
+          assign: 'belongsToOrganizationManagingStudents'
         }],
         validate: {
           query: Joi.object({
@@ -145,8 +145,8 @@ exports.register = async (server) => {
       path: '/api/organizations/{id}/import-students',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserIsAdminInScoOrganizationAndManagesStudents,
-          assign: 'isAdminInScoOrganizationAndManagesStudents'
+          method: securityPreHandlers.checkUserIsAdminInOrganizationManagingStudents,
+          assign: 'isAdminInOrganizationManagingStudents'
         }],
         payload: {
           maxBytes: 1048576 * 10, // 10MB

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -127,6 +127,9 @@ exports.register = async (server) => {
           assign: 'belongsToOrganizationManagingStudents'
         }],
         validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
           query: Joi.object({
             'page[size]': Joi.number().integer().empty(''),
             'page[number]': Joi.number().integer().empty(''),
@@ -148,6 +151,11 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserIsAdminInOrganizationManagingStudents,
           assign: 'isAdminInOrganizationManagingStudents'
         }],
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required()
+          }),
+        },
         payload: {
           maxBytes: 1048576 * 10, // 10MB
           parse: 'gunzip',

--- a/api/lib/application/usecases/checkUserBelongsToOrganizationManagingStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToOrganizationManagingStudents.js
@@ -1,0 +1,10 @@
+const membershipRepository = require('../../infrastructure/repositories/membership-repository');
+
+module.exports = {
+
+  async execute(userId, organizationId) {
+    const memberships = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
+    return memberships.reduce((belongsToScoOrganization, membership) =>
+      belongsToScoOrganization || membership.organization.isManagingStudents, false);
+  }
+};

--- a/api/lib/domain/usecases/retrieve-campaign-information.js
+++ b/api/lib/domain/usecases/retrieve-campaign-information.js
@@ -15,7 +15,7 @@ module.exports = async function retrieveCampaignInformation({
   foundCampaign.organizationLogoUrl = foundOrganization.logoUrl;
   foundCampaign.organizationName = foundOrganization.name;
 
-  if (foundOrganization.isManagingStudents && foundOrganization.type === 'SCO') {
+  if (foundOrganization.isManagingStudents) {
     foundCampaign.isRestricted = true;
   }
 

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -835,22 +835,6 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(403);
       });
 
-      it('should respond with a 403 - Forbidden access - if Organization type is not SCO', async () => {
-        // given
-        const organizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: true }).id;
-        const userId = databaseBuilder.factory.buildUser.withMembership({ organizationId }).id;
-        await databaseBuilder.commit();
-
-        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-        options.url = `/api/organizations/${organizationId}/students`;
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
-
       it('should respond with a 403 - Forbidden access - if Organization does not manage schoolingRegistrations', async () => {
         // given
         const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false }).id;

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -769,30 +769,6 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
         });
       });
 
-      context('when Organization type is not SCO', () => {
-        beforeEach(async () => {
-          // given
-          const organizationId = databaseBuilder.factory.buildOrganization({ type: 'PRO', isManagingStudents: true }).id;
-          const userId = databaseBuilder.factory.buildUser.withMembership({
-            organizationId,
-            organizationRole: Membership.roles.ADMIN
-          }).id;
-          await databaseBuilder.commit();
-
-          options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-          options.url = `/api/organizations/${organizationId}/import-students`;
-        });
-
-        it('should respond with a 403 - Forbidden access', async () => {
-          // when
-          const response = await server.inject(options);
-
-          // then
-          expect(response.statusCode).to.equal(403);
-        });
-
-      });
-
       context('when Organization does not manage schoolingRegistrations', () => {
         beforeEach(async () => {
           // given

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -10,9 +10,10 @@ describe('Integration | Application | Organizations | Routes', () => {
 
   beforeEach(() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
-    sinon.stub(securityPreHandlers, 'checkUserIsAdminInScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationManagingStudents').callsFake((request, h) => h.response(true));
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').callsFake((request, h) => h.response(true));
+    sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganizationManagingStudents').callsFake((request, h) => h.response(true));
     sinon.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
 
     sinon.stub(organizationController, 'create').returns('ok');
@@ -151,10 +152,10 @@ describe('Integration | Application | Organizations | Routes', () => {
         // given
         const method = 'GET';
         const url = '/api/organizations/:id/students?page[size]=blabla';
-  
+
         // when
         const response = await httpTestServer.request(method, url);
-  
+
         // then
         expect(response.statusCode).to.equal(400);
       });
@@ -163,10 +164,10 @@ describe('Integration | Application | Organizations | Routes', () => {
         // given
         const method = 'GET';
         const url = '/api/organizations/:id/students?page[number]=blabla';
-  
+
         // when
         const response = await httpTestServer.request(method, url);
-  
+
         // then
         expect(response.statusCode).to.equal(400);
       });

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -79,7 +79,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should call the organization controller to import schoolingRegistrations', async () => {
       // given
       const method = 'POST';
-      const url = '/api/organizations/:id/import-students';
+      const url = '/api/organizations/1/import-students';
       const payload = {};
 
       // when
@@ -88,6 +88,19 @@ describe('Integration | Application | Organizations | Routes', () => {
       // then
       expect(response.statusCode).to.equal(201);
       expect(organizationController.importSchoolingRegistrationsFromSIECLE).to.have.been.calledOnce;
+    });
+
+    it('should throw an error when id is invalid', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/organizations/wrongId/import-students';
+      const payload = {};
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 
@@ -136,7 +149,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should call the organization controller to return students', async () => {
       // given
       const method = 'GET';
-      const url = '/api/organizations/:id/students';
+      const url = '/api/organizations/1/students';
 
       // when
       const response = await httpTestServer.request(method, url);
@@ -146,12 +159,12 @@ describe('Integration | Application | Organizations | Routes', () => {
       expect(organizationController.findPaginatedFilteredSchoolingRegistrations).to.have.been.calledOnce;
     });
 
-    describe('When page parameters are not valid', () => {
+    describe('When parameters are not valid', () => {
 
       it('should throw an error when page size is invalid', async () => {
         // given
         const method = 'GET';
-        const url = '/api/organizations/:id/students?page[size]=blabla';
+        const url = '/api/organizations/1/students?page[size]=blabla';
 
         // when
         const response = await httpTestServer.request(method, url);
@@ -163,7 +176,19 @@ describe('Integration | Application | Organizations | Routes', () => {
       it('should throw an error when page number is invalid', async () => {
         // given
         const method = 'GET';
-        const url = '/api/organizations/:id/students?page[number]=blabla';
+        const url = '/api/organizations/1/students?page[number]=blabla';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should throw an error when id is invalid', async () => {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/wrongId/students';
 
         // when
         const response = await httpTestServer.request(method, url);

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -27,6 +27,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
     sandbox.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
     sandbox.stub(securityPreHandlers, 'checkUserIsAdminInOrganizationOrHasRolePixMaster');
+    sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganizationManagingStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganizationOrHasRolePixMaster');
     httpTestServer = new HttpTestServer(moduleUnderTest);
@@ -156,7 +157,7 @@ describe('Integration | Application | Organizations | organization-controller', 
   describe('#findOrganizationsStudentsWithUserInfo', () => {
 
     beforeEach(() => {
-      securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents.returns(true);
+      securityPreHandlers.checkUserBelongsToOrganizationManagingStudents.returns(true);
     });
 
     context('Success cases', () => {
@@ -191,7 +192,7 @@ describe('Integration | Application | Organizations | organization-controller', 
       context('when user is not allowed to access resource', () => {
 
         beforeEach(() => {
-          securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents.callsFake((request, h) => {
+          securityPreHandlers.checkUserBelongsToOrganizationManagingStudents.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
         });

--- a/api/tests/unit/application/usecases/checkUserBelongsToOrganizationManagingStudents_test.js
+++ b/api/tests/unit/application/usecases/checkUserBelongsToOrganizationManagingStudents_test.js
@@ -1,0 +1,54 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const usecase = require('../../../../lib/application/usecases/checkUserBelongsToOrganizationManagingStudents');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+
+describe('Unit | Application | Use Case | checkUserBelongsToOrganizationManagingStudents', () => {
+
+  beforeEach(() => {
+    membershipRepository.findByUserIdAndOrganizationId = sinon.stub();
+  });
+
+  it('should return true when user belongs to organization managing students', async () => {
+    // given
+    const userId = 1234;
+
+    const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
+    const membership = domainBuilder.buildMembership({ organization });
+    membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+    // when
+    const response = await usecase.execute(userId, organization.id);
+
+    // then
+    expect(response).to.equal(true);
+  });
+
+  it('should return false when organization does not manage students', async () => {
+    // given
+    const userId = 1234;
+
+    const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
+    const membership = domainBuilder.buildMembership({ organization });
+    membershipRepository.findByUserIdAndOrganizationId.resolves([membership]);
+
+    // when
+    const response = await usecase.execute(userId, organization.id);
+
+    // then
+    expect(response).to.equal(false);
+  });
+
+  it('should return false when user is not a member of organization', async () => {
+    // given
+    const userId = 1234;
+
+    const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
+    membershipRepository.findByUserIdAndOrganizationId.resolves([]);
+
+    // when
+    const response = await usecase.execute(userId, organization.id);
+
+    // then
+    expect(response).to.equal(false);
+  });
+});

--- a/api/tests/unit/domain/usecases/retrieve-campaign-information_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-campaign-information_test.js
@@ -11,7 +11,7 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
   let campaignRepoStub;
   let orgaRepoStub;
   const organizationId = 'organizationId';
-  const organization = { id: organizationId, logoUrl: 'a logo url', type: 'SCO', name: 'College Victor Hugo' };
+  const organization = { id: organizationId, logoUrl: 'a logo url', name: 'College Victor Hugo' };
   const campaignCode = 'QWERTY123';
   const user = { id: 1, firstName: 'John', lastName: 'Snow' };
 
@@ -41,12 +41,13 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
       campaignRepoStub.resolves(campaign);
     });
 
-    it('should return the campaign ', async () => {
+    it('should return the campaign', async () => {
       // when
       const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
       // then
       expect(campaignRepository.getByCode).to.have.been.calledWithExactly(campaignCode);
+      expect(result).to.be.instanceof(Campaign);
       expect(result).to.deep.equal(campaign);
     });
 
@@ -64,38 +65,35 @@ describe('Unit | UseCase | retrieve-campaign-information', () => {
         expect(foundCampaign).to.deep.equal(augmentedCampaign);
       });
 
-      context('Organization of the campaign is managing student', () => {
+      context('Organization of the campaign is managing students', () => {
 
         beforeEach(() => {
           orgaRepoStub.resolves(Object.assign(organization, { isManagingStudents: true }));
         });
 
-        it('return a campaign with isRestricted equal true', async () => {
+        it('should return a campaign with isRestricted to true', async () => {
           // when
           const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
           // then
-          expect(result).to.be.instanceof(Campaign);
           expect(result.isRestricted).to.be.true;
         });
       });
 
-      context('Organization of the campaign is not managing student', () => {
+      context('Organization of the campaign is not managing students', () => {
 
         beforeEach(() => {
           orgaRepoStub.resolves(Object.assign(organization, { isManagingStudents: false }));
         });
 
-        it('should resolve and return a campaign', async () => {
+        it('should return a campaign with isRestricted to false', async () => {
           // when
           const result = await usecases.retrieveCampaignInformation({ code: campaignCode });
 
           // then
-          expect(result).to.be.instanceof(Campaign);
           expect(result.isRestricted).to.be.false;
         });
       });
     });
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement seules les organisations SCO peuvent gérer des élèves. Demain d'autres types d'orgas vont pouvoir le faire.

## :robot: Solution
Décorréler cet usage là où c'est nécéssaire :
- lors de l'import ;
- lors de la récupération des élèves.

## :rainbow: Remarques
Cette corrélation a été laissée en place pour les cas suivants (valable uniquement pour le SCO qui gèrent des élèves - il y a des SCO qui ne gèrent pas encore d'élèves) :
- la mise à jour du mot de passe des élèves ;
- l'accès à la documentation pour gérer des élèves dans Pix Orga ;
- l'accès à la page /eleves (puisque pour les étudiants du SUP ce sera une autre page).

## :100: Pour tester
Non régression de :
- l'affichage des élèves ; 
- la modification des élèves (changement mot de passe) ;
- accès à la documentation (dans le panel à gauche et lors de la création d'une campagne) ;
- la réconciliation des élèves ;
- la dissociation des élèves.

Vérifier le non-affichage de l'onglet "élèves" pour le SUP et le PRO, même si `isManagingStudents`.