### PR TITLE
[FEATURE] Traduire la page "Oups" (PIX-791).

### DIFF
--- a/mon-pix/app/controllers/error.js
+++ b/mon-pix/app/controllers/error.js
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class ErrorController extends Controller {
+  @service intl;
+
+  pageTitle = this.intl.t('navigation.error');
+}
+

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -6,13 +6,10 @@
     <div class="error-page">
       <div class="rounded-panel rounded-panel--strong error-page__body-section">
         <div class="error-page__main-content">
-          <h1 class="error-page-main-content__title">Oups, une erreur est survenue !</h1>
-          <p>Nous vous invitons à recharger cette page ou <LinkTo @route="login">revenir à la page d’accueil</LinkTo>.</p>
-          <p>Vous pouvez aussi nous contacter via <a href="https://support.pix.fr/support/tickets/new">le formulaire du centre d'aide</a> en nous précisant le code d'erreur ci-dessous dans la description.</p>
-          <p>Nous vous prions de nous excuser pour la gêne occasionnée.</p>
-          <p>L'équipe Pix.</p>
+          <h1 class="error-page-main-content__title">{{t "pages.error.first-title"}}</h1>
+          {{t "pages.error.content-text" htmlSafe=true}}
           <LinkTo @route="login" class="button button--extra-big button--link error-page__index-link">
-            Revenir à la page d'accueil</LinkTo>
+            {{t "navigation.back-to-homepage"}}</LinkTo>
         </div>
         <div class="error-page__error">
           <p class="error-page__error-title">{{this.errorTitle}}</p>

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -1,3 +1,4 @@
+{{title pageTitle}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -172,6 +172,11 @@
       }
     },
 
+    "error": {
+      "content-text": "'<p>'You can reload the current page or '<LinkTo @route=\"login\">'go back to the homepage'</LinkTo>'.'</p><p>'You can also contact us with '<a href=\"https://support.pix.fr/support/tickets/new\">'the help center form'</a>' specifying the above error code in the description.'</p><p>'We apologize for the inconvenience.'</p><p>'The Pix Team.'</p>'",
+      "first-title": "Oups, an error has occured!"
+    },
+
     "sign-in" : {
       "title" : "Sign in",
       "actions": {
@@ -236,6 +241,7 @@
 
   "navigation": {
     "homepage": "Home page",
+    "back-to-homepage": "Back to homepage",
     "back-to-profile": "Back to profile",
     "pix": "Pix"
   }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -240,6 +240,7 @@
   },
 
   "navigation": {
+    "error": "Error",
     "homepage": "Home page",
     "back-to-homepage": "Back to homepage",
     "back-to-profile": "Back to profile",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -172,6 +172,11 @@
       }
     },
 
+    "error": {
+      "content-text": "'<p>'Nous vous invitons à recharger cette page ou '<LinkTo @route=\"login\">'revenir à la page d’accueil'</LinkTo>'.'</p><p>'Vous pouvez aussi nous contacter via '<a href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d'aide'</a>' en nous précisant le code d’erreur ci-dessous dans la description.'</p><p>'Nous vous prions de nous excuser pour la gêne occasionnée.'</p><p>'L’équipe Pix.'</p>'",
+      "first-title": "Oups, une erreur est survenue !"
+    },
+
     "sign-in" : {
       "title" : "Connexion",
       "actions": {
@@ -236,6 +241,7 @@
 
   "navigation": {
     "homepage": "Page d'accueil",
+    "back-to-homepage": "Revenir à la page d’accueil",
     "back-to-profile": "Retour Profil",
     "pix": "Pix"
   }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -240,6 +240,7 @@
   },
 
   "navigation": {
+    "error": "Erreur",
     "homepage": "Page d'accueil",
     "back-to-homepage": "Revenir à la page d’accueil",
     "back-to-profile": "Retour Profil",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'internationalisation de Pix, nous devons adapter notre plateforme dans d'autres langues et contextes régionaux.
La page d'erreur (Oups) n'est pas encore traductible.

## :robot: Solution
Ajout des traductions des composants utilisés par la page Oups.

## :rainbow: Remarques
RAS

## :100: Pour tester
Sur la review app, mettre la variable d'environnement LOCALE à en.
Se rendre sur la page d'erreur.
Vérifier que les textes sont affichés en langue anglaise.
