### PR TITLE
[BUGFIX] Retour en arrière sur le correctif des liens téléchargeables (`target=_blank`)(PIX-835).

### DIFF
--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -18,6 +18,7 @@
         <div class="challenge-statement__action">
           <a class="challenge-statement__action-link"
              href="{{@challenge.attachments.firstObject}}"
+             target="_blank"
              rel="noopener noreferrer"
              download>
             <span class="challenge-statement__action-label">Télécharger</span>
@@ -58,6 +59,7 @@
         <div class="challenge-statement__action">
           <a class="challenge-statement__action-link"
              href="{{this.selectedAttachmentUrl}}"
+             target="_blank"
              rel="noopener noreferrer"
              download>
             <span class="challenge-statement__action-label">Télécharger</span>


### PR DESCRIPTION
## :unicorn: Problème
Suite à la suppression du `target=_blank` pour des raisons d'accessibilité, lorsqu'on clique sur le bouton de téléchargement, on sort de l'assessment. (cf. #1575)

## :robot: Solution
Une solution "quick & dirty" a été tentée (cf. #1605) mais celle-ci entraîne d'autres problèmes.
Dans un premier temps, on choisit de revenir en arrière sur cette correction.
Une solution pérenne sera ensuite implémentée, sur la base des suggestions de @jonathanperret (cf. https://github.com/1024pix/pix/pull/1605#issuecomment-654175891).

## :rainbow: Remarques
RAS

## :100: Pour tester

https://app-pr1612.review.pix.fr/challenges/recP1GPtuYjQE5mPM/preview
https://app-pr1612.review.pix.fr/challenges/rec65HeFvjaeC2QA2/preview

