### PR TITLE
[BUGFIX] Ajouter un peu d'espace entre le nombre d'acquis et la barre d'évaluation dans Pix Orga (PIX-1018)

### DIFF
--- a/orga/app/styles/components/progress-bar.scss
+++ b/orga/app/styles/components/progress-bar.scss
@@ -1,4 +1,5 @@
 .progress-bar {
+  margin-bottom: 4px;
   width: 160px;
   height: 6px;
   border-radius: 10px;


### PR DESCRIPTION
## :unicorn: Problème
Le nombre d'acquis est un peu collé à la barre. 

## :robot: Solution
Ajout d'un margin-bottom de 4px dans la classe progress-bar.scss.

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller dans une campagne d'évaluation.
