### PR TITLE
[FEATURE] Traduction de la page d'envoi de profil (pix-808)

### DIFF
--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -1,8 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class SendProfileController extends Controller {
+  @service intl;
 
   @tracked isLoading = false;
   @tracked errorMessage = null;
@@ -28,7 +30,7 @@ export default class SendProfileController extends Controller {
     if (errors && errors.length > 0) {
       errors.forEach((error) => {
         if (error.status === '412') {
-          this.errorMessage = 'L’envoi de votre profil n’est plus possible car l’organisateur a archivé la collecte de profils.';
+          this.errorMessage = this.intl.t('pages.send-profile.errors.archived');
         }
       });
     }

--- a/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/send-profile.hbs
@@ -1,23 +1,24 @@
-{{page-title 'Envoyer mon profil'}}
+{{page-title (t 'pages.send-profile.title')}}
+
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
 
     <div class="send-profile-header__announcement">
-      <h1 class="send-profile-header__title">Envoi de votre profil Pix</h1>
+      <h1 class="send-profile-header__title">
+        {{t "pages.send-profile.first-title"}}
+      </h1>
       <p class="send-profile-header__instruction">
-        Vous allez transmettre le score et les niveaux de compétence présents sur votre profil Pix.
-        <br>Toute évolution de votre profil après cet envoi ne sera pas transmise.
-        <br>Pensez à le vérifier avant de l'envoyer !
+        {{t "pages.send-profile.instructions" htmlSafe=true}}
       </p>
     </div>
 
     <ProfileSharingForm
-            @sendProfile={{action "sendProfile"}}
-            @campaignParticipation={{this.model.campaignParticipation}}
-            @campaign={{this.model.campaign}}
-            @isLoading={{this.isLoading}}
-            @errorMessage={{this.errorMessage}}
+      @sendProfile={{action "sendProfile"}}
+      @campaignParticipation={{this.model.campaignParticipation}}
+      @campaign={{this.model.campaign}}
+      @isLoading={{this.isLoading}}
+      @errorMessage={{this.errorMessage}}
     />
 
     <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
@@ -28,11 +29,11 @@
     </div>
 
     <ProfileSharingForm
-            @sendProfile={{action "sendProfile"}}
-            @campaignParticipation={{this.model.campaignParticipation}}
-            @campaign={{this.model.campaign}}
-            @isLoading={{this.isLoading}}
-            @errorMessage={{this.errorMessage}}
+      @sendProfile={{action "sendProfile"}}
+      @campaignParticipation={{this.model.campaignParticipation}}
+      @campaign={{this.model.campaign}}
+      @isLoading={{this.isLoading}}
+      @errorMessage={{this.errorMessage}}
     />
   </div>
 </div>

--- a/mon-pix/app/templates/components/profile-sharing-form.hbs
+++ b/mon-pix/app/templates/components/profile-sharing-form.hbs
@@ -1,24 +1,34 @@
 <form {{action @sendProfile on="submit"}} class="send-profile-header__form">
-  <p class="send-profile-header__recipient">Destinataire : {{@campaign.organizationName}}</p>
+  <p class="send-profile-header__recipient">
+    {{t "pages.send-profile.form.recipient" recipient=@campaign.organizationName}}
+  </p>
 
   {{#if @campaignParticipation.isShared}}
-    <p class="skill-review-share__thanks">Merci, votre profil a bien été envoyé !</p>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+    <p class="skill-review-share__thanks">
+      {{t "pages.send-profile.form.shared"}}
+    </p>
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">
+      {{t "pages.send-profile.form.continue"}}
+    </LinkTo>
   {{else if @errorMessage}}
     <p class="skill-review-share__thanks">{{@errorMessage}}</p>
-    <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">
+      {{t "pages.send-profile.form.continue"}}
+    </LinkTo>
   {{else}}
     {{#if @isLoading}}
       <button type="button" disabled class="button button--big">
         <span class="loader-in-button">&nbsp;</span>
       </button>
     {{else}}
-      <button type="submit" class="button button--big">J'envoie mon profil</button>
+      <button type="submit" class="button button--big">
+        {{t "pages.send-profile.form.send"}}
+      </button>
     {{/if}}
 
     <p class="send-profile-header__warning">
       <FaIcon @icon="exclamation-circle"></FaIcon>
-      Cet envoi n’est possible qu’une seule fois
+      {{t "pages.send-profile.form.info"}}
     </p>
   {{/if}}
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -392,6 +392,22 @@
       "timedout": "Timed out"
     },
 
+    "send-profile": {
+      "title": "Send my profile",
+      "first-title": "Send your Pix profile",
+      "errors": {
+        "archived": "Sending your profile is no longer possible because the organizer has archived the collection of profiles."
+      },
+      "form": {
+        "info": "This sending is only possible once",
+        "continue": "Continue your Pix experience",
+        "recipient": "Recipient: {recipient}",
+        "send": "I send my profile",
+        "shared": "Thank you, your profile has been sent!"
+      },
+      "instructions": "You will transmit the score and skill levels present on your Pix profile. <br/> Any changes to your profile after this submission will not be transmitted. <br/> Remember to check it before sending it!"
+    },
+
     "sign-in": {
       "title": "Sign in",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -392,6 +392,22 @@
       "timedout": "Temps dépassé"
     },
 
+    "send-profile": {
+      "title": "Envoyer mon profil",
+      "first-title": "Envoi de votre profil Pix",
+      "errors": {
+        "archived": "L’envoi de votre profil n’est plus possible car l’organisateur a archivé la collecte de profils."
+      },
+      "form": {
+        "info": "Cet envoi n’est possible qu’une seule fois",
+        "continue": "Continuez votre expérience Pix",
+        "recipient": "Destinataire : {recipient}",
+        "send": "J'envoie mon profil",
+        "shared": "Merci, votre profil a bien été envoyé !"
+      },
+      "instructions": "Vous allez transmettre le score et les niveaux de compétence présents sur votre profil Pix. <br/> Toute évolution de votre profil après cet envoi ne sera pas transmise. <br/> Pensez à le vérifier avant de l'envoyer !"
+    },
+
     "sign-in": {
       "title": "Connexion",
       "actions": {


### PR DESCRIPTION
## :unicorn: Problème

La page d'envoi de profil n'est pas traduite

## :robot: Solution

Tranduire la page d'envoi de profil

## :rainbow: Remarques

N/A

## :100: Pour tester
1. Saisir un code de collecte de profil (SNAP123)
2. Passer la landing page
3. Vérifier la traduction de la page d'envoi de profil

> Pour vérifier les traductions, il suffit d'ajouter ?lang=en dans l'URL