### PR TITLE
[INFRA] Ajoute une cible test:api:bail pour avoir du feedback plus rapidement

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -121,6 +121,7 @@
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
+    "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint"
   },
   "nodemonConfig": {


### PR DESCRIPTION
## :unicorn: Problème

Quand on lance les tests pour avoir du feedback, `npm t` commence par les tests les plus lents (acceptance puis intégration puis unitaires), et attend d'avoir parcouru tous les tests avant de donner les messages d'erreurs.

## :robot: Solution

Idée d'Etienne : ajouter une target `test:api:bail` qui commence par les tests les plus rapides (unitaires puis intégration puis acceptance) et qui s'arrête au premier échec pour afficher le premier message d'erreur.

## :rainbow: Remarques

On pourrait réfléchir à "est-ce qu'on veut reconstruire la base" à l'étape intégration ?