### PR TITLE
[FEATURE]  Traduction de la page de fin de certification (Pix-798)

### DIFF
--- a/mon-pix/app/templates/components/certification-results-page.hbs
+++ b/mon-pix/app/templates/components/certification-results-page.hbs
@@ -6,14 +6,13 @@
   {{#if this.notFinishedYet}}
 
     <div class="result-content__panel-picture">
-      <img src="{{@rootURL}}/images/flag.svg" alt="drapeau">
+      <img src="{{@rootURL}}/images/flag.svg" alt={{t "pages.certification-results.flag-alt"}}>
     </div>
     <div class="result-content__panel-title">
-      Vous avez presque terminé
+      {{t "pages.certification-results.not-finished.title"}}
     </div>
     <div class="result-content__panel-description-supervisor">
-      Appelez le surveillant :
-      <br>Il doit impérativement voir cet écran pour finaliser votre certification.
+      {{t "pages.certification-results.not-finished.supervisor" htmlSafe=true}}
     </div>
 
     <div class="result-content__warning-container">
@@ -21,30 +20,30 @@
         <Input @type="checkbox" @id="validSupervisor" @checked={{this.validSupervisor}} @alt="Le surveillant doit cliquer ici." />
 
         <span class="result-content__warning-text">
-          Le surveillant a bien vu cet écran.
+          {{t "pages.certification-results.not-finished.warning-text"}}
         </span>
       </div>
 
       {{#if this.validSupervisor}}
-        <button class="result-content__button result-content__validation-button button button--big button--thin" {{on "click" this.validateBySupervisor}}>Je confirme</button>
+        <button class="result-content__button result-content__validation-button button button--big button--thin" {{on "click" this.validateBySupervisor}}>{{t "pages.certification-results.action.confirm"}}</button>
       {{else}}
-        <button class="result-content__button result-content__button-blocked">Je confirme</button>
+        <button class="result-content__button result-content__button-blocked">{{t "pages.certification-results.action.confirm"}}</button>
       {{/if}}
     </div>
 
   {{else}}
     <div class="result-content__panel-title">
-      Bravo, c'est fini !
+      {{t "pages.certification-results.finished.title"}}
     </div>
     <div class="result-content__panel-description">
-      Vos résultats seront prochainement disponibles depuis votre compte.
+      {{t "pages.certification-results.finished.description"}}
     </div>
     <div class="result-content__warning-container">
       <div class="result-content__warning-text">
-        Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter.
+        {{t "pages.certification-results.finished.warning-text"}}
       </div>
 
-      <LinkTo @route="logout" class="result-content__logout-button result-content__button button button--big button--thin">Se déconnecter</LinkTo>
+      <LinkTo @route="logout" class="result-content__logout-button result-content__button button button--big button--thin">{{t "pages.certification-results.action.logout"}}</LinkTo>
 
     </div>
   {{/if}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -67,6 +67,24 @@
       }
     },
 
+    "certification-results": {
+      "action": {
+        "confirm": "Je confirme",
+        "logout": "Se déconnecter"
+      },
+      "finished": {
+        "title": "Bravo, c'est fini !",
+        "description": "Vos résultats seront prochainement disponibles depuis votre compte.",
+        "warning-text": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter."
+      },
+      "flag-alt": "Drapeau",
+      "not-finished": {
+        "title": "Vous avez presque terminé",
+        "supervisor": "Appelez le surveillant : '<br>'Il doit impérativement voir cet écran pour finaliser votre certification.",
+        "warning-text": "Le surveillant a bien vu cet écran."
+      }
+    },
+
     "certification-start": {
       "title" : "Join a certification session",
       "access-code": "Enter the access code communicated by the supervisor",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -67,6 +67,24 @@
       }
     },
 
+    "certification-results": {
+      "action": {
+        "confirm": "Je confirme",
+        "logout": "Se déconnecter"
+      },
+      "finished": {
+        "title": "Bravo, c'est fini !",
+        "description": "Vos résultats seront prochainement disponibles depuis votre compte.",
+        "warning-text": "Si cet ordinateur n’est pas le vôtre, pensez à vous déconnecter."
+      },
+      "flag-alt": "Drapeau",
+      "not-finished": {
+        "title": "Vous avez presque terminé",
+        "supervisor": "Appelez le surveillant : '<br>'Il doit impérativement voir cet écran pour finaliser votre certification.",
+        "warning-text": "Le surveillant a bien vu cet écran."
+      }
+    },
+
     "certification-start": {
       "title" : "Rejoindre une session de certification",
       "access-code": "Saisissez le code d'accès communiqué par le surveillant",


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, la page de fin de certification n'est disponible qu'en français

## :robot: Solution
Ajouter les textes de la page de fin de certification dans les fichiers de traduction

## :100: Pour tester
Passer une certification et constater que la page de fin de certification s'affiche correctement