### PR TITLE
[FEATURE] Traduire la page des tutos (PIX-796).

### DIFF
--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -45,14 +45,14 @@ export default class TutorialItemComponent extends Component {
 
   get buttonLabel() {
     return this.savingStatus === buttonStatusTypes.recorded ?
-      this.intl.t('pages.user-tutorials.tutorial.actions.remove.label') :
-      this.intl.t('pages.user-tutorials.tutorial.actions.save.label');
+      this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.label') :
+      this.intl.t('pages.user-tutorials.list.tutorial.actions.save.label');
   }
 
   get buttonExtraInformation() {
     return this.savingStatus === buttonStatusTypes.recorded ?
-      this.intl.t('pages.user-tutorials.tutorial.actions.remove.extra-information') :
-      this.intl.t('pages.user-tutorials.tutorial.actions.save.extra-information');
+      this.intl.t('pages.user-tutorials.list.tutorial.actions.remove.extra-information') :
+      this.intl.t('pages.user-tutorials.list.tutorial.actions.save.extra-information');
   }
 
   get isSaveButtonDisabled() {

--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -7,6 +7,7 @@ import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 export default class TutorialItemComponent extends Component {
   @service store;
   @service currentUser;
+  @service intl;
 
   imageForFormat = {
     'vidéo': 'video',
@@ -43,11 +44,15 @@ export default class TutorialItemComponent extends Component {
   }
 
   get buttonText() {
-    return this.savingStatus === buttonStatusTypes.recorded ? 'Retirer' : 'Enregistrer';
+    return this.savingStatus === buttonStatusTypes.recorded ?
+      this.intl.t('pages.user-tutorials.tutorial.actions.remove.title') :
+      this.intl.t('pages.user-tutorials.tutorial.actions.save.title');
   }
 
   get buttonTitle() {
-    return this.savingStatus === buttonStatusTypes.recorded ? 'Retirer' : 'Enregistrer dans ma liste de tutos';
+    return this.savingStatus === buttonStatusTypes.recorded ?
+      this.intl.t('pages.user-tutorials.tutorial.actions.remove.title') :
+      this.intl.t('pages.user-tutorials.tutorial.actions.save.description');
   }
 
   get isSaveButtonDisabled() {

--- a/mon-pix/app/components/tutorial-item.js
+++ b/mon-pix/app/components/tutorial-item.js
@@ -43,16 +43,16 @@ export default class TutorialItemComponent extends Component {
     return this.evaluationStatus === buttonStatusTypes.recorded;
   }
 
-  get buttonText() {
+  get buttonLabel() {
     return this.savingStatus === buttonStatusTypes.recorded ?
-      this.intl.t('pages.user-tutorials.tutorial.actions.remove.title') :
-      this.intl.t('pages.user-tutorials.tutorial.actions.save.title');
+      this.intl.t('pages.user-tutorials.tutorial.actions.remove.label') :
+      this.intl.t('pages.user-tutorials.tutorial.actions.save.label');
   }
 
-  get buttonTitle() {
+  get buttonExtraInformation() {
     return this.savingStatus === buttonStatusTypes.recorded ?
-      this.intl.t('pages.user-tutorials.tutorial.actions.remove.title') :
-      this.intl.t('pages.user-tutorials.tutorial.actions.save.description');
+      this.intl.t('pages.user-tutorials.tutorial.actions.remove.extra-information') :
+      this.intl.t('pages.user-tutorials.tutorial.actions.save.extra-information');
   }
 
   get isSaveButtonDisabled() {

--- a/mon-pix/app/controllers/user-tutorials.js
+++ b/mon-pix/app/controllers/user-tutorials.js
@@ -1,7 +1,8 @@
-import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
-@classic
 export default class UserTutorialsController extends Controller {
-  pageTitle = 'Mes tutos';
+  @service intl;
+
+  pageTitle = this.intl.t('navigation.user.tutorials');
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -13,6 +13,7 @@ export default Route.extend(ApplicationRouteMixin, {
   currentUser: service(),
   session: service(),
   intl: service(),
+  moment: service(),
 
   activate() {
     this.splash.hide();
@@ -27,8 +28,7 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   async beforeModel(transition) {
-    const defaultLocale = 'fr';
-    this.intl.setLocale([ENV.APP.LOCALE, defaultLocale]);
+    this._setLocale();
     await this._checkForURLAuthentication(transition);
     return this._loadCurrentUser();
   },
@@ -44,6 +44,12 @@ export default Route.extend(ApplicationRouteMixin, {
   // when coming from the GAR authentication
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
   sessionInvalidated() {},
+
+  _setLocale() {
+    const defaultLocale = 'fr';
+    this.intl.setLocale([ENV.APP.LOCALE, defaultLocale]);
+    this.moment.setLocale(ENV.APP.LOCALE || defaultLocale);
+  },
 
   _loadCurrentUser() {
     return this.currentUser.load().catch(() => this.session.invalidate());

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -3,7 +3,7 @@
     <a target="_blank" rel="noopener noreferrer" href="{{tutorial.link}}"
        class="tutorial-content__title">{{tutorial.title}}</a>
     <div class="tutorial-content__description">
-      <span class="tutorial-content__source">Par {{tutorial.source}}</span>
+      <span class="tutorial-content__source">{{t 'pages.user-tutorials.tutorial.source'}} {{tutorial.source}}</span>
       • <span class="tutorial-content__format">{{tutorial.format}}</span>
       • <span class="tutorial-content__duration">{{moment-duration tutorial.duration}}</span>
     </div>
@@ -15,11 +15,11 @@
           <FaIcon @prefix={{if this.isSaved 'fas' 'far'}} @icon='bookmark'/>
           {{buttonText}}
         </button>
-        <button class="tutorial-content-actions__evaluate" title="Donner mon avis sur ce tuto"
+        <button class="tutorial-content-actions__evaluate" title={{t 'pages.user-tutorials.tutorial.actions.evaluate.description'}}
           {{on 'click' this.evaluateTutorial}}
           disabled={{this.isEvaluateButtonDisabled}}>
           <FaIcon @prefix={{if this.isEvaluated 'fas' 'far'}} @icon='thumbs-up'/>
-          Tuto utile
+          {{t 'pages.user-tutorials.tutorial.actions.evaluate.title'}}
         </button>
       </div>
     {{/if}}

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -3,7 +3,7 @@
     <a target="_blank" rel="noopener noreferrer" href="{{tutorial.link}}"
        class="tutorial-content__title">{{tutorial.title}}</a>
     <div class="tutorial-content__description">
-      <span class="tutorial-content__source">{{t 'pages.user-tutorials.tutorial.source'}} {{tutorial.source}}</span>
+      <span class="tutorial-content__source">{{t 'pages.user-tutorials.list.tutorial.source'}} {{tutorial.source}}</span>
       • <span class="tutorial-content__format">{{tutorial.format}}</span>
       • <span class="tutorial-content__duration">{{moment-duration tutorial.duration}}</span>
     </div>
@@ -15,11 +15,11 @@
           <FaIcon @prefix={{if this.isSaved 'fas' 'far'}} @icon='bookmark'/>
           {{buttonLabel}}
         </button>
-        <button class="tutorial-content-actions__evaluate" title={{t 'pages.user-tutorials.tutorial.actions.evaluate.extra-information'}}
+        <button class="tutorial-content-actions__evaluate" title={{t 'pages.user-tutorials.list.tutorial.actions.evaluate.extra-information'}}
           {{on 'click' this.evaluateTutorial}}
           disabled={{this.isEvaluateButtonDisabled}}>
           <FaIcon @prefix={{if this.isEvaluated 'fas' 'far'}} @icon='thumbs-up'/>
-          {{t 'pages.user-tutorials.tutorial.actions.evaluate.label'}}
+          {{t 'pages.user-tutorials.list.tutorial.actions.evaluate.label'}}
         </button>
       </div>
     {{/if}}

--- a/mon-pix/app/templates/components/tutorial-item.hbs
+++ b/mon-pix/app/templates/components/tutorial-item.hbs
@@ -9,17 +9,17 @@
     </div>
     {{#if this.currentUser.user}}
       <div class="tutorial-content__actions">
-        <button class="tutorial-content-actions__save" title={{this.buttonTitle}}
+        <button class="tutorial-content-actions__save" title={{this.buttonExtraInformation}}
           {{on 'click' (if this.isSaved this.removeTutorial this.saveTutorial)}}
           disabled={{this.isSaveButtonDisabled}}>
           <FaIcon @prefix={{if this.isSaved 'fas' 'far'}} @icon='bookmark'/>
-          {{buttonText}}
+          {{buttonLabel}}
         </button>
-        <button class="tutorial-content-actions__evaluate" title={{t 'pages.user-tutorials.tutorial.actions.evaluate.description'}}
+        <button class="tutorial-content-actions__evaluate" title={{t 'pages.user-tutorials.tutorial.actions.evaluate.extra-information'}}
           {{on 'click' this.evaluateTutorial}}
           disabled={{this.isEvaluateButtonDisabled}}>
           <FaIcon @prefix={{if this.isEvaluated 'fas' 'far'}} @icon='thumbs-up'/>
-          {{t 'pages.user-tutorials.tutorial.actions.evaluate.title'}}
+          {{t 'pages.user-tutorials.tutorial.actions.evaluate.label'}}
         </button>
       </div>
     {{/if}}

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -14,7 +14,7 @@
           <div class="logged-user-menu-details__identifier">{{displayedIdentifier}}</div>
         </div>
         <LinkTo @route="user-tutorials" class="logged-user-menu__link">
-          Mes tutos
+          {{t 'navigation.user.tutorials'}}
         </LinkTo>
         <LinkTo @route="user-certifications" class="logged-user-menu__link">
           Mes certifications

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -7,7 +7,7 @@
         <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt=""/>
         <h3 class="user-tutorials-banner__title">{{t 'pages.user-tutorials.title'}}</h3>
         <p class="user-tutorials-banner__description">
-          Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.
+          {{t 'pages.user-tutorials.description'}}
         </p>
       </div>
     </header>
@@ -24,14 +24,14 @@
       <article aria-label="tutoriels" class="rounded-panel user-tutorials-no-tutorial">
         <div class="user-tutorials-no-tutorial__illustration">
           <img src="{{rootURL}}/images/user-tutorials/illustration.svg"
-               alt="Cliquez sur l'icône enregistrer sur un tutoriel pour le retrouver sur cette page"/>
+               alt=""/>
         </div>
         <div class="user-tutorials-no-tutorial__instructions">
-          <h4 class="user-tutorials-no-tutorial-instructions__title">Vous n'avez encore rien enregistré</h4>
-          <p class="user-tutorials-no-tutorial-instructions__description">Au fil de vos tests, des tutos vous sont
-            recommandés : cliquez sur l'icône marque page
+          <h4 class="user-tutorials-no-tutorial-instructions__title">{{t 'pages.user-tutorials.empty-list-info.title'}}</h4>
+          <p class="user-tutorials-no-tutorial-instructions__description">
+            {{t 'pages.user-tutorials.empty-list-info.description.part1'}}
             <FaIcon @prefix="far" @icon='bookmark'></FaIcon>
-            pour enregistrer ceux que vous souhaitez retrouver ici !
+            {{t 'pages.user-tutorials.empty-list-info.description.part2'}}
           </p>
         </div>
       </article>

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -13,7 +13,7 @@
     </header>
     {{#if this.model}}
       <article aria-label="tutoriels" class="user-tutorials-content">
-        <h3 class="user-tutorials-content__title">Ma liste</h3>
+        <h3 class="user-tutorials-content__title">{{t 'pages.user-tutorials.list.title'}}</h3>
         <div>
           {{#each this.model as |userTutorial|}}
             <TutorialItem @tutorial={{userTutorial.tutorial}} />

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -23,7 +23,7 @@
     {{else}}
       <article aria-label="tutoriels" class="rounded-panel user-tutorials-no-tutorial">
         <div class="user-tutorials-no-tutorial__illustration">
-          <img src="{{rootURL}}/images/user-tutorials/illustration.svg"
+          <img src="{{rootURL}}/{{t 'pages.user-tutorials.empty-list-info.image-link'}}"
                alt=""/>
         </div>
         <div class="user-tutorials-no-tutorial__instructions">

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -5,7 +5,7 @@
     <header role="banner" class="background-banner">
       <div class="user-tutorials-banner">
         <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt=""/>
-        <h3 class="user-tutorials-banner__title">Mes tutos</h3>
+        <h3 class="user-tutorials-banner__title">{{t 'pages.user-tutorials.title'}}</h3>
         <p class="user-tutorials-banner__description">
           Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.
         </p>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -105,6 +105,8 @@ module.exports = function(environment) {
     },
 
     moment: {
+      // Locale supported by moment.js
+      // English is bundled automatically, not need to add en in includeLocales
       includeLocales: ['fr'],
     },
 

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -78,7 +78,7 @@ describe('Integration | Component | user logged menu', function() {
 
       return settled().then(() => {
         // then
-        expect(findAll('.logged-user-menu__link')[0].textContent.trim()).to.equal('Mes tutos');
+        expect(findAll('.logged-user-menu__link')[0].textContent.trim()).to.equal(this.intl.t('navigation.user.tutorials'));
       });
     });
 

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -2,18 +2,22 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
+import Service from '@ember/service';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
 
 describe('Unit | Component | tutorial item', function() {
   setupTest();
 
   let component;
+  const intl = Service.create({ t: sinon.spy() });
   const tutorial = {
     format: 'son',
     id: 'tutorialId'
   };
+
   beforeEach(function() {
     component = createGlimmerComponent('component:tutorial-item', { tutorial });
+    component.intl = intl;
   });
 
   describe('#formatImageName', function() {
@@ -107,10 +111,10 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return "Enregistré" when the tutorial is not saved', function() {
       // when
-      const result = component.buttonText;
+      component.buttonText;
 
       // then
-      expect(result).to.equal('Enregistrer');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.title');
     });
 
     it('should return "Enregistrer" when the tutorial is succesfully saved', function() {
@@ -118,10 +122,10 @@ describe('Unit | Component | tutorial item', function() {
       component.savingStatus = 'recorded';
 
       // when
-      const result = component.buttonText;
+      component.buttonText;
 
       // then
-      expect(result).to.equal('Retirer');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.title');
     });
 
   });
@@ -130,10 +134,10 @@ describe('Unit | Component | tutorial item', function() {
 
     it('should return "Enregistrer dans ma liste de tutos" when the tutorial has not already been saved', function() {
       // when
-      const result = component.buttonTitle;
+      component.buttonTitle;
 
       // then
-      expect(result).to.equal('Enregistrer dans ma liste de tutos');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.description');
     });
 
     it('should return "Retirer" when the tutorial has been saved', function() {
@@ -141,10 +145,10 @@ describe('Unit | Component | tutorial item', function() {
       component.savingStatus = 'recorded';
 
       // when
-      const result = component.buttonTitle;
+      component.buttonTitle;
 
       // then
-      expect(result).to.equal('Retirer');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.title');
     });
 
   });

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -107,14 +107,14 @@ describe('Unit | Component | tutorial item', function() {
 
   });
 
-  describe('#buttonText', function() {
+  describe('#buttonLabel', function() {
 
     it('should return "Enregistré" when the tutorial is not saved', function() {
       // when
-      component.buttonText;
+      component.buttonLabel;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.title');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.label');
     });
 
     it('should return "Enregistrer" when the tutorial is succesfully saved', function() {
@@ -122,22 +122,22 @@ describe('Unit | Component | tutorial item', function() {
       component.savingStatus = 'recorded';
 
       // when
-      component.buttonText;
+      component.buttonLabel;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.title');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.label');
     });
 
   });
 
-  describe('#buttonTitle', function() {
+  describe('#buttonExtraInformation', function() {
 
     it('should return "Enregistrer dans ma liste de tutos" when the tutorial has not already been saved', function() {
       // when
-      component.buttonTitle;
+      component.buttonExtraInformation;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.description');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.extra-information');
     });
 
     it('should return "Retirer" when the tutorial has been saved', function() {
@@ -145,10 +145,10 @@ describe('Unit | Component | tutorial item', function() {
       component.savingStatus = 'recorded';
 
       // when
-      component.buttonTitle;
+      component.buttonExtraInformation;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.title');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.extra-information');
     });
 
   });

--- a/mon-pix/tests/unit/components/tutorial-item-test.js
+++ b/mon-pix/tests/unit/components/tutorial-item-test.js
@@ -114,7 +114,7 @@ describe('Unit | Component | tutorial item', function() {
       component.buttonLabel;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.label');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.list.tutorial.actions.save.label');
     });
 
     it('should return "Enregistrer" when the tutorial is succesfully saved', function() {
@@ -125,7 +125,7 @@ describe('Unit | Component | tutorial item', function() {
       component.buttonLabel;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.label');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.list.tutorial.actions.remove.label');
     });
 
   });
@@ -137,7 +137,7 @@ describe('Unit | Component | tutorial item', function() {
       component.buttonExtraInformation;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.save.extra-information');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.list.tutorial.actions.save.extra-information');
     });
 
     it('should return "Retirer" when the tutorial has been saved', function() {
@@ -148,7 +148,7 @@ describe('Unit | Component | tutorial item', function() {
       component.buttonExtraInformation;
 
       // then
-      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.tutorial.actions.remove.extra-information');
+      sinon.assert.calledWith(intl.t, 'pages.user-tutorials.list.tutorial.actions.remove.extra-information');
     });
 
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -186,6 +186,22 @@
           "part2": "to save a tuto"
         },
         "title": "No tuto saved"
+      },
+      "tutorial": {
+        "actions": {
+          "evaluate": {
+            "description": "Evaluate this tutorial",
+            "title": "Useful tutorial"
+          },
+          "remove": {
+            "title": "Remove"
+          },
+          "save": {
+            "description": "Save in my tutorials",
+            "title": "Save"
+          }
+        },
+        "source": "By"
       }
     },
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -190,15 +190,16 @@
       "tutorial": {
         "actions": {
           "evaluate": {
-            "description": "Evaluate this tutorial",
-            "title": "Useful tutorial"
+            "extra-information": "Evaluate this tutorial",
+            "label": "Useful tutorial"
           },
           "remove": {
-            "title": "Remove"
+            "extra-information": "Remove from my tutorials",
+            "label": "Remove"
           },
           "save": {
-            "description": "Save in my tutorials",
-            "title": "Save"
+            "extra-information": "Save in my tutorials",
+            "label": "Save"
           }
         },
         "source": "By"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -249,22 +249,25 @@
         "image-link": "images/user-tutorials/illustration.svg",
         "title": "No tuto saved"
       },
-      "tutorial": {
-        "actions": {
-          "evaluate": {
-            "extra-information": "Evaluate this tutorial",
-            "label": "Useful tutorial"
+      "list": {
+        "title": "My list",
+        "tutorial": {
+          "actions": {
+            "evaluate": {
+              "extra-information": "Evaluate this tutorial",
+              "label": "Useful tutorial"
+            },
+            "remove": {
+              "extra-information": "Remove from my tutorials",
+              "label": "Remove"
+            },
+            "save": {
+              "extra-information": "Save in my tutorials",
+              "label": "Save"
+            }
           },
-          "remove": {
-            "extra-information": "Remove from my tutorials",
-            "label": "Remove"
-          },
-          "save": {
-            "extra-information": "Save in my tutorials",
-            "label": "Save"
-          }
-        },
-        "source": "By"
+          "source": "By"
+        }
       }
     }
   },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -177,6 +177,10 @@
       "first-title": "Oups, an error has occured!"
     },
 
+    "user-tutorials": {
+      "title": "My tutorials"
+    },
+
     "sign-in" : {
       "title" : "Sign in",
       "actions": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -244,6 +244,9 @@
     "homepage": "Home page",
     "back-to-homepage": "Back to homepage",
     "back-to-profile": "Back to profile",
-    "pix": "Pix"
+    "pix": "Pix",
+    "user": {
+      "tutorials": "My tutorials"
+    }
   }
 }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -246,6 +246,7 @@
           "part1": "Use a bookmark",
           "part2": "to save a tuto"
         },
+        "image-link": "images/user-tutorials/illustration.svg",
         "title": "No tuto saved"
       },
       "tutorial": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -178,7 +178,15 @@
     },
 
     "user-tutorials": {
-      "title": "My tutorials"
+      "title": "My tutorials",
+      "description": "Improve with tutorials",
+      "empty-list-info": {
+        "description": {
+          "part1": "Use a bookmark",
+          "part2": "to save a tuto"
+        },
+        "title": "No tuto saved"
+      }
     },
 
     "sign-in" : {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -177,35 +177,6 @@
       "first-title": "Oups, an error has occured!"
     },
 
-    "user-tutorials": {
-      "title": "My tutorials",
-      "description": "Improve with tutorials",
-      "empty-list-info": {
-        "description": {
-          "part1": "Use a bookmark",
-          "part2": "to save a tuto"
-        },
-        "title": "No tuto saved"
-      },
-      "tutorial": {
-        "actions": {
-          "evaluate": {
-            "extra-information": "Evaluate this tutorial",
-            "label": "Useful tutorial"
-          },
-          "remove": {
-            "extra-information": "Remove from my tutorials",
-            "label": "Remove"
-          },
-          "save": {
-            "extra-information": "Save in my tutorials",
-            "label": "Save"
-          }
-        },
-        "source": "By"
-      }
-    },
-
     "sign-in" : {
       "title" : "Sign in",
       "actions": {
@@ -264,6 +235,35 @@
       "legal-information": "By signing in, you allow Pix to store your data. They will be kept for a maximum of 5 years, starting with your last sign in date, and will then be archived according to statutory limitation periods (5 years). They are only used by Pix and Pix's service providers. In accordance to the law « informatique et libertés », you can exercise your right of access to data and correct them by sending an email to dpd@pix.fr.",
       "subtitle": {
         "link": "sign in"
+      }
+    },
+
+    "user-tutorials": {
+      "title": "My tutorials",
+      "description": "Improve with tutorials",
+      "empty-list-info": {
+        "description": {
+          "part1": "Use a bookmark",
+          "part2": "to save a tuto"
+        },
+        "title": "No tuto saved"
+      },
+      "tutorial": {
+        "actions": {
+          "evaluate": {
+            "extra-information": "Evaluate this tutorial",
+            "label": "Useful tutorial"
+          },
+          "remove": {
+            "extra-information": "Remove from my tutorials",
+            "label": "Remove"
+          },
+          "save": {
+            "extra-information": "Save in my tutorials",
+            "label": "Save"
+          }
+        },
+        "source": "By"
       }
     }
   },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -249,22 +249,25 @@
         "image-link": "images/user-tutorials/illustration.svg",
         "title": "Vous n'avez encore rien enregistré"
       },
-      "tutorial": {
-        "actions": {
-          "evaluate": {
-            "extra-information": "Donner mon avis sur ce tuto",
-            "label": "Tuto utile"
+      "list": {
+        "title": "Ma liste",
+        "tutorial": {
+          "actions": {
+            "evaluate": {
+              "extra-information": "Donner mon avis sur ce tuto",
+              "label": "Tuto utile"
+            },
+            "remove": {
+              "extra-information": "Retirer de ma liste de tutos",
+              "label": "Retirer"
+            },
+            "save": {
+              "extra-information": "Enregistrer dans ma liste de tutos",
+              "label": "Enregistrer"
+            }
           },
-          "remove": {
-            "extra-information": "Retirer de ma liste de tutos",
-            "label": "Retirer"
-          },
-          "save": {
-            "extra-information": "Enregistrer dans ma liste de tutos",
-            "label": "Enregistrer"
-          }
-        },
-        "source": "Par"
+          "source": "Par"
+        }
       }
     }
   },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -190,15 +190,16 @@
       "tutorial": {
         "actions": {
           "evaluate": {
-            "description": "Donner mon avis sur ce tuto",
-            "title": "Tuto utile"
+            "extra-information": "Donner mon avis sur ce tuto",
+            "label": "Tuto utile"
           },
           "remove": {
-            "title": "Retirer"
+            "extra-information": "Retirer de ma liste de tutos",
+            "label": "Retirer"
           },
           "save": {
-            "description": "Enregistrer dans ma liste de tutos",
-            "title": "Enregistrer"
+            "extra-information": "Enregistrer dans ma liste de tutos",
+            "label": "Enregistrer"
           }
         },
         "source": "Par"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -177,35 +177,6 @@
       "first-title": "Oups, une erreur est survenue !"
     },
 
-    "user-tutorials": {
-      "title": "Mes tutos",
-      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
-      "empty-list-info": {
-        "description": {
-          "part1": "Au fil de vos tests, des tutos vous sont recommandés : cliquez sur l'icône marque page",
-          "part2": "pour enregistrer ceux que vous souhaitez retrouver ici !"
-        },
-        "title": "Vous n'avez encore rien enregistré"
-      },
-      "tutorial": {
-        "actions": {
-          "evaluate": {
-            "extra-information": "Donner mon avis sur ce tuto",
-            "label": "Tuto utile"
-          },
-          "remove": {
-            "extra-information": "Retirer de ma liste de tutos",
-            "label": "Retirer"
-          },
-          "save": {
-            "extra-information": "Enregistrer dans ma liste de tutos",
-            "label": "Enregistrer"
-          }
-        },
-        "source": "Par"
-      }
-    },
-
     "sign-in" : {
       "title" : "Connexion",
       "actions": {
@@ -264,6 +235,35 @@
       "legal-information": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l'accès au service offert par Pix. Elles sont conservées pendant une durée de 5 ans maximum à compter du dernier accès au compte utilisateur, et archivées selon les délais de prescription légale (5 ans). Elles sont destinées à Pix et à ses prestataires techniques exclusivement. Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à dpd@pix.fr.",
       "subtitle": {
         "link": "connectez-vous à votre compte"
+      }
+    },
+
+    "user-tutorials": {
+      "title": "Mes tutos",
+      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
+      "empty-list-info": {
+        "description": {
+          "part1": "Au fil de vos tests, des tutos vous sont recommandés : cliquez sur l'icône marque page",
+          "part2": "pour enregistrer ceux que vous souhaitez retrouver ici !"
+        },
+        "title": "Vous n'avez encore rien enregistré"
+      },
+      "tutorial": {
+        "actions": {
+          "evaluate": {
+            "extra-information": "Donner mon avis sur ce tuto",
+            "label": "Tuto utile"
+          },
+          "remove": {
+            "extra-information": "Retirer de ma liste de tutos",
+            "label": "Retirer"
+          },
+          "save": {
+            "extra-information": "Enregistrer dans ma liste de tutos",
+            "label": "Enregistrer"
+          }
+        },
+        "source": "Par"
       }
     }
   },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -178,7 +178,15 @@
     },
 
     "user-tutorials": {
-      "title": "Mes tutos"
+      "title": "Mes tutos",
+      "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",
+      "empty-list-info": {
+        "description": {
+          "part1": "Au fil de vos tests, des tutos vous sont recommandés : cliquez sur l'icône marque page",
+          "part2": "pour enregistrer ceux que vous souhaitez retrouver ici !"
+        },
+        "title": "Vous n'avez encore rien enregistré"
+      }
     },
 
     "sign-in" : {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -177,6 +177,10 @@
       "first-title": "Oups, une erreur est survenue !"
     },
 
+    "user-tutorials": {
+      "title": "Mes tutos"
+    },
+
     "sign-in" : {
       "title" : "Connexion",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -244,6 +244,9 @@
     "homepage": "Page d'accueil",
     "back-to-homepage": "Revenir à la page d’accueil",
     "back-to-profile": "Retour Profil",
-    "pix": "Pix"
+    "pix": "Pix",
+    "user": {
+      "tutorials": "Mes tutos"
+    }
   }
 }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -186,6 +186,22 @@
           "part2": "pour enregistrer ceux que vous souhaitez retrouver ici !"
         },
         "title": "Vous n'avez encore rien enregistré"
+      },
+      "tutorial": {
+        "actions": {
+          "evaluate": {
+            "description": "Donner mon avis sur ce tuto",
+            "title": "Tuto utile"
+          },
+          "remove": {
+            "title": "Retirer"
+          },
+          "save": {
+            "description": "Enregistrer dans ma liste de tutos",
+            "title": "Enregistrer"
+          }
+        },
+        "source": "Par"
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -246,6 +246,7 @@
           "part1": "Au fil de vos tests, des tutos vous sont recommandés : cliquez sur l'icône marque page",
           "part2": "pour enregistrer ceux que vous souhaitez retrouver ici !"
         },
+        "image-link": "images/user-tutorials/illustration.svg",
         "title": "Vous n'avez encore rien enregistré"
       },
       "tutorial": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'internationalisation de Pix, nous devons adapter notre plateforme dans d'autres langues et contextes régionaux.
La page des tutoriels d'un utilisateur n'est pas encore traductible.

## :robot: Solution
Ajout des traductions de la page "Mes tutos".

## :rainbow: Remarques
- Cette PR ne traite pas la traduction des tutos eux-mêmes (les infos provenant d'Airtable)
- dans `routes/application.js`, la locale de moment.js est settée afin de pouvoir assurer la traduction du temps en toutes lettres (on affiche sur la carte de tutoriel le temps estimée de lecture - ex: `3 minutes`)

## :100: Pour tester
- changer la `LOCALE` de la review app pour `fr` ou `en`
- visualiser les changements sur la page `Mes tutos` https://app-pr1660.review.pix.fr/mes-tutos
avant et après avoir sauvegardé un tuto
