### PR TITLE
[BUGFIX] Ne pas afficher le timer lorsque l'utilisateur revient sur une question timée (PIX-931)

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -56,6 +56,16 @@ const ChallengeItemGeneric = Component.extend({
     return !this.hasTimerDefined() || (this.hasTimerDefined() && this._isUserAwareThatChallengeIsTimed);
   }),
 
+  displayTimer: computed('answer', 'hasUserConfirmWarning', function() {
+    if (!this.answer
+      && this.hasTimerDefined()
+      && this.hasUserConfirmWarning) {
+
+      return true;
+    }
+    return false;
+  }),
+
   hasTimerDefined() {
     return _.isInteger(this.challenge.timer);
   },

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -18,7 +18,7 @@ const ChallengeItemGeneric = Component.extend({
 
   isValidateButtonEnabled: true,
   isSkipButtonEnabled: true,
-  hasUserConfirmWarning: false,
+  hasUserConfirmedWarning: false,
 
   _elapsedTime: null,
   _timer: null,
@@ -34,7 +34,7 @@ const ChallengeItemGeneric = Component.extend({
   didUpdateAttrs() {
     this._super(...arguments);
     if (!this._isUserAwareThatChallengeIsTimed) {
-      this.set('hasUserConfirmWarning', false);
+      this.set('hasUserConfirmedWarning', false);
     }
   },
 
@@ -52,19 +52,19 @@ const ChallengeItemGeneric = Component.extend({
     return !this.hasChallengeTimer || (this.hasChallengeTimer && this._isUserAwareThatChallengeIsTimed);
   }),
 
-  displayTimer: computed('answer', 'hasUserConfirmWarning', 'hasChallengeTimer', function() {
+  displayTimer: computed('answer', 'hasUserConfirmedWarning', 'hasChallengeTimer', function() {
     if (!this.answer
       && this.hasChallengeTimer
-      && this.hasUserConfirmWarning) {
+      && this.hasUserConfirmedWarning) {
 
       return true;
     }
     return false;
   }),
 
-  displayChallenge: computed('hasUserConfirmWarning', 'hasChallengeTimer', function() {
+  displayChallenge: computed('hasUserConfirmedWarning', 'hasChallengeTimer', function() {
     return !this.hasChallengeTimer
-        || (this.hasUserConfirmWarning && this.hasChallengeTimer);
+        || (this.hasUserConfirmedWarning && this.hasChallengeTimer);
   }),
 
   _getTimeout() {
@@ -131,7 +131,7 @@ const ChallengeItemGeneric = Component.extend({
 
     setUserConfirmation() {
       this._start();
-      this.set('hasUserConfirmWarning', true);
+      this.set('hasUserConfirmedWarning', true);
       this.set('_isUserAwareThatChallengeIsTimed', true);
     },
   },

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -52,7 +52,7 @@ const ChallengeItemGeneric = Component.extend({
     return this.hasTimerDefined();
   }),
 
-  canDisplayFeedbackPanel: computed('_isUserAwareThatChallengeIsTimed', function() {
+  displayFeedbackPanel: computed('_isUserAwareThatChallengeIsTimed', function() {
     return !this.hasTimerDefined() || (this.hasTimerDefined() && this._isUserAwareThatChallengeIsTimed);
   }),
 

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -18,6 +18,7 @@ const ChallengeItemGeneric = Component.extend({
 
   isValidateButtonEnabled: true,
   isSkipButtonEnabled: true,
+  hasUserConfirmWarning: false,
 
   _elapsedTime: null,
   _timer: null,
@@ -34,7 +35,6 @@ const ChallengeItemGeneric = Component.extend({
     this._super(...arguments);
     if (!this._isUserAwareThatChallengeIsTimed) {
       this.set('hasUserConfirmWarning', false);
-      this.set('hasChallengeTimer', this.hasTimerDefined());
     }
   },
 
@@ -44,21 +44,17 @@ const ChallengeItemGeneric = Component.extend({
     cancel(timer);
   },
 
-  hasUserConfirmWarning: computed('challenge', function() {
-    return false;
+  hasChallengeTimer: computed('challenge.timer', function() {
+    return _.isInteger(this.challenge.timer);
   }),
 
-  hasChallengeTimer: computed('challenge', function() {
-    return this.hasTimerDefined();
+  displayFeedbackPanel: computed('_isUserAwareThatChallengeIsTimed', 'hasChallengeTimer', function() {
+    return !this.hasChallengeTimer || (this.hasChallengeTimer && this._isUserAwareThatChallengeIsTimed);
   }),
 
-  displayFeedbackPanel: computed('_isUserAwareThatChallengeIsTimed', function() {
-    return !this.hasTimerDefined() || (this.hasTimerDefined() && this._isUserAwareThatChallengeIsTimed);
-  }),
-
-  displayTimer: computed('answer', 'hasUserConfirmWarning', function() {
+  displayTimer: computed('answer', 'hasUserConfirmWarning', 'hasChallengeTimer', function() {
     if (!this.answer
-      && this.hasTimerDefined()
+      && this.hasChallengeTimer
       && this.hasUserConfirmWarning) {
 
       return true;
@@ -66,9 +62,10 @@ const ChallengeItemGeneric = Component.extend({
     return false;
   }),
 
-  hasTimerDefined() {
-    return _.isInteger(this.challenge.timer);
-  },
+  displayChallenge: computed('hasUserConfirmWarning', 'hasChallengeTimer', function() {
+    return !this.hasChallengeTimer
+        || (this.hasUserConfirmWarning && this.hasChallengeTimer);
+  }),
 
   _getTimeout() {
     return this.$('.timeout-jauge-remaining').attr('data-spent');
@@ -134,8 +131,7 @@ const ChallengeItemGeneric = Component.extend({
 
     setUserConfirmation() {
       this._start();
-      this.toggleProperty('hasUserConfirmWarning');
-      this.toggleProperty('hasChallengeTimer');
+      this.set('hasUserConfirmWarning', true);
       this.set('_isUserAwareThatChallengeIsTimed', true);
     },
   },

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -1,6 +1,6 @@
 {{#if this.hasChallengeTimer}}
-  {{#unless this.hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+  {{#unless this.hasUserConfirmedWarning}}
+    <WarningPage @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -21,13 +21,11 @@
           <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
-      
-      {{#if @challenge.timer}}
-        {{#if this.hasUserConfirmWarning}}
-          <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{@challenge.timer}} />
-          </div>
-        {{/if}}
+
+      {{#if this.displayTimer}}
+        <div class="timeout-jauge-wrapper">
+          <TimeoutJauge @allotedTime={{@challenge.timer}} />
+        </div>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -4,7 +4,7 @@
   {{/unless}}
 {{/if}}
 
-{{#unless this.hasChallengeTimer}}
+{{#if this.displayChallenge}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
@@ -46,7 +46,7 @@
                         @class="rounded-panel__row" />
     {{/if}}
   </form>
-{{/unless}}
+{{/if}}
 
 {{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -48,7 +48,7 @@
   </form>
 {{/unless}}
 
-{{#if this.canDisplayFeedbackPanel}}
+{{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">
     <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,6 +1,6 @@
 {{#if this.hasChallengeTimer}}
-  {{#unless this.hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+  {{#unless this.hasUserConfirmedWarning}}
+    <WarningPage @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -21,13 +21,11 @@
           <FaIcon @icon='lock' class='challenge-response-locked__icon' />
         </div>
       {{/if}}
-      
-      {{#if @challenge.timer}}
-        {{#if this.hasUserConfirmWarning}}
-          <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{@challenge.timer}} />
-          </div>
-        {{/if}}
+
+      {{#if this.displayTimer}}
+        <div class="timeout-jauge-wrapper">
+          <TimeoutJauge @allotedTime={{@challenge.timer}} />
+        </div>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -4,7 +4,7 @@
   {{/unless}}
 {{/if}}
 
-{{#unless this.hasChallengeTimer}}
+{{#if this.displayChallenge}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
@@ -46,7 +46,7 @@
                         @class="rounded-panel__row" />
     {{/if}}
   </form>
-{{/unless}}
+{{/if}}
 
 {{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -48,7 +48,7 @@
   </form>
 {{/unless}}
 
-{{#if this.canDisplayFeedbackPanel}}
+{{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">
     <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,6 +1,6 @@
 {{#if this.hasChallengeTimer}}
-  {{#unless this.hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+  {{#unless this.hasUserConfirmedWarning}}
+    <WarningPage @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -51,7 +51,7 @@
   </form>
 {{/unless}}
 
-{{#if this.canDisplayFeedbackPanel}}
+{{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">
     <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -24,12 +24,10 @@
           </div>
         {{/if}}
 
-        {{#if @challenge.timer}}
-          {{#if this.hasUserConfirmWarning}}
-            <div class="timeout-jauge-wrapper">
-              <TimeoutJauge @allotedTime={{@challenge.timer}} />
-            </div>
-          {{/if}}
+        {{#if this.displayTimer}}
+          <div class="timeout-jauge-wrapper">
+            <TimeoutJauge @allotedTime={{@challenge.timer}} />
+          </div>
         {{/if}}
       </div>
     {{/if}}

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -4,7 +4,7 @@
   {{/unless}}
 {{/if}}
 
-{{#unless this.hasChallengeTimer}}
+{{#if this.displayChallenge}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
@@ -49,7 +49,7 @@
                         @class="rounded-panel__row" />
     {{/if}}
   </form>
-{{/unless}}
+{{/if}}
 
 {{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,6 +1,6 @@
 {{#if this.hasChallengeTimer}}
-  {{#unless this.hasUserConfirmWarning}}
-    <WarningPage @hasUserConfirmWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+  {{#unless this.hasUserConfirmedWarning}}
+    <WarningPage @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
   {{/unless}}
 {{/if}}
 

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -23,12 +23,10 @@
         </div>
       {{/if}}
 
-      {{#if @challenge.timer}}
-        {{#if this.hasUserConfirmWarning}}
-          <div class="timeout-jauge-wrapper">
-            <TimeoutJauge @allotedTime={{@challenge.timer}} />
-          </div>
-        {{/if}}
+      {{#if this.displayTimer}}
+        <div class="timeout-jauge-wrapper">
+          <TimeoutJauge @allotedTime={{@challenge.timer}} />
+        </div>
       {{/if}}
     </div>
 

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -49,7 +49,7 @@
   </form>
 {{/unless}}
 
-{{#if this.canDisplayFeedbackPanel}}
+{{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">
     <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}} @isFormOpened={{false}} />
   </div>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -4,7 +4,7 @@
   {{/unless}}
 {{/if}}
 
-{{#unless this.hasChallengeTimer}}
+{{#if this.displayChallenge}}
   <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
     <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
@@ -47,7 +47,7 @@
                         @class="rounded-panel__row" />
     {{/if}}
   </form>
-{{/unless}}
+{{/if}}
 
 {{#if this.displayFeedbackPanel}}
   <div class="challenge-item__feedback">

--- a/mon-pix/app/templates/components/warning-page.hbs
+++ b/mon-pix/app/templates/components/warning-page.hbs
@@ -13,6 +13,6 @@
     </div>
   </div>
   <div class="challenge-item-warning__action">
-    <button {{action hasUserConfirmWarning}} class="challenge-item-warning__confirm-btn">Commencer</button>
+    <button {{action hasUserConfirmedWarning}} class="challenge-item-warning__confirm-btn">Commencer</button>
   </div>
 </div>

--- a/mon-pix/tests/acceptance/challenge-timed-test.js
+++ b/mon-pix/tests/acceptance/challenge-timed-test.js
@@ -12,52 +12,101 @@ describe('Acceptance | Timed challenge', () => {
   let timedChallenge;
   let notTimedChallenge;
 
-  beforeEach(() => {
-    assessment = server.create('assessment', 'ofCompetenceEvaluationType');
-    timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
-    notTimedChallenge = server.create('challenge', 'forCompetenceEvaluation');
-  });
+  context('Timed Challenge', () => {
 
-  describe('Timed Challenge', () => {
-
-    beforeEach(async () => {
-      // when
-      await visit(`/assessments/${assessment.id}/challenges/${timedChallenge.id}`);
-    });
-    it('should hide the challenge statement', async () => {
-      expect(find('.challenge-statement')).to.not.exist;
-    });
-
-    it('should ensure the challenge does not automatically start', async () => {
-      expect(find('.timeout-jauge')).to.not.exist;
-    });
-
-    it('should ensure the feedback form is not displayed until the user has started the challenge', async () => {
-      expect(find('.feedback-panel')).to.not.exist;
-    });
-    describe('when the confirmation button is clicked', () => {
+    context('when asking for confirmation', function() {
 
       beforeEach(async () => {
-        await click('.challenge-item-warning button');
+        // given
+        assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+        timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+
+        // when
+        await visit(`/assessments/${assessment.id}/challenges/${timedChallenge.id}`);
       });
 
-      it('should hide the warning button', () => {
-        expect(find('.challenge-item-warning button')).to.not.exist;
+      it('should hide the challenge statement', async () => {
+        expect(find('.challenge-statement')).to.not.exist;
       });
 
-      it('should display the challenge statement and the feedback form', () => {
-        expect(find('.challenge-statement')).to.exist;
-        expect(find('.feedback-panel')).to.exist;
+      it('should ensure the challenge does not automatically start', async () => {
+        expect(find('.timeout-jauge')).to.not.exist;
       });
 
-      it('should start the timer', () => {
-        expect(find('.timeout-jauge')).to.exist;
+      it('should ensure the feedback form is not displayed until the user has started the challenge', async () => {
+        expect(find('.feedback-panel')).to.not.exist;
+      });
+    });
+
+    context('when the confirmation button is clicked', () => {
+
+      context('and the challenge has not been already answered', function() {
+
+        beforeEach(async () => {
+          // given
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+          timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+
+          // when
+          await visit(`/assessments/${assessment.id}/challenges/${timedChallenge.id}`);
+          await click('.challenge-item-warning button');
+        });
+
+        it('should hide the warning button', () => {
+          expect(find('.challenge-item-warning button')).to.not.exist;
+        });
+
+        it('should display the challenge statement and the feedback form', () => {
+          expect(find('.challenge-statement')).to.exist;
+          expect(find('.feedback-panel')).to.exist;
+        });
+
+        it('should start the timer', () => {
+          expect(find('.timeout-jauge')).to.exist;
+        });
+
+      });
+
+      context('and the challenge has already been skipped before', function() {
+
+        beforeEach(async () => {
+          // given
+          assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+          timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
+          server.create('answer', 'skipped', {
+            assessment,
+            challenge: timedChallenge
+          });
+
+          // when
+          await visit(`/assessments/${assessment.id}/challenges/${timedChallenge.id}`);
+          await click('.challenge-item-warning button');
+        });
+
+        it('should hide the warning button', () => {
+          expect(find('.challenge-item-warning button')).to.not.exist;
+        });
+
+        it('should display the challenge statement and the feedback form', () => {
+          expect(find('.challenge-statement')).to.exist;
+          expect(find('.feedback-panel')).to.exist;
+        });
+
+        it('should not display the timer', () => {
+          expect(find('.timeout-jauge')).to.not.exist;
+        });
+
       });
 
     });
   });
 
-  describe('Not Timed Challenge', () => {
+  context('Not Timed Challenge', () => {
+
+    beforeEach(() => {
+      assessment = server.create('assessment', 'ofCompetenceEvaluationType');
+      notTimedChallenge = server.create('challenge', 'forCompetenceEvaluation');
+    });
 
     it('should display the challenge statement', async () => {
       // when


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur revient sur une question timée auquel il a déjà répondu, le timer s'affiche et s'écoule.

## :robot: Solution
Ne pas afficher le timer dans lorsque la question est déjà répondue.

## :100: Pour tester
Sur le challenge https://app-pr1653.review.pix.fr/challenges/rec9ObZ5yUfzWKqGC/preview
- répondre ou passer la question
- revenir sur cette question via le bouton back du navigateur
- vérifier que le timer ne s'affiche pas
