### PR TITLE
[BUGFIX] Problème d'affichage du lien des CGU lors de l'inscription (PIX-1028).

### DIFF
--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -70,6 +70,7 @@
         <div class="signup-form__cgu">
           <Input @type="checkbox" @id="pix-cgu" @checked={{user.cgu}} />
            {{t 'pages.sign-up.fields.cgu.label' cguUrl=cguUrl htmlSafe=true}}
+          <a href={{cguUrl}} class="link" target="_blank"> {{t 'pages.sign-up.fields.cgu.cgu' cguUrl=cguUrl htmlSafe=true}} </a>
         </div>
 
         {{#if user.errors.cgu}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -252,7 +252,8 @@
       "fields": {
         "cgu": {
           "error": "Please accept terms of service before you sign up",
-          "label": "'<abbr title=\"mandatory\">'*'</abbr>' I accept '<a href=\"{cguUrl}\" class=\"link\" target=\"_blank\">'Pix's CGU'</a>'"
+          "label": "'<abbr title=\"mandatory\">'*'</abbr>' I accept ",
+          "cgu": "Pix's CGU"
         },
         "email": {
           "error": "Your email is invalid",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -253,7 +253,8 @@
       "fields": {
         "cgu": {
           "error": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
-          "label": "'<abbr title=\"obligatoire\">'*'</abbr>' J'accepte les '<a href=\"{cguUrl}\" class=\"link\" target=\"_blank\">'conditions d'utilisation de Pix'</a>'"
+          "label": "'<abbr title=\"obligatoire\">'*'</abbr>' J'accepte les ",
+          "cgu": "conditions d'utilisation de Pix"
         },
         "email": {
           "error": "Votre adresse e-mail n’est pas valide.",


### PR DESCRIPTION
## :unicorn: Problème
Passer le paramètre `cguUrl` dans le html de la traduction ne marche pas, `ember-intl` le considère comme du texte.

## :robot: Solution
Sortir le html du lien de la trad

## :rainbow: Remarques

## :100: Pour tester
- Aller sur la page inscription de la review app