### PR TITLE
[FEATURE] Ajout de la validation sans saisie de mot réponse pour les épreuves de type QROC autovalidées (PIX-958).

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -11,13 +11,23 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
     return this._getAnswerValue().length < 1;
   }
 
-  // FIXME refactor that
   _getAnswerValue() {
     return this.showProposal ? (document.querySelector('[data-uid="qroc-proposal-uid"]')).value : this.autoReplyAnswer;
   }
 
   _getErrorMessage() {
     return 'Jouer l\'épreuve pour valider. Sinon, passer.';
+  }
+
+  _addEventListener() {
+    this.postMessageHandler = this._receiveEmbedMessage.bind(this);
+    window.addEventListener('message', this.postMessageHandler);
+  }
+
+  _receiveEmbedMessage(event) {
+    if (typeof event.data === 'string') {
+      this.autoReplyAnswer = event.data;
+    }
   }
 
   get showProposal() {
@@ -28,6 +38,19 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
   answerChanged() {
     this.set('errorMessage', null);
   }
+
+  didInsertElement() {
+    if (this.challenge.autoReply) {
+      this._addEventListener();
+    }
+  }
+
+  didDestroyElement() {
+    if (this.challenge.autoReply) {
+      window.removeEventListener('message', this.postMessageHandler);
+    }
+  }
+
 }
 
 export default ChallengeItemQroc;

