### PR TITLE
[TECH] Inclure toute la stack trace asynchrone dans les erreurs Knex

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,6 +1,6 @@
 require('dotenv').config({ path: `${__dirname}/../.env` });
 
-function localPostgresEnv(databaseUrl) {
+function localPostgresEnv(databaseUrl, knexAsyncStacktraceEnabled) {
   return {
     client: 'postgresql',
     connection: databaseUrl,
@@ -15,14 +15,21 @@ function localPostgresEnv(databaseUrl) {
     seeds: {
       directory: './seeds',
     },
+    asyncStackTraces: (knexAsyncStacktraceEnabled !== 'false'),
   };
 }
 
 module.exports = {
 
-  development: localPostgresEnv(process.env.DATABASE_URL),
+  development: localPostgresEnv(
+    process.env.DATABASE_URL,
+    process.env.KNEX_ASYNC_STACKTRACE_ENABLED
+  ),
 
-  test: localPostgresEnv(process.env.TEST_DATABASE_URL),
+  test: localPostgresEnv(
+    process.env.TEST_DATABASE_URL,
+    process.env.KNEX_ASYNC_STACKTRACE_ENABLED
+  ),
 
   staging: {
     client: 'postgresql',
@@ -38,6 +45,7 @@ module.exports = {
     seeds: {
       directory: './seeds',
     },
+    asyncStackTraces: (process.env.KNEX_ASYNC_STACKTRACE_ENABLED !== 'false'),
   },
 
   production: {
@@ -55,5 +63,6 @@ module.exports = {
       directory: './seeds',
     },
     ssl: ('true' === process.env.DATABASE_SSL_ENABLED),
+    asyncStackTraces: (process.env.KNEX_ASYNC_STACKTRACE_ENABLED !== 'false'),
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Quand une exception survient au niveau de knex, la stacktrace visible dans Sentry ne comprend que peu d'information:
![image](https://user-images.githubusercontent.com/34715194/86601635-db69b800-bfa1-11ea-8253-677be5590d3a.png)

## :robot: Solution
En activant l'option asyncStackTraces: true il est possible d'y inclure toute la stacktrace :
![image](https://user-images.githubusercontent.com/34715194/86601913-3a2f3180-bfa2-11ea-994e-b6cfe3a7f8ab.png)

## :rainbow: Remarques
L'option knex en question est décrite ici : http://knexjs.org/#Installation-asyncStackTraces

À noter :
> _This has small performance overhead, so it is advised to use only for development. Turned off by default._

## :100: Pour tester
Me demander.

