### PR TITLE
[BUGFIX] Bannière "Votre profil n'est pas encore certifiable." KO (PIX-963)

### DIFF
--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -71,9 +71,7 @@
 .result-content__button {
   border: none;
   display: block;
-  font-size: 0.813rem;
-  text-transform: uppercase;
-  font-weight: $font-bold;
+  font-size: 1rem;
   text-align: center;
   color: $white;
   padding: 6px 15px;
@@ -83,6 +81,7 @@
   width: 170px;
   height: 40px;
   text-decoration: none;
+  cursor: pointer;
 
   &:hover {
     color: $white;
@@ -95,7 +94,8 @@
 
 }
 .result-content__button-blocked {
-  background: lighten($blue, 50%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .result-content__logout-button,

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -4,6 +4,15 @@
   }
 }
 
+.certification-start-page__title {
+  color: $grey-100;
+  font-family: $font-open-sans;
+  font-size: 2.625rem;
+  font-weight: $font-light;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
 .certification-course-page__order {
   color: $grey-80;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -4,6 +4,10 @@
   }
 }
 
+.certification-start-page__block {
+  padding: 12px;
+}
+
 .certification-start-page__title {
   color: $grey-100;
   font-family: $font-open-sans;

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -6,7 +6,7 @@
     <PixBackgroundHeader>
 
       {{#if model.isCertifiable}}
-        <PixBlock @shadow="heavy">
+        <PixBlock @shadow="heavy" class="certification-start-page__block">
           <Stepper @steps={{array "certification-stepper-join" "certification-stepper-start"}}/>
         </PixBlock>
       {{else}}

--- a/mon-pix/app/templates/components/certification-not-certifiable.hbs
+++ b/mon-pix/app/templates/components/certification-not-certifiable.hbs
@@ -1,4 +1,4 @@
-<div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner certification-not-certifiable__panel">
+<PixBlock class="certification-not-certifiable__panel">
   <h3 class="certification-not-certifiable__title">
       Votre profil n'est pas encore certifiable.
   </h3>
@@ -7,4 +7,4 @@
   </p>
 
   <LinkTo @route="index" class="button button--link button--big button--thin certification-not-certifiable__button">Retour à l'accueil</LinkTo>
-</div>
+</PixBlock>

--- a/mon-pix/app/templates/components/certification-results-page.hbs
+++ b/mon-pix/app/templates/components/certification-results-page.hbs
@@ -26,7 +26,7 @@
       </div>
 
       {{#if this.validSupervisor}}
-        <button class="result-content__button result-content__validation-button" {{action "validateBySupervisor"}}>Je confirme</button>
+        <button class="result-content__button result-content__validation-button button button--big button--thin" {{on "click" this.validateBySupervisor}}>Je confirme</button>
       {{else}}
         <button class="result-content__button result-content__button-blocked">Je confirme</button>
       {{/if}}
@@ -44,7 +44,7 @@
         Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.
       </div>
 
-      <LinkTo @route="logout" class="result-content__logout-button result-content__button">Se déconnecter</LinkTo>
+      <LinkTo @route="logout" class="result-content__logout-button result-content__button button button--big button--thin">Se déconnecter</LinkTo>
 
     </div>
   {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Le design de la page pour rejoindre une certif est complètement KO: le bloc affichant " Votre profil n'est pas encore certifiable." est décalé très haut, on ne peut plus le lire.

AVANT (le bug)
![image](https://user-images.githubusercontent.com/38167520/87058360-47e5f080-c208-11ea-8fff-77630eb169d4.png)


## :robot: Solution
Cela était dû à la mise en place du composant PixBackgroundBanner. De base le bloc blanc était décalé vers le haut de -200pixel (`.rounded-panel--over-background-banner`) par rapport à la bannière de fond bleu. Maintenant que le fond bleu n'est pas positionné il n'est pas nécessaire de faire ce décalage là. Et par la même occasion remplacer par un PixBlock.
APRES
<img width="1221" alt="image" src="https://user-images.githubusercontent.com/38167520/87058320-3866a780-c208-11ea-98e1-408c7539e6ce.png">


## :100: Pour tester
- aller sur l'onglet 'Certification' avec un profil non certifiable (- de 5 compétences ayant un niveau, niveau 1 ou plus)
- voir que la page s'affiche bien
