### PR TITLE
[BUGFIX] Les liens de téléchargement doivent rester sur la page d'assessment (PIX-942).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'mon-pix/config/environment';
 import Component from '@glimmer/component';
+import FileSaver from 'file-saver';
 import _ from 'lodash';
 
 export default class ChallengeStatement extends Component {
@@ -41,6 +42,13 @@ export default class ChallengeStatement extends Component {
   @action
   chooseAttachmentUrl(attachementUrl) {
     this.selectedAttachmentUrl = attachementUrl;
+  }
+
+  @action
+  openAttachmentToDownload(attachment) {
+    const splittedUrl = attachment.split('/');
+    const name = splittedUrl[splittedUrl.length - 1];
+    FileSaver.saveAs(attachment, name);
   }
 
   _initialiseDefaultAttachment() {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -159,19 +159,11 @@
   justify-content: center;
 }
 
-.challenge-statement__action-link {
+.challenge-statement__action-button {
   width: 156px;
   height: 46px;
-  border-radius: 23px;
-  background-color: $blue;
-  color: $white;
-  cursor: pointer;
-  text-align: center;
-}
-
-.challenge-statement__action-link:hover,
-.challenge-statement__action-link:focus {
-  color: $white;
+  display: flex;
+  align-items: center;
 }
 
 .challenge-statement__action-label {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -168,7 +168,6 @@
 
 .challenge-statement__action-label {
   width: 76px;
-  line-height: 46px;
   font-size: 1rem;
   font-weight: $font-heavy;
   text-transform: uppercase;

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -16,12 +16,13 @@
 
       {{#if @challenge.hasSingleAttachment}}
         <div class="challenge-statement__action">
-          <a class="challenge-statement__action-link"
-             href="{{@challenge.attachments.firstObject}}"
-             rel="noopener noreferrer"
-             download>
+          <button class="button button--thin button--round challenge-statement__action-button"
+                  type="button"
+                  name="Télécharger le fichier de l'exercice"
+                  value={{@challenge.attachments.firstObject}}
+                  {{on "click" (fn this.openAttachmentToDownload @challenge.attachments.firstObject)}}>
             <span class="challenge-statement__action-label">Télécharger</span>
-          </a>
+          </button>
         </div>
       {{/if}}
 
@@ -56,12 +57,13 @@
           {{/each}}
         </ul>
         <div class="challenge-statement__action">
-          <a class="challenge-statement__action-link"
-             href="{{this.selectedAttachmentUrl}}"
-             rel="noopener noreferrer"
-             download>
+          <button class="button button--thin button--round challenge-statement__action-button"
+                  type="button"
+                  name="Télécharger le fichier de l'exercice"
+                  value={{this.selectedAttachmentUrl}}
+                  {{on "click" (fn this.openAttachmentToDownload this.selectedAttachmentUrl)}}>
             <span class="challenge-statement__action-label">Télécharger</span>
-          </a>
+          </button>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -28585,6 +28585,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==",
+      "dev": true
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",
+    "file-saver": "^2.0.2",
     "js-yaml": "^3.13.1",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",

--- a/mon-pix/tests/acceptance/challenge-attachment-test.js
+++ b/mon-pix/tests/acceptance/challenge-attachment-test.js
@@ -25,17 +25,17 @@ describe('Acceptance | Download an attachment from a challenge', function() {
     });
 
     it('should have a way to download the attachment', function() {
-      expect(find('.challenge-statement__action-link')).to.exist;
+      expect(find('.challenge-statement__action-button')).to.exist;
     });
 
     it('should expose the correct attachment link', function() {
-      expect(find('.challenge-statement__action-link').textContent).to.contain('Télécharger');
+      expect(find('.challenge-statement__action-button').textContent).to.contain('Télécharger');
       expect(challengeWithAttachment.attachments.length).to.equal(1);
-      expect(find('.challenge-statement__action-link').getAttribute('href')).to.equal(challengeWithAttachment.attachments[0]);
+      expect(find('.challenge-statement__action-button').value).to.equal(challengeWithAttachment.attachments[0]);
     });
 
     it('should only have one file downloadable', function() {
-      expect(find('.challenge-statement__action-link')).to.exist;
+      expect(find('.challenge-statement__action-button')).to.exist;
     });
   });
 
@@ -50,7 +50,7 @@ describe('Acceptance | Download an attachment from a challenge', function() {
       expect(find('.challenge-item')).to.exist;
 
       // ... but attachment is hidden
-      expect(find('.challenge-statement__action-link')).not.to.exist;
+      expect(find('.challenge-statement__action-button')).not.to.exist;
     });
   });
 

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -165,10 +165,10 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
       it('should display the correct challenge for first one', async function() {
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocWithFile1Challenge.instruction);
-        expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile1Challenge.attachments[0]);
+        expect(find('.challenge-statement__action-button').value).to.contains(qrocWithFile1Challenge.attachments[0]);
 
         await click(find('#attachment1'));
-        expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile1Challenge.attachments[1]);
+        expect(find('.challenge-statement__action-button').value).to.contains(qrocWithFile1Challenge.attachments[1]);
       });
 
       it('should display the error alert if the users tries to validate an empty answer', async function() {
@@ -176,10 +176,10 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(currentURL()).to.equal(`/assessments/${assessment.id}/challenges/${qrocWithFile2Challenge.id}`);
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocWithFile2Challenge.instruction);
-        expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile2Challenge.attachments[0]);
+        expect(find('.challenge-statement__action-button').value).to.contains(qrocWithFile2Challenge.attachments[0]);
 
         await click(find('#attachment1'));
