### PR TITLE
[TECH] Augmenter la taille des messages d'erreur dans Sentry

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -126,6 +126,7 @@ module.exports = (function() {
       environment: (process.env.SENTRY_ENVIRONMENT || 'development'),
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
       debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
+      maxValueLength: 1000,
     },
   };
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -76,6 +76,7 @@ const plugins = [
           release: `v${Pack.version}`,
           maxBreadcrumbs: settings.sentry.maxBreadcrumbs,
           debug: settings.sentry.debug,
+          maxValueLength: settings.sentry.maxValueLength
         },
         scope: {
           tags: [


### PR DESCRIPTION
## :unicorn: Problème
Par défaut, le message d'erreur envoyé depuis l'api à Sentry est tronqué à 250 caractères.
![image](https://user-images.githubusercontent.com/34715194/86610374-892e9400-bfad-11ea-860d-83bd13d937c6.png)



## :robot: Solution
[Depuis la version 5.0.0 il est possible de surcharger ce comportement grâce au paramètre `maxValueLength`.](https://docs.sentry.io/platforms/javascript/#truncating-strings-on-the-event)
![image](https://user-images.githubusercontent.com/34715194/86610206-4bca0680-bfad-11ea-873d-2b26b95bb5e6.png)

## :rainbow: Remarques
J'ai arbitrairement mis une limite à 1000 caractères. Prix à débattre.

## :100: Pour tester
Me demander.