### PR TITLE
[TECH] Empêcher la création d'appartenance à une organisation si le rôle n'est pas connu.

### DIFF
--- a/api/db/migrations/20200702114943_add_check_on_memberships_role.js
+++ b/api/db/migrations/20200702114943_add_check_on_memberships_role.js
@@ -1,0 +1,10 @@
+// Switching to raw SQL, because knex can't add CHECK constraint on existing column
+// https://github.com/knex/knex/issues/1699
+
+exports.up = function(knex) {
+  return knex.raw('ALTER TABLE memberships ADD CONSTRAINT "memberships_organizationRole_check" CHECK ( "organizationRole" IN (\'ADMIN\', \'MEMBER\' ) )');
+};
+
+exports.down = function(knex) {
+  return knex.raw('ALTER TABLE memberships DROP CONSTRAINT "memberships_organizationRole_check" ');
+};


### PR DESCRIPTION
## :unicorn: Problème
La table memberships contient des rôles, mais ceux-ci ne sont référencés que dans le code [API](https://github.com/1024pix/pix/blob/prod/api/lib/domain/models/Membership.js)
`const roles = {
  ADMIN: 'ADMIN',
  MEMBER: 'MEMBER',
};`

Des scripts SQL étant exécutés en dehors de l'API, il est possible que, par erreur, un rôle incohérent (ex: `ADMI`) soit attribué.

## :robot: Solution
Implémenter cette vérification côté BDD avec une contrainte CHECK.

## :rainbow: Remarques
Lors de la création de la contrainte, une vérification des données existantes est effectuée, qui peut prendre du temps sur une table volumineuse (FULL TABLE SCAN en l'absence d'index). Cette étape peut être annulée avec l'option NO VALID. 
Comme la table memberships est peu volumineuse (20 000 enregistrements), et que l'exécution de cette étape sur la réplication de la production a pris moins d'une seconde, cette option n'a pas été utilisée.

Knex ne permettant pas l'ajout d'une contrainte CHECK à une colonne existante ([issue 1699](https://github.com/knex/knex/issues/1699)), le mode natif (knex.raw) a été utilisé, en utilisant la convention de nommage des contraintes utilisée par Knex.

Changer le type de la colonne organizationRole de STRING à ENUM permettrait une solution plus concise.

## :100: Pour tester
Vérfiier que tous les rôles sont ceux autorisés (ADMIN ou MEMBER
`SELECT "organizationRole", COUNT(1) FROM memberships GROUP BY "organizationRole";   `

Insérer un rôle autorisé et vérifier que l'on obtient pas de message d'erreur
```
DELETE FROM memberships WHERE id = 100009;`

INSERT INTO memberships
  (id, "userId", "organizationId", "organizationRole")
VALUES
  (100009, 3, 1, 'ADMIN');
```

Insérer un rôle non autorisé 
```
DELETE FROM memberships WHERE id = 100009;
INSERT INTO memberships
  (id, "userId", "organizationId", "organizationRole")
VALUES
  (100009, 3, 1, 'ADMI');
```
Vérifier que l'on obtient ce message d'erreur `new row for relation "memberships" violates check constraint "memberships_organizationRole_check"`