### PR TITLE
[FEATURE] Réconcilier les élèves automatiquement lors de l'import du fichier SIECLE (PIX-920).

### DIFF
--- a/api/db/migrations/20200721180935_add_nationalStudentId_index_to_schooling-registrations_table.js
+++ b/api/db/migrations/20200721180935_add_nationalStudentId_index_to_schooling-registrations_table.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => {
+  return knex.raw('CREATE INDEX "schooling-registrations_nationalstudentid_index" ON "schooling-registrations" ("nationalStudentId");');
+};
+
+exports.down = (knex) => {
+  return knex.raw('DROP INDEX "schooling-registrations_nationalstudentid_index";');
+};

--- a/api/lib/domain/models/Student.js
+++ b/api/lib/domain/models/Student.js
@@ -1,0 +1,12 @@
+class Student {
+
+  constructor({
+    nationalStudentId,
+    account,
+  } = {}) {
+    this.nationalStudentId = nationalStudentId;
+    this.account = account;
+  }
+}
+
+module.exports = Student;

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -1,0 +1,34 @@
+const _ = require('lodash');
+const Student = require('../../domain/models/Student');
+const Bookshelf = require('../bookshelf');
+
+module.exports = {
+
+  _toStudents(results) {
+    const students = [];
+    const resultsGroupedByNatId = _.groupBy(results, 'nationalStudentId');
+    for (const [nationalStudentId, accounts] of Object.entries(resultsGroupedByNatId)) {
+      const mostRelevantAccount = _.orderBy(accounts, ['certificationCount', 'updatedAt'], ['desc', 'desc'])[0];
+      students.push(new Student({ nationalStudentId, account: _.pick(mostRelevantAccount, ['userId', 'certificationCount', 'updatedAt']) }));
+    }
+    return students;
+  },
+
+  async findReconciledStudentsByNationalStudentId(nationalStudentIds) {
+    const results = await Bookshelf.knex
+      .select({
+        nationalStudentId: 'schooling-registrations.nationalStudentId',
+        userId: 'users.id',
+        updatedAt: 'users.updatedAt',
+      })
+      .count('certification-courses.id as certificationCount')
+      .from('schooling-registrations')
+      .join('users', 'users.id', 'schooling-registrations.userId')
+      .leftJoin('certification-courses', 'certification-courses.userId', 'users.id')
+      .whereIn('nationalStudentId', nationalStudentIds)
+      .groupBy('schooling-registrations.nationalStudentId', 'users.id', 'users.updatedAt')
+      .orderBy('users.id');
+
+    return this._toStudents(results);
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -1,0 +1,37 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const studentRepository = require('../../../../lib/infrastructure/repositories/student-repository');
+
+describe('Integration | Infrastructure | Repository | student-repository', () => {
+
+  describe('#findReconciledStudentsByNationalStudentId', () => {
+
+    it('should return instances of Student', async () => {
+      // given
+      const firstNationalStudentId = '123456789AB';
+      const firstAccount = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCourse({ userId: firstAccount.id });
+      databaseBuilder.factory.buildCertificationCourse({ userId: firstAccount.id });
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: firstAccount.id, nationalStudentId: firstNationalStudentId });
+
+      const secondAccount = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCourse({ userId: secondAccount.id });
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: secondAccount.id, nationalStudentId: firstNationalStudentId });
+
+      const secondNationalStudentId = '567891234CD';
+      const thirdAccount = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: thirdAccount.id, nationalStudentId: secondNationalStudentId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const students = await studentRepository.findReconciledStudentsByNationalStudentId([firstNationalStudentId, secondNationalStudentId]);
+
+      // then
+      expect(students.length).to.equal(2);
+      expect(students[0].nationalStudentId).to.equal(firstNationalStudentId);
+      expect(students[0].account).to.deep.equal({ userId: firstAccount.id, updatedAt: firstAccount.updatedAt, certificationCount: 2 });
+      expect(students[1].nationalStudentId).to.equal(secondNationalStudentId);
+      expect(students[1].account).to.deep.equal({ userId: thirdAccount.id, updatedAt: thirdAccount.updatedAt, certificationCount: 0 });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lors d'un changement d'établissement, un élève est obligé de se réconcilier manuellement. Afin de faciliter cette démarche, nous avons mis en place un moyen de rendre cette opération automatique. 

## :robot: Solution
Vérifier lors de l'import d'un fichier SIECLE s'il existe pour un étudiant donné, représenté par son INE, un ou plusieurs `schooling-registrations` et le réconcilier si tel est le cas. Dans le cas où il existe plusieurs `schooling-registrations`, préférer le compte qui:
- A le plus de certifications
- Est le plus récent

## :rainbow: Remarques
Nous avons utilisé des find natif car il est plus rapide que celui de lodash (cf: [tests de performance](https://jsperf.com/lodash-find-vs-array-find) et [cet article](https://blog.bitsrc.io/you-dont-need-lodash-or-how-i-started-loving-javascript-functions-3f45791fa6cd))

Nous avons ajouté un index sur le `nationalStudentId` dans la table `schooling-registrations` 
Nous pouvons voir dans les captures d'écran si dessous que l'on passe de 300ms sans index à 0,3ms avec index.

### Query Plan sans index  
![sans_index](https://user-images.githubusercontent.com/26384707/88142721-4ba94800-cbf6-11ea-8bbc-02ed4912c5fe.png)
### Query Plan avec index
![avec_index](https://user-images.githubusercontent.com/26384707/88142727-4e0ba200-cbf6-11ea-97cf-37df09fc2e80.png)

## :100: Pour tester
- Importer un fichier SIECLE contenant les informations d'un élève déjà importé et réconcilié dans une autre organisation.