### PR TITLE
[TECH] Utiliser un token pix-service dédié à la Github Action Auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     types:
       - labeled
-  pull_request_review:
-    types:
-      - submitted
   check_suite:
     types:
       - completed
@@ -16,7 +13,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.8.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
           MERGE_LABELS: "Merge-auto test"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: "Merge-auto test"


### PR DESCRIPTION
## :unicorn: Problème

La github action pour l'auto-merge n'a pas les autorisations de pusher sur la branche protégée `dev`.

## :robot: Solution

La solution pour contourner ce problème est de créer un Personal Access Token ayant les droits de push sur le repo.
(voir https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/23)

Nous avons le compte de service `pix-service`. Nous pourrions utiliser son Personal Access Token avec les droits nécessaires et ensuite de l'ajouter en tant que secret dans les settings du repo pix. On peut alors utiliser ce token dans la Github Action.

## :rainbow: Remarques
J'ai également enlevé le trigger de l'action quand un utilisateur approuve une PR qui n'était pas forcément nécessaire.