### PR TITLE
[FEATURE] Cacher le champ de réponse si l’épreuve est un embed auto-validé (PIX-900)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -17,6 +17,10 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
     return 'Pour valider, saisir une réponse. Sinon, passer.';
   }
 
+  get showProposal() {
+    return !this.challenge.autoReply;
+  }
+
   @action
   answerChanged() {
     this.set('errorMessage', null);

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -14,7 +14,7 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Pour valider, saisir une réponse. Sinon, passer.';
+    return 'Jouer l\'épreuve pour valider. Sinon, passer.';
   }
 
   get showProposal() {

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -4,13 +4,16 @@ import classic from 'ember-classic-decorator';
 
 @classic
 class ChallengeItemQroc extends ChallengeItemGeneric {
+
+  autoReplyAnswer = '';
+
   _hasError() {
     return this._getAnswerValue().length < 1;
   }
 
   // FIXME refactor that
   _getAnswerValue() {
-    return (this.$('[data-uid="qroc-proposal-uid"]')).val();
+    return this.showProposal ? (document.querySelector('[data-uid="qroc-proposal-uid"]')).value : this.autoReplyAnswer;
   }
 
   _getErrorMessage() {

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -1,3 +1,8 @@
 .challenge-item__feedback {
   margin-bottom: 20px;
 }
+
+.challenge-item .alert {
+  margin: 6px;
+}
+

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -8,29 +8,31 @@
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-    <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
-      <div class="challenge-proposals">
-        <QrocProposal @answer={{@answer}}
-                      @format={{@challenge.format}}
-                      @proposals={{@challenge.proposals}}
-                      @answerValue={{@answer.value}}
-                      @answerChanged={{action "answerChanged"}} />
-      </div>
-
-      {{#if @answer}}
-        <div class="challenge-response__locked-overlay">
-          <FaIcon @icon='lock' class='challenge-response-locked__icon' />
+    {{#if this.showProposal}}
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+        <div class="challenge-proposals">
+          <QrocProposal @answer={{@answer}}
+                        @format={{@challenge.format}}
+                        @proposals={{@challenge.proposals}}
+                        @answerValue={{@answer.value}}
+                        @answerChanged={{action "answerChanged"}} />
         </div>
-      {{/if}}
 
-      {{#if @challenge.timer}}
-        {{#if this.hasUserConfirmWarning}}
-          <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{@challenge.timer}} />
+        {{#if @answer}}
+          <div class="challenge-response__locked-overlay">
+            <FaIcon @icon='lock' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
-      {{/if}}
-    </div>
+
+        {{#if @challenge.timer}}
+          {{#if this.hasUserConfirmWarning}}
+            <div class="timeout-jauge-wrapper">
+              <TimeoutJauge @allotedTime={{@challenge.timer}} />
+            </div>
+          {{/if}}
+        {{/if}}
+      </div>
+    {{/if}}
 
     {{#if this.errorMessage}}
       <div class="alert alert-danger" role="alert">

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -72,6 +72,10 @@ export default Factory.extend({
     proposals: 'Entrez le prénom de B. Gates : ${firstname#prénom} (en toutes lettres)\nSVP'
   }),
 
+  withAutoReply: trait({
+    autoReply: true,
+  }),
+
   withTextArea: trait({
     format: 'paragraphe',
   }),

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -17,6 +17,20 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROC');
     });
 
+    describe('When challenge is an auto validated embed (autoReply=true)', () => {
+      beforeEach(async () => {
+        const qrocChallengeWithAutoReply = server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withAutoReply');
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/${qrocChallengeWithAutoReply.id}`);
+      });
+
+      it('should render challenge information and question', () => {
+        // then
+        expect(find('.challenge-response__proposal')).to.not.exist;
+      });
+
+    });
+
     describe('When challenge is not already answered', () => {
       beforeEach(async () => {
         // when
@@ -42,6 +56,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
+        // TODO: Change this message
         expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
       });
 

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -29,6 +29,16 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__proposal')).to.not.exist;
       });
 
+      it('should display the alert box when user validates', async () => {
+        // when
+        expect(find('.alert')).to.not.exist;
+        await click(find('.challenge-actions__action-validate'));
+
+        // then
+        expect(find('.alert')).to.exist;
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
+      });
+
     });
 
     describe('When challenge is not already answered', () => {
@@ -124,7 +134,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
           value: 'Banane',
           result: 'ko',
           assessmentId: assessment.id,
-          challengeId :qrocChallenge.id,
+          challengeId: qrocChallenge.id,
           correction
         });
 
@@ -299,7 +309,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
           value: 'Banane',
           result: 'ko',
           assessmentId: assessment.id,
-          challengeId :qrocChallenge.id,
+          challengeId: qrocChallenge.id,
           correction
         });
 

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -56,8 +56,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        // TODO: Change this message
-        expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {
@@ -232,7 +231,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Pour valider, saisir une réponse. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {

--- a/mon-pix/tests/integration/components/form-textfield-date-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date-test.js
@@ -40,10 +40,18 @@ describe('Integration | Component | form textfield date', function() {
       this.set('yearValidationMessage', 'year message');
 
       // When
-      await render(hbs`{{form-textfield-date label=label 
-        dayValidationStatus=dayValidationStatus monthValidationStatus=monthValidationStatus yearValidationStatus=yearValidationStatus
-        dayValidationMessage=dayValidationMessage monthValidationMessage=monthValidationMessage yearValidationMessage=yearValidationMessage
-        dayTextfieldName=dayTextfieldName monthTextfieldName=monthTextfieldName yearTextfieldName=yearTextfieldName}}`);
+      await render(hbs`<FormTextfieldDate
+        @label={{this.label}}
+        @dayValidationStatus={{this.dayValidationStatus}}
+        @monthValidationStatus={{this.monthValidationStatus}}
+        @yearValidationStatus={{this.yearValidationStatus}}
+        @dayValidationMessage={{this.dayValidationMessage}}
+        @monthValidationMessage={{this.monthValidationMessage}}
+        @yearValidationMessage={{this.yearValidationMessage}}
+        @dayTextfieldName={{this.dayTextfieldName}}
+        @monthTextfieldName={{this.monthTextfieldName}}
+        @yearTextfieldName={{this.yearTextfieldName}}
+      />`);
     });
 
     [
@@ -95,10 +103,22 @@ describe('Integration | Component | form textfield date', function() {
       this.set('monthTextfieldName', 'month');
       this.set('yearTextfieldName', 'year');
 
-      await render(hbs`{{form-textfield-date label=label 
-        dayValidationStatus=dayValidationStatus monthValidationStatus=monthValidationStatus yearValidationStatus=yearValidationStatus
-        dayTextfieldName=dayTextfieldName monthTextfieldName=monthTextfieldName yearTextfieldName=yearTextfieldName
-        onValidateDay=(action validate) onValidateMonth=(action validate) onValidateYear=(action validate)}}`);
+      await render(hbs`<FormTextfieldDate
+        @label={{this.label}}
+        @dayValidationStatus={{this.dayValidationStatus}}
+        @monthValidationStatus={{this.monthValidationStatus}}
+        @yearValidationStatus={{this.yearValidationStatus}}
+        @dayValidationMessage={{this.dayValidationMessage}}
+        @monthValidationMessage={{this.monthValidationMessage}}
+        @yearValidationMessage={{this.yearValidationMessage}}
+        @dayTextfieldName={{this.dayTextfieldName}}
+        @monthTextfieldName={{this.monthTextfieldName}}
+        @yearTextfieldName={{this.yearTextfieldName}}
+        @onValidateDay={{action this.validate}}
+        @onValidateMonth={{action this.validate}}
+        @onValidateYear={{action this.validate}}
+      />`);
+
       // when
       await fillIn('#day', '10');
       await fillIn('#month', '12');
@@ -125,10 +145,18 @@ describe('Integration | Component | form textfield date', function() {
         this.set('yearValidationMessage', '');
 
         // When
-        await render(hbs`{{form-textfield-date label=label 
-          dayValidationStatus=dayValidationStatus monthValidationStatus=monthValidationStatus yearValidationStatus=yearValidationStatus
-          dayValidationMessage=dayValidationMessage monthValidationMessage=monthValidationMessage yearValidationMessage=yearValidationMessage
-          dayTextfieldName=dayTextfieldName monthTextfieldName=monthTextfieldName yearTextfieldName=yearTextfieldName}}`);
+        await render(hbs`<FormTextfieldDate
+          @label={{this.label}}
+          @dayValidationStatus={{this.dayValidationStatus}}
+          @monthValidationStatus={{this.monthValidationStatus}}
+          @yearValidationStatus={{this.yearValidationStatus}}
+          @dayValidationMessage={{this.dayValidationMessage}}
+          @monthValidationMessage={{this.monthValidationMessage}}
+          @yearValidationMessage={{this.yearValidationMessage}}
+          @dayTextfieldName={{this.dayTextfieldName}}
+          @monthTextfieldName={{this.monthTextfieldName}}
+          @yearTextfieldName={{this.yearTextfieldName}}
+        />`);
       });
 
       it('return true if any svg doesn\'t exist', function() {
@@ -164,10 +192,18 @@ describe('Integration | Component | form textfield date', function() {
         this.set('yearValidationMessage', 'year message');
 
         // When
-        await render(hbs`{{form-textfield-date label=label 
-        dayValidationStatus=dayValidationStatus monthValidationStatus=monthValidationStatus yearValidationStatus=yearValidationStatus
-        dayValidationMessage=dayValidationMessage monthValidationMessage=monthValidationMessage yearValidationMessage=yearValidationMessage
-        dayTextfieldName=dayTextfieldName monthTextfieldName=monthTextfieldName yearTextfieldName=yearTextfieldName}}`);
+        await render(hbs`<FormTextfieldDate
+          @label={{this.label}}
+          @dayValidationStatus={{this.dayValidationStatus}}
+          @monthValidationStatus={{this.monthValidationStatus}}
+          @yearValidationStatus={{this.yearValidationStatus}}
+          @dayValidationMessage={{this.dayValidationMessage}}
+          @monthValidationMessage={{this.monthValidationMessage}}
+          @yearValidationMessage={{this.yearValidationMessage}}
+          @dayTextfieldName={{this.dayTextfieldName}}
+          @monthTextfieldName={{this.monthTextfieldName}}
+          @yearTextfieldName={{this.yearTextfieldName}}
+        />`);
       });
 
       it('return true if any img does exist', function() {
@@ -204,10 +240,18 @@ describe('Integration | Component | form textfield date', function() {
         this.set('yearValidationMessage', 'year message');
 
         // When
-        await render(hbs`{{form-textfield-date label=label 
-        dayValidationStatus=dayValidationStatus monthValidationStatus=monthValidationStatus yearValidationStatus=yearValidationStatus
-        dayValidationMessage=dayValidationMessage monthValidationMessage=monthValidationMessage yearValidationMessage=yearValidationMessage
-        dayTextfieldName=dayTextfieldName monthTextfieldName=monthTextfieldName yearTextfieldName=yearTextfieldName}}`);
+        await render(hbs`<FormTextfieldDate
+          @label={{this.label}}
+          @dayValidationStatus={{this.dayValidationStatus}}
+          @monthValidationStatus={{this.monthValidationStatus}}
+          @yearValidationStatus={{this.yearValidationStatus}}
+          @dayValidationMessage={{this.dayValidationMessage}}
+          @monthValidationMessage={{this.monthValidationMessage}}
+          @yearValidationMessage={{this.yearValidationMessage}}
+          @dayTextfieldName={{this.dayTextfieldName}}
+          @monthTextfieldName={{this.monthTextfieldName}}
+          @yearTextfieldName={{this.yearTextfieldName}}
+        />`);
       });
 
       it('return true if any img does exist', function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une épreuve est un embed auto-validé nous ne voulons pas faire apparaître le champ de réponse.

## :robot: Solution
Cacher le champ de réponse.

## :rainbow: Remarques
L'alerte prévenant qu'il faut que le champs réponse soit remplis si l'on veut valider l'épreuve a été modifiée pour toutes les épreuves de type QROC, par la phrase "'Jouer l'épreuve pour valider. Sinon, passer.'"  

## :100: Pour tester

Utiliser ces challenges : 

- [recWndEZbiReZ0zsz](https://app-pr1597.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)
- [recab7EiQWXfuVKqI](https://app-pr1597.review.pix.fr/challenges/recab7EiQWXfuVKqI/preview)
- [recy37FMPthJpfWmd](https://app-pr1597.review.pix.fr/challenges/recy37FMPthJpfWmd/preview)
- [rec0w9GHcxIPxDY5z](https://app-pr1597.review.pix.fr/challenges/rec0w9GHcxIPxDY5z/preview)