### PR TITLE
[BUGFIX] Problème de taille du champ de sélection du type d'organisation (PIX-914).

### DIFF
--- a/admin/app/components/organization-form.hbs
+++ b/admin/app/components/organization-form.hbs
@@ -16,7 +16,7 @@
 
     <div class="form-field form-group">
       <label class="form-field__label" for="organizationType">Type : </label>
-      <div id="organizationTypeSelector" class="form-field__select {{if @organization.errors.type 'is-invalid' ''}}">
+      <div id="organizationTypeSelector" class="form-field__select {{if @organization.errors.type 'is-invalid' ''}} organization-form__select-type">
         <PowerSelect
                 @options={{this.organizationTypes}}
                 @searchEnabled={{false}}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -37,6 +37,7 @@
 @import 'components/confirm-popup';
 @import 'components/member-item';
 @import 'components/menu-bar';
+@import 'components/organization-form';
 @import 'components/organization-information-section';
 @import 'components/pagination-control';
 @import 'components/user-detail-personal-information-section';

--- a/admin/app/styles/components/organization-form.scss
+++ b/admin/app/styles/components/organization-form.scss
@@ -1,0 +1,5 @@
+.organization-form__select-type {
+    .ember-power-select-trigger {
+        width: 250px;
+    }
+}


### PR DESCRIPTION
## :unicorn: Problème
Les types d'organisations ne tiennent pas sur une ligne.
![image](https://user-images.githubusercontent.com/13931126/88160977-b0bd6780-cc0f-11ea-963f-27c67e66a277.png)

## :robot: Solution
Ajout d'une classe css afin d'augmenter la taille du sélecteur.
<img width="816" alt="Capture d’écran 2020-07-22 à 11 39 43" src="https://user-images.githubusercontent.com/13931126/88161264-0c87f080-cc10-11ea-8aed-c569791d57db.png">

## :100: Pour tester
Créer une organisation dans Pix Admin.
