### PR TITLE
[BUGFIX] Réparer le dropdown de sélections des organisations (PIX-1022).

### DIFF
--- a/orga/app/components/routes/register-form.js
+++ b/orga/app/components/routes/register-form.js
@@ -105,4 +105,9 @@ export default class RegisterForm extends Component {
     const scope = 'pix-orga';
     return this.session.authenticate('authenticator:oauth2', email, password, scope);
   }
+
+  willDestroy() {
+    this.user.unloadRecord();
+    super.willDestroy(...arguments);
+  }
 }

--- a/orga/app/components/user-logged-menu.js
+++ b/orga/app/components/user-logged-menu.js
@@ -29,7 +29,7 @@ export default class UserLoggedMenu extends Component {
     return memberships.toArray()
       .map((membership) => membership.organization)
       .filter((organization) => organization.get('id') !== this.currentUser.organization.id)
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort((a, b) => a.get('name').localeCompare(b.get('name')));
   }
 
   @action

--- a/orga/app/models/organization-invitation-response.js
+++ b/orga/app/models/organization-invitation-response.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 const { Model, attr } = DS;
 
-export default class CampaignAssessmentParticipationSummary extends Model {
+export default class OrganizationInvitationResponse extends Model {
   @attr('string') code;
   @attr('string') email;
 }

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -42,6 +42,9 @@ module('Integration | Component | routes/register-form', function(hooks) {
         return EmberObject.create({
           save() {
             return resolve();
+          },
+          unloadRecord() {
+            return resolve();
           }
         });
       };
@@ -182,7 +185,10 @@ module('Integration | Component | routes/register-form', function(hooks) {
         this.owner.unregister('service:store');
         this.owner.register('service:store', storeStub);
         storeStub.prototype.createRecord = sinon.stub().returns({
-          save: spy
+          save: spy,
+          unloadRecord: () => {
+            return resolve();
+          }
         });
 
         await render(hbs`<Routes::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);


### PR DESCRIPTION
## :unicorn: Problème
Le dropdown de sélections d'organisations ne s'affiche plus lorsqu'on a plus de 1 organisation. 

## :robot: Solution
Utiliser le get ember pour récupérer les données afin de faire un appel asynchrone si les champs ne sont toujours pas présent. 


## :rainbow: Remarques
SR  sur le nom d'une classe et petit bug à la connexion suite à une invitation. 

![unload-record](https://user-images.githubusercontent.com/26384707/88544671-08960d00-d01a-11ea-9f9a-8f1df4d153cc.gif)


## :100: Pour tester
Se connecter à Pix Orga avec un compte lié à plusieurs organisations, et essayer de changer d'organisation. 