### PR TITLE
[BUGFIX] Il manque des certifs dans le détails d'une session (PIX-877)

### DIFF
--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -7,7 +7,7 @@ module.exports = {
   async findBySessionId(sessionId) {
     const results = await knex.with('certifications_every_assess_results', (qb) => {
       qb.select('certification-courses.*', 'assessment-results.pixScore', 'assessment-results.status')
-        .select(knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS asr_rank',
+        .select(knex.raw('RANK() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS asr_rank',
           ['assessmentId', 'assessment-results.createdAt']))
         .from('certification-courses')
         .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -31,12 +31,14 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
       let manyAsrCertification;
       let latestAssessmentResult;
       let startedCertification;
+      let otherStartedCertification;
 
       beforeEach(() => {
         const dbf = databaseBuilder.factory;
         sessionId = dbf.buildSession().id;
         manyAsrCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'AAA' });
         startedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
+        otherStartedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'DDD' });
 
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
         dbf.buildAssessment({ certificationCourseId: startedCertification.id });
@@ -53,7 +55,7 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
         const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
         // then
-        expect(juryCertificationSummaries).to.have.length(2);
+        expect(juryCertificationSummaries).to.have.length(3);
         expect(juryCertificationSummaries[0]).to.be.instanceOf(JuryCertificationSummary);
         expect(juryCertificationSummaries[0].id).to.equal(manyAsrCertification.id);
         expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
@@ -80,20 +82,16 @@ describe('Integration | Repository | JuryCertificationSummary', function() {
 
       context('when the certification has no assessment-result', () => {
 
-        it('should return JuryCertificationSummary with status started', async () => {
+        it('should return all juryCertificationSummaries with status started', async () => {
           // when
           const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
           // then
+          expect(juryCertificationSummaries[1].id).to.equal(startedCertification.id);
           expect(juryCertificationSummaries[1].status).to.equal(JuryCertificationSummary.statuses.STARTED);
-          expect(juryCertificationSummaries[1].pixScore).to.be.null;
-          expect(juryCertificationSummaries[1].firstName).to.equal(startedCertification.firstName);
-          expect(juryCertificationSummaries[1].lastName).to.equal(startedCertification.lastName);
-          expect(juryCertificationSummaries[1].createdAt).to.deep.equal(startedCertification.createdAt);
-          expect(juryCertificationSummaries[1].completedAt).to.deep.equal(startedCertification.completedAt);
-          expect(juryCertificationSummaries[1].isPublished).to.equal(startedCertification.isPublished);
-          expect(juryCertificationSummaries[1].examinerComment).to.equal(startedCertification.examinerComment);
-          expect(juryCertificationSummaries[1].hasSeendEndTestScreen).to.equal(startedCertification.hasSeendEndTestScreen);
+
+          expect(juryCertificationSummaries[2].id).to.equal(otherStartedCertification.id);
+          expect(juryCertificationSummaries[2].status).to.equal(JuryCertificationSummary.statuses.STARTED);
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
La liste des certifications dans Pix Admin ne se met pas à jour quand on a plusieurs certif en "started"


## :robot: Solution
Le problème venait de la requête qu'on faisait pour récupérer les certifs.

AVANT, avec un ROW_NUMBER() : 
<img width="389" alt="image" src="https://user-images.githubusercontent.com/38167520/86456890-17dbb080-bd23-11ea-94b3-bd0fca98bbd6.png">

APRES, avec un RANK() : 
<img width="389" alt="image" src="https://user-images.githubusercontent.com/38167520/86457033-52454d80-bd23-11ea-9fd2-4c9c3de92e0e.png">


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- rejoindre une session de certification avec un candidat 
- entrer le code d’accès a la session : un nouveau certif-course est créé
- ne PAS finir la certif de façon à ce qu’elle reste au statut “started”
- aller dans Pix Admin sur la page de détails de la session puis cliquer sur l’onglet “Certifications” : la certif “started” est affichée
- rejoindre la même session avec un autre candidat
- ne PAS finir non plus cette certif de façon à ce qu’elle reste également au statut “started”
- aller dans Pix Admin sur la liste des certifications
