### PR TITLE
[BUGFIX] Corriger le titre et la barre de progression des previews (PIX-943).

### DIFF
--- a/mon-pix/app/utils/progress-in-assessment.js
+++ b/mon-pix/app/utils/progress-in-assessment.js
@@ -1,6 +1,12 @@
 import ENV from 'mon-pix/config/environment';
+const PREVIEW_UNIQUE_STEP = 1;
+const PREVIEW_UNIQUE_CURRENT_STEP_INDEX = 0;
 
 function getMaxStepsNumber(assessment) {
+  if (assessment.isPreview) {
+    return PREVIEW_UNIQUE_STEP;
+  }
+
   if (assessment.hasCheckpoints) {
     return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
   }
@@ -13,6 +19,9 @@ function getMaxStepsNumber(assessment) {
 }
 
 function getCurrentStepIndex(assessment, answerId) {
+  if (assessment.isPreview) {
+    return PREVIEW_UNIQUE_CURRENT_STEP_INDEX;
+  }
   const persistedAnswersIds = assessment.hasMany('answers').ids().filter((id) => id != null);
   const currentAnswerId = answerId;
 

--- a/mon-pix/tests/unit/utils/progress-in-assessment-test.js
+++ b/mon-pix/tests/unit/utils/progress-in-assessment-test.js
@@ -20,7 +20,7 @@ describe('Unit | Utility | progress-in-assessment', function() {
       });
     });
 
-    it('should return the current step index modulus maxStepsNumber', async function() {
+    it('should return the current step index modulus maxStepsNumber', function() {
       // given
       const answerId = null;
       // when
@@ -30,7 +30,7 @@ describe('Unit | Utility | progress-in-assessment', function() {
       expect(currentStepIndex).to.equal(1);
     });
 
-    it('should return the current step index for already answered challenge', async function() {
+    it('should return the current step index for already answered challenge', function() {
       // given
       const answerId = 3;
 
@@ -40,11 +40,22 @@ describe('Unit | Utility | progress-in-assessment', function() {
       // then
       expect(currentStepIndex).to.equal(2);
     });
+
+    it('should return O when the assessment is a preview', function() {
+      // given
+      assessment.isPreview = true;
+
+      // when
+      const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment);
+
+      // then
+      expect(currentStepIndex).to.equal(0);
+    });
   });
 
   describe('#getMaxStepsNumber', function() {
 
-    it('when assessment has checkpoint, should return the number of challenges in checkpoint', async function() {
+    it('when assessment has checkpoint, should return the number of challenges in checkpoint', function() {
       // given
       const assessment = EmberObject.create({ hasCheckpoints: true });
 
@@ -55,7 +66,7 @@ describe('Unit | Utility | progress-in-assessment', function() {
       expect(maxStepNumber).to.equal(ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS);
     });
 
-    it('when assessment is certification, should return the number of challenges in certification', async function() {
+    it('when assessment is certification, should return the number of challenges in certification', function() {
       // given
       const nbChallenges = 23;
       const assessment = EmberObject.create({ isCertification: true, certificationCourse : EmberObject.create({ nbChallenges }) });
@@ -67,7 +78,7 @@ describe('Unit | Utility | progress-in-assessment', function() {
       expect(maxStepNumber).to.equal(nbChallenges);
     });
 
-    it('should return the number of challenge in course', async function() {
+    it('should return the number of challenge in course', function() {
       // given
       const nbChallenges = 21;
       const assessment = EmberObject.create({ course : EmberObject.create({ nbChallenges }) });
@@ -79,6 +90,16 @@ describe('Unit | Utility | progress-in-assessment', function() {
       expect(maxStepNumber).to.equal(nbChallenges);
     });
 
+    it('should return 1 when the assessment is a preview', function() {
+      // given
+      const assessment = EmberObject.create({ isPreview: true });
+
+      // when
+      const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
+
+      // then
+      expect(maxStepNumber).to.equal(1);
+    });
   });
 
   describe('#getCurrentStepNumber', function() {


### PR DESCRIPTION
## :unicorn: Problème
Sur les preview, la barre de progression et le titre affichait Epreuve NaN sur undefine

## :robot: Solution
Pour les preview, la preview sera toujours de 1/1

## :100: Pour tester
Lancer une preview d'épreuve