### PR TITLE
[FEATURE] Traduire la page de campagne non existante (PIX-1001)

### DIFF
--- a/mon-pix/app/templates/campaigns-error.hbs
+++ b/mon-pix/app/templates/campaigns-error.hbs
@@ -1,3 +1,3 @@
 <InaccessibleCampaign>
-  La campagne demandée n’est pas accessible.
+  {{t "pages.not-accessible-campaign.message"}}
 </InaccessibleCampaign>

--- a/mon-pix/app/templates/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/templates/components/inaccessible-campaign.hbs
@@ -3,19 +3,27 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
     <div class="campaign-landing-page__start__image__container">
       <div class="campaign-landing-page__pix-logo">
-        <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+        <img
+          class="campaign-landing-page__image"
+          src="{{rootURL}}/images/pix-logo.svg"
+          alt="{{t "navigation.pix"}}"
+        />
       </div>
       {{#if this.shouldShowTheMarianneLogo}}
         <div class="campaign-landing-page__marianne-logo">
-          <img class="campaign-landing-page__image" src="{{rootURL}}/images/logo-de-la-republique-francaise.svg"
-               alt="République française">
+          <img
+            class="campaign-landing-page__image"
+            src="{{rootURL}}/images/logo-de-la-republique-francaise.svg"
+            alt="{{t "common.french-republic"}}"
+          />
         </div>
       {{/if}}
     </div>
     <div class="campaign-landing-page__error-text">
       <p class="campaign-landing-page__error-text title">{{yield}}</p>
       <LinkTo @route="index" class="button button--extra-big button--link campaign-landing-page__error-button">
-        Revenir au profil</LinkTo>
+        {{t "navigation.back-to-profile"}}
+      </LinkTo>
     </div>
   </div>
 </div>

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -741,7 +741,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
         it('should show an error message', async function() {
           // then
           expect(currentURL()).to.equal('/campagnes/codefaux');
-          expect(find('.title').textContent).to.contains('La campagne demandée n’est pas accessible.');
+          expect(find('.title').textContent).to.contains('Oups, la page demandée n’est pas accessible.');
         });
       });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -356,6 +356,10 @@
       "obtained-level": "Level { level } obtained!"
     },
 
+    "not-accessible-campaign": {
+      "message": "Oups, the requested page is not accessible."
+    },
+
     "profile": {
       "title": "Your profile",
       "competence-card": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -352,6 +352,10 @@
       "info": "Ces liens vers les tutos ont été proposés par des utilisateurs de Pix."
     },
 
+    "not-accessible-campaign": {
+      "message": "Oups, la page demandée n’est pas accessible."
+    },
+
     "profile": {
       "title": "Votre profil",
       "competence-card": {
@@ -553,7 +557,7 @@
     "error": "Erreur",
     "homepage": "Page d'accueil",
     "back-to-homepage": "Revenir à la page d’accueil",
-    "back-to-profile": "Retour Profil",
+    "back-to-profile": "Revenir au profil",
     "main": {
       "code": "J'ai un code",
       "help": "Aide",


### PR DESCRIPTION
## :unicorn: Problème

La page d'une campagne qui n'existe pas n'est pas traduite.

## :robot: Solution

Traduire la page de campagne non existante

## :rainbow: Remarques

N/A

## :100: Pour tester

Saisir l'URL https://ra-name/campagnes/blablabla?lang=en

Vérifier la traduction.
