### PR TITLE
[FEATURE] Utilisation d'un nouveau template e-mail pour rejoindre une Organisation SCO (PIX-883).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -65,6 +65,7 @@ module.exports = (function() {
         templates: {
           accountCreationTemplateId: process.env.SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID,
           organizationInvitationTemplateId: process.env.SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID,
+          organizationInvitationScoTemplateId: process.env.SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID,
           passwordResetTemplateId: process.env.SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID
         },
       },
@@ -142,7 +143,7 @@ module.exports = (function() {
     config.domain.pixOrga = 'https://orga.pix';
 
     config.mailing.enabled = false;
-    config.mailing.provider = 'mailjet';
+    config.mailing.provider = 'sendinblue';
     config.mailing.mailjet.apiKey = 'test-api-key';
     config.mailing.mailjet.apiSecret = 'test-api-secret';
     config.mailing.mailjet.templates.accountCreationTemplateId = 'test-account-creation-template-id';
@@ -152,6 +153,7 @@ module.exports = (function() {
     config.mailing.sendinblue.apiKey = 'test-api-key';
     config.mailing.sendinblue.templates.accountCreationTemplateId = 'test-account-creation-template-id';
     config.mailing.sendinblue.templates.organizationInvitationTemplateId = 'test-organization-invitation-demand-template-id';
+    config.mailing.sendinblue.templates.organizationInvitationScoTemplateId = 'test-organization-invitation-sco-demand-template-id';
     config.mailing.sendinblue.templates.passwordResetTemplateId = 'test-password-reset-template-id';
 
     config.captcha.enabled = false;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -12,6 +12,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
     redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldFr}/connexion`,
     locale
   };
+
   if (locale === 'fr') {
     variables = {
       homeName: `pix${settings.domain.tldOrg}`,
@@ -76,6 +77,7 @@ function sendOrganizationInvitationEmail({
     redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldFr}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
     locale
   };
+
   if (locale === 'fr') {
     variables = {
       organizationName,
@@ -98,8 +100,53 @@ function sendOrganizationInvitationEmail({
   });
 }
 
+function sendOrganizationInvitationScoEmail({
+  email,
+  organizationName,
+  firstName, lastName,
+  organizationInvitationId,
+  code,
+  locale,
+  tags
+}) {
+  locale = locale ? locale : 'fr-fr';
+
+  let variables = {
+    organizationName,
+    firstName, lastName,
+    pixHomeName: `pix${settings.domain.tldFr}`,
+    pixHomeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+    pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldFr}`,
+    redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldFr}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+    locale
+  };
+
+  if (locale === 'fr') {
+    variables = {
+      organizationName,
+      firstName, lastName,
+      pixHomeName: `pix${settings.domain.tldOrg}`,
+      pixHomeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
+      pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}`,
+      redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
+      locale
+    };
+  }
+
+  return mailer.sendEmail({
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_ORGA_NAME,
+    to: email,
+    subject: 'Accès à votre espace Pix Orga',
+    template: mailer.organizationInvitationScoTemplateId,
+    variables,
+    tags: tags || null
+  });
+}
+
 module.exports = {
   sendAccountCreationEmail,
   sendOrganizationInvitationEmail,
+  sendOrganizationInvitationScoEmail,
   sendResetPasswordDemandEmail,
 };

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -53,6 +53,10 @@ class Mailer extends MailingProvider {
     return mailing[this._providerName].templates.organizationInvitationTemplateId;
   }
 
+  get organizationInvitationScoTemplateId() {
+    return mailing[this._providerName].templates.organizationInvitationScoTemplateId;
+  }
+
 }
 
 module.exports = new Mailer();

--- a/api/sample.env
+++ b/api/sample.env
@@ -157,6 +157,17 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID=
 
 # ID of the template used for generating the e-mail when a user want to
+# join a SCO organization.
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID=
+
+# ID of the template used for generating the e-mail when a user want to
 # generate a new password.
 #
 # If not present when required, the e-mail will not be sent and an error will

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -234,5 +234,53 @@ describe('Unit | Service | MailService', () => {
     });
   });
 
+  describe('#sendOrganizationInvitationScoEmail', () => {
+
+    const fromName = 'Pix Orga - Ne pas répondre';
+
+    const subject = 'Accès à votre espace Pix Orga';
+    const template = 'test-organization-invitation-sco-demand-template-id';
+
+    const organizationName = 'Organization SCO';
+    const firstName = 'FirstName';
+    const lastName = 'LastName';
+    const pixHomeName = 'pix.fr';
+    const pixHomeUrl = 'https://pix.fr';
+    const pixOrgaUrl = 'https://orga.pix.fr';
+    const organizationInvitationId = 1;
+    const code = 'ABCDEFGH01';
+
+    it('should call mail provider with pix-orga url, organization-invitation id, code and null tags', async () => {
+      // given
+      const expectedOptions = {
+        from: senderEmailAddress,
+        fromName,
+        to: userEmailAddress,
+        subject, template,
+        variables: {
+          organizationName,
+          firstName, lastName,
+          pixHomeName,
+          pixHomeUrl,
+          pixOrgaHomeUrl: pixOrgaUrl,
+          locale: 'fr-fr',
+          redirectionUrl: `${pixOrgaUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`
+        },
+        tags: null
+      };
+
+      // when
+      await mailService.sendOrganizationInvitationScoEmail({
+        email: userEmailAddress,
+        organizationName,
+        firstName, lastName,
+        organizationInvitationId, code
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+    });
+  });
+
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Accès simplifié aux espaces Pix Orga SCO, on voudrait utiliser un template e-mail spécifique.
Entre autres, les prénom et nom du futur membre d'une organisation SCO devront apparaitre dans l'e-mail envoyé.

## :robot: Solution
- Créer un nouveau template (qui sera une duplication du template Organisation-Invitation).
- Créer et utiliser la variable d'environnement  qui portera l'ID du template.
- Créer la fonction `mail-service.sendOrganizationInvitationScoEmail()`.

## :rainbow: Remarques
- Ce ticket est le complément d'un autre ticket front/API à venir.

## :100: Pour tester
- Les tests fonctionnels ne pourront être réalisés qu'à la livraison du ticket mentionné ci-dessus.
