### PR TITLE
[BUGFIX] Corriger l'erreur undefined lorsque l'on finit une épreuve contenant un embed

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -24,7 +24,7 @@ export default class ChallengeStatement extends Component {
   }
 
   get challengeEmbedDocument() {
-    if (this.args.challenge.hasValidEmbedDocument) {
+    if (this.args.challenge && this.args.challenge.hasValidEmbedDocument) {
       return {
         url: this.args.challenge.embedUrl,
         title: this.args.challenge.embedTitle,


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on valide ou passe une épreuve avec un embed, on a une erreur dans la console signalant une variable `undefined`.

## :robot: Solution
Ajouter un contrôle sur la variable `challenge` pour éviter le cas `undefined` dans la fonction `challengeEmbedDocument`.

## :rainbow: Remarques
L'appel à la fonction est déjà conditionnée par un `if`.
Pourquoi fait-on appel au composant `ChallengeEmbedSimulator` si `challenge` est null/undefined?
```
{{#if @challenge.hasValidEmbedDocument}}
  <ChallengeEmbedSimulator @embedDocument={{this.challengeEmbedDocument}} />
{{/if}}
```

## :100: Pour tester
Sur rendre sur une épreuve avec un embed, et le passer/valider.
Vérifier qu'il n'y a pas d'erreur en console.

Epreuves avec Embed:
- recWndEZbiReZ0zsz
- recab7EiQWXfuVKqI
