### PR TITLE
[FEATURE] Afficher une icone pour les liens dans les consignes des épreuves (PIX-932).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -24,6 +24,17 @@
       color: $blue-hover;
     }
   }
+
+  a::after {
+    content:'';
+    display:inline-block;
+    margin: 0 0.2rem;
+    height:1rem;
+    width:1rem;
+    background-size: 1rem;
+    background-image: url('/images/icons/external-link-alt.svg');
+    background-repeat: no-repeat;
+  }
 }
 
 .challenge-statement__instruction-section {

--- a/mon-pix/public/images/icons/external-link-alt.svg
+++ b/mon-pix/public/images/icons/external-link-alt.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false" aria-hidden="true" data-icon="external-link-alt" data-prefix="fas" id="ember260" class="svg-inline--fa fa-external-link-alt fa-w-16 ember-view">
+  <path fill="#3257D9" d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"></path>
+</svg>


### PR DESCRIPTION
## :unicorn: Problème
Les liens présents dans les consignes des épreuves s'ouvrent dans un nouveau lien, ce qui n'est pas toujours visible pour l'utilisateur. Pour une meilleure compréhension, nous souhaitons ajouter une icône après les liens des consignes.

## :robot: Solution
- Ajout de l'icone FontAwesome en .svg dans les icones
- Utiliser `a::after` pour pouvoir mettre l'icone à chaque lien de la consigne

## :rainbow: Remarques
Plusieurs autres méthodes ont été tentés : 
- Utiliser FontAwesome dans le CSS, mais avec https://github.com/FortAwesome/ember-fontawesome que nous utilisons, ça n'est pas possible
- Modifier le MarkdownToHtml, qui utilise (https://github.com/showdownjs/showdown). Dans un premier temps, en utilisant une extension pour transformer chaque `</a>` en `</a><FaIcon @icon='external-link-alt' />`. Mais cela ne faisait que transformer le <FaIcon> en <faicon> qui était toujours incompréhensible au HTML
- Faire la précédente manipulation ainsi que le markdown to html dans notre JS et utiliser les triples brackets pour que le html soit considéré :  même problème que précédemment

## :100: Pour tester
Voir une épreuve : /challenges/rec29JatkiEtyRoT5/preview