### PR TITLE
[TECH] Mettre à disposition des configurations d'IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ api/.vscode
 api/.nvmrc
 .nvmrc
 .vscode/*
-!.vscode/launch.json
+!.vscode/sample.launch.json
+!.vscode/sample.settings.json
 .history
 
 # ember-try

--- a/.run/debug_admin.run.xml
+++ b/.run/debug_admin.run.xml
@@ -1,17 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug admin" type="JavascriptDebugType" uri="http://localhost:4202">
-    <mapping url="http://localhost:4202/index.html" local-file="$PROJECT_DIR$/admin/dist/index.html" />
-    <mapping url="http://localhost:4202/assets/admin.js" local-file="$PROJECT_DIR$/admin/dist/assets/pix-admin.js" />
     <mapping url="http://localhost:4202/assets/admin" local-file="$PROJECT_DIR$/admin/app" />
+    <mapping url="http://localhost:4202/assets/admin.js" local-file="$PROJECT_DIR$/admin/dist/assets/pix-admin.js" />
     <mapping url="http://localhost:4202/assets/vendor.js" local-file="$PROJECT_DIR$/admin/dist/assets/vendor.js" />
     <mapping url="http://localhost:4202" local-file="$PROJECT_DIR$/admin/dist" />
-    <method v="2">
-      <option name="NpmBeforeRunTask" enabled="true">
-        <package-json value="$PROJECT_DIR$/admin/package.json" />
-        <command value="start" />
-        <node-interpreter value="project" />
-        <envs />
-      </option>
-    </method>
+    <mapping url="http://localhost:4202/index.html" local-file="$PROJECT_DIR$/admin/dist/index.html" />
+    <method v="2" />
   </configuration>
 </component>

--- a/.run/debug_certif.run.xml
+++ b/.run/debug_certif.run.xml
@@ -5,13 +5,6 @@
     <mapping url="http://localhost:4203/assets/certif" local-file="$PROJECT_DIR$/certif/app" />
     <mapping url="http://localhost:4203/assets/vendor.js" local-file="$PROJECT_DIR$/certif/dist/assets/vendor.js" />
     <mapping url="http://localhost:4203" local-file="$PROJECT_DIR$/certif/dist" />
-    <method v="2">
-      <option name="NpmBeforeRunTask" enabled="true">
-        <package-json value="$PROJECT_DIR$/certif/package.json" />
-        <command value="start" />
-        <node-interpreter value="project" />
-        <envs />
-      </option>
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/.run/debug_mon-pix.run.xml
+++ b/.run/debug_mon-pix.run.xml
@@ -5,13 +5,6 @@
     <mapping url="http://localhost:4200/assets/mon-pix" local-file="$PROJECT_DIR$/mon-pix/app" />
     <mapping url="http://localhost:4200/assets/vendor.js" local-file="$PROJECT_DIR$/mon-pix/dist/assets/vendor.js" />
     <mapping url="http://localhost:4200" local-file="$PROJECT_DIR$/mon-pix/dist" />
-    <method v="2">
-      <option name="NpmBeforeRunTask" enabled="true">
-        <package-json value="$PROJECT_DIR$/mon-pix/package.json" />
-        <command value="start" />
-        <node-interpreter value="project" />
-        <envs />
-      </option>
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/.run/debug_orga.run.xml
+++ b/.run/debug_orga.run.xml
@@ -5,13 +5,6 @@
     <mapping url="http://localhost:4201/assets/orga" local-file="$PROJECT_DIR$/orga/app" />
     <mapping url="http://localhost:4201/assets/vendor.js" local-file="$PROJECT_DIR$/orga/dist/assets/vendor.js" />
     <mapping url="http://localhost:4201" local-file="$PROJECT_DIR$/orga/dist" />
-    <method v="2">
-      <option name="NpmBeforeRunTask" enabled="true">
-        <package-json value="$PROJECT_DIR$/orga/package.json" />
-        <command value="start" />
-        <node-interpreter value="project" />
-        <envs />
-      </option>
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/.run/start_api.run.xml
+++ b/.run/start_api.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Start API" type="js.build_tools.npm">
+  <configuration default="false" name="Start API watch" type="js.build_tools.npm">
     <package-json value="$PROJECT_DIR$/api/package.json" />
     <command value="run" />
     <scripts>

--- a/.vscode/sample.launch.json
+++ b/.vscode/sample.launch.json
@@ -1,0 +1,107 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "api start",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/api/bin/www"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "api watch",
+      "runtimeExecutable": "nodemon",
+      "program": "${workspaceFolder}/api/bin/www",
+      "restart": true,
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "api mocha all tests",
+      "program": "${workspaceFolder}/api/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-ui",
+        "bdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "--exit",
+        "--recursive",
+        "${workspaceFolder}/api/tests"
+      ],
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": [
+        "<node_internals>/**",
+        "api/tests/test-helper.js"
+      ]
+    },
+    {
+      "name": "api mocha current file",
+      "type": "node",
+      "request": "launch",
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "program": "${workspaceRoot}/api/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--no-timeouts", "${relativeFile}"
+      ],
+      "cwd": "${workspaceRoot}"
+    },
+    {
+      "name": "mon-pix chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}/mon-pix",
+      "sourceMapPathOverrides": {
+        "mon-pix/*": "${workspaceRoot}/mon-pix/app/*"
+      }
+    },
+    {
+      "name": "certif chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:4203",
+      "webRoot": "${workspaceFolder}/certif",
+      "sourceMapPathOverrides": {
+        "certif/*": "${workspaceRoot}/certif/app/*"
+      }
+    },
+    {
+      "name": "orga chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:4201",
+      "webRoot": "${workspaceFolder}/orga",
+      "sourceMapPathOverrides": {
+        "orga/*": "${workspaceRoot}/orga/app/*"
+      }
+    },
+    {
+      "name": "admin chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:4202",
+      "webRoot": "${workspaceFolder}/admin",
+      "sourceMapPathOverrides": {
+        "admin/*": "${workspaceRoot}/admin/app/*"
+      }
+    }
+  ]
+}

--- a/.vscode/sample.settings.json
+++ b/.vscode/sample.settings.json
@@ -1,0 +1,10 @@
+{
+    "eslint.format.enable": true,
+    "eslint.workingDirectories": [
+        "./admin",
+        "./certif",
+        "./mon-pix",
+        "./api",
+        "./orga"
+    ]
+}


### PR DESCRIPTION
## :unicorn: Problème
Un commit a ete supprimé sur les configs d'IDE (vscode/intellij)
Les debug ember ne fonctionne pas en l'etat
Les confs vs code n'existe pas

## :robot: Solution
- intellij:  supprimer le start ember qui entrait en conflit avec le debug
- vscode: ajout des fichiers de config "sample"


## :100: Pour tester
Les debug ember (vscode ou intellij), nécessite d'avoir lancé au préalable un ember start (`cd mon-pix && npm start`)

### vscode: (si vous avez des configs specifique, ne pas renommer le fichier mais prendre uniquement les entrées qui vous interesse)
`cp .vscode/sample.launch.json .vscode/launch.json`
`cp .vscode/sample.settings.json .vscode/settings.json`

Depuis la vue "debug", on voit apparaitre différent run
- **api watch**: lance l'api en watch (nodemon)
- **api mocha current file api**: lance les tests du fichier courant
- **api mocha all tests**: lance tout les tests api
- **mon-pix chrome**: lance une fenêtre chrome sur mon-pix (+debug dans l'IDE)
- **certif chrome**: lance une fenêtre chrome sur certif (+debug dans l'IDE)
- **orga chrome**: lance une fenêtre chrome sur orga (+debug dans l'IDE)
- **admin chrome:** lance une fenêtre chrome sur admin (+debug dans l'IDE)

![image](https://user-images.githubusercontent.com/3769147/86330633-3e78e900-bc48-11ea-8e9c-e611f906ec8a.png)

### IntelliJ
Les configurations sont visibles à partir de la version _2019.3_
- **start api watch**: lance l'api en watch (nodemon)
- **api tests**: lance les tests api
- **api tests with watch**: lance les tests api en _watch_
- **debug mon-pix**: lance une fenêtre chrome sur mon-pix (+debug dans l'IDE)
- **debug certif**: lance une fenêtre chrome sur certif (+debug dans l'IDE)
- **debug orga**: lance une fenêtre chrome sur orga (+debug dans l'IDE)
- **debug admin**: lance une fenêtre chrome sur admin (+debug dans l'IDE)

<img width="1339" alt="Screenshot 2020-07-02 at 09 44 14" src="https://user-images.githubusercontent.com/3769147/86330976-ba733100-bc48-11ea-90ac-c50aee918663.png">


