### PR TITLE
[TECH] Ajouter le linter pour assurer la glimmerization (PIX-927).

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   ],
   extends: [
     ...(fs.existsSync('../.eslintrc.yaml') ? ['../.eslintrc.yaml'] : []),
-    'plugin:ember/recommended'
+    'plugin:ember/octane'
   ],
   env: {
     browser: true
@@ -39,10 +39,6 @@ module.exports = {
     /* Recommended rules */
     'ember/no-mixins': 'off',
     'ember/no-jquery': 'off',
-    'ember/require-computed-property-dependencies': 'off',
-    'ember/no-private-routing-service': 'off',
-    'ember/require-computed-macros': 'off',
-
   },
   overrides: [
     // node files

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/certifications-list-item.js
+++ b/mon-pix/app/components/certifications-list-item.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { classNames, classNameBindings } from '@ember-decorators/component';
 import { computed } from '@ember/object';

--- a/mon-pix/app/components/certifications-list.js
+++ b/mon-pix/app/components/certifications-list.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/challenge-actions.js
+++ b/mon-pix/app/components/challenge-actions.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/challenge-illustration.js
+++ b/mon-pix/app/components/challenge-illustration.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { classNames } from '@ember-decorators/component';
 import { trySet, action } from '@ember/object';

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,3 +1,9 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import { cancel, later } from '@ember/runloop';
 import Component from '@ember/component';

--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,3 +1,5 @@
+/* eslint ember/classic-decorator-no-classic-methods: 0 */
+
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
 

--- a/mon-pix/app/components/checkpoint-continue.js
+++ b/mon-pix/app/components/checkpoint-continue.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/circle-chart.js
+++ b/mon-pix/app/components/circle-chart.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import resultIconUrl from 'mon-pix/utils/result-icon-url';

--- a/mon-pix/app/components/competence-card-mobile.js
+++ b/mon-pix/app/components/competence-card-mobile.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 

--- a/mon-pix/app/components/corner-ribbon.js
+++ b/mon-pix/app/components/corner-ribbon.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';

--- a/mon-pix/app/components/form-textfield-date.js
+++ b/mon-pix/app/components/form-textfield-date.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';

--- a/mon-pix/app/components/g-recaptcha.js
+++ b/mon-pix/app/components/g-recaptcha.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action, computed } from '@ember/object';
 import { isNone } from '@ember/utils';
 import Component from '@ember/component';

--- a/mon-pix/app/components/learning-more-panel.js
+++ b/mon-pix/app/components/learning-more-panel.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/levelup-notif.js
+++ b/mon-pix/app/components/levelup-notif.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/navbar-burger-menu.js
+++ b/mon-pix/app/components/navbar-burger-menu.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';

--- a/mon-pix/app/components/navbar-desktop-menu.js
+++ b/mon-pix/app/components/navbar-desktop-menu.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/navbar-mobile-header.js
+++ b/mon-pix/app/components/navbar-mobile-header.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Component from '@glimmer/component';

--- a/mon-pix/app/components/no-certification-panel.js
+++ b/mon-pix/app/components/no-certification-panel.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 

--- a/mon-pix/app/components/pix-logo.js
+++ b/mon-pix/app/components/pix-logo.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/pix-modal.js
+++ b/mon-pix/app/components/pix-modal.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { on } from '@ember/object/evented';
 import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
 import {

--- a/mon-pix/app/components/pix-toggle.js
+++ b/mon-pix/app/components/pix-toggle.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/components/progression-gauge.js
+++ b/mon-pix/app/components/progression-gauge.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qcm-proposals.js
+++ b/mon-pix/app/components/qcm-proposals.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qcu-proposals.js
+++ b/mon-pix/app/components/qcu-proposals.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@ember/component';

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import Component from '@ember/component';

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import { filterBy } from '@ember/object/computed';

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action, computed } from '@ember/object';
 import { inject } from '@ember/service';
 import Component from '@ember/component';

--- a/mon-pix/app/components/routes/login-or-register.js
+++ b/mon-pix/app/components/routes/login-or-register.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action, computed } from '@ember/object';
 import { inject } from '@ember/service';
 import Component from '@ember/component';

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import isEmailValid from 'mon-pix/utils/email-validator';

