### PR TITLE
[CLEANUP] Intégrer le setup de l'i18n dans les tests d'integration (PIX-972).

### DIFF
--- a/mon-pix/tests/helpers/setup-integration.js
+++ b/mon-pix/tests/helpers/setup-integration.js
@@ -1,0 +1,7 @@
+import setupIntl from './setup-intl';
+import { setupRenderingTest } from 'ember-mocha';
+
+export default function setupIntegration() {
+  setupRenderingTest();
+  setupIntl();
+}

--- a/mon-pix/tests/helpers/setup-intl-rendering.js
+++ b/mon-pix/tests/helpers/setup-intl-rendering.js
@@ -1,7 +1,7 @@
 import setupIntl from './setup-intl';
 import { setupRenderingTest } from 'ember-mocha';
 
-export default function setupIntegration() {
+export default function setupIntlRenderingTest() {
   setupRenderingTest();
   setupIntl();
 }

--- a/mon-pix/tests/integration/components/assessment-banner-test.js
+++ b/mon-pix/tests/integration/components/assessment-banner-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | assessment-banner', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{assessment-banner}}`);

--- a/mon-pix/tests/integration/components/assessment-banner-test.js
+++ b/mon-pix/tests/integration/components/assessment-banner-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | assessment-banner', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{assessment-banner}}`);

--- a/mon-pix/tests/integration/components/badge-acquired-card-test.js
+++ b/mon-pix/tests/integration/components/badge-acquired-card-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Badge Acquired Card', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   beforeEach(function() {
     this.set('title', 'Badge de winner');

--- a/mon-pix/tests/integration/components/badge-acquired-card-test.js
+++ b/mon-pix/tests/integration/components/badge-acquired-card-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Badge Acquired Card', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   beforeEach(function() {
     this.set('title', 'Badge de winner');

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | campaign-start-block template', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('should display all text arguments correctly', async function() {
     // given

--- a/mon-pix/tests/integration/components/campaign-start-block-test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | campaign-start-block template', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('should display all text arguments correctly', async function() {
     // given
@@ -26,7 +26,7 @@ describe('Integration | Component | campaign-start-block template', function() {
         @startCampaignParticipation={{this.startCampaignParticipation}}
         @titleText={{this.titleText}}
         @announcementText={{this.announcementText}}
-        @buttonText={{this.buttonText}} 
+        @buttonText={{this.buttonText}}
         @legalText={{this.legalText}}
       />`);
 
@@ -59,7 +59,7 @@ describe('Integration | Component | campaign-start-block template', function() {
         @startCampaignParticipation={{this.startCampaignParticipation}}
         @titleText={{this.titleText}}
         @announcementText={{this.announcementText}}
-        @buttonText={{this.buttonText}} 
+        @buttonText={{this.buttonText}}
         @legalText={{this.legalText}}
       />`);
 
@@ -87,7 +87,7 @@ describe('Integration | Component | campaign-start-block template', function() {
         @startCampaignParticipation={{this.startCampaignParticipation}}
         @titleText={{this.titleText}}
         @announcementText={{this.announcementText}}
-        @buttonText={{this.buttonText}} 
+        @buttonText={{this.buttonText}}
         @legalText={{this.legalText}}
       />`);
 

--- a/mon-pix/tests/integration/components/certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banner-test.js
@@ -4,13 +4,13 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Certification Banner', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   context('On component rendering', function() {
     const fullName = 'shi fu';

--- a/mon-pix/tests/integration/components/certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banner-test.js
@@ -4,13 +4,13 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Certification Banner', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('On component rendering', function() {
     const fullName = 'shi fu';

--- a/mon-pix/tests/integration/components/certification-not-certifiable-test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | certification-not-certifiable', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
 

--- a/mon-pix/tests/integration/components/certification-not-certifiable-test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | certification-not-certifiable', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
 

--- a/mon-pix/tests/integration/components/certification-results-page-test.js
+++ b/mon-pix/tests/integration/components/certification-results-page-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | certification results template', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   context('When component is rendered', function() {
     const certificationNumber = 'certification-number';

--- a/mon-pix/tests/integration/components/certification-results-page-test.js
+++ b/mon-pix/tests/integration/components/certification-results-page-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | certification results template', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('When component is rendered', function() {
     const certificationNumber = 'certification-number';

--- a/mon-pix/tests/integration/components/certifications-list-item-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item-test.js
@@ -3,10 +3,10 @@ import { describe, it, beforeEach } from 'mocha';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | certifications list item', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let certification;
   const PUBLISH_CLASS = '.certifications-list-item__published-item';

--- a/mon-pix/tests/integration/components/certifications-list-item-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-item-test.js
@@ -1,14 +1,12 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntegration from '../../helpers/setup-integration';
 
 describe('Integration | Component | certifications list item', function() {
-  setupRenderingTest();
-  setupIntl();
+  setupIntegration();
 
   let certification;
   const PUBLISH_CLASS = '.certifications-list-item__published-item';

--- a/mon-pix/tests/integration/components/certifications-list-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | certifications list', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{certifications-list}}`);

--- a/mon-pix/tests/integration/components/certifications-list-test.js
+++ b/mon-pix/tests/integration/components/certifications-list-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | certifications list', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{certifications-list}}`);

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -10,7 +10,7 @@ const SKIP_BUTTON = '.challenge-actions__action-skip';
 
 describe('Integration | Component | challenge actions', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{challenge-actions}}`);

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -10,7 +10,7 @@ const SKIP_BUTTON = '.challenge-actions__action-skip';
 
 describe('Integration | Component | challenge actions', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{challenge-actions}}`);

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Challenge Embed Simulator', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Acknowledgment overlay', function() {
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { click, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Challenge Embed Simulator', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Acknowledgment overlay', function() {
 

--- a/mon-pix/tests/integration/components/challenge-illustration-test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import hbs from 'htmlbars-inline-precompile';
 import { find, render, triggerEvent } from '@ember/test-helpers';
 
 describe('Integration | Component | challenge-illustration', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   const IMG_SRC = 'http://www.example.com/this-is-an-example.png';
   const IMG_ALT = 'texte alternatif à l\'image';

--- a/mon-pix/tests/integration/components/challenge-illustration-test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
 import { find, render, triggerEvent } from '@ember/test-helpers';
 
 describe('Integration | Component | challenge-illustration', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const IMG_SRC = 'http://www.example.com/this-is-an-example.png';
   const IMG_ALT = 'texte alternatif à l\'image';

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 describe('Integration | Component | ChallengeStatement', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   function addChallengeToContext(component, challenge) {
     component.set('challenge', challenge);

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 describe('Integration | Component | ChallengeStatement', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   function addChallengeToContext(component, challenge) {
     component.set('challenge', challenge);

--- a/mon-pix/tests/integration/components/checkpoint-continue-test.js
+++ b/mon-pix/tests/integration/components/checkpoint-continue-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | checkpoint-continue', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{checkpoint-continue}}`);

--- a/mon-pix/tests/integration/components/checkpoint-continue-test.js
+++ b/mon-pix/tests/integration/components/checkpoint-continue-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | checkpoint-continue', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{checkpoint-continue}}`);

--- a/mon-pix/tests/integration/components/circle-chart-test.js
+++ b/mon-pix/tests/integration/components/circle-chart-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | circle-chart', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/circle-chart-test.js
+++ b/mon-pix/tests/integration/components/circle-chart-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | circle-chart', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/communication-banner-test.js
+++ b/mon-pix/tests/integration/components/communication-banner-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'mon-pix/config/environment';
 
 describe('Integration | Component | communication-banner', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const originalBannerContent = ENV.APP.BANNER_CONTENT;
   const originalBannerType = ENV.APP.BANNER_TYPE;

--- a/mon-pix/tests/integration/components/communication-banner-test.js
+++ b/mon-pix/tests/integration/components/communication-banner-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'mon-pix/config/environment';
 
 describe('Integration | Component | communication-banner', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   const originalBannerContent = ENV.APP.BANNER_CONTENT;
   const originalBannerType = ENV.APP.BANNER_TYPE;

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | comparison-window', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('rendering', function() {
 

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | comparison-window', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('rendering', function() {
 

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import  EmberObject  from '@ember/object';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from 'mon-pix/config/environment';
 
 describe('Integration | Component | competence-card-default', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import  EmberObject  from '@ember/object';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from 'mon-pix/config/environment';
 
 describe('Integration | Component | competence-card-default', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/competence-card-mobile-test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import  EmberObject  from '@ember/object';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence-card-mobile', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/competence-card-mobile-test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import  EmberObject  from '@ember/object';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | competence-card-mobile', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/corner-ribbon-test.js
+++ b/mon-pix/tests/integration/components/corner-ribbon-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | CornerRibbonComponent', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{corner-ribbon}}`);

--- a/mon-pix/tests/integration/components/corner-ribbon-test.js
+++ b/mon-pix/tests/integration/components/corner-ribbon-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | CornerRibbonComponent', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{corner-ribbon}}`);

--- a/mon-pix/tests/integration/components/feedback-certification-section-test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | feedback-certification-section', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
 

--- a/mon-pix/tests/integration/components/feedback-certification-section-test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | feedback-certification-section', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
 

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -6,7 +6,7 @@ import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import {
   blur,
   click,
@@ -48,7 +48,7 @@ async function setContent(content) {
 
 describe('Integration | Component | feedback-panel', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Default rendering', function() {
     context('when assessment is not of type certification', function() {

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -6,7 +6,7 @@ import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   blur,
   click,
@@ -48,7 +48,7 @@ async function setContent(content) {
 
 describe('Integration | Component | feedback-panel', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Default rendering', function() {
     context('when assessment is not of type certification', function() {

--- a/mon-pix/tests/integration/components/form-textfield-date-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import {
   fillIn,
   find,
@@ -12,7 +12,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | form textfield date', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   const LABEL = '.form-textfield__label';
   const LABEL_TEXT = 'date';

--- a/mon-pix/tests/integration/components/form-textfield-date-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   fillIn,
   find,
@@ -12,7 +12,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | form textfield date', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const LABEL = '.form-textfield__label';
   const LABEL_TEXT = 'date';

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   click,
   fillIn,
@@ -13,7 +13,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | form textfield', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const LABEL = '.form-textfield__label';
   const LABEL_TEXT = 'NOM';

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import {
   click,
   fillIn,
@@ -13,7 +13,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | form textfield', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   const LABEL = '.form-textfield__label';
   const LABEL_TEXT = 'NOM';

--- a/mon-pix/tests/integration/components/g-recaptcha-test.js
+++ b/mon-pix/tests/integration/components/g-recaptcha-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import RSVP from 'rsvp';
@@ -32,7 +32,7 @@ const stubGoogleRecaptchaService = Service.extend({
 
 describe('Integration | Component | g recaptcha', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   beforeEach(function() {
     this.owner.register('service:google-recaptcha', stubGoogleRecaptchaService);

--- a/mon-pix/tests/integration/components/g-recaptcha-test.js
+++ b/mon-pix/tests/integration/components/g-recaptcha-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import RSVP from 'rsvp';
@@ -32,7 +32,7 @@ const stubGoogleRecaptchaService = Service.extend({
 
 describe('Integration | Component | g recaptcha', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   beforeEach(function() {
     this.owner.register('service:google-recaptcha', stubGoogleRecaptchaService);

--- a/mon-pix/tests/integration/components/hexagon-score-test.js
+++ b/mon-pix/tests/integration/components/hexagon-score-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | hexagon-score', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/hexagon-score-test.js
+++ b/mon-pix/tests/integration/components/hexagon-score-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | hexagon-score', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/inaccessible-campaign-test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign-test.js
@@ -3,13 +3,13 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import Service from '@ember/service';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | inaccessible-campaign', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('should not display marianne logo when url does not have frenchDomainExtension', async function() {
     // given

--- a/mon-pix/tests/integration/components/inaccessible-campaign-test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign-test.js
@@ -3,13 +3,13 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import Service from '@ember/service';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | inaccessible-campaign', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('should not display marianne logo when url does not have frenchDomainExtension', async function() {
     // given

--- a/mon-pix/tests/integration/components/learning-more-panel-test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | learning-more-panel', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders a list item when there is at least one learningMore item', async function() {
     // given

--- a/mon-pix/tests/integration/components/learning-more-panel-test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | learning-more-panel', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders a list item when there is at least one learningMore item', async function() {
     // given

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -4,13 +4,13 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | navbar-burger-menu', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   beforeEach(async function() {
     this.owner.register('service:currentUser', Service.extend({

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -4,13 +4,13 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | navbar-burger-menu', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   beforeEach(async function() {
     this.owner.register('service:currentUser', Service.extend({

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
@@ -13,7 +13,7 @@ import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | navbar-desktop-header', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('when user is not logged', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
@@ -13,7 +13,7 @@ import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | navbar-desktop-header', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   context('when user is not logged', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | navbar desktop menu', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('should be rendered', async function() {
     // when

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | navbar desktop menu', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('should be rendered', async function() {
     // when

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -4,14 +4,14 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | navbar-header', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('when user is on desktop', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -4,14 +4,14 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | navbar-header', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   context('when user is on desktop', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header-test.js
@@ -4,14 +4,14 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | navbar-mobile-header', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('when user is not logged', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/navbar-mobile-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header-test.js
@@ -4,14 +4,14 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | navbar-mobile-header', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   context('when user is not logged', function() {
     beforeEach(async function() {

--- a/mon-pix/tests/integration/components/no-certification-panel-test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | no certification panel', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{no-certification-panel}}`);

--- a/mon-pix/tests/integration/components/no-certification-panel-test.js
+++ b/mon-pix/tests/integration/components/no-certification-panel-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | no certification panel', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{no-certification-panel}}`);

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -3,14 +3,14 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { fillIn, find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
 
 describe('Integration | Component | password reset demand form', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`<PasswordResetDemandForm />`);

--- a/mon-pix/tests/integration/components/password-reset-demand-form-test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form-test.js
@@ -3,14 +3,14 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { fillIn, find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
 
 describe('Integration | Component | password reset demand form', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`<PasswordResetDemandForm />`);

--- a/mon-pix/tests/integration/components/pix-logo-test.js
+++ b/mon-pix/tests/integration/components/pix-logo-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | pix logo', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   beforeEach(async function() {
     await render(hbs`{{pix-logo}}`);

--- a/mon-pix/tests/integration/components/pix-logo-test.js
+++ b/mon-pix/tests/integration/components/pix-logo-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | pix logo', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   beforeEach(async function() {
     await render(hbs`{{pix-logo}}`);

--- a/mon-pix/tests/integration/components/pix-toggle-test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render , click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | pix-toggle', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   beforeEach(async function() {
 

--- a/mon-pix/tests/integration/components/pix-toggle-test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render , click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | pix-toggle', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   beforeEach(async function() {
 

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -3,14 +3,14 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | Profile-content', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   context('On component rendering', function() {
     let model;

--- a/mon-pix/tests/integration/components/profile-content-test.js
+++ b/mon-pix/tests/integration/components/profile-content-test.js
@@ -3,14 +3,14 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { setBreakpoint } from 'ember-responsive/test-support';
 
 describe('Integration | Component | Profile-content', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('On component rendering', function() {
     let model;

--- a/mon-pix/tests/integration/components/progression-gauge-test.js
+++ b/mon-pix/tests/integration/components/progression-gauge-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | progression-gauge', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/progression-gauge-test.js
+++ b/mon-pix/tests/integration/components/progression-gauge-test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | progression-gauge', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/qcm-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCM proposals', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{qcm-proposals}}`);

--- a/mon-pix/tests/integration/components/qcm-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcm-proposals-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCM proposals', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{qcm-proposals}}`);

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, before } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
@@ -13,7 +13,7 @@ let solution = null;
 
 describe('Integration | Component | qcm-solution-panel.js', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('#Component should renders: ', function() {
 

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, before } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
@@ -13,7 +13,7 @@ let solution = null;
 
 describe('Integration | Component | qcm-solution-panel.js', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('#Component should renders: ', function() {
 

--- a/mon-pix/tests/integration/components/qcu-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCU proposals', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   /* Rendering
    ----------------------------------------------------- */

--- a/mon-pix/tests/integration/components/qcu-proposals-test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QCU proposals', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   /* Rendering
    ----------------------------------------------------- */

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
@@ -12,7 +12,7 @@ let answer = null;
 let solution = null;
 
 describe('Integration | Component | qcu-solution-panel.js', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   const correctAnswer = {
     id: 'answer_id', assessment, challenge, value: '2'

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import _ from 'mon-pix/utils/lodash-custom';
@@ -12,7 +12,7 @@ let answer = null;
 let solution = null;
 
 describe('Integration | Component | qcu-solution-panel.js', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const correctAnswer = {
     id: 'answer_id', assessment, challenge, value: '2'

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROC proposal', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`<QrocProposal />`);

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROC proposal', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`<QrocProposal />`);

--- a/mon-pix/tests/integration/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROC solution panel', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('When format is paragraph', function() {
     it('should display disabled textarea', async function() {

--- a/mon-pix/tests/integration/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROC solution panel', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('When format is paragraph', function() {
     it('should display disabled textarea', async function() {

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -21,7 +21,7 @@ const classByResultKey = {
 
 describe('Integration | Component | QROCm dep solution panel', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -21,7 +21,7 @@ const classByResultKey = {
 
 describe('Integration | Component | QROCm dep solution panel', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -18,7 +18,7 @@ const CORRECT_ANSWER_POSITION = 2;
 
 describe('Integration | Component | QROCm ind solution panel', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -18,7 +18,7 @@ const CORRECT_ANSWER_POSITION = 2;
 
 describe('Integration | Component | QROCm ind solution panel', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROCm proposal', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{qrocm-proposal}}`);

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | QROCm proposal', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{qrocm-proposal}}`);

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { resolve, reject } from 'rsvp';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import {
   click,
   find,
@@ -15,7 +15,7 @@ import hbs from 'htmlbars-inline-precompile';
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | reset password form', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { resolve, reject } from 'rsvp';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   click,
   find,
@@ -15,7 +15,7 @@ import hbs from 'htmlbars-inline-precompile';
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | reset password form', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/result-item-campaign-test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | result item', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/result-item-campaign-test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign-test.js
@@ -1,13 +1,13 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | result item', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | resume-campaign-banner', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Banner display', function() {
     const campaignToResume = EmberObject.create({

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | resume-campaign-banner', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('Banner display', function() {
     const campaignToResume = EmberObject.create({
@@ -46,52 +46,52 @@ describe('Integration | Component | resume-campaign-banner', function() {
         it('should display the resume campaign banner', async function() {
           // given
           this.set('campaignParticipations', [campaignToResume, oldCampaignNotFinished, campaignFinished]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__container')).to.exist;
         });
-  
+
         it('should display a link to resume the campaign', async function() {
           // given
           this.set('campaignParticipations', [campaignToResume]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
         });
-  
+
         it('should display a sentence to ask user to resume with the title of campaign', async function() {
           // given
           this.set('campaignParticipations', [campaignToResume]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__title').textContent).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
         });
-  
+
         it('should display a simple sentence to ask user to resume when campaign has no title', async function() {
           // given
           campaignToResume.campaign.set('title', null);
           this.set('campaignParticipations', [campaignToResume]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__title').textContent).to.equal('Vous n\'avez pas terminé votre parcours');
         });
-  
+
       });
-  
+
       context('when campaign is finished but not shared', function() {
-  
+
         const campaignFinishedButNotShared = EmberObject.create({
           isShared: false,
           createdAt: '2019-09-30T10:30:00Z',
@@ -104,7 +104,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
             isCompleted: true,
           }),
         });
-  
+
         it('should display the resume campaign banner', async function() {
           // given
           this.set('campaignParticipations', [oldCampaignNotFinished, campaignFinished, campaignFinishedButNotShared]);
@@ -113,44 +113,44 @@ describe('Integration | Component | resume-campaign-banner', function() {
           // then
           expect(find('.resume-campaign-banner__container')).to.exist;
         });
-  
+
         it('should display a link to shared the results', async function() {
           // given
           this.set('campaignParticipations', [campaignFinishedButNotShared]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
         });
-  
+
         it('should display a sentence to ask user to share his results with the title of campaign', async function() {
           // given
           this.set('campaignParticipations', [campaignFinishedButNotShared]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__title').textContent).to.equal(`Parcours "${campaignFinishedButNotShared.campaign.title}" terminé. N'oubliez pas de finaliser votre envoi !`);
         });
-  
+
         it('should display a simple sentence to ask user to share his results when campaign has no title', async function() {
           // given
           campaignFinishedButNotShared.campaign.set('title', null);
           this.set('campaignParticipations', [campaignFinishedButNotShared]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
         });
       });
-  
+
       context('when campaign is finished and shared', function() {
-  
+
         it('should not display the resume campaign banner when the list of campaigns contains only finished campaign', async function() {
           // given
           this.set('campaignParticipations', [campaignFinished]);
@@ -164,7 +164,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
     });
 
     context('when campaign is not started yet', function() {
-  
+
       it('should not display the resume campaign banner when the list of campaigns is empty', async function() {
         // given
         this.set('campaignParticipations', []);
@@ -177,7 +177,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
     context('when campaign has type collect profiles', function() {
       context('when campaign is not shared', function() {
-  
+
         const campaignCollectNotShared = EmberObject.create({
           isShared: false,
           createdAt: '2019-09-30T14:30:00Z',
@@ -186,18 +186,18 @@ describe('Integration | Component | resume-campaign-banner', function() {
             isTypeAssessment: false,
           }),
         });
-  
+
         it('should display the resume campaign banner', async function() {
           // given
           this.set('campaignParticipations', [campaignCollectNotShared]);
-  
+
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
-  
+
           // then
           expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
         });
-  
+
       });
     });
 

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntegration from '../../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import EmberObject from '@ember/object';
 import { click, fillIn, render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -12,7 +12,7 @@ import { reject, resolve } from 'rsvp';
 import sinon from 'sinon';
 
 describe('Integration | Component | routes/login-form', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let sessionStub;
   let storeStub;

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../../helpers/setup-integration';
 import EmberObject from '@ember/object';
 import { click, fillIn, render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -12,7 +12,7 @@ import { reject, resolve } from 'rsvp';
 import sinon from 'sinon';
 
 describe('Integration | Component | routes/login-form', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   let sessionStub;
   let storeStub;

--- a/mon-pix/tests/integration/components/routes/login-or-register-test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Unit | Component | routes/login-or-register', () => {
+describe('Integration | Routes | routes/login-or-register', () => {
 
-  setupRenderingTest();
+  setupIntegration();
 
   it('should render', async () => {
     // when

--- a/mon-pix/tests/integration/components/routes/login-or-register-test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Routes | routes/login-or-register', () => {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('should render', async () => {
     // when

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntegration from '../../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { resolve, reject } from 'rsvp';
 import {
   click,
@@ -25,7 +25,7 @@ const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 describe('Integration | Component | routes/register-form', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let sessionStub;
   let storeStub;

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../../helpers/setup-integration';
 import { resolve, reject } from 'rsvp';
 import {
   click,
@@ -25,7 +25,7 @@ const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
 describe('Integration | Component | routes/register-form', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   let sessionStub;
   let storeStub;

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -5,10 +5,10 @@ import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from '../../../config/environment';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | scorecard-details', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -1,20 +1,14 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { A } from '@ember/array';
-import { setupRenderingTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from '../../../config/environment';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntegration from '../../helpers/setup-integration';
 
 describe('Integration | Component | scorecard-details', function() {
-  setupRenderingTest();
-  setupIntl();
-  
-  beforeEach(function() {
-    this.intl.setLocale('fr');
-  });
+  setupIntegration();
 
   describe('Component rendering', function() {
 

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import {
   click,
   fillIn,
@@ -11,15 +10,14 @@ import {
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-import setupIntl from '../../helpers/setup-intl';
 import ENV from '../../../config/environment';
+import setupIntegration from '../../helpers/setup-integration';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 describe('Integration | Component | signin form', function() {
 
-  setupRenderingTest();
-  setupIntl();
+  setupIntegration();
 
   describe('Rendering', async function() {
 

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -11,13 +11,13 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 import ENV from '../../../config/environment';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 describe('Integration | Component | signin form', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Rendering', async function() {
 

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -8,7 +8,6 @@ import Component from '@ember/component';
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import {
   click,
   fillIn,
@@ -20,8 +19,8 @@ import {
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import setupIntl from '../../helpers/setup-intl';
 import ENV from '../../../config/environment';
+import setupIntegration from '../../helpers/setup-integration';
 
 const FORM_CONTAINER = '.sign-form__container';
 const FORM_HEADER_CONTAINER = '.sign-form__header';
@@ -44,8 +43,7 @@ const CAPTCHA_CONTAINER = '.signup-form__captcha-container';
 
 describe('Integration | Component | signup form', function() {
 
-  setupRenderingTest();
-  setupIntl();
+  setupIntegration();
 
   describe('Localization', function() {
     const originalLocale = ENV.APP.LOCALE;

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -20,7 +20,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import ENV from '../../../config/environment';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const FORM_CONTAINER = '.sign-form__container';
 const FORM_HEADER_CONTAINER = '.sign-form__header';
@@ -43,7 +43,7 @@ const CAPTCHA_CONTAINER = '.signup-form__captcha-container';
 
 describe('Integration | Component | signup form', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('Localization', function() {
     const originalLocale = ENV.APP.LOCALE;

--- a/mon-pix/tests/integration/components/timeout-jauge-test.js
+++ b/mon-pix/tests/integration/components/timeout-jauge-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | TimeoutJauge', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   /* Rendering
   ----------------------------------------------------- */

--- a/mon-pix/tests/integration/components/timeout-jauge-test.js
+++ b/mon-pix/tests/integration/components/timeout-jauge-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | TimeoutJauge', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   /* Rendering
   ----------------------------------------------------- */

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -4,12 +4,12 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | tutorial panel', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   context('when the result is not ok', function() {
     context('and a hint is present', function() {

--- a/mon-pix/tests/integration/components/tutorial-panel-test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel-test.js
@@ -4,12 +4,12 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | tutorial panel', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   context('when the result is not ok', function() {
     context('and a hint is present', function() {

--- a/mon-pix/tests/integration/components/update-expired-password-form-test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { resolve, reject } from 'rsvp';
 import {
   click,
@@ -15,7 +15,7 @@ import hbs from 'htmlbars-inline-precompile';
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | update-expired-password-form', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let isSaveMethodCalled, saveMethodOptions;
 

--- a/mon-pix/tests/integration/components/update-expired-password-form-test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { resolve, reject } from 'rsvp';
 import {
   click,
@@ -15,7 +15,7 @@ import hbs from 'htmlbars-inline-precompile';
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | update-expired-password-form', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   let isSaveMethodCalled, saveMethodOptions;
 

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import { A as EmberArray } from '@ember/array';
 
 describe('Integration | Component | user-certifications-detail-competence', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   let area;
   const PARENT_SELECTOR = '.user-certifications-detail-competence';

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import { A as EmberArray } from '@ember/array';
 
 describe('Integration | Component | user-certifications-detail-competence', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let area;
   const PARENT_SELECTOR = '.user-certifications-detail-competence';

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
@@ -4,10 +4,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | user-certifications-detail-competences-list', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let resultCompetenceTree;
   const PARENT_SELECTOR = '.user-certifications-detail-competences-list';

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list-test.js
@@ -2,14 +2,12 @@ import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntegration from '../../helpers/setup-integration';
 
 describe('Integration | Component | user-certifications-detail-competences-list', function() {
-  setupRenderingTest();
-  setupIntl();
+  setupIntegration();
 
   let resultCompetenceTree;
   const PARENT_SELECTOR = '.user-certifications-detail-competences-list';

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -1,14 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntegration from '../../helpers/setup-integration';
 
 describe('Integration | Component | user certifications detail header', function() {
-  setupRenderingTest();
-  setupIntl();
+  setupIntegration();
 
   let certification;
   const PARENT_SELECTOR = '.user-certifications-detail-header';

--- a/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header-test.js
@@ -3,10 +3,10 @@ import { describe, it } from 'mocha';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | user certifications detail header', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let certification;
   const PARENT_SELECTOR = '.user-certifications-detail-header';

--- a/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications detail result', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   let certification;
 

--- a/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications detail result', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   let certification;
 

--- a/mon-pix/tests/integration/components/user-certifications-panel-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-panel-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications panel', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   it('renders', async function() {
     await render(hbs`{{user-certifications-panel}}`);

--- a/mon-pix/tests/integration/components/user-certifications-panel-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-panel-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 describe('Integration | Component | user certifications panel', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   it('renders', async function() {
     await render(hbs`{{user-certifications-panel}}`);

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import {
   click,
   find,
@@ -17,7 +17,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user logged menu', function() {
 
-  setupRenderingTest();
+  setupIntegration();
 
   describe('when rendering for logged user', function() {
 

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -4,7 +4,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   click,
   find,
@@ -17,7 +17,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user logged menu', function() {
 
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('when rendering for logged user', function() {
 

--- a/mon-pix/tests/unit/helpers/contains-test.js
+++ b/mon-pix/tests/unit/helpers/contains-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import setupIntegration from '../../helpers/setup-integration';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 import { contains, containsAll } from '../../helpers/contains';
 
 describe('Unit | Helpers | contains', function() {
-  setupRenderingTest();
+  setupIntegration();
 
   describe('contains', function() {
     it('should contains Hello', async function() {

--- a/mon-pix/tests/unit/helpers/contains-test.js
+++ b/mon-pix/tests/unit/helpers/contains-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import setupIntegration from '../../helpers/setup-integration';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 import { contains, containsAll } from '../../helpers/contains';
 
 describe('Unit | Helpers | contains', function() {
-  setupIntegration();
+  setupIntlRenderingTest();
 
   describe('contains', function() {
     it('should contains Hello', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on traduit une page, il faut ajouter `setupIntl` dans les tests d'integration, ce qui oblige à le faire dans chaque fichier

## :robot: Solution
- Création d'un `setupIntegration` qui gère le `setupRenderingTest` ainsi que le `setupIntl`

## :rainbow: Remarques
- Cette action n'a été faite que dans les tests d'intégration
