### PR TITLE
[CLEANUP] Mettre des valeurs de base aux variables de reset/retry pour les tests.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -142,6 +142,9 @@ module.exports = (function() {
     config.domain.pix = 'https://pix';
     config.domain.pixOrga = 'https://orga.pix';
 
+    config.features.dayBeforeImproving = 4;
+    config.features.dayBeforeCompetenceResetV2 = 7;
+
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';
     config.mailing.mailjet.apiKey = 'test-api-key';


### PR DESCRIPTION
## :unicorn: Problème
- Lorsqu'on a `DAY_BEFORE_COMPETENCE_RESET_V2` à 0 en local pour tester, les tests API cassent car les tests attendent que la valeur soit 7.

## :robot: Solution
- Modifier la config de l'API en mode test pour préciser les valeurs et ne pas prendre celle du fichier .env