### PR TITLE
[FEATURE] Permettre le téléchargement du modèle d'import des étudiants inscrits dans Pix Orga (PIX-935).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -266,6 +266,28 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/organizations/{id}/schooling-registrations/csv-template',
+      config: {
+        auth: false,
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required(),
+          }),
+          query: Joi.object({
+            accessToken: Joi.string().required(),
+          }).options({ allowUnknown: true }),
+        },
+        handler: organizationController.getSchoolingRegistrationsCsvTemplate,
+        notes: [
+          '- **Cette route est restreinte via un token dédié passé en paramètre avec l\'id de l\'utilisateur.**\n' +
+          '- Récupération d\'un template CSV qui servira à téléverser les inscriptions d’étudiants\n' +
+          '- L‘utilisateur doit avoir les droits d‘accès ADMIN à l‘organisation',
+        ],
+        tags: ['api', 'schooling-registrations']
+      }
+    },
   ]);
 };
 

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -1,4 +1,5 @@
 const organizationService = require('../../domain/services/organization-service');
+const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
 
 const campaignSerializer = require('../../infrastructure/serializers/jsonapi/campaign-serializer');
@@ -131,5 +132,16 @@ module.exports = {
 
     return usecases.findPendingOrganizationInvitations({ organizationId })
       .then((invitations) => organizationInvitationSerializer.serialize(invitations));
+  },
+
+  async getSchoolingRegistrationsCsvTemplate(request, h) {
+    const organizationId = parseInt(request.params.id);
+    const token = request.query.accessToken;
+    const userId = tokenService.extractUserId(token);
+    const template = await usecases.getSchoolingRegistrationsCsvTemplate({ userId, organizationId });
+
+    return h.response(template)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', 'attachment; filename=modele-import.csv');
   }
 };

