### PR TITLE
[FEATURE] Générer un identifiant avec mot de passe temporaire pour l'utilisateur qui se connecte uniquement avec le GAR (PIX-953).

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -120,4 +120,39 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     birthdate: '2003-09-30',
     organizationId: 3,
   });
+
+  const userAuthentificationMethodIsEmailOnly  = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'user',
+    lastName: 'pix',
+    email: 'user.pix@example.net',
+    username: null,
+    rawPassword: 'Pix123',
+    cgu: false
+  });
+  databaseBuilder.factory.buildSchoolingRegistration({
+    userId: userAuthentificationMethodIsEmailOnly.id,
+    firstName: userAuthentificationMethodIsEmailOnly.firstName,
+    lastName: userAuthentificationMethodIsEmailOnly.lastName,
+    birthdate: '2010-09-30',
+    samlId: userAuthentificationMethodIsEmailOnly.samlId,
+    organizationId: 3,
+  });
+
+  const userAuthentificationMethodIsSamlIdOnly = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    firstName: 'user',
+    lastName: 'gar',
+    email: null,
+    username: null,
+    samlId: '1234567',
+    rawPassword: 'Pix123',
+    cgu: false
+  });
+  databaseBuilder.factory.buildSchoolingRegistration({
+    userId: userAuthentificationMethodIsSamlIdOnly.id,
+    firstName: userAuthentificationMethodIsSamlIdOnly.firstName,
+    lastName: userAuthentificationMethodIsSamlIdOnly.lastName,
+    birthdate: '2010-09-30',
+    samlId: userAuthentificationMethodIsSamlIdOnly.samlId,
+    organizationId: 3,
+  });
 };

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -83,6 +83,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToGetCertificationCoursesError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToGenerateUsernamePasswordError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.CertificationCandidateAlreadyLinkedToUserError) {
     return new HttpErrors.ForbiddenError('Le candidat de certification est déjà lié à un utilisateur.');
   }

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -75,6 +75,44 @@ exports.register = async function(server) {
         tags: ['api', 'schoolingRegistrationDependentUser'],
       }
     },
+    {
+      method: 'POST',
+      path: '/api/schooling-registration-dependent-users/generate-username-password',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents,
+          assign: 'belongsToScoOrganizationAndManageStudents'
+        }],
+        handler: schoolingRegistrationDependentUserController.generateUsernameWithTemporaryPassword,
+        validate: {
+          options: {
+            allowUnknown: true
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'organization-id': Joi.number().required(),
+                'schooling-registration-id': Joi.number().required()
+              }
+            }
+          }),
+          failAction: (request, h, err) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              code: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: err.details[0].message,
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          }
+        },
+        notes : [
+          '- Génère un identifiant pour l\'élève avec un mot de passe temporaire \n' +
+          '- La demande de génération d\'identifiant doit être effectuée par un membre de l\'organisation à laquelle appartient l\'élève.'
+        ],
+        tags: ['api', 'schoolingRegistrationDependentUser', 'username'],
+      }
+    }
   ]);
 };
 

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -45,4 +45,27 @@ module.exports = {
 
     return h.response(schoolingRegistrationWithGeneratedPasswordResponse).code(200);
   },
+
+  async generateUsernameWithTemporaryPassword(request, h) {
+    const payload = request.payload.data.attributes;
+    const organizationId = parseInt(payload['organization-id']);
+    const schoolingRegistrationId = parseInt(payload['schooling-registration-id']);
+
+    const result = await usecases.generateUsernameWithTemporaryPassword({
+      schoolingRegistrationId,
+      organizationId,
+    });
+
+    const schoolingRegistrationWithGeneratedUsernamePasswordResponse = {
+      data: {
+        attributes: {
+          'generated-password': result.generatedPassword,
+          'username': result.username,
+        },
+        type: 'schooling-registration-dependent-user'
+      }
+    };
+
+    return h.response(schoolingRegistrationWithGeneratedUsernamePasswordResponse).code(200);
+  },
 };

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -1,5 +1,6 @@
 const usecases = require('../../domain/usecases');
 const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
+const schoolingRegistrationDependentUser = require('../../infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
@@ -56,15 +57,7 @@ module.exports = {
       organizationId,
     });
 