-        expect(find('.challenge-statement__action-link').href).to.contains(qrocWithFile2Challenge.attachments[1]);
+        expect(find('.challenge-statement__action-button').value).to.contains(qrocWithFile2Challenge.attachments[1]);
 
       });
 

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -163,8 +163,8 @@ describe('Integration | Component | ChallengeStatement', function() {
         await renderChallengeStatement();
 
         // then
-        expect(find('.challenge-statement__action-link')).to.exist;
-        expect(find('.challenge-statement__action-link').href).to.equal('http://challenge.file.url/');
+        expect(find('.challenge-statement__action-button')).to.exist;
+        expect(find('.challenge-statement__action-button').value).to.equal('http://challenge.file.url');
       });
 
     });

--- a/mon-pix/tests/unit/components/challenge-statement-test.js
+++ b/mon-pix/tests/unit/components/challenge-statement-test.js
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 import EmberObject from '@ember/object';
 import { setupTest } from 'ember-mocha';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import sinon from 'sinon';
+import FileSaver from 'file-saver';
 
 describe('Unit | Component | challenge statement', function() {
 
@@ -48,4 +50,35 @@ describe('Unit | Component | challenge statement', function() {
     });
   });
 
+  describe('#openAttachmentToDownload', function() {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should call FileSaver.saveAs method with the right arguments', function() {
+      // given
+      const saveAsStub = sinon.stub(FileSaver, 'saveAs');
+
+      const challenge = EmberObject.create({
+        hasValidEmbedDocument: true,
+        embedUrl: 'https://challenge-embed.url',
+        embedTitle: 'Challenge embed document title',
+        embedHeight: 300,
+        id: 'rec_123',
+        attachments: ['http://dl.airtable.com/EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt'],
+      });
+
+      const component = createGlimmerComponent('component:challenge-statement', { challenge });
+
+      const expectedName = 'EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt';
+      const expectedAttachment = 'http://dl.airtable.com/EL9k935vQQS1wAGIhcZU_PIX_parchemin.ppt';
+
+      // when
+      component.openAttachmentToDownload(challenge.attachments[0]);
+
+      // then
+      sinon.assert.calledOnce(saveAsStub);
+      sinon.assert.calledWith(saveAsStub, expectedAttachment, expectedName);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on clique sur le bouton de téléchargement, on sort de l'assessment.
Aussi, on ne peut pas créer de nouvel onglet avec `target=_blank` pour des raisons d'accessibilité. (cf. https://github.com/1024pix/pix/pull/1575)

## :robot: Solution
Utilisation de https://github.com/eligrey/FileSaver.js/

## 🌈 Remarques
Quelques problèmes apparaissent avec cette solution :
- L'adresse du lien est remplacée par `blob:` sur Firefox. Nous n'avons pas réussi à le configurer, à voir si quelqu'un y arrive / si c'est un problème. -> vue avec @PhilippineLoison : ce n'est pas un problème.

<img width="1043" alt="Screenshot 2020-07-03 at 18 10 29" src="https://user-images.githubusercontent.com/46371288/86489428-999ffe00-bd64-11ea-8525-c51bc4479aff.png">

- L'adresse du lien n’apparaît plus au survol. On a ajouté l'attribut `value` au `button` pour préserver l'intégrité de nos tests existants et affiche un peu de transparence sur l'origine du téléchargement.

- Le dernier commit est en WIP. Il contient le test unitaire de la méthode. Pour une raison inconnue, nous n'avons pas pu faire fonctionner le stub de FileSaver.

## :100: Pour tester
- https://app-pr1605.review.pix.fr/challenges/recP1GPtuYjQE5mPM/preview
- https://app-pr1605.review.pix.fr/challenges/rec65HeFvjaeC2QA2/preview