### PR TITLE
[BUGFIX] Harmonisation des boutons d'archivage et de modification d'une campagne (PIX-1016)

### DIFF
--- a/orga/app/components/routes/authenticated/campaigns/details/parameters-tab.hbs
+++ b/orga/app/components/routes/authenticated/campaigns/details/parameters-tab.hbs
@@ -63,7 +63,7 @@
             Modifier
           </LinkTo>
         </div>
-        <div class="campaign-details-content campaign-details-content--button campaign-details-content--left">
+        <div class="campaign-details-content campaign-details-content--button campaign-details--button campaign-details-content--left">
           <button
             type="button"
             {{on 'click' (fn this.archiveCampaign @campaign.id)}}

--- a/orga/app/styles/globals/buttons.scss
+++ b/orga/app/styles/globals/buttons.scss
@@ -1,4 +1,6 @@
 .button {
+  box-sizing: border-box;
+  font-family: $roboto;
   padding: 13px 20px;
   font-size: 0.875rem;
   font-weight: 500;


### PR DESCRIPTION
## :unicorn: Problème
Les deux boutons sont différents en terme de design.

## :robot: Solution
Modification de la classe css de .button

## :rainbow: Remarques
RAS.

## :100: Pour tester
Aller dans la page détail d'une campagne et constater l'affichage des 2 boutons.
