### PR TITLE
[BUGFIX] Supprimer les données lors de la déconnexion (PIX-954).

### DIFF
--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -1,0 +1,30 @@
+# General
+Authentication is implemented using Oauth2 standard.
+
+Once authentication completes, a JWT token is provided to the client application to maintain connexion.
+
+Following business constraints, token lifetime is seven days.
+   
+Token revocation is set up in front-end and API (endpoint /api/revoke), but not yet implemented.
+
+# Authorization server # 
+Authorization server can: 
+* store identities locally;
+* delegate authentication to an external service using SAML standard.
+
+# Front-end #
+All features are provided by [Ember Simple Auth (ESA) plugin](https://github.com/simplabs/ember-simple-auth)
+
+## Authentication persistence
+JWT token is stored in browser's local storage, in order for users to reconnect after closing the session (eg: closing the browser).
+This is ESA [default policy](https://github.com/simplabs/ember-simple-auth#session-stores) 
+ 
+## Local state management
+State is stored in browser's memory space, mainly in Ember Store.
+
+In case several users are sharing the same OS session, we need to prevent them from accessing previous sessions's state.
+This is enforced by default on ESA. On logout, the [handleSessionInvalidated](https://github.com/simplabs/ember-simple-auth/blob/master/packages/ember-simple-auth/addon/-internals/routing.js) function call 
+browser's native `location.replace()` method, which ensure no state is left behind.
+
+Wherever ESA default behavior is replaced by redefining `sessionInvalidated `(eg [in mon-pix](https://github.com/1024pix/pix/blob/dev/mon-pix/app/routes/application.js)), 
+this very browser method `location.replace()` is called to ensure the same goal (eg: [in mon-pix]([https://github.com/1024pix/pix/blob/dev/mon-pix/app/routes/logout.js]).

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -7,6 +7,7 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   routeAfterAuthentication = 'authenticated';
 
   @service currentUser;
+  @service url;
 
   beforeModel() {
     return this._loadCurrentUser();
@@ -18,14 +19,20 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   }
 
   sessionInvalidated() {
-    const alternativeRootURL = this.session.alternativeRootURL;
+    const redirectionUrl = this._redirectionUrl();
+    this._clearStateAndRedirect(redirectionUrl);
+  }
 
-    if (alternativeRootURL) {
-      this.session.alternativeRootURL = null;
-      window.location.replace(alternativeRootURL);
-    } else {
-      this.transitionTo('login');
-    }
+  _redirectionUrl() {
+
+    const alternativeRootURL = this.session.alternativeRootURL;
+    this.session.alternativeRootURL = null;
+
+    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
+  }
+
+  _clearStateAndRedirect(url) {
+    return window.location.replace(url);
   }
 
   _loadCurrentUser() {

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -6,10 +6,17 @@ export default class Url extends Service {
   @service currentDomain;
   definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
   pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
+  definedHomeUrl = ENV.APP.HOME_URL;
 
   get campaignsRootUrl() {
     return this.definedCampaignsRootUrl ?
       this.definedCampaignsRootUrl :
       `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/campagnes/`;
   }
+
+  get homeUrl() {
+    const homeUrl = `https://orga.pix.${this.currentDomain.getExtension()}`;
+    return this.definedHomeUrl || homeUrl;
+  }
+
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -29,8 +29,9 @@ module.exports = function(environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
-      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.'
     },
 
     googleFonts: [
@@ -74,6 +75,7 @@ module.exports = function(environment) {
 
   if (environment === 'development') {
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -93,6 +95,8 @@ module.exports = function(environment) {
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.HOME_URL = '/';
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -49,17 +49,6 @@ module('Acceptance | terms-of-service', function(hooks) {
       assert.equal(currentURL(), '/campagnes');
     });
 
-    test('it should logout when user clicks on cancel button', async function(assert) {
-      // given
-      await visit('/cgu');
-
-      // when
-      await click('#terms-of-service-cancel-button');
-
-      // then
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still authenticated');
-    });
-
     test('it should not be possible to visit another page if cgu are not accepted', async function(assert) {
       // given
       await visit('/cgu');


### PR DESCRIPTION
## :unicorn: Problème
La totalité des données données applicatives (venant de l'API, hors token) est stocké dans l'espace mémoire du navigateur, dont le store Ember.
Sur l'application MonPix, lorsque l'utilisateur se déconnecte du site, le store Ember est vidé.
Sur les applications Certif/Orga/Admin, ce n'est pas le cas.
Si l'utilisateur n'arrête pas le navigateur et ne verrouille pas sa session, un autre utilisateur a accès à l'ensemble des données qu'il a consultées avec:
* le plugin Ember Inspector
* la console.

Par exemple, sur PixOrga, s'il a visité la page Elèves, l'ensemble des emails des prescrit peut être obtenu dans la console avec: `Ember.Application.NAMESPACES_BY_ID['pix-orga'].__container__.lookup('service:currentUser').prescriber.fullName`

Cela est dû au fait que, suite à une montée de version (commit bf99c2e9d655025a1c3304b9115d340c5aca7275), le comportement par défaut de Ember SimpleAuth est redéfini et remplacé par transitionTo au lieu de la fonction native du browser `window.location.replace`. 

## :robot: Solution
Appeller la fonction native du browser `window.location.replace`
Refactorer le code pour mettre en avant l'action implicite de suppression du state par `window.location.replace`, afin que l'introduction de nouvelles redirection n'entraîne pas de régression

## :rainbow: Remarques
Il n'est pas possible de faire de test automatisé simplement sur cette fonctionnalité, car l'appel à window.location.replace.. décharge la librairie de test.
En test unitaire, ESA [mocke window.location.replace](https://github.com/simplabs/ember-simple-auth/blob/master/packages/ember-simple-auth/tests/unit/services/session-test.js#L523)
D'ailleurs, cette fonctionnalité n'est pas testée sur mon-pix.
J'ai donc supprimé le test d'acceptance qui testait cette fonctionnalité (et qui passait car Ember était toujours présent).

J'ai documenté les principales fonctionnalités de sécurité dans un document Markdown

## :100: Pour tester
Etapes:
- se connecter à l'application
- ouvrir l'inspecteur Ember, onglet Data
- consulter des pages et vérifier que les données apparaissent dans Data
- se déconnecter
- vérifier que Data ne contient plus aucune donnée
- vérifier que Ember n'est plus monté en mémoire: `Ember.Application.NAMESPACES_BY_ID['pix-orga'].__container__.lookup('service:currentUser').prescriber.fullName`

Répéter les étapes, pour le scénario suivant:
- localiser un utilisateur n'ayant jamais accepté les CGU
- se connecter
- lorsque les CGU  sont présentées, cliquer sur le bouton Annuler
