### PR TITLE
[FEATURE] Traduire la landing page des campagnes (pix-807)

### DIFF
--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
 export default class CampaignLandingPageController extends Controller {
+
   @tracked isLoading = false;
 
   @action

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -1,4 +1,4 @@
-{{page-title 'Présentation'}}
+{{page-title (t 'pages.campaign-landing.title')}}
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
@@ -9,27 +9,29 @@
         @campaign={{@model}}
         @isLoading={{this.isLoading}}
         @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText="Commencez votre parcours"
-        @announcementText="Démarrez votre parcours d'évaluation personnalisé.<br /> Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test."
-        @buttonText="Je commence"
-        @legalText="Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre de vous accompagner. Les résultats des tests ne seront transmis qu’avec votre consentement."
+        @titleText={{t "pages.campaign-landing.assessment.title"}}
+        @announcementText={{t "pages.campaign-landing.assessment.announcement" htmlSafe=true}}
+        @buttonText={{t "pages.campaign-landing.assessment.action"}}
+        @legalText={{t "pages.campaign-landing.assessment.legal"}}
       />
     {{else}}
       <CampaignStartBlock
         @campaign={{@model}}
         @isLoading={{this.isLoading}}
         @startCampaignParticipation={{this.startCampaignParticipation}}
-        @titleText="Envoyez votre profil"
-        @announcementText="Inscrivez-vous ou connectez-vous sur la plateforme Pix et envoyez votre profil à l'organisation destinataire."
-        @buttonText="C’est parti !"
-        @legalText="Les informations relatives à votre profil PIX seront transmises à l'organisateur pour lui permettre de vous accompagner. Elle ne seront transmises qu'avec votre consentement."
+        @titleText={{t "pages.campaign-landing.profiles-collection.title"}}
+        @announcementText={{t "pages.campaign-landing.profiles-collection.announcement" htmlSafe=true}}
+        @buttonText={{t "pages.campaign-landing.profiles-collection.action"}}
+        @legalText={{t "pages.campaign-landing.profiles-collection.legal"}}
       />
     {{/if}}
 
     {{#if @model.isTypeAssessment}}
       <div class="rounded-panel campaign-landing-page__container__details">
         <div class="campaign-landing-page__details__text">
-          <p class="campaign-landing-page__details__text title">Durant ce parcours, vous aurez l’opportunité de :</p>
+          <p class="campaign-landing-page__details__text title">
+            {{t "pages.campaign-landing.assessment.details"}}
+          </p>
           <hr class="campaign-landing-page__details__line">
 
           <div class="campaign-landing-page__details__measure__container">
@@ -37,21 +39,18 @@
                  src="{{this.rootURL}}/images/landing-page/icon-mesurer.svg" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
-                Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :
+                {{t "pages.campaign-landing.assessment.evaluate.title"}}
               </p>
               <p class="campaign-landing-page__details__text article-list">
-                • rechercher de l’information sur internet,<br>
-                • rédiger des documents,<br>
-                • communiquer et collaborer en ligne,<br>
-                • sécuriser son environnement de travail,<br>
-                etc.<br>
+                {{t "pages.campaign-landing.assessment.evaluate.list" htmlSafe=true}}
               </p>
             </div>
           </div>
           <p class="campaign-landing-page__details__text article-text complement">
-            Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son
-            niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.
-            <a href="https://pix.fr/competences" target="_BLANK">En savoir plus.</a>
+            {{t "pages.campaign-landing.assessment.evaluate.complement"}}
+            <a href={{t "pages.campaign-landing.assessment.evaluate.more-info.link"}} target="_BLANK">
+              {{t "pages.campaign-landing.assessment.evaluate.more-info.label"}}
+            </a>
           </p>
 
           <hr class="campaign-landing-page__dash-line">
@@ -60,11 +59,10 @@
             <img src="{{this.rootURL}}/images/landing-page/icon-conseil.svg" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
-                Découvrir vos résultats au fil du test et consulter des indices pour progresser.
+                {{t "pages.campaign-landing.assessment.develop.title"}}
               </p>
               <p class="campaign-landing-page__details__text article-text">
-                Après 5 épreuves, vous pouvez visualiser vos réponses et suivre des tutos pour développer vos
-                compétences.
+                {{t "pages.campaign-landing.assessment.develop.description"}}
               </p>
             </div>
 
@@ -75,10 +73,10 @@
             <img src="{{this.rootURL}}/images/landing-page/icon-certif.svg" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
-                Préparer une certification reconnue par l’État et le monde professionnel
+                {{t "pages.campaign-landing.assessment.certify.title"}}
               </p>
               <p class="campaign-landing-page__details__text article-text">
-                La certification Pix permet de valoriser ses compétences numériques auprès des employeurs.
+                {{t "pages.campaign-landing.assessment.certify.description"}}
               </p>
             </div>
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -34,6 +34,41 @@
         "header": "Your answers"
       }
     },
+  
+    "campaign-landing": {
+      "title": "Presentation",
+      "assessment": {
+        "title": "Start your journey",
+        "action": "I begin",
+        "announcement": "Start your personalized assessment path. <br /> Register or log into the Pix platform and start your test.",
+        "details": "During this course, you will have the opportunity to:",
+        "legal": "Information relating to your progress will be sent to the course organizer to enable him to accompany you. ",
+        "evaluate": {
+          "title": "Measure your digital skills with fun tests on different topics such as:",
+          "complement": "The public digital skills assessment and certification service Pix allows you to assess your level in 5 major skill areas, which cover all current digital uses.",
+          "list": "'<ul><li>'search the internet for information,'</li><li>'write documents,'</li><li>'communicate and collaborate online,'</li><li>'secure your working environment,'</li><li>'etc.'</li></ul>'",
+          "more-info": {
+            "link": "https://pix.org/competences",
+            "label": "Find out more."
+          }
+        },
+        "certify": {
+          "title": "Prepare for certification recognized by the State and the professional world",
+          "description": "The Pix certification allows you to promote your digital skills to employers."
+        },
+        "develop": {
+          "title": "Discover your results during the test and consult clues to progress.",
+          "description": "After 5 tests, you can view your answers and follow tutorials to develop your skills."
+        }
+      },
+      "profiles-collection": {
+        "title": "Submit your profile",
+        "action": "Let's go !",
+        "announcement": "Register or log in to the Pix platform and send your profile to the recipient organization.",
+        "legal": "Information relating to your PIX profile will be sent to the organizer to enable him to accompany you. "
+      }
+    },
+  
     "certificate": {
       "title": "Pix certificate",
       "back-link": "Back to my certifications",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -34,6 +34,41 @@
         "header": "Vos réponses"
       }
     },
