### PR TITLE
[ORGA] Mettre à jour le lien de la documentation pour les organisation de type SCO. (Pix-817)

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -8,7 +8,7 @@ export default class SidebarMenu extends Component {
   @computed('currentUser.organization')
   get documentationUrl() {
     if (this.currentUser.isSCOManagingStudents) {
-      return 'https://bit.ly/ressourcespixorga';
+      return 'https://cloud.pix.fr/s/rWcNFSgdnnNSdqF';
     }
 
     if (this.currentUser.organization.isPro) {

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     await render(hbs`<SidebarMenu />`);
 
     // then
-    assert.dom('a[href="https://bit.ly/ressourcespixorga"]').exists();
+    assert.dom('a[href="https://cloud.pix.fr/s/rWcNFSgdnnNSdqF"]').exists();
   });
 
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le lien de la documentation pour les orga SCO is managing Student pointe vers un sous-dossier d’un espace partagé en public. Or, il doit contenir des docs qui ne doivent pas être partagés en mode public.

## :robot: Solution
Changer le lien de la documentation.


## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier qu'on a le bon lien