### PR TITLE
[BUGFIX] Niveau certifié non affiché dans le détail d'une certification (PIX-930)

### DIFF
--- a/admin/app/templates/components/certification-details-competence.hbs
+++ b/admin/app/templates/components/certification-details-competence.hbs
@@ -19,7 +19,7 @@
           <div class="progress">
             <div class="progress-bar competence-level certificate" role="progressbar"
                  aria-valuenow="{{this.competence.obtainedLevel}}" aria-valuemin="0" aria-valuemax="8"
-                 style={{this.certifiedWidth}}>{{this.competence.obtainedLeve }}</div>
+                 style={{this.certifiedWidth}}>{{this.competence.obtainedLevel}}</div>
           </div>
         </div>
         <div class="col-2 certificate">{{this.competence.obtainedScore}} Pix</div>

--- a/admin/tests/integration/components/certification-details-competence-test.js
+++ b/admin/tests/integration/components/certification-details-competence-test.js
@@ -62,7 +62,6 @@ module('Integration | Component | certification-details-competence', function(ho
     this.set('externalAction', () => {
       return resolve();
     });
-    assert.expect(4);
 
     // when
     await render(hbs`{{certification-details-competence competence=competenceData rate=60 juryRate=70 onUpdateRate=(action externalAction)}}`);
@@ -72,6 +71,7 @@ module('Integration | Component | certification-details-competence', function(ho
     assert.dom('.jury.competence-score').exists();
     assert.dom('.jury.competence-level').hasText('2');
     assert.dom('.jury.competence-score').hasText('18 Pix');
+    assert.dom('.progress-bar.competence-level.certificate').hasText('-1');
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Le niveau certifié n'est plus affiché. Cela rends la lecture plus compliquée.
![image](https://user-images.githubusercontent.com/38167520/86360945-65004980-bc73-11ea-9dc4-2fd692dfeab4.png)


## :robot: Solution
Le bug a été introduit il y a 3 jours dans [cette PR](https://github.com/1024pix/pix/pull/1562/commits/bd7eabea1dd359c88bffd460c23a3e11dbeabf5c).
C'était un simple bug dût à une lettre retirée.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- aller sur la page de détail d'une certification et constater que le niveau certifié est bien affiché dans la barre orange.
