### PR TITLE
[FEATURE] Assurer à l'utilisateur auto-invité un rôle d'administrateur (PIX-845).

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -40,7 +40,8 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     name: 'The Night Watch',
     isManagingStudents: true,
     canCollectProfiles: true,
-    email: 'sco.generic.account@example.net'
+    email: 'sco.generic.account@example.net',
+    externalId: '1237457A'
   });
   databaseBuilder.factory.buildMembership({
     userId: 4,

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -7,9 +7,9 @@ exports.register = async (server) => {
       path: '/api/organization-invitations/{id}/response',
       config: {
         auth: false,
-        handler: organizationInvitationController.answerToOrganizationInvitation,
+        handler: organizationInvitationController.acceptOrganizationInvitation,
         notes: [
-          '- Cette route permet de répondre à l\'invitation de rejoindre une organisation, via un **code**, un **status** et un **email**'
+          '- Cette route permet d\'accepter l\'invitation à rejoindre une organisation, via un **code** et un **email**'
         ],
         tags: ['api', 'invitations']
       }

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -1,3 +1,5 @@
+const Joi = require('@hapi/joi');
+const JSONAPIError = require('jsonapi-serializer').Error;
 const organizationInvitationController = require('./organization-invitation-controller');
 
 exports.register = async (server) => {
@@ -8,6 +10,27 @@ exports.register = async (server) => {
       config: {
         auth: false,
         handler: organizationInvitationController.acceptOrganizationInvitation,
+        validate: {
+          payload: Joi.object({
+            data: {
+              id: Joi.string().required(),
+              type: Joi.string().required(),
+              attributes: {
+                code: Joi.string().required(),
+                email: Joi.string().email().required()
+              }
+            }
+          }),
+          failAction: (request, h, err) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              code: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: err.details[0].message,
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          },
+        },
         notes: [
           '- Cette route permet d\'accepter l\'invitation à rejoindre une organisation, via un **code** et un **email**'
         ],
@@ -32,6 +55,20 @@ exports.register = async (server) => {
       config: {
         auth: false,
         handler: organizationInvitationController.getOrganizationInvitation,
+        validate: {
+          query: Joi.object({
+            code: Joi.string().required(),
+          }),
+          failAction: (request, h, err) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              code: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: err.details[0].message,
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          },
+        },
         notes: [
           '- Cette route permet de récupérer les détails d\'une invitation selon un **id d\'invitation** et un **code**\n',
         ],

--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -8,11 +8,11 @@ const { extractLocaleFromRequest } = require('../../infrastructure/utils/request
 
 module.exports = {
 
-  async answerToOrganizationInvitation(request) {
+  async acceptOrganizationInvitation(request) {
     const organizationInvitationId = request.params.id;
-    const { code, status, email } = request.payload.data.attributes;
+    const { code, email } = request.payload.data.attributes;
 
-    await usecases.answerToOrganizationInvitation({ organizationInvitationId, code, status, email });
+    await usecases.answerToOrganizationInvitation({ organizationInvitationId, code, email });
     return null;
   },
 

--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -12,7 +12,7 @@ module.exports = {
     const organizationInvitationId = request.params.id;
     const { code, email } = request.payload.data.attributes;
 
-    await usecases.answerToOrganizationInvitation({ organizationInvitationId, code, email });
+    await usecases.acceptOrganizationInvitation({ organizationInvitationId, code, email });
     return null;
   },
 

--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -28,7 +28,7 @@ module.exports = {
     const temporaryKey = request.params.temporaryKey;
     await tokenService.verifyValidity(temporaryKey);
     const passwordResetDemand = await resetPasswordService.verifyDemand(temporaryKey);
-    const user = await userRepository.findByEmail(passwordResetDemand.email);
+    const user = await userRepository.getByEmail(passwordResetDemand.email);
 
     return userSerializer.serialize(user);
   },

--- a/api/lib/domain/models/OrganizationInvitation.js
+++ b/api/lib/domain/models/OrganizationInvitation.js
@@ -24,6 +24,7 @@ class OrganizationInvitation {
     this.status = status;
     this.code = code;
     this.organizationName = organizationName;
+    this.role = role;
     this.createdAt = createdAt;
     this.role = role;
     this.updatedAt = updatedAt;

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -5,7 +5,7 @@ function getOrganizationRole({ hasMembers, invitationRole }) {
   return invitationRole || (hasMembers ? roles.MEMBER : roles.ADMIN);
 }
 
-module.exports = async function answerToOrganizationInvitation({
+module.exports = async function acceptOrganizationInvitation({
   organizationInvitationId, code, email,
   userRepository, membershipRepository, organizationInvitationRepository
 }) {

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -18,7 +18,7 @@ module.exports = async function acceptOrganizationInvitation({
     throw new AlreadyExistingOrganizationInvitationError(`Invitation already accepted with the id ${organizationInvitationId}`);
   } else {
 
-    const userFound = await userRepository.findByEmail(email);
+    const userFound = await userRepository.getByEmail(email);
 
     const { organizationId, role: invitationRole } = foundOrganizationInvitation;
     const memberships = await membershipRepository.findByOrganizationId({ organizationId });

--- a/api/lib/domain/usecases/answer-to-organization-invitation.js
+++ b/api/lib/domain/usecases/answer-to-organization-invitation.js
@@ -1,6 +1,10 @@
 const { roles } = require('../models/Membership');
 const { AlreadyExistingOrganizationInvitationError, AlreadyExistingMembershipError } = require('../../domain/errors');
 
+function getOrganizationRole({ hasMembers, invitationRole }) {
+  return invitationRole || (hasMembers ? roles.MEMBER : roles.ADMIN);
+}
+
 module.exports = async function answerToOrganizationInvitation({
   organizationInvitationId, code, email,
   userRepository, membershipRepository, organizationInvitationRepository
@@ -16,16 +20,20 @@ module.exports = async function answerToOrganizationInvitation({
 
     const userFound = await userRepository.findByEmail(email);
 
-    const { organizationId } = foundOrganizationInvitation;
+    const { organizationId, role: invitationRole } = foundOrganizationInvitation;
     const memberships = await membershipRepository.findByOrganizationId({ organizationId });
+    const existingMembership = memberships.find((membership) => membership.user.id === userFound.id);
 
-    const isAlreadyMember = memberships.find((membership) => membership.user.id === userFound.id);
-    if (isAlreadyMember) {
+    if (existingMembership && !invitationRole) {
       throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
     }
 
-    const organizationRole = memberships.length ? roles.MEMBER : roles.ADMIN;
-    await membershipRepository.create(userFound.id, organizationId, organizationRole);
+    if (existingMembership) {
+      await membershipRepository.updateById({ id: existingMembership.id, membershipAttributes: { organizationRole: invitationRole } });
+    } else {
+      const organizationRole = getOrganizationRole({ hasMembers: memberships.length, invitationRole });
+      await membershipRepository.create(userFound.id, organizationId, organizationRole);
+    }
 
     return organizationInvitationRepository.markAsAccepted(organizationInvitationId);
   }

--- a/api/lib/domain/usecases/answer-to-organization-invitation.js
+++ b/api/lib/domain/usecases/answer-to-organization-invitation.js
@@ -1,12 +1,10 @@
 const { roles } = require('../models/Membership');
-const OrganizationInvitation = require('../models/OrganizationInvitation');
 const { AlreadyExistingOrganizationInvitationError, AlreadyExistingMembershipError } = require('../../domain/errors');
 
 module.exports = async function answerToOrganizationInvitation({
-  organizationInvitationId, code, status, email,
+  organizationInvitationId, code, email,
   userRepository, membershipRepository, organizationInvitationRepository
 }) {
-
   const foundOrganizationInvitation = await organizationInvitationRepository.getByIdAndCode({
     id: organizationInvitationId,
     code
@@ -16,21 +14,20 @@ module.exports = async function answerToOrganizationInvitation({
     throw new AlreadyExistingOrganizationInvitationError(`Invitation already accepted with the id ${organizationInvitationId}`);
   } else {
 
-    if (status === OrganizationInvitation.StatusType.ACCEPTED) {
-      const userFound = await userRepository.findByEmail(email);
+    const userFound = await userRepository.findByEmail(email);
 
-      const { organizationId } = foundOrganizationInvitation;
-      const memberships = await membershipRepository.findByOrganizationId({ organizationId });
+    const { organizationId } = foundOrganizationInvitation;
+    const memberships = await membershipRepository.findByOrganizationId({ organizationId });
 
-      const isAlreadyMember = memberships.find((membership) => membership.user.id === userFound.id);
-      if (isAlreadyMember) {
-        throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
-      }
-
-      const organizationRole = memberships.length ? roles.MEMBER : roles.ADMIN;
-      await membershipRepository.create(userFound.id, organizationId, organizationRole);
-
-      return organizationInvitationRepository.markAsAccepted(organizationInvitationId);
+    const isAlreadyMember = memberships.find((membership) => membership.user.id === userFound.id);
+    if (isAlreadyMember) {
+      throw new AlreadyExistingMembershipError(`User is already member of organisation ${organizationId}`);
     }
+
+    const organizationRole = memberships.length ? roles.MEMBER : roles.ADMIN;
+    await membershipRepository.create(userFound.id, organizationId, organizationRole);
+
+    return organizationInvitationRepository.markAsAccepted(organizationInvitationId);
   }
+
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -72,6 +72,7 @@ const dependencies = {
 const { injectDependencies } = require('../../infrastructure/utils/dependency-injection');
 
 module.exports = injectDependencies({
+  acceptOrganizationInvitation: require('./accept-organization-invitation'),
   acceptPixLastTermsOfService: require('./accept-pix-last-terms-of-service'),
   acceptPixCertifTermsOfService: require('./accept-pix-certif-terms-of-service'),
   acceptPixOrgaTermsOfService: require('./accept-pix-orga-terms-of-service'),
@@ -79,7 +80,6 @@ module.exports = injectDependencies({
   addTutorialEvaluation: require('./add-tutorial-evaluation'),
   addTutorialToUser: require('./add-tutorial-to-user'),
   anonymizeUser: require('./anonymize-user'),
-  answerToOrganizationInvitation: require('./answer-to-organization-invitation'),
   attachTargetProfilesToOrganization: require('./attach-target-profiles-to-organization'),
   archiveCampaign: require('./archive-campaign'),
   assignCertificationOfficerToJurySession: require('./assign-certification-officer-to-jury-session'),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -132,7 +132,7 @@ function _adaptModelToDb(user) {
 module.exports = {
 
   // TODO use _toDomain()
-  findByEmail(email) {
+  getByEmail(email) {
     return BookshelfUser
       .where({ email: email.toLowerCase() })
       .fetch({ require: true })

--- a/api/tests/acceptance/application/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitation-controller_test.js
@@ -39,15 +39,17 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
           code: code
         }).id;
 
-        const status = OrganizationInvitation.StatusType.ACCEPTED;
-
         options = {
           method: 'POST',
           url: `/api/organization-invitations/${organizationInvitationId}/response`,
           payload: {
             data: {
-              type: 'organization-invitations',
-              attributes: { code, status, email: userToInviteEmail },
+              id: '100047_DZWMP7L5UM',
+              type: 'organization-invitation-responses',
+              attributes: {
+                code,
+                email: userToInviteEmail
+              },
             }
           }
         };
@@ -84,11 +86,12 @@ describe('Acceptance | Application | organization-invitation-controller', () => 
           url: `/api/organization-invitations/${organizationInvitationId}/response`,
           payload: {
             data: {
-              type: 'organization-invitations',
+              id: '100047_DZWMP7L5UM',
+              type: 'organization-invitation-responses',
               attributes: {
                 code: 'notExistCode',
-                status: OrganizationInvitation.StatusType.ACCEPTED,
-              }
+                email: 'user@example.net'
+              },
             }
           }
         };

--- a/api/tests/integration/application/organization-invitations/index_test.js
+++ b/api/tests/integration/application/organization-invitations/index_test.js
@@ -14,7 +14,7 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
   describe('POST /api/organization-invitations/:id/response', () => {
 
     beforeEach(async () => {
-      sinon.stub(organisationInvitationController, 'answerToOrganizationInvitation').callsFake((request, h) => h.response().code(204));
+      sinon.stub(organisationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
       await server.register(route);
     });
 

--- a/api/tests/integration/application/organization-invitations/index_test.js
+++ b/api/tests/integration/application/organization-invitations/index_test.js
@@ -18,12 +18,35 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
       await server.register(route);
     });
 
-    it('should exist', async () => {
+    it('should return 200 when payload is valid', async () => {
+
+      const options = {
+        method: 'POST',
+        url: '/api/organization-invitations/1/response',
+        payload: {
+          data: {
+            id: '100047_DZWMP7L5UM',
+            type: 'organization-invitation-responses',
+            attributes: {
+              code: 'DZWMP7L5UM',
+              email: 'user@example.net'
+            },
+          }
+        }
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should return 400 when payload is missing', async () => {
       // when
       const response = await server.inject({ method: 'POST', url: '/api/organization-invitations/1/response' });
 
       // then
-      expect(response.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(400);
     });
   });
 
@@ -50,12 +73,20 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
       await server.register(route);
     });
 
-    it('should exist', async () => {
+    it('should return 200 when query is valid', async () => {
+      // when
+      const response = await server.inject({ method: 'GET', url: '/api/organization-invitations/1?code=DZWMP7L5UM' });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 when query is invalid', async () => {
       // when
       const response = await server.inject({ method: 'GET', url: '/api/organization-invitations/1' });
 
       // then
-      expect(response.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(400);
     });
   });
 

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases');
-const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const scoOrganizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer');
 const moduleUnderTest = require('../../../../lib/application/organization-invitations');
 
@@ -29,16 +28,14 @@ describe('Integration | Application | Organization-invitations | organization-in
 
   describe('#acceptOrganizationInvitation', () => {
 
-    const status = OrganizationInvitation.StatusType.ACCEPTED;
-    const temporaryKey = 'temporaryKey';
-
     const payload = {
       data: {
-        type: 'organization-invitations',
+        id: '100047_DZWMP7L5UM',
+        type: 'organization-invitation-responses',
         attributes: {
-          temporaryKey,
-          status
-        },
+          code: 'DZWMP7L5UM',
+          email: 'user@example.net'
+        }
       }
     };
 

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -16,7 +16,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(usecases, 'answerToOrganizationInvitation');
+    sandbox.stub(usecases, 'acceptOrganizationInvitation');
     sandbox.stub(usecases, 'sendScoInvitation');
     sandbox.stub(scoOrganizationInvitationSerializer, 'serialize');
 
@@ -27,7 +27,7 @@ describe('Integration | Application | Organization-invitations | organization-in
     sandbox.restore();
   });
 
-  describe('#answerToOrganizationInvitation', () => {
+  describe('#acceptOrganizationInvitation', () => {
 
     const status = OrganizationInvitation.StatusType.ACCEPTED;
     const temporaryKey = 'temporaryKey';
@@ -46,7 +46,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
       it('should return an HTTP response with status code 204', async () => {
         // given
-        usecases.answerToOrganizationInvitation.resolves();
+        usecases.acceptOrganizationInvitation.resolves();
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
@@ -60,7 +60,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
       it('should respond an HTTP response with status code 412 when AlreadyExistingOrganizationInvitationError', async () => {
         // given
-        usecases.answerToOrganizationInvitation.rejects(new AlreadyExistingOrganizationInvitationError());
+        usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingOrganizationInvitationError());
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
@@ -71,7 +71,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
       it('should respond an HTTP response with status code 404 when NotFoundError', async () => {
         // given
-        usecases.answerToOrganizationInvitation.rejects(new NotFoundError());
+        usecases.acceptOrganizationInvitation.rejects(new NotFoundError());
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);
@@ -82,7 +82,7 @@ describe('Integration | Application | Organization-invitations | organization-in
 
       it('should respond an HTTP response with status code 404 when UserNotFoundError', async () => {
         // given
-        usecases.answerToOrganizationInvitation.rejects(new UserNotFoundError());
+        usecases.acceptOrganizationInvitation.rejects(new UserNotFoundError());
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -20,7 +20,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(usecases, 'findPaginatedFilteredOrganizationMemberships');
     sandbox.stub(usecases, 'findPaginatedFilteredSchoolingRegistrations');
     sandbox.stub(usecases, 'createOrganizationInvitations');
-    sandbox.stub(usecases, 'answerToOrganizationInvitation');
+    sandbox.stub(usecases, 'acceptOrganizationInvitation');
     sandbox.stub(usecases, 'findPendingOrganizationInvitations');
     sandbox.stub(usecases, 'attachTargetProfilesToOrganization');
 

--- a/api/tests/integration/domain/services/organization-invitation-service_test.js
+++ b/api/tests/integration/domain/services/organization-invitation-service_test.js
@@ -29,8 +29,7 @@ describe('Integration | Service | Organization-Invitation Service', () => {
       const expectedOrganizationInvitation = {
         organizationId,
         email,
-        status: OrganizationInvitation.StatusType.PENDING,
-        role: null,
+        status: OrganizationInvitation.StatusType.PENDING
       };
 
       // when
@@ -42,7 +41,7 @@ describe('Integration | Service | Organization-Invitation Service', () => {
 
       // then
       expect(result).to.be.instanceOf(OrganizationInvitation);
-      expect(_.omit(result, ['id', 'code', 'organizationName', 'createdAt', 'updatedAt'])).to.deep.equal(expectedOrganizationInvitation);
+      expect(_.omit(result, ['id', 'code', 'organizationName', 'role', 'createdAt', 'updatedAt'])).to.deep.equal(expectedOrganizationInvitation);
     });
 
     it('should re-send an email with same code when organization-invitation already exist with status pending', async () => {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -67,7 +67,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
   describe('find user', () => {
 
-    describe('#findByEmail', () => {
+    describe('#getByEmail', () => {
 
       let userInDb;
 
@@ -78,7 +78,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       it('should be a function', () => {
         // then
-        expect(userRepository.findByEmail).to.be.a('function');
+        expect(userRepository.getByEmail).to.be.a('function');
       });
 
       it('should handle a rejection, when user id is not found', async () => {
@@ -86,7 +86,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         const emailThatDoesNotExist = '10093';
 
         // when
-        const result = await catchErr(userRepository.findByEmail)(emailThatDoesNotExist);
+        const result = await catchErr(userRepository.getByEmail)(emailThatDoesNotExist);
 
         // then
         expect(result).to.be.instanceOf(NotFoundError);
@@ -94,7 +94,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       it('should return a domain user when found', async () => {
         // when
-        const user = await userRepository.findByEmail(userInDb.email);
+        const user = await userRepository.getByEmail(userInDb.email);
 
         // then
         expect(user.email).to.equal(userInDb.email);
@@ -105,7 +105,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         const uppercaseEmailAlreadyInDb = userInDb.email.toUpperCase();
 
         // when
-        const user = await userRepository.findByEmail(uppercaseEmailAlreadyInDb);
+        const user = await userRepository.getByEmail(uppercaseEmailAlreadyInDb);
 
         // then
         expect(user.email).to.equal(userInDb.email);

--- a/api/tests/tooling/domain-builder/factory/build-organization-invitation.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-invitation.js
@@ -8,6 +8,7 @@ module.exports = function buildOrganizationInvitation({
   email = faker.internet.exampleEmail(),
   status = OrganizationInvitation.StatusType.PENDING,
   code = faker.random.alphaNumeric(10),
+  role,
   createdAt = faker.date.recent(),
   updatedAt = faker.date.recent(),
 } = {}) {
@@ -18,6 +19,7 @@ module.exports = function buildOrganizationInvitation({
     email,
     status,
     code,
+    role,
     createdAt,
     updatedAt,
   });

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -12,7 +12,7 @@ function startServer() {
 describe('Unit | Router | organization-invitation-router', () => {
 
   beforeEach(() => {
-    sinon.stub(organizationInvitationController, 'answerToOrganizationInvitation').callsFake((request, h) => h.response().code(204));
+    sinon.stub(organizationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
     sinon.stub(organizationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
 
     startServer();

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -20,11 +20,22 @@ describe('Unit | Router | organization-invitation-router', () => {
 
   describe('POST /api/organization-invitations/{id}/response', () => {
 
-    it('should exist', async () => {
+    it('should exists', async () => {
       // given
       const options = {
         method: 'POST',
-        url: '/api/organization-invitations/1/response'
+        url: '/api/organization-invitations/1/response',
+        payload: {
+          data: {
+            id: '100047_DZWMP7L5UM',
+            type: 'organization-invitation-responses',
+            attributes: {
+              code: 'DZWMP7L5UM',
+              email: 'user@example.net'
+            },
+
+          }
+        }
       };
 
       // when
@@ -37,11 +48,11 @@ describe('Unit | Router | organization-invitation-router', () => {
 
   describe('GET /api/organization-invitations/{id}', () => {
 
-    it('should exist', async () => {
+    it('should exists', async () => {
       // given
       const options = {
         method: 'GET',
-        url: '/api/organization-invitations/1'
+        url: '/api/organization-invitations/1?code=DZWMP7L5UM'
       };
 
       // when

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -3,18 +3,16 @@ const { expect, sinon, catchErr } = require('../../../test-helper');
 const { MissingQueryParamError } = require('../../../../lib/application/http-errors');
 const organizationInvitationController = require('../../../../lib/application/organization-invitations/organization-invitation-controller');
 const usecases = require('../../../../lib/domain/usecases');
-const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 
 describe('Unit | Application | Organization-Invitations | organization-invitation-controller', () => {
 
   let request;
 
-  describe('#answerToOrganizationInvitation', () => {
+  describe('#acceptOrganizationInvitation', () => {
 
     const organizationInvitationId = 1;
     const code = 'ABCDEFGH01';
-    const status = OrganizationInvitation.StatusType.ACCEPTED;
     const email = 'random@email.com';
 
     beforeEach(() => {
@@ -23,7 +21,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
         payload: {
           data: {
             type: 'organization-invitations',
-            attributes: { code, status, email },
+            attributes: { code, email },
           }
         }
       };
@@ -31,16 +29,16 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
       sinon.stub(usecases, 'answerToOrganizationInvitation');
     });
 
-    it('should call the usecase to update invitation with organizationInvitationId, code and status', async () => {
+    it('should call the usecase to accept invitation with organizationInvitationId and code', async () => {
       // given
       usecases.answerToOrganizationInvitation.resolves();
 
       // when
-      await organizationInvitationController.answerToOrganizationInvitation(request);
+      await organizationInvitationController.acceptOrganizationInvitation(request);
 
       // then
       expect(usecases.answerToOrganizationInvitation).to.have.been.calledWith({
-        organizationInvitationId, code, status, email });
+        organizationInvitationId, code, email });
     });
   });
 

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -26,18 +26,18 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
         }
       };
 
-      sinon.stub(usecases, 'answerToOrganizationInvitation');
+      sinon.stub(usecases, 'acceptOrganizationInvitation');
     });
 
     it('should call the usecase to accept invitation with organizationInvitationId and code', async () => {
       // given
-      usecases.answerToOrganizationInvitation.resolves();
+      usecases.acceptOrganizationInvitation.resolves();
 
       // when
       await organizationInvitationController.acceptOrganizationInvitation(request);
 
       // then
-      expect(usecases.answerToOrganizationInvitation).to.have.been.calledWith({
+      expect(usecases.acceptOrganizationInvitation).to.have.been.calledWith({
         organizationInvitationId, code, email });
     });
   });

--- a/api/tests/unit/application/passwords/password-controller_test.js
+++ b/api/tests/unit/application/passwords/password-controller_test.js
@@ -94,7 +94,7 @@ describe('Unit | Controller | PasswordController', () => {
       sinon.stub(resetPasswordService, 'verifyDemand');
       sinon.stub(tokenService, 'verifyValidity').resolves({});
       sinon.stub(errorSerializer, 'serialize');
-      sinon.stub(userRepository, 'findByEmail').resolves(fetchedUser);
+      sinon.stub(userRepository, 'getByEmail').resolves(fetchedUser);
       sinon.stub(userSerializer, 'serialize');
     });
 
@@ -133,15 +133,15 @@ describe('Unit | Controller | PasswordController', () => {
         await passwordController.checkResetDemand(request, hFake);
 
         // then
-        sinon.assert.calledOnce(userRepository.findByEmail);
-        sinon.assert.calledWith(userRepository.findByEmail, fetchedPasswordResetDemand.email);
+        sinon.assert.calledOnce(userRepository.getByEmail);
+        sinon.assert.calledWith(userRepository.getByEmail, fetchedPasswordResetDemand.email);
       });
 
       it('should reply with a serialized user with some fields', async () => {
         // given
         const serializedUser = {};
         resetPasswordService.verifyDemand.resolves(fetchedPasswordResetDemand);
-        userRepository.findByEmail.resolves(fetchedUser);
+        userRepository.getByEmail.resolves(fetchedUser);
         userSerializer.serialize.returns(serializedUser);
 
         // when

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -12,7 +12,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
 
   beforeEach(() => {
     userRepository = {
-      findByEmail: sinon.stub(),
+      getByEmail: sinon.stub(),
     };
     membershipRepository = {
       create: sinon.stub(),
@@ -75,7 +75,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
       organizationInvitationRepository.getByIdAndCode.resolves(pendingOrganizationInvitation);
 
       userToInvite = domainBuilder.buildUser({ email });
-      userRepository.findByEmail.resolves(userToInvite);
+      userRepository.getByEmail.resolves(userToInvite);
     });
 
     context('when the user is the first one to join the organization', () => {
@@ -93,7 +93,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
         });
 
         // then
-        expect(userRepository.findByEmail).to.have.been.calledWith(email);
+        expect(userRepository.getByEmail).to.have.been.calledWith(email);
         expect(membershipRepository.findByOrganizationId).to.have.been.calledWith({ organizationId });
         expect(membershipRepository.create).to.have.been.calledWith(userToInvite.id, organizationId, Membership.roles.ADMIN);
         expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);
@@ -114,7 +114,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
         });
 
         // then
-        expect(userRepository.findByEmail).to.have.been.calledWith(email);
+        expect(userRepository.getByEmail).to.have.been.calledWith(email);
         expect(membershipRepository.findByOrganizationId).to.have.been.calledWith({ organizationId });
         expect(membershipRepository.create).to.have.been.calledWith(userToInvite.id, organizationId, Membership.roles.MEMBER);
         expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);
@@ -136,7 +136,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
         });
 
         // then
-        expect(userRepository.findByEmail).to.have.been.calledWith(email);
+        expect(userRepository.getByEmail).to.have.been.calledWith(email);
         expect(membershipRepository.findByOrganizationId).to.have.been.calledWith({ organizationId });
         expect(membershipRepository.create).to.have.been.calledWith(userToInvite.id, organizationId, role);
         expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);
@@ -182,7 +182,7 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
           });
 
           // then
-          expect(userRepository.findByEmail).to.have.been.calledWith(email);
+          expect(userRepository.getByEmail).to.have.been.calledWith(email);
           expect(membershipRepository.findByOrganizationId).to.have.been.calledWith({ organizationId });
           expect(membershipRepository.updateById).to.have.been.calledWith({ id: membership.id, membershipAttributes: { organizationRole: pendingOrganizationInvitation.role } });
           expect(organizationInvitationRepository.markAsAccepted).to.have.been.calledWith(organizationInvitationId);

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -86,7 +86,6 @@ describe('Unit | UseCase | accept-organization-invitation', () => {
         membershipRepository.findByOrganizationId.resolves([]);
 
         // when
-        // when
         await acceptOrganizationInvitation({
           organizationInvitationId, code, email,
           userRepository, membershipRepository, organizationInvitationRepository

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -67,11 +67,9 @@ export default class LoginForm extends Component {
   }
 
   _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, email) {
-    const status = 'accepted';
     return this.store.createRecord('organization-invitation-response', {
       id: organizationInvitationId + '_' + organizationInvitationCode,
       code: organizationInvitationCode,
-      status,
       email,
     }).save({ adapterOptions: { organizationInvitationId } });
   }

--- a/orga/app/components/routes/register-form.js
+++ b/orga/app/components/routes/register-form.js
@@ -93,11 +93,9 @@ export default class RegisterForm extends Component {
   }
 
   _acceptOrganizationInvitation(organizationInvitationId, organizationInvitationCode, createdUserEmail) {
-    const status = 'accepted';
     return this.store.createRecord('organization-invitation-response', {
       id: organizationInvitationId + '_' + organizationInvitationCode,
       code: organizationInvitationCode,
-      status,
       email: createdUserEmail,
     }).save({ adapterOptions: { organizationInvitationId } });
   }

--- a/orga/app/models/organization-invitation-response.js
+++ b/orga/app/models/organization-invitation-response.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  status: DS.attr('string'),
   code: DS.attr('string'),
   email: DS.attr('string'),
 });

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -131,7 +131,7 @@ export default function() {
   this.post('/organization-invitations/:id/response', (schema, request) => {
     const organizationInvitationId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);
-    const { code, status } = requestBody.data.attributes;
+    const { code } = requestBody.data.attributes;
 
     const organizationInvitation = schema.organizationInvitations.findBy({ id: organizationInvitationId, code });
     const prescriber = schema.prescribers.first();
@@ -145,7 +145,7 @@ export default function() {
     prescriber.memberships = [membership];
     prescriber.save();
 
-    organizationInvitation.update({ status });
+    organizationInvitation.update({ status: 'accepted' });
     schema.organizationInvitationResponses.create();
 
     return new Response(204);


### PR DESCRIPTION
## :unicorn: Problème
Les professeurs voulant récupérer l'accès d'administration à Pix Orga suite au départ d'un collègue se voient attribuer le rôle de membre.

## :robot: Solution
Leur attribuer le rôle d'administrateur, soit en créant ce rôle, soit en mettant à jour le rôle existant.

## :rainbow: Remarques
Attente du ticket pour PIX-882 pour rebase (colonne en BDD)
La prise en compte du statut envoyé par Pix Orga a été supprimée (code mort)

## :100: Pour tester
Etapes:
- créer une [demande d'invitation](https://orga-pr1609.review.pix.fr/demande-administration-sco), sur l'UAI `1234567A`
- récupérer le code et l'id associée `select email, id, code from "organization-invitations"`
- construire l'URL`https://orga-pr1609.review.pix.fr/rejoindre?invitationId=<ID>&code=<CODE>`
- se rendre sur l'URL, créer un compte pour accepter l'invitation
- se connecter sur ce compte et vérifier que le rôle est celui d'administrateur


En local, pour générer l'URL sur une seed présente
>SELECT 'http://localhost:4201/rejoindre?invitationId=' || id || '&code=' || code AS accept_URL 
>FROM "organization-invitations" WHERE status = 'pending'; 

