### PR TITLE
[BUGFIX] Corriger l'affichage du texte de bouton de validation des épreuves au format mobile (PIX-604)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -47,11 +47,15 @@
 .challenge-actions__action-skip-text {
   text-align: center;
   flex-grow: 1;
-  font-size: 1rem;
+  font-size: 0.8rem;
   font-weight: $font-semi-bold;
   color: $grey-50;
   text-transform: uppercase;
   letter-spacing: 0.031rem;
+
+  @include device-is('tablet') {
+    font-size: 1rem;
+  }
 }
 .challenge-actions__action-skip__loader {
   margin-right: 15px;
@@ -97,12 +101,16 @@
 .challenge-actions__action-validate-text {
   width: 76px;
   flex-grow: 1;
-  font-size: 1rem;
+  font-size: 0.8rem;
   font-weight: $font-semi-bold;
   text-transform: uppercase;
   letter-spacing: 0.094rem;
   color: white;
   text-decoration: none;
+
+  @include device-is('tablet') {
+    font-size: 1rem;
+  }
 }
 .challenge-actions__action-validate__loader {
   order: 1;

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -1,6 +1,5 @@
 .button {
   font-family: $font-roboto;
-  padding: 14px 20px;
   font-size: 1rem;
   font-weight: 500;
   letter-spacing: 0.012rem;
@@ -136,6 +135,10 @@
     &:hover, &:active, &:focus {
       background-color: $grey-20;
     }
+  }
+
+  @include device-is('tablet') {
+    padding: 14px 20px;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Le texte sur les boutons de validation des épreuves apparait sur deux lignes sur téléphone iphone 6/7 et sony Xperia XZ1 compact.

![Capture d’écran 2020-07-24 à 16 11 28](https://user-images.githubusercontent.com/36371437/88400260-5fa4a380-cdc8-11ea-986c-77c9fdbe05f8.png)

## :robot: Solution
Retirer le padding au format mobile pour les deux boutons de validation et de passage à la question suivante et adapter la taille du texte au petits écrans.

![Capture d’écran 2020-07-24 à 16 06 45](https://user-images.githubusercontent.com/36371437/88399797-b8c00780-cdc7-11ea-98c7-d6a30efe9ae2.png)

## :100: Pour tester
Sur Chrome, Safari et Firefox, ne pas passer par l'émulation de format mobile (impossible de recréer) mais réduire la taille de la fenêtre manuellement via un cliquer-glisser.
