### PR TITLE
[BUGFIX] Résoudre le flaky test de schooling-registrations

### DIFF
--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -86,7 +86,7 @@ module.exports = {
             })
             .update(_.omit(schoolingRegistrationToUpdate, ['id', 'createdAt']));
         }),
-        Bookshelf.knex.batchInsert('schooling-registrations', schoolingRegistrationsToCreate)
+        trx.batchInsert('schooling-registrations', schoolingRegistrationsToCreate)
       ]);
       await trx.commit();
     } catch (err) {


### PR DESCRIPTION
## :unicorn: Problème
Un test passe au rouge de temps en temps.

## :robot: Solution
Faire en sorte que la méthode `addOrUpdateOrganizationSchoolingRegistrations` utilise la même transaction pour mettre à jour et insérer.
