### PR TITLE
[FEATURE] Mise en place de la création et sauvegarde de Snapshot de knowledge-elements pour l'amélioration des performances de l'export CSV des collectes de profil (PIX-988)

### DIFF
--- a/api/db/migrations/20200718085730_create-table-knowledge-element-snapshots.js
+++ b/api/db/migrations/20200718085730_create-table-knowledge-element-snapshots.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable(TABLE_NAME, (table) => {
+      table.increments('id').primary();
+      table.integer('userId').notNullable();
+      table.dateTime('snappedAt').notNullable();
+      table.jsonb('snapshot').notNullable();
+      table.index('userId');
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable(TABLE_NAME);
+};

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -119,6 +119,7 @@ module.exports = (function() {
 
     infra: {
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),
+      chunkSizeForCampaignResultProcessing: _getNumber(process.env.INFRA_CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING, 10),
     },
 
     sentry: {

--- a/api/lib/domain/services/certification-profile-service.js
+++ b/api/lib/domain/services/certification-profile-service.js
@@ -154,7 +154,32 @@ async function _generateCertificationProfileV2({ userId, profileDate, competence
   return certificationProfile;
 }
 
+async function getCertificationProfilesWithSnapshotting({ userIdsAndDates, competences, allowExcessPixAndLevels = true }) {
+  const knowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository
+    .findSnapshotGroupedByCompetencesForUsers(userIdsAndDates);
+
+  const certificationProfilesList = [];
+  for (const [strUserId, knowledgeElementsByCompetence] of Object.entries(knowledgeElementsByUserIdAndCompetenceId)) {
+    const userId = parseInt(strUserId);
+    const certificationProfile = new CertificationProfile({
+      userId,
+      profileDate: userIdsAndDates[userId],
+    });
+
+    certificationProfile.userCompetences = _createUserCompetencesV2({
+      knowledgeElementsByCompetence,
+      allCompetences: competences,
+      allowExcessPixAndLevels,
+    });
+    
+    certificationProfilesList.push(certificationProfile);
+  }
+
+  return certificationProfilesList;
+}
+
 module.exports = {
   getCertificationProfile,
+  getCertificationProfilesWithSnapshotting,
   fillCertificationProfileWithChallenges,
 };

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -174,6 +174,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
       allowExcessPixAndLevels: false
     });
 
+    let csvLines = '';
     for (const certificationProfile of certificationProfiles) {
       const campaignParticipationResultData = _.find(campaignParticipationResultDataChunk, { userId: certificationProfile.userId });
       const csvLine = _createOneLineOfCSV({
@@ -186,9 +187,10 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
         participantFirstName: campaignParticipationResultData.participantFirstName,
         participantLastName: campaignParticipationResultData.participantLastName,
       });
-
-      writableStream.write(csvLine);
+      csvLines = csvLines.concat(csvLine);
     }
+
+    writableStream.write(csvLines);
   }, { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS }).then(() => {
     writableStream.end();
   }).catch((error) => {

--- a/api/lib/infrastructure/constants.js
+++ b/api/lib/infrastructure/constants.js
@@ -2,4 +2,5 @@ const settings = require('../config');
 
 module.exports = {
   CONCURRENCY_HEAVY_OPERATIONS: settings.infra.concurrencyForHeavyOperations,
+  CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING: settings.infra.chunkSizeForCampaignResultProcessing,
 };

--- a/api/lib/infrastructure/data/knowledge-element-snapshot.js
+++ b/api/lib/infrastructure/data/knowledge-element-snapshot.js
@@ -1,0 +1,12 @@
+const Bookshelf = require('../bookshelf');
+
+const modelName = 'KnowledgeElementSnapshot';
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'knowledge-element-snapshots',
+  requireFetch: false,
+
+}, {
+  modelName
+});

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -5,6 +5,7 @@ const { knex } = require('../bookshelf');
 const KnowledgeElement = require('../../domain/models/KnowledgeElement');
 const BookshelfKnowledgeElement = require('../data/knowledge-element');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const knowledgeElementSnapshotRepository = require('./knowledge-element-snapshot-repository');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 function _getUniqMostRecents(knowledgeElements) {
@@ -57,6 +58,14 @@ async function _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, 
   });
 }
 
