### PR TITLE
[BUGFIX] Rendre des tests plus déterministes dans l'API (PIX-959). 

### DIFF
--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -13,12 +13,12 @@ function extractParameters(query) {
 }
 
 function _extractFilter(query) {
-  const regex = /filter\[([a-zA-Z]*)]/;
+  const regex = /filter\[([a-zA-Z]*)\]/;
   return _extractObjectParameter(query, regex);
 }
 
 function _extractPage(query) {
-  const regex = /page\[([a-zA-Z]*)]/;
+  const regex = /page\[([a-zA-Z]*)\]/;
   const params = _extractObjectParameter(query, regex);
 
   return _convertObjectValueToInt(params);

--- a/api/tests/acceptance/application/users/users-controller-find-users_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-users_test.js
@@ -7,24 +7,23 @@ describe('Acceptance | users-controller-find-users', () => {
   let options;
 
   beforeEach(async () => {
-    // create server
     server = await createServer();
 
-    // Insert 1 user with role PixMaster
-    const userPixMaster = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+    const userPixMasterId = databaseBuilder.factory.buildUser.withPixRolePixMaster({
+      firstName: 'PixMaster_firstName',
+      lastName: 'PixMaster_lastName'
+    }).id;
 
-    // Insert 2 more users
     databaseBuilder.factory.buildUser({ firstName: 'Jean-Paul', lastName: 'Grand', email: 'jean-paul.grand@example.net' });
     databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Coula', email: 'jean.coula@example.org' });
 
     options = {
       method: 'GET',
       url: '/api/users',
-      payload: { },
-      headers: { authorization: generateValidRequestAuthorizationHeader(userPixMaster.id) },
+      headers: { authorization: generateValidRequestAuthorizationHeader(userPixMasterId) },
     };
 
-    return databaseBuilder.commit();
+    await databaseBuilder.commit();
   });
 
   describe('GET /users', () => {

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -7,19 +7,32 @@ const {
 describe('Unit | Service | user-reconciliation-service', () => {
 
   let schoolingRegistrations;
-  let user;
+
+  beforeEach(() => {
+    schoolingRegistrations = [
+      domainBuilder.buildSchoolingRegistration({
+        firstName: 'firstName',
+        middleName: 'middleName',
+        thirdName: 'thirdName',
+        lastName: 'lastName',
+        preferredLastName: 'preferredLastName',
+      }),
+      domainBuilder.buildSchoolingRegistration({
+        firstName: 'secondRegistration_firstName',
+        middleName: 'secondRegistration_middleName',
+        thirdName: 'secondRegistration_thirdName',
+        lastName: 'secondRegistration_lastName',
+        preferredLastName: 'secondRegistration_preferredLastName',
+      }),
+    ];
+  });
 
   describe('#findMatchingCandidateIdForGivenUser', () => {
-    beforeEach(() => {
-      schoolingRegistrations = [
-        domainBuilder.buildSchoolingRegistration(),
-        domainBuilder.buildSchoolingRegistration(),
-      ];
-      user = {
-        firstName: 'Joe',
-        lastName: 'Poe',
-      };
-    });
+
+    const user = {
+      firstName: 'Joe',
+      lastName: 'Poe',
+    };
 
     context('When schoolingRegistration list is not empty', () => {
 
@@ -256,14 +269,12 @@ describe('Unit | Service | user-reconciliation-service', () => {
   });
 
   describe('#findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser', () => {
+
+    let user;
     let organizationId;
     let schoolingRegistrationRepositoryStub;
 
     beforeEach(() => {
-      schoolingRegistrations = [
-        domainBuilder.buildSchoolingRegistration(),
-        domainBuilder.buildSchoolingRegistration(),
-      ];
       organizationId = domainBuilder.buildOrganization().id;
       schoolingRegistrationRepositoryStub = { findByOrganizationIdAndUserBirthdate: sinon.stub() };
     });
@@ -397,17 +408,16 @@ describe('Unit | Service | user-reconciliation-service', () => {
 
   describe('#createUsernameByUserAndStudentId', () => {
 
+    const user = {
+      firstName: 'fakeFirst-Name',
+      lastName: 'fake LastName',
+      birthdate: '2008-03-01'
+    };
+    const originaldUsername = 'fakefirstname.fakelastname0103';
+
     let userRepository;
-    let originaldUsername;
 
     beforeEach(() => {
-      user = {
-        firstName: 'fakeFirst-Name',
-        lastName: 'fake LastName',
-        birthdate: '2008-03-01'
-      };
-      originaldUsername = 'fakefirstname.fakelastname0103';
-
       userRepository = {
         isUsernameAvailable: sinon.stub()
       };


### PR DESCRIPTION
## :unicorn: Problème
Les tests suivants sortent en erreur de manière non déterminisite sur la CI (pas en local).

```javascript
Unit | Service | user-reconciliation-service
       #findMatchingCandidateIdForGivenUser
         When schoolingRegistration list is not empty
           When one schoolingRegistration matched on names
             When schoolingRegistration found based on his...
               ...middleName:
     AssertionError: expected null to equal 0
```

```javascript
Acceptance | users-controller-find-users 
       GET /users 
         Success case 
           should return a 200 status code with paginated and filtered data:
  
      AssertionError: expected { Object (page, pageSize, ...) } to deeply equal { Object (page, pageSize, ...) } 
      + expected - actual
  
       { 
         "page": 2 
      -  "pageCount": 3 
      +  "pageCount": 2 
         "pageSize": 1 
      -  "rowCount": 3 
      +  "rowCount": 2 
       } 
```

## :robot: Solution
Le faire exécuter par la CI avec des console.log et voir ce qui se passe
Puis corriger

## :rainbow: Remarques
- https://app.circleci.com/pipelines/github/1024pix/pix/12379/workflows/75823e11-743f-4f97-b262-500e652c90c3/jobs/121175
- https://app.circleci.com/pipelines/github/1024pix/pix/12485/workflows/99f2e717-ad5b-49bc-8951-ebf459fb74a0/jobs/121861/steps

## :100: Pour tester
Exécuter la CI plusieurs fois, résultat attendu OK
