### PR TITLE
[FEATURE] Permettre d'envoyer une invitation pour rejoindre une organisation SCO en tant qu'administrateur (Pix-882)

### DIFF
--- a/api/db/migrations/20200706144840_add_role_to_organization_invitation.js
+++ b/api/db/migrations/20200706144840_add_role_to_organization_invitation.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organization-invitations';
+const COLUMN_NAME = 'role';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.enu(COLUMN_NAME, ['MEMBER', 'ADMIN']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -134,6 +134,15 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.ObjectValidationError) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
+  if (error instanceof DomainErrors.OrganizationNotFoundError) {
+    return new HttpErrors.NotFoundError(error.message);
+  }
+  if (error instanceof DomainErrors.OrganizationWithoutEmailError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
+  if (error instanceof DomainErrors.ManyOrganizationsFoundError) {
+    return new HttpErrors.ConflictError(error.message);
+  }
   if (error instanceof DomainErrors.FileValidationError) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -15,9 +15,9 @@ class UnprocessableEntityError extends BaseHttpError {
 }
 
 class PreconditionFailedError extends BaseHttpError {
-  constructor(message) {
+  constructor(message, title) {
     super(message);
-    this.title = 'Precondition Failed';
+    this.title = title || 'Precondition Failed';
     this.status = 412;
   }
 }
@@ -40,9 +40,9 @@ class MissingQueryParamError extends BaseHttpError {
 }
 
 class NotFoundError extends BaseHttpError {
-  constructor(message) {
+  constructor(message, title) {
     super(message);
-    this.title = 'Not Found';
+    this.title = title || 'Not Found';
     this.status = 404;
   }
 }

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -15,6 +15,18 @@ exports.register = async (server) => {
       }
     },
     {
+      method: 'POST',
+      path: '/api/organization-invitations/sco',
+      config: {
+        auth: false,
+        handler: organizationInvitationController.sendScoInvitation,
+        notes: [
+          '- Cette route permet d\'envoyer une invitation pour rejoindre une organisation de type SCO en tant que ADMIN, en renseignant un **UAI**, un **NOM** et un **PRENOM**'
+        ],
+        tags: ['api', 'invitations', 'SCO']
+      }
+    },
+    {
       method: 'GET',
       path: '/api/organization-invitations/{id}',
       config: {

--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -3,6 +3,8 @@ const _ = require('lodash');
 const { MissingQueryParamError } = require('../http-errors');
 const usecases = require('../../domain/usecases');
 const organizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/organization-invitation-serializer');
+const scoOrganizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/sco-organization-invitation-serializer');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -12,6 +14,21 @@ module.exports = {
 
     await usecases.answerToOrganizationInvitation({ organizationInvitationId, code, status, email });
     return null;
+  },
+
+  async sendScoInvitation(request, h) {
+
+    const {
+      'uai': uai,
+      'first-name': firstName,
+      'last-name': lastName,
+    } = request.payload.data.attributes;
+
+    const locale = extractLocaleFromRequest(request);
+
+    const organizationSCOInvitation = await usecases.sendScoInvitation({ uai, firstName, lastName, locale });
+
+    return h.response(scoOrganizationInvitationSerializer.serialize(organizationSCOInvitation)).created();
   },
 
   async getOrganizationInvitation(request) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -10,6 +10,24 @@ class AlreadyExistingMembershipError extends DomainError {
   }
 }
 
+class OrganizationNotFoundError extends DomainError {
+  constructor(message = 'Organisation non trouvée.') {
+    super(message);
+  }
+}
+
+class OrganizationWithoutEmailError extends DomainError {
+  constructor(message = 'Organisation sans email renseigné.') {
+    super(message);
+  }
+}
+
+class ManyOrganizationsFoundError extends DomainError {
+  constructor(message = 'Plusieurs organisations ont été retrouvées.') {
+    super(message);
+  }
+}
+
 class AlreadyExistingOrganizationInvitationError extends DomainError {
   constructor(message = 'L\'invitation de l\'organisation existe déjà.') {
     super(message);
@@ -523,6 +541,9 @@ module.exports = {
   NotEligibleCandidateError,
   NotFoundError,
   ObjectValidationError,
+  OrganizationNotFoundError,
+  OrganizationWithoutEmailError,
+  ManyOrganizationsFoundError,
   PasswordNotMatching,
   PasswordResetDemandNotFoundError,
   SameNationalStudentIdInFileError,

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -1,3 +1,9 @@
+const types = {
+  SCO : 'SCO',
+  SUP: 'SUP',
+  PRO: 'PRO',
+};
+
 class Organization {
 
   constructor({
@@ -39,4 +45,5 @@ class Organization {
   }
 }
 
+Organization.types = types;
 module.exports = Organization;

--- a/api/lib/domain/models/OrganizationInvitation.js
+++ b/api/lib/domain/models/OrganizationInvitation.js
@@ -12,6 +12,7 @@ class OrganizationInvitation {
     status,
     code,
     organizationName,
+    role,
     createdAt,
     updatedAt,
     //references
@@ -24,6 +25,7 @@ class OrganizationInvitation {
     this.code = code;
     this.organizationName = organizationName;
     this.createdAt = createdAt;
+    this.role = role;
     this.updatedAt = updatedAt;
     //references
     this.organizationId = organizationId;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -100,7 +100,7 @@ function sendOrganizationInvitationEmail({
   });
 }
 
-function sendOrganizationInvitationScoEmail({
+function sendScoOrganizationInvitationEmail({
   email,
   organizationName,
   firstName, lastName,
@@ -147,6 +147,6 @@ function sendOrganizationInvitationScoEmail({
 module.exports = {
   sendAccountCreationEmail,
   sendOrganizationInvitationEmail,
-  sendOrganizationInvitationScoEmail,
+  sendScoOrganizationInvitationEmail,
   sendResetPasswordDemandEmail,
 };

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -1,5 +1,5 @@
 const randomString = require('randomstring');
-
+const Membership = require('../models/Membership');
 const mailService = require('../../domain/services/mail-service');
 
 // TODO Export all functions generating random codes to an appropriate service
@@ -33,6 +33,36 @@ const createOrganizationInvitation = async ({
   return organizationInvitation;
 };
 
+const createScoOrganizationInvitation = async ({
+  organizationRepository, organizationInvitationRepository, organizationId,firstName, lastName, email, locale, tags
+}) => {
+  let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
+
+  if (!organizationInvitation) {
+    const code = _generateCode();
+    const role = Membership.roles.ADMIN;
+    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, code, role });
+  }
+
+  const { name: organizationName } = await organizationRepository.get(organizationId);
+
+  await mailService.sendScoOrganizationInvitationEmail({
+    email,
+    organizationName,
+    firstName,
+    lastName,
+    organizationInvitationId: organizationInvitation.id,
+    code: organizationInvitation.code,
+    locale,
+    tags
+  });
+
+  await organizationInvitationRepository.updateModificationDate(organizationInvitation.id);
+
+  return organizationInvitation;
+};
+
 module.exports = {
-  createOrganizationInvitation
+  createOrganizationInvitation,
+  createScoOrganizationInvitation
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -175,6 +175,7 @@ module.exports = injectDependencies({
   retrieveLastOrCreateCertificationCourse: require('./retrieve-last-or-create-certification-course'),
   saveCertificationCenter: require('./save-certification-center'),
   shareCampaignResult: require('./share-campaign-result'),
+  sendScoInvitation: require('./send-sco-invitation'),
   startCampaignParticipation: require('./start-campaign-participation'),
   startOrResumeCompetenceEvaluation: require('./start-or-resume-competence-evaluation'),
   startWritingCampaignAssessmentResultsToStream: require('./start-writing-campaign-assessment-results-to-stream'),

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -1,0 +1,48 @@
+const _ = require('lodash');
+const { OrganizationNotFoundError, OrganizationWithoutEmailError, ManyOrganizationsFoundError } = require('../errors');
+const organizationInvitationService = require('../../domain/services/organization-invitation-service');
+let errorMessage = null;
+let organizationsFound = null;
+
+module.exports = async function sendScoInvitation({ uai, firstName, lastName, locale, organizationRepository, organizationInvitationRepository }) {
+
+  organizationsFound = await organizationRepository.findScoOrganizationByUai(uai);
+
+  const nbOrganizations = _.get(organizationsFound, 'length', 0);
+
+  _checkIfManyOrganizationsFoundError(nbOrganizations, uai);
+
+  _checkIfOrganizationNotFoundError(nbOrganizations, uai);
+
+  _checkIfOrganizationWithoutEmailError(nbOrganizations, uai);
+
+  const email = organizationsFound[0].email;
+  const organizationId = organizationsFound[0].id;
+
+  const scoOrganizationInvitation = await organizationInvitationService.createScoOrganizationInvitation({
+    organizationRepository, organizationInvitationRepository, organizationId, firstName, lastName, email, locale
+  });
+
+  return scoOrganizationInvitation;
+};
+
+function _checkIfOrganizationNotFoundError(nbOrganizations, uai) {
+  if (nbOrganizations == 0) {
+    errorMessage = `L'UAI/RNE ${uai} de l'établissement n’est pas reconnu.`;
+    throw new OrganizationNotFoundError(errorMessage);
+  }
+}
+
+function _checkIfManyOrganizationsFoundError(nbOrganizations, uai) {
+  if (nbOrganizations > 1) {
+    errorMessage = `Plusieurs établissements de type SCO ont été retrouvés pour L'UAI/RNE ${uai}.`;
+    throw new ManyOrganizationsFoundError(errorMessage);
+  }
+}
+
+function _checkIfOrganizationWithoutEmailError(nbOrganizations, uai) {
+  if (nbOrganizations == 1 && _.isEmpty(organizationsFound[0].email)) {
+    errorMessage = `Nous n’avons pas d’adresse e-mail de contact associée à l'établissement concernant l'UAI/RNE ${uai}.`;
+    throw new OrganizationWithoutEmailError(errorMessage);
+  }
+}

--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -26,9 +26,9 @@ function _checkNotFoundErrorWithCode({ error, id, code }) {
 
 module.exports = {
 
-  create({ organizationId, email, code }) {
+  create({ organizationId, email, code, role }) {
     const status = OrganizationInvitation.StatusType.PENDING;
-    return new BookshelfOrganizationInvitation({ organizationId, email, status, code })
+    return new BookshelfOrganizationInvitation({ organizationId, email, status, code, role })
       .save()
       .then(_toDomain);
   },

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -101,6 +101,13 @@ module.exports = {
       .then((organizations) => organizations.models.map(_toDomain));
   },
 
+  findScoOrganizationByUai(uai) {
+    return BookshelfOrganization
+      .where({ externalId: uai, type: Organization.types.SCO })
+      .fetchAll({ columns: ['id', 'type', 'externalId', 'email'] })
+      .then((organizations) => organizations.models.map(_toDomain));
+  },
+
   findPaginatedFiltered({ filter, page }) {
     return BookshelfOrganization
       .query((qb) => _setSearchFiltersForQueryBuilder(filter, qb))

--- a/api/lib/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer.js
@@ -1,0 +1,11 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(invitation) {
+    return new Serializer('sco-organization-invitation', {
+      attributes: ['uai', 'lastName', 'firstName'],
+    }).serialize(invitation);
+  },
+
+};

--- a/api/tests/integration/application/organization-invitations/index_test.js
+++ b/api/tests/integration/application/organization-invitations/index_test.js
@@ -27,6 +27,22 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
     });
   });
 
+  describe('POST /api/organization-invitations/sco', () => {
+
+    beforeEach(async () => {
+      sinon.stub(organisationInvitationController, 'sendScoInvitation').callsFake((request, h) => h.response().code(201));
+      await server.register(route);
+    });
+
+    it('should exists', async () => {
+      // when
+      const response = await server.inject({ method: 'POST', url: '/api/organization-invitations/sco' });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+
   describe('GET /api/organization-invitations/:id', () => {
 
     beforeEach(async () => {

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -2,10 +2,11 @@ const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
+const scoOrganizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer');
 const moduleUnderTest = require('../../../../lib/application/organization-invitations');
 
 const {
-  AlreadyExistingOrganizationInvitationError, NotFoundError, UserNotFoundError
+  AlreadyExistingOrganizationInvitationError, NotFoundError, UserNotFoundError, OrganizationWithoutEmailError, OrganizationNotFoundError, ManyOrganizationsFoundError
 } = require('../../../../lib/domain/errors');
 
 describe('Integration | Application | Organization-invitations | organization-invitation-controller', () => {
@@ -16,6 +17,8 @@ describe('Integration | Application | Organization-invitations | organization-in
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(usecases, 'answerToOrganizationInvitation');
+    sandbox.stub(usecases, 'sendScoInvitation');
+    sandbox.stub(scoOrganizationInvitationSerializer, 'serialize');
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -86,6 +89,71 @@ describe('Integration | Application | Organization-invitations | organization-in
 
         // then
         expect(response.statusCode).to.equal(404);
+      });
+    });
+  });
+
+  describe('#sendScoInvitation', () => {
+
+    const uai = '1234567A';
+    const payload = {
+      data: {
+        type: 'organization-invitations',
+        attributes: {
+          uai,
+          'first-name': 'john',
+          'last-name': 'harry',
+        },
+      }
+    };
+
+    context('Success cases', () => {
+
+      it('should return an HTTP response with status code 201', async () => {
+        // given
+        usecases.sendScoInvitation.resolves();
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/sco', payload);
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+
+    context('Error cases', () => {
+
+      it('should respond an HTTP response with status code 404 when OrganizationNotFoundError', async () => {
+        // given
+        usecases.sendScoInvitation.rejects(new OrganizationNotFoundError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/sco', payload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+
+      it('should respond an HTTP response with status code 409 when OrganizationWithoutEmailError', async () => {
+        // given
+        usecases.sendScoInvitation.rejects(new OrganizationWithoutEmailError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/sco', payload);
+
+        // then
+        expect(response.statusCode).to.equal(412);
+      });
+
+      it('should respond an HTTP response with status code 409 when ManyOrganizationsFoundError', async () => {
+        // given
+        usecases.sendScoInvitation.rejects(new ManyOrganizationsFoundError());
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/organization-invitations/sco', payload);
+
+        // then
+        expect(response.statusCode).to.equal(409);
       });
     });
   });

--- a/api/tests/integration/domain/services/organization-invitation-service_test.js
+++ b/api/tests/integration/domain/services/organization-invitation-service_test.js
@@ -30,6 +30,7 @@ describe('Integration | Service | Organization-Invitation Service', () => {
         organizationId,
         email,
         status: OrganizationInvitation.StatusType.PENDING,
+        role: null,
       };
 
       // when

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -1,12 +1,14 @@
 const _ = require('lodash');
 const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
-
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const Membership = require('../../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const organizationInvitationRepository = require('../../../../lib/infrastructure/repositories/organization-invitation-repository');
 const BookshelfOrganizationInvitation = require('../../../../lib/infrastructure/data/organization-invitation');
 
 describe('Integration | Repository | OrganizationInvitationRepository', () => {
+
+  const role = Membership.roles.ADMIN;
 
   describe('#create', () => {
 
@@ -26,9 +28,8 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       const email = 'member@organization.org';
       const status = OrganizationInvitation.StatusType.PENDING;
       const code = 'ABCDEFGH01';
-
       // when
-      const savedInvitation = await organizationInvitationRepository.create({ organizationId, email, code });
+      const savedInvitation = await organizationInvitationRepository.create({ organizationId, email, code, role });
 
       // then
       expect(savedInvitation).to.be.instanceof(OrganizationInvitation);
@@ -36,6 +37,8 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       expect(savedInvitation.email).equal(email);
       expect(savedInvitation.status).equal(status);
       expect(savedInvitation.code).equal(code);
+      expect(savedInvitation.role).equal(role);
+
     });
   });
 
@@ -58,6 +61,7 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       expect(foundOrganizationInvitation.email).to.equal(insertedOrganizationInvitation.email);
       expect(foundOrganizationInvitation.status).to.equal(insertedOrganizationInvitation.status);
       expect(foundOrganizationInvitation.code).to.equal(insertedOrganizationInvitation.code);
+
     });
 
     it('should return a rejection when organization-invitation id is not found', async () => {
@@ -94,6 +98,7 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       expect(foundOrganizationInvitation.email).to.equal(insertedOrganizationInvitation.email);
       expect(foundOrganizationInvitation.status).to.equal(insertedOrganizationInvitation.status);
       expect(foundOrganizationInvitation.code).to.equal(insertedOrganizationInvitation.code);
+
     });
 
     it('should return a rejection when organization-invitation id and code are not found', async () => {
@@ -154,6 +159,7 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
       expect(organizationInvitationSaved.email).to.equal(organizationInvitation.email);
       expect(organizationInvitationSaved.status).to.equal(statusAccepted);
       expect(organizationInvitationSaved.code).to.equal(organizationInvitation.code);
+
     });
   });
 
@@ -173,10 +179,13 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
     });
 
     it('should retrieve one pending organization-invitation with given organizationId and email', async () => {
+
       const { organizationId, email } = organizationInvitation;
 
       // when
       const foundOrganizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
+      console.log(foundOrganizationInvitation);
+      console.log(organizationInvitation);
 
       // then
       expect(_.omit(foundOrganizationInvitation, 'organizationName')).to.deep.equal(organizationInvitation);

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -184,8 +184,6 @@ describe('Integration | Repository | OrganizationInvitationRepository', () => {
 
       // when
       const foundOrganizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
-      console.log(foundOrganizationInvitation);
-      console.log(organizationInvitation);
 
       // then
       expect(_.omit(foundOrganizationInvitation, 'organizationName')).to.deep.equal(organizationInvitation);

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -273,6 +273,38 @@ describe('Integration | Repository | Organization', function() {
     });
   });
 
+  describe('#findScoOrganizationByUai', () => {
+    let organizations;
+
+    beforeEach(async () => {
+      organizations = _.map([
+        { type: 'PRO', name: 'organization 1', externalId: '1234567', email: null },
+        { type: 'SCO', name: 'organization 2', externalId: '1234568', email: 'sco.generic.account@example.net' },
+        { type: 'SUP', name: 'organization 3', externalId: '1234569', email: null },
+      ], (organization) => {
+        return databaseBuilder.factory.buildOrganization(organization);
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return external identifier and email for SCO organizations matching given UAI', async () => {
+      // given
+      const uai = '1234568';
+      const organizationSCO = organizations[1];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+
+      // then
+      expect(foundOrganization).to.have.lengthOf(1);
+      expect(foundOrganization[0]).to.be.an.instanceof(Organization);
+      expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
+      expect(foundOrganization[0].type).to.equal(organizationSCO.type);
+      expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+  });
+
   describe('#findPaginatedFiltered', () => {
 
     context('when there are Organizations in the database', () => {

--- a/api/tests/tooling/database-builder/factory/build-organization-invitation.js
+++ b/api/tests/tooling/database-builder/factory/build-organization-invitation.js
@@ -11,11 +11,13 @@ module.exports = function buildOrganizationInvitation(
     email,
     status = OrganizationInvitation.StatusType.PENDING,
     code = faker.random.alphaNumeric(10).toUpperCase(),
+    role,
     updatedAt = new Date(),
   } = {}) {
 
   organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
   email = _.isUndefined(email) ? faker.internet.exampleEmail().toLowerCase() : email.toLowerCase();
+  role = null;
 
   const values = {
     id,
@@ -23,6 +25,7 @@ module.exports = function buildOrganizationInvitation(
     email,
     status,
     code,
+    role,
     createdAt: new Date(),
     updatedAt,
   };

--- a/api/tests/unit/domain/models/OrganizationInvitation_test.js
+++ b/api/tests/unit/domain/models/OrganizationInvitation_test.js
@@ -16,6 +16,7 @@ describe('Unit | Domain | Models | OrganizationInvitation', () => {
         email: 'member@team.org',
         status: 'pending',
         code: 'ABCDEFGH01',
+        role: null,
         createdAt: today,
         updatedAt: today,
       };

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -234,7 +234,7 @@ describe('Unit | Service | MailService', () => {
     });
   });
 
-  describe('#sendOrganizationInvitationScoEmail', () => {
+  describe('#sendScoOrganizationInvitationEmail', () => {
 
     const fromName = 'Pix Orga - Ne pas répondre';
 
@@ -270,7 +270,7 @@ describe('Unit | Service | MailService', () => {
       };
 
       // when
-      await mailService.sendOrganizationInvitationScoEmail({
+      await mailService.sendScoOrganizationInvitationEmail({
         email: userEmailAddress,
         organizationName,
         firstName, lastName,

--- a/api/tests/unit/domain/usecases/send-sco-invitation_test.js
+++ b/api/tests/unit/domain/usecases/send-sco-invitation_test.js
@@ -1,0 +1,64 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const Organization  = require('../../../../lib/domain/models/Organization');
+const { OrganizationNotFoundError, OrganizationWithoutEmailError, ManyOrganizationsFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | find-organizations', () => {
+
+  const organizationRepository = {
+    findScoOrganizationByUai: sinon.stub(),
+    get: sinon.stub(),
+  };
+
+  it('should throw an NotFoundOrganization when UAI did not match', async () => {
+    // given
+    const  uai = '1234567A' ;
+    const message = 'L\'UAI/RNE 1234567A de l\'établissement n’est pas reconnu.';
+
+    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([]);
+
+    const requestErr = await catchErr(usecases.sendScoInvitation)({
+      uai,
+      organizationRepository
+    });
+
+    expect(requestErr).to.be.instanceOf(OrganizationNotFoundError);
+    expect(requestErr.message).to.be.equal(message);
+  });
+
+  it('should throw an OrganizationWithoutEmailError when email is not present', async () => {
+    // given
+    const  uai = '1234567A' ;
+    const organization = new Organization({ id: 2, type: 'SCO', name: 'organization 2', externalId: '1234568' , email: null });
+    const message = 'Nous n’avons pas d’adresse e-mail de contact associée à l\'établissement concernant l\'UAI/RNE 1234567A.';
+    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization]);
+
+    const requestErr = await catchErr(usecases.sendScoInvitation)({
+      uai,
+      organizationRepository
+    });
+
+    expect(requestErr).to.be.instanceOf(OrganizationWithoutEmailError);
+    expect(requestErr.message).to.be.equal(message);
+  });
+
+  it('should throw a ManyOrganizationsFoundError when many organizations found', async () => {
+    // given
+    const  uai = '1234567A' ;
+    const organization1 = new Organization({ id: 2, type: 'SCO', name: 'organization 2', externalId: '1234568' , email: 'sco.generic.account@example.net' });
+    const organization2 = new Organization({ id: 2, type: 'SCO', name: 'organization 2', externalId: '1234568' , email: 'sco.generic.account@example.net' });
+    const message = 'Plusieurs établissements de type SCO ont été retrouvés pour L\'UAI/RNE 1234567A.';
+
+    organizationRepository.findScoOrganizationByUai.withArgs(uai).resolves([organization1, organization2]);
+
+    // when
+    const requestErr = await catchErr(usecases.sendScoInvitation)({
+      uai,
+      organizationRepository
+    });
+
+    // then
+    expect(requestErr).to.be.instanceOf(ManyOrganizationsFoundError);
+    expect(requestErr.message).to.be.equal(message);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer_test.js
@@ -1,0 +1,25 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/sco-organization-invitation-serializer');
+
+describe('Unit | Serializer | JSONAPI | sco-organization-invitation-serializer', () => {
+
+  describe('#serialize', () => {
+
+    const invitationObject = domainBuilder.buildOrganizationInvitation();
+
+    const expectedInvitationJson = {
+      data: {
+        type: 'sco-organization-invitations',
+        id: invitationObject.id.toString(),
+      }
+    };
+
+    it('should convert an organization-invitation object into JSON API data', () => {
+      // when
+      const json = serializer.serialize(invitationObject);
+
+      // then
+      expect(json).to.deep.equal(expectedInvitationJson);
+    });
+  });
+});

--- a/orga/app/adapters/sco-organization-invitation.js
+++ b/orga/app/adapters/sco-organization-invitation.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class ScoOrganizationInvitation extends ApplicationAdapter {
+
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/organization-invitations/sco`;
+  }
+}

--- a/orga/app/components/routes/join-request-form.js
+++ b/orga/app/components/routes/join-request-form.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import InputValidator from '../../utils/input-validator';
 import isUAIValid from '../../utils/uai-validator';
 
@@ -11,10 +12,14 @@ export default class JoinRequestForm extends Component {
   @service session;
   @service store;
 
-  isLoading = false;
+  @tracked uai;
+  @tracked firstName;
+  @tracked lastName;
+
+  @tracked isLoading = false;
 
   validation = {
-    uai: new InputValidator(isUAIValid, 'L\'UAI n\'est pas correct.'),
+    uai: new InputValidator(isUAIValid, 'L\'UAI n\'est pas au bon format.'),
     firstName: new InputValidator(isStringValid, 'Votre prénom n’est pas renseigné.'),
     lastName: new InputValidator(isStringValid, 'Votre nom n’est pas renseigné.'),
   };
@@ -22,5 +27,14 @@ export default class JoinRequestForm extends Component {
   @action
   validateInput(key, value) {
     this.validation[key].validate({ value, resetServerMessage: true });
+  }
+
+  @action
+  async submit(event) {
+    event.preventDefault();
+    this.isLoading = true;
+    const scoOrganizationInvitation = { uai: this.uai, firstName: this.firstName, lastName: this.lastName };
+    await this.args.createScoOrganizationInvitation(scoOrganizationInvitation);
+    this.isLoading = false;
   }
 }

--- a/orga/app/controllers/join-request.js
+++ b/orga/app/controllers/join-request.js
@@ -1,0 +1,54 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import _ from 'lodash';
+
+export default class JoinRequestController extends Controller {
+
+  @tracked isSubmit = false;
+  @tracked isOrganizationNotFound = false;
+  @tracked organizationHasNoEmail = false;
+  @tracked hasErrorMessage = false;
+
+  @action
+  async createScoOrganizationInvitation(scoOrganizationInvitation) {
+    this._resetErrorState();
+    try {
+      await this.store.createRecord('sco-organization-invitation', scoOrganizationInvitation).save();
+      this.isSubmit = true;
+    } catch (response) {
+      this._manageApiErrors(response);
+    }
+  }
+
+  _manageApiErrors(response = {}) {
+    const nbErrors = _.get(response, 'errors.length', 0);
+    if (nbErrors > 0) {
+      const firstError = response.errors[0];
+      this._showErrorMessages(firstError.status);
+    } else {
+      this.hasErrorMessage = true;
+    }
+  }
+
+  _showErrorMessages(status) {
+    switch (status) {
+      case '404':
+        this.isOrganizationNotFound = true;
+        break;
+      case '412':
+        this.organizationHasNoEmail = true;
+        break;
+      case '409':
+      default:
+        this.hasErrorMessage = true;
+    }
+  }
+
+  _resetErrorState() {
+    this.isOrganizationNotFound = false;
+    this.organizationHasNoEmail = false;
+    this.hasErrorMessage = false;
+  }
+
+}

--- a/orga/app/models/sco-organization-invitation.js
+++ b/orga/app/models/sco-organization-invitation.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+const { Model, attr } = DS;
+
+export default class ScoOrganizationInvitation extends Model {
+
+  @attr('string') uai;
+  @attr('string') firstName;
+  @attr('string') lastName;
+
+}

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -7,12 +7,6 @@
     margin: 0 0 24px;
   }
 
-  &__error-message {
-    margin-bottom: 10px;
-    font-size: 0.875rem;
-    text-align: center;
-  }
-
   &__back {
     font-size: 1rem;
     text-align: left;

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -8,6 +8,14 @@
   justify-content: center;
   min-height: 800px;
 
+  a {
+    color: $communication-dark;
+
+    &:visited {
+      color: $communication-dark;
+    }
+  }
+
   &__panel {
     border-radius: 10px;
     display: flex;
@@ -38,5 +46,20 @@
     font-weight: 400;
     line-height: 1.375rem;
     margin: 0 0 48px;
+  }
+
+  &__error-message {
+    max-width: 497px;
+    margin-bottom: 24px;
+    font-size: 0.875rem;
+    text-align: center;
+  }
+
+  &__success {
+    text-align: center;
+    color: $grey-90;
+    letter-spacing: .15px;
+    margin-top: 54px;
+    margin-bottom: 24px;
   }
 }

--- a/orga/app/templates/components/routes/join-request-form.hbs
+++ b/orga/app/templates/components/routes/join-request-form.hbs
@@ -1,11 +1,8 @@
 <div class="join-request-form">
-  {{#if this.hasErrorMessage}}
-    <div id="join-request-form-error-message" class="join-request-form__error-message error-message">{{this.errorMessage}}</div>
-  {{/if}}
 
   <p class="join-request-form__information">Tous les champs sont obligatoires.</p>
 
-  <form>
+  <form {{on "submit" this.submit}}>
 
     <div class="input-container">
       <label for="uai" class="label">UAI/RNE de l'établissement</label>
@@ -65,8 +62,5 @@
       {{/if}}
     </div>
 
-    <div class="join-request-form__back">
-      <LinkTo @route="login"><FaIcon @icon="arrow-left" />Revenir à la page de connexion</LinkTo>
-    </div>
   </form>
 </div>

--- a/orga/app/templates/join-request.hbs
+++ b/orga/app/templates/join-request.hbs
@@ -3,12 +3,43 @@
     <div class="panel__image">
       <img src="/pix-orga.svg" alt="Pix Orga">
     </div>
-    <h1 class="join-request__title">Activez ou récupérez votre espace</h1>
-    <p class="join-request__description">
-      A l'attention des personnels de direction. <br/>
-      Saisissez ces informations pour recevoir un lien d'activation à l'adresse e-mail
-      de votre établissement et devenir administrateur de l'espace Pix Orga.
-    </p>
-    <Routes::JoinRequestForm />
+    {{#if this.isSubmit}}
+      <p class="join-request__success">
+        Un e-mail contenant la démarche à suivre a été envoyé <br/>
+        à l'adresse email de votre établissement. <br/>
+        Si vous ne le recevez pas, vérifiez les courriers indésirables,<br/>
+        ou <a href="https://support.pix.fr/support/tickets/new">contactez le support</a>.
+      </p>
+    {{else}}
+      <h1 class="join-request__title">Activez ou récupérez votre espace</h1>
+      <p class="join-request__description">
+        A l'attention des personnels de direction. <br/>
+        Saisissez ces informations pour recevoir un lien d'activation à l'adresse e-mail
+        de votre établissement et devenir administrateur de l'espace Pix Orga.
+      </p>
+
+      {{#if this.isOrganizationNotFound}}
+        <div class="join-request__error-message error-message">
+          L'UAI/RNE de l'établissement n’est pas reconnu. Merci de <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.
+        </div>
+      {{/if}}
+
+      {{#if this.organizationHasNoEmail}}
+        <div class="join-request__error-message error-message">
+          Nous n’avons pas d’adresse e-mail de contact associée à votre établissement, merci de <a href="https://support.pix.fr/support/tickets/new">contacter le support</a> pour récupérer votre accès.
+        </div>
+      {{/if}}
+
+      {{#if this.hasErrorMessage}}
+        <div class="join-request__error-message error-message">
+          Une erreur est survenue. Merci de <a href="https://support.pix.fr/support/tickets/new">contacter le support</a>.
+        </div>
+      {{/if}}
+
+      <Routes::JoinRequestForm @createScoOrganizationInvitation={{this.createScoOrganizationInvitation}} />
+    {{/if}}
+    <div class="join-request-form__back">
+      <LinkTo @route="login"><FaIcon @icon="arrow-left" />Revenir à la page de connexion</LinkTo>
+    </div>
   </div>
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -151,6 +151,23 @@ export default function() {
     return new Response(204);
   });
 
+  this.post('/organization-invitations/sco', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+    const { uai, firstName, lastName } = requestBody.data.attributes;
+
+    const organization = schema.organizations.findBy({ externalId: uai });
+
+    if (!organization || organization.type !== 'SCO') {
+      return new Response(404, {}, { errors: [ { status: '404', title: 'OrganizationNotFoundError', detail: 'L\'UAI/RNE de l\'établissement ne correspond à aucun établissement dans la base de données Pix. Merci de contacter le support.' } ] });
+    }
+
+    if (!organization.email) {
+      return new Response(412, {}, { errors: [ { status: '412', title: 'OrganizationWithoutEmailError', detail: 'Nous n\'avons pas d\'adresse e-mail de contact associé à votre établissement, merci de contacter le support pour récupérer votre accès.' } ] });
+    }
+
+    return schema.scoOrganizationInvitations.create({ uai, firstName, lastName });
+  });
+
   this.get('/organizations/:id/students', findFilteredPaginatedStudents);
 
   this.post('/organizations/:id/import-students', (schema, request) => {

--- a/orga/tests/acceptance/join-request-test.js
+++ b/orga/tests/acceptance/join-request-test.js
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { visit, fillIn, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import Response from 'ember-cli-mirage/response';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | join-request', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    await visit('/demande-administration-sco');
+  });
+
+  module('When user submits the join request form', function() {
+
+    test('it should fail if the uai does not belong to any organization', async function(assert) {
+      // given
+      await fillIn('#uai', '1111111A');
+      await fillIn('#firstName', 'firstName');
+      await fillIn('#lastName', 'lastName');
+
+      // when
+      await click('button.join-request-form__button');
+
+      // then
+      assert.contains('L\'UAI/RNE de l\'établissement n’est pas reconnu. Merci de contacter le support.');
+    });
+
+    test('it should fail if the uai does not belong to a SCO organization', async function(assert) {
+      // given
+      const proOrganization = server.create('organization', { type: 'PRO', externalId: '1234567P' });
+
+      await fillIn('#uai', proOrganization.externalId);
+      await fillIn('#firstName', 'firstName');
+      await fillIn('#lastName', 'lastName');
+
+      // when
+      await click('button.join-request-form__button');
+
+      // then
+      assert.contains('L\'UAI/RNE de l\'établissement n’est pas reconnu. Merci de contacter le support.');
+    });
+
+    test('it should fail if the SCO organization does not have an email', async function(assert) {
+      // given
+      const scoOrganization = server.create('organization', { type: 'SCO', externalId: '1234567S' });
+
+      await fillIn('#uai', scoOrganization.externalId);
+      await fillIn('#firstName', 'firstName');
+      await fillIn('#lastName', 'lastName');
+
+      // when
+      await click('button.join-request-form__button');
+
+      // then
+      assert.contains('Nous n’avons pas d’adresse e-mail de contact associée à votre établissement, merci de contacter le support pour récupérer votre accès.');
+    });
+
+    test('it should display error message if there is an unknown error', async function(assert) {
+      // given
+      server.post('/organization-invitations/sco', () => new Response(500, {}, { errors: [{ status: '500', title: 'Internal Server Error' }] }));
+
+      await fillIn('#uai', '1111111A');
+      await fillIn('#firstName', 'firstName');
+      await fillIn('#lastName', 'lastName');
+
+      // when
+      await click('button.join-request-form__button');
+
+      // then
+      assert.contains('Une erreur est survenue. Merci de contacter le support.');
+    });
+
+    test('it should succeed if there is no errors', async function(assert) {
+      // given
+      const scoOrganization = server.create('organization', { type: 'SCO', externalId: '1234567S', email: 'sco@example.net' });
+
+      await fillIn('#uai', scoOrganization.externalId);
+      await fillIn('#firstName', 'firstName');
+      await fillIn('#lastName', 'lastName');
+
+      // when
+      await click('button.join-request-form__button');
+
+      // then
+      assert.dom('.join-request__success').exists();
+    });
+  });
+});

--- a/orga/tests/integration/components/routes/join-request-form-test.js
+++ b/orga/tests/integration/components/routes/join-request-form-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | routes/join-request-form', function(hooks) {
 
     const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
     const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
-    const INCORRECT_UAI_FORMAT_ERROR_MESSAGE = 'L\'UAI n\'est pas correct.';
+    const INCORRECT_UAI_FORMAT_ERROR_MESSAGE = 'L\'UAI n\'est pas au bon format.';
 
     [{ stringFilledIn: ' ' },
       { stringFilledIn: '123456Z' },


### PR DESCRIPTION
## :unicorn: Problème
Les professeurs ne peuvent pas récupérer l'accès d'administration à Pix Orga suite au départ de l'administrateur.


## :robot: Solution
Permettre d'envoyer une invitation pour rejoindre une organisation de type SCO en tant qu'administrateur. Cette invitation est envoyée à l'adresse email de l'organisation.

## :rainbow: Remarques
Cette PR permet d'implementer le bouton d'envoi d'invitation ainsi que de la gestion des erreurs de la page.

## :100: Pour tester

Modifier l'email de l'organisation suivante avec votre adresse email pour le test:
https://admin-pr1630.review.pix.fr/organizations/3/members

Cas droit:
Aller sur l'url publique: https://orga-pr1630.review.pix.fr/demande-administration-sco.
Saisir l'UAI de l'organization SCO 1234567A , nom et prénom. 
Cliquer sur envoyer.
Vérifier qu'une invitation est envoyée dans l'email de l'organisation.

Vérifier les messages lors des Cas d'erreur:
1-Nous n’avons pas d’adresse e-mail de contact associée à votre établissement, merci de contacter le support pour récupérer votre accès.
Saisir l'UAI de l'organization SCO 1234567C , nom et prénom. ==> organisation sans email
2-Une erreur est survenue. Merci de contacter le support.
Saisir l'UAI de l'organization SCO 1234567D , nom et prénom. ==> plusieurs orga pour le même UAI
3-L'UAI/RNE de l'établissement n’est pas reconnu. Merci de contacter le support.
Saisir l'UAI de l'organization SCO 1234567T , nom et prénom. ==> organisation non trouvée ou elle est pas de type SCO.


