### PR TITLE
[FEATURE] Créer un knowledge-elements snapshot quand l'utilisateur partage une campagne participation

### DIFF
--- a/api/db/migrations/20200724115030_replace-knowledge-element-snapshots-index-by-unique-index-on-userId-and-snappedAt.js
+++ b/api/db/migrations/20200724115030_replace-knowledge-element-snapshots-index-by-unique-index-on-userId-and-snappedAt.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'knowledge-element-snapshots';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex('userId');
+    table.unique(['userId', 'snappedAt']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index('userId');
+    table.dropUnique(['userId', 'snappedAt']);
+  });
+};

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -113,6 +113,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidParametersForSessionPublication) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.AlreadyExistingEntity) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.AlreadyExistingMembershipError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -4,6 +4,12 @@ class DomainError extends Error {
   }
 }
 
+class AlreadyExistingEntity extends DomainError {
+  constructor(message = 'L’entité existe déjà.') {
+    super(message);
+  }
+}
+
 class AlreadyExistingMembershipError extends DomainError {
   constructor(message = 'Le membership existe déjà.') {
     super(message);
@@ -504,6 +510,7 @@ class NotImplementedError extends Error {
 
 module.exports = {
   DomainError,
+  AlreadyExistingEntity,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,
   AlreadyExistingOrganizationInvitationError,

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -27,6 +27,14 @@ describe('Integration | API | Controller Error', () => {
   context('412 Precondition Failed', () => {
     const PRECONDITION_FAILED = 412;
 
+    it('responds Precondition Failed when a AlreadyExistingEntity error occurs', async () => {
+      routeHandler.throws(new DomainErrors.AlreadyExistingEntity());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
+      expect(responseDetail(response)).to.equal('L’entité existe déjà.');
+    });
+
     it('responds Precondition Failed when a AlreadyRatedAssessmentError error occurs', async () => {
       routeHandler.throws(new DomainErrors.AlreadyRatedAssessmentError());
       const response = await server.inject(options);


### PR DESCRIPTION
## :unicorn: Problème

Le knowledge-element-snapshots ont été introduit afin d'améliorer les performances de génération des exports CSV. Jusqu'à maintenant ces snapshots étaient créés en mode lazy (si au premier appel ils n'existent pas alors ils sont créés). Ce qui implique des exports long à générer sur les premiers appels. De plus à chaque fois qu'un utilisateur partage ses résultats pour une campagne, il faut recalculer ces snapshots au moment de l'export

## :robot: Solution

Créer un knowledge-elements snapshot quand l'utilisateur partage un campagne participation.

## :rainbow: Remarques

## :100: Pour tester

1. Se connecter à pix-app pour la campagne SNAP123
2. Partager son profil pour la campagne
2. Vérifier en base de données que le snapshot a bien été créé pour l'utilisateur