--- a/mon-pix/app/components/stepper.js
+++ b/mon-pix/app/components/stepper.js
@@ -1,3 +1,10 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-computed-macros: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import ProgressionTrackerMixin from 'mon-pix/mixins/progression-tracker';
 import { computed } from '@ember/object';

--- a/mon-pix/app/components/timeout-jauge.js
+++ b/mon-pix/app/components/timeout-jauge.js
@@ -1,3 +1,10 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/no-component-lifecycle-hooks: 0 */
+/* eslint ember/require-computed-macros: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { htmlSafe } from '@ember/string';
 import Component from '@ember/component';
 import { run } from '@ember/runloop';

--- a/mon-pix/app/components/tutorial-item-on-scorecard.js
+++ b/mon-pix/app/components/tutorial-item-on-scorecard.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { action } from '@ember/object';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';

--- a/mon-pix/app/components/user-certifications-detail-result.js
+++ b/mon-pix/app/components/user-certifications-detail-result.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/user-certifications-panel.js
+++ b/mon-pix/app/components/user-certifications-panel.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -1,3 +1,8 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+/* eslint ember/no-private-routing-service: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+
 import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import { on } from '@ember-decorators/object';

--- a/mon-pix/app/components/warning-page.js
+++ b/mon-pix/app/components/warning-page.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -1,3 +1,5 @@
+/* eslint ember/require-computed-property-dependencies: 0 */
+
 import classic from 'ember-classic-decorator';
 import { action, computed } from '@ember/object';
 import Controller from '@ember/controller';

