### PR TITLE
[CLEANUP] Faciliter le changement de langue.

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -14,9 +14,9 @@ export default class Application extends JSONAPIAdapter.extend(DataAdapterMixin)
   currentDomain;
   @service
   ajaxQueue;
+  @service intl;
 
   host = ENV.APP.API_HOST;
-  locale = ENV.APP.LOCALE;
   namespace = 'api';
 
   get headers() {
@@ -33,11 +33,11 @@ export default class Application extends JSONAPIAdapter.extend(DataAdapterMixin)
   }
 
   get _locale() {
-    if (this.locale === 'fr') {
+    if (this.intl.get('locale') === 'fr') {
       return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION ?
         FRENCH_LOCALE
         : FRENCHSPOKEN_LOCALE;
     }
-    return this.locale;
+    return this.intl.get('locale');
   }
 }

--- a/mon-pix/app/controllers/application.js
+++ b/mon-pix/app/controllers/application.js
@@ -1,8 +1,4 @@
-import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class ApplicationController extends Controller {
-  @service intl;
-
-  pageTitle = this.intl.t('navigation.pix');
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -27,7 +27,7 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   async beforeModel(transition) {
-    this._setLocale();
+    this._setLocale(transition.to.queryParams);
     await this._checkForURLAuthentication(transition);
     return this._loadCurrentUser();
   },
@@ -44,9 +44,9 @@ export default Route.extend(ApplicationRouteMixin, {
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
   sessionInvalidated() {},
 
-  _setLocale() {
+  _setLocale(queryParams) {
     const defaultLocale = 'fr';
-    const locale = transition.to.queryParams.lang || defaultLocale;
+    const locale = queryParams.lang || defaultLocale;
     this.intl.setLocale([locale, defaultLocale]);
     this.moment.setLocale(locale);
   },

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -1,7 +1,6 @@
 /* eslint ember/no-classic-classes: 0 */
 
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
-import ENV from 'mon-pix/config/environment';
 
 import Route from '@ember/routing/route';
 
@@ -47,8 +46,9 @@ export default Route.extend(ApplicationRouteMixin, {
 
   _setLocale() {
     const defaultLocale = 'fr';
-    this.intl.setLocale([ENV.APP.LOCALE, defaultLocale]);
-    this.moment.setLocale(ENV.APP.LOCALE || defaultLocale);
+    const locale = transition.to.queryParams.lang || defaultLocale;
+    this.intl.setLocale([locale, defaultLocale]);
+    this.moment.setLocale(locale);
   },
 
   _loadCurrentUser() {

--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{title pageTitle prepend=true}}
+{{title (t 'navigation.pix') prepend=true}}
 <HeadLayout />
 <div class="body">
   <CommunicationBanner />

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -45,7 +45,6 @@ module.exports = function(environment) {
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
-      LOCALE: process.env.LOCALE || 'fr',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
 
       API_ERROR_MESSAGES: {

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -42,6 +42,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
     it('should add Accept-Language header set to fr-fr when the current domain contains pix.fr and locale is "fr"', function() {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');
+      applicationAdapter.intl = { get: () => 'fr' };
 
       // When
       applicationAdapter.set('currentDomain', { getExtension() { return 'fr'; } });
@@ -53,6 +54,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
     it('should add Accept-Language header set to fr when the current domain contains pix.digital and locale is "fr"', function() {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');
+      applicationAdapter.intl = { get: () => 'fr' };
 
       // When
       applicationAdapter.set('currentDomain', { getExtension() { return 'digital'; } });
@@ -66,7 +68,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
       const applicationAdapter = this.owner.lookup('adapter:application');
 
       // When
-      applicationAdapter.locale = 'en';
+      applicationAdapter.intl = { get: () => 'en' };
 
       // Then
       expect(applicationAdapter.headers['Accept-Language']).to.equal('en');


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, pour tester les version EN/FR, il faut changer la variable LOCALE et relancer le build de mon-pix, ce qui est très long.

## :robot: Solution
Au lieu de passer par une variable d'env, passer par un queryParams `?lang=en` qui change la langue du site

## :rainbow: Remarques
Cette solution est amené à évoluer vers une solution finale pour l'utilisateur

## :100: Pour tester
- Aller sur la review app.
- Voir la page de connexion en français
- Ajouter `?lang=en` à l'url
- Voir le site en anglais