### PR TITLE
[TECH] Suppression du déclencheur status pour le workflow automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,6 @@ on:
   check_suite:
     types:
       - completed
-  status:
 jobs:
   automerge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :unicorn: Problème
L'action de vérification d'automerge se déclenche beaucoup trop souvent (à chaque changement de status d'un commit) quand passe d'un état (pending, progress et success)

## :robot: Solution
Limiter le déclenchement juste au changement de la fin de la suite de test et pas à chaque changement de status de la PR.

