### PR TITLE
[FEATURE] Internationalisation du démarrage d'une certification (PIX-799) 

### DIFF
--- a/mon-pix/app/controllers/certifications/start.js
+++ b/mon-pix/app/controllers/certifications/start.js
@@ -5,6 +5,7 @@ import Controller from '@ember/controller';
 @classic
 export default class StartController extends Controller {
   @service currentUser;
+  @service intl;
 
-  pageTitle = 'Rejoindre une session de certification';
+  pageTitle = this.intl.t('page-title.certifications-start');
 }

--- a/mon-pix/app/routes/assessments.js
+++ b/mon-pix/app/routes/assessments.js
@@ -1,13 +1,16 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class AssessmentsRoute extends Route {
+  @service intl;
+
   model(params) {
     return this.store.findRecord('assessment', params.assessment_id);
   }
 
   afterModel(model) {
     if (model.isCertification) {
-      model.title = `Certification ${model.title}`;
+      model.title = this.intl.t('page-title.certification-number', { certificationNumber: model.title });
     }
     return model;
   }

--- a/mon-pix/app/templates/components/certification-banner.hbs
+++ b/mon-pix/app/templates/components/certification-banner.hbs
@@ -7,7 +7,7 @@
     <h1 class="assessment-banner__title">{{this.currentUser.user.fullName}}</h1>
 
     <div class="certification-number">
-      <div class="certification-number__label">N° de certification</div>
+      <div class="certification-number__label">{{t "certification-banner.certification-number"}}</div>
       <div class="certification-number__value">{{@certificationNumber}}</div>
     </div>
   </div>

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -3,22 +3,22 @@
 {{/if}}
 
 <section class="certification-joiner">
-  <h1 class="certification-joiner__title">Rejoindre une session</h1>
+  <h1 class="certification-joiner__title">{{t "certification-joiner.title"}}</h1>
     <form autocomplete="off">
         <div class="certification-joiner__row">
-          <label class="certification-joiner__label" for="certificationJoinerSessionId">Numéro de session</label>
+          <label class="certification-joiner__label" for="certificationJoinerSessionId">{{t "certification-joiner.form.session-number"}}</label>
           <Input {{autofocus}} @type="text" @size="6" @value={{this.sessionId}} @id="certificationJoinerSessionId" />
         </div>
         <div class="certification-joiner__row">
-          <label class="certification-joiner__label" for="certificationJoinerFirstName">Prénom</label>
+          <label class="certification-joiner__label" for="certificationJoinerFirstName">{{t "certification-joiner.form.first-name"}}</label>
           <Input @type="text" @value={{this.firstName}} @id="certificationJoinerFirstName" />
         </div>
         <div class="certification-joiner__row">
-          <label class="certification-joiner__label" for="certificationJoinerLastName">Nom de naissance</label>
+          <label class="certification-joiner__label" for="certificationJoinerLastName">{{t "certification-joiner.form.birth-name"}}</label>
           <Input @type="text" @value={{this.lastName}} @id="certificationJoinerLastName" />
         </div>
         <div class="certification-joiner__row">
-          <label class="certification-joiner__label" for="certificationJoinerDayOfBirth">Date de naissance</label>
+          <label class="certification-joiner__label" for="certificationJoinerDayOfBirth">{{t "certification-joiner.form.birth-date"}}</label>
           <div class="certification-joiner__birthdate" id="certificationJoinerBirthDate">
             <Input @min="1"
                     @max="31"
@@ -55,7 +55,7 @@
           </button>
       {{else}}
           <button type="submit" class="button button--big button--thin certification-joiner__attempt-next-btn" {{ action "attemptNext" }}>
-              Continuer
+              {{t "certification-joiner.form.action.submit"}}
           </button>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -1,8 +1,8 @@
 <section class="certification-starter">
-    <h2 class="certification-start-page__title">Vous allez commencer votre test de certification</h2>
+    <h2 class="certification-start-page__title">{{t "certification-start-page.title"}}</h2>
 
     <p class="certification-course-page__order">
-        Saisissez le code d'accès communiqué par le surveillant
+        {{t "certification-start-page.access-code"}}
     </p>
     <form autocomplete="off">
         <div class="certification-course-page__session-code-input">
@@ -19,21 +19,17 @@
               <span class="loader-in-button">&nbsp;</span>
             </button>
           {{else}}
-              <button type="submit" class="button button--thin certification-course-page__submit_button" {{ action "submit" }}>Commencer mon test</button>
+              <button type="submit" class="button button--thin certification-course-page__submit_button" {{ action "submit" }}>{{t "certification-start-page.action.submit"}}</button>
           {{/if}}
         </div>
     </form>
 
     <div class="certification-course-page__cgu">
         <p>
-            En cliquant sur "Commencer mon test", j’accepte que mes données d’identité, le numéro de certification et les
-            circonstances de la passation telles que renseignées par le surveillant soient communiquées à Pix. Pix les utilisera
-            lors de la délibération du jury pour produire et archiver mes résultats et pour éditer mon certificat. Si cette
-            certification m’a été prescrite par une organisation, j’accepte que Pix lui communique mes résultats.
+          {{t "certification-start-page.cgu.info"}}
         </p>
         <p>
-            Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous
-            concernant et les faire rectifier en envoyant un mail à <a href="mailto:dpo@pix.fr">dpo@pix.fr</a>.
+          {{t "certification-start-page.cgu.contact.info"}} <a href="mailto:dpo@pix.fr">{{t "certification-start-page.cgu.contact.email"}}</a>.
         </p>
     </div>
 </section>

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -2,5 +2,5 @@
   <button aria-label="Fermer" class="icon-button congratulations-banner__icon" {{on 'click' @closeBanner}}>
     {{fa-icon 'times'}}
   </button>
-  <p class="congratulations-banner__message">Bravo {{@fullName}},<br>votre profil est certifiable.</p>
+  <p class="congratulations-banner__message">{{t "certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}</p>
 </div>

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -23,10 +23,6 @@ describe('Integration | Component | signin form', function() {
 
   describe('Rendering', async function() {
 
-    beforeEach(function() {
-      this.intl.setLocale('fr-fr');
-    });
-
     it('should display an input for identifiant field', async function() {
       // when
       await render(hbs`<SigninForm />`);

--- a/mon-pix/tests/unit/routes/assessments-test.js
+++ b/mon-pix/tests/unit/routes/assessments-test.js
@@ -2,9 +2,11 @@ import EmberObject from '@ember/object';
 import { describe, it, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import { setupTest } from 'ember-mocha';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Unit | Route | Assessments', function() {
   setupTest();
+  setupIntl();
 
   let route;
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -16,6 +16,7 @@
     }
   },
   "page-title": {
+    "certifications-start": "Rejoindre une session de certification",
     "signin": "Sign in",
     "signup": "Sign up",
     "suffix": "Pix",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -70,6 +70,19 @@
         "title": "Lorem ipsum"
       }
     }
+  }, 
+
+  "certification-joiner": {
+    "title": "Join a session",
+    "form": {
+      "action": {
+        "submit": "Continue"
+      },
+      "session-number": "Session number",
+      "first-name": "Firstname",
+      "birth-name": "Birth name",
+      "birth-date": "Birth date"
+    }
   },
 
   "signin-form": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -17,6 +17,7 @@
   },
   "page-title": {
     "certifications-start": "Rejoindre une session de certification",
+    "certification-number": "Certification {certificationNumber}",
     "signin": "Sign in",
     "signup": "Sign up",
     "suffix": "Pix",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -73,6 +73,9 @@
   }, 
 
   "certification-joiner": {
+    "congratulation-banner": {
+      "message": "Congratulations {fullName},'<br>'your profile is certifiable."
+    },
     "title": "Join a session",
     "form": {
       "action": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -93,6 +93,21 @@
     }
   },
 
+  "certification-start-page": {
+    "title": "Vous allez commencer votre test de certification",
+    "access-code": "Saisissez le code d'accès communiqué par le surveillant",
+    "action": {
+      "submit": "Commencer mon test"
+    },
+    "cgu":  {
+      "info": "En cliquant sur \"Commencer mon test\", j’accepte que mes données d’identité, le numéro de certification et les circonstances de la passation telles que renseignées par le surveillant soient communiquées à Pix. Pix les utilisera lors de la délibération du jury pour produire et archiver mes résultats et pour éditer mon certificat. Si cette certification m’a été prescrite par une organisation, j’accepte que Pix lui communique mes résultats.",
+      "contact": {
+        "info": "Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à",
+        "email": "dpo@pix.fr"
+      }
+    }
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Sign in"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -72,6 +72,10 @@
     }
   }, 
 
+  "certification-banner": {
+    "certification-number": "Certification N°"
+  },
+
   "certification-joiner": {
     "congratulation-banner": {
       "message": "Congratulations {fullName},'<br>'your profile is certifiable."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -16,6 +16,7 @@
     }
   },
   "page-title": {
+    "certifications-start": "Rejoindre une session de certification",
     "signin": "Connexion",
     "signup": "Inscription",
     "suffix": "Pix",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -71,6 +71,19 @@
     }
   },
 
+  "certification-joiner": {
+    "title": "Rejoindre une session",
+    "form": {
+      "action": {
+        "submit": "Continuer"
+      },
+      "session-number": "Numéro de session",
+      "first-name": "Prénom",
+      "birth-name": "Nom de naissance",
+      "birth-date": "Date de naissance"
+    }
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Je me connecte"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -71,6 +71,10 @@
     }
   },
 
+  "certification-banner": {
+    "certification-number": "N° de certification"
+  },
+
   "certification-joiner": {
     "congratulation-banner": {
       "message": "Bravo {fullName},'<br>'votre profil est certifiable."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -19,6 +19,7 @@
 
   "page-title": {
     "certifications-start": "Rejoindre une session de certification",
+    "certification-number": "Certification {certificationNumber}",
     "signin": "Connexion",
     "signup": "Inscription",
     "suffix": "Pix",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -72,6 +72,9 @@
   },
 
   "certification-joiner": {
+    "congratulation-banner": {
+      "message": "Bravo {fullName},'<br>'votre profil est certifiable."
+    },
     "title": "Rejoindre une session",
     "form": {
       "action": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -10,11 +10,13 @@
     "or": "ou",
     "pix": "pix"
   },
+
   "navigation": {
     "homepage": {
       "link": "Page d'accueil"
     }
   },
+
   "page-title": {
     "certifications-start": "Rejoindre une session de certification",
     "signin": "Connexion",
@@ -22,6 +24,7 @@
     "suffix": "Pix",
     "my-certifications": "Mes certifications"
   },
+
   "api-error-messages": {
     "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
     "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -92,6 +95,21 @@
     }
   },
 
+  "certification-start-page": {
+    "title": "Vous allez commencer votre test de certification",
+    "access-code": "Saisissez le code d'accès communiqué par le surveillant",
+    "action": {
+      "submit": "Commencer mon test"
+    },
+    "cgu":  {
+      "info": "En cliquant sur \"Commencer mon test\", j’accepte que mes données d’identité, le numéro de certification et les circonstances de la passation telles que renseignées par le surveillant soient communiquées à Pix. Pix les utilisera lors de la délibération du jury pour produire et archiver mes résultats et pour éditer mon certificat. Si cette certification m’a été prescrite par une organisation, j’accepte que Pix lui communique mes résultats.",
+      "contact": {
+        "info": "Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à ",
+        "email": "dpo@pix.fr"
+      }
+    }
+  },
+
   "signin-form": {
     "actions": {
       "submit": "Je me connecte"
@@ -114,6 +132,7 @@
     },
     "title": "Connectez-vous"
   },
+
   "signup-form": {
     "actions": {
       "submit": "Je m'inscris"
@@ -149,6 +168,7 @@
     },
     "title": "Inscrivez-vous"
   },
+
   "scorecard": {
     "actions": {
       "continue": {
@@ -184,5 +204,4 @@
       "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."
     }
   }
-
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'internationalisation de PIX, on souhaite pouvoir voir le démarrage d'une certification en plusieurs langues

## :robot: Solution
On deplace toutes les chaines de caractères des templates vers le fichiers de traduction d'ember-intl

## :100: Pour tester
Commencer une session de certification sur mon-pix et constater que l'affichage se fait correctement



TODO:
- [x] feedback-panel.hbs
- [x] certification-starter.hbs
- [x] controllers > certifications > start.js
- [x] Vérifier les titres des pages
- [x] corriger les tests
