### PR TITLE
[BUGFIX] Corriger le formulaire d'anonymisation d'utilisateur de Pix Admin (PIX-944).

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -109,7 +109,7 @@
         {{#if this.canAdministratorModifyUserDetails}}
         <button type="button" class="btn btn-outline-default" aria-label="Modifier" {{on "click" this.changeEditionMode}}>Modifier
         </button>
-        <button type="button" class="btn btn-outline-default btn-outline-default--danger" aria-label="Anonymiser" {{on "click" this.toggleDisplayConfirm}}>Anonymiser cet utilisateur
+        <button type="button" class="btn btn-danger" aria-label="Anonymiser" {{on "click" this.toggleDisplayConfirm}}>Anonymiser cet utilisateur
         </button>
         {{/if}}
       </div>
@@ -117,7 +117,7 @@
   {{/if}}
 </section>
 
-<ConfirmPopup @message="Etes-vous sûr de vouloir anonymiser cet utilisateur? Ceci n’est pas réversible"
+<ConfirmPopup @message="Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible."
               @confirm={{this.anonymizeUser}}
               @cancel={{this.toggleDisplayConfirm}}
               @show={{this.displayConfirm}} />

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -295,7 +295,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       await click('button[aria-label=\'Anonymiser\']');
 
       assert.dom('.modal-dialog').exists();
-      assert.contains('Etes-vous sûr de vouloir anonymiser cet utilisateur? Ceci n’est pas réversible');
+      assert.contains('Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible.');
     });
 
     test('should close the modal to cancel action', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Dans le formulaire d'anonymisation de Pix Admin, il y a des typos.
Il y a aussi un petit bug visuel sur le bouton `Anonymiser cet utilisateur` : Au survol la couleur rouge est remplacée par du gris.

## :robot: Solution
- Corriger le texte de la popup par : `Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible.`
- Corriger le css du bouton

## :100: Pour tester
Aller sur la page des utilisateurs.
Vérifier au survol du bouton la couleur rouge.
Vérifier dans la popup que le texte est correct. 