--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -1,38 +1,21 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/no-component-lifecycle-hooks: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { classNames } from '@ember-decorators/component';
-import { action, computed } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
-@classic
-@classNames('qroc-proposal')
 export default class QrocProposal extends Component {
-  format = null;
-  proposals = null;
-  answerValue = null;
-  answerChanged = null; // action
 
-  @computed('proposals')
   get _blocks() {
-    return proposalsAsBlocks(this.proposals);
+    return proposalsAsBlocks(this.args.proposals);
   }
 
-  @computed('answerValue')
   get userAnswer() {
-    const answer = this.answerValue || '';
+    const answer = this.args.answerValue || '';
     return answer.indexOf('#ABAND#') > -1 ? '' : answer;
   }
 
   @action
   onInputChange() {
-    this.answerChanged();
+    this.args.answerChanged();
   }
 
-  willRender() {
-    this.notifyPropertyChange('proposals');
-  }
 }

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -1,50 +1,53 @@
-{{#each _blocks as |block|}}
+<div class="qroc-proposal">
+  {{#each this._blocks as |block|}}
 
-  {{#if block.text}}
-    <label for="qroc_input">{{block.text}}</label>
-  {{/if}}
-
-  {{#if block.input}}
-    {{#if (eq format 'paragraphe')}}
-      <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
-                rows="5"
-                id="qroc_input"
-                onkeydown={{action 'onInputChange'}}
-                name={{block.input}}
-                placeholder={{block.placeholder}}
-                autocomplete="off"
-                value="{{userAnswer}}"
-                data-uid="qroc-proposal-uid"
-                disabled={{if answer true}}>
-      </textarea>
-    {{else if (eq format 'phrase')}}
-      <input class="challenge-response__proposal challenge-response__proposal--sentence"
-             type="text"
-             id="qroc_input"
-             onkeydown={{action 'onInputChange'}}
-             name={{block.input}}
-             placeholder={{block.placeholder}}
-             autocomplete="off"
-             value="{{userAnswer}}"
-             data-uid="qroc-proposal-uid"
-             disabled={{if answer true}}>
-    {{else}}
-      <input class="challenge-response__proposal"
-             size="{{get-qroc-input-size format}}"
-             type="text"
-             id="qroc_input"
-             onkeydown={{action 'onInputChange'}}
-             name={{block.input}}
-             placeholder={{block.placeholder}}
-             autocomplete="off"
-             value="{{userAnswer}}"
-             data-uid="qroc-proposal-uid"
-             disabled={{if answer true}}>
+    {{#if block.text}}
+      <label for="qroc_input">{{block.text}}</label>
     {{/if}}
-  {{/if}}
 
-  {{#if block.breakline}}
-    <br>
-  {{/if}}
+    {{#if block.input}}
+      {{#if (eq @format 'paragraphe')}}
+        <textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
+                  rows="5"
+                  id="qroc_input"
+                  {{on 'keydown' this.onInputChange}}
+                  name={{block.input}}
+                  placeholder={{block.placeholder}}
+                  autocomplete="off"
+                  value="{{this.userAnswer}}"
+                  data-uid="qroc-proposal-uid"
+                  disabled={{if @answer true}}>
+        </textarea>
+      {{else if (eq @format 'phrase')}}
+        <input class="challenge-response__proposal challenge-response__proposal--sentence"
+               type="text"
+               id="qroc_input"
+               {{on 'keydown' this.onInputChange}}
+               name={{block.input}}
+               placeholder={{block.placeholder}}
+               autocomplete="off"
+               value="{{this.userAnswer}}"
+               data-uid="qroc-proposal-uid"
+               disabled={{if @answer true}}>
+      {{else}}
+        <input class="challenge-response__proposal"
+               size="{{get-qroc-input-size @format}}"
+               type="text"
+               id="qroc_input"
+               {{on 'keydown' this.onInputChange}}
+               name={{block.input}}
+               placeholder={{block.placeholder}}
+               autocomplete="off"
+               value="{{this.userAnswer}}"
+               data-uid="qroc-proposal-uid"
+               disabled={{if @answer true}}>
+      {{/if}}
+    {{/if}}
 
-{{/each}}
+    {{#if block.breakline}}
+      <br>
+    {{/if}}
+
+  {{/each}}
+</div>
+

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -122,4 +122,10 @@ export default Factory.extend({
     attachments: [faker.internet.url()],
   }),
 
+  withEmbed: trait({
+    embedUrl: 'https://example.biz',
+    embedTitle: faker.random.words(),
+    embedHeight: '100'
+  }),
+
 });

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -9,7 +9,7 @@ describe('Integration | Component | QROC proposal', function() {
   setupRenderingTest();
 
   it('renders', async function() {
-    await render(hbs`{{qroc-proposal}}`);
+    await render(hbs`<QrocProposal />`);
     expect(find('.qroc-proposal')).to.exist;
   });
 
@@ -21,7 +21,7 @@ describe('Integration | Component | QROC proposal', function() {
       this.set('format', 'paragraphe');
 
       // when
-      await render(hbs`{{qroc-proposal proposals=proposals format=format}}`);
+      await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
 
       // then
       expect(find('.challenge-response__proposal--paragraph').tagName).to.equal('TEXTAREA');
@@ -36,7 +36,7 @@ describe('Integration | Component | QROC proposal', function() {
       this.set('format', 'phrase');
 
       // when
-      await render(hbs`{{qroc-proposal proposals=proposals format=format}}`);
+      await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
 
       // then
       expect(find('.challenge-response__proposal--sentence').tagName).to.equal('INPUT');
@@ -56,7 +56,7 @@ describe('Integration | Component | QROC proposal', function() {
         this.set('format', data.format);
 
         // when
-        await render(hbs`{{qroc-proposal proposals=proposals format=format}}`);
+        await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
 
         // then
         expect(find('.challenge-response__proposal--paragraph')).to.not.exist;
@@ -84,7 +84,8 @@ describe('Integration | Component | QROC proposal', function() {
           this.set('format', `${data.format}`);
 
           // when
-          await render(hbs`{{qroc-proposal proposals=proposals format=format answerValue=answerValue}}`);
+          await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} @answerValue={{this.answerValue}} />`);
+
           // then
           expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('off');
         });
@@ -100,7 +101,8 @@ describe('Integration | Component | QROC proposal', function() {
           this.set('format', `${data.format}`);
 
           // when
-          await render(hbs`{{qroc-proposal proposals=proposals format=format answerValue=answerValue}}`);
+          await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} @answerValue={{this.answerValue}} />`);
+
           // then
           expect(find(`${data.cssClass}`).value).to.equal('myValue');
         });
@@ -126,7 +128,8 @@ describe('Integration | Component | QROC proposal', function() {
             this.set('format', `${data.format}`);
 
             // when
-            await render(hbs`{{qroc-proposal proposals=proposals format=format answerValue=answerValue}}`);
+            await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} @answerValue={{this.answerValue}} />`);
+
             // then
             expect(find(`${data.cssClass}`).value).to.be.equal(output);
           });


### PR DESCRIPTION
## :unicorn: Problème
Certaines épreuves de type `QROC` attendent certaines manipulations dans l'embed associé puis affichent un mot réponse que l'utilisateur doit saisir dans le champ dédié avant de valider sa bonne réponse.
Des épreuves avec autovalidation ont été créées pour affranchir l'utilisateur de cette saisie source d'erreur.
Actuellement, les `embed` permettant l'autovalidation de ces épreuves postent un message de succès mais l'application n'en tient pas compte.

## :robot: Solution
Gérer le message de succès généré par l'embed autovalidé.

## :rainbow: Remarques
A première vue, on souhaitait en profiter pour glimmerizer des composants impactés, mais `challenge-item-qroc` hérite de `challenge-item-generic` qui est la classe mère de tous les composants `challenge-item-*`.
Il faut donc glimmerizer tous les composants en même temps : le choix est fait de le faire dans une PR ultérieure.

## :100: Pour tester
Voici la liste des épreuves pour tester les embed avec validation automatique :
[recWndEZbiReZ0zsz](https://app-pr1628.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)
[recab7EiQWXfuVKqI](https://app-pr1628.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)
[recy37FMPthJpfWmd](https://app-pr1628.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)
[rec0w9GHcxIPxDY5z](https://app-pr1628.review.pix.fr/challenges/recWndEZbiReZ0zsz/preview)

- Se rendre sur l'une d'elles.
- Lancer l'embed
- Dérouler l'épreuve
- Après l'affichage de la popup "Bravo", cliquer sur `Valider`
- Vérifier sur l'écran de correction que la question est considérée comme réussie
