### PR TITLE
[TECH] Ajouter les colonnes SUP à la table schooling-registrations (PIX-925).

### DIFF
--- a/api/db/migrations/20200702135519_add-sup-columns-to-schooling-registrations.js
+++ b/api/db/migrations/20200702135519_add-sup-columns-to-schooling-registrations.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'schooling-registrations';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string('email');
+    table.string('studentNumber');
+    table.string('department');
+    table.string('educationalTeam');
+    table.string('group');
+    table.string('diploma');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('email');
+    table.dropColumn('studentNumber');
+    table.dropColumn('department');
+    table.dropColumn('educationalTeam');
+    table.dropColumn('group');
+    table.dropColumn('diploma');
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Le SUP a besoin d'importer ses étudiants également, en plus du SCO.

## :robot: Solution
Ajouter les colonnes pour le SUP dans la table schooling-registrations.

## :rainbow: Remarques
Pour le "régime" : contient la même chose que la colonne status (formation continue, apprenti, etc) mais sûrement pas sous la même forme (ST, AP, etc). On a choisit de garder une seule colonne.