### PR TITLE
[CLEANUP] Refacto admin save certification (PIX-946)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -123,23 +123,20 @@ export default class CertificationInformationsController extends Controller {
 
   @action
   onCheckMarks() {
-    const markStore = this._markStore;
-    if (markStore.hasState()) {
-      const state = markStore.getState();
-      const certification = this.certification;
-      certification.pixScore = state.score;
-      const newCompetences = Object.keys(state.marks).reduce((competences, code) => {
-        const mark = state.marks[code];
-        competences.addObject({
-          competence_code: code,
-          level: mark.level,
-          score: mark.score,
-          area_code: code.substr(0, 1),
-          'competence-id': mark.competenceId,
+    if (this._markStore.hasState()) {
+      const state = this._markStore.getState();
+      this.certification.pixScore = state.score ;
+      const newCompetences = Object.entries(state.marks)
+        .map(([code, mark]) => {
+          return {
+            'competence-id': mark.competenceId,
+            competence_code: code,
+            area_code: code.substr(0, 1),
+            level: mark.level,
+            score: mark.score,
+          };
         });
-        return competences;
-      }, A());
-      certification.competencesWithMark = newCompetences;
+      this.certification.competencesWithMark = A(newCompetences);
       schedule('afterRender', this, () => {
         this.edition = true;
       });

--- a/admin/app/services/mark-store.js
+++ b/admin/app/services/mark-store.js
@@ -7,15 +7,17 @@ export default class MarkStoreService extends Service {
 
   getState() {
     if (this.available) {
-      this.set('available', false);
-      return this.state;
+      this.available = false;
+      const state = this.state;
+      this.state = null;
+      return state;
     }
     return false;
   }
 
   storeState(state) {
-    this.set('state', state);
-    this.set('available', true);
+    this.state = state;
+    this.available = true;
   }
 
   hasState() {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -1,13 +1,15 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
+import { getSettledState, settled } from '@ember/test-helpers';
+
 import EmberObject from '@ember/object';
 
 module('Unit | Controller | authenticated/certifications/certification/informations', function(hooks) {
 
   setupTest(hooks);
 
-  const competence = (code, score, level) => {
+  const createCompetence = (code, score, level) => {
     return {
       competence_code: code,
       score: score,
@@ -15,17 +17,31 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     };
   };
 
-  const aNewCompetenceId = '4.2';
+  const createMark = ({
+    competence_code,
+    score,
+    level
+  }) => {
+    return {
+      competence_code,
+      level,
+      score,
+      area_code: competence_code.substr(0, 1),
+      'competence-id': undefined,
+    };
+  };
+
+  const aNewCompetenceCode = '4.2';
   const anExistingCompetenceCode = '1.1';
   const anExistingCompetenceWithNoScoreCode = '1.2';
   const anExistingCompetenceWithNoLevelCode = '1.3';
   const anotherExistingCompetenceCode = '5.2';
 
   const competencesWithMark = [
-    competence(anExistingCompetenceCode, 24, 3),
-    competence(anExistingCompetenceWithNoScoreCode, null, 5),
-    competence(anExistingCompetenceWithNoLevelCode, 40, null),
-    competence(anotherExistingCompetenceCode, 33, 4)
+    createCompetence(anExistingCompetenceCode, 24, 3),
+    createCompetence(anExistingCompetenceWithNoScoreCode, null, 5),
+    createCompetence(anExistingCompetenceWithNoLevelCode, 40, null),
+    createCompetence(anotherExistingCompetenceCode, 33, 4)
   ];
 
   let controller;
@@ -82,11 +98,11 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         }));
 
         // when
-        await controller.onUpdateScore(aNewCompetenceId, '55');
+        await controller.onUpdateScore(aNewCompetenceCode, '55');
 
         // then
         const competences = controller.certification.competencesWithMark;
-        const aCompetence = competences.find((value) => value.competence_code === aNewCompetenceId);
+        const aCompetence = competences.find((value) => value.competence_code === aNewCompetenceCode);
         assert.equal(aCompetence.score, 55);
       });
     });
@@ -140,11 +156,11 @@ module('Unit | Controller | authenticated/certifications/certification/informati
         }));
 
         // when
-        await controller.onUpdateLevel(aNewCompetenceId, '8');
+        await controller.onUpdateLevel(aNewCompetenceCode, '8');
 
         // then
         const competences = controller.certification.competencesWithMark;
-        const aCompetence = competences.find((value) => value.competence_code === aNewCompetenceId);
+        const aCompetence = competences.find((value) => value.competence_code === aNewCompetenceCode);
         assert.equal(aCompetence.level, 8);
       });
     });
@@ -189,6 +205,70 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       sinon.assert.calledWith(save, { adapterOptions: { updateMarks: false } });
       sinon.assert.neverCalledWith(save, { adapterOptions: { updateMarks: true } });
       assert.ok(true);
+    });
+  });
+
+  module('#onCheckMarks', () => {
+    module('when there is no mark', () => {
+      test('should not set competencesWithMark', async (assert) => {
+        // given
+        //const store = this.owner.lookup('service:mark-store');
+        controller.certification =  EmberObject.create({ competencesWithMark });
+
+        // when
+        await controller.onCheckMarks();
+        // then
+        assert.deepEqual(controller.certification.competencesWithMark, competencesWithMark);
+      });
+    });
+
+    module('when there are marks', () => {
+      test('should set competencesWithMark', async function(assert) {
+
+        // given
+        const score = 100;
+        const anExistingCompetence =  competencesWithMark.find((value) => value.competence_code === anExistingCompetenceCode);
+
+        const expectedCompetencesWithMark = [
+          createMark({
+            competence_code: anExistingCompetenceCode,
+            level: anExistingCompetence.level + 1,
+            score: anExistingCompetence.score + 1,
+          }),
+          createMark({
+            competence_code: aNewCompetenceCode,
+            level: 5,
+            score: 6,
+          }),
+        ];
+
+        const store = this.owner.lookup('service:mark-store');
+        store.storeState({
+          score,
+          marks: {
+            [anExistingCompetenceCode]: {
+              level: anExistingCompetence.level + 1,
+              score: anExistingCompetence.score + 1,
+            },
+            [aNewCompetenceCode]: {
+              level: 5,
+              score: 6,
+            },
+          },
+        });
+
+        // when
+        await controller.onCheckMarks();
+        const state = await getSettledState();
+
+        // then
+        assert.equal(controller.certification.pixScore, score);
+        assert.deepEqual(controller.certification.competencesWithMark, expectedCompetencesWithMark);
+        assert.ok(state.hasPendingTimers);
+
+        await settled();
+        assert.ok(controller.edition);
+      });
     });
   });
 


### PR DESCRIPTION
## 🦄 Problème
Pas de test sur certification information onSaveConfirm

## 🤖 Solution
Ajout de test + BSR

## 💯 Pour tester
Verifier l'affichage de la popup lors du clic sur la sauvegarde d'une certification, et des messages d'erreur.