### PR TITLE
[BUGFIX] Améliorer l'affichage du message d'erreur lors de la réconciliation d'un élève que l'on ne retrouve pas (PIX-1017)

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -166,7 +166,7 @@ export default class RegisterForm extends Component {
         this.set('isLoading', false);
         errorResponse.errors.forEach((error) => {
           if (error.status === '404') {
-            return this.set('errorMessage', 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+            return this.set('errorMessage', 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
           }
           if (error.status === '409') {
             return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -143,7 +143,7 @@ export default class JoinRestrictedCampaignController extends Controller {
         return this.set('errorMessage', 'Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.');
       }
       if (error.status === '404') {
-        return this.set('errorMessage', 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+        return this.set('errorMessage', 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
       }
       return this.set('errorMessage', error.detail);
     });

--- a/mon-pix/app/templates/campaigns/restricted/join.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/join.hbs
@@ -62,7 +62,7 @@
         </div>
 
         {{#if errorMessage}}
-          <div class="join-restricted-campaign__error" aria-live="polite">{{errorMessage}}</div>
+          <div class="join-restricted-campaign__error" aria-live="polite">{{{errorMessage}}}</div>
         {{/if}}
         {{#if isLoading}}
           <button type="button" disabled class="button button--big"><span class="loader-in-button">&nbsp;</span></button>

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -48,7 +48,7 @@
     </div>
 
     {{#if this.errorMessage}}
-      <div class="register-form__error" aria-live="polite">{{this.errorMessage}}</div>
+      <div class="register-form__error" aria-live="polite">{{{this.errorMessage}}}</div>
     {{/if}}
 
     {{#unless this.matchingStudentFound}}

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -273,7 +273,7 @@ describe('Integration | Component | routes/register-form', function() {
     });
 
     [
-      { status: '404', errorMessage: 'Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.' },
+      { status: '404', errorMessage: 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.' },
       { status: '409', errorMessage: 'Vous possédez déjà un compte Pix. Veuillez vous connecter.' },
     ].forEach(({ status, errorMessage }) => {
       it(`should display an error message if user saves with an error response status ${status}`, async function() {
@@ -309,7 +309,7 @@ describe('Integration | Component | routes/register-form', function() {
 
         await click('#submit-search');
 
-        expect(find('.register-form__error').textContent).to.equal(errorMessage);
+        expect(find('.register-form__error').innerHTML).to.equal(errorMessage);
       });
     });
   });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -463,7 +463,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Vous êtes enseignant ? L’accès à un parcours n’est pas disponible pour le moment. Vous êtes un élève ? Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+      expect(controller.get('errorMessage')).to.equal('Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });


### PR DESCRIPTION
## :unicorn: Problème
Si on ne trouve pas l'élève dans la liste un message d'erreur s'affiche. Celui-ci est beaucoup trop long est peu lisible.

## :robot: Solution
Ajout de saut de ligne dans les fichiers join.js et register-form.js.

## :rainbow: Remarques
RAS.

## :100: Pour tester
Rejoindre la campagne RESTRICTD en étant authentifié et sans être authentifié.
Essayer de se réconcilier avec un élève qui n'existe pas.