--- a/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+
 import Controller from '@ember/controller';
 
 export default Controller.extend({

--- a/mon-pix/app/controllers/update-expired-password.js
+++ b/mon-pix/app/controllers/update-expired-password.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import Controller from '@ember/controller';
 
 export default Controller.extend({

--- a/mon-pix/app/mixins/progression-tracker.js
+++ b/mon-pix/app/mixins/progression-tracker.js
@@ -1,3 +1,5 @@
+/* eslint ember/require-computed-property-dependencies: 0 */
+
 import EmberObject, { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 

--- a/mon-pix/app/models/answer.js
+++ b/mon-pix/app/models/answer.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { equal, not } from '@ember/object/computed';
 import ValueAsArrayOfString from './answer/value-as-array-of-string-mixin';

--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import { equal, or } from '@ember/object/computed';
 import { computed } from '@ember/object';

--- a/mon-pix/app/models/campaign-participation-badge.js
+++ b/mon-pix/app/models/campaign-participation-badge.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import { attr, belongsTo, hasMany } from '@ember-data/model';
 import { mapBy, max } from '@ember/object/computed';
 import Badge from 'mon-pix/models/badge';

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, hasMany } from '@ember-data/model';
 import { mapBy, max } from '@ember/object/computed';
 import { computed } from '@ember/object';

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, belongsTo } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import capitalize from 'lodash/capitalize';

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { notEmpty, equal, gt } from '@ember/object/computed';

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/models/correction.js
+++ b/mon-pix/app/models/correction.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { hasMany, attr } from '@ember-data/model';
 import { and, empty } from '@ember/object/computed';
 

--- a/mon-pix/app/models/partner-competence-result.js
+++ b/mon-pix/app/models/partner-competence-result.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+/* eslint ember/require-computed-property-dependencies: 0 */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/models/progression.js
+++ b/mon-pix/app/models/progression.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { equal, and } from '@ember/object/computed';
 import { computed } from '@ember/object';

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/models/tutorial.js
+++ b/mon-pix/app/models/tutorial.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, belongsTo  } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-computed-properties-in-native-classes: 0 */
+
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -1,3 +1,9 @@
+/* eslint ember/classic-decorator-hooks: 0 */
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import ENV from 'mon-pix/config/environment';
 

--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import campaignTutorial from 'mon-pix/static-data/campaign-tutorial';

--- a/mon-pix/app/routes/inscription.js
+++ b/mon-pix/app/routes/inscription.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-actions-hash: 0 */
+/* eslint ember/no-classic-classes: 0 */
+
 import { inject as service } from '@ember/service';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import Route from '@ember/routing/route';

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -27955,14 +27955,23 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-8.4.0.tgz",
-      "integrity": "sha512-jzSpyA3+aQrEHydo3Tz8cNAbgmtYVlp0eSe8X52OsHYLdVc7i4vzMwA+ptfO06dzpLQNHWW5ziprB5hoAEt95A==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-8.9.0.tgz",
+      "integrity": "sha512-wSZuQM5AkDBc/FRL7jAIMVPQxzXSMUBgzGYzxhLNc4HOSBKVu6qqh2XZg7PTUmhst39VdYjDvep9QHmeRWdLkA==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",
-        "ember-rfc176-data": "^0.3.12",
+        "ember-rfc176-data": "^0.3.13",
+        "lodash.kebabcase": "^4.1.1",
         "snake-case": "^3.0.3"
+      },
+      "dependencies": {
+        "ember-rfc176-data": {
+          "version": "0.3.13",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.13.tgz",
+          "integrity": "sha512-m9JbwQlT6PjY7x/T8HslnXP7Sz9bx/pz3FrNfNi2NesJnbNISly0Lix6NV1fhfo46572cpq4jrM+/6yYlMefTQ==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-es": {
@@ -31406,6 +31415,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.keys": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -96,7 +96,7 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-xregexp": "^1.0.2",
     "eslint": "^6.8.0",
-    "eslint-plugin-ember": "^8.4.0",
+    "eslint-plugin-ember": "^8.9.0",
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",

--- a/mon-pix/tests/integration/components/certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banner-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import EmberObject from '@ember/object';
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
@@ -52,21 +55,21 @@ describe('Integration | Component | feedback-panel', function() {
       beforeEach(async function() {
         await render(hbs`{{feedback-panel isFormOpened=false}}`);
       });
-  
+
       it('should display the feedback panel', function() {
         expect(find('.feedback-panel__view--link')).to.exist;
       });
-  
+
       it('should toggle the form view when clicking on the toggle link', async function() {
         // when
         await click(TOGGLE_LINK);
-  
+
         // then
         expectFormViewToBeVisible();
-  
+
         // then when
         await click(TOGGLE_LINK);
-  
+
         // then
         expectFormViewToNotBeVisible();
       });

--- a/mon-pix/tests/integration/components/g-recaptcha-test.js
+++ b/mon-pix/tests/integration/components/g-recaptcha-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/inaccessible-campaign-test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -1,3 +1,7 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/no-classic-components: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import ArrayProxy from '@ember/array/proxy';
 import { resolve, reject } from 'rsvp';
 import Component from '@ember/component';

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
     // Then
     expect(applicationAdapter.namespace).to.equal('api');
   });
-  
+
   describe('get headers()', function() {
 
     it('should add header with authentication token when the session is authenticated', function() {

--- a/mon-pix/tests/unit/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-mobile-header-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';

--- a/mon-pix/tests/unit/components/signup-form-test.js
+++ b/mon-pix/tests/unit/components/signup-form-test.js
@@ -1,3 +1,6 @@
+/* eslint ember/no-classic-classes: 0 */
+/* eslint ember/require-tagless-components: 0 */
+
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
+++ b/mon-pix/tests/unit/mixins/secured-route-mixin-test.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import Mixin from '@ember/object/mixin';
 import { setOwner } from '@ember/application';
 import RSVP from 'rsvp';

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';

--- a/mon-pix/tests/unit/routes/campaigns/assessment/tutorial-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/tutorial-test.js
@@ -1,3 +1,5 @@
+/* eslint ember/no-classic-classes: 0 */
+
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d'évaluer et d'identifier facilement le reste à faire sur le chantier de la glimmerisation. Nous souhaitons également nous assurer que les nouveaux composants et les passages sur le composant non-glimmerizés le soient à chaque PR pour accélérer dans notre chantier de changement.

## :robot: Solution
Appliquer les recommandations eslint Octane et ajouter des exceptions aux fichiers à glimmerizer.
