### PR TITLE
[CLEANUP] Rétablit des assertions sur le résultat dans quelques tests

### DIFF
--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -1,8 +1,9 @@
 const { roles } = require('../models/Membership');
 const { AlreadyExistingOrganizationInvitationError, AlreadyExistingMembershipError } = require('../../domain/errors');
+const _ = require('lodash');
 
-function getOrganizationRole({ hasMembers, invitationRole }) {
-  return invitationRole || (hasMembers ? roles.MEMBER : roles.ADMIN);
+function _pickDefaultRole(existingMemberships) {
+  return _.isEmpty(existingMemberships) ? roles.ADMIN : roles.MEMBER;
 }
 
 module.exports = async function acceptOrganizationInvitation({
@@ -31,7 +32,7 @@ module.exports = async function acceptOrganizationInvitation({
     if (existingMembership) {
       await membershipRepository.updateById({ id: existingMembership.id, membershipAttributes: { organizationRole: invitationRole } });
     } else {
-      const organizationRole = getOrganizationRole({ hasMembers: memberships.length, invitationRole });
+      const organizationRole = invitationRole || _pickDefaultRole(memberships);
       await membershipRepository.create(userFound.id, organizationId, organizationRole);
     }
 

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -14,17 +14,22 @@ module.exports = async function getCorrectionForAnswer({
   const answer = await answerRepository.get(integerAnswerId);
   const assessment = await assessmentRepository.get(answer.assessmentId);
 
+  if (assessment.userId !== userId) {
+    throw new NotFoundError(`Not found correction for answer of ID ${answerId}`);
+  }
+
   _validateCorrectionIsAccessible(assessment, userId, integerAnswerId);
 
   return correctionRepository.getByChallengeId({ challengeId: answer.challengeId, userId });
 
 };
 
-function _validateCorrectionIsAccessible(assessment, userId, answerId) {
-  if (assessment.userId !== userId) {
-    throw new NotFoundError(`Not found correction for answer of ID ${answerId}`);
+function _validateCorrectionIsAccessible(assessment) {
+  if (assessment.isForCampaign() || assessment.isCompetenceEvaluation()) {
+    return;
   }
-  if (!assessment.isCompleted() && !assessment.isForCampaign() && !assessment.isCompetenceEvaluation()) {
+
+  if (!assessment.isCompleted()) {
     throw new AssessmentNotCompletedError();
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Dans certains tests, il y a des vérifications que des méthodes sont appelées (`sinon.assert.calledWith` ou `to.have.been.calledWith`) soit "à la place de", soit "en plus de" vérifications de résultats, pour des cas d'usages qui se vérifie plutôt par des comparaison de résultat.

## :robot: Solution

Remplacer les vérifications d'appels de méthodes par des spécifications d'appel ou les supprimer quand elles ne sont pas nécessaires.

## :rainbow: Remarques

Note : pour le même prix il y a aussi deux commits de BSR, vous achetez ?

### Dans quel cas est-ce qu'on vérifie un appel de méthode ?

Cette présentation résume bien le cas où une vérification d'appel est utile (la case en bas à droite dans l'image) et tout les autres cas où on souhaite soit ne pas tester, soit plutôt vérifier le résultat de l'opération testée (les cinq autres cases) :

- https://www.youtube.com/watch?v=URSWYvyc42M

<img width="502" alt="MagicTricksOfTesting_SandiMetz" src="https://user-images.githubusercontent.com/7529/88192417-c8f7ab80-cc3c-11ea-9460-40added79912.png">

Voir aussi :
- https://1024pix.atlassian.net/wiki/spaces/DEV/pages/600178695/Tester
