### PR TITLE
[FEATURE] Traduction de la page de résultat de campagne (pix-805)

### DIFF
--- a/api/lib/application/campaignParticipationResults/campaign-participation-result-controller.js
+++ b/api/lib/application/campaignParticipationResults/campaign-participation-result-controller.js
@@ -1,12 +1,14 @@
 const usecases = require('../../domain/usecases');
 const serializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-result-serializer');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
   async get(request) {
+    const locale = extractLocaleFromRequest(request);
     const campaignParticipationId = parseInt(request.params.id);
     const userId = request.auth.credentials.userId;
 
-    const report = await usecases.getCampaignParticipationResult({ campaignParticipationId, userId });
+    const report = await usecases.getCampaignParticipationResult({ campaignParticipationId, userId, locale });
 
     return serializer.serialize(report);
   },

--- a/api/lib/domain/usecases/get-campaign-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-participation-result.js
@@ -2,6 +2,7 @@ const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
 module.exports = async function getCampaignParticipationResult({
   userId,
+  locale,
   campaignParticipationId,
   badgeRepository,
   badgeAcquisitionRepository,
@@ -10,6 +11,7 @@ module.exports = async function getCampaignParticipationResult({
   campaignRepository,
   targetProfileRepository,
 }) {
+
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   await _checkIfUserHasAccessToThisCampaignParticipation(userId, campaignParticipation, campaignRepository);
 
@@ -19,7 +21,7 @@ module.exports = async function getCampaignParticipationResult({
 
   const acquiredBadgeIds = await badgeAcquisitionRepository.getAcquiredBadgeIds({ userId, badgeIds: campaignBadgeIds });
 
-  return campaignParticipationResultRepository.getByParticipationId(campaignParticipationId, campaignBadges, acquiredBadgeIds);
+  return campaignParticipationResultRepository.getByParticipationId(campaignParticipationId, campaignBadges, acquiredBadgeIds, locale);
 };
 
 async function _checkIfUserHasAccessToThisCampaignParticipation(userId, campaignParticipation, campaignRepository) {

--- a/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
@@ -6,12 +6,12 @@ const assessmentRepository = require('./assessment-repository');
 const knowledgeElementRepository = require('./knowledge-element-repository');
 
 const campaignParticipationResultRepository = {
-  async getByParticipationId(campaignParticipationId, campaignBadges, acquiredBadgeIds) {
+  async getByParticipationId(campaignParticipationId, campaignBadges, acquiredBadgeIds, locale) {
     const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
     const [targetProfile, competences, assessment, knowledgeElements] = await Promise.all([
       targetProfileRepository.getByCampaignId(campaignParticipation.campaignId),
-      competenceRepository.list(),
+      competenceRepository.list({ locale }),
       assessmentRepository.get(campaignParticipation.assessmentId),
       knowledgeElementRepository.findUniqByUserId({
         userId: campaignParticipation.userId,

--- a/api/tests/unit/application/campaignParticipationResult/campaign-participation-result_test.js
+++ b/api/tests/unit/application/campaignParticipationResult/campaign-participation-result_test.js
@@ -8,6 +8,7 @@ describe('Unit | Controller | campaign-participation-result-controller', () => {
 
     const campaignParticipationId = 1;
     const userId = 1;
+    const locale = 'fr';
 
     beforeEach(() => {
       sinon.stub(usecases, 'getCampaignParticipationResult');
@@ -18,7 +19,8 @@ describe('Unit | Controller | campaign-participation-result-controller', () => {
       // given
       usecases.getCampaignParticipationResult.withArgs({
         campaignParticipationId,
-        userId
+        userId,
+        locale,
       }).resolves({});
       campaignParticipationResultSerializer.serialize.withArgs({}).returns('ok');
 
@@ -27,7 +29,8 @@ describe('Unit | Controller | campaign-participation-result-controller', () => {
         params: { id: campaignParticipationId },
         auth: {
           credentials: { userId }
-        }
+        },
+        headers: { 'accept-language': locale },
       });
 
       // then

--- a/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
@@ -7,6 +7,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
   const campaignParticipationId = 1;
   const targetProfileId = 1;
   const userId = 2;
+  const locale = 'someLocale';
   const campaignId = 'campaignId';
   const otherUserId = 3;
   const campaignParticipation = {
@@ -37,6 +38,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
 
     usecaseDependencies = {
       userId,
+      locale,
       campaignParticipationId,
       campaignParticipationRepository,
       campaignRepository,
@@ -101,6 +103,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
             campaignParticipationId,
             campaignBadges,
             acquiredBadgeIds,
+            locale,
           ).resolves(campaignParticipationResult);
 
           // when
@@ -130,6 +133,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
             campaignParticipationId,
             campaignBadges,
             acquiredBadgeIds,
+            locale,
           ).resolves(campaignParticipationResult);
 
           // when

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -105,6 +105,12 @@
     text-align: center;
     text-transform: none;
     margin: 16px 0;
+
+    > strong {
+      color: $blue;
+      display: inline-block;
+      font-weight: 300;
+    }
   }
 
   &__dash-line {
@@ -153,13 +159,6 @@
     font-size: 1.5rem;
     font-weight: $font-normal;
     margin: 28px 0 24px;
-  }
-}
-
-.skill-review-result-abstract {
-  &__percentage {
-    color: $blue;
-    display: inline-block;
   }
 }
 

--- a/mon-pix/app/templates/campaigns.hbs
+++ b/mon-pix/app/templates/campaigns.hbs
@@ -1,3 +1,3 @@
-{{page-title 'Parcours'}}
+{{page-title (t 'pages.campaign.title')}}
 
 <div>{{outlet}}</div>

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -1,4 +1,4 @@
-{{page-title 'Résultat'}}
+{{page-title (t 'pages.skill-review.title')}}
 
 <div class="background-banner-wrapper">
   <div class="skill-review__banner">
@@ -7,24 +7,24 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner skill-review__result-container">
     {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
       <h3 class="rounded-panel-title skill-review-result__abstract">
-        Vous maîtrisez
-        <span class="skill-review-result-abstract__percentage">
-          {{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
-        </span>
-        <br> des compétences testées.
+        {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
       </h3>
       <div class="skill-review-result__share-container">
         {{#if this.model.campaignParticipation.isShared}}
-          <p class="skill-review-share__thanks">Merci, vos résultats ont bien été envoyés !</p>
-          <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+          <p class="skill-review-share__thanks">
+            {{t 'pages.skill-review.already-shared'}}
+          </p>
+          <LinkTo @route="index" class="skill-review-share__back-to-home link">
+            {{t 'pages.skill-review.actions.continue'}}
+          </LinkTo>
         {{else}}
           <p class="skill-review-share__legal">
-            Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.
+            {{t 'pages.skill-review.send-results'}}
           </p>
 
           {{#if this.displayErrorMessage}}
             <div class="skill-review-share__error" aria-live="polite">
-              Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.
+              {{t 'pages.skill-review.not-finished'}}
             </div>
           {{/if}}
 
@@ -33,9 +33,8 @@
               <span class="loader-in-button">&nbsp;</span>
             </button>
           {{else}}
-            <button class="button button--extra-big skill-review-share__button" {{on "click"
-                                                                                     this.shareCampaignParticipation}}>
-              J'envoie mes résultats
+            <button class="button button--extra-big skill-review-share__button" {{on "click" this.shareCampaignParticipation}}>
+              {{t 'pages.skill-review.actions.send'}}
             </button>
           {{/if}}
         {{/if}}
@@ -44,12 +43,16 @@
         {{#unless model.campaignParticipation.isShared}}
           <div class="skill-review-result__dash-line"></div>
           <div class="skill-review__begin-improvement">
-            <div><h2 class="skill-review__subtitle">Envie d'améliorer vos résultats ?</h2>
-              <p class="skill-review__explain-text">Vous pouvez retenter certaines questions</p>
+            <div>
+              <h2 class="skill-review__subtitle">
+                {{t 'pages.skill-review.try-again.title'}}
+              </h2>
+              <p class="skill-review__explain-text">
+                {{t 'pages.skill-review.try-again.description'}}
+              </p>
             </div>
-            <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click"
-                                                                                                       this.improvementCampaignParticipation}}>
-              Je retente
+            <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" this.improvementCampaignParticipation}}>
+              {{t 'pages.skill-review.actions.try-again'}}
             </button>
           </div>
         {{/unless}}
@@ -57,9 +60,12 @@
     {{else}}
       <div class="skill-review__campaign-archived">
         <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg">
-        <p class="skill-review__campaign-archived-text">Ce parcours a été archivé par l'organisateur.
-          <br> L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.</p>
-        <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+        <p class="skill-review__campaign-archived-text">
+          {{t 'pages.skill-review.archived' htmlSafe=true}}
+        </p>
+        <LinkTo @route="index" class="skill-review-share__back-to-home link">
+          {{t 'pages.skill-review.actions.continue'}}
+        </LinkTo>
       </div>
     {{/if}}
     <div class="skill-review-result__dash-line"></div>
@@ -67,17 +73,23 @@
     {{#if this.showBadges}}
       <div class="badge-acquired-container">
         {{#each this.acquiredBadges as |badge|}}
-          <BadgeAcquiredCard @title="{{badge.title}}" @message="{{badge.message}}" @imageUrl="{{badge.imageUrl}}"
-                             @altMessage="{{badge.altMessage}}"/>
+          <BadgeAcquiredCard
+            @title="{{badge.title}}"
+            @message="{{badge.message}}"
+            @imageUrl="{{badge.imageUrl}}"
+            @altMessage="{{badge.altMessage}}"
+          />
         {{/each}}
       </div>
       <div class="skill-review-result__dash-line"></div>
     {{/if}}
 
     <div class="skill-review-result__table-header">
-      <h2 class="skill-review-result__subtitle">Vos résultats détaillés</h2>
+      <h2 class="skill-review-result__subtitle">
+        {{t 'pages.skill-review.details.title'}}
+      </h2>
       <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
-        <span aria-label="Résultat global" class="skill-review-table-header__circle-chart-value">
+        <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
           {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
         </span>
       </CircleChart>
@@ -86,15 +98,15 @@
     <table class="default-table">
       <thead>
       <tr>
-        <th>Compétences testées</th>
-        <th>Résultats</th>
+        <th>{{t 'pages.skill-review.details.header-skill'}}</th>
+        <th>{{t 'pages.skill-review.details.header-result'}}</th>
       </tr>
       </thead>
 
       <tbody>
       {{#if this.showCleaCompetences}}
         {{#each this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults as |partnerCompetence|}}
-          <tr aria-label="Résultats par compétence">
+          <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
             <td>
               <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}">&#8226;</span>
               <span>{{partnerCompetence.name}}</span>
@@ -102,16 +114,14 @@
             <td>
               <ProgressionGauge @total={{partnerCompetence.totalSkillsCountPercentage}}
                                 @value={{partnerCompetence.masteryPercentage}}>
-                <p class="sr-only">Vous avez validé </p>{{partnerCompetence.masteryPercentage}}%<p class="sr-only"> de
-                la
-                compétence {{partnerCompetence.name}}.</p>
+                {{t 'pages.skill-review.details.skill-progress' percentage=partnerCompetence.masteryPercentage skill=partnerCompetence.name htmlSafe=true}}
               </ProgressionGauge>
             </td>
           </tr>
         {{/each}}
       {{else}}
         {{#each this.model.campaignParticipation.campaignParticipationResult.competenceResults as |competence|}}
-          <tr aria-label="Résultats par compétence">
+          <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
             <td>
               <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}">&#8226;</span>
               <span>{{competence.name}}</span>
@@ -119,8 +129,7 @@
             <td>
               <ProgressionGauge @total={{competence.totalSkillsCountPercentage}}
                                 @value={{competence.masteryPercentage}}>
-                <p class="sr-only">Vous avez validé </p>{{competence.masteryPercentage}}%<p class="sr-only"> de la
-                compétence {{competence.name}}.</p>
+                {{t 'pages.skill-review.details.skill-progress' percentage=competence.masteryPercentage skill=competence.name htmlSafe=true}}
               </ProgressionGauge>
             </td>
           </tr>
@@ -133,8 +142,7 @@
     <div class="skill-review-result__information">
       {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}
       <div class="skill-review-information__text">
-        Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été
-        posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.
+        {{t 'pages.skill-review.information'}}
       </div>
     </div>
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -35,6 +35,10 @@
       }
     },
   
+    "campaign": {
+      "title": "Path"
+    },
+  
     "campaign-landing": {
       "title": "Presentation",
       "assessment": {
@@ -68,7 +72,7 @@
         "legal": "Information relating to your PIX profile will be sent to the organizer to enable him to accompany you. "
       }
     },
-  
+
     "certificate": {
       "title": "Pix certificate",
       "back-link": "Back to my certifications",
@@ -522,6 +526,33 @@
       }
     },
 
+    "skill-review": {
+      "title": "Result",
+      "abstract": "You control '<strong>'{percentage}%'</strong>'<br/> of tested skills.",
+      "actions": {
+        "continue": "Continue your Pix experience",
+        "send": "I send my results",
+        "try-again": "I retry"
+      },
+      "already-shared": "Thank you, your results have been sent!",
+      "archived": "This route has been archived by the organizer. <br/> Sending results is no longer possible but they are taken into account in your route.",
+      "details": {
+        "title": "Your detailed results",
+        "header-skill": "Skills tested",
+        "header-result": "Results",
+        "result": "Overall result",
+        "result-by-skill": "Results by skill",
+        "skill-progress": "'<p class=\"sr-only\">'You have validated '</p>'{percentage}%'<p class=\"sr-only\">' of the skill {skill}.'</p>'"
+      },
+      "information": "If you've ridden on Pix before, the questions you answered weren't asked again. However, the result displayed here takes into account all of your answers.",
+      "not-finished": "You cannot send your results yet, we still have a few questions for you.",
+      "send-results": "Send your results to the course organizer so that he can accompany you.",
+      "try-again": {
+        "title": "Want to improve your results?",
+        "description": "You can retry some questions"
+      }
+    },
+
     "tutorial": {
       "next":"Next",
       "pages": {
@@ -554,7 +585,7 @@
       "title": "To succeed next time",
       "info": "These links were recommended by Pix users."
     },
-
+  
     "user-tutorials": {
       "title": "My tutorials",
       "description": "Improve with tutorials",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -34,7 +34,11 @@
         "header": "Vos réponses"
       }
     },
-
+  
+    "campaign": {
+      "title": "Parcours"
+    },
+  
     "campaign-landing": {
       "title": "Présentation",
       "assessment": {
@@ -68,7 +72,7 @@
         "legal": "Les informations relatives à votre profil PIX seront transmises à l'organisateur pour lui permettre de vous accompagner. Elle ne seront transmises qu'avec votre consentement."
       }
     },
-  
+
     "certificate": {
       "title": "Certificat Pix",
       "back-link": "Retour à mes certifications",
@@ -519,6 +523,33 @@
       "legal-information": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l'accès au service offert par Pix. Elles sont conservées pendant une durée de 5 ans maximum à compter du dernier accès au compte utilisateur, et archivées selon les délais de prescription légale (5 ans). Elles sont destinées à Pix et à ses prestataires techniques exclusivement. Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à dpd@pix.fr.",
       "subtitle": {
         "link": "connectez-vous à votre compte"
+      }
+    },
+
+    "skill-review": {
+      "title": "Résultat",
+      "abstract": "Vous maîtrisez '<strong>'{percentage}%'</strong>'<br/> des compétences testées.",
+      "actions": {
+        "continue": "Continuez votre expérience Pix",
+        "send": "J'envoie mes résultats",
+        "try-again": "Je retente"
+      },
+      "already-shared": "Merci, vos résultats ont bien été envoyés !",
+      "archived": "Ce parcours a été archivé par l'organisateur.<br/> L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.",
+      "details": {
+        "title": "Vos résultats détaillés",
+        "header-skill": "Compétences testées",
+        "header-result": "Résultats",
+        "result": "Résultat global",
+        "result-by-skill": "Résultats par compétence",
+        "skill-progress": "'<p class=\"sr-only\">'Vous avez validé '</p>'{percentage}%'<p class=\"sr-only\">' de la compétence {skill}.'</p>'"
+      },
+      "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
+      "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
+      "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
+      "try-again": {
+        "title": "Envie d'améliorer vos résultats ?",
+        "description": "Vous pouvez retenter certaines questions"
       }
     },
 


### PR DESCRIPTION
## :unicorn: Problème
La page de "Résultat de campagne" n'est pas encore traduite.

## :robot: Solution
Traduire l'ensemble de la page (hors badge)
J'ai également traduit la partie "Retenter" et "Archivage" de la page

## :rainbow: Remarques
- Badge non traduits

## :100: Pour tester
1. Lancer un parcours de campagne d'évaluation (AZERTY123 ou AZERTY456)
2. Finir le parcours et voir la page de résultat => Vérifier les traductions
3. Envoyer les résultats => Vérifier les traductions

> Pour vérifier les traductions, il suffit d'ajouter ?lang=en dans l'URL