### PR TITLE
[BUGFIX] Fix une erreur d'utilisation du service `intl`

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -8,15 +8,18 @@ export default class NavbarDesktopHeader extends Component {
   @service router;
   @service session;
   @service intl;
-  _menuItems = [
-    { name: this.intl.get('navigation.not-logged.sign-in'), link: 'login', class: 'navbar-menu-signin-link' },
-    { name: this.intl.get('navigation.not-logged.sign-up'), link: 'inscription', class: 'navbar-menu-signup-link' }
-  ];
 
   @alias('session.isAuthenticated') isUserLogged;
 
   get menu() {
     const menuItems = this._menuItems;
     return this.isUserLogged ? menuItems.filterBy('permanent', true) : menuItems;
+  }
+
+  get _menuItems() {
+    return [
+      { name: this.intl.t('navigation.not-logged.sign-in'), link: 'login', class: 'navbar-menu-signin-link' },
+      { name: this.intl.t('navigation.not-logged.sign-up'), link: 'inscription', class: 'navbar-menu-signup-link' }
+    ];
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les textes des boutons de connexion/inscription ne s'affichent plus sur la page /campagnes en tant qu'utilisateur non connecté.

## :robot: Solution
- On utilisait le service intl avec `this.intl.get` au lieu de `this.intl.t`.
- Corriger les lignes de code concernées

## :100: Pour tester
- Se rendre sur /campagnes en étant non connecté
- Vérifier que les bouton de connexion/inscription s'affichent correctement
