### PR TITLE
[FEATURE] Traduire la page d'une épreuve (PIX-782).

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.js
+++ b/mon-pix/app/components/challenge-item-qcm.js
@@ -1,9 +1,11 @@
 /* eslint ember/classic-decorator-no-classic-methods: 0 */
 
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import ChallengeItemGeneric from './challenge-item-generic';
 
 export default class ChallengeItemQcm extends ChallengeItemGeneric {
+  @service intl;
   checkedValues = new Set();
 
   _hasError() {
@@ -15,7 +17,7 @@ export default class ChallengeItemQcm extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Pour valider, sélectionner au moins une réponse. Sinon, passer.';
+    return this.intl.t('pages.challenge.skip-error-message.qcm');
   }
 
   @action

--- a/mon-pix/app/components/challenge-item-qcu.js
+++ b/mon-pix/app/components/challenge-item-qcu.js
@@ -1,9 +1,12 @@
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
+import { inject as service } from '@ember/service';
 import classic from 'ember-classic-decorator';
 
 @classic
 class ChallengeItemQcu extends ChallengeItemGeneric {
+  @service intl;
+
   _hasError() {
     return this._getAnswerValue().length < 1;
   }
@@ -17,7 +20,7 @@ class ChallengeItemQcu extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Pour valider, sélectionner une réponse. Sinon, passer.';
+    return this.intl.t('pages.challenge.skip-error-message.qcu');
   }
 
   @action

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -1,9 +1,11 @@
 import { action } from '@ember/object';
 import ChallengeItemGeneric from './challenge-item-generic';
+import { inject as service } from '@ember/service';
 import classic from 'ember-classic-decorator';
 
 @classic
 class ChallengeItemQroc extends ChallengeItemGeneric {
+  @service intl;
 
   autoReplyAnswer = '';
 
@@ -16,7 +18,7 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Jouer l\'épreuve pour valider. Sinon, passer.';
+    return this.intl.t('pages.challenge.skip-error-message.qroc');
   }
 
   _addEventListener() {

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import _ from 'lodash';
+import { inject as service } from '@ember/service';
 import classic from 'ember-classic-decorator';
 
 import ChallengeItemGeneric from './challenge-item-generic';
@@ -7,6 +8,8 @@ import jsyaml from 'js-yaml';
 
 @classic
 class ChallengeItemQrocm extends ChallengeItemGeneric {
+  @service intl;
+
   _hasError() {
     const allAnswers = this._getRawAnswerValue(); // ex. {"logiciel1":"word", "logiciel2":"excel", "logiciel3":""}
     return this._hasEmptyAnswerFields(allAnswers);
@@ -33,7 +36,7 @@ class ChallengeItemQrocm extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return 'Pour valider, veuillez remplir tous les champs réponse. Sinon, passer.';
+    return this.intl.t('pages.challenge.skip-error-message.qrocm');
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled'];
+  @service intl;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
 
@@ -13,11 +15,9 @@ export default class ChallengeController extends Controller {
   }
 
   get pageTitle() {
-    const challengeText = 'Épreuve';
-    const outOfText = 'sur';
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, _.get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
 
-    return `${challengeText} ${stepNumber} ${outOfText} ${totalChallengeNumber}`;
+    return this.intl.t('pages.challenge.title', { stepNumber, totalChallengeNumber });
   }
 }

--- a/mon-pix/app/templates/components/assessment-banner.hbs
+++ b/mon-pix/app/templates/components/assessment-banner.hbs
@@ -1,7 +1,7 @@
 <div class="background-banner assessment-banner">
   <div class="assessment-banner-container">
     <div class="assessment-banner__pix-logo">
-      <img src="/images/pix-logo-blanc.svg" alt="Pix">
+      <img src="/images/pix-logo-blanc.svg" alt="{{t 'common.pix'}}">
     </div>
     {{#if @title}}
       <div class="assessment-banner__splitter"></div>
@@ -9,7 +9,7 @@
     {{/if}}
     {{#if @displayHomeLink}}
       <LinkTo @route="index" class="assessment-banner__home-link">
-        Quitter <FaIcon @icon='sign-out-alt'></FaIcon>
+        {{t "common.actions.quit"}} <FaIcon @icon='sign-out-alt'></FaIcon>
       </LinkTo>
     {{/if}}
   </div>

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,12 +1,12 @@
 {{#if @answer}}
-  <span class="challenge-actions__already-answered">Vous avez déjà répondu à cette question</span>
+  <span class="challenge-actions__already-answered">{{t "pages.challenge.already-answered"}}</span>
   <button class="button challenge-actions__action challenge-actions__action-continue" {{action resumeAssessment @assessment}}>
-    <span class="challenge-actions__action-continue-text">Poursuivre</span>
+    <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}</span>
   </button>
 {{else}}
   {{#if this.isValidateButtonEnabled}}
     <button class="button challenge-actions__action challenge-actions__action-validate" type="submit" {{action validateAnswer}}>
-      <span class="challenge-actions__action-validate-text">Je valide</span>
+      <span class="challenge-actions__action-validate-text">{{t "pages.challenge.actions.validate"}}</span>
     </button>
   {{else}}
     <div class="challenge-actions__action challenge-actions__action-validate__loader">
@@ -15,7 +15,7 @@
   {{/if}}
   {{#if this.isSkipButtonEnabled}}
     <button class="button challenge-actions__action challenge-actions__action-skip" {{action skipChallenge}}>
-      <span class="challenge-actions__action-skip-text">Je passe</span>
+      <span class="challenge-actions__action-skip-text">{{t "pages.challenge.actions.skip"}}</span>
     </button>
   {{else}}
     <div class="challenge-actions__action challenge-actions__action-skip__loader">

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -1,6 +1,6 @@
 <div class="challenge-embed-simulator" style="{{this.embedDocumentHeightStyle}}">
   {{#if this.isLoadingEmbed}}
-    <div class="embed placeholder blurred" aria-label="Chargement de l'application en cours">
+    <div class="embed placeholder blurred" aria-label="{{t "pages.challenge.embed-simulator.placeholder"}}">
       <FaIcon @icon="image"></FaIcon>
     </div>
   {{/if}}
@@ -8,7 +8,7 @@
   <div class="embed rounded-panel {{if this.isLoadingEmbed 'hidden-visibility' ''}}">
     {{#unless this.isSimulatorLaunched}}
       <div class="embed__acknowledgment-overlay">
-        <button class="embed__launch-simulator-button" type="button" {{on 'click' this.launchSimulator}}>Je lance l’application</button>
+        <button class="embed__launch-simulator-button" type="button" {{on 'click' this.launchSimulator}}>{{t "pages.challenge.embed-simulator.actions.launch"}}</button>
       </div>
     {{/unless}}
 
@@ -25,7 +25,7 @@
   <div class="embed__reboot">
     <div class="link link--grey embed-reboot__content" role="button" {{on 'click' this.rebootSimulator}}>
       <FaIcon @icon="redo-alt"></FaIcon>
-      <div class="embed-reboot-content__text"> Réinitialiser </div>
+      <div class="embed-reboot-content__text">{{t "pages.challenge.embed-simulator.actions.reset"}} </div>
     </div>
   </div>
 </div>

--- a/mon-pix/app/templates/components/progress-bar.hbs
+++ b/mon-pix/app/templates/components/progress-bar.hbs
@@ -23,7 +23,7 @@
   </div>
 {{else}}
   <div class="assessment-progress">
-    <div class="assessment-progress__label">Question</div>
+    <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
     <div class="assessment-progress__value">
       {{this.currentStepNumber}} / {{this.maxStepsNumber}}
     </div>

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
       });
 
       it('should go to the next challenge when user validates after finishing successfully the embed', async () => {
@@ -72,7 +72,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         await click('.challenge-actions__action-validate');
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
       });
     });
 
@@ -101,7 +101,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {
@@ -276,7 +276,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l\'épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {

--- a/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator-test.js
@@ -29,7 +29,7 @@ describe('Integration | Component | Challenge Embed Simulator', function() {
 
   describe('Launch simulator button', () => {
 
-    it('should have text "Je lance le simulateur"', async function() {
+    it('should have text "Je lance l\'application"', async function() {
       // when
       await render(hbs`<ChallengeEmbedSimulator />`);
 

--- a/mon-pix/tests/unit/controllers/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge-test.js
@@ -1,6 +1,6 @@
-import { expect } from 'chai';
 import { beforeEach, afterEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import Service from '@ember/service';
 import sinon from 'sinon';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 
@@ -9,9 +9,11 @@ describe('Unit | Controller | Assessments | Challenge', function() {
   setupTest();
 
   let controller;
+  const intl = Service.create({ t: sinon.spy() });
 
   beforeEach(function() {
     controller = this.owner.lookup('controller:assessments/challenge');
+    controller.intl = intl;
   });
 
   afterEach(function() {
@@ -20,6 +22,7 @@ describe('Unit | Controller | Assessments | Challenge', function() {
 
   describe('#pageTitle', () => {
     it('should return Épreuve 2 sur 5', function() {
+      // given
       const model = {
         assessment: {},
         answer: null,
@@ -28,8 +31,11 @@ describe('Unit | Controller | Assessments | Challenge', function() {
       sinon.stub(progressInAssessment, 'getCurrentStepNumber').returns(2);
       sinon.stub(progressInAssessment, 'getMaxStepsNumber').returns(5);
 
+      // when
+      controller.pageTitle;
+
       // then
-      expect(controller.pageTitle).to.equal('Épreuve 2 sur 5');
+      sinon.assert.calledWith(intl.t, 'pages.challenge.title', { stepNumber: 2, totalChallengeNumber: 5 });
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -105,6 +105,12 @@
     },
 
     "challenge" : {
+      "actions": {
+        "continue": "Continue",
+        "validate": "Validate",
+        "skip": "Skip"
+      },
+      "already-answered": "You already answerd this question",
       "certification" : {
         "title": "Certification {certificationNumber}",
         "banner": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -125,6 +125,9 @@
         },
         "placeholder": "Loading application"
       },
+      "progress-bar": {
+        "label": "Challenge"
+      },
       "skip-error-message": {
         "qcm": "Choose at least one answer to validate. Skip otherwise.",
         "qcu": "Choose an answer to validate. Skip otherwise.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -105,6 +105,7 @@
     },
 
     "challenge" : {
+      "title": "Challenge {stepNumber} out of {totalChallengeNumber}",
       "actions": {
         "continue": "Continue",
         "validate": "Validate",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -8,7 +8,8 @@
   "common": {
     "actions" : {
       "cancel": "Cancel",
-      "close": "Close"
+      "close": "Close",
+      "quit": "Quit"
     },
     "form": {
       "mandatory": "mandatory",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -124,6 +124,12 @@
           "reset": "Reset"
         },
         "placeholder": "Loading application"
+      },
+      "skip-error-message": {
+        "qcm": "Choose at least one answer to validate. Skip otherwise.",
+        "qcu": "Choose an answer to validate. Skip otherwise.",
+        "qroc": "Play the challenge to validate. Skip otherwise.",
+        "qrocm":  "Fill in all the answer fields to validate. Skip otherwise."
       }
     },
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -116,6 +116,13 @@
         "banner": {
           "certification-number": "N° of certification"
         }
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Launch application",
+          "reset": "Reset"
+        },
+        "placeholder": "Loading application"
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -105,6 +105,12 @@
     },
 
     "challenge" : {
+      "actions": {
+        "continue": "Poursuivre",
+        "validate": "Je valide",
+        "skip": "Je passe"
+      },
+      "already-answered": "Vous avez déjà répondu à cette question",
       "certification" : {
         "title": "Certification {certificationNumber}",
         "banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -125,6 +125,9 @@
         },
         "placeholder": "Chargement de l'application en cours"
       },
+      "progress-bar": {
+        "label": "Question"
+      },
       "skip-error-message": {
         "qcm": "Pour valider, sélectionner au moins une réponse. Sinon, passer.",
         "qcu": "Pour valider, sélectionner une réponse. Sinon, passer.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -124,6 +124,12 @@
           "reset": "Réinitialiser"
         },
         "placeholder": "Chargement de l'application en cours"
+      },
+      "skip-error-message": {
+        "qcm": "Pour valider, sélectionner au moins une réponse. Sinon, passer.",
+        "qcu": "Pour valider, sélectionner une réponse. Sinon, passer.",
+        "qroc": "Jouer l’épreuve pour valider. Sinon, passer.",
+        "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passer."
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -8,7 +8,8 @@
   "common": {
     "actions" : {
       "cancel": "Annuler",
-      "close": "Fermer"
+      "close": "Fermer",
+      "quit": "Quitter"
     },
     "form": {
       "mandatory": "obligatoire",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -116,6 +116,13 @@
         "banner": {
           "certification-number": "N° de certification"
         }
+      },
+      "embed-simulator": {
+        "actions": {
+          "launch": "Je lance l’application",
+          "reset": "Réinitialiser"
+        },
+        "placeholder": "Chargement de l'application en cours"
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -105,6 +105,7 @@
     },
 
     "challenge" : {
+      "title": "Épreuve {stepNumber} sur {totalChallengeNumber}",
       "actions": {
         "continue": "Poursuivre",
         "validate": "Je valide",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'internationalisation de Pix, nous devons adapter notre plateforme dans d'autres langues et contextes régionaux.
La page d'une épreuve n'est pas encore traductible.

## :robot: Solution
Ajout des traductions des composants utilisés par la page d'une épreuve.

## :rainbow: Remarques
Cette PR ne traite pas la traduction de l'épreuve elle même ni la partie "Signalements".

## :100: Pour tester
Sur la review app, mettre la variable d'environnement `LOCALE` à `en`.
Se rendre sur une épreuve.
Vérifier que les textes sont affichés en langue anglaise.
