### PR TITLE
[FEATURE] Ne pas afficher le champ "Réponse" sur la page de résultat pour les challenges QROC sans réponse(PIX-902).

### DIFF
--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -39,6 +39,18 @@ const TEXT_FOR_RESULT = {
     tooltip: 'Temps dépassé'
   },
 
+  okAutoReply: {
+    status: 'ok',
+    title: 'Vous avez réussi l’épreuve',
+    tooltip: 'Épreuve réussie'
+  },
+
+  koAutoReply: {
+    status: 'ko',
+    title: 'Vous n’avez pas réussi l’épreuve',
+    tooltip: 'Épreuve non réussie'
+  },
+
   default: {
     status: 'default',
     title: '',
@@ -69,10 +81,18 @@ export default class ComparisonWindow extends Component {
   @equal('answer.challenge.type', 'QROCM-dep')
   isAssessmentChallengeTypeQrocmDep;
 
+  @equal('answer.challenge.autoReply', true)
+  isAutoReply;
+
+  @computed('answer.challenge.autoReply')
+  get answerSuffix() {
+    return this.isAutoReply ? 'AutoReply' : '';
+  }
+
   @computed('answer.result')
   get resultItem() {
     let resultItem = TEXT_FOR_RESULT['default'];
-    const answerStatus = this.answer.result;
+    const answerStatus = `${this.answer.result}${this.answerSuffix}`;
 
     if (answerStatus && (answerStatus in TEXT_FOR_RESULT)) {
       resultItem = TEXT_FOR_RESULT[answerStatus];

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -17,13 +17,13 @@ const TEXT_FOR_RESULT = {
 
   ko: {
     status: 'ko',
-    title: 'Vous n\'avez pas la bonne réponse',
+    title: 'Vous n’avez pas la bonne réponse',
     tooltip: 'Réponse incorrecte'
   },
 
   aband: {
     status: 'aband',
-    title: 'Vous n\'avez pas donné de réponse',
+    title: 'Vous n’avez pas donné de réponse',
     tooltip: 'Sans réponse'
   },
 
@@ -105,3 +105,4 @@ export default class ComparisonWindow extends Component {
     return resultIconUrl(this.resultItem.status);
   }
 }
+

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -44,6 +44,12 @@ const TEXT_FOR_RESULT = {
     tooltip: 'Épreuve non réussie'
   },
 
+  abandAutoReply: {
+    status: 'aband',
+    title: 'Vous avez passé l’épreuve',
+    tooltip: 'Épreuve passée'
+  },
+
   default: {
     status: 'default',
     title: '',

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -1,12 +1,5 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
 import resultIconUrl from 'mon-pix/utils/result-icon-url';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 
 const TEXT_FOR_RESULT = {
   ok: {
@@ -58,41 +51,42 @@ const TEXT_FOR_RESULT = {
   }
 };
 
-@classic
 export default class ComparisonWindow extends Component {
-  answer = null;
-  index = null;
+  get isAssessmentChallengeTypeQroc() {
+    return this.args.answer.challenge.get('type') === 'QROC';
+  }
 
-  @equal('answer.challenge.type', 'QROC')
-  isAssessmentChallengeTypeQroc;
+  get isAssessmentChallengeTypeQcm() {
+    return this.args.answer.challenge.get('type') === 'QCM';
+  }
 
-  @equal('answer.challenge.type', 'QCM')
-  isAssessmentChallengeTypeQcm;
+  get isAssessmentChallengeTypeQcu() {
+    return this.args.answer.challenge.get('type') === 'QCU';
+  }
 
-  @equal('answer.challenge.type', 'QCU')
-  isAssessmentChallengeTypeQcu;
+  get isAssessmentChallengeTypeQrocm() {
+    return this.args.answer.challenge.get('type') === 'QROCM';
+  }
 
-  @equal('answer.challenge.type', 'QROCM')
-  isAssessmentChallengeTypeQrocm;
+  get isAssessmentChallengeTypeQrocmInd() {
+    return this.args.answer.challenge.get('type') === 'QROCM-ind';
+  }
 
-  @equal('answer.challenge.type', 'QROCM-ind')
-  isAssessmentChallengeTypeQrocmInd;
+  get isAssessmentChallengeTypeQrocmDep() {
+    return this.args.answer.challenge.get('type') === 'QROCM-dep';
+  }
 
-  @equal('answer.challenge.type', 'QROCM-dep')
-  isAssessmentChallengeTypeQrocmDep;
+  get isAutoReply() {
+    return this.args.answer.challenge.get('autoReply');
+  }
 
-  @equal('answer.challenge.autoReply', true)
-  isAutoReply;
-
-  @computed('answer.challenge.autoReply')
   get answerSuffix() {
     return this.isAutoReply ? 'AutoReply' : '';
   }
 
-  @computed('answer.result')
   get resultItem() {
     let resultItem = TEXT_FOR_RESULT['default'];
-    const answerStatus = `${this.answer.result}${this.answerSuffix}`;
+    const answerStatus = `${this.args.answer.result}${this.answerSuffix}`;
 
     if (answerStatus && (answerStatus in TEXT_FOR_RESULT)) {
       resultItem = TEXT_FOR_RESULT[answerStatus];
@@ -100,7 +94,6 @@ export default class ComparisonWindow extends Component {
     return resultItem;
   }
 
-  @computed('resultItem')
   get resultItemIcon() {
     return resultIconUrl(this.resultItem.status);
   }

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -41,7 +41,7 @@
             <QcuSolutionPanel @challenge={{answer.challenge}} @answer={{answer}} @solution={{answer.correction.solution}} />
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQroc}}
+          {{#if (and isAssessmentChallengeTypeQroc (not isAutoReply))}}
             <div class="comparison-window__corrected-answers--qroc">
               <QrocSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} />
             </div>

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -1,6 +1,6 @@
-<PixModal @class="comparison-window-modal" @onClose={{closeComparisonWindow}}>
+<PixModal @class="comparison-window-modal" @onClose={{@closeComparisonWindow}}>
 
-  <div class="pix-modal__close-link" aria-label="Fermer" {{action (action closeComparisonWindow)}}>
+  <div class="pix-modal__close-link" aria-label="Fermer" {{action (action @closeComparisonWindow)}}>
     <span>Fermer</span>
     <FaIcon @icon="times-circle" class="logged-user-menu__icon"></FaIcon>
   </div>
@@ -9,12 +9,12 @@
 
     <div class="pix-modal-header comparison-window-header">
       <div class="comparison-window__title">
-        <div title="{{resultItem.tooltip}}">
-          <img class="comparison-window__result-icon comparison-window__result-icon--{{resultItem.status}}"
-               src={{resultItemIcon}} alt={{resultItem.tooltip}}>
+        <div title="{{this.resultItem.tooltip}}">
+          <img class="comparison-window__result-icon comparison-window__result-icon--{{this.resultItem.status}}"
+               src={{this.resultItemIcon}} alt={{this.resultItem.tooltip}}>
         </div>
       </div>
-      <div class="comparison-window__title-text">{{resultItem.title}}</div>
+      <div class="comparison-window__title-text">{{this.resultItem.title}}</div>
     </div>
 
     <div class="comparison-window--content">
@@ -23,48 +23,48 @@
 
         <div class="rounded-panel comparison-window__instruction">
           <div class="rounded-panel__row ">
-            <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{answer.challenge.instruction}} />
+            <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{@answer.challenge.instruction}} />
           </div>
 
-         {{#if answer.challenge.illustrationUrl}}
+         {{#if @answer.challenge.illustrationUrl}}
             <div class="rounded-panel__row challenge-statement__illustration-section">
-              <ChallengeIllustration @src={{answer.challenge.illustrationUrl}} @alt={{answer.challenge.illustrationAlt}} />
+              <ChallengeIllustration @src={{@answer.challenge.illustrationUrl}} @alt={{@answer.challenge.illustrationAlt}} />
             </div>
          {{/if}}
         </div>
         <div class="comparison-window__corrected-answers">
-          {{#if isAssessmentChallengeTypeQcm}}
-            <QcmSolutionPanel @challenge={{answer.challenge}} @answer={{answer}} @solution={{answer.correction.solution}} />
+          {{#if this.isAssessmentChallengeTypeQcm}}
+            <QcmSolutionPanel @challenge={{@answer.challenge}} @answer={{@answer}} @solution={{@answer.correction.solution}} />
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQcu}}
-            <QcuSolutionPanel @challenge={{answer.challenge}} @answer={{answer}} @solution={{answer.correction.solution}} />
+          {{#if this.isAssessmentChallengeTypeQcu}}
+            <QcuSolutionPanel @challenge={{@answer.challenge}} @answer={{@answer}} @solution={{@answer.correction.solution}} />
           {{/if}}
 
-          {{#if (and isAssessmentChallengeTypeQroc (not isAutoReply))}}
+          {{#if (and this.isAssessmentChallengeTypeQroc (not this.isAutoReply))}}
             <div class="comparison-window__corrected-answers--qroc">
-              <QrocSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} />
+              <QrocSolutionPanel @answer={{@answer}} @solution={{@answer.correction.solution}} />
             </div>
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQrocmInd}}
+          {{#if this.isAssessmentChallengeTypeQrocmInd}}
             <div class="comparison-window__corrected-answers--qrocm">
-              <QrocmIndSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} @challenge={{answer.challenge}} />
+              <QrocmIndSolutionPanel @answer={{@answer}} @solution={{@answer.correction.solution}} @challenge={{@answer.challenge}} />
             </div>
           {{/if}}
 
-          {{#if isAssessmentChallengeTypeQrocmDep}}
+          {{#if this.isAssessmentChallengeTypeQrocmDep}}
             <div class="comparison-window__corrected-answers--qrocm">
-              <QrocmDepSolutionPanel @answer={{answer}} @solution={{answer.correction.solution}} @challenge={{answer.challenge}} />
+              <QrocmDepSolutionPanel @answer={{@answer}} @solution={{@answer.correction.solution}} @challenge={{@answer.challenge}} />
             </div>
           {{/if}}
         </div>
 
-        {{#if answer.isResultNotOk}}
-          {{#if answer.correction.noHintsNorTutorialsAtAll }}
+        {{#if @answer.isResultNotOk}}
+          {{#if @answer.correction.noHintsNorTutorialsAtAll}}
             <div class="comparison-windows__default-message-container">
               <div class="comparison-windows__default-message-picto-container">
-                <img src="{{rootURL}}/images/comparison-window/icon-tuto.svg"
+                <img src="{{this.rootURL}}/images/comparison-window/icon-tuto.svg"
                     alt=""
                     class="comparison-windows__default-message-picto">
               </div>
@@ -73,15 +73,15 @@
               </div>
             </div>
           {{else}}
-            <TutorialPanel @hint={{answer.correction.hint}} @tutorials={{answer.correction.tutorials}} />
+            <TutorialPanel @hint={{@answer.correction.hint}} @tutorials={{@answer.correction.tutorials}} />
           {{/if}}
         {{/if}}
-        <LearningMorePanel @learningMoreTutorials={{answer.correction.learningMoreTutorials}} />
+        <LearningMorePanel @learningMoreTutorials={{@answer.correction.learningMoreTutorials}} />
       </div>
 
       <div class="pix-modal-footer">
         <div class="comparison-window__feedback-panel">
-          <FeedbackPanel @assessment={{answer.assessment}} @challenge={{answer.challenge}} @context="comparison-window" @answer={{answer}} @isFormOpened={{true}} />
+          <FeedbackPanel @assessment={{@answer.assessment}} @challenge={{@answer.challenge}} @context="comparison-window" @answer={{@answer}} @isFormOpened={{true}} />
         </div>
       </div>
     </div>

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -136,7 +136,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await click('.result-item__correction-button');
 
       // then
-      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcmChallenge.instruction);
 
       const goodAnswer = findAll('.qcm-proposal-label__oracle')[0];

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -134,7 +134,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await click('.result-item__correction-button');
 
       // then
-      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
 
       const goodAnswer = findAll('.qcu-proposal-label__oracle')[0];

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -154,7 +154,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await click('.result-item__correction-button');
 
         // then
-        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
 
         const goodAnswer = find('.correction-qroc-box__solution');
@@ -329,7 +329,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await click('.result-item__correction-button');
 
         // then
-        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
 
         const goodAnswer = find('.correction-qroc-box__solution');

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -154,7 +154,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       await click(findAll('.result-item__correction-button')[0]);
 
       // then
-      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocmDepChallenge.instruction);
 
       const goodAnswers = find('.correction-qrocm__solution-text');
@@ -181,7 +181,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       await click(findAll('.result-item__correction-button')[1]);
 
       // then
-      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n\'avez pas la bonne réponse');
+      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocmIndChallenge.instruction);
 
       const goodAnswers = findAll('.correction-qrocm__solution-text');

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -82,9 +82,9 @@ describe('Integration | Component | comparison-window', function() {
       expect(find('.comparison-window__corrected-answers--qroc')).to.not.exist;
     });
 
-    it('should render corrected answers when challenge type is QROC', async function() {
+    it('should render corrected answers when challenge type is QROC and challenge is not autoReply', async function() {
       // given
-      challenge = EmberObject.create({ type: 'QROC' });
+      challenge = EmberObject.create({ type: 'QROC', autoReply: false });
       answer.set('challenge', challenge);
 
       // when
@@ -92,6 +92,16 @@ describe('Integration | Component | comparison-window', function() {
 
       // then
       expect(find('.comparison-window__corrected-answers--qroc')).to.exist;
+    });
+
+    it('should not render corrected answers when challenge type is QROC and challenge is autoReply', async function() {
+      // given
+      challenge = EmberObject.create({ type: 'QROC', autoReply: true });
+      answer.set('challenge', challenge);
+      // when
+      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      // then
+      expect(find('.qcm-solution-panel')).to.not.exist;
     });
 
     it('should render corrected answers when challenge type is QROCM-ind', async function() {

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -39,7 +39,7 @@ describe('Integration | Component | comparison-window', function() {
 
     it('renders', async function() {
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.pix-modal-overlay')).to.exist;
@@ -51,7 +51,7 @@ describe('Integration | Component | comparison-window', function() {
       challenge.set('illustrationAlt', 'texte alternatif');
 
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.challenge-illustration__loaded-image').src).to.contains(challenge.illustrationUrl);
@@ -60,7 +60,7 @@ describe('Integration | Component | comparison-window', function() {
 
     it('should render challenge result in the header', async function() {
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.comparison-window-header')).to.exist;
@@ -69,7 +69,7 @@ describe('Integration | Component | comparison-window', function() {
 
     it('should render challenge instruction', async function() {
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.comparison-window__instruction')).to.exist;
@@ -77,7 +77,7 @@ describe('Integration | Component | comparison-window', function() {
 
     it('should not render corrected answers when challenge has no type', async function() {
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
       // then
       expect(find('.comparison-window__corrected-answers--qroc')).to.not.exist;
     });
@@ -88,7 +88,7 @@ describe('Integration | Component | comparison-window', function() {
       answer.set('challenge', challenge);
 
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.comparison-window__corrected-answers--qroc')).to.exist;
@@ -99,7 +99,7 @@ describe('Integration | Component | comparison-window', function() {
       challenge = EmberObject.create({ type: 'QROC', autoReply: true });
       answer.set('challenge', challenge);
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
       // then
       expect(find('.qcm-solution-panel')).to.not.exist;
     });
@@ -110,7 +110,7 @@ describe('Integration | Component | comparison-window', function() {
       correction.set('solution',  '');
       answer.set('challenge', challenge);
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
       // then
       expect(find('.comparison-window__corrected-answers--qrocm')).to.exist;
     });
@@ -120,14 +120,14 @@ describe('Integration | Component | comparison-window', function() {
       challenge = EmberObject.create({ type: 'QCM' });
       answer.set('challenge', challenge);
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
       // then
       expect(find('.qcm-solution-panel')).to.exist;
     });
 
     it('should render a feedback panel already opened',async  function() {
       //when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       //then
       expect(find('.comparison-window__feedback-panel')).to.exist;
@@ -151,7 +151,7 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
         // then
         expect(find(`.comparison-window__result-icon--${data.status}`)).to.exist;
@@ -165,7 +165,7 @@ describe('Integration | Component | comparison-window', function() {
       correction.set('hint', 'Conseil : mangez des épinards.');
 
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.tutorial-panel')).to.contain.text('Conseil : mangez des épinards.');
@@ -178,7 +178,7 @@ describe('Integration | Component | comparison-window', function() {
       });
 
       // when
-      await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+      await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
       // then
       expect(find('.learning-more-panel__container')).to.exist;
@@ -193,7 +193,7 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
         // then
         expect(find('.tutorial-panel')).to.not.exist;
@@ -211,7 +211,7 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
         // then
         expect(find('.comparison-windows__default-message-container')).to.exist;
@@ -229,7 +229,7 @@ describe('Integration | Component | comparison-window', function() {
         });
 
         // when
-        await render(hbs`{{comparison-window answer=answer closeComparisonWindow=closeComparisonWindow}}`);
+        await render(hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`);
 
         // then
         expect(find('.tutorial-panel')).to.exist;

--- a/mon-pix/tests/unit/components/comparison-window-test.js
+++ b/mon-pix/tests/unit/components/comparison-window-test.js
@@ -243,5 +243,18 @@ describe('Unit | Component | comparison-window', function() {
       _assertResultItemTitle(resultItem, 'Vous avez réussi l’épreuve');
       _assertResultItemTooltip(resultItem, 'Épreuve réussie');
     });
+
+    it('should return adapted title and tooltip when result is "aband" and challenge is auto validated', function() {
+      // given
+      answer.set('result', 'aband');
+      answer.set('challenge', challengeQrocWithAutoReply);
+
+      // when
+      resultItem = component.resultItem;
+
+      // then
+      _assertResultItemTitle(resultItem, 'Vous avez passé l’épreuve');
+      _assertResultItemTooltip(resultItem, 'Épreuve passée');
+    });
   });
 });

--- a/mon-pix/tests/unit/components/comparison-window-test.js
+++ b/mon-pix/tests/unit/components/comparison-window-test.js
@@ -112,7 +112,6 @@ describe('Unit | Component | comparison-window', function() {
       const isAssessmentChallengeTypeQrocmDep = component.get('isAssessmentChallengeTypeQrocmDep');
       // then
       expect(isAssessmentChallengeTypeQrocmDep).to.be.false;
-
     });
 
   });
@@ -176,7 +175,7 @@ describe('Unit | Component | comparison-window', function() {
       resultItem = component.get('resultItem');
 
       // then
-      _assertResultItemTitle(resultItem, 'Vous n\'avez pas la bonne réponse');
+      _assertResultItemTitle(resultItem, 'Vous n’avez pas la bonne réponse');
       _assertResultItemTooltip(resultItem, 'Réponse incorrecte');
     });
 
@@ -188,7 +187,7 @@ describe('Unit | Component | comparison-window', function() {
       resultItem = component.get('resultItem');
 
       // then
-      _assertResultItemTitle(resultItem, 'Vous n\'avez pas donné de réponse');
+      _assertResultItemTitle(resultItem, 'Vous n’avez pas donné de réponse');
       _assertResultItemTooltip(resultItem, 'Sans réponse');
     });
 

--- a/mon-pix/tests/unit/components/comparison-window-test.js
+++ b/mon-pix/tests/unit/components/comparison-window-test.js
@@ -19,7 +19,8 @@ describe('Unit | Component | comparison-window', function() {
   let answer;
   let resultItem;
 
-  const challengeQroc = { type: 'QROC' };
+  const challengeQroc = { type: 'QROC', autoReply: false };
+  const challengeQrocWithAutoReply = { type: 'QROC', autoReply: true };
   const challengeQcm = { type: 'QCM' };
   const challengeQrocmInd = { type: 'QROCM-ind' };
   const challengeQrocmDep = { type: 'QROCM-dep' };
@@ -213,6 +214,32 @@ describe('Unit | Component | comparison-window', function() {
       // then
       _assertResultItemTitle(resultItem, 'Vous avez dépassé le temps imparti');
       _assertResultItemTooltip(resultItem, 'Temps dépassé');
+    });
+
+    it('should return adapted title and tooltip when result is "ko" and challenge is auto validated', function() {
+      // given
+      answer.set('result', 'ko');
+      answer.set('challenge', challengeQrocWithAutoReply);
+
+      // when
+      resultItem = component.get('resultItem');
+
+      // then
+      _assertResultItemTitle(resultItem, 'Vous n’avez pas réussi l’épreuve');
+      _assertResultItemTooltip(resultItem, 'Épreuve non réussie');
+    });
+
+    it('should return adapted title and tooltip when result is "ok" and challenge is auto validated', function() {
+      // given
+      answer.set('result', 'ok');
+      answer.set('challenge', challengeQrocWithAutoReply);
+
+      // when
+      resultItem = component.get('resultItem');
+
+      // then
+      _assertResultItemTitle(resultItem, 'Vous avez réussi l’épreuve');
+      _assertResultItemTooltip(resultItem, 'Épreuve réussie');
     });
   });
 });

--- a/mon-pix/tests/unit/components/comparison-window-test.js
+++ b/mon-pix/tests/unit/components/comparison-window-test.js
@@ -2,6 +2,7 @@ import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 function _assertResultItemTitle(resultItem, expected) {
   expect(resultItem.title).to.equal(expected);
@@ -19,16 +20,15 @@ describe('Unit | Component | comparison-window', function() {
   let answer;
   let resultItem;
 
-  const challengeQroc = { type: 'QROC', autoReply: false };
-  const challengeQrocWithAutoReply = { type: 'QROC', autoReply: true };
-  const challengeQcm = { type: 'QCM' };
-  const challengeQrocmInd = { type: 'QROCM-ind' };
-  const challengeQrocmDep = { type: 'QROCM-dep' };
+  const challengeQroc = EmberObject.create({ type: 'QROC', autoReply: false });
+  const challengeQrocWithAutoReply = EmberObject.create({ type: 'QROC', autoReply: true });
+  const challengeQcm = EmberObject.create({ type: 'QCM' });
+  const challengeQrocmInd = EmberObject.create({ type: 'QROCM-ind' });
+  const challengeQrocmDep = EmberObject.create({ type: 'QROCM-dep' });
 
   beforeEach(function() {
-    component = this.owner.lookup('component:comparison-window');
     answer = EmberObject.create();
-    component.set('answer', answer);
+    component = createGlimmerComponent('component:comparison-window', { answer });
   });
 
   describe('#isAssessmentChallengeTypeQroc', function() {
@@ -37,7 +37,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQroc);
       // when
-      const isAssessmentChallengeTypeQroc = component.get('isAssessmentChallengeTypeQroc');
+      const isAssessmentChallengeTypeQroc = component.isAssessmentChallengeTypeQroc;
       // then
       expect(isAssessmentChallengeTypeQroc).to.be.true;
     });
@@ -46,7 +46,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQrocmInd);
       // when
-      const isAssessmentChallengeTypeQroc = component.get('isAssessmentChallengeTypeQroc');
+      const isAssessmentChallengeTypeQroc = component.isAssessmentChallengeTypeQroc;
       // then
       expect(isAssessmentChallengeTypeQroc).to.be.false;
     });
@@ -58,7 +58,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQcm);
       // when
-      const isAssessmentChallengeTypeQcm = component.get('isAssessmentChallengeTypeQcm');
+      const isAssessmentChallengeTypeQcm = component.isAssessmentChallengeTypeQcm;
       // then
       expect(isAssessmentChallengeTypeQcm).to.be.true;
     });
@@ -67,7 +67,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQroc);
       // when
-      const isAssessmentChallengeTypeQcm = component.get('isAssessmentChallengeTypeQcm');
+      const isAssessmentChallengeTypeQcm = component.isAssessmentChallengeTypeQcm;
       // then
       expect(isAssessmentChallengeTypeQcm).to.be.false;
     });
@@ -79,7 +79,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQrocmInd);
       // when
-      const isAssessmentChallengeTypeQrocmInd = component.get('isAssessmentChallengeTypeQrocmInd');
+      const isAssessmentChallengeTypeQrocmInd = component.isAssessmentChallengeTypeQrocmInd;
       // then
       expect(isAssessmentChallengeTypeQrocmInd).to.be.true;
     });
@@ -88,7 +88,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQroc);
       // when
-      const isAssessmentChallengeTypeQrocmInd = component.get('isAssessmentChallengeTypeQrocmInd');
+      const isAssessmentChallengeTypeQrocmInd = component.isAssessmentChallengeTypeQrocmInd;
       // then
       expect(isAssessmentChallengeTypeQrocmInd).to.be.false;
     });
@@ -100,7 +100,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQrocmDep);
       // when
-      const isAssessmentChallengeTypeQrocmDep = component.get('isAssessmentChallengeTypeQrocmDep');
+      const isAssessmentChallengeTypeQrocmDep = component.isAssessmentChallengeTypeQrocmDep;
       // then
       expect(isAssessmentChallengeTypeQrocmDep).to.be.true;
     });
@@ -109,7 +109,7 @@ describe('Unit | Component | comparison-window', function() {
       // given
       answer.set('challenge', challengeQroc);
       // when
-      const isAssessmentChallengeTypeQrocmDep = component.get('isAssessmentChallengeTypeQrocmDep');
+      const isAssessmentChallengeTypeQrocmDep = component.isAssessmentChallengeTypeQrocmDep;
       // then
       expect(isAssessmentChallengeTypeQrocmDep).to.be.false;
     });
@@ -117,13 +117,16 @@ describe('Unit | Component | comparison-window', function() {
   });
 
   describe('#resultItem', function() {
+    beforeEach(function() {
+      answer.set('challenge', challengeQcm);
+    });
 
     it('should return adapted title and tooltip when validation is unavailable (i.e. empty)', function() {
       // given
       answer.set('result', '');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, '');
@@ -135,7 +138,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'xxx');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, '');
@@ -148,7 +151,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', undefined);
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, '');
@@ -160,7 +163,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'ok');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous avez la bonne réponse !');
@@ -172,7 +175,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'ko');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous n’avez pas la bonne réponse');
@@ -184,7 +187,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'aband');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous n’avez pas donné de réponse');
@@ -196,7 +199,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'partially');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous avez donné une réponse partielle');
@@ -208,7 +211,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('result', 'timedout');
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous avez dépassé le temps imparti');
@@ -221,7 +224,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('challenge', challengeQrocWithAutoReply);
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous n’avez pas réussi l’épreuve');
@@ -234,7 +237,7 @@ describe('Unit | Component | comparison-window', function() {
       answer.set('challenge', challengeQrocWithAutoReply);
 
       // when
-      resultItem = component.get('resultItem');
+      resultItem = component.resultItem;
 
       // then
       _assertResultItemTitle(resultItem, 'Vous avez réussi l’épreuve');


### PR DESCRIPTION
## :unicorn: Problème
Les questions avec des embed validés automatiquement n'affichent pas de champs texte à l'utilisateur. 
Il n'y a donc pas de champ réponse dans la fenêtre "Réponses et tutos".

## :robot: Solution
Dans le cas d'un challenge de type QROC dont `autoReply` vaut `true`.
Dans le composant `comparison-window` :
 - Changer le titre par 
       `Vous n’avez pas réussi l'épreuve` ou
       `Vous avez réussi l'épreuve` ou
       `Vous avez passé l’épreuve`
 - Retirer `correction-qroc-box rounded-panel`

## :rainbow: Remarques
On en profite pour corriger les apostrophes de tous les messages présents dans `comparison-window`.

## :100: Pour tester
Utiliser ces challenges :

[recWndEZbiReZ0zsz](https://app-pr1621.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)
    [recab7EiQWXfuVKqI](https://app-pr1621.review.pix.fr/challenges/recab7EiQWXfuVKqI/preview)
    [recy37FMPthJpfWmd](https://app-pr1621.review.pix.fr/challenges/recy37FMPthJpfWmd/preview)
    [rec0w9GHcxIPxDY5z](https://app-pr1621.review.pix.fr/challenges/rec0w9GHcxIPxDY5z/preview)