+async function _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate }) {
+  const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
+  if (limitDate) {
+    await knowledgeElementSnapshotRepository.save({ userId, snappedAt: limitDate, knowledgeElements });
+  }
+  return knowledgeElements;
+}
+
 module.exports = {
 
   async save(knowledgeElement) {
@@ -67,10 +76,7 @@ module.exports = {
   },
 
   async findUniqByUserId({ userId, limitDate }) {
-    const knowledgeElementRows = await _findByUserIdAndLimitDateQuery({ userId, limitDate });
-
-    const knowledgeElements = _.map(knowledgeElementRows, (knowledgeElementRow) => new KnowledgeElement(knowledgeElementRow));
-    return _applyFilters(knowledgeElements);
+    return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
   },
 
   async findUniqByUserIdAndAssessmentId({ userId, assessmentId }) {
@@ -123,7 +129,21 @@ module.exports = {
     ));
 
     return _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, campaignId);
+  },
 
+  async findSnapshotGroupedByCompetencesForUsers(userIdsAndDates) {
+    const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
+
+    const knowledgeElementsGroupedByUserIdAndCompetenceId = {};
+    for (const [strUserId, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
+      const userId = parseInt(strUserId);
+      let knowledgeElements = knowledgeElementsFromSnapshot;
+      if (!knowledgeElements) {
+        knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate: userIdsAndDates[userId] });
+      }
+      knowledgeElementsGroupedByUserIdAndCompetenceId[userId] = _.groupBy(knowledgeElements, 'competenceId');
+    }
+    return knowledgeElementsGroupedByUserIdAndCompetenceId;
   }
 };
 

--- a/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -1,0 +1,11 @@
+const BookshelfKnowledgeElementSnapshot = require('../data/knowledge-element-snapshot');
+
+module.exports = {
+  save({ userId, snappedAt, knowledgeElements }) {
+    return new BookshelfKnowledgeElementSnapshot({
+      userId,
+      snappedAt,
+      snapshot: JSON.stringify(knowledgeElements),
+    }).save();
+  },
+};

--- a/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -1,4 +1,15 @@
+const _ = require('lodash');
+const { knex } = require('../bookshelf');
 const BookshelfKnowledgeElementSnapshot = require('../data/knowledge-element-snapshot');
+const KnowledgeElement = require('../../domain/models/KnowledgeElement');
+
+function _toKnowledgeElementCollection({ snapshot } = {}) {
+  if (!snapshot) return null;
+  return snapshot.map((data) => new KnowledgeElement({
+    ...data,
+    createdAt: new Date(data.createdAt)
+  }));
+}
 
 module.exports = {
   save({ userId, snappedAt, knowledgeElements }) {
@@ -7,5 +18,25 @@ module.exports = {
       snappedAt,
       snapshot: JSON.stringify(knowledgeElements),
     }).save();
+  },
+
+  async findByUserIdsAndSnappedAtDates(userIdsAndSnappedAtDates = {}) {
+    const params = Object.entries(userIdsAndSnappedAtDates);
+    const results = await knex
+      .select('userId', 'snapshot')
+      .from('knowledge-element-snapshots')
+      .whereIn(['userId', 'snappedAt'], params);
+
+    const knowledgeElementsByUserId = {};
+    for (const result of results) {
+      knowledgeElementsByUserId[result.userId] = _toKnowledgeElementCollection(result);
+    }
+
+    const userIdsWithoutSnapshot = _.difference(Object.keys(userIdsAndSnappedAtDates), Object.keys(knowledgeElementsByUserId));
+    for (const userId of userIdsWithoutSnapshot) {
+      knowledgeElementsByUserId[userId] = null;
+    }
+
+    return knowledgeElementsByUserId;
   },
 };

--- a/api/tests/integration/domain/services/certification-profile-service_test.js
+++ b/api/tests/integration/domain/services/certification-profile-service_test.js
@@ -318,6 +318,172 @@ describe('Integration | Service | Certification Profile Service', function() {
     });
   });
 
