### PR TITLE
[CLEANUP] Requête SQL plus cohérente pour les détails d'une session (PIX-877)

### DIFF
--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -7,8 +7,8 @@ module.exports = {
   async findBySessionId(sessionId) {
     const results = await knex.with('certifications_every_assess_results', (qb) => {
       qb.select('certification-courses.*', 'assessment-results.pixScore', 'assessment-results.status')
-        .select(knex.raw('RANK() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS asr_rank',
-          ['assessmentId', 'assessment-results.createdAt']))
+        .select(knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS asr_row_number',
+          ['certification-courses.id', 'assessment-results.createdAt']))
         .from('certification-courses')
         .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
         .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
@@ -16,8 +16,7 @@ module.exports = {
     })
       .select('*')
       .from('certifications_every_assess_results')
-      .where('asr_rank', 1)
-      .orWhereNull('asr_rank')
+      .where('asr_row_number', 1)
       .orderBy('lastName', 'ASC')
       .orderBy('firstName', 'ASC');
 


### PR DESCRIPTION
## :unicorn: Problème

La requête pour récupérer le dernier assessmentResult d'une certification fonctionne par coïncidence (voir conversation liée dans les remarques).

## :robot: Solution

Faire un ROW_NUMBER en regroupant par certificationCourseId

## :rainbow: Remarques

[Lien vers la conversation de @jonathanperret à propos du ticket pix-877](https://github.com/1024pix/pix/pull/1599#discussion_r450182948
)

## :100: Pour tester

Mêmes tests que pour #877 :

- rejoindre une session de certification avec un candidat 
- entrer le code d’accès a la session : un nouveau certif-course est créé
- ne PAS finir la certif de façon à ce qu’elle reste au statut “started”
- aller dans Pix Admin sur la page de détails de la session puis cliquer sur l’onglet “Certifications” : la certif “started” est affichée
- rejoindre la même session avec un autre candidat
- ne PAS finir non plus cette certif de façon à ce qu’elle reste également au statut “started”
- aller dans Pix Admin sur la liste des certifications