+
+    "campaign-landing": {
+      "title": "Présentation",
+      "assessment": {
+        "title": "Commencez votre parcours",
+        "action": "Je commence",
+        "announcement": "Démarrez votre parcours d'évaluation personnalisé.<br /> Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
+        "details": "Durant ce parcours, vous aurez l’opportunité de :",
+        "legal": "Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre de vous accompagner. Les résultats des tests ne seront transmis qu’avec votre consentement.",
+        "evaluate": {
+          "title": "Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :",
+          "complement": "Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.",
+          "list": "'<ul><li>'rechercher de l’information sur internet,'</li><li>'rédiger des documents,'</li><li>'communiquer et collaborer en ligne,'</li><li>'sécuriser son environnement de travail,'</li><li>'etc.'</li></ul>'",
+          "more-info": {
+            "link": "https://pix.fr/competences",
+            "label": "En savoir plus."
+          }
+        },
+        "develop": {
+          "title": "Découvrir vos résultats au fil du test et consulter des indices pour progresser.",
+          "description": "Après 5 épreuves, vous pouvez visualiser vos réponses et suivre des tutos pour développer vos compétences."
+        },
+        "certify": {
+          "title": "Préparer une certification reconnue par l’État et le monde professionnel",
+          "description": "La certification Pix permet de valoriser ses compétences numériques auprès des employeurs."
+        }
+      },
+      "profiles-collection": {
+        "title": "Envoyez votre profil",
+        "action": "C’est parti !",
+        "announcement": "Inscrivez-vous ou connectez-vous sur la plateforme Pix et envoyez votre profil à l'organisation destinataire.",
+        "legal": "Les informations relatives à votre profil PIX seront transmises à l'organisateur pour lui permettre de vous accompagner. Elle ne seront transmises qu'avec votre consentement."
+      }
+    },
+  
     "certificate": {
       "title": "Certificat Pix",
       "back-link": "Retour à mes certifications",


### PR DESCRIPTION
## :unicorn: Problème

La landing page des campagnes n'est pas traduite

## :robot: Solution

Traduire la landing page des campagnes (il s'agit de la page pour les campagnes d'évaluation ET de collecte de profils)

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Saisir un code d'une campagne d'évaluation (AZERTY123) => Vérifier les traductions
2. Saisir un code d'une campagne de collecte de profils (SNAP123) => Vérifier les traductions

> Pour vérifier les traductions, il suffit d'ajouter ?lang=en dans l'URL
