### PR TITLE
[FEATURE] Internationalisation de "mes certifications" (PIX-797)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class UserCertificationsDetailHeader extends Component {
+  @service intl;
+  get birthdate() {
+    return this.intl.formatDate(this.args.certification.birthdate, { format: 'LL' });
+  }
+}

--- a/mon-pix/app/controllers/user-certifications.js
+++ b/mon-pix/app/controllers/user-certifications.js
@@ -1,7 +1,10 @@
 import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 @classic
 export default class UserCertificationsController extends Controller {
-  pageTitle = 'Mes certifications';
+  @service intl;
+
+  pageTitle = this.intl.t('page-title.my-certifications');
 }

--- a/mon-pix/app/formats.js
+++ b/mon-pix/app/formats.js
@@ -11,6 +11,11 @@ export default {
       hour: 'numeric',
       minute: 'numeric',
       second: 'numeric'
+    },
+    LL: {
+      day:'numeric',
+      month:'long',
+      year:'numeric'
     }
   },
   number: {

--- a/mon-pix/app/formats.js
+++ b/mon-pix/app/formats.js
@@ -12,6 +12,11 @@ export default {
       minute: 'numeric',
       second: 'numeric'
     },
+    L: {
+      day:'2-digit',
+      month:'2-digit',
+      year:'numeric'
+    },
     LL: {
       day:'numeric',
       month:'long',

--- a/mon-pix/app/styles/components/_certifications-list-item.scss
+++ b/mon-pix/app/styles/components/_certifications-list-item.scss
@@ -142,14 +142,8 @@
   flex-flow: row-reverse nowrap;
   justify-content: left;
 
-  .certifications-list-item__cell-detail-button {
-    font-size: 0.813rem;
-    color: $blue;
-    border: none;
-    background: none;
-  }
-
-  .certifications-list-item__cell-detail-link {
+  div {
+    text-transform: uppercase;
     font-size: 0.813rem;
     color: $blue;
     border: none;

--- a/mon-pix/app/styles/components/_certifications-list-item.scss
+++ b/mon-pix/app/styles/components/_certifications-list-item.scss
@@ -142,12 +142,13 @@
   flex-flow: row-reverse nowrap;
   justify-content: left;
 
-  div {
+  & :first-child {
     text-transform: uppercase;
     font-size: 0.813rem;
     color: $blue;
     border: none;
     background: none;
+    cursor: pointer;
   }
 }
 

--- a/mon-pix/app/styles/components/_certifications-list.scss
+++ b/mon-pix/app/styles/components/_certifications-list.scss
@@ -36,6 +36,10 @@
   @extend .certifications-list__table-row;
 
   font-weight: $font-bold;
+
+  div {
+    text-transform: uppercase;
+  }
 }
 
 .certifications-list__table-header-cell {

--- a/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
+++ b/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
@@ -21,6 +21,7 @@
       font-weight: lighter;
       font-size: 0.8rem;
       letter-spacing: 0.219rem;
+      text-transform: uppercase;
     }
 
     &-pix-score {

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -18,9 +18,7 @@
 
       <div class="certifications-list-item__cell-detail">
         {{#if this.shouldDisplayComment}}
-          <div class="certifications-list-item__cell-detail-button">
-            DÉTAIL
-          </div>
+          <div class="certifications-list-item__cell-detail-button">détail</div>
         {{/if}}
       </div>
     </panel.toggle>
@@ -57,7 +55,7 @@
     </div>
 
     <div class="certifications-list-item__cell-detail">
-      <div class="certifications-list-item__cell-detail-link">VOIR LES RÉSULTATS</div>
+      <div class="certifications-list-item__cell-detail-link">voir les résultats</div>
     </div>
   </LinkTo>
 {{/if}}

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -18,7 +18,7 @@
 
       <div class="certifications-list-item__cell-detail">
         {{#if this.shouldDisplayComment}}
-          <div class="certifications-list-item__cell-detail-button">détail</div>
+          <button>détail</button>
         {{/if}}
       </div>
     </panel.toggle>
@@ -55,7 +55,7 @@
     </div>
 
     <div class="certifications-list-item__cell-detail">
-      <div class="certifications-list-item__cell-detail-link">voir les résultats</div>
+      <a>voir les résultats</a>
     </div>
   </LinkTo>
 {{/if}}

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -8,7 +8,7 @@
 
       <div class="certifications-list-item__cell-double-width">
         <img src="/images/icons/icon-croix.svg" alt="" class="certifications-list-item__cross-img">
-        Certification non obtenue
+        {{t "certifications-list.statuses.fail.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score"></div>
 
@@ -18,7 +18,7 @@
 
       <div class="certifications-list-item__cell-detail">
         {{#if this.shouldDisplayComment}}
-          <button>détail</button>
+          <button>{{t "certifications-list.statuses.fail.action"}}</button>
         {{/if}}
       </div>
     </panel.toggle>
@@ -42,7 +42,7 @@
 
     <div class="certifications-list-item__cell-double-width">
       <img src="/images/icons/icon-check-vert.svg" alt="" class="certifications-list-item__green-check-img">
-      Certification obtenue
+      {{t "certifications-list.statuses.success.title"}}
     </div>
     <div class="certifications-list-item__cell-pix-score">
       <div class="certifications-list-item__pix-score">
@@ -55,7 +55,7 @@
     </div>
 
     <div class="certifications-list-item__cell-detail">
-      <a>voir les résultats</a>
+      <a>{{t "certifications-list.statuses.success.action"}}</a>
     </div>
   </LinkTo>
 {{/if}}
@@ -68,7 +68,7 @@
 
     <div class="certifications-list-item__cell-double-width">
       <img src="/images/sablier.svg" alt="" class="certifications-list-item__hourglass-img">
-      En attente du résultat
+      {{t "certifications-list.statuses.not-published.title"}}
     </div>
     <div class="certifications-list-item__cell-pix-score"></div>
 

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -3,7 +3,7 @@
     <panel.toggle @class="certifications-list-item__row-presentation" @role="tab">
 
       <div class="certifications-list-item__cell">
-        {{moment-format this.certification.date 'DD/MM/YYYY' allow-empty=true}}
+        {{format-date this.certification.date format='L'}}
       </div>
 
       <div class="certifications-list-item__cell-double-width">
@@ -37,7 +37,7 @@
 {{#if this.isPublishedAndValidated}}
   <LinkTo @route="user-certifications.get" @model={{this.certification.id}} class="certifications-list-item__row-presentation">
     <div class="certifications-list-item__cell">
-      {{moment-format this.certification.date 'DD/MM/YYYY' allow-empty=true}}
+      {{format-date this.certification.date format='L'}}
     </div>
 
     <div class="certifications-list-item__cell-double-width">
@@ -63,7 +63,7 @@
 {{#if this.isNotPublished}}
   <div class="certifications-list-item__row-presentation">
     <div class="certifications-list-item__cell">
-      {{moment-format this.certification.date 'DD/MM/YYYY' allow-empty=true}}
+      {{format-date this.certification.date format='L'}}
     </div>
 
     <div class="certifications-list-item__cell-double-width">

--- a/mon-pix/app/templates/components/certifications-list.hbs
+++ b/mon-pix/app/templates/components/certifications-list.hbs
@@ -1,9 +1,9 @@
 <div class="certifications-list__table">
   <div class="certifications-list__table-header">
-    <div class="certifications-list__table-header-cell">DATE</div>
-    <div class="certifications-list__table-header-cell-double-width">STATUT</div>
-    <div class="certifications-list__table-header-cell">SCORE PIX</div>
-    <div class="certifications-list__table-header-cell-certification-center">CENTRE DE CERTIFICATION</div>
+    <div class="certifications-list__table-header-cell">date</div>
+    <div class="certifications-list__table-header-cell-double-width">statut</div>
+    <div class="certifications-list__table-header-cell">score pix</div>
+    <div class="certifications-list__table-header-cell-certification-center">centre de certification</div>
     <div class="certifications-list__table-header-cell"></div>
   </div>
 

--- a/mon-pix/app/templates/components/certifications-list.hbs
+++ b/mon-pix/app/templates/components/certifications-list.hbs
@@ -1,9 +1,9 @@
 <div class="certifications-list__table">
   <div class="certifications-list__table-header">
-    <div class="certifications-list__table-header-cell">date</div>
-    <div class="certifications-list__table-header-cell-double-width">statut</div>
-    <div class="certifications-list__table-header-cell">score pix</div>
-    <div class="certifications-list__table-header-cell-certification-center">centre de certification</div>
+    <div class="certifications-list__table-header-cell">{{t "certifications-list.header.date"}}</div>
+    <div class="certifications-list__table-header-cell-double-width">{{t "certifications-list.header.status"}}</div>
+    <div class="certifications-list__table-header-cell">{{t "certifications-list.header.score"}}</div>
+    <div class="certifications-list__table-header-cell-certification-center">{{t "certifications-list.header.certification-center"}}</div>
     <div class="certifications-list__table-header-cell"></div>
   </div>
 

--- a/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competence.hbs
@@ -1,7 +1,7 @@
 <PixBlock class="user-certifications-detail-competence user-certifications-detail-competence--{{@area.color}}">
   <h3 class="user-certifications-detail-competence__title">
     {{@area.title}}
-    <span class="user-certifications-detail-competence__title--level">niveau</span>
+    <span class="user-certifications-detail-competence__title--level">{{t "certificate.competences.level"}}</span>
   </h3>
 
   {{#each sortedCompetences as |competence index|}}

--- a/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
@@ -1,5 +1,5 @@
 <div class="user-certifications-detail-competences-list">
-  <h2>Compétences certifiées <span>(niveaux sur 5)</span></h2>
+  <h2>{{t "certificate.competences.title"}}<span>{{t "certificate.competences.sub-title"}}</span></h2>
 
   {{#each this.sortedAreas as |area index|}}
 
@@ -8,7 +8,6 @@
   {{/each}}
 
   <p class="user-certifications-detail-competences-list__note">
-  Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil.
-  Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum.
+    {{t "certificate.competences.informations"}}
   </p>
 </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
@@ -1,5 +1,5 @@
 <div class="user-certifications-detail-competences-list">
-  <h2>{{t "certificate.competences.title"}} <span>{{t "certificate.competences.sub-title"}}</span></h2>
+  <h2>{{t "certificate.competences.title"}} <span>{{t "certificate.competences.subtitle"}}</span></h2>
 
   {{#each this.sortedAreas as |area index|}}
 

--- a/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
@@ -1,5 +1,5 @@
 <div class="user-certifications-detail-competences-list">
-  <h2>{{t "certificate.competences.title"}}<span>{{t "certificate.competences.sub-title"}}</span></h2>
+  <h2>{{t "certificate.competences.title"}} <span>{{t "certificate.competences.sub-title"}}</span></h2>
 
   {{#each this.sortedAreas as |area index|}}
 

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -3,21 +3,25 @@
     <UserCertificationsHexagonScore @score={{@certification.pixScore}} />
     <div class="user-certifications-detail-header__info-certificate">
 
-      <h1>Certificat Pix</h1>
+      <h1>{{t "certificate.title"}}</h1>
 
       <p class="user-certifications-detail-header__info-certificate--grey">
-        Délivré le {{moment-format @certification.deliveredAt 'LL' locale='fr' allow-empty=true}}
+        {{t "certificate.issued-on"}}{{moment-format @certification.deliveredAt 'LL' locale='fr' allow-empty=true}}
       </p>
       <p class="user-certifications-detail-header__info-certificate--grey">
-        Certificat valable 3 ans
+        {{t "certificate.validity"}}
       </p>
 
       <p>{{@certification.fullName}}</p>
-      <p>Né(e) le {{moment-format @certification.birthdate 'LL' locale='fr' allow-empty=true}} à {{@certification.birthplace}}</p>
+      <p>
+        {{t "certificate.candidate-birth"}}{{moment-format @certification.birthdate 'LL' locale='fr' allow-empty=true}}{{t "certificate.candidate-birth-at"}}{{@certification.birthplace}}
+      </p>
+
       {{#if @certification.certificationCenter}}
-      <p>Centre de certification : {{@certification.certificationCenter}}</p>
+        <p>{{t "certificate.certification-center"}}{{@certification.certificationCenter}}</p>
       {{/if}}
-      <p>Date de passage : {{moment-format @certification.date 'LL' locale='fr' allow-empty=true}}</p>
+
+      <p>{{t "certificate.exam-date"}}{{moment-format @certification.date 'LL' locale='fr' allow-empty=true}}</p>
 
     </div>
   </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -5,7 +5,7 @@
       <h1>{{t "certificate.title"}}</h1>
 
       <p class="user-certifications-detail-header__info-certificate--grey">
-        {{t "certificate.issued-on"}}{{format-date @certification.deliveredAt format="LL"}}
+        {{t "certificate.issued-on"}} {{format-date @certification.deliveredAt format="LL"}}
       </p>
       <p class="user-certifications-detail-header__info-certificate--grey">
         {{t "certificate.validity"}}
@@ -17,10 +17,10 @@
       </p>
 
       {{#if @certification.certificationCenter}}
-        <p>{{t "certificate.certification-center"}}{{@certification.certificationCenter}}</p>
+        <p>{{t "certificate.certification-center"}} {{@certification.certificationCenter}}</p>
       {{/if}}
 
-      <p>{{t "certificate.exam-date"}}{{format-date @certification.date format="LL"}}</p>
+      <p>{{t "certificate.exam-date"}} {{format-date @certification.date format="LL"}}</p>
 
     </div>
   </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -2,11 +2,10 @@
   <div class="user-certifications-detail-header">
     <UserCertificationsHexagonScore @score={{@certification.pixScore}} />
     <div class="user-certifications-detail-header__info-certificate">
-
       <h1>{{t "certificate.title"}}</h1>
 
       <p class="user-certifications-detail-header__info-certificate--grey">
-        {{t "certificate.issued-on"}}{{moment-format @certification.deliveredAt 'LL' locale='fr' allow-empty=true}}
+        {{t "certificate.issued-on"}}{{format-date @certification.deliveredAt format="LL"}}
       </p>
       <p class="user-certifications-detail-header__info-certificate--grey">
         {{t "certificate.validity"}}
@@ -14,14 +13,14 @@
 
       <p>{{@certification.fullName}}</p>
       <p>
-        {{t "certificate.candidate-birth"}}{{moment-format @certification.birthdate 'LL' locale='fr' allow-empty=true}}{{t "certificate.candidate-birth-at"}}{{@certification.birthplace}}
+        {{t "certificate.candidate-birth-complete" birthdate=birthdate birthplace=@certification.birthplace}}
       </p>
 
       {{#if @certification.certificationCenter}}
         <p>{{t "certificate.certification-center"}}{{@certification.certificationCenter}}</p>
       {{/if}}
 
-      <p>{{t "certificate.exam-date"}}{{moment-format @certification.date 'LL' locale='fr' allow-empty=true}}</p>
+      <p>{{t "certificate.exam-date"}}{{format-date @certification.date format="LL"}}</p>
 
     </div>
   </div>

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,5 +1,5 @@
 {{#if certification.commentForCandidate}}
-  <h2>Observations du jury</h2>
+  <h2>{{t "certificate.jury-title"}}</h2>
   <PixBlock>
     <p class="user-certifications-detail-result__comment-jury">
       {{certification.commentForCandidate}}
@@ -8,7 +8,7 @@
 {{/if}}
 
 {{#if certification.hasCleaCertif}}
-  <h2>Certifié Cléa</h2>
+  <h2>{{t "certificate.clea-title"}}</h2>
   <PixBlock>
     <div class="user-certifications-detail-result__badge-clea">
       <img

--- a/mon-pix/app/templates/components/user-certifications-hexagon-score.hbs
+++ b/mon-pix/app/templates/components/user-certifications-hexagon-score.hbs
@@ -1,7 +1,7 @@
 <div class="user-certification-hexagon-score">
   <div class="user-certification-hexagon-score__content">
-    <p class="user-certification-hexagon-score__content-title">PIX</p>
+    <p class="user-certification-hexagon-score__content-title">{{t "common.pix"}}</p>
     <p class="user-certification-hexagon-score__content-pix-score">{{@score}}</p>
-    <p class="user-certification-hexagon-score__content-certified">certifiés</p>
+    <p class="user-certification-hexagon-score__content-certified">{{t "certificate.hexagon-score.certified"}}</p>
   </div>
 </div>

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -3,7 +3,7 @@
   <PixBlock>
     <LinkTo @route="user-certifications" class="link__return-to">
       <span aria-hidden="true" class="icon-button"> {{fa-icon 'arrow-left'}} </span>
-      Retour à mes certifications
+      {{t "certificate.back-link"}}
     </LinkTo>
     <UserCertificationsDetailHeader @certification={{@model}} />
   </PixBlock>

--- a/mon-pix/app/templates/user-certifications/index.hbs
+++ b/mon-pix/app/templates/user-certifications/index.hbs
@@ -1,5 +1,5 @@
 <div class="user-certifications-page__container">
-    <h1 class="user-certifications-page__title">Mes Certifications</h1>
+    <h1 class="user-certifications-page__title">{{t "certifications-list.title"}}</h1>
 
     <UserCertificationsPanel @certifications={{@model}} />
 </div>

--- a/mon-pix/tests/helpers/setup-intl.js
+++ b/mon-pix/tests/helpers/setup-intl.js
@@ -1,6 +1,7 @@
 
-export default function setupIntl() {
+export default function setupIntl(locale = ['fr']) {
   beforeEach(function() {
     this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale(locale);
   });
 }

--- a/mon-pix/tests/integration/components/certifications-list-item-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item-test.js
@@ -11,6 +11,15 @@ describe('Integration | Component | certifications list item', function() {
   setupIntl();
 
   let certification;
+  const PUBLISH_CLASS = '.certifications-list-item__published-item';
+  const CERTIFICATION_CELL_SELECTOR = '.certifications-list-item__cell';
+  const STATUS_SELECTOR = '.certifications-list-item__cell-double-width';
+  const IMG_FOR_STATUS_SELECTOR = 'img.certifications-list-item__cross-img';
+  const PIX_SCORE_CELL_SELECTOR = '.certifications-list-item__pix-score';
+  const DETAIL_SELECTOR = '.certifications-list-item__cell-detail';
+  const REJECTED_DETAIL_SELECTOR = `${DETAIL_SELECTOR} button`;
+  const VALIDATED_DETAIL_SELECTOR = `${DETAIL_SELECTOR} a`;
+  const COMMENT_CELL_SELECTOR = '.certifications-list-item__row-comment-cell';
 
   it('renders', async function() {
     await render(hbs`{{certifications-list-item certification=certification}}`);
@@ -42,7 +51,7 @@ describe('Integration | Component | certifications list item', function() {
 
     it('should show en attente de résultat', function() {
       expect(find('img.certifications-list-item__hourglass-img')).to.exist;
-      expect(find('.certifications-list-item').textContent).to.include('En attente du résultat');
+      expect(find(STATUS_SELECTOR).textContent).to.include('En attente du résultat');
     });
   });
 
@@ -68,23 +77,24 @@ describe('Integration | Component | certifications list item', function() {
 
       // then
       it('should render a certifications-list-item__published-item div', function() {
-        expect(find('.certifications-list-item__published-item')).to.exist;
+        expect(find(PUBLISH_CLASS)).to.exist;
       });
 
       it('should show Certification non obtenue', function() {
-        expect(find('img.certifications-list-item__cross-img')).to.exist;
-        expect(find('.certifications-list-item').textContent).to.include('Certification non obtenue');
+        expect(find(IMG_FOR_STATUS_SELECTOR)).to.exist;
+        expect(find(STATUS_SELECTOR).textContent).to.include('Certification non obtenue');
       });
 
       it('should not show Détail in last column', function() {
-        expect(find('.certifications-list-item__cell-detail-button')).to.not.exist;
+        expect(find(REJECTED_DETAIL_SELECTOR)).to.not.exist;
       });
 
       it('should not show comment for candidate panel when clicked on row', async function() {
+        // when
+        await click(CERTIFICATION_CELL_SELECTOR);
 
-        await click('.certifications-list-item__cell');
-
-        expect(find('.certifications-list-item__row-comment-cell')).to.not.exist;
+        // then
+        expect(find(COMMENT_CELL_SELECTOR)).to.not.exist;
       });
     });
 
@@ -111,25 +121,25 @@ describe('Integration | Component | certifications list item', function() {
 
       // then
       it('should render a certifications-list-item__published-item div', function() {
-        expect(find('.certifications-list-item__published-item')).to.exist;
+        expect(find(PUBLISH_CLASS)).to.exist;
       });
 
       it('should show Certification non obtenue', function() {
-        expect(find('img.certifications-list-item__cross-img')).to.exist;
-        expect(find('.certifications-list-item').textContent).to.include('Certification non obtenue');
+        expect(find(IMG_FOR_STATUS_SELECTOR)).to.exist;
+        expect(find(STATUS_SELECTOR).textContent).to.include('Certification non obtenue');
       });
 
       it('should show Détail in last column', function() {
-        expect(find('.certifications-list-item__cell-detail-button')).to.exist;
-        expect(find('.certifications-list-item__cell-detail-button').textContent).to.include('détail');
+        expect(find(REJECTED_DETAIL_SELECTOR)).to.exist;
+        expect(find(REJECTED_DETAIL_SELECTOR).textContent).to.include('détail');
       });
 
       it('should show comment for candidate panel when clicked on row', async function() {
 
-        await click('.certifications-list-item__cell');
+        await click(CERTIFICATION_CELL_SELECTOR);
 
-        expect(find('.certifications-list-item__row-comment-cell')).to.exist;
-        expect(find('.certifications-list-item__row-comment-cell').textContent).to.include(commentForCandidate);
+        expect(find(COMMENT_CELL_SELECTOR)).to.exist;
+        expect(find(COMMENT_CELL_SELECTOR).textContent).to.include(commentForCandidate);
       });
     });
   });
@@ -154,22 +164,22 @@ describe('Integration | Component | certifications list item', function() {
 
     // then
     it('should render certifications-list-item__published-item with a link inside', function() {
-      expect(find('.certifications-list-item__published-item a')).to.exist;
+      expect(find(`${PUBLISH_CLASS} a`)).to.exist;
     });
 
     it('should show Certification obtenue', function() {
       expect(find('img.certifications-list-item__green-check-img')).to.exist;
-      expect(find('.certifications-list-item').textContent).to.include('Certification obtenue');
+      expect(find(STATUS_SELECTOR).textContent).to.include('Certification obtenue');
     });
 
     it('should show the Pix Score', function() {
-      expect(find('.certifications-list-item__pix-score')).to.exist;
-      expect(find('.certifications-list-item__pix-score').textContent).to.include('231');
+      expect(find(PIX_SCORE_CELL_SELECTOR)).to.exist;
+      expect(find(PIX_SCORE_CELL_SELECTOR).textContent).to.include('231');
     });
 
     it('should show link to certification page in last column', function() {
-      expect(find('.certifications-list-item__cell-detail-link')).to.exist;
-      expect(find('.certifications-list-item__cell-detail-link').textContent).to.include('résultats');
+      expect(find(VALIDATED_DETAIL_SELECTOR)).to.exist;
+      expect(find(VALIDATED_DETAIL_SELECTOR).textContent).to.include('résultats');
     });
   });
 });

--- a/mon-pix/tests/integration/components/certifications-list-item-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item-test.js
@@ -4,9 +4,11 @@ import { setupRenderingTest } from 'ember-mocha';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Integration | Component | certifications list item', function() {
   setupRenderingTest();
+  setupIntl();
 
   let certification;
 
@@ -119,7 +121,7 @@ describe('Integration | Component | certifications list item', function() {
 
       it('should show Détail in last column', function() {
         expect(find('.certifications-list-item__cell-detail-button')).to.exist;
-        expect(find('.certifications-list-item__cell-detail-button').textContent).to.include('DÉTAIL');
+        expect(find('.certifications-list-item__cell-detail-button').textContent).to.include('détail');
       });
 
       it('should show comment for candidate panel when clicked on row', async function() {
@@ -167,7 +169,7 @@ describe('Integration | Component | certifications list item', function() {
 
     it('should show link to certification page in last column', function() {
       expect(find('.certifications-list-item__cell-detail-link')).to.exist;
-      expect(find('.certifications-list-item__cell-detail-link').textContent).to.include('RÉSULTATS');
+      expect(find('.certifications-list-item__cell-detail-link').textContent).to.include('résultats');
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
@@ -5,9 +5,11 @@ import { describe, it } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Integration | Component | user-certifications-detail-competences-list', function() {
   setupRenderingTest();
+  setupIntl();
 
   let resultCompetenceTree;
   const PARENT_SELECTOR = '.user-certifications-detail-competences-list';

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -4,9 +4,11 @@ import { setupRenderingTest } from 'ember-mocha';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Integration | Component | user certifications detail header', function() {
   setupRenderingTest();
+  setupIntl();
 
   let certification;
   const PARENT_SELECTOR = '.user-certifications-detail-header';

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -38,7 +38,15 @@
     "exam-date": "Lorem ipsum",
     "hexagon-score": {
       "certified": "Lorem ipsum"
-    }
+    },
+    "competences": {
+      "title": "Lorem ipsum",
+      "sub-title": "Lorem ipsum",
+      "level": "Lorem ipsum",
+      "informations": "Lorem ipsum"
+    },
+    "jury-title": "Lorem ipsum",
+    "clea-title": "Lorem ipsum"
   },
 
   "certifications-list": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -27,6 +27,29 @@
     "internal-server-error": "The service is temporarily unavailable. Please try again later."
   },
 
+  "certifications-list": {
+    "title": "Lorem ipsum",
+    "header": {
+      "date": "Lorem ipsum",
+      "status": "Lorem ipsum",
+      "score": "Lorem ipsum",
+      "certification-center": "Lorem ipsum"
+    },
+    "statuses": {
+      "success": {
+        "title": "Lorem ipsum",
+        "action": "Lorem ipsum"
+      },
+      "fail": {
+        "title": "Lorem ipsum",
+        "action": "Lorem ipsum"
+      },
+      "not-published": {
+        "title": "Lorem ipsum"
+      }
+    }
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Sign in"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -18,7 +18,8 @@
   "page-title": {
     "signin": "Sign in",
     "signup": "Sign up",
-    "suffix": "Pix"
+    "suffix": "Pix",
+    "my-certifications": "Lorem Ipsum"
   },
 
   "api-error-messages": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -41,7 +41,7 @@
     },
     "competences": {
       "title": "Lorem ipsum",
-      "sub-title": "Lorem ipsum",
+      "subtitle": "Lorem ipsum",
       "level": "Lorem ipsum",
       "informations": "Lorem ipsum"
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -32,8 +32,7 @@
     "title": "Lorem ipsum",
     "issued-on": "Lorem ipsum",
     "validity": "Lorem ipsum",
-    "candidate-birth": "Lorem ipsum",
-    "candidate-birth-at": "at",
+    "candidate-birth-complete": "Lorem ipsum",
     "certification-center": "Lorem ipsum",
     "exam-date": "Lorem ipsum",
     "hexagon-score": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -27,6 +27,20 @@
     "internal-server-error": "The service is temporarily unavailable. Please try again later."
   },
 
+  "certificate": {
+    "back-link": "Lorem ipsum",
+    "title": "Lorem ipsum",
+    "issued-on": "Lorem ipsum",
+    "validity": "Lorem ipsum",
+    "candidate-birth": "Lorem ipsum",
+    "candidate-birth-at": "at",
+    "certification-center": "Lorem ipsum",
+    "exam-date": "Lorem ipsum",
+    "hexagon-score": {
+      "certified": "Lorem ipsum"
+    }
+  },
+
   "certifications-list": {
     "title": "Lorem ipsum",
     "header": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -37,7 +37,15 @@
     "exam-date": "Date de passage : ",
     "hexagon-score": {
       "certified": "certifiés"
-    }
+    },
+    "competences": {
+      "title": "Compétences certifiées ",
+      "sub-title": "(niveaux sur 5)",
+      "level": "niveau",
+      "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum."
+    },
+    "jury-title": "Observations du jury",
+    "clea-title": "Certifié Cléa"
   },
 
   "certifications-list": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -31,8 +31,7 @@
     "title": "Certificat Pix",
     "issued-on": "Délivré le ",
     "validity": "Certificat valable 3 ans",
-    "candidate-birth": "Né(e) le ",
-    "candidate-birth-at": " à ",
+    "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
     "certification-center": "Centre de certification : ",
     "exam-date": "Date de passage : ",
     "hexagon-score": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -26,6 +26,20 @@
     "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement."
   },
 
+  "certificate": {
+    "back-link": "Retour à mes certifications",
+    "title": "Certificat Pix",
+    "issued-on": "Délivré le ",
+    "validity": "Certificat valable 3 ans",
+    "candidate-birth": "Né(e) le ",
+    "candidate-birth-at": " à ",
+    "certification-center": "Centre de certification : ",
+    "exam-date": "Date de passage : ",
+    "hexagon-score": {
+      "certified": "certifiés"
+    }
+  },
+
   "certifications-list": {
     "title": "Mes Certifications",
     "header": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -25,6 +25,30 @@
     "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
     "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement."
   },
+
+  "certifications-list": {
+    "title": "Mes Certifications",
+    "header": {
+      "date": "date",
+      "status": "statut",
+      "score": "score pix",
+      "certification-center": "centre de certification"
+    },
+    "statuses": {
+      "success": {
+        "title": "Certification obtenue",
+        "action": "voir les résultats"
+      },
+      "fail": {
+        "title": "Certification non obtenue",
+        "action": "détail"
+      },
+      "not-published": {
+        "title": "En attente du résultat"
+      }
+    }
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Je me connecte"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -18,7 +18,8 @@
   "page-title": {
     "signin": "Connexion",
     "signup": "Inscription",
-    "suffix": "Pix"
+    "suffix": "Pix",
+    "my-certifications": "Mes certifications"
   },
   "api-error-messages": {
     "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -39,10 +39,10 @@
       "certified": "certifiés"
     },
     "competences": {
-      "title": "Compétences certifiées",
-      "sub-title": "(niveaux sur 5)",
+      "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum.",
       "level": "niveau",
-      "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum."
+      "sub-title": "(niveaux sur 5)",
+      "title": "Compétences certifiées"
     },
     "jury-title": "Observations du jury",
     "clea-title": "Certifié Cléa"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -41,7 +41,7 @@
     "competences": {
       "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum.",
       "level": "niveau",
-      "sub-title": "(niveaux sur 5)",
+      "subtitle": "(niveaux sur 5)",
       "title": "Compétences certifiées"
     },
     "jury-title": "Observations du jury",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -29,16 +29,16 @@
   "certificate": {
     "back-link": "Retour à mes certifications",
     "title": "Certificat Pix",
-    "issued-on": "Délivré le ",
+    "issued-on": "Délivré le",
     "validity": "Certificat valable 3 ans",
     "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
-    "certification-center": "Centre de certification : ",
-    "exam-date": "Date de passage : ",
+    "certification-center": "Centre de certification :",
+    "exam-date": "Date de passage :",
     "hexagon-score": {
       "certified": "certifiés"
     },
     "competences": {
-      "title": "Compétences certifiées ",
+      "title": "Compétences certifiées",
       "sub-title": "(niveaux sur 5)",
       "level": "niveau",
       "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 640 pix au maximum."


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'internationalisation de PIX, on souhaite pouvoir voir la page "mes certifications" en plusieurs langues

## :robot: Solution
On deplace toutes les chaines de caractères des templates vers le fichiers de traduction d'_ember-intl_

## :100: Pour tester
Aller sur les certifications et voir que l'affichage se fait correctement. On peut modifier la variable d'environnement pour changer de langue mais le fichier en anglais sera fait par des professionnels