+  describe('#getCertificationProfilesWithSnapshotting', () => {
+
+    it('should assign 0 pixScore and level of 0 to user competence when not assessed', async () => {
+      // given
+      sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
+        .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: {} });
+
+      // when
+      const actualCertificationProfiles = await certificationProfileService.getCertificationProfilesWithSnapshotting({
+        userIdsAndDates: { [userId]: 'someLimitDate' },
+        competences
+      });
+
+      // then
+      expect(actualCertificationProfiles[0].userCompetences).to.deep.equal([
+        {
+          id: 'competenceRecordIdOne',
+          index: '1.1',
+          area: { code: '1' },
+          name: '1.1 Construire un flipper',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+          challenges: []
+        },
+        {
+          id: 'competenceRecordIdTwo',
+          index: '1.2',
+          area: { code: '1' },
+          name: '1.2 Adopter un dauphin',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+          challenges: []
+        },
+        {
+          id: 'competenceRecordIdThree',
+          index: '1.3',
+          area: { code: '1' },
+          name: '1.3 Se faire manger par un requin',
+          skills: [],
+          pixScore: 0,
+          estimatedLevel: 0,
+          challenges: []
+        }]);
+    });
+
+    describe('PixScore by competences', () => {
+
+      it('should assign pixScore and level to user competence based on knowledge elements', async () => {
+        // given
+        const ke = domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: skillRemplir2.id,
+          earnedPix: 23
+        });
+
+        sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
+          .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdTwo: [ke] } });
+
+        // when
+        const actualCertificationProfiles = await certificationProfileService.getCertificationProfilesWithSnapshotting({
+          userIdsAndDates: { [userId]: 'someLimitDate' },
+          competences
+        });
+
+        // then
+        expect(actualCertificationProfiles[0].userCompetences[0]).to.include({
+          id: 'competenceRecordIdOne',
+          pixScore: 0,
+          estimatedLevel: 0
+        });
+        expect(actualCertificationProfiles[0].userCompetences[1]).to.include({
+          id: 'competenceRecordIdTwo',
+          pixScore: 23,
+          estimatedLevel: 2,
+        });
+      });
+
+      it('should include both inferred and direct KnowlegdeElements to compute PixScore', async () => {
+        // given
+        const inferredKe = domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: skillRemplir2.id,
+          earnedPix: 8,
+          source: KnowledgeElement.SourceType.INFERRED
+        });
+
+        const directKe = domainBuilder.buildKnowledgeElement({
+          competenceId: 'competenceRecordIdTwo',
+          skillId: skillRemplir4.id,
+          earnedPix: 9,
+          source: KnowledgeElement.SourceType.DIRECT
+        });
+
+        sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
+          .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { 'competenceRecordIdTwo': [inferredKe, directKe] } });
+
+        // when
+        const actualCertificationProfiles = await certificationProfileService.getCertificationProfilesWithSnapshotting({
+          userIdsAndDates: { [userId]: 'someLimitDate' },
+          competences
+        });
+
+        // then
+        expect(actualCertificationProfiles[0].userCompetences[1].pixScore).to.equal(17);
+      });
+
+      context('when we dont want to limit pix score', () => {
+        it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async () => {
+          const ke = domainBuilder.buildKnowledgeElement({
+            competenceId: 'competenceRecordIdOne',
+            earnedPix: 64
+          });
+
+          sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
+            .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdOne: [ke] } });
+
+          // when
+          const actualCertificationProfiles = await certificationProfileService.getCertificationProfilesWithSnapshotting({
+            userIdsAndDates: { [userId]: 'someLimitDate' },
+            competences,
+            allowExcessPixAndLevels: true
+          });
+
+          // then
+          expect(actualCertificationProfiles[0].userCompetences[0]).to.include({
+            id: 'competenceRecordIdOne',
+            pixScore: 64,
+            estimatedLevel: 8
+          });
+        });
+
+      });
+
+      context('when we want to limit pix score', () => {
+        it('should limit pixScore to 40 and level to 5', async () => {
+          const ke = domainBuilder.buildKnowledgeElement({
+            competenceId: 'competenceRecordIdOne',
+            earnedPix: 64
+          });
+
+          sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
+            .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdOne: [ke] } });
+
+          // when
+          const actualCertificationProfiles = await certificationProfileService.getCertificationProfilesWithSnapshotting({
+            userIdsAndDates: { [userId]: 'someLimitDate' },
+            competences,
+            allowExcessPixAndLevels: false
+          });
+
+          // then
+          expect(actualCertificationProfiles[0].userCompetences[0]).to.include({
+            id: 'competenceRecordIdOne',
+            pixScore: 40,
+            estimatedLevel: 5
+          });
+
+        });
+
+      });
+    });
+
+  });
+
   describe('#fillCertificationProfileWithChallenges', () => {
     let certificationProfile;
     let userCompetence1;

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1,10 +1,11 @@
-const { expect, knex, domainBuilder, databaseBuilder } = require('../../../test-helper');
-const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
-const KnowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
 const _ = require('lodash');
 const moment = require('moment');
+const { expect, knex, domainBuilder, databaseBuilder, sinon } = require('../../../test-helper');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
 
-describe('Integration | Repository | KnowledgeElementRepository', () => {
+describe('Integration | Repository | knowledgeElementRepository', () => {
 
   afterEach(() => {
     return knex('knowledge-elements').delete();
@@ -32,7 +33,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       knowledgeElement.id = undefined;
 
       // when
-      promise = KnowledgeElementRepository.save(knowledgeElement);
+      promise = knowledgeElementRepository.save(knowledgeElement);
     });
 
     it('should save the knowledgeElement in db', async () => {
@@ -104,7 +105,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     context('when there is no limit date', () => {
       it('should find the knowledge elements for campaign assessment associated with a user id', async () => {
         // when
-        const knowledgeElementsFound = await KnowledgeElementRepository.findUniqByUserId({ userId });
+        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId });
 
         expect(knowledgeElementsFound).have.lengthOf(3);
         expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
@@ -114,7 +115,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
     context('when there is a limit date', () => {
       it('should find the knowledge elements for campaign assessment associated with a user id created before limit date', async () => {
         // when
-        const knowledgeElementsFound = await KnowledgeElementRepository.findUniqByUserId({ userId, limitDate: today });
+        const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: today });
 
         expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWantedWithLimitDate);
         expect(knowledgeElementsFound).have.lengthOf(2);
@@ -147,7 +148,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
     it('should find the knowledge elements for assessment associated with a user id', async () => {
       // when
-      const knowledgeElementsFound = await KnowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId, assessmentId });
+      const knowledgeElementsFound = await knowledgeElementRepository.findUniqByUserIdAndAssessmentId({ userId, assessmentId });
 
       // then
       expect(knowledgeElementsFound).to.have.deep.members(knowledgeElementsWanted);
@@ -176,7 +177,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
     it('should find the knowledge elements grouped by competence id', async () => {
       // when
-      const actualKnowledgeElementsGroupedByCompetenceId = await KnowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
+      const actualKnowledgeElementsGroupedByCompetenceId = await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({ userId });
 
       // then
       expect(actualKnowledgeElementsGroupedByCompetenceId[1]).to.have.length(2);
@@ -218,7 +219,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
 
     it('should find only the knowledge elements matching both userId and competenceId', async () => {
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+      const actualKnowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
 
       expect(actualKnowledgeElements).to.have.deep.members(wantedKnowledgeElements);
 
@@ -255,7 +256,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(actualKnowledgeElements[0].skillId).to.equal('12');
@@ -279,7 +280,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(actualKnowledgeElements).to.be.empty;
@@ -326,7 +327,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1,2]);
@@ -360,7 +361,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -392,7 +393,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -424,7 +425,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -456,7 +457,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -501,7 +502,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(actualKnowledgeElements).to.have.length(3);
@@ -547,7 +548,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation(campaignId);
 
       // then
       expect(actualKnowledgeElements).to.have.length(1);
@@ -606,7 +607,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1,2]);
@@ -638,7 +639,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -677,7 +678,7 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
 
       // then
       expect(_.map(actualKnowledgeElements, 'id')).to.exactlyContain([1]);
@@ -709,10 +710,142 @@ describe('Integration | Repository | KnowledgeElementRepository', () => {
       await databaseBuilder.commit();
 
       // when
-      const actualKnowledgeElements = await KnowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
+      const actualKnowledgeElements = await knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation({ campaignId, userId });
 
       // then
       expect(actualKnowledgeElements).to.have.length(0);
+    });
+  });
+
+  describe('#findUniqByUserIdsAndDatesGroupedByCompetenceIdWithSnapshot', () => {
+    const sandbox = sinon.createSandbox();
+    let userId1;
+    let userId2;
+
+    beforeEach(() => {
+      userId1 = databaseBuilder.factory.buildUser().id;
+      userId2 = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      return knex('knowledge-element-snapshots').delete();
+    });
+
+    it('should return knowledge elements within respective dates grouped by userId the competenceId', async () => {
+      // given
+      const competence1 = 'competenceId1';
+      const competence2 = 'competenceId2';
+      const dateUserId1 = new Date('2020-01-03');
+      const dateUserId2 = new Date('2019-01-03');
+      const knowledgeElement1_1 = databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1, userId: userId1, createdAt: new Date('2020-01-01') });
+      const knowledgeElement1_2 = databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1, userId: userId1, createdAt: new Date('2020-01-02') });
+      databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1, userId: userId1, createdAt: new Date('2021-01-02') });
+      const knowledgeElement2_1 = databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1, userId: userId2, createdAt: new Date('2019-01-01') });
+      const knowledgeElement2_2 = databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2, userId: userId2, createdAt: new Date('2019-01-02') });
+      databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1, userId: userId2, createdAt: new Date('2020-01-02') });
+      await databaseBuilder.commit();
+
+      // when
+      const knowledgeElementsByUserIdAndCompetenceId =
+        await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: dateUserId1, [userId2]: dateUserId2 });
+
+      // then
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1][0]).to.be.instanceOf(KnowledgeElement);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1].length).to.equal(2);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId1][competence1]).to.deep.include.members([knowledgeElement1_1, knowledgeElement1_2]);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId2]).to.deep.equal({
+        [competence1]: [knowledgeElement2_1],
+        [competence2]: [knowledgeElement2_2],
+      });
+    });
+
+    context('when user has a snapshot for this date', () => {
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the knowledge elements in the snapshot', async () => {
+        // given
+        sandbox.spy(knowledgeElementSnapshotRepository);
+        const dateUserId1 = new Date('2020-01-03');
+        const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId: userId1 });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId: userId1, snappedAt: dateUserId1, snapshot: JSON.stringify([knowledgeElement]) });
+        await databaseBuilder.commit();
+
+        // when
+        const knowledgeElementsByUserIdAndCompetenceId =
+          await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: dateUserId1 });
+
+        // then
+        expect(knowledgeElementsByUserIdAndCompetenceId[userId1][knowledgeElement.competenceId][0]).to.deep.equal(knowledgeElement);
+        expect(knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates).to.have.been.calledWith({ [userId1]: dateUserId1 });
+        await expect(knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates.firstCall.returnValue).to.eventually.deep.equal({
+          [userId1]: [knowledgeElement],
+        });
+      });
+    });
+
+    context('when user does not have a snapshot for this date', () => {
+
+      context('when no date is provided along with the user', () => {
+        let expectedKnowledgeElement;
+
+        beforeEach(() => {
+          expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, createdAt: new Date('2018-01-01') });
+          return databaseBuilder.commit();
+        });
+
+        it('should return the knowledge elements with limit date as now', async () => {
+          // when
+          const knowledgeElementsByUserIdAndCompetenceId =
+            await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: null });
+
+          // then
+          expect(knowledgeElementsByUserIdAndCompetenceId[userId1]).to.deep.equal({
+            [expectedKnowledgeElement.competenceId]: [expectedKnowledgeElement],
+          });
+        });
+
+        it('should not trigger snapshotting', async () => {
+          // when
+          await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: null });
+
+          // then
+          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId: userId1 });
+          expect(actualUserSnapshots.length).to.equal(0);
+        });
+      });
+
+      context('when a date is provided along with the user', () => {
+        let expectedKnowledgeElement;
+
+        beforeEach(() => {
+          expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, createdAt: new Date('2018-01-01') });
+          return databaseBuilder.commit();
+        });
+
+        it('should return the knowledge elements at date', async () => {
+          // when
+          const knowledgeElementsByUserIdAndCompetenceId =
+            await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: new Date('2018-02-01') });
+
+          // then
+          expect(knowledgeElementsByUserIdAndCompetenceId[userId1]).to.deep.equal({
+            [expectedKnowledgeElement.competenceId]: [expectedKnowledgeElement],
+          });
+        });
+
+        it('should save a snasphot', async () => {
+          // when
+          await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: new Date('2018-02-01') });
+
+          // then
+          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId: userId1 });
+          expect(actualUserSnapshots.length).to.equal(1);
+        });
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-snapshot-repository_test.js
@@ -1,0 +1,39 @@
+const { knex, expect, databaseBuilder } = require('../../../test-helper');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
+
+describe('Integration | Repository | KnowledgeElementSnapshotRepository', () => {
+
+  describe('#save', () => {
+
+    afterEach(() => {
+      return knex('knowledge-element-snapshots').delete();
+    });
+
+    it('should save knowledge elements snapshot for a userId and a date', async () => {
+      // given
+      const snappedAt = new Date('2019-04-01');
+      const userId = databaseBuilder.factory.buildUser().id;
+      const knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2019-03-01') });
+      const knowledgeElement2 = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2019-03-01') });
+      const knowledgeElements =  [knowledgeElement1,knowledgeElement2];
+      await databaseBuilder.commit();
+
+      // when
+      await knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
+
+      // then
+      const actualUserSnapshot = await knex.select('*').from('knowledge-element-snapshots').first();
+      expect(actualUserSnapshot.userId).to.deep.equal(userId);
+      expect(actualUserSnapshot.snappedAt).to.deep.equal(snappedAt);
+      const actualKnowledgeElements = [];
+      for (const knowledgeElementData of actualUserSnapshot.snapshot) {
+        actualKnowledgeElements.push(new KnowledgeElement({
+          ...knowledgeElementData,
+          createdAt: new Date(knowledgeElementData.createdAt),
+        }));
+      }
+      expect(actualKnowledgeElements).to.deep.equal(knowledgeElements);
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-knowledge-element-snapshot.js
+++ b/api/tests/tooling/database-builder/factory/build-knowledge-element-snapshot.js
@@ -1,0 +1,34 @@
+const faker = require('faker');
+const buildKnowledgeElement = require('./build-knowledge-element');
+const buildUser = require('./build-user');
+const databaseBuffer = require('../database-buffer');
+const _ = require('lodash');
+
+module.exports = function buildKnowledgeElementSnapshot({
+  id,
+  userId,
+  snappedAt = faker.date.recent(),
+  snapshot,
+} = {}) {
+
+  const dateMinusOneDay = new Date(snappedAt.getTime() - 1000 * 60 * 60 * 24 * 7);
+  userId = _.isUndefined(userId) ? buildUser().id : userId;
+  if (!snapshot) {
+    const knowledgeElements = [];
+    knowledgeElements.push(buildKnowledgeElement({ userId, createdAt: dateMinusOneDay }));
+    knowledgeElements.push(buildKnowledgeElement({ userId, createdAt: dateMinusOneDay }));
+    snapshot = JSON.stringify(knowledgeElements);
+  }
+
+  const values = {
+    id,
+    userId,
+    snappedAt,
+    snapshot
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'knowledge-element-snapshots',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -24,6 +24,7 @@ module.exports = {
   buildCompetenceEvaluation: require('./build-competence-evaluation'),
   buildCompetenceMark: require('./build-competence-mark'),
   buildKnowledgeElement: require('./build-knowledge-element'),
+  buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildOrganization: require('./build-organization'),
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildMembership: require('./build-membership'),

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -34,6 +34,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
     });
 
     const certificationProfile = new CertificationProfile({
+      userId: 123,
       userCompetences: [{
         id: 'recCompetence1',
         pixScore: 9,
@@ -50,7 +51,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
     const competenceRepository = { listPixCompetencesOnly: () => undefined };
     const organizationRepository = { get: () => undefined };
     const campaignParticipationRepository = { findProfilesCollectionResultDataByCampaignId: () => undefined };
-    const certificationProfileService = { getCertificationProfile: () => undefined };
+    const certificationProfileService = { getCertificationProfilesWithSnapshotting: () => undefined };
     let findProfilesCollectionResultDataByCampaignIdStub;
 
     let writableStream;
@@ -62,7 +63,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
       sinon.stub(organizationRepository, 'get').resolves(organization);
       findProfilesCollectionResultDataByCampaignIdStub = sinon.stub(campaignParticipationRepository, 'findProfilesCollectionResultDataByCampaignId');
       sinon.stub(campaignRepository, 'get').resolves(campaign);
-      sinon.stub(certificationProfileService, 'getCertificationProfile').resolves(certificationProfile);
+      sinon.stub(certificationProfileService, 'getCertificationProfilesWithSnapshotting').resolves([certificationProfile]);
 
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);


### PR DESCRIPTION
## :unicorn: Contexte
Plus généralement, une grande partie des fonctionnalités proposées sur PixOrga, lorsqu’il s’agit de campagnes dépassant un certain nombre de participants et/ou avec un targetProfile qui couvre un certain nombre d’acquis, sont lentes. Les seuils à partir desquels les fonctionnalités sont lentes sont, à l’heure actuelle, assez bas. De fait, l’expérience sur PixOrga s’avère, pour certains utilisateurs, assez pénible. L’amélioration de cette expérience est nécessaire, d’une part pour ne pas ternir l’image de Pix, et d’autre part si l’on tient compte du flux d’utilisateurs à venir à court terme (rentrée 2020) en lien avec le déploiement SCO.

L’objectif général de l'été 2020 pour l’activité de prescription consiste à améliorer la performance de ces fonctionnalités.
A cet effet, lors de PR drafts préalables (https://github.com/1024pix/pix/pull/1579 et https://github.com/1024pix/pix/pull/1639), on a étudié la faisabilité d'une solution consistant à capturer la liste des knowledge-elements d'un utilisateur représentatifs de son profil à une date donnée.
Compilation de l'étude --> https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1578238020/2020-06-01+Enqu+te+pour+l+am+lioration+de+l+export+CSV+de+campagnes+de+type+Collecte+de+profils#Introduction


## :robot: Solution
Solution arrêtée :
- Création d'une table `knowledge-element-snapshots` contenant un `userId`, une date de capture `snappedAt` et un `snapshot` (`jsonb` d'une collection de `knowledge-elements` telle qu'obtenue en passant par la méthode `knowledgeElementRepository.findUniqByUserId()`)
- Création dite lazy des snapshots lors de l'export CSV : Le participant a t'il un snapshot ? Oui, le prendre. Non, on récupère les knowledge-elements pour constituer son profil, puis Le participant a t'il partagé sa participation ? Oui, enregistrer le snapshot. Non, ne pas enregistrer le snapshot.
- Traitement par "batch" des participants (plus un par un, mais 10 par 10)

## :rainbow: Étude spécifique
On a souhaité ré-étudier l'impact de façon un peu plus précise de la solution sur cette opération selon un mode opératoire un peu plus spécifique (mode opératoire par ailleurs appliqué aux améliorations à venir sur les autres opérations) :
afin de pouvoir efficacement améliorer à la fois le côté BDD ET le côté pure script JS, on a décidé de mesurer l'amélioration des performances sur deux setups distincts :
- 1 API locale paramétrée à 256 Mb de RAM (prod-like) connectée à une BDD locale comportant une campagne de collecte de profils de 1500 participants  (BUT: se concentrer sur le Javascript, puisqu'il y a peu de volume de données dans la BDD, donc les requêtes vont très très vite.
- 1 API locale paramétrée à 256 Mb de RAM (prod-like) connectée à la BDD de réplication en utilisant une campagne de 249 participants (BUT: se concentrer sur les améliorations BDD, puisque le volume de données différentes de celles exploitées est grand (réplication quoi) ).

On a mesuré la moyenne de temps d'exécution de l'opération sur ces deux setups sur différents "commits" représentatifs, on a aussi tracé la courbe mémoire de l'opération au fil des commits (sur un seul setup uniquement, aucune raison que le comportement mémoire soit différent pour le coup entre les deux setups).

Résultats :
![perf_stats_1](https://user-images.githubusercontent.com/48727874/88026926-ddea1700-cb36-11ea-887b-67509142b1ea.png)
ChunkSnap : mise en place de l'usage de snapshots et de traitement par "batch" des participations
SeveralCSVLines : on écrit plusieurs lignes de CSV d'un coup (1 écriture par batch, donc 10 par 10)

![mem_stats_1](https://user-images.githubusercontent.com/48727874/88027457-91eba200-cb37-11ea-8a1b-5c020f2b752b.png)

## :100: Pour tester
Récupérer la branche en locale, créez une grosse campagne de collecte de profils à l'aide du script generate-campaign-with-participants.js (créez une campagne avec tout plein de participants !).
Puis essayez d'exporter les résultats : lent la première fois, rapide les fois consécutives.
