### PR TITLE
[FEATURE] Mettre à jour les conditions d'utilisation de Pix Orga en incluant le pix.org ( PIX-871 )

### DIFF
--- a/orga/app/templates/terms-of-service.hbs
+++ b/orga/app/templates/terms-of-service.hbs
@@ -15,8 +15,8 @@
       <h3>Article 1.      Préambule</h3>
       <p>
         Le Groupement d’intérêt public (GIP) « Pix », approuvé par arrêté du 27 avril 2017 portant approbation de la
-        convention constitutive du groupement d'intérêt public « Pix », ayant son siège social 110, rue de grenelle
-        Paris (France), a développé la Plateforme Pix dans le cadre d’un projet public en partenariat avec le Ministère
+        convention constitutive du groupement d'intérêt public « Pix », ayant son siège social 156, boulevard Haussmann,
+        75008 Paris (France), a développé la Plateforme Pix dans le cadre d’un projet public en partenariat avec le Ministère
         en charge de l’Education nationale et le Ministère en charge de l’Enseignement supérieur, de la Recherche et de
         l’Innovation.
       </p>
@@ -42,7 +42,7 @@
         d’analyser les résultats issus de la plateforme Pix.
       </p>
       <p>
-      La plateforme Pix Orga est accessible à l'adresse URL suivante : orga.pix.fr.
+      La plateforme Pix Orga est accessible à l'adresse URL suivante : orga.pix.fr et orga.pix.org.
       </p>
       <p>
         Elle propose un espace privé et limité appelé « espace organisation », offrant aux utilisateurs identifiés un
@@ -263,7 +263,7 @@
       L’accès d’un utilisateur à un espace Pix Orga est mis en place par le GIP Pix.
       </p>
       <p>
-      Il suppose que l’utilisateur se soit déjà créé un compte Pix. Une fois cet accès mis en place, l’utilisateur peut accéder à son espace organisation en se connectant à orga.pix.fr.
+      Il suppose que l’utilisateur se soit déjà créé un compte Pix. Une fois cet accès mis en place, l’utilisateur peut accéder à son espace organisation en se connectant à orga.pix.fr ou orga.pix.org.
       </p>
       <p>
       Lors de sa première connexion à Pix Orga il accepte les CGU.
@@ -662,7 +662,7 @@
         Les informations relatives à l’utilisation des cookies par la plateforme en ligne, leur gestion et leur
         suppression par l’utilisateur, et au droit d’accès, de retrait et de modification des données à caractère
         personnel communiquées par le biais des cookies, sont détaillées au sein de la politique cookie au sein des
-        conditions générales du site www.pix.fr.
+        conditions générales du site www.pix.fr et www.pix.org.
       </p>
 
       <h3>Article 17. Résolution et résiliation</h3>


### PR DESCRIPTION
## :unicorn: Problème
Les conditions d'utilisations ne correspondent pas au pix.org.

## :robot: Solution
Mettre à jour les conditions d'utilisations avec la mention vers pix.orga

## :100: Pour tester

Se connecter à [Pix orga](https://orga-pr1596.review.pix.fr) avec l'utilisateur testcgu@example.net Password123
Vérifier que les commentaires sont bien appliquées dans les conditions d'utilisations de Pix Orga.
https://docs.google.com/document/d/1EDxhHB5P3ZIrveD2poNh3PM_uS2UN519AY5fQjh1kZ0/edit#