### PR TITLE
[FEATURE] Traduire la page détails de compétence (PIX-366).

### DIFF
--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -13,16 +13,6 @@ export default class ScorecardDetails extends Component {
 
   @tracked showResetModal = false;
 
-  get computeRemainingDaysBeforeImproving() {
-    const _remainingDaysBeforeImproving = this.args.scorecard.remainingDaysBeforeImproving;
-
-    if (_remainingDaysBeforeImproving > 1) {
-      return _remainingDaysBeforeImproving + ' jours';
-    } else {
-      return _remainingDaysBeforeImproving + ' jour';
-    }
-  }
-
   get level() {
     return this.args.scorecard.isNotStarted ? null : this.args.scorecard.level;
   }
@@ -49,11 +39,6 @@ export default class ScorecardDetails extends Component {
 
   get shouldWaitBeforeImproving() {
     return this.args.scorecard.remainingDaysBeforeImproving > 0;
-  }
-
-  get remainingDaysText() {
-    const daysBeforeReset = this.args.scorecard.remainingDaysBeforeReset;
-    return `Remise à zéro disponible dans ${daysBeforeReset} ${daysBeforeReset <= 1 ? 'jour' : 'jours'}`;
   }
 
   get tutorialsGroupedByTubeName() {

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -4,7 +4,7 @@
     <span class="icon-button">
       {{fa-icon 'arrow-left'}}
     </span>
-      Retour Profil
+      {{t 'scorecard.global.back'}}
     </LinkTo>
   </div>
 
@@ -28,7 +28,7 @@
           {{#if @scorecard.isFinishedWithMaxLevel}}
             <div class="competence-card__congrats">
               <div class="competence-card__level competence-card__level--congrats">
-                <span class="score-label competence-card__score-label--congrats">Niveau</span>
+                <span class="score-label competence-card__score-label--congrats">{{t 'common.level'}}</span>
                 <span class="score-value competence-card__score-value competence-card__score-value--congrats">{{level}}</span>
               </div>
             </div>
@@ -38,14 +38,14 @@
                          @chartClass="circle-chart__content--big"
                          @thicknessClass="circle--thick">
               <div class="competence-card__level">
-                <span class="score-label">Niveau</span>
+                <span class="score-label">{{t 'common.level'}}</span>
                 <span class="score-value">{{replace-zero-by-dash level}}</span>
               </div>
             </CircleChart>
           {{/if}}
 
           <div class="scorecard-details-content-right-score-container__pix-earned">
-            <div class="score-label">pix</div>
+            <div class="score-label">{{t 'common.pix'}}</div>
             <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
         </div>
@@ -53,7 +53,8 @@
 
       {{#if this.isProgressable}}
         <div class="scorecard-details-content-right__level-info">
-          {{@scorecard.remainingPixToNextLevel}} pix avant le niveau {{inc @scorecard.level}}
+          {{t 'scorecard.details.levelInfo' remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
+              level=@scorecard.level}}
         </div>
       {{/if}}
 
@@ -62,15 +63,17 @@
           {{#if this.canImprove}}
             {{#if this.shouldWaitBeforeImproving}}
               <div class="scorecard-details__improvement-countdown">
-                <span class="scorecard-details-improvement-countdown__label">Tenter le niveau supérieur dans</span>
-                <span class="scorecard-details-improvement-countdown__count">{{this.computeRemainingDaysBeforeImproving}}</span>
+                <span class="scorecard-details-improvement-countdown__label">{{t 'scorecard.improve.label'}}</span>
+                <span class="scorecard-details-improvement-countdown__count">{{t 'scorecard.improve.count'
+                                                                                 daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
               </div>
             {{else}}
-              <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action "improveCompetenceEvaluation"}}>
-                Retenter
-                <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+              <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action
+                      "improveCompetenceEvaluation"}}>
+                {{t 'scorecard.improve.startover'}}
+                <div class="sr-only">{{t 'scorecard.improve.startoverCompetence' competence=@scorecard.name }}"</div>
               </button>
-              <span class="scorecard-details__improving-text">Tentez d'obtenir le niveau supérieur !</span>
+              <span class="scorecard-details__improving-text">{{t 'scorecard.improve.improvingText' }}</span>
             {{/if}}
           {{/if}}
         {{/if}}
@@ -80,21 +83,22 @@
                 class={{concat "button button--big button--thin button--round button--link button--green "
                                (if @scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
           {{#if @scorecard.isStarted}}
-            Reprendre
-            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+            {{t 'scorecard.global.startover'}}
+            <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
           {{else}}
-            Commencer
-            <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+            {{t 'scorecard.global.start'}}
+            <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
           {{/if}}
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
         <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
-          Remettre à zéro
-          <div class="sr-only">la compétence "{{@scorecard.name}}"</div>
+          {{t 'scorecard.reset.button'}}
+          <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
         </button>
       {{else if this.displayWaitSentence}}
-        <p class="scorecard-details-content-right__reset-message">{{remainingDaysText}}</p>
+        <p class="scorecard-details-content-right__reset-message">{{t 'scorecard.reset.label'
+                                                                      daysBeforeReset=@scorecard.remainingDaysBeforeReset}}</p>
       {{/if}}
     </div>
   </div>
@@ -102,9 +106,8 @@
     <div class="scorecard-details__content">
       <div class="tutorials">
         <div class="tutorials__header">
-          <h3 class="tutorials-header__title">Cultivez vos compétences</h3>
-          <p class="tutorials-header__description">Voici une sélection de tutos qui pourront vous aider à gagner des
-            Pix.</p>
+          <h3 class="tutorials-header__title">{{t 'scorecard.tutorials.title'}}</h3>
+          <p class="tutorials-header__description">{{t 'scorecard.tutorials.description'}}</p>
         </div>
         <div class="tutorial__list">
           {{#each this.tutorialsGroupedByTubeName as |tube|}}
@@ -132,27 +135,26 @@
 
     <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
       <div class="pix-modal-header">
-        <h1 class="pix-modal-header__title pix-modal-header__title--thin">Remise à zéro de la compétence</h1>
+        <h1 class="pix-modal-header__title pix-modal-header__title--thin">{{t 'scorecard.reset.modal.title'}}</h1>
         <h2 class="pix-modal-header__subtitle">{{@scorecard.name}}</h2>
       </div>
 
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="scorecard-details-reset-modal__important-message">
           {{#if @scorecard.hasNotReachLevelOne}}
-            Vos {{@scorecard.earnedPix}} Pix vont être supprimés.
+            {{t 'scorecard.reset.modal.importantMessage' earnedPix=@scorecard.earnedPix}}
           {{else if @scorecard.hasReachAtLeastLevelOne}}
-            Votre niveau {{@scorecard.level}} et vos {{@scorecard.earnedPix}} Pix vont être supprimés.
+            {{t 'scorecard.reset.modal.importantMessage' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">
-          <p> Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être
-            reposées.</p>
+          <p>{{t 'scorecard.reset.modal.warning'}}</p>
         </div>
       </div>
 
       <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
-        <button class="button button--big button--extra-thin button--red" {{action "reset"}}>Remettre à zéro</button>
-        <button class="button button--regular button--extra-thin button--grey" {{action "closeModal"}}>Annuler</button>
+        <button class="button button--big button--extra-thin button--red" {{action "reset"}}>{{t 'scorecard.global.reset'}}</button>
+        <button class="button button--regular button--extra-thin button--grey" {{action "closeModal"}}>{{t 'common.cancel'}}</button>
       </div>
     </div>
   </PixModal>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -4,7 +4,7 @@
     <span class="icon-button">
       {{fa-icon 'arrow-left'}}
     </span>
-      {{t 'scorecard.linkToProfile'}}
+      {{t 'scorecard.link-to-profile'}}
     </LinkTo>
   </div>
 
@@ -53,7 +53,7 @@
 
       {{#if this.isProgressable}}
         <div class="scorecard-details-content-right__level-info">
-          {{t 'scorecard.nextLevelInfo' remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
+          {{t 'scorecard.next-level-info' remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
               level=(inc @scorecard.level)}}
         </div>
       {{/if}}
@@ -63,15 +63,15 @@
           {{#if this.canImprove}}
             {{#if this.shouldWaitBeforeImproving}}
               <div class="scorecard-details__improvement-countdown">
-                <span class="scorecard-details-improvement-countdown__label">{{t 'scorecard.actions.improve.description.waitingText'}}</span>
-                <span class="scorecard-details-improvement-countdown__count">{{t 'scorecard.actions.improve.description.dayBefore'
+                <span class="scorecard-details-improvement-countdown__label">{{t 'scorecard.actions.improve.description.waiting-text'}}</span>
+                <span class="scorecard-details-improvement-countdown__count">{{t 'scorecard.actions.improve.description.countdown'
                                                                                  daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
               </div>
             {{else}}
               <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action
                       "improveCompetenceEvaluation"}}>
                 {{t 'scorecard.actions.improve.label'}}
-                <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name }}"</div>
+                <div class="sr-only">{{t 'scorecard.for-competence' competence=@scorecard.name }}"</div>
               </button>
               <span class="scorecard-details__improving-text">{{t 'scorecard.actions.improve.improvingText' }}</span>
             {{/if}}
@@ -84,17 +84,17 @@
                                (if @scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
           {{#if @scorecard.isStarted}}
             {{t 'scorecard.actions.continue.label'}}
-            <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
+            <div class="sr-only">{{t 'scorecard.for-competence' competence=@scorecard.name}}</div>
           {{else}}
             {{t 'scorecard.actions.start.label'}}
-            <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
+            <div class="sr-only">{{t 'scorecard.for-competence' competence=@scorecard.name}}</div>
           {{/if}}
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
         <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
           {{t 'scorecard.actions.reset.label'}}
-          <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
+          <div class="sr-only">{{t 'scorecard.for-competence' competence=@scorecard.name}}</div>
         </button>
       {{else if this.displayWaitSentence}}
         <p class="scorecard-details-content-right__reset-message">{{t 'scorecard.actions.reset.description'
@@ -142,9 +142,9 @@
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="scorecard-details-reset-modal__important-message">
           {{#if @scorecard.hasNotReachLevelOne}}
-            {{t 'scorecard.actions.reset.modal.importantMessage' earnedPix=@scorecard.earnedPix}}
+            {{t 'scorecard.actions.reset.modal.important-message' earnedPix=@scorecard.earnedPix}}
           {{else if @scorecard.hasReachAtLeastLevelOne}}
-            {{t 'scorecard.actions.reset.modal.importantMessageAboveLevelOne' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
+            {{t 'scorecard.actions.reset.modal.important-message-above-level-one' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -4,7 +4,7 @@
     <span class="icon-button">
       {{fa-icon 'arrow-left'}}
     </span>
-      {{t 'scorecard.global.back'}}
+      {{t 'scorecard.linkToProfile'}}
     </LinkTo>
   </div>
 
@@ -53,8 +53,8 @@
 
       {{#if this.isProgressable}}
         <div class="scorecard-details-content-right__level-info">
-          {{t 'scorecard.details.levelInfo' remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
-              level=@scorecard.level}}
+          {{t 'scorecard.nextLevelInfo' remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
+              level=(inc @scorecard.level)}}
         </div>
       {{/if}}
 
@@ -63,17 +63,17 @@
           {{#if this.canImprove}}
             {{#if this.shouldWaitBeforeImproving}}
               <div class="scorecard-details__improvement-countdown">
-                <span class="scorecard-details-improvement-countdown__label">{{t 'scorecard.improve.label'}}</span>
-                <span class="scorecard-details-improvement-countdown__count">{{t 'scorecard.improve.count'
+                <span class="scorecard-details-improvement-countdown__label">{{t 'scorecard.actions.improve.description.waitingText'}}</span>
+                <span class="scorecard-details-improvement-countdown__count">{{t 'scorecard.actions.improve.description.dayBefore'
                                                                                  daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
               </div>
             {{else}}
               <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action
                       "improveCompetenceEvaluation"}}>
-                {{t 'scorecard.improve.startover'}}
-                <div class="sr-only">{{t 'scorecard.improve.startoverCompetence' competence=@scorecard.name }}"</div>
+                {{t 'scorecard.actions.improve.label'}}
+                <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name }}"</div>
               </button>
-              <span class="scorecard-details__improving-text">{{t 'scorecard.improve.improvingText' }}</span>
+              <span class="scorecard-details__improving-text">{{t 'scorecard.actions.improve.improvingText' }}</span>
             {{/if}}
           {{/if}}
         {{/if}}
@@ -83,21 +83,21 @@
                 class={{concat "button button--big button--thin button--round button--link button--green "
                                (if @scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")}}>
           {{#if @scorecard.isStarted}}
-            {{t 'scorecard.global.startover'}}
-            <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
+            {{t 'scorecard.actions.continue.label'}}
+            <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
           {{else}}
-            {{t 'scorecard.global.start'}}
-            <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
+            {{t 'scorecard.actions.start.label'}}
+            <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
           {{/if}}
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
         <button class="link link--underline scorecard-details__reset-button" {{action "openModal"}}>
-          {{t 'scorecard.reset.button'}}
-          <div class="sr-only">{{t 'scorecard.improve.startOverCompetence' competence=@scorecard.name}}</div>
+          {{t 'scorecard.actions.reset.label'}}
+          <div class="sr-only">{{t 'scorecard.forCompetence' competence=@scorecard.name}}</div>
         </button>
       {{else if this.displayWaitSentence}}
-        <p class="scorecard-details-content-right__reset-message">{{t 'scorecard.reset.label'
+        <p class="scorecard-details-content-right__reset-message">{{t 'scorecard.actions.reset.description'
                                                                       daysBeforeReset=@scorecard.remainingDaysBeforeReset}}</p>
       {{/if}}
     </div>
@@ -127,33 +127,33 @@
 </div>
 {{#if this.showResetModal}}
   <PixModal @containerClass="scorecard-details__reset-modal pix-modal-dialog--wide" @onClose={{action "closeModal"}}>
-    <div class="pix-modal__close-link" aria-label="Fermer" {{action "closeModal"}}>
-      <span>Fermer</span>
+    <div class="pix-modal__close-link" aria-label="{{t 'common.close'}}" {{action "closeModal"}}>
+      <span>{{t 'common.close'}}</span>
       <FaIcon @icon="times-circle" class="logged-user-menu__icon"></FaIcon>
     </div>
 
 
     <div class="pix-modal__container pix-modal__container--white pix-modal__container--with-padding">
       <div class="pix-modal-header">
-        <h1 class="pix-modal-header__title pix-modal-header__title--thin">{{t 'scorecard.reset.modal.title'}}</h1>
+        <h1 class="pix-modal-header__title pix-modal-header__title--thin">{{t 'scorecard.actions.reset.modal.title'}}</h1>
         <h2 class="pix-modal-header__subtitle">{{@scorecard.name}}</h2>
       </div>
 
       <div class="pix-modal-body pix-modal-body--with-padding">
         <div class="scorecard-details-reset-modal__important-message">
           {{#if @scorecard.hasNotReachLevelOne}}
-            {{t 'scorecard.reset.modal.importantMessage' earnedPix=@scorecard.earnedPix}}
+            {{t 'scorecard.actions.reset.modal.importantMessage' earnedPix=@scorecard.earnedPix}}
           {{else if @scorecard.hasReachAtLeastLevelOne}}
-            {{t 'scorecard.reset.modal.importantMessage' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
+            {{t 'scorecard.actions.reset.modal.importantMessageAboveLevelOne' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">
-          <p>{{t 'scorecard.reset.modal.warning'}}</p>
+          <p>{{t 'scorecard.actions.reset.modal.warning'}}</p>
         </div>
       </div>
 
       <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
-        <button class="button button--big button--extra-thin button--red" {{action "reset"}}>{{t 'scorecard.global.reset'}}</button>
+        <button class="button button--big button--extra-thin button--red" {{action "reset"}}>{{t 'scorecard.actions.reset.label'}}</button>
         <button class="button button--regular button--extra-thin button--grey" {{action "closeModal"}}>{{t 'common.cancel'}}</button>
       </div>
     </div>

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -6,9 +6,15 @@ import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from '../../../config/environment';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Integration | Component | scorecard-details', function() {
   setupRenderingTest();
+  setupIntl();
+  
+  beforeEach(function() {
+    this.intl.setLocale('fr');
+  });
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/unit/components/competence-card-default-test.js
+++ b/mon-pix/tests/unit/components/competence-card-default-test.js
@@ -31,38 +31,6 @@ describe('Unit | Component | competence-card-default ', function() {
     });
   });
 
-  describe('#computeRemainingDaysBeforeImproving', function() {
-    let component, scorecard;
-
-    beforeEach(() => {
-      const competenceId = 'recCompetenceId';
-      scorecard = EmberObject.create({ competenceId });
-      component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
-    });
-
-    it('should return a singular sentence when remaining days before improving are equal to 1', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 1;
-
-      // when
-      const result = component.computeRemainingDaysBeforeImproving;
-
-      // then
-      expect(result).to.be.equal('1 jour');
-    });
-
-    it('should return a plural sentence when remaining days before improving are different than 1', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 3;
-
-      // when
-      const result = component.computeRemainingDaysBeforeImproving;
-
-      // then
-      expect(result).to.be.equal('3 jours');
-    });
-  });
-
   describe('#shouldWaitBeforeImproving', function() {
     let component, scorecard;
 

--- a/mon-pix/tests/unit/components/scorecard-details-test.js
+++ b/mon-pix/tests/unit/components/scorecard-details-test.js
@@ -179,38 +179,6 @@ describe('Unit | Component | scorecard-details ', function() {
     });
   });
 
-  describe('#computeRemainingDaysBeforeImproving', function() {
-    let component, scorecard;
-
-    beforeEach(() => {
-      const competenceId = 'recCompetenceId';
-      scorecard = EmberObject.create({ competenceId });
-      component = createGlimmerComponent('component:scorecard-details', { scorecard });
-    });
-
-    it('should return a singular sentence when remaining days before improving are equal to 1', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 1;
-
-      // when
-      const result = component.computeRemainingDaysBeforeImproving;
-
-      // then
-      expect(result).to.be.equal('1 jour');
-    });
-
-    it('should return a plural sentence when remaining days before improving are different than 1', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 3;
-
-      // when
-      const result = component.computeRemainingDaysBeforeImproving;
-
-      // then
-      expect(result).to.be.equal('3 jours');
-    });
-  });
-
   describe('#shouldWaitBeforeImproving', function() {
     let component, scorecard;
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1,18 +1,19 @@
 {
   "common": {
+    "cancel": "cancel",
     "form": {
       "mandatory-fields": "Fields marked with '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' are mandatory"
     },
+    "level": "level",
     "mandatory": "mandatory",
-    "or": "or"
+    "or": "or",
+    "pix": "pix"
   },
-
   "navigation": {
     "homepage": {
       "link": "Homepage"
     }
   },
-
   "page-title": {
     "signin": "Sign in",
     "signup": "Sign up",
@@ -47,7 +48,6 @@
     },
     "title": "Sign in"
   },
-
   "signup-form": {
     "actions": {
       "submit": "I sign up"
@@ -82,5 +82,37 @@
       "link": "sign in"
     },
     "title": "Sign up"
+  },
+  "scorecard": {
+    "global": {
+      "back": "Retour Profil",
+      "startover": "reprendre",
+      "reset": "remettre à zéro",
+      "start": "Commencer"
+    },
+    "details": {
+      "levelInfo": "{ remainingPixToNextLevel } pix left before level { level }"
+    },
+    "improve": {
+      "label": "You will be able to start over in",
+      "count": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+      "startover": "Start over",
+      "startOverCompetence": "la compétence {competence}",
+      "improvingText": "Tentez d'obtenir le niveau supérieur !"
+    },
+    "reset": {
+      "button": "Remettre à zéro",
+      "label": "{ daysBeforeReset, plural, =0 {0 day} =1 {1 day} other {# days} } left before reset.",
+      "modal": {
+        "title": "Remise à zéro de la compétence",
+        "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
+        "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+        "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+      }
+    },
+    "tutorials": {
+      "title": "Cultivez vos compétences",
+      "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."
+    }
   }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -92,8 +92,8 @@
       "improve": {
         "label": "Retry",
         "description": {
-          "waitingText": "You will be able to start over in",
-          "dayBefore": "{ daysBeforeImproving, plural, =0 {0 day.} =1 {1 day.} other {# days.} }"
+          "waiting-text": "You will be able to start over in",
+          "countdown": "{ daysBeforeImproving, plural, =0 {0 day.} =1 {1 day.} other {# days.} }"
         },
         "improvingText": "Try to have a better level !"
       },
@@ -102,8 +102,8 @@
         "description": "{ daysBeforeReset, plural, =0 {0 day} =1 {1 day} other {# days} } left before reset.",
         "modal": {
           "title": "Reset competence",
-          "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
-          "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+          "important-message": "Vos { earnedPix } Pix vont être supprimés.",
+          "important-message-above-level-one": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
           "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
         }
       },
@@ -111,9 +111,9 @@
         "label": "Start"
       }
     },
-    "forCompetence": "the competence {competence}",
-    "linkToProfile": "Back to Profile",
-    "nextLevelInfo": "{ remainingPixToNextLevel } pix left before level { level }",
+    "for-competence": "the competence {competence}",
+    "link-to-profile": "Back to Profile",
+    "next-level-info": "{ remainingPixToNextLevel } pix left before level { level }",
     "tutorials": {
       "title": "Cultivez vos compétences",
       "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
-    "cancel": "cancel",
+    "cancel": "Cancel",
+    "close": "Close",
     "form": {
       "mandatory-fields": "Fields marked with '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' are mandatory"
     },
@@ -84,32 +85,35 @@
     "title": "Sign up"
   },
   "scorecard": {
-    "global": {
-      "back": "Retour Profil",
-      "startover": "reprendre",
-      "reset": "remettre à zéro",
-      "start": "Commencer"
-    },
-    "details": {
-      "levelInfo": "{ remainingPixToNextLevel } pix left before level { level }"
-    },
-    "improve": {
-      "label": "You will be able to start over in",
-      "count": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
-      "startover": "Start over",
-      "startOverCompetence": "la compétence {competence}",
-      "improvingText": "Tentez d'obtenir le niveau supérieur !"
-    },
-    "reset": {
-      "button": "Remettre à zéro",
-      "label": "{ daysBeforeReset, plural, =0 {0 day} =1 {1 day} other {# days} } left before reset.",
-      "modal": {
-        "title": "Remise à zéro de la compétence",
-        "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
-        "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
-        "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+    "actions": {
+      "continue": {
+        "label": "Continue"
+      },
+      "improve": {
+        "label": "Retry",
+        "description": {
+          "waitingText": "You will be able to start over in",
+          "dayBefore": "{ daysBeforeImproving, plural, =0 {0 day.} =1 {1 day.} other {# days.} }"
+        },
+        "improvingText": "Try to have a better level !"
+      },
+      "reset": {
+        "label": "Reset",
+        "description": "{ daysBeforeReset, plural, =0 {0 day} =1 {1 day} other {# days} } left before reset.",
+        "modal": {
+          "title": "Reset competence",
+          "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
+          "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+          "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+        }
+      },
+      "start": {
+        "label": "Start"
       }
     },
+    "forCompetence": "the competence {competence}",
+    "linkToProfile": "Back to Profile",
+    "nextLevelInfo": "{ remainingPixToNextLevel } pix left before level { level }",
     "tutorials": {
       "title": "Cultivez vos compétences",
       "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -90,8 +90,8 @@
       "improve": {
         "label": "Retenter",
         "description": {
-          "waitingText": "Tenter le niveau supérieur dans",
-          "dayBefore": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }"
+          "waiting-text": "Tenter le niveau supérieur dans",
+          "countdown": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }"
         },
         "improvingText": "Tentez d'obtenir le niveau supérieur !"
       },
@@ -100,8 +100,8 @@
         "description": "Remise à zéro disponible dans { daysBeforeReset, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
         "modal": {
           "title": "Remise à zéro de la compétence",
-          "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
-          "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+          "important-message": "Vos { earnedPix } Pix vont être supprimés.",
+          "important-message-above-level-one": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
           "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
         }
       },
@@ -109,9 +109,9 @@
         "label": "Commencer"
       }
     },
-    "forCompetence": "la compétence {competence}",
-    "linkToProfile": "Retour Profil",
-    "nextLevelInfo": "{ remainingPixToNextLevel } pix avant le niveau { level }",
+    "for-competence": "la compétence {competence}",
+    "link-to-profile": "Retour Profil",
+    "next-level-info": "{ remainingPixToNextLevel } pix avant le niveau { level }",
     "tutorials": {
       "title": "Cultivez vos compétences",
       "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1,6 +1,7 @@
 {
   "common": {
-    "cancel": "annuler",
+    "cancel": "Annuler",
+    "close": "Fermer",
     "form": {
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
     },
@@ -82,35 +83,39 @@
     "title": "Inscrivez-vous"
   },
   "scorecard": {
-    "global": {
-      "back": "Retour Profil",
-      "startover": "reprendre",
-      "reset": "remettre à zéro",
-      "start": "Commencer"
-    },
-    "details": {
-      "levelInfo": "{ remainingPixToNextLevel } pix avant le niveau { level }"
-    },
-    "improve": {
-      "label": "Tenter le niveau supérieur dans",
-      "count": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
-      "startover": "Retenter",
-      "startOverCompetence": "la compétence {competence}",
-      "improvingText": "Tentez d'obtenir le niveau supérieur !"
-    },
-    "reset": {
-      "button": "Remettre à zéro",
-      "label": "Remise à zéro disponible dans { daysBeforeReset, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
-      "modal": {
-        "title": "Remise à zéro de la compétence",
-        "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
-        "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
-        "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+    "actions": {
+      "continue": {
+        "label": "Reprendre"
+      },
+      "improve": {
+        "label": "Retenter",
+        "description": {
+          "waitingText": "Tenter le niveau supérieur dans",
+          "dayBefore": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }"
+        },
+        "improvingText": "Tentez d'obtenir le niveau supérieur !"
+      },
+      "reset": {
+        "label": "Remettre à zéro",
+        "description": "Remise à zéro disponible dans { daysBeforeReset, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+        "modal": {
+          "title": "Remise à zéro de la compétence",
+          "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
+          "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+          "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+        }
+      },
+      "start": {
+        "label": "Commencer"
       }
     },
+    "forCompetence": "la compétence {competence}",
+    "linkToProfile": "Retour Profil",
+    "nextLevelInfo": "{ remainingPixToNextLevel } pix avant le niveau { level }",
     "tutorials": {
       "title": "Cultivez vos compétences",
       "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."
     }
   }
+
 }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1,30 +1,29 @@
 {
   "common": {
+    "cancel": "annuler",
     "form": {
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
     },
+    "level": "niveau",
     "mandatory": "obligatoire",
-    "or": "ou"
+    "or": "ou",
+    "pix": "pix"
   },
-
   "navigation": {
     "homepage": {
       "link": "Page d'accueil"
     }
   },
-
   "page-title": {
     "signin": "Connexion",
     "signup": "Inscription",
     "suffix": "Pix"
   },
-
   "api-error-messages": {
     "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
     "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
     "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement."
   },
-
   "signin-form": {
     "actions": {
       "submit": "Je me connecte"
@@ -47,7 +46,6 @@
     },
     "title": "Connectez-vous"
   },
-
   "signup-form": {
     "actions": {
       "submit": "Je m'inscris"
@@ -82,5 +80,37 @@
       "link": "connectez-vous à votre compte"
     },
     "title": "Inscrivez-vous"
+  },
+  "scorecard": {
+    "global": {
+      "back": "Retour Profil",
+      "startover": "reprendre",
+      "reset": "remettre à zéro",
+      "start": "Commencer"
+    },
+    "details": {
+      "levelInfo": "{ remainingPixToNextLevel } pix avant le niveau { level }"
+    },
+    "improve": {
+      "label": "Tenter le niveau supérieur dans",
+      "count": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+      "startover": "Retenter",
+      "startOverCompetence": "la compétence {competence}",
+      "improvingText": "Tentez d'obtenir le niveau supérieur !"
+    },
+    "reset": {
+      "button": "Remettre à zéro",
+      "label": "Remise à zéro disponible dans { daysBeforeReset, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+      "modal": {
+        "title": "Remise à zéro de la compétence",
+        "importantMessage": "Vos { earnedPix } Pix vont être supprimés.",
+        "importantMessageAboveLevelOne": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
+        "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+      }
+    },
+    "tutorials": {
+      "title": "Cultivez vos compétences",
+      "description": "Voici une sélection de tutos qui pourront vous aider à gagner des Pix."
+    }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Pour lancer l'internationalisation de Pix App, il faut que les templates soient remplis avec des tokens qui représentent les strings à afficher dans les différentes langues, plutôt que les textes directement en dur.

## :robot: Solution
Ember-intl a été préalablement installé, les fichiers `fr.json` et `en.json` crées. Il faut remplacer les strings en dur dans les template et compléter ces deux fichiers.

## :rainbow: Remarques
- suppression de la méthode `computeRemainingDaysBeforeImproving` qui a été remplacée par la fonction de pluralisation de ember-intl : 
```javascript
"count": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
```
Les tests ont été supprimés.

- que faire des wordings qui sont fréquemment utilisés à plusieurs endroits ? > Ils sont regroupés pour l'instant dans `common`
- comment gérer la capitalisation des mots ? Est-ce qu'on stocke dans les fichiers de traduction les strings avec des majuscules ou est-ce qu'on gère ça en CSS (ou autrement) ? > Nous avons décidé de garder la majuscule car c'est le cas le plus fréquent, et ça sera plus facile de faire un `text-transform: lowercase` au besoin
- tentative de gérer ce genre de logique dans le template `ember-intl`, selon la technique de la pluralisation, en vain : 
```javascript
{{#if @scorecard.hasNotReachLevelOne}}
  {{t 'scorecard.reset.modal.importantMessage' earnedPix=@scorecard.earnedPix}}
{{else if @scorecard.hasReachAtLeastLevelOne}}
  {{t 'scorecard.reset.modal.importantMessage' level=@scorecard.level earnedPix=@scorecard.earnedPix}}
{{/if}}
```

## :100: Pour tester
- Changer la variable d'env LOCALE=en sur la review app (et relancer).
- Voir les textes en anglais sur la page compétence