### PR TITLE
[CLEANUP] Corrige des tests unitaires qui appellent la base de données

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -116,7 +116,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "npm run test:api:path -- tests",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
-    "test:api:unit": "npm run test:api:path -- tests/unit",
+    "test:api:unit": "TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",
     "test:api:acceptance": "npm run test:api:path -- tests/acceptance",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -59,14 +59,16 @@ describe('Unit | Service | Certification Service', function() {
   describe('#getCertificationResult', () => {
     const certificationCourseId = 1;
     const cleaCertificationStatus = 'someStatus';
+    const assessmentId = Symbol('assessmentId');
 
     beforeEach(() => {
       sinon.stub(cleaCertificationStatusRepository, 'getCleaCertificationStatus').resolves(cleaCertificationStatus);
+      sinon.stub(assessmentRepository, 'getIdByCertificationCourseId')
+        .withArgs(certificationCourseId).resolves(assessmentId);
     });
 
     context('when certification is finished', () => {
       let certificationCourse;
-      const assessmentId = Symbol('assessmentId');
 
       beforeEach(() => {
         certificationCourse = new CertificationCourse({
@@ -87,8 +89,6 @@ describe('Unit | Service | Certification Service', function() {
         assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1', 'rec2.1')];
         sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks')
           .withArgs({ certificationCourseId }).resolves(assessmentResult);
-        sinon.stub(assessmentRepository, 'getIdByCertificationCourseId')
-          .withArgs(certificationCourseId).resolves(assessmentId);
       });
 
       it('should return certification results with pix score, date and certified competences levels', async () => {

--- a/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
+++ b/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
@@ -9,6 +9,7 @@ describe('Unit | UseCase | update-user-details-for-administration', () => {
 
   beforeEach(() => {
     sinon.stub(userRepository, 'updateUserDetailsForAdministration');
+    sinon.stub(userRepository, 'isEmailAllowedToUseForCurrentUser');
   });
 
   it('should update user email,firstName,lastName', async () => {
@@ -19,7 +20,8 @@ describe('Unit | UseCase | update-user-details-for-administration', () => {
       firstName: 'firstName',
       lastName: 'lastName',
     };
-    userRepository.updateUserDetailsForAdministration.withArgs(userId,userToUpdate).resolves();
+
+    userRepository.isEmailAllowedToUseForCurrentUser.withArgs(userId,userToUpdate.email).resolves();
 
     // when
     await updateUserDetailsForAdministration_test({
@@ -40,7 +42,7 @@ describe('Unit | UseCase | update-user-details-for-administration', () => {
       email: 'partial@update.net',
     };
 
-    userRepository.updateUserDetailsForAdministration.withArgs(userId,userToUpdate).resolves();
+    userRepository.isEmailAllowedToUseForCurrentUser.withArgs(userId,userToUpdate.email).resolves();
 
     // when
     await updateUserDetailsForAdministration_test({


### PR DESCRIPTION
## :unicorn: Problème

Quand on appelle les tests unitaires il ne doit pas y avoir d'appel à la base de donnée. Or 4 tests faisaient des appels à la base.

## :robot: Solution

- Utiliser des test doubles dans ces 4 tests pour éviter les appels à la base.
- Faire que la base n'est pas joignable dans la cible `test:api:unit` (en fournissant une mauvaise URL pour la base).

## 🌈 Remarque

Compatible avec #1665.