-    const schoolingRegistrationWithGeneratedUsernamePasswordResponse = {
-      data: {
-        attributes: {
-          'generated-password': result.generatedPassword,
-          'username': result.username,
-        },
-        type: 'schooling-registration-dependent-user'
-      }
-    };
+    const schoolingRegistrationWithGeneratedUsernamePasswordResponse = schoolingRegistrationDependentUser.serialize(result);
 
     return h.response(schoolingRegistrationWithGeneratedUsernamePasswordResponse).code(200);
   },

--- a/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
@@ -1,11 +1,12 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository');
+const Organisation = require('../../domain/models/Organization')
 
 module.exports = {
 
   execute(userId, organizationId) {
     return membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true })
       .then((memberships) => memberships.reduce((belongsToScoOrganization, membership) => {
-        return belongsToScoOrganization || (membership.organization.isManagingStudents && membership.organization.type === 'SCO');
+        return belongsToScoOrganization || (membership.organization.isManagingStudents && Organisation.types.SCO === membership.organization.type);
       }, false));
   }
 };

--- a/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
+++ b/api/lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js
@@ -1,5 +1,5 @@
 const membershipRepository = require('../../infrastructure/repositories/membership-repository');
-const Organisation = require('../../domain/models/Organization')
+const Organisation = require('../../domain/models/Organization');
 
 module.exports = {
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -131,6 +131,12 @@ class UserNotAuthorizedToGetCertificationCoursesError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToGenerateUsernamePasswordError extends DomainError {
+  constructor(message = 'Cet utilisateur n\'est pas autorisé à générer un identifiant et un mot de passe.') {
+    super(message);
+  }
+}
+
 class CertificationCourseUpdateError extends DomainError {
   constructor(message = 'Echec lors la création ou de la mise à jour du test de certification.') {
     super(message);
@@ -557,6 +563,7 @@ module.exports = {
   UserNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateResourceError,
   UserNotAuthorizedToGetCampaignResultsError,
+  UserNotAuthorizedToGenerateUsernamePasswordError,
   UserNotAuthorizedToGetCertificationCoursesError,
   UserNotAuthorizedToUpdateCampaignError,
   UserNotAuthorizedToUpdatePasswordError,

--- a/api/lib/domain/usecases/generate-username-with-temporary-password.js
+++ b/api/lib/domain/usecases/generate-username-with-temporary-password.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+const { UserNotAuthorizedToGenerateUsernamePasswordError } = require('../errors');
+
+module.exports = async function generateUsernameWithTemporaryPassword({
+  schoolingRegistrationId,
+  organizationId,
+  passwordGenerator,
+  encryptionService,
+  userReconciliationService,
+  userRepository,
+  schoolingRegistrationRepository
+}) {
+
+  const schoolingRegistration = await schoolingRegistrationRepository.get(schoolingRegistrationId);
+  _checkIfStudentHasAccessToOrganization(schoolingRegistration, organizationId);
+
+  const studentAccount = await userRepository.get(schoolingRegistration.userId);
+  _checkIfStudentAccountAlreadyHasUsername(studentAccount);
+
+  const username = await userReconciliationService.createUsernameByUser({ user: schoolingRegistration , userRepository });
+  const generatedPassword = passwordGenerator.generate();
+  const hashedPassword = await encryptionService.hashPassword(generatedPassword);
+
+  await userRepository.updateUsernameAndPassword(studentAccount.id, username, hashedPassword);
+
+  return { username, generatedPassword };
+};
+
+function _checkIfStudentHasAccessToOrganization(schoolingRegistration, organizationId) {
+  if (schoolingRegistration.organizationId !== organizationId) {
+    throw new UserNotAuthorizedToGenerateUsernamePasswordError(`L'élève avec l'INE ${schoolingRegistration.nationalStudentId} n'appartient pas à l'organisation.`);
+  }
+}
+
+function _checkIfStudentAccountAlreadyHasUsername(studentAccount) {
+  if (!_.isEmpty(studentAccount.username)) {
+    throw new UserNotAuthorizedToGenerateUsernamePasswordError(`Ce compte utilisateur dispose déjà d'un identifiant: ${studentAccount.username}.`);
+  }
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -128,6 +128,7 @@ module.exports = injectDependencies({
   findPaginatedFilteredSchoolingRegistrations: require('./find-paginated-filtered-schooling-registrations'),
   flagSessionResultsAsSentToPrescriber: require('./flag-session-results-as-sent-to-prescriber'),
   generateUsername: require('./generate-username'),
+  generateUsernameWithTemporaryPassword: require('./generate-username-with-temporary-password'),
   getAnswer: require('./get-answer'),
   getAssessment: require('./get-assessment'),
   getAttendanceSheet: require('./get-attendance-sheet'),

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -407,6 +407,19 @@ module.exports = {
     return username;
   },
 
+  updateUsernameAndPassword(id, username, hashedPassword) {
+    return BookshelfUser
+      .where({ id })
+      .save({ username, password: hashedPassword, shouldChangePassword: true }, { patch: true, method: 'update' })
+      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .catch((err) => {
+        if (err instanceof BookshelfUser.NoRowsUpdatedError) {
+          throw new UserNotFoundError(`User not found for ID ${id}`);
+        }
+        throw err;
+      });
+  },
+
   updatePasswordThatShouldBeChanged(id, hashedPassword) {
     return BookshelfUser
       .where({ id })

--- a/api/lib/infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer.js
@@ -1,0 +1,11 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(schoolingRegistrationDependentUser) {
+    return new Serializer('schooling-registration-dependent-user', {
+      attributes: ['username', 'generatedPassword'],
+    }).serialize(schoolingRegistrationDependentUser);
+  },
+
+};

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -137,6 +137,105 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
     });
   });
 
+  describe('POST /api/schooling-registration-dependent-users/generate-username-password', () => {
+
+    let organizationId;
+    let schoolingRegistrationId;
+    let options;
+
+    beforeEach(async () => {
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      const user = databaseBuilder.factory.buildUser();
+      user.username = null;
+      const userId = user.id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+      schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId, userId
+      }).id;
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'POST',
+        url: '/api/schooling-registration-dependent-users/generate-username-password',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        payload: {
+          data: {
+            attributes: {
+              'organization-id': organizationId,
+              'schooling-registration-id': schoolingRegistrationId,
+            }
+          }
+        }
+      };
+    });
+
+    it('should return a 200 status after having successfully generated username and temporary password', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+
+    });
+
+    it('should return a 404 status when schoolingRegistration does not exist', async () => {
+      // given
+      options.payload.data.attributes['schooling-registration-id'] = 0;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return a 404 status when schoolingRegistration\'s userId does not exist', async () => {
+      // given
+      const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId, userId: null
+      }).id;
+      options.payload.data.attributes['schooling-registration-id'] = schoolingRegistrationId;
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return a 403 status when student does not belong to the same organization as schoolingRegistration', async () => {
+      // given
+      options.payload.data.attributes['organization-id'] = 0;
+      options.payload.data.attributes['schooling-registration-id'] = schoolingRegistrationId;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should return a 403 status when user does not belong to the same organization as schoolingRegistration', async () => {
+      // given
+      const wrongOrganization = databaseBuilder.factory.buildOrganization();
+      const schoolingRegistrationWithWrongOrganization = databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: wrongOrganization.id,
+      });
+      await databaseBuilder.commit();
+
+      options.payload.data.attributes['schooling-registration-id'] = schoolingRegistrationWithWrongOrganization.id;
+      options.payload.data.attributes['organization-id'] = wrongOrganization.id;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
   describe('POST /api/schooling-registration-dependent-users/password-update', () => {
 
     let organizationId;

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -11,6 +11,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
   beforeEach(() => {
     sinon.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
     sinon.stub(schoolingRegistrationDependentUserController, 'createAndAssociateUserToSchoolingRegistration').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(schoolingRegistrationDependentUserController, 'generateUsernameWithTemporaryPassword').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationDependentUserController, 'updatePassword').callsFake((request, h) => h.response('ok').code(200));
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -122,6 +123,29 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
       // given
       const method = 'POST';
       const url = '/api/schooling-registration-dependent-users/password-update';
+      const payload = {
+        data: {
+          attributes: {
+            'schooling-registration-id': 1,
+            'organization-id': 3
+          }
+        }
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('POST /api/schooling-registration-dependent-users/generate-username-password', () => {
+
+    it('should succeed', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/schooling-registration-dependent-users/generate-username-password';
       const payload = {
         data: {
           attributes: {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -851,6 +851,44 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
   });
 
+  describe('#updateUsernameAndPassword', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser(userToInsert);
+      await databaseBuilder.commit();
+    });
+
+    it('should update the username and password', async () => {
+      // given
+      const username = 'blue.carter0701';
+      const generatedPassword = '1235Pix!';
+
+      // when
+      const updatedUser = await userRepository.updateUsernameAndPassword(userInDb.id, username, generatedPassword);
+
+      // then
+      expect(updatedUser).to.be.an.instanceOf(User);
+      expect(updatedUser.username).to.equal(username);
+      expect(updatedUser.password).to.equal(generatedPassword);
+      expect(updatedUser.shouldChangePassword).to.be.true;
+    });
+
+    it('should throw UserNotFoundError when user id not found', async () => {
+      // given
+      const wrongUserId = 0;
+      const username = 'blue.carter0701';
+      const generatedPassword = '1235Pix!';
+
+      // when
+      const error = await catchErr(userRepository.updateUsernameAndPassword)(wrongUserId, username, generatedPassword);
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+  });
+
   describe('#isUserExistingByEmail', () => {
     const email = 'shi@fu.fr';
 

--- a/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
+++ b/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
@@ -1,0 +1,100 @@
+const generateUsernameWithTemporaryPassword = require('../../../../lib/domain/usecases/generate-username-with-temporary-password.js');
+const { sinon, expect, catchErr, domainBuilder } = require('../../../test-helper');
+const passwordGenerator = require('../../../../lib/domain/services/password-generator');
+const encryptionService = require('../../../../lib/domain/services/encryption-service');
+const userReconciliationService = require('../../../../lib/domain/services/user-reconciliation-service');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
+const { UserNotAuthorizedToGenerateUsernamePasswordError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | generate-username-with-temporary-password', () => {
+
+  const connectedUser = domainBuilder.buildUser();
+  const userRelatedToStudent = domainBuilder.buildUser();
+  const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+  const expectedUsername = 'john.harry0207';
+  schoolingRegistration.lastName = 'harry';
+  schoolingRegistration.firstName = 'john';
+  schoolingRegistration.birthdate = '1989-07-02';
+
+  beforeEach(() => {
+    sinon.stub(userRepository, 'getWithMemberships').resolves(connectedUser);
+    sinon.stub(userRepository, 'get').resolves(connectedUser);
+    sinon.stub(userRepository, 'updateUsernameAndPassword').resolves(connectedUser);
+    sinon.stub(schoolingRegistrationRepository, 'get').resolves(schoolingRegistration);
+    sinon.stub(encryptionService, 'hashPassword');
+  });
+
+  it('should generate username and temporary password', async () => {
+    // given
+    const organizationId = connectedUser.memberships[0].organization.id;
+    userRelatedToStudent.organizationId = organizationId;
+    schoolingRegistration.organizationId = organizationId;
+    connectedUser.username = null;
+
+    // when
+    const result = await generateUsernameWithTemporaryPassword({
+      connectedUserId: connectedUser.id,
+      schoolingRegistrationId: schoolingRegistration.id,
+      organizationId,
+      passwordGenerator,
+      encryptionService,
+      userReconciliationService,
+      userRepository,
+      schoolingRegistrationRepository
+    });
+
+    // then
+    expect(result.username).to.be.equal(expectedUsername);
+    expect(result.generatedPassword).to.be.not.empty;
+    expect(result.generatedPassword).to.have.lengthOf(8);
+
+  });
+
+  it('should throw an error when student has not access to the organization', async () => {
+    // given
+    const organizationId = connectedUser.memberships[0].organization.id;
+    schoolingRegistration.organizationId = 99;
+
+    // when
+    const error = await catchErr(generateUsernameWithTemporaryPassword)({
+      connectedUserId: connectedUser.id,
+      schoolingRegistrationId: schoolingRegistration.id,
+      organizationId: organizationId,
+      passwordGenerator,
+      encryptionService,
+      userReconciliationService,
+      userRepository,
+      schoolingRegistrationRepository
+    });
+
+    // then
+    expect(error).to.be.instanceof(UserNotAuthorizedToGenerateUsernamePasswordError);
+    expect(error.message).to.be.equal(`L'élève avec l'INE ${schoolingRegistration.nationalStudentId} n'appartient pas à l'organisation.`);
+  });
+
+  it('should throw an error when student account has already a username', async () => {
+    // given
+    const organizationId = connectedUser.memberships[0].organization.id;
+    userRelatedToStudent.organizationId = organizationId;
+    schoolingRegistration.organizationId = organizationId;
+    connectedUser.username = expectedUsername;
+
+    // when
+    const error = await catchErr(generateUsernameWithTemporaryPassword)({
+      connectedUserId: connectedUser.id,
+      schoolingRegistrationId: schoolingRegistration.id,
+      organizationId,
+      passwordGenerator,
+      encryptionService,
+      userReconciliationService,
+      userRepository,
+      schoolingRegistrationRepository
+    });
+
+    // then
+    expect(error).to.be.instanceof(UserNotAuthorizedToGenerateUsernamePasswordError);
+    expect(error.message).to.be.equal(`Ce compte utilisateur dispose déjà d'un identifiant: ${connectedUser.username}.`);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/schooling-registration-dependent-user_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/schooling-registration-dependent-user_test.js
@@ -1,0 +1,31 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer');
+
+describe('Unit | Serializer | JSONAPI | schooling-registration-dependent-user-serializer', () => {
+
+  describe('#serialize', () => {
+
+    const schoolingRegistrationWithUsernameAndPassword = domainBuilder.buildSchoolingRegistration();
+    schoolingRegistrationWithUsernameAndPassword.username = 'john.harry0702';
+    schoolingRegistrationWithUsernameAndPassword.generatedPassword = 'AZFETGFR';
+
+    const expectedSchoolingRegistrationJson = {
+      data: {
+        type: 'schooling-registration-dependent-users',
+        id: schoolingRegistrationWithUsernameAndPassword.id.toString(),
+        attributes: {
+          username: 'john.harry0702',
+          'generated-password': 'AZFETGFR',
+        }
+      }
+    };
+
+    it('should convert a schooling-registration-dependent-user object into JSON API data', () => {
+      // when
+      const json = serializer.serialize(schoolingRegistrationWithUsernameAndPassword);
+
+      // then
+      expect(json).to.deep.equal(expectedSchoolingRegistrationJson);
+    });
+  });
+});

--- a/orga/app/adapters/schooling-registration-dependent-user.js
+++ b/orga/app/adapters/schooling-registration-dependent-user.js
@@ -2,7 +2,15 @@ import ApplicationAdapter from './application';
 
 export default class SchoolingRegistrationDependentUserAdapter extends ApplicationAdapter {
 
-  urlForCreateRecord() {
+  urlForCreateRecord(modelName, { adapterOptions }) {
+
+    const url = super.urlForCreateRecord(...arguments);
+
+    if (adapterOptions && adapterOptions.generateUsernameAndTemporaryPassword) {
+      delete adapterOptions.generateUsernameAndTemporaryPassword;
+      return url + '/generate-username-password';
+    }
+
     return `${this.host}/${this.namespace}/schooling-registration-dependent-users/password-update`;
   }
 }

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -69,6 +69,13 @@
                       Dissocier le compte
                     </Dropdown::Item>
                   {{/if}}
+                {{#if this.isGenerateUsernameFeatureIsEnabled}}
+                  {{#if student.isAuthenticatedFromGarOnly}}
+                    <Dropdown::Item @onClick={{fn this.generateUsernameWithTemporaryPassword student}}>
+                      Générer identifiant
+                    </Dropdown::Item>
+                  {{/if}}
+                {{/if}}
                 </Dropdown::IconTrigger>
               {{/if}}
             </td>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -1,15 +1,21 @@
+import _ from 'lodash';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import ENV from 'pix-orga/config/environment';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListItems extends Component {
 
   @service currentUser;
+  @service store;
+  @service router;
+  @service notifications;
 
   @tracked student = null;
   @tracked isShowingModal = false;
   @tracked isShowingDissociateModal = false;
+  isGenerateUsernameFeatureIsEnabled = ENV.APP.IS_GENERATE_USERNAME_FEATURE_ENABLED;
 
   @action
   openPasswordReset(student) {
@@ -32,4 +38,23 @@ export default class ListItems extends Component {
   closeDissociateModal() {
     this.isShowingDissociateModal = false;
   }
+
+  @action
+  async generateUsernameWithTemporaryPassword(student) {
+    const schoolingRegistrationDependentUser = this.store.createRecord('schooling-registration-dependent-user', {
+      organizationId: this.currentUser.organization.id,
+      schoolingRegistrationId: student.id
+    });
+
+    try {
+      await schoolingRegistrationDependentUser.save({ adapterOptions: { generateUsernameAndTemporaryPassword: true } });
+      this.username = schoolingRegistrationDependentUser.username;
+      this.generatedPassword = schoolingRegistrationDependentUser.generatedPassword;
+      this.args.refreshModel();
+    } catch (response) {
+      const errorDetail = _.get(response, 'errors[0].detail', 'Une erreur est survenue, veuillez réessayer ultérieurement.');
+      this.notifications.sendError(errorDetail);
+    }
+  }
+
 }

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -40,4 +40,9 @@ export default class Student extends Model {
   get isStudentAssociated() {
     return Boolean(this.email || this.username || this.isAuthenticatedFromGar);
   }
+
+  @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
+  get isAuthenticatedFromGarOnly() {
+    return Boolean(!this.email && !this.username && this.isAuthenticatedFromGar);
+  }
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -31,7 +31,8 @@ module.exports = function(environment) {
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
       HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
-      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.'
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      IS_GENERATE_USERNAME_FEATURE_ENABLED: process.env.IS_GENERATE_USERNAME_FEATURE_ENABLED === 'true',
     },
 
     googleFonts: [
@@ -88,6 +89,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.IS_GENERATE_USERNAME_FEATURE_ENABLED = true;
 
     // Testem prefers this...
     ENV.locationType = 'none';

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -143,7 +143,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
-  module('when user is reconciled with username', function({ beforeEach }) {
+  module('when user authentification method is username', function({ beforeEach }) {
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -167,7 +167,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
-  module('when user is reconciled with email', function({ beforeEach }) {
+  module('when user authentification method is email', function({ beforeEach }) {
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -188,6 +188,38 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
     test('it should display actions menu for email', async function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').exists();
+    });
+  });
+
+  module('when user authentification method is samlId', function({ beforeEach }) {
+    beforeEach(function() {
+      const store = this.owner.lookup('service:store');
+      this.set('students', [
+        store.createRecord('student', {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          birthdate: '2010-01-01',
+          email: null,
+          username: null,
+          isAuthenticatedFromGar: true,
+        })
+      ]);
+      return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+    });
+
+    test('it should display "Mediacentre" as authentication method', async function(assert) {
+      assert.dom('[aria-label="Élève"]').containsText('Mediacentre');
+    });
+
+    test('it should display the action menu', async function(assert) {
+      assert.dom('[aria-label="Afficher les actions"]').exists();
+    });
+
+    test('it should display the button generate username in the menu', async function(assert) {
+      await click('[aria-label="Afficher les actions"]');
+
+      // then
+      assert.contains('Générer identifiant');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Quand un élève change d'établissement, il ne peut plus se connecter avec son compte GAR.

## :robot: Solution
Redonner l'accès à l'élève en lui générant un identifiant et un mot de passe temporaire pour se connecter.
Rajouter une entrée dans le menu qui va permettre au prof de générer un identifiant à l'élève.

## :rainbow: Remarques
Cette entrée ne sera visible à l'utilisateur que lorsque le reste des fonctionnalités de l’Epix sera développé.

## :100: Pour tester
Se connecter à Pix Orga avec le compte sco@example.net
Aller dans la vue élève https://orga-pr1664.review.pix.fr/eleves
Utiliser le compte élève qui dispose uniquement de la méthode de connexion GAR.
Vérifier que l'entrée 'Générer identifiant' s'affiche pour ledit élève.
En cliquant sur ce bouton, vérifier que l'identifiant a été créé. La vue des méthodes de connexion de l'élève doit contenir 'Médiacentre, identifiant'. 