--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -7,8 +7,7 @@ module.exports = async function getSchoolingRegistrationsCsvTemplate({
   membershipRepository,
 }) {
   const [membership] = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
-  const isAdminInSupOrganizationManagingStudents = membership && membership.isAdmin && membership.organization.isManagingStudents && membership.organization.type === 'SUP';
-  if (!isAdminInSupOrganizationManagingStudents) {
+  if (!_isAdminInSupOrganizationManagingStudents(membership)) {
     throw new UserNotAuthorizedToAccessEntity('User is not allowed to download csv template.');
   }
 
@@ -37,4 +36,8 @@ function _createHeaderOfCSV() {
     'Diplôme',
     'Régime'
   ];
+}
+
+function _isAdminInSupOrganizationManagingStudents(membership) {
+  return membership && membership.isAdmin && membership.organization.isManagingStudents && membership.organization.type === 'SUP';
 }

--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -1,0 +1,40 @@
+const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
+const { UserNotAuthorizedToAccessEntity } = require('../errors');
+
+module.exports = async function getSchoolingRegistrationsCsvTemplate({
+  userId,
+  organizationId,
+  membershipRepository,
+}) {
+  const [membership] = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
+  const isAdminInSupOrganizationManagingStudents = membership && membership.isAdmin && membership.organization.isManagingStudents && membership.organization.type === 'SUP';
+  if (!isAdminInSupOrganizationManagingStudents) {
+    throw new UserNotAuthorizedToAccessEntity('User is not allowed to download csv template.');
+  }
+
+  //Create HEADER of CSV
+  const headers = _createHeaderOfCSV();
+
+  // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
+  // - https://en.wikipedia.org/wiki/Byte_order_mark
+  // - https://stackoverflow.com/a/38192870
+  return '\uFEFF' + csvSerializer.serializeLine(headers);
+};
+
+function _createHeaderOfCSV() {
+  return [
+    'Premier prénom',
+    'Deuxième prénom',
+    'Troisième prénom',
+    'Nom de famille',
+    'Nom d’usage',
+    'Date de naissance (jj/mm/aaaa)',
+    'Email',
+    'Numéro étudiant',
+    'Composante',
+    'Équipe pédagogique',
+    'Groupe',
+    'Diplôme',
+    'Régime'
+  ];
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -151,6 +151,7 @@ module.exports = injectDependencies({
   getOrganizationInvitation: require('./get-organization-invitation'),
   getPrescriber: require('./get-prescriber'),
   getProgression: require('./get-progression'),
+  getSchoolingRegistrationsCsvTemplate: require('./get-schooling-registrations-csv-template'),
   getScorecard: require('./get-scorecard'),
   getSession: require('./get-session'),
   getSessionCertificationCandidates: require('./get-session-certification-candidates'),

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -1178,4 +1178,37 @@ describe('Acceptance | Application | organization-controller', () => {
       expect(targetProfileShares).to.have.lengthOf(0);
     });
   });
+
+  describe('GET /api/organizations/{id}/schooling-registrations/csv-template', function() {
+
+    let organization, accessToken;
+
+    beforeEach(async () => {
+      const userId = databaseBuilder.factory.buildUser().id;
+      organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+      await databaseBuilder.commit();
+
+      const authHeader = generateValidRequestAuthorizationHeader(userId);
+      accessToken = authHeader.replace('Bearer ', '');
+    });
+
+    it('should return csv file with statusCode 200', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/schooling-registrations/csv-template?accessToken=${accessToken}`
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200, response.payload);
+    });
+  });
 });

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -221,5 +221,4 @@ describe('Integration | Application | Organizations | Routes', () => {
       expect(response.statusCode).to.equal(204);
     });
   });
-
 });

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -19,6 +19,7 @@ describe('Unit | Router | organization-router', () => {
 
     sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
     sinon.stub(organizationController, 'sendInvitations').callsFake((request, h) => h.response().created());
+    sinon.stub(organizationController, 'getSchoolingRegistrationsCsvTemplate').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -119,6 +120,73 @@ describe('Unit | Router | organization-router', () => {
         // given
         const method = 'POST';
         const url = '/api/organizations/qsdqsd/schooling-registrations/import-csv';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+
+  describe('GET /api/organizations/{id}/schooling-registrations/csv-template', () => {
+
+    it('should call the organization controller to csv template', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/organizations/1/schooling-registrations/csv-template?accessToken=token';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(organizationController.getSchoolingRegistrationsCsvTemplate).to.have.been.calledOnce;
+    });
+
+    describe('When parameters are not valid', () => {
+
+      it('should throw an error when id is not a number', async () => {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/ABC/schooling-registrations/csv-template?accessToken=token';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should throw an error when id is null', async () => {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/null/schooling-registrations/csv-template?accessToken=token';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should throw an error when access token is not specified', async () => {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/ABC/schooling-registrations/csv-template';
+
+        // when
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should throw an error when access token is null', async () => {
+        // given
+        const method = 'GET';
+        const url = '/api/organizations/null/schooling-registrations/csv-template?accessToken=null';
 
         // when
         const response = await httpTestServer.request(method, url);

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -6,14 +6,14 @@ const organizationController = require('../../../../lib/application/organization
 
 const usecases = require('../../../../lib/domain/usecases');
 const organizationService = require('../../../../lib/domain/services/organization-service');
+const tokenService = require('../../../../lib/domain/services/token-service');
 
-const organizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
 const campaignSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-serializer');
-const targetProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-serializer');
-const studentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-serializer');
-const userWithSchoolingRegistrationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
-
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
+const organizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
+const studentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-serializer');
+const targetProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-serializer');
+const userWithSchoolingRegistrationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
 
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 
@@ -586,4 +586,30 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     });
   });
 
+  describe('#getSchoolingRegistrationsCsvTemplate', () => {
+    const userId = 1;
+    const organizationId = 2;
+    const request = {
+      query: {
+        accessToken: 'token'
+      },
+      params: {
+        id: organizationId
+      }
+    };
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getSchoolingRegistrationsCsvTemplate').resolves('template');
+      sinon.stub(tokenService, 'extractUserId').returns(userId);
+    });
+
+    it('should return a response with correct headers', async () => {
+      // when
+      const response = await organizationController.getSchoolingRegistrationsCsvTemplate(request, hFake);
+
+      // then
+      expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
+      expect(response.headers['Content-Disposition']).to.equal('attachment; filename=modele-import.csv');
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -1,0 +1,89 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const getSchoolingRegistrationsCsvTemplate = require('../../../../lib/domain/usecases/get-schooling-registrations-csv-template');
+const _ = require('lodash');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
+
+  const userId = Symbol('userId');
+  const organizationId = Symbol('organizationId');
+  const membershipRepository = { findByUserIdAndOrganizationId: _.noop };
+
+  context('When user is ADMIN in a SUP organization managing students', () => {
+    it('should return headers line', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: true, type: 'SUP' } }]);
+
+      // when
+      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository });
+
+      // then
+      const csvExpected = '\uFEFF"Premier prénom";' +
+        '"Deuxième prénom";' +
+        '"Troisième prénom";' +
+        '"Nom de famille";' +
+        '"Nom d’usage";' +
+        '"Date de naissance (jj/mm/aaaa)";' +
+        '"Email";' +
+        '"Numéro étudiant";' +
+        '"Composante";' +
+        '"Équipe pédagogique";' +
+        '"Groupe";' +
+        '"Diplôme";' +
+        '"Régime"\n';
+      expect(result).to.deep.equal(csvExpected);
+    });
+  });
+
+  context('When user is not a member of the organization', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('When user is member of a SUP organization managing students but not ADMIN', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: false, organization: { isManagingStudents: true, type: 'SUP' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('When user is ADMIN in an organization managing students but not a SUP one', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: true, type: 'SCO' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('When user is ADMIN in an SUP organization but it does not manage students', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: false, type: 'SUP' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+});

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -2,6 +2,10 @@
   <div class="page__title page-title">Étudiants</div>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
+      <a class="button button--link button--no-color"
+         href="{{this.urlToDownloadCsvTemplate}}" target="_blank" rel="noopener noreferrer" download>
+        Télécharger le modèle
+      </a>
       <FileUpload @name="file-upload" @for="students-file-upload" @accept=".csv" @multiple={{false}} @onfileadd={{@importStudents}}>
         <span class="button" role="button" tabindex="0">Importer (.csv)</span>
       </FileUpload>

--- a/orga/app/components/routes/authenticated/sup-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.js
@@ -1,6 +1,14 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import ENV from 'pix-orga/config/environment';
 
 export default class ListItems extends Component {
   @service currentUser;
+  @service session;
+
+  @computed('currentUser.organization.id')
+  get urlToDownloadCsvTemplate() {
+    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
+  }
 }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -14,6 +14,10 @@ $margin-right: 32px;
   &__import-students-button {
     margin-top: 20px;
     margin-left: auto;
+
+    & :last-child {
+      margin-left: 10px;
+    }
   }
 
   &__authentication-methods {


### PR DESCRIPTION
## :unicorn: Problème
Pix Orga va (bientôt : #1638) permettre d'importer des étudiants inscrits dans une Organisation SUP via un fichier CSV. Cependant, aucun modèle de fichier n'est pour l'instant fourni.

## :robot: Solution
Permettre aux utilisateurs de Pix Orga de télécharger ce modèle de fichier, afin de le remplir, puis de l'importer dans Pix Orga par la suite.

## :rainbow: Remarques
Les wording sont encore à valider.

## :100: Pour tester
- Se connecter à Pix Orga en tant qu'orga SUP (sup@example.net) ;
- Aller dans l'onglet "Étudiants" ;
- Cliquer sur le bouton "Télécharger le modèle" ;
- Ouvrir le fichier téléchargé et vérifier les colonnes.

Bonus avec l'import :
- Remplir le fichier avec des informations ;
- Importer le fichier ;
- Voir afficher les informations.
